### PR TITLE
fix: amplify-ios version bump ~> 1.11.0 - nullsafety

### DIFF
--- a/packages/amplify_analytics_pinpoint/ios/amplify_analytics_pinpoint.podspec
+++ b/packages/amplify_analytics_pinpoint/ios/amplify_analytics_pinpoint.podspec
@@ -15,8 +15,8 @@ This code is the iOS part of the Amplify Flutter Pinpoint Analytics Plugin.  The
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify'
-  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin'
+  s.dependency 'Amplify', '~> 1.11.0'
+  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '~> 1.11.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/amplify_api/ios/amplify_api.podspec
+++ b/packages/amplify_api/ios/amplify_api.podspec
@@ -15,8 +15,8 @@ The API module for Amplify Flutter.
   s.source           = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin'
+  s.dependency 'Amplify', '~> 1.11.0'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '~> 1.11.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/amplify_auth_cognito/ios/amplify_auth_cognito.podspec
+++ b/packages/amplify_auth_cognito/ios/amplify_auth_cognito.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin'
+  s.dependency 'Amplify', '~> 1.11.0'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '~> 1.11.0'
   s.dependency 'ObjectMapper'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,8 +15,8 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin'
+  s.dependency 'Amplify', '~> 1.11.0'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '~> 1.11.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '13.0'
 

--- a/packages/amplify_flutter/ios/amplify_flutter.podspec
+++ b/packages/amplify_flutter/ios/amplify_flutter.podspec
@@ -15,9 +15,9 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify'
-  s.dependency 'AWSPluginsCore'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin'
+  s.dependency 'Amplify', '~> 1.11.0'
+  s.dependency 'AWSPluginsCore', '~> 1.11.0'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '~> 1.11.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/amplify_storage_s3/ios/amplify_storage_s3.podspec
+++ b/packages/amplify_storage_s3/ios/amplify_storage_s3.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify'
-  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin'
+  s.dependency 'Amplify', '~> 1.11.0'
+  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '~> 1.11.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
** Note: This PR should not be released until the next version of amplify-ios is released and the version number verified.**

*Description of changes:*
Includes bug fix for amplify-ios Datastore.delete


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
