### PR TITLE
fix(amplify_analytics): fix analyticsProperties

### DIFF
--- a/packages/amplify_analytics_pinpoint/android/src/main/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/AmplifyAnalyticsBridge.kt
+++ b/packages/amplify_analytics_pinpoint/android/src/main/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/AmplifyAnalyticsBridge.kt
@@ -55,9 +55,17 @@ class AmplifyAnalyticsBridge {
         }
 
         fun registerGlobalProperties(@NonNull arguments: Any, @NonNull result: MethodChannel.Result) {
-            val globalProperties = arguments as HashMap<String, Any>
+            val argumentsMap = arguments as HashMap<*, *>
+            var properties : HashMap<String, Any>
+
+            properties = if(argumentsMap.containsKey("propertiesMap")){
+                argumentsMap["propertiesMap"] as HashMap<String, Any>;
+            } else{
+                HashMap<String, Any>()
+            }
+
             Amplify.Analytics.registerGlobalProperties(
-                    AmplifyAnalyticsBuilder.createAnalyticsProperties(globalProperties))
+                    AmplifyAnalyticsBuilder.createAnalyticsProperties(properties))
             result.success(true)
         }
 

--- a/packages/amplify_analytics_pinpoint/android/src/main/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/AmplifyAnalyticsBuilder.kt
+++ b/packages/amplify_analytics_pinpoint/android/src/main/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/AmplifyAnalyticsBuilder.kt
@@ -98,9 +98,12 @@ class AmplifyAnalyticsBuilder {
                         val locationMap = item.value as HashMap<String, String>
                         userProfileBuilder.location(createUserLocation(locationMap))
                     }
