### PR TITLE
chore(api): Override `toString` on `GraphQLResponseError`

### DIFF
--- a/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLResponseError.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLResponseError.dart
@@ -43,7 +43,7 @@ class GraphQLResponseError {
 
   @override
   String toString() {
-    return 'GraphQLResponseError${prettyPrintJson(toJson())}';
+    return 'GraphQLResponseError${prettyPrintJson(this)}';
   }
 }
 

--- a/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLResponseError.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLResponseError.dart
@@ -13,9 +13,56 @@
  * permissions and limitations under the License.
  */
 
-//TODO: This class needs to be fleshed out further to match the GraphQLError spec
-class GraphQLResponseError {
-  String message;
+import 'dart:convert';
 
-  GraphQLResponseError({required this.message});
+import 'package:meta/meta.dart';
+
+/// Contains an error produced via a GraphQL invocation. Corresponds to one
+/// entry in the `errors` field on a GraphQL response.
+///
+/// [locations] and [path] may be null.
+class GraphQLResponseError {
+  /// The description of the error.
+  final String message;
+
+  /// The locations of the error-causing fields in the request document.
+  final List<GraphQLResponseErrorLocation>? locations;
+
+  /// The key paths of the error-causing fields in the response JSON.
+  final List<dynamic>? path;
+
+  const GraphQLResponseError({
+    required this.message,
+    this.locations,
+    this.path,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'message': message,
+        if (locations != null) 'locations': locations,
+        if (path != null) 'path': path,
+      };
+
+  @override
+  String toString() {
+    return 'GraphQLResponseError${prettyPrintJson(toJson())}';
+  }
+}
+
+/// Represents a location in the GraphQL response where an error occurred. [line]
+/// and [column] correspond to the beginning of the syntax element associated
+/// with the error.
+class GraphQLResponseErrorLocation {
+  /// The line in the GraphQL response where the syntax element starts.
+  final int line;
+
+  /// The column in the GraphQL response where the syntax element starts.
+  final int column;
+
+  const GraphQLResponseErrorLocation(this.line, this.column);
+
+  Map<String, dynamic> toJson() => {
+        'line': line,
+        'column': column,
+      };
 }

--- a/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLResponseError.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLResponseError.dart
@@ -13,9 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'dart:convert';
-
-import 'package:meta/meta.dart';
+import '../util.dart';
 
 /// Contains an error produced via a GraphQL invocation. Corresponds to one
 /// entry in the `errors` field on a GraphQL response.
@@ -28,7 +26,7 @@ class GraphQLResponseError {
   /// The locations of the error-causing fields in the request document.
   final List<GraphQLResponseErrorLocation>? locations;
 
-  /// The key paths of the error-causing fields in the response JSON.
+  /// The key path of the error-causing field in the response's `data` object.
   final List<dynamic>? path;
 
   const GraphQLResponseError({
@@ -49,14 +47,16 @@ class GraphQLResponseError {
   }
 }
 
-/// Represents a location in the GraphQL response where an error occurred. [line]
-/// and [column] correspond to the beginning of the syntax element associated
+/// Represents a location in the GraphQL request document where an error occurred.
+/// [line] and [column] correspond to the beginning of the syntax element associated
 /// with the error.
 class GraphQLResponseErrorLocation {
-  /// The line in the GraphQL response where the syntax element starts.
+  /// The line in the GraphQL request document where the error-causing syntax
+  /// element starts.
   final int line;
 
-  /// The column in the GraphQL response where the syntax element starts.
+  /// The column in the GraphQL request document where the error-causing syntax
+  /// element starts.
   final int column;
 
   const GraphQLResponseErrorLocation(this.line, this.column);

--- a/packages/amplify_api_plugin_interface/lib/src/util.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/util.dart
@@ -1,0 +1,7 @@
+import 'dart:convert';
+
+String prettyPrintJson(dynamic json) {
+  const defaultIndent = '  ';
+  const jsonIndent = JsonEncoder.withIndent(defaultIndent);
+  return jsonIndent.convert(json);
+}

--- a/packages/amplify_api_plugin_interface/lib/src/util.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/util.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+/// Encodes [json] with indentation for easier debugging.
 String prettyPrintJson(dynamic json) {
   const defaultIndent = '  ';
   const jsonIndent = JsonEncoder.withIndent(defaultIndent);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Overrides the `toString` method on `GraphQLResponseError`
- Adds missing fields for use in the future (`locations`, `path`)... is `extensions` used by AppSync?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
