### PR TITLE
chore: clean up package pubspec.yaml files

### DIFF
--- a/packages/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/amplify_analytics_pinpoint/pubspec.yaml
@@ -1,5 +1,5 @@
 name: amplify_analytics_pinpoint
-description: A new flutter plugin project.
+description: The Amplify Flutter Analytics category plugin using the AWS Pinpoint provider.
 version: 0.0.1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_analytics_pinpoint
 

--- a/packages/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/amplify_analytics_pinpoint/pubspec.yaml
@@ -1,8 +1,7 @@
 name: amplify_analytics_pinpoint
 description: A new flutter plugin project.
 version: 0.0.1
-author:
-homepage:
+homepage: https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_analytics_pinpoint
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -18,20 +17,11 @@ dependencies:
   amplify_core:
     path: ../amplify_core
 
-
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-  # This section identifies this Flutter project as a plugin project.
-  # The 'pluginClass' and Android 'package' identifiers should not ordinarily
-  # be modified. They are used by the tooling to maintain consistency when
-  # adding or updating assets for this project.
   plugin:
     platforms:
       android:
@@ -39,34 +29,3 @@ flutter:
         pluginClass: AmplifyAnalyticsPinpointPlugin
       ios:
         pluginClass: AmplifyAnalyticsPinpointPlugin
-
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/packages/amplify_analytics_plugin_interface/pubspec.yaml
+++ b/packages/amplify_analytics_plugin_interface/pubspec.yaml
@@ -14,5 +14,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter:

--- a/packages/amplify_analytics_plugin_interface/pubspec.yaml
+++ b/packages/amplify_analytics_plugin_interface/pubspec.yaml
@@ -1,8 +1,7 @@
 name: amplify_analytics_plugin_interface
-description: A new Flutter package project.
+description: The platform interface for the analytics module of Amplify-Flutter.
 version: 0.0.1
-author:
-homepage:
+homepage: https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_analytics_plugin_interface
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -16,39 +15,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/packages/amplify_auth_cognito/pubspec.yaml
+++ b/packages/amplify_auth_cognito/pubspec.yaml
@@ -1,5 +1,5 @@
 name: amplify_auth_cognito
-description: A new flutter plugin project.
+description: The Amplify Flutter Auth category plugin using the AWS Cognito provider.
 version: 0.0.1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_auth_cognito
 

--- a/packages/amplify_auth_cognito/pubspec.yaml
+++ b/packages/amplify_auth_cognito/pubspec.yaml
@@ -1,8 +1,7 @@
 name: amplify_auth_cognito
 description: A new flutter plugin project.
 version: 0.0.1
-author:
-homepage:
+homepage: https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_auth_cognito
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -22,15 +21,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-  # This section identifies this Flutter project as a plugin project.
-  # The 'pluginClass' and Android 'package' identifiers should not ordinarily
-  # be modified. They are used by the tooling to maintain consistency when
-  # adding or updating assets for this project.
   plugin:
     platforms:
       android:
@@ -38,34 +29,3 @@ flutter:
         pluginClass: AuthCognito
       ios:
         pluginClass: AuthCognito
-
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/packages/amplify_auth_plugin_interface/pubspec.yaml
+++ b/packages/amplify_auth_plugin_interface/pubspec.yaml
@@ -17,5 +17,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter:

--- a/packages/amplify_auth_plugin_interface/pubspec.yaml
+++ b/packages/amplify_auth_plugin_interface/pubspec.yaml
@@ -6,9 +6,6 @@ homepage: https://github.com/aws-amplify/amplify-flutter/tree/master/packages/am
 environment:
   sdk: ">=2.7.0 <3.0.0"
 
-transformers:
-  - dartson
-
 dependencies:
   flutter:
     sdk: flutter

--- a/packages/amplify_auth_plugin_interface/pubspec.yaml
+++ b/packages/amplify_auth_plugin_interface/pubspec.yaml
@@ -1,8 +1,7 @@
 name: amplify_auth_plugin_interface
 description: The platform interface for the auth module of Amplify-Flutter.
 version: 0.0.1
