### PR TITLE
ci: fix flutter test workflow passing in circleci when tests fail

### DIFF
--- a/.circleci/test_all_plugins.sh
+++ b/.circleci/test_all_plugins.sh
@@ -7,6 +7,7 @@ failed_plugins=()
 skipped_plugins=()
 
 set +e
+set -o pipefail
 
 for plugin_dir in */; do
     cd "$plugin_dir" || exit


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add `set -o pipefail` to test script, so the return value of `flutter test` is properly read by the script.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
