### PR TITLE
fix(amplify_storage_s3): fixes dual response from upload

### DIFF
--- a/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/AmplifyStorageOperations.kt
+++ b/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/AmplifyStorageOperations.kt
@@ -53,7 +53,7 @@ class AmplifyStorageOperations {
                                     responseSent = true;
                                     prepareError(flutterResult, FlutterStorageErrorMessage.UPLOAD_FILE_OPERATION_FAILED.name, error.localizedMessage, error.recoverySuggestion)
                                 } else {
-                                    LOG.error("S3 Upload Failed", error)
+                                    LOG.error(FlutterStorageErrorMessage.UPLOAD_FILE_OPERATION_FAILED.name, error)
                                 }
                             })
                 } catch (e: Exception) {


### PR DESCRIPTION
*Description of changes:*
Uses a simple flag to prevent attempt at sending multiple errors across method channel on upload.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
