### PR TITLE
fix(amplify_datastore) remove unnecessary ios logs

### DIFF
--- a/packages/amplify_datastore/ios/Classes/types/model/FlutterSerializedModel.swift
+++ b/packages/amplify_datastore/ios/Classes/types/model/FlutterSerializedModel.swift
@@ -29,7 +29,6 @@ struct FlutterSerializedModel: Model, JSONValueHolder {
 
     public init(from decoder: Decoder) throws {
 
-        print("Decoder \(decoder)")
         let y = try decoder.container(keyedBy: CodingKeys.self)
         id = try y.decode(String.self, forKey: .id)
         


### PR DESCRIPTION
Very small change to remove an unnecessary log line message in iOS that was spamming the log with: 

`Decoder Foundation.(unknown context at $7fff5407fe98).__JSONDecoder
`
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
