### PR TITLE
fix(amplify_auth_cognito): Pass additionalInfo to AuthNextSignUpStep

### DIFF
--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterSignInResult.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterSignInResult.kt
@@ -27,7 +27,7 @@ data class FlutterSignInResult(private val raw: AuthSignInResult) {
 
     return mapOf(
       "signInStep" to raw.nextStep.signInStep.toString(),
-      "additionalInfo" to Gson().toJson(raw.nextStep.additionalInfo),
+      "additionalInfo" to (raw.nextStep.additionalInfo ?: emptyMap<String, String>()),
       "codeDeliveryDetails" to mapOf(
         "destination" to (raw.nextStep.codeDeliveryDetails?.destination ?: ""),
         "deliveryMedium" to (raw.nextStep.codeDeliveryDetails?.deliveryMedium?.name ?: ""),

--- a/packages/amplify_auth_cognito/lib/method_channel_auth_cognito.dart
+++ b/packages/amplify_auth_cognito/lib/method_channel_auth_cognito.dart
@@ -316,9 +316,7 @@ class AmplifyAuthCognitoMethodChannel extends AmplifyAuthCognito {
         nextStep: AuthNextSignInStep(
             signInStep: res["nextStep"]["signInStep"],
             codeDeliveryDetails: res["nextStep"]["codeDeliveryDetails"],
-            additionalInfo: res["nextStep"]["additionalInfo"] is String
-                ? jsonDecode(res["nextStep"]["additionalInfo"])
-                : {}));
+            additionalInfo: res["nextStep"]["additionalInfo"] ?? {}));
   }
 
   UpdatePasswordResult _formatPasswordResponse(Map<String, dynamic> res) {


### PR DESCRIPTION
See details in issue #544

I'm submitting this mostly as an FYI since I was able to track down the issue(s), which span both amplify-flutter and amplify-ios. I'm not familiar with these code bases (or Swift for that matter), but I do know that these two changes resolve the issue. What I don't know is if these changes will break other use cases. So, let me know if there's another way of resolving this or additional changes needed.

There is a dependent fix in `amplify-ios` that is needed in order for this change to resolve the issue:
https://github.com/aws-amplify/amplify-ios/pull/1190

The problem here appears to be that `res["nextStep"]["additionalInfo"]` is never a String because it has already been json decoded into an object.

Also, there is one other place in the code (`_formatResetPasswordResponse()` in the same file) that may also need to be changed. However, that's not a use case that I use, so I didn't modify that function. (I can update the PR if needed.)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
