### PR TITLE
fix(amplify_api): throw ApiException in android when PUT, POST, and PATCH REST requests have no body to prevent fatal error

### DIFF
--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/FlutterApiRequest.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/FlutterApiRequest.kt
@@ -58,7 +58,7 @@ class FlutterApiRequest {
             return request[CANCEL_TOKEN_KEY] as String
         }
 
-        fun getRestOptions(request: Map<String, Any>) : RestOptions {
+        fun getRestOptions(request: Map<String, Any>, methodName: String) : RestOptions {
 
             try {
                 val builder: RestOptions.Builder = RestOptions.builder()
@@ -80,6 +80,10 @@ class FlutterApiRequest {
                             builder.addHeaders(value as Map<String, String>)
                         }
                     }
+                }
+
+                if (methodName == "PATCH" && request[BODY_KEY] == null) {
+                    builder.addBody("".toByteArray())
                 }
                 return builder.build()
             } catch (cause: Exception) {

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/FlutterApiRequest.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/FlutterApiRequest.kt
@@ -15,7 +15,9 @@
 
 package com.amazonaws.amplify.amplify_api
 
+import com.amazonaws.amplify.amplify_api.rest_api.FlutterRestApi
 import com.amplifyframework.AmplifyException
+import com.amplifyframework.api.ApiException
 import com.amplifyframework.api.rest.RestOptions
 import io.flutter.plugin.common.MethodChannel
 
@@ -33,7 +35,7 @@ class FlutterApiRequest {
         private val HEADERS_KEY = "headers"
 
         // ====== Rest API ======
-        fun getCancelToken(request: Map<String, Any>) : String {
+        fun getCancelToken(request: Map<String, Any>): String {
             try {
                 return request[CANCEL_TOKEN_KEY] as String
             } catch (cause: Exception) {
@@ -45,7 +47,7 @@ class FlutterApiRequest {
             return request[CANCEL_TOKEN_KEY] as String
         }
 
-        fun getApiPath(request: Map<String, Any>) : String? {
+        fun getApiPath(request: Map<String, Any>): String? {
             try {
                 val restOptionsMap = request[REST_OPTIONS_KEY] as Map<String, Any>
                 return restOptionsMap[API_NAME_KEY] as String?
@@ -58,7 +60,7 @@ class FlutterApiRequest {
             return request[CANCEL_TOKEN_KEY] as String
         }
 
-        fun getRestOptions(request: Map<String, Any>) : RestOptions {
+        fun getRestOptions(request: Map<String, Any>): RestOptions {
 
             try {
                 val builder: RestOptions.Builder = RestOptions.builder()
@@ -90,16 +92,24 @@ class FlutterApiRequest {
             }
         }
 
+        @JvmStatic
+        fun checkForEmptyBodyIfRequired(options: RestOptions, methodName: String): Void? {
+            if ((methodName == FlutterRestApi.PUT || methodName == FlutterRestApi.POST || methodName == FlutterRestApi.PATCH) && !options.hasData()) {
+                throw ApiException("$methodName request must have a body", "Add a body to the request.")
+            }
+            return null
+        }
+
         // ====== GraphQL ======
         @JvmStatic
         fun getGraphQLDocument(request: Map<String, Any>): String {
             try {
                 return request["document"] as String
             } catch (cause: Exception) {
-                   throw AmplifyException(
-                            "The graphQL document request argument was not passed as a String",
-                            cause,
-                            "The request should include the graphQL document as a String")
+                throw AmplifyException(
+                        "The graphQL document request argument was not passed as a String",
+                        cause,
+                        "The request should include the graphQL document as a String")
             }
         }
 

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/FlutterApiRequest.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/FlutterApiRequest.kt
@@ -93,11 +93,10 @@ class FlutterApiRequest {
         }
 
         @JvmStatic
-        fun checkForEmptyBodyIfRequired(options: RestOptions, methodName: String): Void? {
+        fun checkForEmptyBodyIfRequired(options: RestOptions, methodName: String) {
             if ((methodName == FlutterRestApi.PUT || methodName == FlutterRestApi.POST || methodName == FlutterRestApi.PATCH) && !options.hasData()) {
                 throw ApiException("$methodName request must have a body", "Add a body to the request.")
             }
-            return null
         }
 
         // ====== GraphQL ======

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/FlutterApiRequest.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/FlutterApiRequest.kt
@@ -58,7 +58,7 @@ class FlutterApiRequest {
             return request[CANCEL_TOKEN_KEY] as String
         }
 
-        fun getRestOptions(request: Map<String, Any>, requiresBody: Boolean) : RestOptions {
+        fun getRestOptions(request: Map<String, Any>, methodName: String) : RestOptions {
 
             try {
                 val builder: RestOptions.Builder = RestOptions.builder()
@@ -82,9 +82,8 @@ class FlutterApiRequest {
                     }
                 }
 
-                // Needed to prevent Android library from throwing a fatal error when body not present in some methods. https://github.com/aws-amplify/amplify-android/issues/1355
-                if (requiresBody && restOptionsMap[BODY_KEY] == null) {
-                    builder.addBody(" ".toByteArray())
+                if (methodName == "PATCH" && request[BODY_KEY] == null) {
+                    builder.addBody("".toByteArray())
                 }
                 return builder.build()
             } catch (cause: Exception) {

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/FlutterApiRequest.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/FlutterApiRequest.kt
@@ -58,7 +58,7 @@ class FlutterApiRequest {
             return request[CANCEL_TOKEN_KEY] as String
         }
 
-        fun getRestOptions(request: Map<String, Any>, methodName: String) : RestOptions {
+        fun getRestOptions(request: Map<String, Any>, requiresBody: Boolean) : RestOptions {
 
             try {
                 val builder: RestOptions.Builder = RestOptions.builder()
@@ -82,8 +82,9 @@ class FlutterApiRequest {
                     }
                 }
 
-                if (methodName == "PATCH" && request[BODY_KEY] == null) {
-                    builder.addBody("".toByteArray())
+                // Needed to prevent Android library from throwing a fatal error when body not present in some methods. https://github.com/aws-amplify/amplify-android/issues/1355
+                if (requiresBody && restOptionsMap[BODY_KEY] == null) {
+                    builder.addBody(" ".toByteArray())
                 }
                 return builder.build()
             } catch (cause: Exception) {

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/FlutterApiRequest.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/FlutterApiRequest.kt
@@ -58,7 +58,7 @@ class FlutterApiRequest {
             return request[CANCEL_TOKEN_KEY] as String
         }
 
-        fun getRestOptions(request: Map<String, Any>, methodName: String) : RestOptions {
+        fun getRestOptions(request: Map<String, Any>) : RestOptions {
 
             try {
                 val builder: RestOptions.Builder = RestOptions.builder()
@@ -80,10 +80,6 @@ class FlutterApiRequest {
                             builder.addHeaders(value as Map<String, String>)
                         }
                     }
-                }
-
-                if (methodName == "PATCH" && request[BODY_KEY] == null) {
-                    builder.addBody("".toByteArray())
                 }
                 return builder.build()
             } catch (cause: Exception) {

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/rest_api/FlutterRestApi.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/rest_api/FlutterRestApi.kt
@@ -33,6 +33,12 @@ class FlutterRestApi {
     companion object {
         private val LOG = Amplify.Logging.forNamespace("amplify:flutter:api")
         private val handler = Handler(Looper.getMainLooper())
+        private const val GET = "get"
+        private const val POST = "post"
+        private const val PUT = "put"
+        private const val DELETE = "delete"
+        private const val HEAD = "head"
+        private const val PATCH = "patch"
 
         private fun restFunctionHelper(
                 methodName: String,
@@ -58,6 +64,18 @@ class FlutterRestApi {
             }
 
             try {
+                // Needed to prevent Android library from throwing a fatal error when body not present in some methods. https://github.com/aws-amplify/amplify-android/issues/1355
+                if (!options.hasData() && (methodName == PUT || methodName == POST || methodName == PATCH)) {
+                    handler.post {
+                        ExceptionUtil.postExceptionToFlutterChannel(flutterResult, "ApiException",
+                                ExceptionUtil.createSerializedError(
+                                        ApiException("$methodName request must have a body", "Add a body to the request.")
+                                )
+                        )
+                    }
+                    return
+                }
+
                 var operation: RestOperation?
                 if (apiName == null) {
                     operation = functionWithoutApiName(options,
@@ -116,27 +134,27 @@ class FlutterRestApi {
         }
 
         fun get(flutterResult: Result, arguments: Map<String, Any>) {
-            restFunctionHelper("get", flutterResult, arguments, this::get, this::get)
+            restFunctionHelper(GET, flutterResult, arguments, this::get, this::get)
         }
 
         fun post(flutterResult: Result, arguments: Map<String, Any>) {
-            restFunctionHelper("post", flutterResult, arguments, this::post, this::post)
+            restFunctionHelper(POST, flutterResult, arguments, this::post, this::post)
         }
 
         fun put(flutterResult: Result, arguments: Map<String, Any>) {
-            restFunctionHelper("put", flutterResult, arguments, this::put, this::put)
+            restFunctionHelper(PUT, flutterResult, arguments, this::put, this::put)
         }
 
         fun delete(flutterResult: Result, arguments: Map<String, Any>) {
-            restFunctionHelper("delete", flutterResult, arguments, this::delete, this::delete)
+            restFunctionHelper(DELETE, flutterResult, arguments, this::delete, this::delete)
         }
 
         fun head(flutterResult: Result, arguments: Map<String, Any>) {
-            restFunctionHelper("head", flutterResult, arguments, this::head, this::head)
+            restFunctionHelper(HEAD, flutterResult, arguments, this::head, this::head)
         }
 
         fun patch(flutterResult: Result, arguments: Map<String, Any>) {
-            restFunctionHelper("patch", flutterResult, arguments, this::patch, this::patch)
+            restFunctionHelper(PATCH, flutterResult, arguments, this::patch, this::patch)
         }
 
 

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/rest_api/FlutterRestApi.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/rest_api/FlutterRestApi.kt
@@ -54,7 +54,7 @@ class FlutterRestApi {
             try {
                 cancelToken = FlutterApiRequest.getCancelToken(request)
                 apiName = FlutterApiRequest.getApiPath(request)
-                options = FlutterApiRequest.getRestOptions(request)
+                options = FlutterApiRequest.getRestOptions(request, methodName)
             } catch (e: Exception) {
                 handler.post {
                     ExceptionUtil.postExceptionToFlutterChannel(flutterResult, "ApiException",

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/rest_api/FlutterRestApi.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/rest_api/FlutterRestApi.kt
@@ -54,7 +54,7 @@ class FlutterRestApi {
             try {
                 cancelToken = FlutterApiRequest.getCancelToken(request)
                 apiName = FlutterApiRequest.getApiPath(request)
-                options = FlutterApiRequest.getRestOptions(request, methodName)
+                options = FlutterApiRequest.getRestOptions(request, (methodName == PUT || methodName == POST || methodName == PATCH))
             } catch (e: Exception) {
                 handler.post {
                     ExceptionUtil.postExceptionToFlutterChannel(flutterResult, "ApiException",
@@ -64,18 +64,6 @@ class FlutterRestApi {
             }
 
             try {
-                // Needed to prevent Android library from throwing a fatal error when body not present in some methods. https://github.com/aws-amplify/amplify-android/issues/1355
-                if (!options.hasData() && (methodName == PUT || methodName == POST || methodName == PATCH)) {
-                    handler.post {
-                        ExceptionUtil.postExceptionToFlutterChannel(flutterResult, "ApiException",
-                                ExceptionUtil.createSerializedError(
-                                        ApiException("$methodName request must have a body", "Add a body to the request.")
-                                )
-                        )
-                    }
-                    return
-                }
-
                 var operation: RestOperation?
                 if (apiName == null) {
                     operation = functionWithoutApiName(options,

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/rest_api/FlutterRestApi.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/rest_api/FlutterRestApi.kt
@@ -54,7 +54,7 @@ class FlutterRestApi {
             try {
                 cancelToken = FlutterApiRequest.getCancelToken(request)
                 apiName = FlutterApiRequest.getApiPath(request)
-                options = FlutterApiRequest.getRestOptions(request, methodName)
+                options = FlutterApiRequest.getRestOptions(request)
             } catch (e: Exception) {
                 handler.post {
                     ExceptionUtil.postExceptionToFlutterChannel(flutterResult, "ApiException",


### PR DESCRIPTION
*Issue #, if available:* #612

*Description of changes:* In android, PUT, POST, and PATCH methods throw a fatal error if no body is included (iOS works fine) https://github.com/aws-amplify/amplify-android/issues/1355. This is because of okhttp3 library, underlying HTTP library for amplify-android. This PR smoothes that over by making it an API exception in android that will not crash the app.

Alternatively, this could be changed to just add a blank body in this scenario but that might have some unexpected behavior for customers if they are not aware. It could also have some handling in dart layer to make it consistent across platforms. However, I would rather not change the iOS behavior here to introduce an exception for something that does not currently throw one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
