### PR TITLE
chore(amplify_flutter): Revert isConfigured in favor of throwing specific exception in future

### DIFF
--- a/packages/amplify_flutter/lib/amplify.dart
+++ b/packages/amplify_flutter/lib/amplify.dart
@@ -58,10 +58,9 @@ class AmplifyClass extends PlatformInterface {
   AmplifyHub Hub = AmplifyHub();
 
   /// Adds one plugin at a time. Note: this method can only
-  /// be called before Amplify has been configured. Customers are expected
-  /// to check the configuration state by calling `Amplify.isConfigured`
+  /// be called before Amplify has been configured.
   Future<void> addPlugin(AmplifyPluginInterface plugin) async {
-    if (!isConfigured) {
+    if (!_isConfigured) {
       try {
         if (plugin is AuthPluginInterface) {
           Auth.addPlugin(plugin);
@@ -91,18 +90,12 @@ class AmplifyClass extends PlatformInterface {
   }
 
   /// Adds multiple plugins at the same time. Note: this method can only
-  /// be called before Amplify has been configured. Customers are expected
-  /// to check the configuration state by calling `Amplify.isConfigured`
+  /// be called before Amplify has been configured.
   Future<void> addPlugins(List<AmplifyPluginInterface> plugins) async {
     plugins.forEach((plugin) async {
       await addPlugin(plugin);
     });
     return;
-  }
-
-  /// Returns whether Amplify has been configured or not.
-  bool get isConfigured {
-    return _isConfigured;
   }
 
   String _getVersion() {
@@ -112,13 +105,11 @@ class AmplifyClass extends PlatformInterface {
   /// Configures Amplify with the provided configuration string.
   /// This method can only be called once, after all the plugins
   /// have been added and no plugin shall be added after amplify
-  /// is configured. Clients are expected to call `Amplify.isConfigured`
-  /// to check if their app is configured before calling this method.
+  /// is configured.
   Future<void> configure(String configuration) async {
-    if (isConfigured) {
+    if (_isConfigured) {
       throw StateError(
-          "Amplify has already been configured and re-configuration is not supported. " +
-              "Please use Amplify.isConfigured to check before calling configure again.");
+          "Amplify has already been configured and re-configuration is not supported.");
     }
     assert(configuration != null, 'configuration is null');
     var res = await AmplifyClass.instance

--- a/packages/amplify_flutter/lib/amplify_hub.dart
+++ b/packages/amplify_flutter/lib/amplify_hub.dart
@@ -17,18 +17,16 @@ import 'dart:async';
 
 import 'package:amplify_core/types/index.dart';
 import 'package:flutter/foundation.dart';
-import 'package:amplify_core/types/hub/HubEvent.dart';
 import 'amplify.dart';
 
 typedef void Listener(dynamic event);
 
 class AmplifyHub {
-
   final Map<HubChannel, Stream> availableStreams = {};
 
   /// Expose listen method which instantiates new StreamController listening to one or more availableStreams
-  StreamSubscription listen(List<HubChannel> channels, @required Listener listener) {
-
+  StreamSubscription listen(
+      List<HubChannel> channels, @required Listener listener) {
     List<StreamSubscription> platformSubscriptions = [];
     StreamController controller;
 
@@ -39,29 +37,28 @@ class AmplifyHub {
     }
 
     controller = StreamController.broadcast(
-      onListen: () {
-        channels.forEach((c) {
-          if (availableStreams[c] != null) {
-            StreamSubscription subscription = availableStreams[c].listen((msg) {
-              /// Emit events via Hub
-              controller.add(msg);
-            });
-            platformSubscriptions.add(subscription);
-          } else {
-            print('You are attempting to listen to a plugin that has not been added.');
-          }
-      });
-    },
-      onCancel: cancelPluginStreams
-    );
+        onListen: () {
+          channels.forEach((c) {
+            if (availableStreams[c] != null) {
+              StreamSubscription subscription =
+                  availableStreams[c].listen((msg) {
+                /// Emit events via Hub
+                controller.add(msg);
+              });
+              platformSubscriptions.add(subscription);
+            } else {
+              print(
+                  'You are attempting to listen to a plugin that has not been added.');
+            }
+          });
+        },
+        onCancel: cancelPluginStreams);
 
     return controller.stream.listen(listener);
   }
 
   /// Adds Plugin level streams in preparation for 'listen'
-  void addChannel(HubChannel name, StreamController controller) async  {
-    if (!Amplify.isConfigured) {
-      availableStreams[name] = controller.stream;
-    }
+  void addChannel(HubChannel name, StreamController controller) async {
+    availableStreams[name] = controller.stream;
   }
 }

--- a/packages/amplify_flutter/test/amplify_test.dart
+++ b/packages/amplify_flutter/test/amplify_test.dart
@@ -25,14 +25,11 @@ void main() {
   AmplifyClass amplify;
   String dummyConfiguration = "dummy";
   String amplifyAlreadyConfiguredError =
-      "Amplify has already been configured and re-configuration is not supported. " +
-          "Please use Amplify.isConfigured to check before calling configure again.";
+      "Amplify has already been configured and re-configuration is not supported.";
   String amplifyAlreadyConfiguredForAddPluginError =
       "Amplify is already configured. Adding plugins after configure is not supported.";
   String multiplePluginsForAuthError = "Auth plugin has already been added, " +
       "multiple plugins for Auth category are currently not supported.";
-  String amplifyConfigureFailedError = "Amplify failed to configure. " +
-      "Please raise an issue in amplify-flutter repository.";
 
   TestWidgetsFlutterBinding.ensureInitialized();
 

--- a/packages/amplify_flutter/test/amplify_test.dart
+++ b/packages/amplify_flutter/test/amplify_test.dart
@@ -62,27 +62,6 @@ void main() {
         .catchError((e) => expect(e, isAssertionError));
   });
 
-  test('before calling configure, isConfigure should be false', () {
-    expect(amplify.isConfigured, false);
-  });
-
-  test('after calling configure, isConfigure should be true', () async {
-    await amplify.configure(dummyConfiguration);
-    expect(amplify.isConfigured, true);
-  });
-
-  test('Failed configure should result in isConfigure to be false', () async {
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
-      return false; // configuration failed
-    });
-    try {
-      await amplify.configure(dummyConfiguration);
-    } catch (e) {
-      expect(e, amplifyConfigureFailedError);
-    }
-    expect(amplify.isConfigured, false);
-  });
-
   test('calling configure twice results in an error', () async {
     await amplify.configure(dummyConfiguration);
     try {
@@ -100,13 +79,11 @@ void main() {
     await amplify
         .addPlugins([AmplifyAuthCognito(), AmplifyAnalyticsPinpoint()]);
     await amplify.configure(dummyConfiguration);
-    expect(amplify.isConfigured, true);
   });
 
   test("adding single plugins using addPlugin method doesn't throw", () async {
     await amplify.addPlugin(AmplifyAuthCognito());
     await amplify.configure(dummyConfiguration);
-    expect(amplify.isConfigured, true);
   });
 
   test("adding multiple plugins from same Auth category throws error",
@@ -125,7 +102,6 @@ void main() {
   test("adding plugins after configure throws an error", () async {
     await amplify.addPlugin(AmplifyAuthCognito());
     await amplify.configure(dummyConfiguration);
-    expect(amplify.isConfigured, true);
     try {
       await amplify.addPlugin(AmplifyAnalyticsPinpoint());
     } catch (e) {


### PR DESCRIPTION
*Issue #, if available:* Revert https://github.com/aws-amplify/amplify-flutter/pull/303

*Description of changes:*
After discussing internally, we decided against adding this new API. Rather amplify will throw a new `AmplifyAlreadyConfiguredException` when customers try to configure Amplify again. The exception will be added in the next release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