-                    "properties" -> {
+                    "propertiesMap" -> {
                         val propertiesMap = item.value as HashMap<String, Any>
                         userProfileBuilder.customProperties(createAnalyticsProperties(propertiesMap))
+                    }
+                    "propertiesTypesMap" -> {
+                        // Ignore, we can infer types just using propertiesMap
                     }
                     // This case should not be possible as UserProfile is typed on Dart side
                     else -> {

--- a/packages/amplify_analytics_pinpoint/android/src/test/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/AmplifyAnalyticsPinpointPluginTest.kt
+++ b/packages/amplify_analytics_pinpoint/android/src/test/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/AmplifyAnalyticsPinpointPluginTest.kt
@@ -72,9 +72,17 @@ class AmplifyAnalyticsPinpointPluginTest {
                 "AnalyticsDoubleProperty" to 3.14,
                 "AnalyticsIntegerProperty" to 42
         )
+        val propertiesTypesMap = hashMapOf<String, Any>(
+                "AnalyticsStringProperty" to "STRING",
+                "AnalyticsBooleanProperty" to "BOOL",
+                "AnalyticsDoubleProperty" to "DOUBLE",
+                "AnalyticsIntegerProperty" to "INT"
+        )
+
         val arguments: HashMap<*, *> = hashMapOf(
                 "name" to "amplify-event",
-                "propertiesMap" to propertiesMap
+                "propertiesMap" to propertiesMap,
+                "propertiesTypesMap" to propertiesTypesMap
         )
 
         val call = MethodCall("recordEvent", arguments)
@@ -101,8 +109,19 @@ class AmplifyAnalyticsPinpointPluginTest {
                 "AnalyticsDoubleProperty" to 3.14,
                 "AnalyticsIntegerProperty" to 42
         )
+        val propertiesTypesMap = hashMapOf<String, Any>(
+                "AnalyticsStringProperty" to "STRING",
+                "AnalyticsBooleanProperty" to "BOOL",
+                "AnalyticsDoubleProperty" to "DOUBLE",
+                "AnalyticsIntegerProperty" to "INT"
+        )
 
-        val call = MethodCall("registerGlobalProperties", propertiesMap)
+        val arguments: HashMap<*, *> = hashMapOf(
+                "propertiesMap" to propertiesMap,
+                "propertiesTypesMap" to propertiesTypesMap
+        )
+
+        val call = MethodCall("registerGlobalProperties", arguments)
         var mockResult: MethodChannel.Result = mock(MethodChannel.Result::class.java)
         plugin.onMethodCall(call, mockResult)
         verify(mockResult).success(true)
@@ -123,13 +142,18 @@ class AmplifyAnalyticsPinpointPluginTest {
                 "TestStringProperty" to "TestStringValue",
                 "TestDoubleProperty" to 1.0
         )
+        val customPropertiesTypesMap = hashMapOf<String, Any>(
+                "TestStringProperty" to "STRING",
+                "TestDoubleProperty" to "DOUBLE"
+        )
 
         val userProfileMap = hashMapOf<String, Any>(
                 "name" to "test-user",
                 "email" to "user@test.com",
                 "plan" to "test-plan",
                 "location" to locationMap,
-                "properties" to customPropertiesMap
+                "propertiesMap" to customPropertiesMap,
+                "propertiesTypesMap" to customPropertiesTypesMap
         )
 
         val userMap = hashMapOf<String, Any>(

--- a/packages/amplify_analytics_pinpoint/example/ios/unit_tests/AnalyticsUnitTests.swift
+++ b/packages/amplify_analytics_pinpoint/example/ios/unit_tests/AnalyticsUnitTests.swift
@@ -72,9 +72,16 @@ class AnalyticsUnitTests: XCTestCase {
             "AnalyticsDoubleProperty" : 3.14,
             "AnalyticsIntegerProperty" : 42
         ]
+        let propertiesTypesMap : [String : String] = [
+            "AnalyticsStringProperty" : "STRING",
+            "AnalyticsBooleanProperty" : "BOOL",
+            "AnalyticsDoubleProperty" : "DOUBLE",
+            "AnalyticsIntegerProperty" : "INT"
+        ]
         let arguments: [String : Any] = [
             "name" : "amplify-event",
-            "propertiesMap" : propertiesMap
+            "propertiesMap" : propertiesMap,
+            "propertiesTypesMap" : propertiesTypesMap
         ]
         
         pluginUnderTest.innerHandle(
@@ -129,10 +136,20 @@ class AnalyticsUnitTests: XCTestCase {
             "AnalyticsDoubleProperty" : 3.14,
             "AnalyticsIntegerProperty" : 42
         ]
+        let propertiesTypesMap : [String : String] = [
+            "AnalyticsStringProperty" : "STRING",
+            "AnalyticsBooleanProperty" : "BOOL",
+            "AnalyticsDoubleProperty" : "DOUBLE",
+            "AnalyticsIntegerProperty" : "INT"
+        ]
+        let arguments: [String : Any] = [
+            "propertiesMap" : propertiesMap,
+            "propertiesTypesMap" : propertiesTypesMap
+        ]
         
         pluginUnderTest.innerHandle(
             method: "registerGlobalProperties",
-            callArgs: propertiesMap,
+            callArgs: arguments,
             result: { (results) in
                 XCTAssertEqual(results as! Bool, true)
             }
@@ -181,13 +198,20 @@ class AnalyticsUnitTests: XCTestCase {
             "TestBoolProperty" : true,
             "TestIntProperty" : 1
         ]
+        let customPropertiesTypesMap : [String : String] = [
+            "TestStringProperty" : "STRING",
+            "TestDoubleProperty" : "DOUBLE",
+            "TestBoolProperty" : "BOOL",
+            "TestIntProperty" : "INT"
+        ]
 
         let userProfileMap : [String : Any] = [
             "name" : "test-user",
             "email" : "user.com",
             "plan" : "test-plan",
             "location" : locationMap,
-            "properties" : customPropertiesMap
+            "propertiesMap" : customPropertiesMap,
+            "propertiesTypesMap" : customPropertiesTypesMap
         ]
 
         let userMap : [String : Any] = [

--- a/packages/amplify_analytics_pinpoint/example/lib/main.dart
+++ b/packages/amplify_analytics_pinpoint/example/lib/main.dart
@@ -70,6 +70,7 @@ class _MyAppState extends State<MyApp> {
     print("register global properties: " + _globalProp);
 
     AnalyticsProperties properties = new AnalyticsProperties();
+    properties.addIntProperty(_globalProp + "_1numKey", 1);
     properties.addBoolProperty(_globalProp + "_boolKey", true);
     properties.addDoubleProperty(_globalProp + "_doubleKey", 10.0);
     properties.addIntProperty(_globalProp + "_intKey", 10);
@@ -115,6 +116,9 @@ class _MyAppState extends State<MyApp> {
 
     AnalyticsProperties properties = new AnalyticsProperties();
     properties.addStringProperty(_userId + "_stringKey", "stringValue");
+    properties.addIntProperty(_userId + "_intKey", 10);
+    properties.addDoubleProperty(_userId + "_doubleKey", 10.0);
+    properties.addBoolProperty(_userId + "_boolKey", false);
 
     analyticsUserProfile.properties = properties;
 

--- a/packages/amplify_analytics_pinpoint/ios/Classes/AmplifyAnalyticsBuilder.swift
+++ b/packages/amplify_analytics_pinpoint/ios/Classes/AmplifyAnalyticsBuilder.swift
@@ -18,8 +18,27 @@ import AmplifyPlugins
 
 public class AmplifyAnalyticsBuilder {
 
-    public static func createAnalyticsProperties(propertiesMap : Dictionary<String, Any>) -> AnalyticsProperties{
-        return propertiesMap as? AnalyticsProperties ?? [:]
+    public static func createAnalyticsProperties(map : [String: Any]) -> AnalyticsProperties{
+        let propertiesMap = map["propertiesMap"] as! [String: Any]
+        let propertiesTypesMap = map["propertiesTypesMap"] as! [String: String]
+        
+        var analyticsProperties = AnalyticsProperties()
+        
+        for (key,value) in propertiesTypesMap {
+            switch value{
+                case "STRING":
+                    analyticsProperties[key] = propertiesMap[key] as! String
+                case "INT":
+                    analyticsProperties[key] = propertiesMap[key] as! Int
+                case "DOUBLE":
+                    analyticsProperties[key] = propertiesMap[key] as! Double
+                case "BOOL":
+                    analyticsProperties[key] = propertiesMap[key] as! Bool
+                default:
+                    print("Unknown type for AnalyticsProperties")
+            }
+        }
+        return analyticsProperties
     }
 
     public static func createUserProfile(userProfileMap : Dictionary<String, Any>) -> AnalyticsUserProfile{
@@ -37,9 +56,8 @@ public class AmplifyAnalyticsBuilder {
             case "location":
                 let locationMap = value as! Dictionary<String, Any>
                 userProfile.location = createUserLocation(userLocationMap: locationMap)
-            case "properties":
-                let propertiesMap = value as! Dictionary<String, Any>
-                userProfile.properties = createAnalyticsProperties(propertiesMap: propertiesMap)
+            case "propertiesMap":
+                userProfile.properties = createAnalyticsProperties(map: userProfileMap)
             // This case should not be possible as UserProfile is typed on Dart side
             default:
                 print("Unknown key for UserProfile")

--- a/packages/amplify_analytics_pinpoint/ios/Classes/AmplifyAnalyticsBuilder.swift
+++ b/packages/amplify_analytics_pinpoint/ios/Classes/AmplifyAnalyticsBuilder.swift
@@ -27,13 +27,13 @@ public class AmplifyAnalyticsBuilder {
         for (key,value) in propertiesTypesMap {
             switch value{
                 case "STRING":
-                    analyticsProperties[key] = propertiesMap[key] as! String
+                    analyticsProperties[key] = propertiesMap[key] as? String
                 case "INT":
-                    analyticsProperties[key] = propertiesMap[key] as! Int
+                    analyticsProperties[key] = propertiesMap[key] as? Int
                 case "DOUBLE":
-                    analyticsProperties[key] = propertiesMap[key] as! Double
+                    analyticsProperties[key] = propertiesMap[key] as? Double
                 case "BOOL":
-                    analyticsProperties[key] = propertiesMap[key] as! Bool
+                    analyticsProperties[key] = propertiesMap[key] as? Bool
                 default:
                     print("Unknown type for AnalyticsProperties")
             }
@@ -58,6 +58,9 @@ public class AmplifyAnalyticsBuilder {
                 userProfile.location = createUserLocation(userLocationMap: locationMap)
             case "propertiesMap":
                 userProfile.properties = createAnalyticsProperties(map: userProfileMap)
+            case "propertiesTypesMap":
+                // Can ignore this case as it is handled in propertiesMap above
+                continue
             // This case should not be possible as UserProfile is typed on Dart side
             default:
                 print("Unknown key for UserProfile")

--- a/packages/amplify_analytics_pinpoint/ios/Classes/FlutterAnalytics.swift
+++ b/packages/amplify_analytics_pinpoint/ios/Classes/FlutterAnalytics.swift
@@ -25,14 +25,12 @@ public class FlutterAnalytics {
     
     public static func record(arguments: Any?, result: @escaping FlutterResult, bridge: AnalyticsBridge){
         let argumentsMap = arguments as! Dictionary<String, Any>
-
         let name = argumentsMap["name"] as! String
-        
         let event: BasicAnalyticsEvent
         
         if(argumentsMap["propertiesMap"] != nil){
-            let propertiesMap = argumentsMap["propertiesMap"] as! Dictionary<String, Any>
-            event = BasicAnalyticsEvent(name: name, properties: AmplifyAnalyticsBuilder.createAnalyticsProperties(propertiesMap: propertiesMap))
+            let analyticsProperties = AmplifyAnalyticsBuilder.createAnalyticsProperties(map: argumentsMap)
+            event = BasicAnalyticsEvent(name: name, properties: analyticsProperties )
         }
         else{
             event = BasicAnalyticsEvent(name: name)
@@ -48,8 +46,9 @@ public class FlutterAnalytics {
     }
     
     public static func registerGlobalProperties(arguments: Any?, result: @escaping FlutterResult, bridge: AnalyticsBridge){
-        let propertiesMap = arguments as! Dictionary<String , Any>
-        bridge.registerGlobalProperties(analyticsProperties: AmplifyAnalyticsBuilder.createAnalyticsProperties(propertiesMap: propertiesMap))
+        let argumentsMap = arguments as! Dictionary<String, Any>
+        let analyticsProperties = AmplifyAnalyticsBuilder.createAnalyticsProperties(map: argumentsMap)
+        bridge.registerGlobalProperties(analyticsProperties: analyticsProperties)
         result(true);
     }
     

--- a/packages/amplify_analytics_pinpoint/lib/method_channel_amplify.dart
+++ b/packages/amplify_analytics_pinpoint/lib/method_channel_amplify.dart
@@ -32,6 +32,7 @@ class AmplifyAnalyticsPinpointMethodChannel extends AmplifyAnalyticsPinpoint {
       <String, Object>{
         'name': name,
         'propertiesMap': eventProperties.getAllProperties(),
+        'propertiesTypesMap': eventProperties.getAllPropertiesTypes()
       },
     );
   }
@@ -45,7 +46,12 @@ class AmplifyAnalyticsPinpointMethodChannel extends AmplifyAnalyticsPinpoint {
   Future<void> registerGlobalProperties(
       {AnalyticsProperties globalProperties}) async {
     await _channel.invokeMethod<bool>(
-        'registerGlobalProperties', globalProperties.getAllProperties());
+      'registerGlobalProperties',
+      <String, Object>{
+        'propertiesMap': globalProperties.getAllProperties(),
+        'propertiesTypesMap': globalProperties.getAllPropertiesTypes()
+      },
+    );
   }
 
   @override

--- a/packages/amplify_analytics_plugin_interface/lib/src/Analytics/AnalyticsProperties.dart
+++ b/packages/amplify_analytics_plugin_interface/lib/src/Analytics/AnalyticsProperties.dart
@@ -16,25 +16,34 @@
 class AnalyticsProperties {
 
   Map<String, Object> _properties = new Map<String,Object>();
+  Map<String, String> _propertiesTypes = new Map<String, String>();
 
   void addStringProperty(String key, String value){
     _properties[key] = value;
+    _propertiesTypes[key] = "STRING";
   }
 
   void addDoubleProperty(String key, double value){
     _properties[key] = value;
+    _propertiesTypes[key] = "DOUBLE";
   }
 
   void addBoolProperty(String key, bool value){
     _properties[key] = value;
+    _propertiesTypes[key] = "BOOL";
   }
 
   void addIntProperty(String key, int value){
     _properties[key] = value;
+    _propertiesTypes[key] = "INT";
   }
 
   Map<String, Object> getAllProperties(){
     return new Map<String, Object>.from(_properties);
+  }
+
+  Map<String, String> getAllPropertiesTypes(){
+    return new Map<String, String>.from(_propertiesTypes);
   }
 
 }

--- a/packages/amplify_analytics_plugin_interface/lib/src/Analytics/AnalyticsUserProfile.dart
+++ b/packages/amplify_analytics_plugin_interface/lib/src/Analytics/AnalyticsUserProfile.dart
@@ -51,7 +51,8 @@ class AnalyticsUserProfile {
       allProperties["location"] = location.getAllProperties();
     }
     if (properties != null) {
-      allProperties["properties"] = properties.getAllProperties();
+      allProperties["propertiesMap"] = properties.getAllProperties();
+      allProperties["propertiesTypesMap"] = properties.getAllPropertiesTypes();
     }
 
     return allProperties;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix sending of AnalyticsProperties in iOS 

Before iOS was converting Dart maps representing AnalyticsProperties to blank maps every time. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
