### PR TITLE
fix(amplify_api): address issue #685, prevent type error when using s…

### DIFF
--- a/packages/amplify_api/lib/method_channel_api.dart
+++ b/packages/amplify_api/lib/method_channel_api.dart
@@ -158,7 +158,7 @@ class AmplifyAPIMethodChannel extends AmplifyAPI {
       final errors = _deserializeGraphQLResponseErrors(result);
 
       GraphQLResponse<T> response =
-          GraphQLResponse<T>(data: result['data'], errors: errors);
+          GraphQLResponse<T>(data: result['data'] ?? '', errors: errors);
 
       return response;
     } on PlatformException catch (e) {


### PR DESCRIPTION
*Issue #, if available:* #685

*Description of changes:* In some error cases the serialized GraphQL response from method channels has null `data`. Often, this occurs when there is an error that does not throw an exception but instead passes the error to the `errors` parameter when instantiating the GraphQL response in dart. With sound null safety, the null data throws a type error, making it difficult for the developer to see the real error. This is an issue with sound null safety because the `data` key is not always present on the map from the method channel even though there is a null check on the map itself.

This PR applies a quick fix to prevent type error when using sound null safety by providing blank string as GraphQL response data (often when error).

Potential alternative solutions:
* actually throw an exception here, raises some questions about when to throw exception and when to pass to `error` parameter
* provide the defaults from the platform side instead of dart
* make the data param nullable in `GraphQLResponse`

The other solutions I could think of would take more time and investigation, so I thought it prudent to at least prevent the type error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
