### PR TITLE
refactor: Minor refactor of DataStore methods

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -107,13 +107,13 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
             "delete" -> onDelete(result, data)
             "save" -> onSave(result, data)
             "clear" -> onClear(result)
-            "setupObserve" -> onSetupObserve(result)
-            "configureModelProvider" -> onConfigureModelProvider(result, data)
+            "setUpObserve" -> onSetUpObserve(result)
+            "configureDataStore" -> onConfigureDataStore(result, data)
             else -> result.notImplemented()
         }
     }
 
-    private fun onConfigureModelProvider(flutterResult: Result, request: Map<String, Any>) {
+    private fun onConfigureDataStore(flutterResult: Result, request: Map<String, Any>) {
 
         if (!request.containsKey("modelSchemas") || !request.containsKey(
                         "modelProviderVersion") || request["modelSchemas"] !is List<*>) {
@@ -304,7 +304,7 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         )
     }
 
-    fun onSetupObserve(result: Result) {
+    fun onSetUpObserve(flutterResult: Result) {
         val plugin = Amplify.DataStore.getPlugin("awsDataStorePlugin") as AWSDataStorePlugin
 
         plugin.observe(

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePluginTest.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePluginTest.kt
@@ -407,7 +407,7 @@ class AmplifyDataStorePluginTest {
                 any<Consumer<DataStoreException>>(),
                 any<Action>())
 
-        flutterPlugin.onSetupObserve(mockResult)
+        flutterPlugin.onSetUpObserve(mockResult)
 
         verify(mockResult, times(1)).success(true)
         verify(mockStreamHandler, times(1)).sendEvent(eventData)
@@ -427,7 +427,7 @@ class AmplifyDataStorePluginTest {
                 any<Consumer<DataStoreException>>(),
                 any<Action>())
 
-        flutterPlugin.onSetupObserve(mockResult)
+        flutterPlugin.onSetUpObserve(mockResult)
 
         verify(mockResult, times(1)).success(true)
         verify(mockStreamHandler, times(1)).error(

--- a/packages/amplify_datastore/example/ios/unit_tests/DataStorePluginUnitTests.swift
+++ b/packages/amplify_datastore/example/ios/unit_tests/DataStorePluginUnitTests.swift
@@ -230,9 +230,8 @@ class DataStorePluginUnitTests: XCTestCase {
                                                       flutterModelRegistration: flutterModelSchemaRegistration,
                                                       dataStoreObserveEventStreamHandler: streamHandler)
 
-        pluginUnderTest.onSetupObserve(flutterResult: {
-            (results) -> Void in
-            XCTAssertTrue(results as! Bool)
+        pluginUnderTest.onSetUpObserve(flutterResult: { result in
+            XCTAssertNil(result)
         })
 
         dataStoreBridge.mockPublisher.send(MutationEvent(
@@ -273,9 +272,8 @@ class DataStorePluginUnitTests: XCTestCase {
                                                       flutterModelRegistration: flutterModelSchemaRegistration,
                                                       dataStoreObserveEventStreamHandler: streamHandler)
 
-        pluginUnderTest.onSetupObserve(flutterResult: {
-            (results) -> Void in
-            XCTAssertTrue(results as! Bool)
+        pluginUnderTest.onSetUpObserve(flutterResult: { result in
+            XCTAssertNil(result)
         })
 
         dataStoreBridge.mockPublisher.send(MutationEvent(
@@ -315,9 +313,8 @@ class DataStorePluginUnitTests: XCTestCase {
                                                       flutterModelRegistration: flutterModelSchemaRegistration,
                                                       dataStoreObserveEventStreamHandler: streamHandler)
 
-        pluginUnderTest.onSetupObserve(flutterResult: {
-            (results) -> Void in
-            XCTAssertTrue(results as! Bool)
+        pluginUnderTest.onSetUpObserve(flutterResult: { result in
+            XCTAssertNil(result)
         })
 
         dataStoreBridge.mockPublisher.send(completion:

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -61,16 +61,16 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
         }
 
         switch call.method {
-        case "configureModelProvider":
-            onConfigureModelProvider(args: arguments, result: result)
+        case "configureDataStore":
+            onConfigureDataStore(args: arguments, result: result)
         case "query":
             onQuery(args: arguments, flutterResult: result)
         case "save":
             onSave(args: arguments, flutterResult: result)
         case "delete":
             onDelete(args: arguments, flutterResult: result)
-        case "setupObserve":
-            onSetupObserve(flutterResult: result)
+        case "setUpObserve":
+            onSetUpObserve(flutterResult: result)
         case "clear":
             onClear(flutterResult: result)
         default:
@@ -78,7 +78,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
         }
     }
 
-    private func onConfigureModelProvider(args: [String: Any], result: @escaping FlutterResult) {
+    private func onConfigureDataStore(args: [String: Any], result: @escaping FlutterResult) {
 
         guard let modelSchemaList = args["modelSchemas"] as? [[String: Any]] else {
             result(false)
@@ -254,7 +254,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
         }
     }
 
-    public func onSetupObserve(flutterResult: @escaping FlutterResult) {
+    public func onSetUpObserve(flutterResult: @escaping FlutterResult) {
         do {
             observeSubscription = try observeSubscription ?? bridge.onObserve().sink { completion in
                 switch completion {
@@ -291,6 +291,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
             print("Failed to get the datastore plugin \(error)")
             flutterResult(false)
         }
+        flutterResult(nil)
     }
 
     func onClear(flutterResult: @escaping FlutterResult) {
@@ -307,7 +308,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
                     // iOS tears down the publisher after clear. Let's setup again.
                     // See https://github.com/aws-amplify/amplify-flutter/issues/395
                     self.observeSubscription = nil
-                    self.onSetupObserve(flutterResult: flutterResult)
+                    self.onSetUpObserve(flutterResult: flutterResult)
                     flutterResult(nil)
                 }
             }

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -45,7 +45,7 @@ class AmplifyDataStore extends DataStorePluginInterface {
   }
 
   @override
-  Future<void> configureModelProvider(
+  Future<void> configureDataStore(
       {ModelProviderInterface modelProvider}) async {
     ModelProviderInterface provider =
         modelProvider == null ? this.modelProvider : modelProvider;
@@ -55,8 +55,11 @@ class AmplifyDataStore extends DataStorePluginInterface {
               'Pass in a modelProvider instance while instantiating DataStorePlugin');
     }
     streamWrapper.registerModelsForHub(provider);
-    return _instance.configureModelProvider(modelProvider: modelProvider);
+    return _instance.configureDataStore(modelProvider: modelProvider);
   }
+
+  @override
+  Future<void> setUpObserve() async => _instance.setUpObserve();
 
   @override
   Future<void> configure({String configuration}) async {
@@ -82,6 +85,7 @@ class AmplifyDataStore extends DataStorePluginInterface {
     return _instance.save(model);
   }
 
+  @override
   Stream<SubscriptionEvent<T>> observe<T extends Model>(
       ModelType<T> modelType) {
     return _instance.observe(modelType);

--- a/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
@@ -51,10 +51,13 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
       {@required Object token, @required this.modelProvider})
       : super(token: token);
 
-  Future<void> configureModelProvider(
+  Future<void> configureDataStore(
       {@required ModelProviderInterface modelProvider}) {
-    throw UnimplementedError(
-        'configureModelProvider() has not been implemented.');
+    throw UnimplementedError('configureDataStore() has not been implemented.');
+  }
+
+  Future<void> setUpObserve() {
+    throw UnimplementedError('setUpObserve() has not been implemented.');
   }
 
   StreamController get streamController {

--- a/packages/amplify_flutter/lib/amplify.dart
+++ b/packages/amplify_flutter/lib/amplify.dart
@@ -119,12 +119,8 @@ class AmplifyClass extends PlatformInterface {
   /// Adds multiple plugins at the same time. Note: this method can only
   /// be called before Amplify has been configured. Customers are expected
   /// to check the configuration state by calling `Amplify.isConfigured`
-  Future<void> addPlugins(List<AmplifyPluginInterface> plugins) async {
-    plugins.forEach((plugin) async {
-      await addPlugin(plugin);
-    });
-    return;
-  }
+  Future<void> addPlugins(List<AmplifyPluginInterface> plugins) =>
+      Future.wait(plugins.map((plugin) => addPlugin(plugin)));
 
   /// Returns whether Amplify has been configured or not.
   bool get isConfigured {
@@ -197,7 +193,7 @@ class AmplifyClass extends PlatformInterface {
       }
     }
 
-    await DataStore.configure(configuration);
+    await DataStore.setUpObserve();
   }
 
   /// Adds the configuration and return true if it was successful.


### PR DESCRIPTION
*Description of changes:*

* Free up `configure` method for native passthrough
* Move observe configuration into its own explicit method
* Corrected observe setup method in swift to call the invokeMethod callback so the call can be properly awaited upon in dart layer
* Broaden `configureDataStore` naming to convey more than model provider being able to be configured through this method
* Allow plugins to be added in parallel instead of in a series
* Update unit tests to correctly assert observe call result

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
