### PR TITLE
fix: update incorrect link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Amplify for Flutter is an open-source project and welcomes contributions from th
 
 3. Using the Amplify CLI, run `amplify init` from the root of your project:
 
-See [Amplify CLI Installation](https://github.com/aws-amplify/amplify-cli#install-the-cli)
+See [Amplify CLI Installation](https://docs.amplify.aws/lib/project-setup/prereq/q/platform/flutter#install-and-configure-the-amplify-cli)
 
 ```bash
 ==> amplify init


### PR DESCRIPTION
Currently, it is necessary to use a custom version of the Amplify CLI, in order to use Flutter:
```console
npm install -g @aws-amplify/cli@flutter-preview
```

The `README.md` contained a link to the _generic_ CLI installation instructions, which won't work, here, right now.

Resolves: https://github.com/aws-amplify/amplify-flutter/issues/126

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
