### PR TITLE
fix: prevent android test exhausting jvm memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,8 @@ jobs:
 
   unit_test_android:
     executor: docker-executor
+    environment:
+      JVM_OPTS: -XX:MaxRAMPercentage=80.0
     steps:
       - install_flutter
       - checkout


### PR DESCRIPTION
Refer: https://circleci.com/docs/2.0/java-oom/
Refer: https://discuss.circleci.com/t/circleci-android-build-randomly-falls/29394

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
