### PR TITLE
RaisedButton is obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,11 +199,11 @@ class _MyAppState extends State<MyApp> {
               child: Column (
                 children: [
                   const Padding(padding: EdgeInsets.all(5.0)),
-                  RaisedButton(
+                  ElevatedButton(
                     onPressed: _amplifyConfigured ? null : _configureAmplify,
                     child: const Text('configure Amplify')
                   ),
-                  RaisedButton(
+                  ElevatedButton(
                     onPressed: _amplifyConfigured ? _recordEvent : null,
                     child: const Text('record event')
                   )

--- a/example/lib/Pages/LandingPage.dart
+++ b/example/lib/Pages/LandingPage.dart
@@ -33,7 +33,7 @@ class _LandingPageState extends State<LandingPage> {
         context: context,
         child: new SimpleDialog(title: Text(text), children: [
           dialogWidget,
-          RaisedButton(
+          ElevatedButton(
             child: Text("Cancel"),
             onPressed: () {
               Navigator.pop(context, false);
@@ -47,8 +47,8 @@ class _LandingPageState extends State<LandingPage> {
   // dialogWidget must return true or false
   Widget openDialogButton(
       String text, Function onSuccess, Widget dialogWidget) {
-    return RaisedButton(
-        child: Text(text),
+    return ElevatedButton(
+        child: const Text(text),
         onPressed: () {
           _showDialogForResult(text, onSuccess, dialogWidget);
         });

--- a/example/lib/Pages/LandingPage.dart
+++ b/example/lib/Pages/LandingPage.dart
@@ -34,7 +34,7 @@ class _LandingPageState extends State<LandingPage> {
         child: new SimpleDialog(title: Text(text), children: [
           dialogWidget,
           ElevatedButton(
-            child: Text("Cancel"),
+            child: const Text("Cancel"),
             onPressed: () {
               Navigator.pop(context, false);
             },

--- a/example/lib/Views/ImageLineItem.dart
+++ b/example/lib/Views/ImageLineItem.dart
@@ -17,8 +17,8 @@ class ImageLineItem extends StatelessWidget {
         child: Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [
           Text(storageKey),
           Spacer(),
-          RaisedButton(
-              child: Text("open"),
+          ElevatedButton(
+              child: const Text("open"),
               onPressed: () => {
                     showDialog(
                         context: context,

--- a/example/lib/Views/ImageUploader.dart
+++ b/example/lib/Views/ImageUploader.dart
@@ -30,8 +30,8 @@ class ImageUploader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(children: [
-      RaisedButton(
-        child: Text("Upload Image"),
+      ElevatedButton(
+        child: const Text("Upload Image"),
         onPressed: () {
           _upload(context);
         },

--- a/example/lib/Views/SignInView.dart
+++ b/example/lib/Views/SignInView.dart
@@ -90,7 +90,7 @@ class _SignInViewState extends State<SignInView> {
                   ),
                 ),
                 const Padding(padding: EdgeInsets.all(10.0)),
-                RaisedButton(
+                ElevatedButton(
                   onPressed: _signIn,
                   child: const Text('Sign In'),
                 ),

--- a/example/lib/Views/SignUpView.dart
+++ b/example/lib/Views/SignUpView.dart
@@ -136,7 +136,7 @@ class _SignUpViewState extends State<SignUpView> {
                         labelText: 'Phone number *',
                       ),
                     ),
-                    RaisedButton(
+                    ElevatedButton(
                       onPressed: _signUp,
                       child: const Text('Sign Up'),
                     ),
@@ -152,7 +152,7 @@ class _SignUpViewState extends State<SignUpView> {
                             hintText: 'The code we sent you',
                             labelText: 'Confirmation Code *',
                           )),
-                      RaisedButton(
+                      ElevatedButton(
                         onPressed: _confirmSignUp,
                         child: const Text('Confirm Sign Up'),
                       ),

--- a/example/lib/Views/UserView.dart
+++ b/example/lib/Views/UserView.dart
@@ -48,7 +48,7 @@ class _UserProfileState extends State<UserView> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: <Widget>[
-        RaisedButton(onPressed: _signOut, child: const Text("Log Out")),
+        ElevatedButton(onPressed: _signOut, child: const Text("Log Out")),
       ],
     );
   }

--- a/packages/amplify_analytics_pinpoint/example/lib/main.dart
+++ b/packages/amplify_analytics_pinpoint/example/lib/main.dart
@@ -145,7 +145,7 @@ class _MyAppState extends State<MyApp> {
                   Text('Amplify.Core',
                       style:
                           TextStyle(fontSize: 25, fontWeight: FontWeight.bold)),
-                  RaisedButton(
+                  ElevatedButton(
                     onPressed: _amplifyConfigured ? null : _configureAmplify,
                     child: const Text('configure Amplify'),
                   ),
@@ -175,13 +175,13 @@ class _MyAppState extends State<MyApp> {
                         _uniqueId = text;
                       }),
                   Center(
-                      child: RaisedButton(
+                      child: ElevatedButton(
                           onPressed: _amplifyConfigured ? _recordEvent : null,
-                          child: Text('Record Event'))),
+                          child: const Text('Record Event'))),
                   Center(
-                      child: RaisedButton(
+                      child: ElevatedButton(
                           onPressed: _amplifyConfigured ? _flushEvents : null,
-                          child: Text('Flush Events'))),
+                          child: const Text('Flush Events'))),
                   const Divider(
                     color: Colors.black,
                     height: 3,
@@ -195,20 +195,20 @@ class _MyAppState extends State<MyApp> {
                       onChanged: (text) {
                         _globalProp = text;
                       }),
-                  RaisedButton(
+                  ElevatedButton(
                       onPressed:
                           _amplifyConfigured ? _registerGlobalProperties : null,
-                      child: Text('Register Global Prop')),
-                  RaisedButton(
+                      child: const Text('Register Global Prop')),
+                  ElevatedButton(
                       onPressed: _amplifyConfigured
                           ? _unregisterGlobalProperties
                           : null,
-                      child: Text('Unregister Global Prop')),
-                  RaisedButton(
+                      child: const Text('Unregister Global Prop')),
+                  ElevatedButton(
                       onPressed: _amplifyConfigured
                           ? _unregisterAllGlobalProperties
                           : null,
-                      child: Text('Unregister All Global Prop')),
+                      child: const Text('Unregister All Global Prop')),
                   const Divider(
                     color: Colors.black,
                     height: 3,
@@ -221,9 +221,9 @@ class _MyAppState extends State<MyApp> {
                       onChanged: (text) {
                         _userId = text;
                       }),
-                  RaisedButton(
+                  ElevatedButton(
                       onPressed: _amplifyConfigured ? _identifyUser : null,
-                      child: Text('Register User')),
+                      child: const Text('Register User')),
                   const Divider(
                     color: Colors.black,
                     height: 3,
@@ -231,12 +231,12 @@ class _MyAppState extends State<MyApp> {
                     indent: 1,
                     endIndent: 0,
                   ),
-                  RaisedButton(
+                  ElevatedButton(
                       onPressed: _amplifyConfigured ? _enable : null,
-                      child: Text('Enable')),
-                  RaisedButton(
+                      child: const Text('Enable')),
+                  ElevatedButton(
                       onPressed: _amplifyConfigured ? _disable : null,
-                      child: Text('Disable')),
+                      child: const Text('Disable')),
                 ]))
           ])),
     );

--- a/packages/amplify_api/example/lib/graphql_api_view.dart
+++ b/packages/amplify_api/example/lib/graphql_api_view.dart
@@ -94,21 +94,21 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
       children: <Widget>[
         Padding(padding: EdgeInsets.all(10.0)),
         Center(
-          child: RaisedButton(
+          child: ElevatedButton(
             onPressed: widget.isAmplifyConfigured ? query : null,
-            child: Text('Run Query'),
+            child: const Text('Run Query'),
           ),
         ),
         Padding(padding: EdgeInsets.all(10.0)),
         Center(
-          child: RaisedButton(
+          child: ElevatedButton(
             onPressed: widget.isAmplifyConfigured ? mutate : null,
-            child: Text('Run Mutation'),
+            child: const Text('Run Mutation'),
           ),
         ),
         Padding(padding: EdgeInsets.all(5.0)),
-        RaisedButton(
-          child: Text("Cancel"),
+        ElevatedButton(
+          child: const Text("Cancel"),
           onPressed: onCancelPressed,
         ),
         Text('Result: \n$_result\n'),

--- a/packages/amplify_api/example/lib/main.dart
+++ b/packages/amplify_api/example/lib/main.dart
@@ -71,11 +71,11 @@ class _MyAppState extends State<MyApp> {
               title: Padding(
                   padding: EdgeInsets.all(10.0),
                   child: Row(children: [
-                    RaisedButton(
-                        child: Text("Rest API"),
+                    ElevatedButton(
+                        child: const Text("Rest API"),
                         onPressed: _onRestApiViewButtonClick),
-                    RaisedButton(
-                        child: Text("GraphQL API"),
+                    ElevatedButton(
+                        child: const Text("GraphQL API"),
                         onPressed: _onGraphQlApiViewButtonClick)
                   ]))),
           body: Padding(

--- a/packages/amplify_api/example/lib/rest_api_view.dart
+++ b/packages/amplify_api/example/lib/rest_api_view.dart
@@ -162,31 +162,31 @@ class _RestApiViewState extends State<RestApiView> {
         decoration:
             InputDecoration(border: OutlineInputBorder(), labelText: "apiPath"),
       ),
-      RaisedButton(
-        child: Text("Post"),
+      ElevatedButton(
+        child: const Text("Post"),
         onPressed: onPostPressed,
       ),
-      RaisedButton(
-        child: Text("Put"),
+      ElevatedButton(
+        child: const Text("Put"),
         onPressed: onPutPressed,
       ),
-      RaisedButton(
-        child: Text("Get"),
+      ElevatedButton(
+        child: const Text("Get"),
         onPressed: onGetPressed,
       ),
-      RaisedButton(
-        child: Text("Cancel"),
+      ElevatedButton(
+        child: const Text("Cancel"),
         onPressed: onCancelPressed,
       ),
-      RaisedButton(
-        child: Text("Delete"),
+      ElevatedButton(
+        child: const Text("Delete"),
         onPressed: onDeletePressed,
       ),
-      RaisedButton(
-        child: Text("Head"),
+      ElevatedButton(
+        child: const Text("Head"),
         onPressed: onHeadPressed,
       ),
-      RaisedButton(child: Text("Patch"), onPressed: onPatchPressed),
+      ElevatedButton(child: const Text("Patch"), onPressed: onPatchPressed),
     ]);
   }
 }

--- a/packages/amplify_auth_cognito/example/lib/Widgets/ConfirmResetWidget.dart
+++ b/packages/amplify_auth_cognito/example/lib/Widgets/ConfirmResetWidget.dart
@@ -66,12 +66,12 @@ class _ConfirmWidgetState extends State<ConfirmResetWidget> {
                     labelText: 'Confirmation Code *',
                   )),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: _confirmReset,
                 child: const Text('Confirm Password Reset'),
               ),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 key: Key('goto-signin-button'),
                 onPressed: widget.backToSignIn,
                 child: const Text('Back to Sign In'),

--- a/packages/amplify_auth_cognito/example/lib/Widgets/ConfirmSignInWidget.dart
+++ b/packages/amplify_auth_cognito/example/lib/Widgets/ConfirmSignInWidget.dart
@@ -50,12 +50,12 @@ class _ConfirmSignInWidgetState extends State<ConfirmSignInWidget> {
                     labelText: 'Challange Response *',
                   )),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: _confirmSignIn,
                 child: const Text('Confirm SignIn'),
               ),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 key: Key('goto-signin-button'),
                 onPressed: widget.backToSignIn,
                 child: const Text('Back to Sign In'),

--- a/packages/amplify_auth_cognito/example/lib/Widgets/ConfirmSignUpWidget.dart
+++ b/packages/amplify_auth_cognito/example/lib/Widgets/ConfirmSignUpWidget.dart
@@ -72,18 +72,18 @@ class _ConfirmSignUpWidgetState extends State<ConfirmSignUpWidget> {
                     labelText: 'Confirmation Code *',
                   )),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 key: Key('confirm-user-button'),
                 onPressed: _confirmSignUp,
                 child: const Text('Confirm SignUp'),
               ),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: _resendSignUpCode,
                 child: const Text('ResendCode'),
               ),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 key: Key('goto-signin-button'),
                 onPressed: widget.backToSignIn,
                 child: const Text('Back to Sign In'),

--- a/packages/amplify_auth_cognito/example/lib/Widgets/SignInWidget.dart
+++ b/packages/amplify_auth_cognito/example/lib/Widgets/SignInWidget.dart
@@ -84,32 +84,32 @@ class _SignInWidgetState extends State<SignInWidget> {
                 childAspectRatio: 3,
                 padding: const EdgeInsets.all(5.0),
                 children: [
-                  RaisedButton(
+                  ElevatedButton(
                     key: Key('signin-button'),
                     onPressed: _signIn,
                     child: const Text('Sign In'),
                   ),
-                  RaisedButton(
+                  ElevatedButton(
                     key: Key('goto-signup-button'),
                     onPressed: widget.showCreateUser,
                     child: const Text('Create User'),
                   ),
-                  RaisedButton(
+                  ElevatedButton(
                     key: Key('reset-button'),
                     onPressed: _resetPassword,
                     child: const Text('Reset Password'),
                   ),
-                  RaisedButton(
+                  ElevatedButton(
                     key: Key('signout-button'),
                     onPressed: widget.signOut,
                     child: const Text('SignOut'),
                   ),
-                  RaisedButton(
+                  ElevatedButton(
                     key: Key('session-button'),
                     onPressed: widget.fetchSession,
                     child: const Text('Get Session'),
                   ),
-                  RaisedButton(
+                  ElevatedButton(
                     key: Key('current-user-button'),
                     onPressed: widget.getCurrentUser,
                     child: const Text('Get Current User'),

--- a/packages/amplify_auth_cognito/example/lib/Widgets/SignUpWidget.dart
+++ b/packages/amplify_auth_cognito/example/lib/Widgets/SignUpWidget.dart
@@ -88,13 +88,13 @@ class _SignUpWidgetState extends State<SignUpWidget> {
                 ),
               ),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 key: Key('signup-button'),
                 onPressed: _signUp,
                 child: const Text('Sign Up'),
               ),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 key: Key('goto-signin-button'),
                 onPressed: widget.backToSignIn,
                 child: const Text('Back to Sign In'),

--- a/packages/amplify_auth_cognito/example/lib/Widgets/UpdatePasswordWidget.dart
+++ b/packages/amplify_auth_cognito/example/lib/Widgets/UpdatePasswordWidget.dart
@@ -59,17 +59,17 @@ class _UpdatePasswordWidgetState extends State<UpdatePasswordWidget> {
                     labelText: 'New Password *',
                   )),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: _updatePassword,
                 child: const Text('Update Password'),
               ),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: widget.backToApp,
                 child: const Text('Back to App'),
               ),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 key: Key('goto-signin-button'),
                 onPressed: widget.backToSignIn,
                 child: const Text('Back to Sign In'),

--- a/packages/amplify_auth_cognito/example/lib/main.dart
+++ b/packages/amplify_auth_cognito/example/lib/main.dart
@@ -210,27 +210,27 @@ class _MyAppState extends State<MyApp> {
               const Padding(padding: EdgeInsets.all(10.0)),
               Text("You are signed in!"),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: _signOut,
                 child: const Text('Sign Out'),
               ),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: _showUpdatePassword,
                 child: const Text('Change Password'),
               ),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: _stopListening,
                 child: const Text('Stop Listening'),
               ),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: _fetchSession,
                 child: const Text('Get Session'),
               ),
               const Padding(padding: EdgeInsets.all(10.0)),
-              RaisedButton(
+              ElevatedButton(
                   onPressed: _getCurrentUser,
                   child: const Text('Get CurrentUser'))
             ],
@@ -321,7 +321,7 @@ class _MyAppState extends State<MyApp> {
                             showResult, changeDisplay, setError, _backToSignIn),
                       if (this.displayState == "SIGNED_IN") showApp(),
                       if (this.error != "") showErrors(),
-                      RaisedButton(
+                      ElevatedButton(
                         key: Key('configure-button'),
                         onPressed:
                             _isAmplifyConfigured ? null : _configureAmplify,

--- a/packages/amplify_datastore/example/lib/main.dart
+++ b/packages/amplify_datastore/example/lib/main.dart
@@ -47,19 +47,19 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  List<Post> _posts = List();
-  List<Comment> _comments = List();
-  List<Blog> _blogs = List();
-  List<Post> _posts4rating = List();
-  List<Post> _posts1To4Rating = List();
-  List<Post> _postWithCreatedDate = List();
-  List<Post> _posts2Or5Rating = List();
-  List<Post> _postWithIdNotEquals = List();
-  List<Post> _firstPostFromResult = List();
-  List<Post> _allPostsWithoutRating2Or5 = List();
-  List<String> _postStreamingData = List();
-  List<String> _blogStreamingData = List();
-  List<String> _commentStreamingData = List();
+  List<Post> _posts = <Post>[];
+  List<Comment> _comments = <Comment>[];
+  List<Blog> _blogs = <Blog>[];
+  List<Post> _posts4rating = <Post>[];
+  List<Post> _posts1To4Rating = <Post>[];
+  List<Post> _postWithCreatedDate = <Post>[];
+  List<Post> _posts2Or5Rating = <Post>[];
+  List<Post> _postWithIdNotEquals = <Post>[];
+  List<Post> _firstPostFromResult = <Post>[];
+  List<Post> _allPostsWithoutRating2Or5 = <Post>[];
+  List<String> _postStreamingData = <String>[];
+  List<String> _blogStreamingData = <String>[];
+  List<String> _commentStreamingData = <String>[];
   bool _isAmplifyConfigured = false;
   String _queriesToView = "Post"; //default view
   Blog _selectedBlogForNewPost;
@@ -154,16 +154,16 @@ class _MyAppState extends State<MyApp> {
   }
 
   void runQueries() async {
-    List<Post> allPosts = List();
-    List<Comment> allComments = List();
-    List<Blog> allBlogs = List();
-    List<Post> posts4Rating = List();
-    List<Post> posts1To4Rating = List();
-    List<Post> posts2Or5Rating = List();
-    List<Post> postWithCreatedDate = List();
-    List<Post> postWithIdNotEquals = List();
-    List<Post> firstPostFromResult = List();
-    List<Post> allPostsWithoutRating2Or5 = List();
+    List<Post> allPosts = <Post>[];
+    List<Comment> allComments = <Comment>[];
+    List<Blog> allBlogs = <Blog>[];
+    List<Post> posts4Rating = <Post>[];
+    List<Post> posts1To4Rating = <Post>[];
+    List<Post> posts2Or5Rating = <Post>[];
+    List<Post> postWithCreatedDate = <Post>[];
+    List<Post> postWithIdNotEquals = <Post>[];
+    List<Post> firstPostFromResult = <Post>[];
+    List<Post> allPostsWithoutRating2Or5 = <Post>[];
 
     // get all comments
     (await Amplify.DataStore.query(Comment.classType)).forEach((element) {

--- a/packages/amplify_datastore/example/lib/save_model_widgets.dart
+++ b/packages/amplify_datastore/example/lib/save_model_widgets.dart
@@ -12,7 +12,7 @@ Widget addBlogWidget(TextEditingController controller, bool isAmplifyConfigured,
         ),
       ),
       divider,
-      RaisedButton(
+      ElevatedButton(
         onPressed: () async {
           if (isAmplifyConfigured) {
             await saveFn(controller.text);
@@ -21,7 +21,7 @@ Widget addBlogWidget(TextEditingController controller, bool isAmplifyConfigured,
           }
           return null;
         },
-        child: Text('Save Blog'),
+        child: const Text('Save Blog'),
       ),
       divider,
     ],
@@ -73,7 +73,7 @@ Widget addPostWidget(
             });
           }),
       divider,
-      RaisedButton(
+      ElevatedButton(
         onPressed: () async {
           if (isAmplifyConfigured) {
             await saveFn(titleController.text, int.parse(ratingController.text),
@@ -84,7 +84,7 @@ Widget addPostWidget(
           }
           return null;
         },
-        child: Text('Save Post'),
+        child: const Text('Save Post'),
       ),
       divider,
     ],
@@ -123,7 +123,7 @@ Widget addCommentWidget(
             });
           }),
       divider,
-      RaisedButton(
+      ElevatedButton(
         onPressed: () async {
           if (isAmplifyConfigured) {
             await saveFn(controller.text, app._selectedPostForNewComment);
@@ -132,7 +132,7 @@ Widget addCommentWidget(
           }
           return null;
         },
-        child: Text('Save Comment'),
+        child: const Text('Save Comment'),
       ),
       divider,
     ],

--- a/packages/amplify_storage_s3/example/lib/main.dart
+++ b/packages/amplify_storage_s3/example/lib/main.dart
@@ -141,33 +141,33 @@ class _MyAppState extends State<MyApp> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: <Widget>[
                   const Padding(padding: EdgeInsets.all(10.0)),
-                  RaisedButton(
+                  ElevatedButton(
                     onPressed: _isAmplifyConfigured ? null : configureAmplify,
                     child: const Text('Configure'),
                   ),
                   const Padding(padding: EdgeInsets.all(5.0)),
                   Text('Amplify Configured: $_isAmplifyConfigured'),
                   const Padding(padding: EdgeInsets.all(10.0)),
-                  RaisedButton(
+                  ElevatedButton(
                     onPressed: upload,
                     child: const Text('Upload File'),
                   ),
                   const Padding(padding: EdgeInsets.all(5.0)),
                   Text('Uploaded File: $_uploadFileResult'),
                   const Padding(padding: EdgeInsets.all(5.0)),
-                  RaisedButton(
+                  ElevatedButton(
                     onPressed: remove,
                     child: const Text('Remove uploaded File'),
                   ),
                   const Padding(padding: EdgeInsets.all(5.0)),
                   Text('Removed File: $_removeResult'),
                   const Padding(padding: EdgeInsets.all(5.0)),
-                  RaisedButton(
+                  ElevatedButton(
                     onPressed: list,
                     child: const Text('List Files'),
                   ),
                   const Padding(padding: EdgeInsets.all(5.0)),
-                  RaisedButton(
+                  ElevatedButton(
                     onPressed: getUrl,
                     child: const Text('GetUrl for uploaded File'),
                   ),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`RaisedButton` https://api.flutter.dev/flutter/material/RaisedButton-class.html is obsolete. we should use `ElevatedButton` https://api.flutter.dev/flutter/material/ElevatedButton-class.html instead.

We should use `DO use collection literals when possible.`
https://dart.dev/guides/language/effective-dart/usage#do-use-collection-literals-when-possible


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
