### PR TITLE
ci: add docker hub auth to config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ executors:
   docker-executor:
     docker:
       - image: circleci/android:api-28
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_ACCESS_TOKEN
     working_directory: ~/amplify-flutter
 
   macos-executor:
@@ -13,8 +16,7 @@ executors:
 
 commands:
   install_flutter:
-    description:
-      Install Flutter and set up paths.
+    description: Install Flutter and set up paths.
     parameters:
       flutter_branch:
         description: Flutter branch or version tag.


### PR DESCRIPTION
Adding Docker Hub authentication to the CircleCI pipeline to accommodate [this change](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress) in Docker's ToS.

Here's the same change in JS for reference: https://github.com/aws-amplify/amplify-js/pull/7007

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
