### PR TITLE
Revert "Revert "chore: remove deprecated method - configureModelProvi…

### DIFF
--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -63,21 +63,6 @@ class AmplifyDataStore extends DataStorePluginInterface {
     return streamWrapper.datastoreStreamController;
   }
 
-  @deprecated
-  @override
-  Future<void> configureModelProvider(
-      {ModelProviderInterface? modelProvider}) async {
-    ModelProviderInterface provider =
-        (modelProvider == null ? this.modelProvider : modelProvider)!;
-    if (provider.modelSchemas.isEmpty) {
-      throw DataStoreException('No modelProvider or modelSchemas found',
-          recoverySuggestion:
-              'Pass in a modelProvider instance while instantiating DataStorePlugin');
-    }
-    streamWrapper.registerModelsForHub(provider);
-    return _instance.configureModelProvider(modelProvider: modelProvider);
-  }
-
   @override
   Future<void> configureDataStore(
       {ModelProviderInterface? modelProvider,

--- a/packages/amplify_datastore/lib/method_channel_datastore.dart
+++ b/packages/amplify_datastore/lib/method_channel_datastore.dart
@@ -28,36 +28,6 @@ class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
   /// Internal use constructor
   AmplifyDataStoreMethodChannel() : super.tokenOnly();
 
-  /// This method adds model schemas which is necessary to instantiate native plugins
-  /// This is needed before the Amplify.configure() can be called, since the native
-  /// plugins are needed to be added before that. As this function is marked for
-  /// deprecation, it actually now invokes configureDataStore internally.
-  /// NOTE: modelProvider is nullable because the parent AmplifyDataStore class
-  /// provides a default value
-  @deprecated
-  @override
-  Future<void> configureModelProvider(
-      {ModelProviderInterface? modelProvider}) async {
-    try {
-      return await _channel
-          .invokeMethod('configureDataStore', <String, dynamic>{
-        'modelSchemas': modelProvider!.modelSchemas
-            .map((schema) => schema.toMap())
-            .toList(),
-        'modelProviderVersion': modelProvider.version
-      });
-    } on PlatformException catch (e) {
-      if (e.code == "AmplifyAlreadyConfiguredException") {
-        throw AmplifyAlreadyConfiguredException(
-            AmplifyExceptionMessages.alreadyConfiguredDefaultMessage,
-            recoverySuggestion:
-                AmplifyExceptionMessages.alreadyConfiguredDefaultSuggestion);
-      } else {
-        throw _deserializeException(e);
-      }
-    }
-  }
-
   /// This method instantiates the native DataStore plugins with plugin
   /// configurations. This needs to happen before Amplify.configure() can be
   /// called.

--- a/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
@@ -74,13 +74,6 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
         'streamController getter has not been implemented.');
   }
 
-  @deprecated
-  Future<void> configureModelProvider(
-      {required ModelProviderInterface modelProvider}) {
-    throw UnimplementedError(
-        'configureModelProvider() has not been implemented.');
-  }
-
   /// Configure AmplifyDataStore plugin with mandatory [modelProvider]
   /// and optional datastore configuration properties including
   ///


### PR DESCRIPTION
This PR removes the `configureModelProvider` method, which was marked for deprecation and has since been replaced by a `configureDataStore` method.

Note: I accidentally pushed this directly to the `null-safety-master` branch instead of my fork, hence the reverts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
