### PR TITLE
add a way to get cognito user pool tokens without requiring an Identi…

### DIFF
--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
@@ -27,6 +27,7 @@ import com.amazonaws.amplify.amplify_auth_cognito.types.FlutterAuthFailureMessag
 import com.amazonaws.amplify.amplify_auth_cognito.types.FlutterSignUpResult
 import com.amazonaws.amplify.amplify_auth_cognito.types.FlutterSignInResult
 import com.amazonaws.amplify.amplify_auth_cognito.types.FlutterFetchCognitoAuthSessionResult
+import com.amazonaws.amplify.amplify_auth_cognito.types.FlutterFetchCognitoAuthTokensSessionResult
 import com.amazonaws.amplify.amplify_auth_cognito.types.FlutterResetPasswordResult
 import com.amazonaws.amplify.amplify_auth_cognito.types.FlutterFetchAuthSessionResult
 import com.amazonaws.amplify.amplify_auth_cognito.types.FlutterResendSignUpCodeRequest
@@ -367,6 +368,9 @@ public class AuthCognito : FlutterPlugin, ActivityAware, MethodCallHandler {
                     AuthSessionResult.Type.SUCCESS -> prepareCognitoSessionResult(flutterResult, cognitoAuthSession)
                     AuthSessionResult.Type.FAILURE -> prepareCognitoSessionFailure(flutterResult, cognitoAuthSession)
                   }