-author:
-homepage:
+homepage: https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_auth_plugin_interface
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -19,39 +18,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -1,8 +1,7 @@
 name: amplify_core
 description: The core module for Amplify-Flutter.
 version: 0.0.1
-author:
-homepage:
+homepage: https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_core
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -22,15 +21,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-  # This section identifies this Flutter project as a plugin project.
-  # The 'pluginClass' and Android 'package' identifiers should not ordinarily
-  # be modified. They are used by the tooling to maintain consistency when
-  # adding or updating assets for this project.
   plugin:
     platforms:
       android:
@@ -38,32 +29,3 @@ flutter:
         pluginClass: Core
       ios:
         pluginClass: Core
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/packages/amplify_core_plugin_interface/pubspec.yaml
+++ b/packages/amplify_core_plugin_interface/pubspec.yaml
@@ -1,8 +1,7 @@
 name: amplify_core_plugin_interface
 description: The platform interface for the core module of Amplify-Flutter.
 version: 0.0.1
-author:
-homepage:
+homepage: https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_core_plugin_interface
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -22,37 +21,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/packages/amplify_core_plugin_interface/pubspec.yaml
+++ b/packages/amplify_core_plugin_interface/pubspec.yaml
@@ -20,5 +20,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter:

--- a/packages/amplify_storage_plugin_interface/pubspec.yaml
+++ b/packages/amplify_storage_plugin_interface/pubspec.yaml
@@ -14,5 +14,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter:

--- a/packages/amplify_storage_plugin_interface/pubspec.yaml
+++ b/packages/amplify_storage_plugin_interface/pubspec.yaml
@@ -1,5 +1,5 @@
 name: amplify_storage_plugin_interface
-description: The Amplify Flutter Storage category plugin interface.
+description: The platform interface for the storage module of Amplify-Flutter.
 version: 0.0.1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_storage_plugin_interface
 

--- a/packages/amplify_storage_plugin_interface/pubspec.yaml
+++ b/packages/amplify_storage_plugin_interface/pubspec.yaml
@@ -1,8 +1,7 @@
 name: amplify_storage_plugin_interface
 description: The Amplify Flutter Storage category plugin interface.
 version: 0.0.1
-author:
-homepage:
+homepage: https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_storage_plugin_interface
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -16,37 +15,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/packages/amplify_storage_s3/pubspec.yaml
+++ b/packages/amplify_storage_s3/pubspec.yaml
@@ -1,8 +1,7 @@
 name: amplify_storage_s3
 description: The Amplify Flutter Storage category plugin using the AWS S3 provider.
 version: 0.0.1
-author:
-homepage:
+homepage: https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_storage_s3
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -21,15 +20,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-  # This section identifies this Flutter project as a plugin project.
-  # The 'pluginClass' and Android 'package' identifiers should not ordinarily
-  # be modified. They are used by the tooling to maintain consistency when
-  # adding or updating assets for this project.
   plugin:
     platforms:
       android:
@@ -37,32 +28,3 @@ flutter:
         pluginClass: AmplifyStorageS3Plugin
       ios:
         pluginClass: AmplifyStorageS3Plugin
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Update the pubspec.yaml files for Amplify-Flutter packages, following the format of pubspec files in FlutterFire (see https://github.com/FirebaseExtended/flutterfire/blob/master/packages/firebase_core/firebase_core/pubspec.yaml and https://github.com/FirebaseExtended/flutterfire/blob/master/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml):

* Update description field.
* Update homepage field with link to package on GitHub.
* Remove deprecated author field.
* Remove comments.
* Remove empty flutter field for plugin interface packages.

Please help review the following:

* Check if package description needs to be changed.
* @haverchuck I removed the `transformers: dartson` line in `amplify_auth_plugin_interface`'s pubspec file, since it seems that it is not a valid field: https://dart.dev/tools/pub/pubspec. Do you think it can be removed?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
