### PR TITLE
feat(datastore): Add ModelField ReadOnly support

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterModelField.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterModelField.kt
@@ -39,6 +39,8 @@ data class FlutterModelField(val map: Map<String, Any>) {
     // True if the field is an instance of model.
     private val isModel: Boolean = type.isModel();
 
+    private val isReadOnly: Boolean = map["isReadOnly"] as Boolean
+
     // An array of rules for owner based authorization
     private val authRules: List<FlutterAuthRule>? =
             (map["authRules"] as List<Map<String, Any>>?)?.map { serializedAuthRule ->
@@ -64,6 +66,7 @@ data class FlutterModelField(val map: Map<String, Any>) {
                 .isArray(isArray)
                 .isEnum(isEnum)
                 .isModel(isModel)
+                .isReadOnly(isReadOnly)
 
         if (!authRules.isNullOrEmpty()) {
             builder = builder.authRules(authRules.map { authRule ->

--- a/packages/amplify_datastore/ios/Classes/types/model/FlutterModelField.swift
+++ b/packages/amplify_datastore/ios/Classes/types/model/FlutterModelField.swift
@@ -23,6 +23,7 @@ public struct FlutterModelField {
     public let type: FlutterModelFieldType
     public let isRequired: Bool
     public let isArray: Bool
+    public let isReadOnly: Bool
     public let association: FlutterModelAssociation?
     public let authRules: [FlutterAuthRule]?
     
@@ -62,6 +63,15 @@ public struct FlutterModelField {
                 desiredType: "Bool")
         }
         self.isArray = isArray
+        
+        guard let isReadOnly = serializedData["isReadOnly"] as? Bool
+        else {
+            throw ModelSchemaError.parse(
+                className: "FlutterModelField",
+                fieldName: "isReadOnly",
+                desiredType: "Bool")
+        }
+        self.isReadOnly = isReadOnly
 
         if let inputAssociationMap = serializedData["association"] as? [String : Any]{
             self.association = try FlutterModelAssociation(serializedData: inputAssociationMap)
@@ -136,6 +146,7 @@ public struct FlutterModelField {
             name: name,
             type: try type.convertToNativeModelField(),
             isRequired: isRequired,
+            isReadOnly: isReadOnly,
             isArray: isArray,
             association: association?.convertToNativeModelAssociation(),
             authRules: authRules?.map{

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/models/model_field.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/models/model_field.dart
@@ -35,6 +35,8 @@ class ModelField {
 
   final bool isArray;
 
+  final bool isReadOnly;
+
   // An array of rules for owner based authorization
   final List<AuthRule> authRules;
 
@@ -45,6 +47,7 @@ class ModelField {
       this.type,
       this.isRequired,
       this.isArray = false,
+      this.isReadOnly = false,
       this.association,
       this.authRules});
 
@@ -53,6 +56,7 @@ class ModelField {
     String type,
     bool isRequired,
     bool isArray,
+    bool isReadOnly,
     ModelAssociation association,
     List<AuthRule> authRules,
   }) {
@@ -61,6 +65,7 @@ class ModelField {
       type: type ?? this.type,
       isRequired: isRequired ?? this.isRequired,
       isArray: isArray ?? this.isArray,
+      isReadOnly: isReadOnly ?? this.isReadOnly,
       association: association ?? this.association,
       authRules: authRules ?? this.authRules,
     );
@@ -72,6 +77,7 @@ class ModelField {
       'type': type.toMap(),
       'isRequired': isRequired,
       'isArray': isArray,
+      'isReadOnly': isReadOnly,
       'association': association?.toMap(),
       'authRules': authRules?.map((x) => x?.toMap())?.toList(),
     };
@@ -86,6 +92,7 @@ class ModelField {
       type: map['type'],
       isRequired: map['isRequired'],
       isArray: map['isArray'],
+      isReadOnly: map['isReadOnly'],
       association:
           map['association'] ?? ModelAssociation.fromMap(map['association']),
       authRules: map['authRules'] ??
@@ -101,7 +108,7 @@ class ModelField {
 
   @override
   String toString() {
-    return 'ModelField(name: $name, type: $type, isRequired: $isRequired, isArray: $isArray, association: $association, authRules: $authRules)';
+    return 'ModelField(name: $name, type: $type, isRequired: $isRequired, isArray: $isArray, isReadOnly: $isReadOnly, association: $association, authRules: $authRules)';
   }
 
   @override
@@ -114,6 +121,7 @@ class ModelField {
         o.type == type &&
         o.isRequired == isRequired &&
         o.isArray == isArray &&
+        o.isReadOnly == isReadOnly &&
         listEquals(o.authRules, authRules);
   }
 
@@ -123,6 +131,7 @@ class ModelField {
         type.hashCode ^
         isRequired.hashCode ^
         isArray.hashCode ^
+        isReadOnly.hashCode ^
         authRules.hashCode;
   }
 }


### PR DESCRIPTION
Add support for "readOnly" modelfield property.  Used for new codegen "createdAt" and "lastUpdatedAt" fields that are auto updated in the background. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
