### PR TITLE
fix(amplify): upgrade plugin_platform_interface

### DIFF
--- a/packages/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/amplify_analytics_pinpoint/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   amplify_core: 0.1.0
   amplify_analytics_plugin_interface: 0.1.0
-  plugin_platform_interface: ^1.0.1
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/amplify_api/pubspec.yaml
+++ b/packages/amplify_api/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   amplify_core: 0.1.0
   amplify_api_plugin_interface: 0.1.0
-  plugin_platform_interface: ^1.0.1
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/amplify_auth_cognito/pubspec.yaml
+++ b/packages/amplify_auth_cognito/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   amplify_auth_plugin_interface: 0.1.0
   amplify_core: 0.1.0
-  plugin_platform_interface: ^1.0.1
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   flutter: ">=1.17.0 <2.0.0"
 
 dependencies:
-  plugin_platform_interface: ^1.0.1
   meta: ^1.1.8
+  plugin_platform_interface: ^2.0.0
   flutter:
     sdk: flutter
 

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -12,9 +12,8 @@ dependencies:
     sdk: flutter
   amplify_datastore_plugin_interface: 0.1.0
   amplify_core: 0.1.0
-  plugin_platform_interface: ^1.0.1
+  plugin_platform_interface: ^2.0.0
   date_time_format: ^1.1.0
-  uuid: ^2.2.2
   meta: ^1.1.8
   collection: ^1.14.13
 

--- a/packages/amplify_flutter/pubspec.yaml
+++ b/packages/amplify_flutter/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^1.0.1
+  plugin_platform_interface: ^2.0.0
   amplify_storage_plugin_interface: 0.1.0
   amplify_analytics_plugin_interface: 0.1.0
   amplify_auth_plugin_interface: 0.1.0

--- a/packages/amplify_storage_s3/pubspec.yaml
+++ b/packages/amplify_storage_s3/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   amplify_storage_plugin_interface: 0.1.0
-  plugin_platform_interface: ^1.0.1
+  plugin_platform_interface: ^2.0.0
   amplify_core: 0.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Update  plugin_platform_interface: ^1.0.1 -> ^2.0.0
To fix dependency conflicts with Firebase

*Issue #, if available:* #434
#461 

*Description of changes:*

Upgrade plugin platform interface to 2.0.0 to fix pubspec version conflicts with Firebase and other 3rd party dependencies. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
