### PR TITLE
fix(amplify_datastore): Send null instead of empty string for nullable enum

### DIFF
--- a/packages/amplify_datastore_plugin_interface/lib/src/types/utils/parsers.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/utils/parsers.dart
@@ -16,7 +16,7 @@
 // ignore_for_file: public_member_api_docs
 
 // only to be used internally by amplify-flutter library
-String enumToString(Object o) => o != null ? o.toString().split('.').last : '';
+String enumToString(Object o) => o != null ? o.toString().split('.').last : null;
 
 // only to be used internally by amplify-flutter library
 T enumFromString<T>(String key, List<T> values) =>

--- a/packages/amplify_datastore_plugin_interface/test/amplify_utility_test.dart
+++ b/packages/amplify_datastore_plugin_interface/test/amplify_utility_test.dart
@@ -33,8 +33,8 @@ void main() {
     expect(enumToString(TestEnum.MAYBE), "MAYBE");
   });
 
-  test('parsers.enumToString generates empty string for null', () {
-    expect(enumToString(null), "");
+  test('parsers.enumToString generates null for null enum value', () {
+    expect(enumToString(null), null);
   });
 
   test('parsers.enumFromString generates proper enum', () {


### PR DESCRIPTION
*Issue #, if available:* #279

Tested on both iOS and Android


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
