### PR TITLE
fix(amplify_auth_cognito): fix example app Podfile

### DIFF
--- a/packages/amplify_auth_cognito/example/ios/Podfile
+++ b/packages/amplify_auth_cognito/example/ios/Podfile
@@ -10,8 +10,6 @@ project 'Runner', {
   'Release' => :release,
 }
 
-platform :ios, '11.0'
-
 def flutter_root
   generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
   unless File.exist?(generated_xcode_build_settings_path)


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
Removed a duplicate `platform :ios, '11.0'` line in the example app Podfile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
