### PR TITLE
fix(amplify_datastore): Save enum lists properly in iOS

### DIFF
--- a/packages/amplify_datastore/ios/Classes/types/model/FlutterModelFieldType.swift
+++ b/packages/amplify_datastore/ios/Classes/types/model/FlutterModelFieldType.swift
@@ -105,6 +105,8 @@ public struct FlutterModelFieldType {
             return Temporal.Date.self
         case "timestamp":
             return Int64.self
+        case "enumeration":
+            return String.self
         default:
             throw DataStoreError.decodingError(typeName + "is not a known primitive type",
                                                ErrorMessages.missingRecoverySuggestion)


### PR DESCRIPTION
*Issue #, if available:* fixes: https://github.com/aws-amplify/amplify-flutter/issues/363

*Description of changes:* Save enum lists properly in iOS


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
