### PR TITLE
chore: categories use selectors to invoke plugins

### DIFF
--- a/packages/amplify_core_plugin_interface/lib/amplify_auth_category.dart
+++ b/packages/amplify_core_plugin_interface/lib/amplify_auth_category.dart
@@ -5,7 +5,6 @@ part of amplify_core_plugin_interface;
 /// be registered and configured and then subsequent API calls will be forwarded
 /// to those plugins.
 class AuthCategory {
-  final errorMsg = "Auth plugin not added correctly";
   const AuthCategory();
   static List<AuthPluginInterface> plugins = [];
 
@@ -14,64 +13,96 @@ class AuthCategory {
     // TODO: Discuss and support multiple plugins
     if (plugins.length == 0) {
       plugins.add(plugin);
-      
     } else {
-      throw("Auth plugin was not added");
+      throw ("Failed to add Auth plugin. You already registered one.");
     }
   }
 
-  Future<SignUpResult> signUp({@required String username, @required password, SignUpOptions options}) {
-    var request = SignUpRequest(username: username, password: password, options: options);
-    return plugins.length == 1 ? plugins[0].signUp(request: request) : throw(errorMsg);
+  Future<SignUpResult> signUp(
+      {@required String username, @required password, SignUpOptions options}) {
+    var request =
+        SignUpRequest(username: username, password: password, options: options);
+    return _select((it) => it.signUp(request: request));
   }
 
-  Future<SignUpResult> confirmSignUp({@required String username, @required String confirmationCode, ConfirmSignUpOptions options}) {
-    var request = ConfirmSignUpRequest(username: username, confirmationCode: confirmationCode, options: options);
-    return plugins.length == 1 ? plugins[0].confirmSignUp(request: request) : throw(errorMsg);
+  Future<SignUpResult> confirmSignUp(
+      {@required String username,
+      @required String confirmationCode,
+      ConfirmSignUpOptions options}) {
+    var request = ConfirmSignUpRequest(
+        username: username,
+        confirmationCode: confirmationCode,
+        options: options);
+    return _select((it) => it.confirmSignUp(request: request));
   }
 
   Future<ResendSignUpCodeResult> resendSignUpCode({@required String username}) {
     var request = ResendSignUpCodeRequest(username: username);
-    return plugins.length == 1 ? plugins[0].resendSignUpCode(request: request) : throw(errorMsg);
+    return _select((it) => it.resendSignUpCode(request: request));
   }
 
-  Future<SignInResult> signIn({@required String username, @required String password, SignInOptions options }) {
-    var request = SignInRequest(username: username, password: password, options: options);
-    return plugins.length == 1 ? plugins[0].signIn(request: request) : throw(errorMsg);
+  Future<SignInResult> signIn(
+      {@required String username,
+      @required String password,
+      SignInOptions options}) {
+    var request =
+        SignInRequest(username: username, password: password, options: options);
+    return _select((it) => it.signIn(request: request));
   }
 
-  Future<SignInResult> confirmSignIn({@required String confirmationValue, ConfirmSignInOptions options}) {
-    var request = ConfirmSignInRequest(confirmationValue: confirmationValue, options: options);
-    return plugins.length == 1 ? plugins[0].confirmSignIn(request: request) : throw(errorMsg);
+  Future<SignInResult> confirmSignIn(
+      {@required String confirmationValue, ConfirmSignInOptions options}) {
+    var request = ConfirmSignInRequest(
+        confirmationValue: confirmationValue, options: options);
+    return _select((it) => it.confirmSignIn(request: request));
   }
 
   Future<SignOutResult> signOut({SignOutOptions options}) {
     var request = SignOutRequest(options: options);
-    return plugins.length == 1 ? plugins[0].signOut(request: request) : throw(errorMsg);
+    return _select((it) => it.signOut(request: request));
   }
 
-  Future<UpdatePasswordResult> updatePassword({@required String oldPassword, @required String newPassword, PasswordOptions options}) {
-    var request = UpdatePasswordRequest(oldPassword: oldPassword, newPassword: newPassword, options: options);
-    return plugins.length == 1 ? plugins[0].updatePassword(request: request) : throw(errorMsg);
+  Future<UpdatePasswordResult> updatePassword(
+      {@required String oldPassword,
+      @required String newPassword,
+      PasswordOptions options}) {
+    var request = UpdatePasswordRequest(
+        oldPassword: oldPassword, newPassword: newPassword, options: options);
+    return _select((it) => it.updatePassword(request: request));
   }
 
-  Future<ResetPasswordResult> resetPassword({@required String username, PasswordOptions options}) {
+  Future<ResetPasswordResult> resetPassword(
+      {@required String username, PasswordOptions options}) {
     var request = ResetPasswordRequest(username: username, options: options);
-    return plugins.length == 1 ? plugins[0].resetPassword(request: request) : throw(errorMsg);
+    return _select((it) => it.resetPassword(request: request));
   }
 
-  Future<UpdatePasswordResult> confirmPassword({@required String username, @required String newPassword, @required String confirmationCode, PasswordOptions options}) {
-    var request = ConfirmPasswordRequest(username: username, newPassword: newPassword, confirmationCode: confirmationCode, options: options);
-    return plugins.length == 1 ? plugins[0].confirmPassword(request: request) : throw(errorMsg);
+  Future<UpdatePasswordResult> confirmPassword(
+      {@required String username,
+      @required String newPassword,
+      @required String confirmationCode,
+      PasswordOptions options}) {
+    var request = ConfirmPasswordRequest(
+        username: username,
+        newPassword: newPassword,
+        confirmationCode: confirmationCode,
+        options: options);
+    return _select((it) => it.confirmPassword(request: request));
   }
 
   Future<AuthUser> getCurrentUser() {
     var request = AuthUserRequest();
-    return plugins.length == 1 ? plugins[0].getCurrentUser(request: request) : throw(errorMsg);
+    return _select((it) => it.getCurrentUser(request: request));
   }
 
   Future<AuthSession> fetchAuthSession({AuthSessionOptions options}) {
     var request = AuthSessionRequest(options: options);
-    return plugins.length == 1 ? plugins[0].fetchAuthSession(request: request) : throw(errorMsg);
+    return _select((it) => it.fetchAuthSession(request: request));
+  }
+
+  Future<R> _select<R>(FutureOr<R> onValue(AuthPluginInterface plugin)) {
+    return plugins.length == 1
+        ? Future.value(plugins[0]).then(onValue)
+        : throw ("Auth plugin not added correctly");
   }
 }

--- a/packages/amplify_core_plugin_interface/lib/amplify_storage_category.dart
+++ b/packages/amplify_core_plugin_interface/lib/amplify_storage_category.dart
@@ -27,7 +27,7 @@ class StorageCategory {
       plugins.add(plugin);
       return true;
     } else {
-      throw ("Failed to add the Storage plugin");
+      throw ("Failed to add Storage plugin. You already registered one.");
     }
   }
 
@@ -35,22 +35,22 @@ class StorageCategory {
       {@required File local, @required String key, UploadFileOptions options}) {
     final UploadFileRequest request =
         UploadFileRequest(local: local, key: key, options: options);
-    return plugins[0].uploadFile(request: request);
+    return _select((it) => it.uploadFile(request: request));
   }
 
   Future<GetUrlResult> getUrl({@required String key, GetUrlOptions options}) {
     final GetUrlRequest request = GetUrlRequest(key: key, options: options);
-    return plugins[0].getUrl(request: request);
+    return _select((it) => it.getUrl(request: request));
   }
 
   Future<RemoveResult> remove({@required String key, RemoveOptions options}) {
     final RemoveRequest request = RemoveRequest(key: key, options: options);
-    return plugins[0].remove(request: request);
+    return _select((it) => it.remove(request: request));
   }
 
   Future<ListResult> list({String path, ListOptions options}) {
     final ListRequest request = ListRequest(path: path, options: options);
-    return plugins[0].list(request: request);
+    return _select((it) => it.list(request: request));
   }
 
   Future<DownloadFileResult> downloadFile(
@@ -59,6 +59,12 @@ class StorageCategory {
       DownloadFileOptions options}) {
     final DownloadFileRequest request =
         DownloadFileRequest(key: key, local: local, options: options);
-    return plugins[0].downloadFile(request: request);
+    return _select((it) => it.downloadFile(request: request));
+  }
+
+  Future<R> _select<R>(FutureOr<R> onValue(StoragePluginInterface plugin)) {
+    return plugins.length == 1
+        ? Future.value(plugins[0]).then(onValue)
+        : throw ("Storage plugin not added correctly");
   }
 }


### PR DESCRIPTION
Updates the category definitions to use a `_select` function. The `_select` function will obtain the first available plugin, and make it available to a closure. The category may then invoke a desired behavior on the plugin within that closure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
