### PR TITLE
chore: categories use selectors to invoke plugins

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -25,10 +25,14 @@ dependencies:
   flutter:
     sdk: flutter
   file_picker: ^1.8.0+1
-  amplify_core: ^0.0.1-dev.4
-  amplify_analytics_pinpoint: ^0.0.1-dev.4
-  amplify_auth_cognito: ^0.0.1-dev.4
-  amplify_storage_s3: ^0.0.1-dev.4
+  amplify_core:
+    path: ../packages/amplify_core
+  amplify_analytics_pinpoint:
+    path: ../packages/amplify_analytics_pinpoint
+  amplify_auth_cognito:
+    path: ../packages/amplify_auth_cognito
+  amplify_storage_s3:
+    path: ../packages/amplify_storage_s3
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3

--- a/packages/amplify_analytics_pinpoint/example/pubspec.yaml
+++ b/packages/amplify_analytics_pinpoint/example/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     # See https://dart.dev/tools/pub/dependencies#version-constraints
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version. 
-    path: ../
+    path: ../../amplify_analytics_pinpoint
 
   amplify_auth_cognito:
     path: ../../amplify_auth_cognito

--- a/packages/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/amplify_analytics_pinpoint/pubspec.yaml
@@ -11,13 +11,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_analytics_plugin_interface: ^0.0.1-dev.4
+  amplify_analytics_plugin_interface:
+    path: ../amplify_analytics_plugin_interface
   plugin_platform_interface: ^1.0.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  amplify_core: ^0.0.1-dev.4
+  amplify_core:
+    path: ../amplify_core
 
 flutter:
   plugin:

--- a/packages/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/amplify_auth_cognito/example/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
     # See https://dart.dev/tools/pub/dependencies#version-constraints
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
-    path: ../
+    path: ../../amplify_auth_cognito
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3

--- a/packages/amplify_auth_cognito/pubspec.yaml
+++ b/packages/amplify_auth_cognito/pubspec.yaml
@@ -10,13 +10,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_auth_plugin_interface: ^0.0.1-dev.4
+  amplify_auth_plugin_interface:
+    path: ../amplify_auth_plugin_interface
   plugin_platform_interface: ^1.0.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  amplify_core: ^0.0.1-dev.4
+  amplify_core:
+    path: ../amplify_core
 
 flutter:
   plugin:

--- a/packages/amplify_auth_plugin_interface/lib/src/Password/ResetPasswordResult.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/Password/ResetPasswordResult.dart
@@ -16,11 +16,30 @@
 import './ResetPasswordStep.dart';
 import 'package:flutter/foundation.dart';
 
