### PR TITLE
chore(amplify_flutter): Add isConfigured API to Amplify

### DIFF
--- a/packages/amplify_flutter/lib/amplify.dart
+++ b/packages/amplify_flutter/lib/amplify.dart
@@ -62,12 +62,13 @@ class AmplifyClass extends PlatformInterface {
   AmplifyHub Hub = AmplifyHub();
 
   /// Adds one plugin at a time. Note: this method can only
-  /// be called before Amplify has been configured.
+  /// be called before Amplify has been configured. Customers are expected
+  /// to check the configuration state by calling `Amplify.isConfigured`
   ///
   /// Throws AmplifyAlreadyConfiguredException if
   /// this method is called after configure (e.g. during hot reload).
   Future<void> addPlugin(AmplifyPluginInterface plugin) async {
-    if (!_isConfigured) {
+    if (!isConfigured) {
       try {
         if (plugin is AuthPluginInterface) {
           Auth.addPlugin(plugin);
@@ -110,13 +111,14 @@ class AmplifyClass extends PlatformInterface {
       throw AmplifyAlreadyConfiguredException(
           'Amplify has already been configured and adding plugins after configure is not supported.',
           recoverySuggestion:
-              'Catch AmplifyAlreadyConfiguredException in your app to avoid this state.');
+              'Check if Amplify is already configured using Amplify.isConfigured.');
     }
     return;
   }
 
   /// Adds multiple plugins at the same time. Note: this method can only
-  /// be called before Amplify has been configured.
+  /// be called before Amplify has been configured. Customers are expected
+  /// to check the configuration state by calling `Amplify.isConfigured`
   Future<void> addPlugins(List<AmplifyPluginInterface> plugins) async {
     plugins.forEach((plugin) async {
       await addPlugin(plugin);
@@ -124,24 +126,30 @@ class AmplifyClass extends PlatformInterface {
     return;
   }
 
+  /// Returns whether Amplify has been configured or not.
+  bool get isConfigured {
+    return _isConfigured;
+  }
+
   String _getVersion() {
     return '0.1.0';
   }
 
   /// Configures Amplify with the provided configuration string.
-  /// This method can only be called once, after all the plugins
+  /// **This method can only be called once**, after all the plugins
   /// have been added and no plugin shall be added after amplify
-  /// is configured.
+  /// is configured. Customers are expected to call `Amplify.isConfigured`
+  /// to check if their app is configured before calling this method.
   ///
   /// Throws AmplifyAlreadyConfiguredException if
   /// this method is called again (e.g. during hot reload).
   Future<void> configure(String configuration) async {
     // Validation #1
-    if (_isConfigured) {
+    if (isConfigured) {
       throw AmplifyAlreadyConfiguredException(
           'Amplify has already been configured and re-configuration is not supported.',
           recoverySuggestion:
-              'Catch AmplifyAlreadyConfiguredException in your app to avoid this state.');
+              'Check if Amplify is already configured using Amplify.isConfigured.');
     }
 
     // Validation #2


### PR DESCRIPTION
*Issue #, if available:* fixes #412

*Description of changes:* Add a new API that customers can call to check if Amplify is already configured rather than having to catch a specific `AmplifyAlreadyConfiguredException`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
