### PR TITLE
fix: address issue #577 by changing iOS error to UserNotConfirmedException

### DIFF
--- a/packages/amplify_auth_cognito/ios/Classes/AuthCognitoBridge.swift
+++ b/packages/amplify_auth_cognito/ios/Classes/AuthCognitoBridge.swift
@@ -70,11 +70,7 @@ class AuthCognitoBridge {
               case .success(let signInResult):
                 switch signInResult.nextStep {
                   case .confirmSignUp:
-                    // This avoids importing the mobileclient code
-                    enum ErrorShim: Error {
-                        case userNotConfirmed
-                    }
-                    self.errorHandler.handleAuthError(authError: AuthError.service("User is not confirmed.", "See attached exception for more details", ErrorShim.userNotConfirmed), flutterResult: flutterResult)
+                    self.errorHandler.handleAuthError(authError: AuthError.service("User is not confirmed.", "See attached exception for more details", AWSCognitoAuthError.userNotConfirmed), flutterResult: flutterResult)
                   default:
                     let signInData = FlutterSignInResult(res: response)
                     flutterResult(signInData.toJSON())


### PR DESCRIPTION
Issue: #577 

Description of changes: fix: address issue #577 by changing custom iOS error to AWSCognitoAuthError.userNotConfirmed so that iOS throws UserNotConfirmedException instead of more generic AuthError (like Android) when trying to signIn unconfirmed user


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
