### PR TITLE
Upgrade android to use loose version numbers

### DIFF
--- a/packages/amplify_analytics_pinpoint/android/build.gradle
+++ b/packages/amplify_analytics_pinpoint/android/build.gradle
@@ -47,8 +47,8 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.6.4'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.6.4'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.+'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.+'
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'

--- a/packages/amplify_auth_cognito/android/build.gradle
+++ b/packages/amplify_auth_cognito/android/build.gradle
@@ -51,7 +51,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:aws-auth-cognito:1.6.4'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.+'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.mockito:mockito-inline:3.1.0'

--- a/packages/amplify_core/android/build.gradle
+++ b/packages/amplify_core/android/build.gradle
@@ -43,6 +43,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.amplifyframework:core:1.6.4'
+    implementation 'com.amplifyframework:core:1.+'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -52,9 +52,9 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.amplifyframework:aws-datastore:1.6.4"
-    implementation "com.amplifyframework:aws-api:1.6.4"
-    implementation "com.amplifyframework:aws-api-appsync:1.6.4"
+    implementation "com.amplifyframework:aws-datastore:1.+"
+    implementation "com.amplifyframework:aws-api:1.+"
+    implementation "com.amplifyframework:aws-api-appsync:1.+"
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.mockito:mockito-inline:3.1.0'

--- a/packages/amplify_storage_s3/android/build.gradle
+++ b/packages/amplify_storage_s3/android/build.gradle
@@ -40,5 +40,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:aws-storage-s3:1.6.4'
+    implementation 'com.amplifyframework:aws-storage-s3:1.+'
 }


### PR DESCRIPTION
So that we get latest and greatest of android without any release. This will be reverted to use fixed/pinned versions in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
