### PR TITLE
bug(datastore): HubEvent null check

### DIFF
--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
@@ -14,6 +14,7 @@
  */
 
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:flutter/material.dart';
 
 part 'HubEventElementWithMetadata.dart';
 
@@ -32,6 +33,14 @@ class HubEventElement {
     var model = _parseModelFromMap(serializedHubEventElement, provider);
     return HubEventElement(model);
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is HubEventElement && model == other.model;
+
+  @override
+  int get hashCode => model.hashCode;
 }
 
 /// Retrieves the model instance from [serializedHubEventElement].

--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
@@ -13,8 +13,6 @@
  * permissions and limitations under the License.
  */
 
-import 'dart:ui' show hashValues;
-
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 
 part 'HubEventElementWithMetadata.dart';

--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'dart:ui';
+import 'dart:ui' show hashValues;
 
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 

--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
@@ -15,20 +15,36 @@
 
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 
-class HubEventElement {
-  late final Model model;
+part 'HubEventElementWithMetadata.dart';
 
-  HubEventElement(
-    Map serializedData,
+/// The model associated with a DataStore `outboxMutationEnqueued` or
+/// `outboxMutationProcessed` Hub event.
+class HubEventElement {
+  /// The instance of the mutated model.
+  final Model model;
+
+  const HubEventElement(this.model);
+
+  factory HubEventElement.fromMap(
+    Map serializedHubEventElement,
     ModelProviderInterface provider,
   ) {
-    var serializedElement = serializedData['element'] as Map;
-    var modelName = serializedData['modelName'] as String;
-    var modelData = serializedElement['model'] as Map;
-    var serializedModelData =
-        (modelData['serializedData'] as Map).cast<String, dynamic>();
-    model = provider
-        .getModelTypeByModelName(modelName)
-        .fromJson(serializedModelData);
+    var model = _parseModelFromMap(serializedHubEventElement, provider);
+    return HubEventElement(model);
   }
+}
+
+/// Retrieves the model instance from [serializedHubEventElement].
+Model _parseModelFromMap(
+  Map serializedHubEventElement,
+  ModelProviderInterface provider,
+) {
+  var serializedElement = serializedHubEventElement['element'] as Map;
+  var modelName = serializedHubEventElement['modelName'] as String;
+  var modelData = serializedElement['model'] as Map;
+  var serializedModelData =
+      (modelData['serializedData'] as Map).cast<String, dynamic>();
+  return provider
+      .getModelTypeByModelName(modelName)
+      .fromJson(serializedModelData);
 }

--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
@@ -13,8 +13,9 @@
  * permissions and limitations under the License.
  */
 
+import 'dart:ui';
+
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
-import 'package:flutter/material.dart';
 
 part 'HubEventElementWithMetadata.dart';
 

--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
@@ -14,21 +14,21 @@
  */
 
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
-import 'package:collection/collection.dart';
 
 class HubEventElement {
-  late Model model;
+  late final Model model;
 
   HubEventElement(
-      Map<dynamic, dynamic> serializedData, ModelProviderInterface provider) {
-    Map<String, dynamic> serializedElement =
-        Map<String, dynamic>.from(serializedData["element"]);
-    Map<String, dynamic> modelData =
-        Map<String, dynamic>.from(serializedElement["model"]);
-    Map<String, dynamic> serializedModelData =
-        Map<String, dynamic>.from(modelData["serializedData"]);
+    Map serializedData,
+    ModelProviderInterface provider,
+  ) {
+    var serializedElement = serializedData['element'] as Map;
+    var modelName = serializedData['modelName'] as String;
+    var modelData = serializedElement['model'] as Map;
+    var serializedModelData =
+        (modelData['serializedData'] as Map).cast<String, dynamic>();
     model = provider
-        .getModelTypeByModelName(serializedData['modelName'])
+        .getModelTypeByModelName(modelName)
         .fromJson(serializedModelData);
   }
 }

--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElement.dart
@@ -34,14 +34,6 @@ class HubEventElement {
     var model = _parseModelFromMap(serializedHubEventElement, provider);
     return HubEventElement(model);
   }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is HubEventElement && model == other.model;
-
-  @override
-  int get hashCode => model.hashCode;
 }
 
 /// Retrieves the model instance from [serializedHubEventElement].

--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElementWithMetadata.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElementWithMetadata.dart
@@ -17,19 +17,18 @@ import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_inte
 import 'HubEventElement.dart';
 
 class HubEventElementWithMetadata extends HubEventElement {
-  late int version;
-  late int lastChangedAt;
-  late bool deleted;
+  late final int version;
+  late final int lastChangedAt;
+  late final bool? deleted;
 
   HubEventElementWithMetadata(
-      Map<dynamic, dynamic> serializedData, ModelProviderInterface provider)
-      : super(serializedData, provider) {
-    Map<String, dynamic> serializedElement =
-        new Map<String, dynamic>.from(serializedData["element"]);
-    Map<String, dynamic> metadata =
-        new Map<String, dynamic>.from(serializedElement["syncMetadata"]);
-    version = metadata["_version"];
-    lastChangedAt = metadata["_lastChangedAt"];
-    deleted = metadata["_deleted"];
+    Map serializedData,
+    ModelProviderInterface provider,
+  ) : super(serializedData, provider) {
+    var serializedElement = serializedData['element'] as Map;
+    var metadata = serializedElement['syncMetadata'] as Map;
+    version = metadata['_version'] as int;
+    lastChangedAt = metadata['_lastChangedAt'] as int;
+    deleted = metadata['_deleted'] as bool?;
   }
 }

--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElementWithMetadata.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElementWithMetadata.dart
@@ -13,22 +13,44 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
-import 'HubEventElement.dart';
+part of 'HubEventElement.dart';
 
+/// The model and metadata associated with a DataStore `outboxMutationProcessed`
+/// Hub event.
 class HubEventElementWithMetadata extends HubEventElement {
-  late final int version;
-  late final int lastChangedAt;
-  late final bool? deleted;
+  /// The version of the model.
+  final int version;
 
-  HubEventElementWithMetadata(
-    Map serializedData,
+  /// The last time the model was updated locally.
+  final DateTime lastChangedAt;
+
+  /// Whether or not the model was deleted.
+  final bool deleted;
+
+  const HubEventElementWithMetadata(
+    Model model, {
+    required this.version,
+    required this.lastChangedAt,
+    required this.deleted,
+  }) : super(model);
+
+  factory HubEventElementWithMetadata.fromMap(
+    Map serializedHubEventElement,
     ModelProviderInterface provider,
-  ) : super(serializedData, provider) {
-    var serializedElement = serializedData['element'] as Map;
+  ) {
+    var model = _parseModelFromMap(serializedHubEventElement, provider);
+    var serializedElement = serializedHubEventElement['element'] as Map;
     var metadata = serializedElement['syncMetadata'] as Map;
-    version = metadata['_version'] as int;
-    lastChangedAt = metadata['_lastChangedAt'] as int;
-    deleted = metadata['_deleted'] as bool?;
+    var version = metadata['_version'] as int;
+    var lastChangedAtSeconds = metadata['_lastChangedAt'] as int;
+    var lastChangedAt =
+        DateTime.fromMillisecondsSinceEpoch(1000 * lastChangedAtSeconds);
+    var deleted = metadata['_deleted'] as bool? ?? false;
+    return HubEventElementWithMetadata(
+      model,
+      version: version,
+      lastChangedAt: lastChangedAt,
+      deleted: deleted,
+    );
   }
 }

--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElementWithMetadata.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElementWithMetadata.dart
@@ -31,8 +31,9 @@ class HubEventElementWithMetadata extends HubEventElement {
     Model model, {
     required this.version,
     required this.lastChangedAt,
-    required this.deleted,
-  }) : super(model);
+    bool? deleted,
+  })  : deleted = deleted ?? false,
+        super(model);
 
   factory HubEventElementWithMetadata.fromMap(
     Map serializedHubEventElement,
@@ -43,7 +44,7 @@ class HubEventElementWithMetadata extends HubEventElement {
     var metadata = serializedElement['syncMetadata'] as Map;
     var version = metadata['_version'] as int;
     var lastChangedAt = metadata['_lastChangedAt'] as int;
-    var deleted = metadata['_deleted'] as bool? ?? false;
+    var deleted = metadata['_deleted'] as bool?;
     return HubEventElementWithMetadata(
       model,
       version: version,

--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElementWithMetadata.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElementWithMetadata.dart
@@ -21,8 +21,8 @@ class HubEventElementWithMetadata extends HubEventElement {
   /// The version of the model.
   final int version;
 
-  /// The last time the model was updated locally.
-  final DateTime lastChangedAt;
+  /// The last time the model was updated locally, in seconds since epoch.
+  final int lastChangedAt;
 
   /// Whether or not the model was deleted.
   final bool deleted;
@@ -42,9 +42,7 @@ class HubEventElementWithMetadata extends HubEventElement {
     var serializedElement = serializedHubEventElement['element'] as Map;
     var metadata = serializedElement['syncMetadata'] as Map;
     var version = metadata['_version'] as int;
-    var lastChangedAtSeconds = metadata['_lastChangedAt'] as int;
-    var lastChangedAt =
-        DateTime.fromMillisecondsSinceEpoch(1000 * lastChangedAtSeconds);
+    var lastChangedAt = metadata['_lastChangedAt'] as int;
     var deleted = metadata['_deleted'] as bool? ?? false;
     return HubEventElementWithMetadata(
       model,
@@ -53,16 +51,4 @@ class HubEventElementWithMetadata extends HubEventElement {
       deleted: deleted,
     );
   }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is HubEventElementWithMetadata &&
-          model == other.model &&
-          version == other.version &&
-          lastChangedAt == other.lastChangedAt &&
-          deleted == other.deleted;
-
-  @override
-  int get hashCode => hashValues(model, version, lastChangedAt, deleted);
 }

--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElementWithMetadata.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/HubEventElementWithMetadata.dart
@@ -53,4 +53,16 @@ class HubEventElementWithMetadata extends HubEventElement {
       deleted: deleted,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is HubEventElementWithMetadata &&
+          model == other.model &&
+          version == other.version &&
+          lastChangedAt == other.lastChangedAt &&
+          deleted == other.deleted;
+
+  @override
+  int get hashCode => hashValues(model, version, lastChangedAt, deleted);
 }

--- a/packages/amplify_datastore/lib/types/DataStoreHubEvents/OutboxMutationEvent.dart
+++ b/packages/amplify_datastore/lib/types/DataStoreHubEvents/OutboxMutationEvent.dart
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_datastore/types/DataStoreHubEvents/HubEventElementWithMetadata.dart';
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:amplify_core/types/hub/HubEventPayload.dart';
 import 'HubEventElement.dart';
@@ -25,8 +24,8 @@ class OutboxMutationEvent extends HubEventPayload {
   OutboxMutationEvent(Map<dynamic, dynamic> serializedData,
       ModelProviderInterface provider, String eventName) {
     element = eventName == "outboxMutationEnqueued"
-        ? HubEventElement(serializedData, provider)
-        : HubEventElementWithMetadata(serializedData, provider);
+        ? HubEventElement.fromMap(serializedData, provider)
+        : HubEventElementWithMetadata.fromMap(serializedData, provider);
     modelName = serializedData["modelName"] as String;
   }
 }

--- a/packages/amplify_datastore/test/amplify_datastore_stream_controller_test.dart
+++ b/packages/amplify_datastore/test/amplify_datastore_stream_controller_test.dart
@@ -20,7 +20,6 @@ import 'package:amplify_core/types/index.dart';
 import 'package:amplify_datastore/amplify_datastore_stream_controller.dart';
 import 'package:amplify_datastore/types/DataStoreHubEvents/DataStoreHubEvent.dart';
 import 'package:amplify_datastore/types/DataStoreHubEvents/HubEventElement.dart';
-import 'package:amplify_datastore/types/DataStoreHubEvents/HubEventElementWithMetadata.dart';
 import 'package:amplify_datastore/types/DataStoreHubEvents/ModelSyncedEvent.dart';
 import 'package:amplify_datastore/types/DataStoreHubEvents/NetworkStatusEvent.dart';
 import 'package:amplify_datastore/types/DataStoreHubEvents/OutboxMutationEvent.dart';
@@ -275,7 +274,7 @@ void main() {
     expect((element.model as Post).created, equals(parsedDate));
     expect(element.deleted, equals(false));
     expect(element.version, equals(1));
-    expect(element.lastChangedAt, equals(1));
+    expect(element.lastChangedAt, equals(DateTime(2021, 6, 23, 17, 1, 0)));
   });
 
   test('Can receive OutboxStatus Event', () async {

--- a/packages/amplify_datastore/test/amplify_datastore_stream_controller_test.dart
+++ b/packages/amplify_datastore/test/amplify_datastore_stream_controller_test.dart
@@ -274,7 +274,7 @@ void main() {
     expect((element.model as Post).created, equals(parsedDate));
     expect(element.deleted, equals(false));
     expect(element.version, equals(1));
-    expect(element.lastChangedAt, equals(DateTime(2021, 6, 23, 17, 1, 0)));
+    expect(element.lastChangedAt, equals(1624492860));
   });
 
   test('Can receive OutboxStatus Event', () async {

--- a/packages/amplify_datastore/test/outbox_mutation_event_test.dart
+++ b/packages/amplify_datastore/test/outbox_mutation_event_test.dart
@@ -1,0 +1,104 @@
+import 'package:amplify_core/test_utils/index.dart';
+import 'package:amplify_datastore/amplify_datastore.dart';
+import 'package:amplify_datastore/types/DataStoreHubEvents/HubEventElement.dart';
+import 'package:amplify_datastore/types/DataStoreHubEvents/OutboxMutationEvent.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_models/ModelProvider.dart';
+
+void main() async {
+  var modelProvider = ModelProvider();
+  var outboxMutationEnqueuedEventJson =
+      await getJsonFromFile('hub/outboxMutationEnqueuedEvent.json') as Map;
+  var outboxMutationEnqueuedEvent = OutboxMutationEvent(
+    outboxMutationEnqueuedEventJson,
+    modelProvider,
+    'outboxMutationEnqueued',
+  );
+  var outboxMutationProcessedEventJson =
+      await getJsonFromFile('hub/outboxMutationProcessedEvent.json') as Map;
+  var outboxMutationProcessedEvent = OutboxMutationEvent(
+    outboxMutationProcessedEventJson,
+    modelProvider,
+    'outboxMutationProcessed',
+  );
+
+  var expectedPost = Post(
+    id: '43036c6b-8044-4309-bddc-262b6c686026',
+    title: 'Title 1',
+    rating: 5,
+    created: TemporalDateTime.fromString('2020-02-20T20:20:20-08:00'),
+  );
+
+  var expectedProcessedHubEvent = HubEventElementWithMetadata(
+    expectedPost,
+    version: 1,
+    lastChangedAt: DateTime(2021, 6, 23, 17, 1, 0),
+    deleted: false,
+  );
+
+  group('OutboxMutationEvent', () {
+    group('outboxMutationEnqueued', () {
+      var enqueuedHubEventElement = outboxMutationEnqueuedEvent.element;
+
+      test('is HubEventElement', () {
+        expect(
+          enqueuedHubEventElement,
+          isNot(isA<HubEventElementWithMetadata>()),
+        );
+      });
+
+      test('fromMap', () {
+        var enqueuedPost = enqueuedHubEventElement.model as Post;
+        expect(enqueuedPost, expectedPost);
+      });
+    });
+
+    group('outboxMutationProcessed', () {
+      test('is HubEventElementWithMetadata', () {
+        expect(
+          outboxMutationProcessedEvent.element,
+          isA<HubEventElementWithMetadata>(),
+        );
+      });
+
+      group('fromMap', () {
+        test('all fields', () {
+          var processedHubEventElement = outboxMutationProcessedEvent.element
+              as HubEventElementWithMetadata;
+          var processedPost = processedHubEventElement.model as Post;
+          expect(processedPost, expectedPost);
+          expect(
+            processedHubEventElement.version,
+            expectedProcessedHubEvent.version,
+          );
+          expect(
+            processedHubEventElement.lastChangedAt,
+            expectedProcessedHubEvent.lastChangedAt,
+          );
+          expect(
+            processedHubEventElement.deleted,
+            expectedProcessedHubEvent.deleted,
+          );
+        });
+
+        test('_deleted = null', () {
+          var outboxMutationProcessedEvent = OutboxMutationEvent(
+            {
+              ...outboxMutationProcessedEventJson,
+              '_deleted': null,
+            },
+            modelProvider,
+            'outboxMutationProcessed',
+          );
+          var processedHubEventElement = outboxMutationProcessedEvent.element
+              as HubEventElementWithMetadata;
+          expect(
+            processedHubEventElement.deleted,
+            expectedProcessedHubEvent.deleted,
+          );
+        });
+      });
+    });
+  });
+}

--- a/packages/amplify_datastore/test/outbox_mutation_event_test.dart
+++ b/packages/amplify_datastore/test/outbox_mutation_event_test.dart
@@ -30,6 +30,7 @@ void main() async {
     created: TemporalDateTime.fromString('2020-02-20T20:20:20-08:00'),
   );
 
+  var expectedEnqueuedHubEvent = HubEventElement(expectedPost);
   var expectedProcessedHubEvent = HubEventElementWithMetadata(
     expectedPost,
     version: 1,
@@ -49,8 +50,7 @@ void main() async {
       });
 
       test('fromMap', () {
-        var enqueuedPost = enqueuedHubEventElement.model as Post;
-        expect(enqueuedPost, expectedPost);
+        expect(enqueuedHubEventElement, expectedEnqueuedHubEvent);
       });
     });
 
@@ -66,20 +66,7 @@ void main() async {
         test('all fields', () {
           var processedHubEventElement = outboxMutationProcessedEvent.element
               as HubEventElementWithMetadata;
-          var processedPost = processedHubEventElement.model as Post;
-          expect(processedPost, expectedPost);
-          expect(
-            processedHubEventElement.version,
-            expectedProcessedHubEvent.version,
-          );
-          expect(
-            processedHubEventElement.lastChangedAt,
-            expectedProcessedHubEvent.lastChangedAt,
-          );
-          expect(
-            processedHubEventElement.deleted,
-            expectedProcessedHubEvent.deleted,
-          );
+          expect(processedHubEventElement, expectedProcessedHubEvent);
         });
 
         test('_deleted = null', () {
@@ -93,10 +80,7 @@ void main() async {
           );
           var processedHubEventElement = outboxMutationProcessedEvent.element
               as HubEventElementWithMetadata;
-          expect(
-            processedHubEventElement.deleted,
-            expectedProcessedHubEvent.deleted,
-          );
+          expect(processedHubEventElement.deleted, false);
         });
       });
     });

--- a/packages/amplify_datastore/test/outbox_mutation_event_test.dart
+++ b/packages/amplify_datastore/test/outbox_mutation_event_test.dart
@@ -30,11 +30,10 @@ void main() async {
     created: TemporalDateTime.fromString('2020-02-20T20:20:20-08:00'),
   );
 
-  var expectedEnqueuedHubEvent = HubEventElement(expectedPost);
   var expectedProcessedHubEvent = HubEventElementWithMetadata(
     expectedPost,
     version: 1,
-    lastChangedAt: DateTime(2021, 6, 23, 17, 1, 0),
+    lastChangedAt: 1624492860,
     deleted: false,
   );
 
@@ -45,12 +44,17 @@ void main() async {
       test('is HubEventElement', () {
         expect(
           enqueuedHubEventElement,
+          isA<HubEventElement>(),
+        );
+        expect(
+          enqueuedHubEventElement,
           isNot(isA<HubEventElementWithMetadata>()),
         );
       });
 
       test('fromMap', () {
-        expect(enqueuedHubEventElement, expectedEnqueuedHubEvent);
+        var post = enqueuedHubEventElement.model as Post;
+        expect(post, expectedPost);
       });
     });
 
