### PR TITLE
fix(amplify_auth_cognito): force user attribute to be string

### DIFF
--- a/packages/amplify_auth_plugin_interface/lib/src/SignUp/SignUpOptions.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/SignUp/SignUpOptions.dart
@@ -16,7 +16,7 @@
 import 'package:flutter/foundation.dart';
 
 class SignUpOptions {
-  final Map<String, dynamic> userAttributes;
+  final Map<String, String> userAttributes;
   const SignUpOptions({@required this.userAttributes});
 
   Map<String, dynamic> serializeAsMap() {


### PR DESCRIPTION
*Description of changes:*
Changes interface to only allows Strings for user attribute on signup. This accomodates amplify-android signUp API, and avoids the need to either expand our API surface or do extensive parsing on platform side. Custom attributes that are 'Numbers' will still be created as such, and will still be parsed as such when customers request them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
