### PR TITLE
fix(amplify_storage_s3): Allow path to be null for Storage.list() in …

### DIFF
--- a/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/types/FlutterListRequest.kt
+++ b/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/types/FlutterListRequest.kt
@@ -49,7 +49,7 @@ data class FlutterListRequest(val request: Map<String, *>) {
     companion object {
         private const val validationErrorMessage: String = "List request malformed."
         fun validate(request: Map<String, *>) {
-            if(request["path"] !is String? || request["path"] == null) {
+            if(request["path"] !is String?) {
                 throw InvalidRequestException(validationErrorMessage, ExceptionMessages.missingAttribute.format( "path" ))
             }
         }


### PR DESCRIPTION
…Android

*Description of changes:*
Allow path to be null for Storage.list() in Android. 
This was a regression that got introduced during the error handling refactor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