@@ -66,7 +70,22 @@ void main() async {
         test('all fields', () {
           var processedHubEventElement = outboxMutationProcessedEvent.element
               as HubEventElementWithMetadata;
-          expect(processedHubEventElement, expectedProcessedHubEvent);
+          expect(
+            processedHubEventElement.model,
+            expectedProcessedHubEvent.model,
+          );
+          expect(
+            processedHubEventElement.version,
+            expectedProcessedHubEvent.version,
+          );
+          expect(
+            processedHubEventElement.lastChangedAt,
+            expectedProcessedHubEvent.lastChangedAt,
+          );
+          expect(
+            processedHubEventElement.deleted,
+            expectedProcessedHubEvent.deleted,
+          );
         });
 
         test('_deleted = null', () {

--- a/packages/amplify_datastore/test/resources/hub/outboxMutationEnqueuedEvent.json
+++ b/packages/amplify_datastore/test/resources/hub/outboxMutationEnqueuedEvent.json
@@ -7,6 +7,7 @@
             "serializedData": {
                 "id": "43036c6b-8044-4309-bddc-262b6c686026",
                 "title": "Title 1",
+                "rating": 5,
                 "created": "2020-02-20T20:20:20-08:00"
             }
         }

--- a/packages/amplify_datastore/test/resources/hub/outboxMutationProcessedEvent.json
+++ b/packages/amplify_datastore/test/resources/hub/outboxMutationProcessedEvent.json
@@ -4,7 +4,7 @@
     "element": {
         "syncMetadata": {
             "id": "43036c6b-8044-4309-bddc-262b6c686026",
-            "_lastChangedAt": 1,
+            "_lastChangedAt": 1624492860,
             "_deleted": false,
             "_version": 1
         },
@@ -13,6 +13,7 @@
             "serializedData": {
                 "id": "43036c6b-8044-4309-bddc-262b6c686026",
                 "title": "Title 1",
+                "rating": 5,
                 "created": "2020-02-20T20:20:20-08:00"
             }
         }


### PR DESCRIPTION
*Issue #, if available:*
`_deleted` can be null on `HubEventWithMetadata`. This is by design, and is shared between both iOS and Android. Both platforms interpret this as being `false`.

*Description of changes:*
- Default to `_deleted = false`.
- Refactor HubEvent/HubEventWithMetadata for better testing.
- Add unit tests.
- Prefer `.cast()` or plain `Map` instead of `Map.from` which creates a new Map.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
