### PR TITLE
UserAgents

### DIFF
--- a/packages/amplify_core/android/build.gradle
+++ b/packages/amplify_core/android/build.gradle
@@ -43,6 +43,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.amplifyframework:core:1.0.+'
+    implementation 'com.amplifyframework:core:1.1.3'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/packages/amplify_core/ios/Classes/SwiftCore.swift
+++ b/packages/amplify_core/ios/Classes/SwiftCore.swift
@@ -32,9 +32,10 @@ public class SwiftCore: NSObject, FlutterPlugin {
       case "configure":
         do {
           let arguments = call.arguments as! Dictionary<String, AnyObject>
+          let version = arguments["version"] as! String
           let configuration = arguments["configuration"] as! String
           let amplifyConfiguration = try JSONDecoder().decode(AmplifyConfiguration.self, from: configuration.data(using: .utf8)!)
-          onConfigure(result: result, amplifyConfiguration: amplifyConfiguration)
+          onConfigure(result: result, version: version, amplifyConfiguration: amplifyConfiguration)
             
         } catch {
             print("Failed to configure Amplify \(error)")
@@ -47,8 +48,10 @@ public class SwiftCore: NSObject, FlutterPlugin {
     }
   }
 
-  private func onConfigure(result: FlutterResult, amplifyConfiguration: AmplifyConfiguration) {
+    private func onConfigure(result: FlutterResult, version: String, amplifyConfiguration: AmplifyConfiguration) {
     do {
+        
+      AmplifyAWSServiceConfiguration.addUserAgentPlatform(.flutter, version: version)
       try Amplify.configure(amplifyConfiguration)
       result(true)
     } catch {

--- a/packages/amplify_core/ios/amplify_core.podspec
+++ b/packages/amplify_core/ios/amplify_core.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.dependency 'Amplify'
-  s.dependency 'AWSPluginsCore'
+  s.dependency 'AWSPluginsCore', '1.1.1'
   s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin'
   s.platform = :ios, '11.0'
 

--- a/packages/amplify_core/lib/amplify_core.dart
+++ b/packages/amplify_core/lib/amplify_core.dart
@@ -16,6 +16,7 @@
 library amplify_core;
 
 import 'dart:async';
+import 'dart:io';
 import 'package:amplify_core_plugin_interface/amplify_core_plugin_interface.dart';
 import 'package:amplify_storage_plugin_interface/amplify_storage_plugin_interface.dart';
 import 'package:amplify_auth_plugin_interface/amplify_auth_plugin_interface.dart';
@@ -61,9 +62,13 @@ class Amplify {
     return null;
   }
 
+  String _getVersion() {
+    return "0.1.0";
+  }
+
   Future<void> configure(String configuration) async {
     assert(configuration != null, 'configuration is null');
-    var res = await Core.instance.configure(configuration);
+    var res = await Core.instance.configure(_getVersion(), configuration);
     _isConfigured = res;
     if (!res) {
       throw ("Amplify plugin was not added");

--- a/packages/amplify_core_plugin_interface/lib/amplify_core_plugin_interface.dart
+++ b/packages/amplify_core_plugin_interface/lib/amplify_core_plugin_interface.dart
@@ -60,7 +60,7 @@ abstract class Core extends PlatformInterface {
   final StorageCategory Storage = StorageCategory();
 
   /// Adds the configuration and return true if it was successful.
-  Future<bool> configure(String configuration) {
+  Future<bool> configure(String version, String configuration) {
     throw UnimplementedError('configure() has not been implemented.');
   }
 }

--- a/packages/amplify_core_plugin_interface/lib/method_channel_amplify.dart
+++ b/packages/amplify_core_plugin_interface/lib/method_channel_amplify.dart
@@ -21,10 +21,11 @@ const MethodChannel _channel = MethodChannel('com.amazonaws.amplify/core');
 /// An implementation of [Core] that uses method channels.
 class MethodChannelAmplifyCore extends Core {
   @override
-  Future<bool> configure(String configuration) {
+  Future<bool> configure(String version, String configuration) {
     return _channel.invokeMethod<bool>(
       'configure',
       <String, Object>{
+        'version': version,
         'configuration': configuration,
       },
     );

--- a/packages/amplify_storage_s3/ios/amplify_storage_s3.podspec
+++ b/packages/amplify_storage_s3/ios/amplify_storage_s3.podspec
@@ -16,7 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.dependency 'Amplify'
-  s.dependency 'AWSPluginsCore'
   s.dependency 'AmplifyPlugins/AWSS3StoragePlugin'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
I'm concerned that the AWSPluginsCore version won't be set properly for developers. 

I set the following in podspec but am unsure what will happpen: 

  s.dependency 'AWSPluginsCore', '1.1.1'

If the user had already installed AWSPluginsCore 



*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
