### PR TITLE
chore(amplify_datastore): conditionally add API plugin if api configuration exists

### DIFF
--- a/packages/amplify_core/android/build.gradle
+++ b/packages/amplify_core/android/build.gradle
@@ -51,6 +51,7 @@ android {
 dependencies {
     implementation 'com.amplifyframework:core:1.+'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "com.amplifyframework:aws-api:1.+"
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.mockito:mockito-inline:3.1.0'

--- a/packages/amplify_core/android/src/main/kotlin/com/amazonaws/amplify/amplify_core/Core.kt
+++ b/packages/amplify_core/android/src/main/kotlin/com/amazonaws/amplify/amplify_core/Core.kt
@@ -20,8 +20,11 @@ import android.content.Context
 import android.util.Log
 import androidx.annotation.NonNull
 import com.amplifyframework.AmplifyException
+import com.amplifyframework.api.aws.AWSApiPlugin
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.AmplifyConfiguration
+import com.amplifyframework.core.category.CategoryType
+import com.amplifyframework.core.category.EmptyCategoryConfiguration
 import com.amplifyframework.util.UserAgent
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -100,11 +103,13 @@ public class Core : FlutterPlugin, ActivityAware, MethodCallHandler {
     private fun onConfigure(@NonNull result: Result, @NonNull version: String, @NonNull config: String) {
         if (!isConfigured) {
             try {
-                Amplify.configure(AmplifyConfiguration.builder(JSONObject(config))
+                val configuration = AmplifyConfiguration.builder(JSONObject(config))
                         .addPlatform(UserAgent.Platform.FLUTTER, version)
-                        .build(),
-                        context
-                );
+                        .build()
+                if(configuration.forCategoryType(CategoryType.API) !is EmptyCategoryConfiguration) {
+                    Amplify.addPlugin(AWSApiPlugin())
+                }
+                Amplify.configure(configuration, context)
                 isConfigured = true;
                 result.success(true);
             } catch (e: AmplifyException) {

--- a/packages/amplify_core/ios/amplify_core.podspec
+++ b/packages/amplify_core/ios/amplify_core.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.dependency 'Amplify'
   s.dependency 'AWSPluginsCore'
   s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -53,7 +53,6 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.amplifyframework:aws-datastore:1.+"
-    implementation "com.amplifyframework:aws-api:1.+"
     implementation "com.amplifyframework:aws-api-appsync:1.+"
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -25,7 +25,6 @@ import com.amazonaws.amplify.amplify_datastore.types.model.FlutterSubscriptionEv
 import com.amazonaws.amplify.amplify_datastore.types.query.QueryOptionsBuilder
 import com.amazonaws.amplify.amplify_datastore.util.safeCastToList
 import com.amazonaws.amplify.amplify_datastore.util.safeCastToMap
-import com.amplifyframework.api.aws.AWSApiPlugin
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.core.async.Cancelable
@@ -136,8 +135,6 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         modelProvider.setVersion(request["modelProviderVersion"] as String)
 
         Amplify.addPlugin(AWSDataStorePlugin(modelProvider))
-        Amplify.addPlugin(AWSApiPlugin())
-
         flutterResult.success(null)
     }
 

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -99,7 +99,6 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
 
             let dataStorePlugin = AWSDataStorePlugin(modelRegistration: flutterModelRegistration)
             try Amplify.add(plugin: dataStorePlugin)
-            try Amplify.add(plugin: AWSAPIPlugin())
             Amplify.Logging.logLevel = .info
             print("Amplify configured with DataStore plugin")
             result(true)

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -17,7 +17,6 @@ The DataStore module for Amplify Flutter.
   s.dependency 'Flutter'
   s.dependency 'Amplify'
   s.dependency 'AmplifyPlugins/AWSDataStorePlugin'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.


### PR DESCRIPTION
*Description of changes:*
This is intended as a workaround until we have a GraphQL API category in flutter which would be added by the flutter users. This whole thing will go away before GA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