+                } else if(req.getOnlyCognitoUserPoolTokens) {
+                  val cognitoAuthSession = result as AWSCognitoAuthSession
+                  prepareCognitoTokensSessionResult(flutterResult, cognitoAuthSession)
                 } else {
                   val session = result as AuthSession;
                   prepareSessionResult(flutterResult, session)
@@ -497,6 +501,13 @@ public class AuthCognito : FlutterPlugin, ActivityAware, MethodCallHandler {
 
   fun prepareCognitoSessionResult(@NonNull flutterResult: Result, @NonNull result: AWSCognitoAuthSession) {
     var session = FlutterFetchCognitoAuthSessionResult(result);
+    Handler (Looper.getMainLooper()).post {
+      flutterResult.success(session.toValueMap());
+    }
+  }
+
+  fun prepareCognitoTokensSessionResult(@NonNull flutterResult: Result, @NonNull result: AWSCognitoAuthSession) {
+    var session = FlutterFetchCognitoAuthTokensSessionResult(result);
     Handler (Looper.getMainLooper()).post {
       flutterResult.success(session.toValueMap());
     }

--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchAuthSessionRequest.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchAuthSessionRequest.kt
@@ -23,4 +23,5 @@ data class FlutterFetchAuthSessionRequest(val map: HashMap<String, *>) {
 //  var sessionOptions: AuthFetchSessionOptions = setOptions()
   val options: HashMap<String, *>? = map["options"] as HashMap<String, *>?;
   val getAWSCredentials: Boolean = options != null && options["getAWSCredentials"] as Boolean? == true;
+  val getOnlyCognitoUserPoolTokens: Boolean = options != null && options["getOnlyCognitoUserPoolTokens"] as Boolean? == true;
 }

--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchCognitoAuthTokensSessionResult.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchCognitoAuthTokensSessionResult.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.amplify.amplify_auth_cognito.types
+
+import com.amazonaws.auth.AWSCredentials
+import com.amplifyframework.auth.cognito.AWSCognitoAuthSession
+import com.amplifyframework.auth.cognito.AWSCognitoUserPoolTokens
+import com.amplifyframework.auth.result.AuthSessionResult
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+data class FlutterFetchCognitoAuthTokensSessionResult(private val raw: AWSCognitoAuthSession) {
+  private val isSignedIn: Boolean = raw.isSignedIn
+  private val tokens: AuthSessionResult<AWSCognitoUserPoolTokens>? = raw.userPoolTokens
+
+  fun toValueMap(): Map<String, Any?> {
+    return mapOf(
+      "isSignedIn" to this.isSignedIn,
+      "tokens" to this.tokens?.serializeToMap()
+    )
+  }
+
+  //convert a data class to a map
+  fun <T> T.serializeToMap(): Map<String, Any> {
+    return convert()
+  }
+
+  //convert an object of type I to type O
+  inline fun <I, reified O> I.convert(): O {
+    val json = gson.toJson(this)
+    return gson.fromJson(json, object : TypeToken<O>() {}.type)
+  }
+}

--- a/packages/amplify_auth_cognito/ios/Classes/AuthCognitoBridge.swift
+++ b/packages/amplify_auth_cognito/ios/Classes/AuthCognitoBridge.swift
@@ -149,6 +149,9 @@ class AuthCognitoBridge {
                 if (request.getAWSCredentials) {
                     let sessionData = try FlutterFetchCognitoSessionResult(res: result)
                     flutterResult(sessionData.toJSON())
+                } else if (request.getOnlyCognitoUserPoolTokens)  {
+                    let sessionData = try FlutterFetchCognitoTokensSessionResult(res: result)
+                    flutterResult(sessionData.toJSON())
                 } else {
                     let sessionData = try FlutterFetchSessionResult(res: result)
                     if (sessionData.isSignedIn) {

--- a/packages/amplify_auth_cognito/ios/Classes/FlutterFetchCognitoTokensSessionResult.swift
+++ b/packages/amplify_auth_cognito/ios/Classes/FlutterFetchCognitoTokensSessionResult.swift
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import Foundation
+import Amplify
+import AWSPluginsCore
+
+struct FlutterFetchCognitoTokensSessionResult {
+  var isSignedIn: Bool
+  var userPoolTokens: [String: String]
+    
+
+  init(res: AmplifyOperation<AuthFetchSessionRequest, AuthSession, AuthError>.OperationResult) throws  {
+    do {
+        let session = try res.get()
+        self.isSignedIn = session.isSignedIn
+        self.userPoolTokens = try getTokens(session: session)
+    } catch  {
+        throw error as! AuthError
+    }
+  }
+      
+  func toJSON() -> Dictionary<String, Any> {
+    
+    return [
+          "isSignedIn": self.isSignedIn,
+          "tokens": self.userPoolTokens       ]
+      }
+    }
+  

--- a/packages/amplify_auth_cognito/ios/Classes/FlutterFetchSessionRequest.swift
+++ b/packages/amplify_auth_cognito/ios/Classes/FlutterFetchSessionRequest.swift
@@ -19,8 +19,10 @@ import Amplify
 struct FlutterFetchSessionRequest {
   // TODO: Implement forceRefresh when/if implemented
     var getAWSCredentials: Bool = false;
+    var getOnlyCognitoUserPoolTokens: Bool = false;
     init(dict: NSMutableDictionary){
         self.getAWSCredentials = self.getCredentialRequest(res: dict)
+        self.getOnlyCognitoUserPoolTokens = self.getOnlyCognitoUserPoolTokensRequest(res: dict)
     }
     
     func getCredentialRequest(res: NSMutableDictionary) -> Bool {
@@ -28,6 +30,16 @@ struct FlutterFetchSessionRequest {
         if (options != nil) {
             if (options?["getAWSCredentials"] != nil) {
                 return options?["getAWSCredentials"] as! Bool
+            }
+        }
+        return false
+    }
+
+    func getOnlyCognitoUserPoolTokensRequest(res: NSMutableDictionary) -> Bool {
+        let options = res["options"] as? Dictionary<String, Any>
+        if (options != nil) {
+            if (options?["getOnlyCognitoUserPoolTokens"] != nil) {
+                return options?["getOnlyCognitoUserPoolTokens"] as! Bool
             }
         }
         return false

--- a/packages/amplify_auth_cognito/lib/src/CognitoSession/CognitoSessionOptions.dart
+++ b/packages/amplify_auth_cognito/lib/src/CognitoSession/CognitoSessionOptions.dart
@@ -18,10 +18,12 @@ import 'package:flutter/foundation.dart';
 
 class CognitoSessionOptions extends AuthSessionOptions {
   bool getAWSCredentials;
-  CognitoSessionOptions({@required this.getAWSCredentials}) : super();
+  bool getOnlyCognitoUserPoolTokens;
+  CognitoSessionOptions({this.getAWSCredentials = false, this.getOnlyCognitoUserPoolTokens = false}) : super();
   Map<String, dynamic> serializeAsMap() {
     final Map<String, dynamic> pendingRequest = <String, dynamic>{};
     pendingRequest["getAWSCredentials"] = getAWSCredentials;
+    pendingRequest["getOnlyCognitoUserPoolTokens"] = getOnlyCognitoUserPoolTokens;
     return pendingRequest;
   }
 } 


### PR DESCRIPTION
*Issue #, if available:*

Solves #148

*Description of changes:*
Added new option field to CognitoSessionOptions called "getOnlyCognitoUserPoolTokens" in order to make it possible to retrieve cognito user pool tokens without requiring an Identity Pool. Also remove @required parameter from CognitoSessionOptions to make it more friendly with the new option field. It can be simply used like this:
```
      final CognitoAuthSession sess = await Amplify.Auth.fetchAuthSession(
        options: CognitoSessionOptions(getOnlyCognitoUserPoolTokens: true),
      );
      print(sess.isSignedIn);
      print(sess.userSub); // will print null
      print(sess.identityId); // will print null
      print(sess.credentials); // will print null
      print(sess.userPoolTokens.accessToken);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
