### PR TITLE
fix(amplify_auth_cognito): android throws SessionExpiredException

### DIFF
--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
@@ -477,7 +477,7 @@ public class AuthCognito : FlutterPlugin, ActivityAware, MethodCallHandler, Plug
   }
 
   fun prepareCognitoSessionFailure(@NonNull flutterResult: Result, @NonNull result: AWSCognitoAuthSession) {
-    errorHandler.handleAuthError(flutterResult, AuthException.SignedOutException())
+    errorHandler.handleAuthError(flutterResult, AuthException.SessionExpiredException())
   }
 
   fun prepareSessionResult(@NonNull flutterResult: Result, @NonNull result: AuthSession) {


### PR DESCRIPTION
*Description of changes:*
This PR makes Android throw SessionExpiredException instead of SignedOutException, when session fails. This creates consistency with amplify-ios (and also makes logical sense).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
