### PR TITLE
chore(amplify_api): add GraphQL API integration tests

### DIFF
--- a/packages/amplify_api/example/integration_test/graph_ql_tests.dart
+++ b/packages/amplify_api/example/integration_test/graph_ql_tests.dart
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:amplify_flutter/amplify.dart';
+import 'package:amplify_api/amplify_api.dart';
+import 'dart:convert';
+
+import 'package:amplify_api_example/amplifyconfiguration.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('GraphQL', () {
+    setUpAll(() async {
+      if (!Amplify.isConfigured) {
+        await Amplify.addPlugins([AmplifyAPI()]);
+        await Amplify.configure(amplifyconfig);
+      }
+    });
+
+    testWidgets('should fetch', (WidgetTester tester) async {
+      const listBlogs = 'listBlogs';
+      const items = 'items';
+      String graphQLDocument = '''query MyQuery {
+        $listBlogs {
+          $items {
+            id
+            name
+            createdAt
+          }
+        }
+      }''';
+
+      var _r = await Amplify.API
+          .query<String>(request: GraphQLRequest(document: graphQLDocument));
+      var response = await _r.response;
+      Map data = jsonDecode(response.data);
+      expect(data[listBlogs][items], hasLength(greaterThanOrEqualTo(0)));
+    });
+  });
+}

--- a/packages/amplify_api/example/integration_test/main_test.dart
+++ b/packages/amplify_api/example/integration_test/main_test.dart
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:amplify_flutter/amplify.dart';
+import 'package:amplify_api/amplify_api.dart';
+import 'package:amplify_api_example/amplifyconfiguration.dart';
+
+import 'graph_ql_tests.dart' as graph_ql_tests;
+
+void main() async {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('amplify_api', () {
+    setUpAll(() async {
+      await Amplify.addPlugins([AmplifyAPI()]);
+      await Amplify.configure(amplifyconfig);
+    });
+
+    graph_ql_tests.main();
+  });
+}

--- a/packages/amplify_api/example/lib/graphql_api_view.dart
+++ b/packages/amplify_api/example/lib/graphql_api_view.dart
@@ -20,7 +20,8 @@ import 'package:amplify_api/amplify_api.dart';
 class GraphQLApiView extends StatefulWidget {
   bool isAmplifyConfigured;
 
-  GraphQLApiView({Key key, this.isAmplifyConfigured}) : super(key: key);
+  GraphQLApiView({Key? key, this.isAmplifyConfigured = false})
+      : super(key: key);
 
   @override
   _GraphQLApiViewState createState() => _GraphQLApiViewState();
@@ -28,9 +29,8 @@ class GraphQLApiView extends StatefulWidget {
 
 class _GraphQLApiViewState extends State<GraphQLApiView> {
   String _result = '';
-  Function _unsubscribe;
-
-  GraphQLOperation _lastOperation;
+  late Function _unsubscribe;
+  late GraphQLOperation _lastOperation;
 
   subscribe() async {
     String graphQLDocument = '''subscription MySubscription {
@@ -150,7 +150,7 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
         Padding(padding: EdgeInsets.all(10.0)),
         Center(
           child: RaisedButton(
-            onPressed: widget.isAmplifyConfigured ? _unsubscribe : null,
+            onPressed: widget.isAmplifyConfigured ? () => _unsubscribe() : null,
             child: Text('Unsubscribe'),
           ),
         ),

--- a/packages/amplify_api/example/lib/main.dart
+++ b/packages/amplify_api/example/lib/main.dart
@@ -21,7 +21,6 @@ import 'package:flutter/material.dart';
 import 'amplifyconfiguration.dart';
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 
-
 void main() {
   runApp(MyApp());
 }
@@ -35,8 +34,6 @@ class _MyAppState extends State<MyApp> {
   bool _isAmplifyConfigured = false;
   bool _showRestApiView = true;
 
-  AmplifyAPI apiRest;
-
   @override
   void initState() {
     super.initState();
@@ -44,10 +41,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   void _configureAmplify() async {
-    apiRest = AmplifyAPI();
-
-    Amplify.addPlugin(apiRest);
-    Amplify.addPlugin(AmplifyAuthCognito());
+    Amplify.addPlugins([AmplifyAuthCognito(), AmplifyAPI()]);
 
     try {
       await Amplify.configure(amplifyconfig);

--- a/packages/amplify_api/example/lib/rest_api_view.dart
+++ b/packages/amplify_api/example/lib/rest_api_view.dart
@@ -25,9 +25,8 @@ class RestApiView extends StatefulWidget {
 }
 
 class _RestApiViewState extends State<RestApiView> {
-  TextEditingController _apiPathController;
-
-  RestOperation _lastRestOperation;
+  late TextEditingController _apiPathController;
+  late RestOperation _lastRestOperation;
 
   @override
   void initState() {

--- a/packages/amplify_api/example/pubspec.yaml
+++ b/packages/amplify_api/example/pubspec.yaml
@@ -6,7 +6,8 @@ description: Demonstrates how to use the amplify_api plugin.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=2.2.0"
 
 dependencies:
   flutter:
@@ -31,6 +32,10 @@ dependencies:
 
 dev_dependencies:
   flutter_test:
+    sdk: flutter
+  flutter_driver:
+    sdk: flutter
+  integration_test:
     sdk: flutter
 
 # For information on the generic Dart part of this file, see the

--- a/packages/amplify_api/example/test_driver/integration_test.dart
+++ b/packages/amplify_api/example/test_driver/integration_test.dart
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();

--- a/packages/amplify_api/example/tool/add_api_request.json
+++ b/packages/amplify_api/example/tool/add_api_request.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "serviceConfiguration": {
+    "serviceName": "AppSync",
+    "apiName": "apiIntegrationTestGraphQL",
+    "transformSchema": "type Blog @model { id: ID!\n name: String!\n createdAt: AWSDate }",
+    "defaultAuthType":  {
+      "mode": "API_KEY",
+      "expirationTime": 365
+    }
+  }
+}

--- a/packages/amplify_api/example/tool/provision_integration_test_resources.sh
+++ b/packages/amplify_api/example/tool/provision_integration_test_resources.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+IFS='|'
+
+FLUTTERCONFIG="{\
+\"ResDir\":\"./lib/\",\
+}"
+
+AMPLIFY="{\
+\"projectName\":\"amplifyApiInteg\",\
+\"envName\":\"test\",\
+\"defaultEditor\":\"code\"\
+}"
+
+FRONTEND="{\
+\"frontend\":\"flutter\",\
+\"config\":$FLUTTERCONFIG\
+}"
+
+amplify init \
+--amplify $AMPLIFY \
+--frontend $FRONTEND \
+--yes
+cat tool/add_api_request.json | jq -c | amplify add api --headless
+amplify push --yes


### PR DESCRIPTION
Adds minimal integration test suite to api category. Here, it's just a GraphQL query along with related provisioning script.

There are also some changes to API example app to make it run with sound null safety.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
