### PR TITLE
ci: only run debug unit tests for android

### DIFF
--- a/.circleci/test_all_plugins.sh
+++ b/.circleci/test_all_plugins.sh
@@ -38,7 +38,7 @@ for plugin_dir in */; do
                 fi
                 cp ../../.circleci/dummy_amplifyconfiguration.dart example/lib/amplifyconfiguration.dart
                 cd example/android
-                if ! flutter build apk; then
+                if ! flutter build apk --debug; then
                     echo "FAILED: Android example failed to build."
                     failed_plugins+=("$plugin")
                     cd ../..


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
For running Android unit tests in CI, build debug APK and only run `testDebugUnitTest` instead of running for all variants (debug, profile, release). This is also done in flutter/plugin_tools (https://github.com/flutter/plugin_tools/blob/5468a10e847a2e0524e4258638ae2278cbf2f8df/lib/src/java_test_command.dart#L59). This change should speed up testing Android native code a little and make the console outputs cleaner (27 gradle tasks vs 81 tasks).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
