### PR TITLE
fix(amplify_datastore): android bug + unit tests

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterModelFieldType.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterModelFieldType.kt
@@ -55,7 +55,7 @@ data class FlutterModelFieldType(val map: Map<String, Any>) {
     fun getJavaClass(): Class<*> {
         return when (fieldType) {
             "string" -> String::class.java
-            "int" -> Int::class.java
+            "int" -> Integer::class.java
             "double" -> Double::class.java
             "date" -> Temporal.Date::class.java
             "dateTime" -> Temporal.DateTime::class.java

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePluginTest.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePluginTest.kt
@@ -115,10 +115,10 @@ class AmplifyDataStorePluginTest {
         doAnswer { invocation: InvocationOnMock ->
             assertEquals(invocation.arguments[0], "Post")
             assertEquals(invocation.arguments[1],
-                    Where.matches(field("id").eq("123").or(field("rating").ge(4).and(not(
+                    Where.matches(field("post.id").eq("123").or(field("rating").ge(4).and(not(
                             field("created").eq("2020-02-20T20:20:20-08:00")))))
                             .paginated(Page.startingAt(2).withLimit(8))
-                            .sorted(field("id").ascending(), field("created").descending()))
+                            .sorted(field("post.id").ascending(), field("created").descending()))
             (invocation.arguments[2] as Consumer<Iterator<Model>>).accept(
                     emptyList<SerializedModel>().iterator())
             null

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/SchemaData.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/SchemaData.kt
@@ -52,7 +52,7 @@ val postSchema = ModelSchema.builder()
                     "rating" to
                             ModelField.builder()
                                     .name("rating")
-                                    .javaClassForValue(Int::class.java)
+                                    .javaClassForValue(Integer::class.java)
                                     .targetType("Integer")
                                     .isRequired(false)
                                     .isArray(false)

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilderTest.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilderTest.kt
@@ -23,7 +23,7 @@ import org.junit.Assert
 import org.junit.Test
 
 class QueryPredicateBuilderTest {
-    private val id: QueryField = QueryField.field("id")
+    private val id: QueryField = QueryField.field("post.id")
     private val title: QueryField = QueryField.field("title")
     private val rating: QueryField = QueryField.field("rating")
     private val created: QueryField = QueryField.field("created")

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QuerySortBuilderTest.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QuerySortBuilderTest.kt
@@ -22,7 +22,7 @@ import org.junit.Assert
 import org.junit.Test
 
 class QuerySortBuilderTest {
-    private val id: QueryField = QueryField.field("id")
+    private val id: QueryField = QueryField.field("post.id")
     private val rating: QueryField = QueryField.field("rating")
 
     @Test

--- a/packages/amplify_datastore/lib/method_channel_datastore.dart
+++ b/packages/amplify_datastore/lib/method_channel_datastore.dart
@@ -43,7 +43,7 @@ class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
   /// method is called.
   Future<void> configure({String configuration}) async {
     // First step to configure datastore is to setup an event channel for observe
-    return _channel.invokeMethod('setupObserve', {});
+    //return _channel.invokeMethod('setupObserve', {});
   }
 
   @override


### PR DESCRIPTION
- fixed android java.lang.ClassNotFoundException: int bug in the logs
- fixed android unit tests to use “post.id” instead of “id”
- deactivated call to datastore configure method (waiting of observe api changes for Android)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
