### PR TITLE
Fix enum string function

### DIFF
--- a/packages/amplify_datastore_plugin_interface/lib/src/types/utils/parsers.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/utils/parsers.dart
@@ -23,4 +23,4 @@ String? enumToString(Object? o) =>
 
 // only to be used internally by amplify-flutter library
 T? enumFromString<T>(String? key, List<T> values) =>
-    values.firstWhereOrNull((v) => key == enumToString(v));
+    key == null ? null : values.firstWhereOrNull((v) => key == enumToString(v));

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/utils/parsers.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/utils/parsers.dart
@@ -23,4 +23,4 @@ String? enumToString(Object? o) =>
 
 // only to be used internally by amplify-flutter library
 T? enumFromString<T>(String? key, List<T> values) =>
-    key == null ? null : values.firstWhereOrNull((v) => key == enumToString(v));
+    values.firstWhereOrNull((v) => key == enumToString(v));

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/utils/parsers.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/utils/parsers.dart
@@ -22,5 +22,5 @@ String? enumToString(Object? o) =>
     o != null ? o.toString().split('.').last : null;
 
 // only to be used internally by amplify-flutter library
-T? enumFromString<T>(String key, List<T> values) =>
+T? enumFromString<T>(String? key, List<T> values) =>
     values.firstWhereOrNull((v) => key == enumToString(v));


### PR DESCRIPTION
*Issue #, if available:*
Exception if decoding an null enum string, like the line below from `AllTypeOptionalModel` where `json['enumType']` is null.

<img width="650" alt="Screen Shot 2021-06-29 at 3 54 18 PM" src="https://user-images.githubusercontent.com/24740863/123877694-83cf0580-d8f2-11eb-8583-cf48cdb2690d.png">

*Description of changes:*
- Make argument nullable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
