### PR TITLE
fix(amplify): call return in addPlugin

### DIFF
--- a/packages/amplify_api/ios/Classes/SwiftAmplifyApiPlugin.swift
+++ b/packages/amplify_api/ios/Classes/SwiftAmplifyApiPlugin.swift
@@ -74,8 +74,8 @@ public class SwiftAmplifyApiPlugin: NSObject, FlutterPlugin {
                         print("Failed to add Amplify API Plugin \(error)")
                         result(false)
                     }
-                    return
                 }
+                return
             }
             
             let arguments = try FlutterApiRequest.getMap(args: callArgs as Any)

--- a/packages/amplify_auth_cognito/ios/Classes/SwiftAuthCognito.swift
+++ b/packages/amplify_auth_cognito/ios/Classes/SwiftAuthCognito.swift
@@ -83,8 +83,8 @@ public class SwiftAuthCognito: NSObject, FlutterPlugin {
                         print("Failed to add Amplify Auth Plugin \(error)")
                         result(false)
                     }
-                    return
                 }
+                return
         }
 
         var arguments: Dictionary<String, AnyObject> = [:]


### PR DESCRIPTION
return was not called in proper location for API and Auth on iOS

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
