### PR TITLE
fix: handle LimitExceededException on Android

### DIFF
--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthErrorHandler.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthErrorHandler.kt
@@ -30,6 +30,7 @@ import com.amazonaws.services.cognitoidentityprovider.model.TooManyFailedAttempt
 import com.amazonaws.services.cognitoidentityprovider.model.TooManyRequestsException
 import com.amazonaws.services.cognitoidentityprovider.model.UnexpectedLambdaException
 import com.amazonaws.services.cognitoidentityprovider.model.UserLambdaValidationException
+import com.amazonaws.services.cognitoidentityprovider.model.LimitExceededException
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.auth.AuthException
 import com.amplifyframework.core.Amplify
@@ -76,6 +77,7 @@ class AuthErrorHandler {
                     is UnexpectedLambdaException -> errorCode = "LambdaException"
                     is UserLambdaValidationException -> errorCode = "LambdaException"
                     is TooManyFailedAttemptsException -> errorCode = "FailedAttemptsLimitExceededException"
+                    is LimitExceededException -> errorCode = "LimitExceededException"
                 }
             }
         }

--- a/packages/amplify_auth_cognito/android/src/test/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AmplifyAuthErrorHandlerTest.kt
+++ b/packages/amplify_auth_cognito/android/src/test/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AmplifyAuthErrorHandlerTest.kt
@@ -575,6 +575,29 @@ class AuthErrorHandlerTest {
         verify(mockResult, times(1)).error(expectedCode, defaultMessage, details);
     }
 
+    @Test
+    fun cognitoLimitExceededException() {
+        // Arrange
+        val expectedCode = "LimitExceededException"
+        val exception = AuthException(expectedCode, LimitExceededException(expectedCode), expectedCode)
+        doAnswer { invocation: InvocationOnMock ->
+            errorHandler.handleAuthError(mockResult, exception)
+            null as Void?
+        }.`when`(mockAuth).signOut(ArgumentMatchers.any<Action>(), ArgumentMatchers.any<Consumer<AuthException>>())
+        val call = MethodCall("signOut", arguments)
+
+        val details = mapOf(
+                "recoverySuggestion" to expectedCode,
+                "message" to expectedCode,
+                "underlyingException" to "${cognitoErrorPrefix}LimitExceededException: ${expectedCode}${cognitoErrorSuffix}"        )
+
+        // Act
+        plugin.onMethodCall(call, mockResult)
+
+        // Assert
+        verify(mockResult, times(1)).error(expectedCode, defaultMessage, details);
+    }
+
     private fun setFinalStatic(field: Field, newValue: Any?) {
         field.isAccessible = true
         val modifiersField: Field = Field::class.java.getDeclaredField("modifiers")


### PR DESCRIPTION
*Issue #, if available:* #513

*Description of changes:*

- Add additional case for `LimitExceededException` from cognitoidentityprovider in AuthErrorHandler
- Add unit test for the new case

The issue can be reproduced by calling `Amplify.Auth.resetPassword()` multiple times on Android. The issue is not present on iOS for this exception.

Prior to this PR we can see the code will throw an `AuthException` instead of a `LimitExceededException`, but the details of the error message do indicate that it is a LimitExceededException.

<img width="994" alt="Screen Shot 2021-04-16 at 4 47 01 PM" src="https://user-images.githubusercontent.com/20613561/115082523-0dfef480-9ed4-11eb-9fd1-ad039a6bb3a8.png">

With the changes in this PR the same code will throw a `LimitExceededException`.

<img width="1064" alt="Screen Shot 2021-04-16 at 4 48 09 PM" src="https://user-images.githubusercontent.com/20613561/115082555-1b1be380-9ed4-11eb-91f3-45b0498e3529.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
