### PR TITLE
fix(amplify_datastore): Handle optional nullable enum types in parser

### DIFF
--- a/packages/amplify_datastore_plugin_interface/lib/src/types/temporal/datetime_parse.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/temporal/datetime_parse.dart
@@ -15,7 +15,9 @@
 
 import 'package:date_time_format/date_time_format.dart';
 
-// ignore: public_member_api_docs
+// ignore_for_file: public_member_api_docs
+
+// only to be used internally by amplify-flutter library
 extension DateTimeParse on DateTime {
   String toDateTimeIso8601String() {
     return DateTimeFormat.format(this, format: DateTimeFormats.iso8601);

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/utils/parsers.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/utils/parsers.dart
@@ -13,9 +13,11 @@
  * permissions and limitations under the License.
  */
 
-import 'package:date_time_format/date_time_format.dart';
+// ignore_for_file: public_member_api_docs
 
-String enumToString(Object o) => o.toString().split('.').last;
+// only to be used internally by amplify-flutter library
+String enumToString(Object o) => o != null ? o.toString().split('.').last : '';
 
+// only to be used internally by amplify-flutter library
 T enumFromString<T>(String key, List<T> values) =>
     values.firstWhere((v) => key == enumToString(v), orElse: () => null);

--- a/packages/amplify_datastore_plugin_interface/test/amplify_utility_test.dart
+++ b/packages/amplify_datastore_plugin_interface/test/amplify_utility_test.dart
@@ -33,7 +33,22 @@ void main() {
     expect(enumToString(TestEnum.MAYBE), "MAYBE");
   });
 
+  test('parsers.enumToString generates empty string for null', () {
+    expect(enumToString(null), "");
+  });
+
   test('parsers.enumFromString generates proper enum', () {
     expect(enumFromString<TestEnum>("MAYBE", TestEnum.values), TestEnum.MAYBE);
+  });
+
+  test('parsers.enumFromString generates null for non existing enum values',
+      () {
+    expect(enumFromString<TestEnum>("RANDOM", TestEnum.values), null);
+  });
+
+  test(
+      'parsers.enumFromString generates null for empty string representing enum',
+      () {
+    expect(enumFromString<TestEnum>("", TestEnum.values), null);
   });
 }


### PR DESCRIPTION
*Issue #, if available:* #241 

*Description of changes:* Handle optional nullable enum types in parser


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
