### PR TITLE
fix(Auth): Remove use of TypeToken

### DIFF
--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchCognitoAuthSessionResult.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/types/FlutterFetchCognitoAuthSessionResult.kt
@@ -90,6 +90,6 @@ data class FlutterFetchCognitoAuthSessionResult(private val raw: AWSCognitoAuthS
   //convert an object of type I to type O
   inline fun <I, reified O> I.convert(): O {
     val json = gson.toJson(this)
-    return gson.fromJson(json, object : TypeToken<O>() {}.type)
+    return gson.fromJson(json, O::class.java)
   }
 }

--- a/packages/amplify_core/android/src/main/kotlin/com/amazonaws/amplify/amplify_core/exception/ExceptionUtil.kt
+++ b/packages/amplify_core/android/src/main/kotlin/com/amazonaws/amplify/amplify_core/exception/ExceptionUtil.kt
@@ -47,9 +47,9 @@ class ExceptionUtil {
             val gsonBuilder = GsonBuilder()
             gsonBuilder.registerTypeAdapter(Throwable::class.java, ThrowableSerializer())
             val gson = gsonBuilder.create()
-            val mapType = object : TypeToken<Map<String, Any>>() {}.type
             val serializedJsonException = gson.toJson(e)
-            var serializedMap: Map<String, Any> = gson.fromJson(serializedJsonException, mapType)
+            @Suppress("UNCHECKED_CAST")
+            var serializedMap: Map<String, Any> = gson.fromJson(serializedJsonException, Map::class.java) as Map<String, Any>
 
             // Remove unnecessary fields
             serializedMap =


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/675

*Description of changes:*
- Remove use of TypeToken from FlutterFetchCognitoAuthSessionResult
- Remove use of TypeToken from ExceptionUtil

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
