### PR TITLE
fix(amplify_auth_cognito): accounts for zoneinfo camelcase in Android

### DIFF
--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterSignUpRequest.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterSignUpRequest.kt
@@ -46,7 +46,11 @@ data class FlutterSignUpRequest(val map: HashMap<String, *>) {
                 }
                 authUserAttributes.add(AuthUserAttribute(AuthUserAttributeKey.custom(keyCopy), value))
             } else {
-                var t: Method = attributeMethods.asIterable().find { it.name.equals(convertSnakeToCamel(key)) } as Method;
+                // special case for amplify-android camelCase zoneinfo
+                if (key == "zoneinfo") {
+                    keyCopy = "zoneInfo"
+                }
+                var t: Method = attributeMethods.asIterable().find { it.name.equals(convertSnakeToCamel(keyCopy)) } as Method;
                 var attr: AuthUserAttributeKey = t.invoke(null) as AuthUserAttributeKey;
                 authUserAttributes.add(AuthUserAttribute(attr, value));
             }


### PR DESCRIPTION
*Description of changes:*
Accounts for amplify-android using camel case version of 'zoneinfo'.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
