### PR TITLE
fix(amplify_datastore) static hub listener

### DIFF
--- a/packages/amplify_datastore/example/lib/main.dart
+++ b/packages/amplify_datastore/example/lib/main.dart
@@ -146,7 +146,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   void listenToHub() {
-    datastorePlugin.events.listenToDataStore((msg) {
+    AmplifyDataStore.events.listenToDataStore((msg) {
       print(msg);
     });
     setState(() {
@@ -155,7 +155,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   void stopListeningToHub() {
-    datastorePlugin.events.stopListeningToDataStore();
+    AmplifyDataStore.events.stopListeningToDataStore();
     setState(() {
       _listeningToHub = false;
     });

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -30,7 +30,7 @@ class AmplifyDataStore extends DataStorePluginInterface {
       : super(token: _token, modelProvider: modelProvider);
 
   static AmplifyDataStore _instance = AmplifyDataStoreMethodChannel();
-  var events = AmplifyDataStoreEventChannel();
+  static AmplifyDataStoreEventChannel events = AmplifyDataStoreEventChannel();
 
 
   static set instance(DataStorePluginInterface instance) {


### PR DESCRIPTION
*Description of changes:*
Makes hub event listener a static member of the plugin.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
