### PR TITLE
fix(tests): add --no-pub to integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ test functionality with real Amplify backends. The integration test script will 
 apps which have integration tests written (skipping those that don't). It runs on Android and iOS simulators.
 
 **Note:** To run integration tests, you will need prerequisite Amplify resources in the example 
-apps where the tests run. The process for creating those is noted below. You will also need to installed dependencies with `melos bootstrap`.
+apps where the tests run. The process for creating those is noted below. You will also need to install dependencies with `melos bootstrap`.
 
 To run all integration tests on available platforms:
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ test functionality with real Amplify backends. The integration test script will 
 apps which have integration tests written (skipping those that don't). It runs on Android and iOS simulators.
 
 **Note:** To run integration tests, you will need prerequisite Amplify resources in the example 
-apps where the tests run. The process for creating those is noted below.
+apps where the tests run. The process for creating those is noted below. You will also need to installed dependencies with `melos bootstrap`.
 
 To run all integration tests on available platforms:
 ```bash

--- a/melos.yaml
+++ b/melos.yaml
@@ -37,14 +37,14 @@ scripts:
       - Requires running Android and iOS simulators.
 
   test:integration:android:
-    run: melos exec "flutter drive --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d sdk"
+    run: melos exec "flutter drive --no-pub --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d sdk"
     select-package:
       file-exists:
         - integration_test/main_test.dart
       scope: "*example*"
 
   test:integration:ios:
-    run: melos exec "flutter drive --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d iPhone"
+    run: melos exec "flutter drive --no-pub --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d iPhone"
     select-package:
       file-exists:
         - integration_test/main_test.dart


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- add `--no-pub` to integration tests so that `flutter pub get` is not run. `flutter pub get` will cause issues in our mono repo. Dependencies need to be installed with melos.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
