### PR TITLE
Fix(amplify_storage_s3): Compile errors after upgrading amplify-android library

### DIFF
--- a/packages/amplify_storage_s3/android/build.gradle
+++ b/packages/amplify_storage_s3/android/build.gradle
@@ -31,7 +31,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/types/FlutterDownloadFileRequest.kt
+++ b/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/types/FlutterDownloadFileRequest.kt
@@ -27,7 +27,7 @@ data class FlutterDownloadFileRequest(val request: Map<String, *>) {
     private fun setOptions(request: Map<String, *>): StorageDownloadFileOptions {
         if (request["options"] != null) {
             val optionsMap = request["options"] as Map<String, *>
-            var options: StorageDownloadFileOptions.Builder = StorageDownloadFileOptions.builder()
+            var options: StorageDownloadFileOptions.Builder<*> = StorageDownloadFileOptions.builder()
 
             optionsMap.forEach { (optionKey, optionValue) ->
                 when (optionKey) {

--- a/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/types/FlutterGetUrlRequest.kt
+++ b/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/types/FlutterGetUrlRequest.kt
@@ -25,7 +25,7 @@ data class FlutterGetUrlRequest(val request: Map<String, *>) {
     private fun setOptions(request: Map<String, *>): StorageGetUrlOptions {
         if (request["options"] != null) {
             val optionsMap = request["options"] as Map<String, *>
-            var options: StorageGetUrlOptions.Builder = StorageGetUrlOptions.builder()
+            var options: StorageGetUrlOptions.Builder<*> = StorageGetUrlOptions.builder()
 
             optionsMap.forEach { (optionKey, optionValue) ->
                 when (optionKey) {

--- a/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/types/FlutterListRequest.kt
+++ b/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/types/FlutterListRequest.kt
@@ -25,7 +25,7 @@ data class FlutterListRequest(val request: Map<String, *>) {
     private fun setOptions(request: Map<String, *>): StorageListOptions {
         if (request["options"] != null) {
             val optionsMap = request["options"] as Map<String, *>
-            var options: StorageListOptions.Builder = StorageListOptions.builder()
+            var options: StorageListOptions.Builder<*> = StorageListOptions.builder()
 
             optionsMap.forEach { (optionKey, optionValue) ->
                 when (optionKey) {

--- a/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/types/FlutterRemoveRequest.kt
+++ b/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/types/FlutterRemoveRequest.kt
@@ -25,7 +25,7 @@ data class FlutterRemoveRequest(val request: Map<String, *>) {
     private fun setOptions(request: Map<String, *>): StorageRemoveOptions {
         if (request["options"] != null) {
             val optionsMap = request["options"] as Map<String, *>
-            var options: StorageRemoveOptions.Builder = StorageRemoveOptions.builder()
+            var options: StorageRemoveOptions.Builder<*> = StorageRemoveOptions.builder()
 
             optionsMap.forEach { (optionKey, optionValue) ->
                 when (optionKey) {

--- a/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/types/FlutterUploadFileRequest.kt
+++ b/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/types/FlutterUploadFileRequest.kt
@@ -27,7 +27,7 @@ data class FlutterUploadFileRequest(val request: Map<String, *>) {
     private fun setOptions(request: Map<String, *>): StorageUploadFileOptions {
         if(request["options"]!= null) {
             val optionsMap = request["options"] as Map<String, *>
-            var options: StorageUploadFileOptions.Builder = StorageUploadFileOptions.builder()
+            var options: StorageUploadFileOptions.Builder<*> = StorageUploadFileOptions.builder()
 
             optionsMap.forEach { (optionKey, optionValue) ->
                 when(optionKey) {

--- a/packages/amplify_storage_s3/example/android/app/build.gradle
+++ b/packages/amplify_storage_s3/example/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.amazonaws.amplify.amplify_storage_s3_example"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
With this change, the whole library builds in android and the tests are successful.

PS: `minSdkVersion` is increased because of increasing >64K methods limit. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