-class ResetPasswordResult { 
+class ResetPasswordResult {
   bool isPasswordReset;
   ResetPasswordStep nextStep;
-  ResetPasswordResult({@required this.isPasswordReset, @required this.nextStep}) {
+  ResetPasswordResult(
+      {@required this.isPasswordReset, @required this.nextStep}) {
     this.isPasswordReset = isPasswordReset;
     this.nextStep = nextStep;
+  }
+
+  @override
+  String toString() {
+    return 'ResetPasswordResult(isPasswordReset: $isPasswordReset, nextStep: $nextStep)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is ResetPasswordResult &&
+        o.isPasswordReset == isPasswordReset &&
+        o.nextStep == nextStep;
+  }
+
+  @override
+  int get hashCode {
+    return isPasswordReset.hashCode ^ nextStep.hashCode;
   }
 }

--- a/packages/amplify_auth_plugin_interface/lib/src/Password/ResetPasswordResult.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/Password/ResetPasswordResult.dart
@@ -19,6 +19,7 @@ import 'package:flutter/foundation.dart';
 class ResetPasswordResult {
   bool isPasswordReset;
   ResetPasswordStep nextStep;
+
   ResetPasswordResult(
       {@required this.isPasswordReset, @required this.nextStep}) {
     this.isPasswordReset = isPasswordReset;

--- a/packages/amplify_auth_plugin_interface/lib/src/Password/ResetPasswordStep.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/Password/ResetPasswordStep.dart
@@ -18,5 +18,32 @@ import '../types/AuthNextStep.dart';
 
 class ResetPasswordStep extends AuthNextStep {
   String updateStep;
-  ResetPasswordStep({additionalInfo, @required codeDeliveryDetails, @required this.updateStep}) : super(additionalInfo: additionalInfo, codeDeliveryDetails: codeDeliveryDetails);
+  ResetPasswordStep(
+      {additionalInfo,
+      @required codeDeliveryDetails,
+      @required this.updateStep})
+      : super(
+            additionalInfo: additionalInfo,
+            codeDeliveryDetails: codeDeliveryDetails);
+
+  @override
+  String toString() {
+    return 'ResetPasswordStep(additionalInfo: $additionalInfo, codeDeliveryDetails: $codeDeliveryDetails, updateStep: $updateStep)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is ResetPasswordStep &&
+        o.additionalInfo == additionalInfo &&
+        o.codeDeliveryDetails == codeDeliveryDetails &&
+        o.updateStep == updateStep;
+  }
+
+  @override
+  int get hashCode {
+    return additionalInfo.hashCode ^
+        codeDeliveryDetails.hashCode ^
+        updateStep.hashCode;
+  }
 }

--- a/packages/amplify_auth_plugin_interface/lib/src/Password/ResetPasswordStep.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/Password/ResetPasswordStep.dart
@@ -18,6 +18,7 @@ import '../types/AuthNextStep.dart';
 
 class ResetPasswordStep extends AuthNextStep {
   String updateStep;
+
   ResetPasswordStep(
       {additionalInfo,
       @required codeDeliveryDetails,

--- a/packages/amplify_auth_plugin_interface/lib/src/Password/UpdatePasswordResult.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/Password/UpdatePasswordResult.dart
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -14,6 +13,23 @@
  * permissions and limitations under the License.
  */
 
-class UpdatePasswordResult { 
+class UpdatePasswordResult {
   UpdatePasswordResult() {}
-} 
+
+  @override
+  String toString() {
+    return 'UpdatePasswordResult()';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is UpdatePasswordResult;
+  }
+
+  @override
+  int get hashCode {
+    Type type = UpdatePasswordResult;
+    return type.hashCode;
+  }
+}

--- a/packages/amplify_auth_plugin_interface/lib/src/Session/AuthSession.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/Session/AuthSession.dart
@@ -13,13 +13,27 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_auth_plugin_interface/amplify_auth_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
-
 
 class AuthSession {
   bool isSignedIn;
   AuthSession({@required this.isSignedIn}) {
     this.isSignedIn = isSignedIn;
-   }
+  }
+
+  @override
+  String toString() {
+    return 'AuthSession(isSignedIn: $isSignedIn)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is AuthSession && o.isSignedIn == isSignedIn;
+  }
+
+  @override
+  int get hashCode {
+    return isSignedIn.hashCode;
+  }
 }

--- a/packages/amplify_auth_plugin_interface/lib/src/Session/AuthUser.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/Session/AuthUser.dart
@@ -15,9 +15,24 @@
 
 import 'package:flutter/foundation.dart';
 
-
 class AuthUser {
   String userId;
   String username;
   AuthUser({@required this.userId, @required this.username});
+
+  @override
+  String toString() {
+    return 'AuthUser(userId: $userId, username: $username)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is AuthUser && o.userId == userId && o.username == username;
+  }
+
+  @override
+  int get hashCode {
+    return userId.hashCode ^ username.hashCode;
+  }
 }

--- a/packages/amplify_auth_plugin_interface/lib/src/SignIn/AuthNextSignInStep.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/SignIn/AuthNextSignInStep.dart
@@ -18,5 +18,27 @@ import '../types/AuthNextStep.dart';
 
 class AuthNextSignInStep extends AuthNextStep {
   String signInStep;
-  AuthNextSignInStep({additionalInfo, @required codeDeliveryDetails, @required this.signInStep}) : super(additionalInfo: additionalInfo, codeDeliveryDetails: codeDeliveryDetails);
+  AuthNextSignInStep(
+      {additionalInfo,
+      @required codeDeliveryDetails,
+      @required this.signInStep})
+      : super(
+            additionalInfo: additionalInfo,
+            codeDeliveryDetails: codeDeliveryDetails);
+
+  @override
+  String toString() {
+    return 'AuthNextSignInStep(signInStep: $signInStep)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is AuthNextSignInStep && o.signInStep == signInStep;
+  }
+
+  @override
+  int get hashCode {
+    return signInStep.hashCode;
+  }
 }

--- a/packages/amplify_auth_plugin_interface/lib/src/SignIn/SignInResult.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/SignIn/SignInResult.dart
@@ -16,12 +16,29 @@
 import 'package:amplify_auth_plugin_interface/amplify_auth_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
-
 class SignInResult {
   bool isSignedIn;
   AuthNextSignInStep nextStep;
   SignInResult({@required this.isSignedIn, this.nextStep}) {
     this.isSignedIn = isSignedIn;
     this.nextStep = nextStep;
-   }
+  }
+
+  @override
+  String toString() {
+    return 'SignInResult(isSignedIn: $isSignedIn, nextStep: $nextStep)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is SignInResult &&
+        o.isSignedIn == isSignedIn &&
+        o.nextStep == nextStep;
+  }
+
+  @override
+  int get hashCode {
+    return isSignedIn.hashCode ^ nextStep.hashCode;
+  }
 }

--- a/packages/amplify_auth_plugin_interface/lib/src/SignOut/SignOutResult.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/SignOut/SignOutResult.dart
@@ -13,6 +13,23 @@
  * permissions and limitations under the License.
  */
 
-class SignOutResult { 
+class SignOutResult {
   SignOutResult() {}
+
+  @override
+  String toString() {
+    return 'SignOutResult()';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is SignOutResult;
+  }
+
+  @override
+  int get hashCode {
+    Type type = SignOutResult;
+    return type.hashCode;
+  }
 }

--- a/packages/amplify_auth_plugin_interface/lib/src/SignUp/AuthNextSignUpStep.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/SignUp/AuthNextSignUpStep.dart
@@ -18,6 +18,7 @@ import '../types/AuthNextStep.dart';
 
 class AuthNextSignUpStep extends AuthNextStep {
   String signUpStep;
+
   AuthNextSignUpStep(
       {additionalInfo,
       @required codeDeliveryDetails,

--- a/packages/amplify_auth_plugin_interface/lib/src/SignUp/AuthNextSignUpStep.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/SignUp/AuthNextSignUpStep.dart
@@ -18,5 +18,32 @@ import '../types/AuthNextStep.dart';
 
 class AuthNextSignUpStep extends AuthNextStep {
   String signUpStep;
-  AuthNextSignUpStep({additionalInfo, @required codeDeliveryDetails, @required this.signUpStep}) : super(additionalInfo: additionalInfo, codeDeliveryDetails: codeDeliveryDetails);
+  AuthNextSignUpStep(
+      {additionalInfo,
+      @required codeDeliveryDetails,
+      @required this.signUpStep})
+      : super(
+            additionalInfo: additionalInfo,
+            codeDeliveryDetails: codeDeliveryDetails);
+
+  @override
+  String toString() {
+    return 'AuthNextSignUpStep(additionalInfo: $additionalInfo, codeDeliveryDetails: $codeDeliveryDetails, signUpStep: $signUpStep)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is AuthNextSignUpStep &&
+        o.additionalInfo == additionalInfo &&
+        o.codeDeliveryDetails == codeDeliveryDetails &&
+        o.signUpStep == signUpStep;
+  }
+
+  @override
+  int get hashCode {
+    return additionalInfo.hashCode ^
+        codeDeliveryDetails.hashCode ^
+        signUpStep.hashCode;
+  }
 }

--- a/packages/amplify_auth_plugin_interface/lib/src/SignUp/ResendSignUpCodeResult.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/SignUp/ResendSignUpCodeResult.dart
@@ -17,13 +17,29 @@ import 'package:flutter/foundation.dart';
 
 import '../types/AuthCodeDeliveryDetails.dart';
 
-class ResendSignUpCodeResult { 
+class ResendSignUpCodeResult {
   AuthCodeDeliveryDetails codeDeliveryDetails;
   ResendSignUpCodeResult({@required codeDeliveryDetails}) {
     this.codeDeliveryDetails = AuthCodeDeliveryDetails(
-      attributeName: codeDeliveryDetails["attributeName"] ?? "",
-      deliveryMedium: codeDeliveryDetails["deliveryMedium"] ?? "",
-      destination: codeDeliveryDetails["destination"]?? ""
-    );
+        attributeName: codeDeliveryDetails["attributeName"] ?? "",
+        deliveryMedium: codeDeliveryDetails["deliveryMedium"] ?? "",
+        destination: codeDeliveryDetails["destination"] ?? "");
+  }
+
+  @override
+  String toString() {
+    return 'ResendSignUpCodeResult(codeDeliveryDetails: $codeDeliveryDetails)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is ResendSignUpCodeResult &&
+        o.codeDeliveryDetails == codeDeliveryDetails;
+  }
+
+  @override
+  int get hashCode {
+    return codeDeliveryDetails.hashCode;
   }
 }

--- a/packages/amplify_auth_plugin_interface/lib/src/SignUp/ResendSignUpCodeResult.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/SignUp/ResendSignUpCodeResult.dart
@@ -19,6 +19,7 @@ import '../types/AuthCodeDeliveryDetails.dart';
 
 class ResendSignUpCodeResult {
   AuthCodeDeliveryDetails codeDeliveryDetails;
+
   ResendSignUpCodeResult({@required codeDeliveryDetails}) {
     this.codeDeliveryDetails = AuthCodeDeliveryDetails(
         attributeName: codeDeliveryDetails["attributeName"] ?? "",

--- a/packages/amplify_auth_plugin_interface/lib/src/SignUp/SignUpResult.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/SignUp/SignUpResult.dart
@@ -16,11 +16,30 @@
 import './AuthNextSignUpStep.dart';
 import 'package:flutter/foundation.dart';
 
-class SignUpResult { 
+class SignUpResult {
   bool isSignUpComplete;
   AuthNextSignUpStep nextStep;
   SignUpResult({@required this.isSignUpComplete, @required this.nextStep}) {
     this.isSignUpComplete = isSignUpComplete;
     this.nextStep = nextStep;
+  }
+
+  @override
+  String toString() {
+    return 'SignUpResult(isSignUpComplete: $isSignUpComplete, nextStep: $nextStep)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+
+    return o is SignUpResult &&
+        o.isSignUpComplete == isSignUpComplete &&
+        o.nextStep == nextStep;
+  }
+
+  @override
+  int get hashCode {
+    return isSignUpComplete.hashCode ^ nextStep.hashCode;
   }
 }

--- a/packages/amplify_auth_plugin_interface/lib/src/SignUp/SignUpResult.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/SignUp/SignUpResult.dart
@@ -19,6 +19,7 @@ import 'package:flutter/foundation.dart';
 class SignUpResult {
   bool isSignUpComplete;
   AuthNextSignUpStep nextStep;
+
   SignUpResult({@required this.isSignUpComplete, @required this.nextStep}) {
     this.isSignUpComplete = isSignUpComplete;
     this.nextStep = nextStep;
@@ -32,7 +33,6 @@ class SignUpResult {
   @override
   bool operator ==(Object o) {
     if (identical(this, o)) return true;
-
     return o is SignUpResult &&
         o.isSignUpComplete == isSignUpComplete &&
         o.nextStep == nextStep;

--- a/packages/amplify_auth_plugin_interface/lib/src/types/AuthCodeDeliveryDetails.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/types/AuthCodeDeliveryDetails.dart
@@ -19,5 +19,29 @@ class AuthCodeDeliveryDetails {
   String attributeName;
   String deliveryMedium;
   String destination;
-  AuthCodeDeliveryDetails({@required this.attributeName,  @required this.deliveryMedium, @required this.destination});
+  AuthCodeDeliveryDetails(
+      {@required this.attributeName,
+      @required this.deliveryMedium,
+      @required this.destination});
+
+  @override
+  String toString() {
+    return 'AuthCodeDeliveryDetails(attributeName: $attributeName, deliveryMedium: $deliveryMedium, destination: $destination)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is AuthCodeDeliveryDetails &&
+        o.attributeName == attributeName &&
+        o.deliveryMedium == deliveryMedium &&
+        o.destination == destination;
+  }
+
+  @override
+  int get hashCode {
+    return attributeName.hashCode ^
+        deliveryMedium.hashCode ^
+        destination.hashCode;
+  }
 }

--- a/packages/amplify_auth_plugin_interface/lib/src/types/AuthNextStep.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/types/AuthNextStep.dart
@@ -22,9 +22,26 @@ class AuthNextStep {
   AuthNextStep({@required codeDeliveryDetails, additionalInfo = const {}}) {
     this.additionalInfo = additionalInfo;
     this.codeDeliveryDetails = AuthCodeDeliveryDetails(
-      attributeName: codeDeliveryDetails["attributeName"] ?? "",
-      deliveryMedium: codeDeliveryDetails["deliveryMedium"] ?? "",
-      destination: codeDeliveryDetails["destination"]?? ""
-    );
+        attributeName: codeDeliveryDetails["attributeName"] ?? "",
+        deliveryMedium: codeDeliveryDetails["deliveryMedium"] ?? "",
+        destination: codeDeliveryDetails["destination"] ?? "");
+  }
+
+  @override
+  String toString() {
+    return 'AuthNextStep(additionalInfo: $additionalInfo, codeDeliveryDetails: $codeDeliveryDetails)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is AuthNextStep &&
+        o.additionalInfo == additionalInfo &&
+        o.codeDeliveryDetails == codeDeliveryDetails;
+  }
+
+  @override
+  int get hashCode {
+    return additionalInfo.hashCode ^ codeDeliveryDetails.hashCode;
   }
 }

--- a/packages/amplify_core/example/pubspec.yaml
+++ b/packages/amplify_core/example/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     # See https://dart.dev/tools/pub/dependencies#version-constraints
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
-    path: ../
+    path: ../../amplify_core
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -10,11 +10,16 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_core_plugin_interface: ^0.0.1-dev.4
-  amplify_storage_plugin_interface: ^0.0.1-dev.4
-  amplify_analytics_plugin_interface: ^0.0.1-dev.4
-  amplify_auth_plugin_interface: ^0.0.1-dev.4
-  amplify_datastore_plugin_interface: ^0.0.1-dev.4
+  amplify_core_plugin_interface:
+    path: ../amplify_core_plugin_interface
+  amplify_storage_plugin_interface:
+    path: ../amplify_storage_plugin_interface
+  amplify_analytics_plugin_interface:
+    path: ../amplify_analytics_plugin_interface
+  amplify_auth_plugin_interface:
+    path: ../amplify_auth_plugin_interface
+  amplify_datastore_plugin_interface:
+    path: ../amplify_datastore_plugin_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/amplify_core_plugin_interface/lib/amplify_auth_category.dart
+++ b/packages/amplify_core_plugin_interface/lib/amplify_auth_category.dart
@@ -5,7 +5,6 @@ part of amplify_core_plugin_interface;
 /// be registered and configured and then subsequent API calls will be forwarded
 /// to those plugins.
 class AuthCategory {
-  final errorMsg = "Auth plugin not added correctly";
   const AuthCategory();
   static List<AuthPluginInterface> plugins = [];
 
@@ -14,64 +13,69 @@ class AuthCategory {
     // TODO: Discuss and support multiple plugins
     if (plugins.length == 0) {
       plugins.add(plugin);
-      
     } else {
-      throw("Auth plugin was not added");
+      throw("Auth plugin was not added. You've already added one.");
     }
   }
 
   Future<SignUpResult> signUp({@required String username, @required password, SignUpOptions options}) {
     var request = SignUpRequest(username: username, password: password, options: options);
-    return plugins.length == 1 ? plugins[0].signUp(request: request) : throw(errorMsg);
+    return _select((it) => it.signUp(request: request));
   }
 
   Future<SignUpResult> confirmSignUp({@required String username, @required String confirmationCode, ConfirmSignUpOptions options}) {
     var request = ConfirmSignUpRequest(username: username, confirmationCode: confirmationCode, options: options);
-    return plugins.length == 1 ? plugins[0].confirmSignUp(request: request) : throw(errorMsg);
+    return _select((it) => it.confirmSignUp(request: request));
   }
 
   Future<ResendSignUpCodeResult> resendSignUpCode({@required String username}) {
     var request = ResendSignUpCodeRequest(username: username);
-    return plugins.length == 1 ? plugins[0].resendSignUpCode(request: request) : throw(errorMsg);
+    return _select((it) => it.resendSignUpCode(request: request));
   }
 
   Future<SignInResult> signIn({@required String username, @required String password, SignInOptions options }) {
     var request = SignInRequest(username: username, password: password, options: options);
-    return plugins.length == 1 ? plugins[0].signIn(request: request) : throw(errorMsg);
+    return _select((it) => it.signIn(request: request));
   }
 
   Future<SignInResult> confirmSignIn({@required String confirmationValue, ConfirmSignInOptions options}) {
     var request = ConfirmSignInRequest(confirmationValue: confirmationValue, options: options);
-    return plugins.length == 1 ? plugins[0].confirmSignIn(request: request) : throw(errorMsg);
+    return _select((it) => it.confirmSignIn(request: request));
   }
 
   Future<SignOutResult> signOut({SignOutOptions options}) {
     var request = SignOutRequest(options: options);
-    return plugins.length == 1 ? plugins[0].signOut(request: request) : throw(errorMsg);
+    return _select((it) => it.signOut(request: request));
   }
 
   Future<UpdatePasswordResult> updatePassword({@required String oldPassword, @required String newPassword, PasswordOptions options}) {
     var request = UpdatePasswordRequest(oldPassword: oldPassword, newPassword: newPassword, options: options);
-    return plugins.length == 1 ? plugins[0].updatePassword(request: request) : throw(errorMsg);
+    return _select((it) => it.updatePassword(request: request));
   }
 
   Future<ResetPasswordResult> resetPassword({@required String username, PasswordOptions options}) {
     var request = ResetPasswordRequest(username: username, options: options);
-    return plugins.length == 1 ? plugins[0].resetPassword(request: request) : throw(errorMsg);
+    return _select((it) => it.resetPassword(request: request));
   }
 
   Future<UpdatePasswordResult> confirmPassword({@required String username, @required String newPassword, @required String confirmationCode, PasswordOptions options}) {
     var request = ConfirmPasswordRequest(username: username, newPassword: newPassword, confirmationCode: confirmationCode, options: options);
-    return plugins.length == 1 ? plugins[0].confirmPassword(request: request) : throw(errorMsg);
+    return _select((it) => it.confirmPassword(request: request));
   }
 
   Future<AuthUser> getCurrentUser() {
     var request = AuthUserRequest();
-    return plugins.length == 1 ? plugins[0].getCurrentUser(request: request) : throw(errorMsg);
+    return _select((it) => it.getCurrentUser(request: request));
   }
 
   Future<AuthSession> fetchAuthSession({AuthSessionOptions options}) {
     var request = AuthSessionRequest(options: options);
-    return plugins.length == 1 ? plugins[0].fetchAuthSession(request: request) : throw(errorMsg);
+    return _select((it) => it.fetchAuthSession(request: request));
+  }
+
+  Future<R> _select<R>(FutureOr<R> onValue(AuthPluginInterface plugin)) {
+    return plugins.length == 1
+        ? Future.value(plugins[0]).then(onValue)
+        : throw ("No Auth plugin is available. Did you add one?");
   }
 }

--- a/packages/amplify_core_plugin_interface/lib/amplify_datastore_category.dart
+++ b/packages/amplify_core_plugin_interface/lib/amplify_datastore_category.dart
@@ -20,7 +20,6 @@ part of amplify_core_plugin_interface;
 /// be registered and configured and then subsequent API calls will be forwarded
 /// to those plugins.
 class DataStoreCategory {
-  final errorMsg = "DataStore plugin not added correctly";
   const DataStoreCategory();
   static List<DataStorePluginInterface> plugins = [];
 
@@ -34,7 +33,7 @@ class DataStoreCategory {
       // in the `onAttachedToEngine` but rather in the `configure()
       await plugin.configureModelProvider(modelProvider: plugin.modelProvider);
     } else {
-      throw (errorMsg);
+      throw ("DataStore plugin was not added. You've already added one.");
     }
   }
 
@@ -42,34 +41,40 @@ class DataStoreCategory {
       {QueryPredicate where,
       QueryPagination pagination,
       List<QuerySortBy> sortBy}) {
-    return plugins.length == 1
-        ? plugins[0].query(modelType,
-            where: where, pagination: pagination, sortBy: sortBy)
-        : throw (errorMsg);
+    return _select((it) => it.query(modelType,
+        where: where, pagination: pagination, sortBy: sortBy));
   }
 
   Future<void> delete<T extends Model>(T model) {
-    return plugins.length == 1 ? plugins[0].delete(model) : throw (errorMsg);
+    return _select((it) => it.delete(model));
   }
 
   Future<void> save<T extends Model>(T model) {
-    return plugins.length == 1 ? plugins[0].save(model) : throw (errorMsg);
+    return _select((it) => it.save(model));
   }
 
   Stream<SubscriptionEvent<T>> observe<T extends Model>(
       ModelType<T> modelType) {
+    // TODO: Howto use _stream()? It will return a Future<Stream<...>>,
+    // not just a Stream<...>.
     return plugins.length == 1
         ? plugins[0].observe(modelType)
-        : throw (errorMsg);
+        : throw ("No DataStore plugin is available. Did you add one?");
   }
 
   Future<void> clear() {
-    return plugins.length == 1 ? plugins[0].clear() : throw (errorMsg);
+    return _select((it) => it.clear());
   }
 
   Future<void> configure(String configuration) async {
     return plugins.forEach((plugin) {
       plugin.configure(configuration: configuration);
     });
+  }
+
+  Future<R> _select<R>(FutureOr<R> onValue(DataStorePluginInterface plugin)) {
+    return plugins.length == 1
+        ? Future.value(plugins[0]).then(onValue)
+        : throw ("No DataStore plugin is available. Did you add one?");
   }
 }

--- a/packages/amplify_core_plugin_interface/lib/amplify_datastore_category.dart
+++ b/packages/amplify_core_plugin_interface/lib/amplify_datastore_category.dart
@@ -55,7 +55,7 @@ class DataStoreCategory {
 
   Stream<SubscriptionEvent<T>> observe<T extends Model>(
       ModelType<T> modelType) {
-    // TODO: Howto use _stream()? It will return a Future<Stream<...>>,
+    // TODO: Howto use _select()? It will return a Future<Stream<...>>,
     // not just a Stream<...>.
     return plugins.length == 1
         ? plugins[0].observe(modelType)

--- a/packages/amplify_core_plugin_interface/lib/amplify_storage_category.dart
+++ b/packages/amplify_core_plugin_interface/lib/amplify_storage_category.dart
@@ -27,7 +27,7 @@ class StorageCategory {
       plugins.add(plugin);
       return true;
     } else {
-      throw ("Failed to add the Storage plugin");
+      throw ("Failed to add the Storage plugin. You've already added one.");
     }
   }
 
@@ -35,22 +35,22 @@ class StorageCategory {
       {@required File local, @required String key, UploadFileOptions options}) {
     final UploadFileRequest request =
         UploadFileRequest(local: local, key: key, options: options);
-    return plugins[0].uploadFile(request: request);
+    return _select((it) => it.uploadFile(request: request));
   }
 
   Future<GetUrlResult> getUrl({@required String key, GetUrlOptions options}) {
     final GetUrlRequest request = GetUrlRequest(key: key, options: options);
-    return plugins[0].getUrl(request: request);
+    return _select((it) => it.getUrl(request: request));
   }
 
   Future<RemoveResult> remove({@required String key, RemoveOptions options}) {
     final RemoveRequest request = RemoveRequest(key: key, options: options);
-    return plugins[0].remove(request: request);
+    return _select((it) => it.remove(request: request));
   }
 
   Future<ListResult> list({String path, ListOptions options}) {
     final ListRequest request = ListRequest(path: path, options: options);
-    return plugins[0].list(request: request);
+    return _select((it) => it.list(request: request));
   }
 
   Future<DownloadFileResult> downloadFile(
@@ -59,6 +59,12 @@ class StorageCategory {
       DownloadFileOptions options}) {
     final DownloadFileRequest request =
         DownloadFileRequest(key: key, local: local, options: options);
-    return plugins[0].downloadFile(request: request);
+    return _select((it) => it.downloadFile(request: request));
+  }
+
+  Future<R> _select<R>(FutureOr<R> onValue(StoragePluginInterface plugin)) {
+    return plugins.length == 1
+        ? Future.value(plugins[0]).then(onValue)
+        : throw ("No storage plugin is available.");
   }
 }

--- a/packages/amplify_core_plugin_interface/pubspec.yaml
+++ b/packages/amplify_core_plugin_interface/pubspec.yaml
@@ -10,10 +10,14 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^1.0.1
-  amplify_storage_plugin_interface: ^0.0.1-dev.4
-  amplify_auth_plugin_interface: ^0.0.1-dev.4
-  amplify_analytics_plugin_interface: ^0.0.1-dev.4
-  amplify_datastore_plugin_interface: ^0.0.1-dev.4
+  amplify_storage_plugin_interface:
+    path: ../amplify_storage_plugin_interface
+  amplify_auth_plugin_interface:
+    path: ../amplify_auth_plugin_interface
+  amplify_analytics_plugin_interface:
+    path: ../amplify_analytics_plugin_interface
+  amplify_datastore_plugin_interface:
+    path: ../amplify_datastore_plugin_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/amplify_core_plugin_interface/test/amplify_auth_category_test.dart
+++ b/packages/amplify_core_plugin_interface/test/amplify_auth_category_test.dart
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_auth_plugin_interface/amplify_auth_plugin_interface.dart';
+import 'package:amplify_core_plugin_interface/amplify_core_plugin_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final USERNAME = 'Tony';
+  final PASSWORD = 'GreatPass33';
+  final NEW_PASSWORD = 'NuPass99';
+  final CONFIRMATION_CODE = 'ExcellentCode22';
+
+  group('AuthCategory without selected plugin', () {
+    final auth = AuthCategory();
+    test('signUp throws', () {
+      expect(() =>
+        auth.signIn(username: USERNAME, password: PASSWORD),
+        throwsA(noPluginError())
+      );
+    });
+    test('confirmSignUp throws', () {
+      expect(() =>
+        auth.confirmSignUp(username: USERNAME, confirmationCode: CONFIRMATION_CODE),
+        throwsA(noPluginError())
+      );
+    });
+    test('resendSignUpCode throws', () {
+      expect(() =>
+        auth.resendSignUpCode(username: USERNAME),
+        throwsA(noPluginError())
+      );
+    });
+    test('signIn throws', () {
+      expect(() =>
+        auth.signIn(username: USERNAME, password: PASSWORD),
+        throwsA(noPluginError())
+      );
+    });
+    test('confirmSignIn throws', () {
+      expect(() =>
+        auth.confirmSignIn(confirmationValue: CONFIRMATION_CODE),
+        throwsA(noPluginError())
+      );
+    });
+    test('signOut throws', () {
+      expect(() => auth.signOut(), throwsA(noPluginError()));
+    });
+    test('updatePassword throws', () {
+      expect(() =>
+        auth.updatePassword(newPassword: NEW_PASSWORD, oldPassword: PASSWORD),
+        throwsA(noPluginError())
+      );
+    });
+    test('resetPassword throws', () {
+      expect(() =>
+        auth.resetPassword(username: USERNAME),
+        throwsA(noPluginError())
+      );
+    });
+    test('confirmPassword throws', () {
+      expect(() =>
+        auth.confirmPassword(username: USERNAME, newPassword: NEW_PASSWORD, confirmationCode: CONFIRMATION_CODE),
+        throwsA(noPluginError())
+      );
+    });
+    test('getCurrentUser throws', () {
+      expect(() => auth.getCurrentUser(), throwsA(noPluginError()));
+    });
+    test('fetchAuthSession throws', () {
+      expect(() =>auth.fetchAuthSession(), throwsA(noPluginError()));
+    });
+  });
+
+  group('AuthCategory with single plugin', () {
+    AuthPluginInterface fakeAuthPlugin;
+    AuthCategory auth;
+
+    setUpAll(() {
+      fakeAuthPlugin = FakeAuthPlugin();
+      auth = AuthCategory();
+      auth.addPlugin(fakeAuthPlugin);
+    });
+    test('signUp passes to plugin', () {
+      final nextStep =
+        AuthNextSignUpStep(codeDeliveryDetails: codeDeliveryDetails(), signUpStep: 'nextStep');
+      final result = SignUpResult(isSignUpComplete: true, nextStep: nextStep);
+      expect(
+        auth.signUp(username: USERNAME, password: PASSWORD),
+        completion(equals(result))
+      );
+    });
+    test('confirmSignUp passes to plugin', () {
+      final nextStep =
+        AuthNextSignUpStep(codeDeliveryDetails: codeDeliveryDetails(), signUpStep: 'nextStep');
+      final result = SignUpResult(isSignUpComplete: true, nextStep: nextStep);
+      expect(
+        auth.confirmSignUp(username: USERNAME, confirmationCode: CONFIRMATION_CODE),
+        completion(equals(result))
+      );
+    });
+    test('resendSignUpCode passes to plugin', () {
+      final result = ResendSignUpCodeResult(codeDeliveryDetails: codeDeliveryDetails());
+      expect(
+        auth.resendSignUpCode(username: USERNAME),
+        completion(equals(result))
+      );
+    });
+    test('signIn passes to plugin', () {
+      expect(
+        auth.signIn(username: USERNAME, password: PASSWORD),
+        completion(equals(SignInResult(isSignedIn: true)))
+      );
+    });
+    test('confirmSignIn passes to plugin', () {
+      expect(
+        auth.confirmSignIn(confirmationValue: CONFIRMATION_CODE),
+        completion(equals(SignInResult(isSignedIn: true)))
+      );
+    });
+    test('signOut passes to plugin', () {
+      expect(auth.signOut(), completion(equals(SignOutResult())));
+    });
+    test('updatePassword passes to plugin', () {
+      expect(
+        auth.updatePassword(newPassword: NEW_PASSWORD, oldPassword: PASSWORD),
+        completion(equals(UpdatePasswordResult()))
+      );
+    });
+    test('resetPassword passes to plugin', () {
+      final nextStep = ResetPasswordStep(codeDeliveryDetails: codeDeliveryDetails(), updateStep: 'updateStep');
+      expect(
+        auth.resetPassword(username: USERNAME),
+        completion(equals(ResetPasswordResult(isPasswordReset: true, nextStep: nextStep)))
+      );
+    });
+    test('confirmPassword passes to plugin', () {
+      expect(
+        auth.confirmPassword(username: USERNAME, newPassword: NEW_PASSWORD, confirmationCode: CONFIRMATION_CODE),
+        completion(equals(UpdatePasswordResult()))
+      );
+    });
+    test('getCurrentUser passes to plugin', () {
+      expect(
+        auth.getCurrentUser(),
+        completion(equals(AuthUser(userId: 'userId', username: 'username')))
+      );
+    });
+    test('fetchAuthSession passes to plugin', () {
+      expect(
+        auth.fetchAuthSession(),
+        completion(equals(AuthSession(isSignedIn: true)))
+      );
+    });
+  });
+}
+
+Matcher noPluginError() {
+  return predicate((e) {
+    return e is String &&
+      e == 'No Auth plugin is available. Did you add one?';
+  });
+}
+
+class FakeAuthPlugin implements AuthPluginInterface {
+  @override
+  bool addPlugin(AuthPluginInterface configuration) {
+    return true;
+  }
+
+  @override
+  Future<UpdatePasswordResult> confirmPassword({ConfirmPasswordRequest request}) {
+    return Future.value(UpdatePasswordResult());
+  }
+
+  @override
+  Future<SignInResult> confirmSignIn({ConfirmSignInRequest request}) {
+    return Future.value(SignInResult(isSignedIn: true));
+  }
+
+  @override
+  Future<SignUpResult> confirmSignUp({ConfirmSignUpRequest request}) {
+    final nextStep = AuthNextSignUpStep(codeDeliveryDetails: codeDeliveryDetails(), signUpStep: 'nextStep');
+    return Future.value(SignUpResult(isSignUpComplete: true, nextStep: nextStep));
+  }
+
+  @override
+  Future<AuthSession> fetchAuthSession({AuthSessionRequest request}) {
+    return Future.value(AuthSession(isSignedIn: true));
+  }
+
+  @override
+  Future<AuthUser> getCurrentUser({AuthUserRequest request}) {
+    return Future.value(AuthUser(userId: 'userId', username: 'username'));
+  }
+
+  @override
+  Future<ResendSignUpCodeResult> resendSignUpCode({ResendSignUpCodeRequest request}) {
+    return Future.value(ResendSignUpCodeResult(codeDeliveryDetails: codeDeliveryDetails()));
+  }
+
+  @override
+  Future<ResetPasswordResult> resetPassword({ResetPasswordRequest request}) {
+    final nextStep = ResetPasswordStep(codeDeliveryDetails: codeDeliveryDetails(), updateStep: 'updateStep');
+    return Future.value(ResetPasswordResult(isPasswordReset: true, nextStep: nextStep));
+  }
+
+  @override
+  Future<SignInResult> signIn({SignInRequest request}) {
+    return Future.value(SignInResult(isSignedIn: true));
+  }
+
+  @override
+  Future<SignOutResult> signOut({SignOutRequest request}) {
+    return Future.value(SignOutResult());
+  }
+
+  @override
+  Future<SignUpResult> signUp({SignUpRequest request}) {
+    final nextStep = AuthNextSignUpStep(codeDeliveryDetails: codeDeliveryDetails(), signUpStep: 'nextStep');
+    return Future.value(SignUpResult(isSignUpComplete: true, nextStep: nextStep));
+  }
+
+  @override
+  Future<UpdatePasswordResult> updatePassword({UpdatePasswordRequest request}) {
+    return Future.value(UpdatePasswordResult());
+  }
+}
+
+Map<String, dynamic> codeDeliveryDetails() {
+  final codeDeliveryDetails = Map<String, dynamic>();
+  codeDeliveryDetails['attributeName'] = 'attributeName';
+  codeDeliveryDetails['deliveryMedium'] = 'deliveryMedium';
+  codeDeliveryDetails['destination'] = 'destination';
+  return codeDeliveryDetails;
+}
+

--- a/packages/amplify_core_plugin_interface/test/amplify_datastore_category_test.dart
+++ b/packages/amplify_core_plugin_interface/test/amplify_datastore_category_test.dart
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_core_plugin_interface/amplify_core_plugin_interface.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DataStoreCategory without selected plugin', () {
+    final datastore = DataStoreCategory();
+    final modelType = FakeModelType();
+    final model = FakeModel('id', modelType);
+
+    test('query throws', () {
+      expect(() => datastore.query(modelType), throwsA(noPluginError()));
+    });
+    test('delete throws', () {
+      expect(() => datastore.delete(model), throwsA(noPluginError()));
+    });
+    test('save throws', () {
+      expect(() => datastore.save(model), throwsA(noPluginError()));
+    });
+    test('observe throws', () {
+      expect(() => datastore.observe(modelType), throwsA(noPluginError()));
+    });
+    test('clear throws', () {
+      expect(() => datastore.clear(), throwsA(noPluginError()));
+    });
+  });
+  group('DataStoreCategory with one selected plugin', () {
+    DataStoreCategory datastore;
+    FakePlugin plugin;
+    FakeModelType modelType;
+    FakeModel model;
+
+    setUpAll(() {
+      datastore = DataStoreCategory();
+      plugin = FakePlugin();
+      datastore.addPlugin(plugin);
+      modelType = FakeModelType();
+      model = FakeModel('id', modelType);
+    });
+    test('query passes to plugin', () {
+      expect(datastore.query(modelType), completion(equals(List())));
+    });
+    test('delete passes to plugin', () {
+      expect(datastore.delete(model), completion(equals(null)));
+    });
+    test('save passes to plugin', () {
+      expect(datastore.save(model), completion(equals(null)));
+    });
+    test('observe passes to plugin', () {
+      expect(datastore.observe(modelType), emitsInOrder([emitsDone]));
+    });
+    test('clear passes to plugin', () {
+      expect(datastore.clear(), completion(equals(null)));
+    });
+  });
+}
+
+Matcher noPluginError() {
+  return predicate((e) {
+    return e is String &&
+      e == 'No DataStore plugin is available. Did you add one?';
+  });
+}
+
+class FakeModelProvider implements ModelProviderInterface {
+  @override
+  List<ModelSchema> modelSchemas;
+
+  @override
+  String version;
+}
+
+class FakePlugin implements DataStorePluginInterface {
+  @override
+  Future<void> clear() {
+    return Future.value(null);
+  }
+
+  @override
+  Future<void> configure({String configuration}) {
+    return Future.value(null);
+  }
+
+  @override
+  Future<void> configureModelProvider({ModelProviderInterface modelProvider}) {
+    return Future.value(null);
+  }
+
+  @override
+  Future<void> delete<T extends Model>(T model) {
+    return Future.value(null);
+  }
+
+  @override
+  ModelProviderInterface get modelProvider {
+    return FakeModelProvider();
+  }
+
+  @override
+  Stream<SubscriptionEvent<T>> observe<T extends Model>(
+      ModelType<T> modelType) {
+    return Stream.empty();
+  }
+
+  @override
+  Future<List<T>> query<T extends Model>(
+      ModelType<T> modelType,
+      {QueryPredicate where, QueryPagination pagination, List<QuerySortBy> sortBy}) {
+    return Future.value(List());
+  }
+
+  @override
+  Future<void> save<T extends Model>(T model) {
+    return Future.value(null);
+  }
+}
+
+class FakeModel implements Model {
+  String modelId;
+  ModelType<Model> modelType;
+
+  FakeModel(id, modelType) {
+    this.modelId = id;
+    this.modelType = modelType;
+  }
+
+  @override
+  String getId() {
+    return modelId;
+  }
+
+  @override
+  ModelType<Model> getInstanceType() {
+    return modelType;
+  }
+
+  @override
+  String get id {
+    return modelId;
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    final value = Map<String, dynamic>();
+    value['id'] = modelId;
+    value['modelType'] = modelType.toString();
+    return value;
+  }
+}
+
+class FakeModelType extends ModelType<FakeModel> {
+  @override
+  FakeModel fromJson(Map<String, dynamic> jsonData) {
+    return FakeModel("id", this);
+  }
+}

--- a/packages/amplify_core_plugin_interface/test/amplify_storage_category_test.dart
+++ b/packages/amplify_core_plugin_interface/test/amplify_storage_category_test.dart
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'dart:io';
+
+import 'package:amplify_core_plugin_interface/amplify_core_plugin_interface.dart';
+import 'package:amplify_storage_plugin_interface/amplify_storage_plugin_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('StorageCategory without selected plugin', () {
+    final storage = StorageCategory();
+    test('uploadFile throws', () {
+      expect(() =>
+        storage.uploadFile(key: 'key', local: File('local')),
+        throwsA(noPluginError())
+      );
+    });
+    test('getUrl throws', () {
+      expect(() => storage.getUrl(key: 'key'), throwsA(noPluginError()));
+    });
+    test('remove throws', () {
+      expect(() => storage.remove(key: 'key'), throwsA(noPluginError()));
+    });
+    test('list throws', () {
+      expect(() => storage.list(path: '/'), throwsA(noPluginError()));
+    });
+    test('downloadFile throws', () {
+      expect(() =>
+        storage.downloadFile(key: 'key', local: File('local')),
+        throwsA(noPluginError())
+      );
+    });
+  });
+  group('StorageCategory with one selected plugin', () {
+    StorageCategory storage;
+    StoragePluginInterface plugin;
+
+    setUpAll(() {
+      storage = StorageCategory();
+      plugin = FakeStoragePlugin();
+      storage.addPlugin(plugin);
+    });
+    test('uploadFile passes to plugin', () {
+      expect(
+        storage.uploadFile(local: File('local'), key: 'key'),
+        completion(equals(UploadFileResult(key: 'key')))
+      );
+    });
+    test('getUrl passes to plugin', () {
+      expect(
+        storage.getUrl(key: 'key'),
+        completion(equals(GetUrlResult(url: 'url')))
+      );
+    });
+    test('remove passes to plugin', () {
+      expect(
+        storage.remove(key: 'key'),
+        completion(equals(RemoveResult(key: 'key')))
+      );
+    });
+    test('list passes to plugin', () {
+      expect(storage.list(path: '/'), completion(equals(ListResult())));
+    });
+    test('downloadFile passes to plugin', () {
+      expect(
+        storage.downloadFile(key: 'key', local: File('local')),
+        completion(equals(DownloadFileResult(file: File('local'))))
+      );
+    });
+  });
+}
+
+Matcher noPluginError() {
+  return predicate((e) {
+    return e is String && e == 'No storage plugin is available.';
+  });
+}
+
+class FakeStoragePlugin implements StoragePluginInterface {
+  @override
+  Future<DownloadFileResult> downloadFile({DownloadFileRequest request}) {
+    return Future.value(DownloadFileResult(file: File('local')));
+  }
+
+  @override
+  Future<GetUrlResult> getUrl({GetUrlRequest request}) {
+    return Future.value(GetUrlResult(url: 'url'));
+  }
+
+  @override
+  Future<ListResult> list({ListRequest request}) {
+    return Future.value(ListResult());
+  }
+
+  @override
+  Future<RemoveResult> remove({RemoveRequest request}) {
+    return Future.value(RemoveResult(key: 'key'));
+  }
+
+  @override
+  Future<UploadFileResult> uploadFile({UploadFileRequest request}) {
+    return Future.value(UploadFileResult(key: 'key'));
+  }
+}

--- a/packages/amplify_datastore/example/pubspec.yaml
+++ b/packages/amplify_datastore/example/pubspec.yaml
@@ -17,8 +17,9 @@ dependencies:
     # See https://dart.dev/tools/pub/dependencies#version-constraints
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
-    path: ../
-  amplify_core: ^0.0.1-dev.4
+    path: ../../amplify_datastore
+  amplify_core:
+    path: ../../amplify_core
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -10,7 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_datastore_plugin_interface: ^0.0.1-dev.4
+  amplify_datastore_plugin_interface:
+    path: ../amplify_datastore_plugin_interface
   plugin_platform_interface: ^1.0.1
   date_time_format: ^1.1.0
   uuid: ^2.2.2

--- a/packages/amplify_storage_plugin_interface/lib/src/DownloadFile/DownloadFileResult.dart
+++ b/packages/amplify_storage_plugin_interface/lib/src/DownloadFile/DownloadFileResult.dart
@@ -20,4 +20,20 @@ class DownloadFileResult {
   File file;
 
   DownloadFileResult({@required this.file});
+
+  @override
+  String toString() {
+    return 'DownloadFileResult(file: $file)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is DownloadFileResult && o.file.path == file.path;
+  }
+
+  @override
+  int get hashCode {
+    return file.hashCode;
+  }
 }

--- a/packages/amplify_storage_plugin_interface/lib/src/GetUrl/GetUrlResult.dart
+++ b/packages/amplify_storage_plugin_interface/lib/src/GetUrl/GetUrlResult.dart
@@ -19,4 +19,20 @@ class GetUrlResult {
   String url;
 
   GetUrlResult({@required this.url});
+
+  @override
+  String toString() {
+    return 'GetUrlResult(url: $url)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is GetUrlResult && o.url == url;
+  }
+
+  @override
+  int get hashCode {
+    return url.hashCode;
+  }
 }

--- a/packages/amplify_storage_plugin_interface/lib/src/List/ListResult.dart
+++ b/packages/amplify_storage_plugin_interface/lib/src/List/ListResult.dart
@@ -13,10 +13,28 @@
  * permissions and limitations under the License.
  */
 
+import 'package:collection/collection.dart';
 import '../Storage/StorageItem.dart';
 
 class ListResult {
   List<StorageItem> items;
 
   ListResult({this.items});
+
+  @override
+  String toString() {
+    return 'ListResult(items: $items)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    final listEquals = const DeepCollectionEquality().equals;
+    return o is ListResult && listEquals(o.items, items);
+  }
+
+  @override
+  int get hashCode {
+    return items.hashCode;
+  }
 }

--- a/packages/amplify_storage_plugin_interface/lib/src/Remove/RemoveResult.dart
+++ b/packages/amplify_storage_plugin_interface/lib/src/Remove/RemoveResult.dart
@@ -19,4 +19,20 @@ class RemoveResult {
   String key;
 
   RemoveResult({@required this.key});
+
+  @override
+  String toString() {
+    return 'RemoveResult(key: $key)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is RemoveResult && o.key == key;
+  }
+
+  @override
+  int get hashCode {
+    return key.hashCode;
+  }
 }

--- a/packages/amplify_storage_plugin_interface/lib/src/UploadFile/UploadFileResult.dart
+++ b/packages/amplify_storage_plugin_interface/lib/src/UploadFile/UploadFileResult.dart
@@ -19,4 +19,20 @@ class UploadFileResult {
   final String key;
 
   UploadFileResult({@required this.key});
+
+  @override
+  String toString() {
+    return 'UploadFileResult(key: $key)';
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    return o is UploadFileResult && o.key == key;
+  }
+
+  @override
+  int get hashCode {
+    return key.hashCode;
+  }
 }

--- a/packages/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/amplify_storage_s3/example/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
     # See https://dart.dev/tools/pub/dependencies#version-constraints
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
-    path: ../
+    path: ../../amplify_storage_s3
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/packages/amplify_storage_s3/pubspec.yaml
+++ b/packages/amplify_storage_s3/pubspec.yaml
@@ -10,13 +10,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_storage_plugin_interface: ^0.0.1-dev.4
+  amplify_storage_plugin_interface:
+    path: ../amplify_storage_plugin_interface
   plugin_platform_interface: ^1.0.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  amplify_core: ^0.0.1-dev.4
+  amplify_core:
+    path: ../amplify_core
 
 flutter:
   plugin:


### PR DESCRIPTION
Updates the category definitions to use a `_select` function. The `_select`
function will obtain the first available plugin, and make it available
to a closure. The category may then invoke a desired behavior on the
plugin within that closure.

Adds coverage over all functions that use `_select`. This introduces
three new unit test files for the Storage, DataStore, and Auth categories.

In order to get passing, tests, several other changes are made:
1. Refer to local packages by their paths;
2. Add equals, toString, and hashCode functions for some result types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
