### PR TITLE
chore(amplify_auth_cognito): Bump Amplify version

### DIFF
--- a/packages/amplify_auth_cognito/android/build.gradle
+++ b/packages/amplify_auth_cognito/android/build.gradle
@@ -58,7 +58,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:aws-auth-cognito:1.6.8'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.6.10'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.mockito:mockito-inline:3.1.0'


### PR DESCRIPTION
Update aws-auth-cognito version for Android.

*Issue #, if available:*

This fixes #271 and #276.

*Description of changes:*

The the custom challenge answer was fixed in aws-amplify/aws-sdk-android#2316. It was released in version v2.21.0 of the AWS Android SDK, which was included in the version 1.6.9 of the Amplify Android SDK.

