### PR TITLE
fix(auth_auth_cognito): Type mismatch: inferred type

### DIFF
--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchCognitoAuthSessionResult.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchCognitoAuthSessionResult.kt
@@ -32,7 +32,7 @@ data class FlutterFetchCognitoAuthSessionResult(private val raw: AWSCognitoAuthS
   private val tokens: AuthSessionResult<AWSCognitoUserPoolTokens>? = raw.userPoolTokens
 
   fun toValueMap(): Map<String, Any?> {
-    var serializedMap = mutableMapOf(
+    var serializedMap = mutableMapOf<String, Any?>(
       "isSignedIn" to this.isSignedIn,
       "identityId" to this.identityId,
       "userSub" to this.userSub


### PR DESCRIPTION
Fixes the issue with:

e: /Users//Development/flutter/.pub-cache/hosted/pub.dartlang.org/amplify_auth_cognito-0.2.0-nullsafety.0/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchCognitoAuthSessionResult.kt: (45, 38): Type mismatch: inferred type is Map<String, Any> but Comparable<{Boolean & String}>? was expected
e: /Users//Development/flutter/.pub-cache/hosted/pub.dartlang.org/amplify_auth_cognito-0.2.0-nullsafety.0/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchCognitoAuthSessionResult.kt: (45, 38): Type mismatch: inferred type is Map<String, Any> but Serializable? was expected
e: /Users//Development/flutter/.pub-cache/hosted/pub.dartlang.org/amplify_auth_cognito-0.2.0-nullsafety.0/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchCognitoAuthSessionResult.kt: (45, 38): Type mismatch: inferred type is Map<String, Any> but {Comparable<{Boolean & String}>? & java.io.Serializable?} was expected
e: /Users//Development/flutter/.pub-cache/hosted/pub.dartlang.org/amplify_auth_cognito-0.2.0-nullsafety.0/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchCognitoAuthSessionResult.kt: (49, 33): Type mismatch: inferred type is Map<String, Any> but Comparable<{Boolean & String}>? was expected
e: /Users//Development/flutter/.pub-cache/hosted/pub.dartlang.org/amplify_auth_cognito-0.2.0-nullsafety.0/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchCognitoAuthSessionResult.kt: (49, 33): Type mismatch: inferred type is Map<String, Any> but Serializable? was expected
e: /Users//Development/flutter/.pub-cache/hosted/pub.dartlang.org/amplify_auth_cognito-0.2.0-nullsafety.0/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchCognitoAuthSessionResult.kt: (49, 33): Type mismatch: inferred type is Map<String, Any> but {Comparable<{Boolean & String}>? & java.io.Serializable?} was expected

FAILURE: Build failed with an exception.


As related by @caravanat .