### PR TITLE
Feature/selective sync

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -28,15 +28,16 @@ import com.amazonaws.amplify.amplify_datastore.types.model.FlutterModelSchema
 import com.amazonaws.amplify.amplify_datastore.types.model.FlutterSerializedModel
 import com.amazonaws.amplify.amplify_datastore.types.model.FlutterSubscriptionEvent
 import com.amazonaws.amplify.amplify_datastore.types.query.QueryOptionsBuilder
+import com.amazonaws.amplify.amplify_datastore.types.query.QueryPredicateBuilder
 import com.amazonaws.amplify.amplify_datastore.util.safeCastToList
 import com.amazonaws.amplify.amplify_datastore.util.safeCastToMap
-import com.amplifyframework.AmplifyException
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.core.async.Cancelable
 import com.amplifyframework.core.model.Model
 import com.amplifyframework.core.model.SerializedModel
 import com.amplifyframework.core.model.query.QueryOptions
+import com.amplifyframework.core.model.query.predicate.QueryPredicate
 import com.amplifyframework.core.model.query.predicate.QueryPredicates
 import com.amplifyframework.datastore.AWSDataStorePlugin
 import com.amplifyframework.datastore.DataStoreConfiguration
@@ -47,6 +48,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 /** AmplifyDataStorePlugin */
@@ -70,23 +72,32 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
     }
 
     @VisibleForTesting
-    constructor(eventHandler: DataStoreObserveEventStreamHandler,
-            hubEventHandler: DataStoreHubEventStreamHandler) {
+    constructor(
+        eventHandler: DataStoreObserveEventStreamHandler,
+        hubEventHandler: DataStoreHubEventStreamHandler
+    ) {
         dataStoreObserveEventStreamHandler = eventHandler
         dataStoreHubEventStreamHandler = hubEventHandler
     }
 
     override fun onAttachedToEngine(
-            @NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-        channel = MethodChannel(flutterPluginBinding.binaryMessenger,
-                "com.amazonaws.amplify/datastore")
+        @NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding
+    ) {
+        channel = MethodChannel(
+            flutterPluginBinding.binaryMessenger,
+            "com.amazonaws.amplify/datastore"
+        )
         channel.setMethodCallHandler(this)
-        eventchannel = EventChannel(flutterPluginBinding.binaryMessenger,
-                "com.amazonaws.amplify/datastore_observe_events")
+        eventchannel = EventChannel(
+            flutterPluginBinding.binaryMessenger,
+            "com.amazonaws.amplify/datastore_observe_events"
+        )
         eventchannel.setStreamHandler(dataStoreObserveEventStreamHandler)
 
-        hubEventChannel = EventChannel(flutterPluginBinding.binaryMessenger,
-                "com.amazonaws.amplify/datastore_hub_events")
+        hubEventChannel = EventChannel(
+            flutterPluginBinding.binaryMessenger,
+            "com.amazonaws.amplify/datastore_hub_events"
+        )
         hubEventChannel.setStreamHandler(dataStoreHubEventStreamHandler)
         LOG.info("Initiated DataStore plugin")
     }
@@ -99,8 +110,10 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
             }
         } catch (e: Exception) {
             handler.post {
-                postExceptionToFlutterChannel(result, "DataStoreException",
-                        createSerializedUnrecognizedError(e))
+                postExceptionToFlutterChannel(
+                    result, "DataStoreException",
+                    createSerializedUnrecognizedError(e)
+                )
             }
             return
         }
@@ -118,30 +131,38 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
     @VisibleForTesting
     fun onConfigureDataStore(flutterResult: Result, request: Map<String, Any>) {
         if (!request.containsKey("modelSchemas") || !request.containsKey(
-                        "modelProviderVersion") || request["modelSchemas"] !is List<*>) {
+                "modelProviderVersion"
+            ) || request["modelSchemas"] !is List<*>
+        ) {
             handler.post {
-                postExceptionToFlutterChannel(flutterResult, "DataStoreException",
-                        createSerializedError(ExceptionMessages.missingExceptionMessage,
-                                ExceptionMessages.missingRecoverySuggestion,
-                                "Received invalid request from Dart, modelSchemas and/or modelProviderVersion" +
-                                        " are not available. Request: " + request.toString()))
+                postExceptionToFlutterChannel(
+                    flutterResult, "DataStoreException",
+                    createSerializedError(
+                        ExceptionMessages.missingExceptionMessage,
+                        ExceptionMessages.missingRecoverySuggestion,
+                        "Received invalid request from Dart, modelSchemas and/or modelProviderVersion" +
+                                " are not available. Request: " + request.toString()
+                    )
+                )
             }
             return
         }
 
         val modelSchemas: List<Map<String, Any>> = request["modelSchemas"].safeCastToList()!!
+        val syncExpressions: List<Map<String, Any>> =
+            request["syncExpressions"].safeCastToList() ?: emptyList()
 
-        val modelProvider = FlutterModelProvider.instance
         val flutterModelSchemaList =
-                modelSchemas.map { modelSchema -> FlutterModelSchema(modelSchema) }
+            modelSchemas.map { modelSchema -> FlutterModelSchema(modelSchema) }
         flutterModelSchemaList.forEach { flutterModelSchema ->
-
             val nativeSchema = flutterModelSchema.convertToNativeModelSchema()
             modelProvider.addModelSchema(
-                    flutterModelSchema.name,
-                    nativeSchema
+                flutterModelSchema.name,
+                nativeSchema
             )
         }
+
+        val dataStoreConfigurationBuilder = DataStoreConfiguration.builder()
 
         modelProvider.setVersion(request["modelProviderVersion"] as String)
         val defaultDataStoreConfiguration = DataStoreConfiguration.defaults()
@@ -155,21 +176,67 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
             (request["syncPageSize"] as? Int)
                 ?: defaultDataStoreConfiguration.syncPageSize
 
-        try {
-            Amplify.addPlugin(
-                AWSDataStorePlugin
-                    .builder()
-                    .modelProvider(modelProvider)
-                    .dataStoreConfiguration(
-                        DataStoreConfiguration
-                            .builder()
-                            .syncInterval(syncInterval, TimeUnit.MINUTES)
-                            .syncMaxRecords(syncMaxRecords)
-                            .syncPageSize(syncPageSize)
-                            .build()
+        syncExpressions.forEach { syncExpression ->
+            try {
+                val id = syncExpression["id"] as String
+                val modelName = syncExpression["modelName"] as String
+                val queryPredicate =
+                    QueryPredicateBuilder.fromSerializedMap(syncExpression["queryPredicate"].safeCastToMap())!!
+                dataStoreConfigurationBuilder.syncExpression(modelName) {
+                    var resolvedQueryPredicate = queryPredicate
+                    val latch = CountDownLatch(1)
+                    handler.post {
+                        channel.invokeMethod("resolveQueryPredicate", id, object : Result {
+                            override fun success(result: Any?) {
+                                try {
+                                    resolvedQueryPredicate =
+                                        QueryPredicateBuilder.fromSerializedMap(result.safeCastToMap())!!
+
+                                } catch (e: Exception) {
+                                    LOG.error("Failed to resolve query predicate. Reverting to original query predicate.")
+                                }
+                                latch.countDown()
+                            }
+
+                            override fun error(code: String?, msg: String?, details: Any?) {
+                                LOG.error("Failed to resolve query predicate. Reverting to original query predicate.")
+                                latch.countDown()
+                            }
+
+                            override fun notImplemented() {
+                                LOG.error("resolveQueryPredicate not implemented.")
+                                latch.countDown()
+                            }
+                        })
+                    }
+                    latch.await()
+                    resolvedQueryPredicate
+                }
+            } catch (e: Exception) {
+                handler.post {
+                    postExceptionToFlutterChannel(
+                        flutterResult, "DataStoreException",
+                        createSerializedUnrecognizedError(e)
                     )
+                }
+                return
+            }
+        }
+
+        val dataStorePlugin = AWSDataStorePlugin
+            .builder()
+            .modelProvider(modelProvider)
+            .dataStoreConfiguration(
+                dataStoreConfigurationBuilder
+                    .syncInterval(syncInterval, TimeUnit.MINUTES)
+                    .syncMaxRecords(syncMaxRecords)
+                    .syncPageSize(syncPageSize)
                     .build()
             )
+            .build()
+
+        try {
+            Amplify.addPlugin(dataStorePlugin)
         } catch (e: Exception) {
             handleAddPluginException("Datastore", e, flutterResult)
             return
@@ -186,39 +253,45 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
             queryOptions = QueryOptionsBuilder.fromSerializedMap(request)
         } catch (e: Exception) {
             handler.post {
-                postExceptionToFlutterChannel(flutterResult, "DataStoreException",
-                        createSerializedUnrecognizedError(e))
+                postExceptionToFlutterChannel(
+                    flutterResult, "DataStoreException",
+                    createSerializedUnrecognizedError(e)
+                )
             }
             return
         }
 
         val plugin = Amplify.DataStore.getPlugin("awsDataStorePlugin") as AWSDataStorePlugin
         plugin.query(
-                modelName,
-                queryOptions,
-                {
-                    try {
-                        val results: List<Map<String, Any>> =
-                                it.asSequence().toList().map { model: Model? ->
-                                    FlutterSerializedModel(model as SerializedModel).toMap()
-                                }
-                        LOG.debug("Number of items received " + results.size)
-
-                        handler.post { flutterResult.success(results) }
-                    } catch (e: Exception) {
-                        handler.post {
-                            postExceptionToFlutterChannel(flutterResult, "DataStoreException",
-                                    createSerializedUnrecognizedError(e))
+            modelName,
+            queryOptions,
+            {
+                try {
+                    val results: List<Map<String, Any>> =
+                        it.asSequence().toList().map { model: Model? ->
+                            FlutterSerializedModel(model as SerializedModel).toMap()
                         }
-                    }
-                },
-                {
-                    LOG.error("Query operation failed.", it)
+                    LOG.debug("Number of items received " + results.size)
+
+                    handler.post { flutterResult.success(results) }
+                } catch (e: Exception) {
                     handler.post {
-                        postExceptionToFlutterChannel(flutterResult, "DataStoreException",
-                                createSerializedError(it))
+                        postExceptionToFlutterChannel(
+                            flutterResult, "DataStoreException",
+                            createSerializedUnrecognizedError(e)
+                        )
                     }
                 }
+            },
+            {
+                LOG.error("Query operation failed.", it)
+                handler.post {
+                    postExceptionToFlutterChannel(
+                        flutterResult, "DataStoreException",
+                        createSerializedError(it)
+                    )
+                }
+            }
         )
     }
 
@@ -230,11 +303,13 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         try {
             modelName = request["modelName"] as String
             serializedModelData =
-                    deserializeNestedModels(request["serializedModel"].safeCastToMap()!!)
+                deserializeNestedModels(request["serializedModel"].safeCastToMap()!!)
         } catch (e: Exception) {
             handler.post {
-                postExceptionToFlutterChannel(flutterResult, "DataStoreException",
-                        createSerializedUnrecognizedError(e))
+                postExceptionToFlutterChannel(
+                    flutterResult, "DataStoreException",
+                    createSerializedUnrecognizedError(e)
+                )
             }
             return
         }
@@ -243,27 +318,29 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         val schema = modelProvider.modelSchemas()[modelName];
 
         val instance = SerializedModel.builder()
-                .serializedData(serializedModelData)
-                .modelSchema(schema)
-                .build()
+            .serializedData(serializedModelData)
+            .modelSchema(schema)
+            .build()
 
         plugin.delete(
-                instance,
-                {
-                    LOG.info("Deleted item: " + it.item().toString())
+            instance,
+            {
+                LOG.info("Deleted item: " + it.item().toString())
+                handler.post { flutterResult.success(null) }
+            },
+            {
+                LOG.error("Delete operation failed.", it)
+                if (it.localizedMessage == "Wanted to delete one row, but deleted 0 rows.") {
                     handler.post { flutterResult.success(null) }
-                },
-                {
-                    LOG.error("Delete operation failed.", it)
-                    if (it.localizedMessage == "Wanted to delete one row, but deleted 0 rows.") {
-                        handler.post { flutterResult.success(null) }
-                    } else {
-                        handler.post {
-                            postExceptionToFlutterChannel(flutterResult, "DataStoreException",
-                                    createSerializedError(it))
-                        }
+                } else {
+                    handler.post {
+                        postExceptionToFlutterChannel(
+                            flutterResult, "DataStoreException",
+                            createSerializedError(it)
+                        )
                     }
                 }
+            }
         )
     }
 
@@ -275,11 +352,13 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         try {
             modelName = request["modelName"] as String
             serializedModelData =
-                    deserializeNestedModels(request["serializedModel"].safeCastToMap()!!)
+                deserializeNestedModels(request["serializedModel"].safeCastToMap()!!)
         } catch (e: Exception) {
             handler.post {
-                postExceptionToFlutterChannel(flutterResult, "DataStoreException",
-                        createSerializedUnrecognizedError(e))
+                postExceptionToFlutterChannel(
+                    flutterResult, "DataStoreException",
+                    createSerializedUnrecognizedError(e)
+                )
             }
             return
         }
@@ -288,26 +367,28 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         val schema = modelProvider.modelSchemas()[modelName];
 
         val serializedModel = SerializedModel.builder()
-                .serializedData(serializedModelData)
-                .modelSchema(schema)
-                .build()
+            .serializedData(serializedModelData)
+            .modelSchema(schema)
+            .build()
 
         val predicate = QueryPredicates.all()
 
         plugin.save(
-                serializedModel,
-                predicate,
-                Consumer {
-                    LOG.info("Saved item: " + it.item().toString())
-                    handler.post { flutterResult.success(null) }
-                },
-                Consumer {
-                    LOG.error("Save operation failed", it)
-                    handler.post {
-                        postExceptionToFlutterChannel(flutterResult, "DataStoreException",
-                                createSerializedError(it))
-                    }
+            serializedModel,
+            predicate,
+            Consumer {
+                LOG.info("Saved item: " + it.item().toString())
+                handler.post { flutterResult.success(null) }
+            },
+            Consumer {
+                LOG.error("Save operation failed", it)
+                handler.post {
+                    postExceptionToFlutterChannel(
+                        flutterResult, "DataStoreException",
+                        createSerializedError(it)
+                    )
                 }
+            }
         )
     }
 
@@ -315,17 +396,19 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         val plugin = Amplify.DataStore.getPlugin("awsDataStorePlugin") as AWSDataStorePlugin
 
         plugin.clear(
-                {
-                    LOG.info("Successfully cleared the store")
-                    handler.post { flutterResult.success(null) }
-                },
-                {
-                    LOG.error("Failed to clear store with error: ", it)
-                    handler.post {
-                        postExceptionToFlutterChannel(flutterResult, "DataStoreException",
-                                createSerializedError(it))
-                    }
+            {
+                LOG.info("Successfully cleared the store")
+                handler.post { flutterResult.success(null) }
+            },
+            {
+                LOG.error("Failed to clear store with error: ", it)
+                handler.post {
+                    postExceptionToFlutterChannel(
+                        flutterResult, "DataStoreException",
+                        createSerializedError(it)
+                    )
                 }
+            }
         )
     }
 
@@ -333,24 +416,29 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         val plugin = Amplify.DataStore.getPlugin("awsDataStorePlugin") as AWSDataStorePlugin
 
         plugin.observe(
-                { cancelable ->
-                    LOG.info("Established a new stream form flutter $cancelable")
-                    observeCancelable = cancelable
-                },
-                { event ->
-                    LOG.debug("Received event: $event")
-                    if (event.item() is SerializedModel) {
-                        dataStoreObserveEventStreamHandler.sendEvent(FlutterSubscriptionEvent(
-                                serializedModel = event.item() as SerializedModel,
-                                eventType = event.type().name.toLowerCase()).toMap())
-                    }
-                },
-                { failure: DataStoreException ->
-                    LOG.error("Received an error", failure)
-                    dataStoreObserveEventStreamHandler.error("DataStoreException",
-                            createSerializedError(failure))
-                },
-                { LOG.info("Observation complete.") }
+            { cancelable ->
+                LOG.info("Established a new stream form flutter $cancelable")
+                observeCancelable = cancelable
+            },
+            { event ->
+                LOG.debug("Received event: $event")
+                if (event.item() is SerializedModel) {
+                    dataStoreObserveEventStreamHandler.sendEvent(
+                        FlutterSubscriptionEvent(
+                            serializedModel = event.item() as SerializedModel,
+                            eventType = event.type().name.toLowerCase()
+                        ).toMap()
+                    )
+                }
+            },
+            { failure: DataStoreException ->
+                LOG.error("Received an error", failure)
+                dataStoreObserveEventStreamHandler.error(
+                    "DataStoreException",
+                    createSerializedError(failure)
+                )
+            },
+            { LOG.info("Observation complete.") }
         )
         flutterResult.success(true)
     }
@@ -371,9 +459,9 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         return serializedModelData.mapValues {
             if (it.value is Map<*, *>) {
                 SerializedModel.builder()
-                        .serializedData(deserializeNestedModels(it.value as HashMap<String, Any>))
-                        .modelSchema(null)
-                        .build() as Any
+                    .serializedData(deserializeNestedModels(it.value as HashMap<String, Any>))
+                    .modelSchema(null)
+                    .build() as Any
             } else
                 it.value
         }

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterSerializedModel.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterSerializedModel.kt
@@ -16,8 +16,8 @@
 package com.amazonaws.amplify.amplify_datastore.types.model
 
 import com.amplifyframework.core.model.Model
-import com.amplifyframework.core.model.temporal.Temporal
 import com.amplifyframework.core.model.SerializedModel
+import com.amplifyframework.core.model.temporal.Temporal
 import java.lang.Exception
 
 

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePluginTest.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePluginTest.kt
@@ -574,17 +574,6 @@ class AmplifyDataStorePluginTest {
 
     @Test
     fun test_observe_success_event() {
-<<<<<<< HEAD
-        flutterPlugin = AmplifyDataStorePlugin(eventHandler = mockStreamHandler,
-                hubEventHandler = mockHubHandler)
-        val eventData: HashMap<String, Any> = (readMapFromFile("observe_api",
-                "post_type_success_event.json",
-                HashMap::class.java) as HashMap<String, Any>)
-        val modelData = mapOf("id" to "43036c6b-8044-4309-bddc-262b6c686026",
-                "title" to "Title 2",
-                "rating" to 0,
-                "created" to Temporal.DateTime("2020-02-20T20:20:20-08:00"))
-=======
         flutterPlugin = AmplifyDataStorePlugin(
             eventHandler = mockStreamHandler,
             hubEventHandler = mockHubHandler
@@ -597,9 +586,9 @@ class AmplifyDataStorePluginTest {
         val modelData = mapOf(
             "id" to "43036c6b-8044-4309-bddc-262b6c686026",
             "title" to "Title 2",
+            "rating" to 0,
             "created" to Temporal.DateTime("2020-02-20T20:20:20-08:00")
         )
->>>>>>> 9c88b30 (feat(datastore): Add selective sync)
         val instance = SerializedModel.builder()
             .serializedData(modelData)
             .modelSchema(modelSchema)

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePluginTest.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePluginTest.kt
@@ -46,10 +46,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
@@ -68,28 +70,31 @@ class AmplifyDataStorePluginTest {
     private var mockAmplifyDataStorePlugin = mock(AWSDataStorePlugin::class.java)
     private val mockResult: MethodChannel.Result = mock(MethodChannel.Result::class.java)
     private val mockStreamHandler: DataStoreObserveEventStreamHandler =
-            mock(DataStoreObserveEventStreamHandler::class.java)
+        mock(DataStoreObserveEventStreamHandler::class.java)
     private val mockHubHandler: DataStoreHubEventStreamHandler =
-            mock(DataStoreHubEventStreamHandler::class.java)
+        mock(DataStoreHubEventStreamHandler::class.java)
     private val dataStoreException =
-            DataStoreException("Some useful exception message", "Some useful recovery message")
-    private val mockModelSchemas = mutableListOf(mapOf(
-        "name" to "Post",
-        "pluralName" to "Posts",
-        "fields" to mapOf(
-            "blog" to mapOf(
-                "name" to "blog",
-                "targetType" to "Blog",
-                "isRequired" to false,
-                "isArray" to false,
-                "type" to mapOf(
-                    "fieldType" to "string"
+        DataStoreException("Some useful exception message", "Some useful recovery message")
+    private val mockModelSchemas = mutableListOf(
+        mapOf(
+            "name" to "Post",
+            "pluralName" to "Posts",
+            "fields" to mapOf(
+                "blog" to mapOf(
+                    "name" to "blog",
+                    "targetType" to "Blog",
+                    "isRequired" to false,
+                    "isArray" to false,
+                    "type" to mapOf(
+                        "fieldType" to "string"
+                    )
                 )
             )
         )
-    ))
+    )
     private val defaultDataStoreConfiguration = DataStoreConfiguration.defaults()
-    private val mockDataStoreConfigurationBuilder = mock(DataStoreConfiguration.Builder::class.java, RETURNS_SELF)
+    private val mockDataStoreConfigurationBuilder =
+        mock(DataStoreConfiguration.Builder::class.java, RETURNS_SELF)
 
     @Before
     fun setup() {
@@ -99,24 +104,30 @@ class AmplifyDataStorePluginTest {
 
         modelSchema = flutterPlugin.modelProvider.modelSchemas()["Post"]!!
         amplifySuccessResults = mutableListOf<SerializedModel>(
-                SerializedModel.builder()
-                        .serializedData(
-                                mapOf("id" to "4281dfba-96c8-4a38-9a8e-35c7e893ea47",
-                                        "title" to "Title 1",
-                                        "rating" to 4,
-                                        "created" to Temporal.DateTime("2020-02-20T20:20:20+03:50")
-                                ))
-                        .modelSchema(modelSchema)
-                        .build(),
-                SerializedModel.builder()
-                        .serializedData(
-                                mapOf("id" to "43036c6b-8044-4309-bddc-262b6c686026",
-                                        "title" to "Title 2",
-                                        "rating" to 6,
-                                        "created" to Temporal.DateTime(
-                                                "2020-02-20T20:20:20-08:00")))
-                        .modelSchema(modelSchema)
-                        .build()
+            SerializedModel.builder()
+                .serializedData(
+                    mapOf(
+                        "id" to "4281dfba-96c8-4a38-9a8e-35c7e893ea47",
+                        "title" to "Title 1",
+                        "rating" to 4,
+                        "created" to Temporal.DateTime("2020-02-20T20:20:20+03:50")
+                    )
+                )
+                .modelSchema(modelSchema)
+                .build(),
+            SerializedModel.builder()
+                .serializedData(
+                    mapOf(
+                        "id" to "43036c6b-8044-4309-bddc-262b6c686026",
+                        "title" to "Title 2",
+                        "rating" to 6,
+                        "created" to Temporal.DateTime(
+                            "2020-02-20T20:20:20-08:00"
+                        )
+                    )
+                )
+                .modelSchema(modelSchema)
+                .build()
         )
         setFinalStatic(Amplify::class.java.getDeclaredField("DataStore"), mockDataStore)
         `when`(mockDataStore.getPlugin("awsDataStorePlugin")).thenReturn(mockAmplifyDataStorePlugin)
@@ -130,13 +141,23 @@ class AmplifyDataStorePluginTest {
         )
 
         mockStatic(DataStoreConfiguration::class.java).use { mockedDataStoreConfiguration ->
-            mockedDataStoreConfiguration.`when`<Any> { DataStoreConfiguration.defaults() }.thenReturn(defaultDataStoreConfiguration)
-            mockedDataStoreConfiguration.`when`<Any> { DataStoreConfiguration.builder() }.thenReturn(mockDataStoreConfigurationBuilder)
+            mockedDataStoreConfiguration.`when`<Any> { DataStoreConfiguration.defaults() }
+                .thenReturn(defaultDataStoreConfiguration)
+            mockedDataStoreConfiguration.`when`<Any> { DataStoreConfiguration.builder() }
+                .thenReturn(mockDataStoreConfigurationBuilder)
 
             flutterPlugin.onConfigureDataStore(mockResult, mockRequestWithoutCustomConfig)
-            verify(mockDataStoreConfigurationBuilder, times(1)).syncInterval(defaultDataStoreConfiguration.syncIntervalInMinutes, TimeUnit.MINUTES)
-            verify(mockDataStoreConfigurationBuilder, times(1)).syncMaxRecords(defaultDataStoreConfiguration.syncMaxRecords)
-            verify(mockDataStoreConfigurationBuilder, times(1)).syncPageSize(defaultDataStoreConfiguration.syncPageSize)
+            verify(mockDataStoreConfigurationBuilder, times(1)).syncInterval(
+                defaultDataStoreConfiguration.syncIntervalInMinutes,
+                TimeUnit.MINUTES
+            )
+            verify(mockDataStoreConfigurationBuilder, times(1)).syncMaxRecords(
+                defaultDataStoreConfiguration.syncMaxRecords
+            )
+            verify(mockDataStoreConfigurationBuilder, times(1)).syncPageSize(
+                defaultDataStoreConfiguration.syncPageSize
+            )
+            verify(mockDataStoreConfigurationBuilder, never()).syncExpression(anyString(), any())
         }
     }
 
@@ -154,13 +175,73 @@ class AmplifyDataStorePluginTest {
         )
 
         mockStatic(DataStoreConfiguration::class.java).use { mockedDataStoreConfiguration ->
-            mockedDataStoreConfiguration.`when`<Any> { DataStoreConfiguration.defaults() }.thenReturn(defaultDataStoreConfiguration)
-            mockedDataStoreConfiguration.`when`<Any> { DataStoreConfiguration.builder() }.thenReturn(mockDataStoreConfigurationBuilder)
+            mockedDataStoreConfiguration.`when`<Any> { DataStoreConfiguration.defaults() }
+                .thenReturn(defaultDataStoreConfiguration)
+            mockedDataStoreConfiguration.`when`<Any> { DataStoreConfiguration.builder() }
+                .thenReturn(mockDataStoreConfigurationBuilder)
 
             flutterPlugin.onConfigureDataStore(mockResult, mockRequestWithCustomConfig)
-            verify(mockDataStoreConfigurationBuilder, times(1)).syncInterval(mockSyncInterval.toLong(), TimeUnit.MINUTES)
+            verify(
+                mockDataStoreConfigurationBuilder,
+                times(1)
+            ).syncInterval(mockSyncInterval.toLong(), TimeUnit.MINUTES)
             verify(mockDataStoreConfigurationBuilder, times(1)).syncMaxRecords(mockSyncMaxRecords)
             verify(mockDataStoreConfigurationBuilder, times(1)).syncPageSize(mockSyncPageSize)
+        }
+    }
+
+    @Test
+    fun test_datastore_with_sync_expressions() {
+        val blogModelName = "Blog"
+        val postModelName = "Post"
+        val mockBlogExpression = mapOf(
+            "id" to "foo",
+            "modelName" to blogModelName,
+            "queryPredicate" to mapOf(
+                "queryPredicateOperation" to mapOf(
+                    "field" to "name",
+                    "fieldOperator" to mapOf(
+                        "operatorName" to "equal",
+                        "value" to "foo"
+                    )
+                )
+            )
+        )
+        val mockPostExpression = mapOf(
+            "id" to "bar",
+            "modelName" to postModelName,
+            "queryPredicate" to mapOf(
+                "queryPredicateOperation" to mapOf(
+                    "field" to "title",
+                    "fieldOperator" to mapOf(
+                        "operatorName" to "equal",
+                        "value" to "bar"
+                    )
+                )
+            )
+        )
+        val mockSyncExpressions = listOf(mockBlogExpression, mockPostExpression)
+        val mockRequestWithCustomConfig = mapOf(
+            "modelSchemas" to mockModelSchemas,
+            "syncExpressions" to mockSyncExpressions,
+            "modelProviderVersion" to "1.0"
+        )
+
+        mockStatic(DataStoreConfiguration::class.java).use { mockedDataStoreConfiguration ->
+            mockedDataStoreConfiguration.`when`<Any> { DataStoreConfiguration.defaults() }
+                .thenReturn(defaultDataStoreConfiguration)
+            mockedDataStoreConfiguration.`when`<Any> { DataStoreConfiguration.builder() }
+                .thenReturn(mockDataStoreConfigurationBuilder)
+
+            flutterPlugin.onConfigureDataStore(mockResult, mockRequestWithCustomConfig)
+            verify(mockDataStoreConfigurationBuilder, times(1)).syncExpression(
+                eq(blogModelName),
+                any()
+            )
+            verify(mockDataStoreConfigurationBuilder, times(1)).syncExpression(
+                eq(postModelName),
+                any()
+            )
         }
     }
 
@@ -170,73 +251,101 @@ class AmplifyDataStorePluginTest {
             assertEquals("Post", invocation.arguments[0])
             assertEquals(Where.matchesAll(), invocation.arguments[1])
             (invocation.arguments[2] as Consumer<Iterator<Model>>).accept(
-                    amplifySuccessResults.iterator())
+                amplifySuccessResults.iterator()
+            )
             null
-        }.`when`(mockAmplifyDataStorePlugin).query(anyString(), any(QueryOptions::class.java),
-                any<Consumer<Iterator<Model>>>(),
-                any<Consumer<DataStoreException>>())
-        flutterPlugin.onQuery(mockResult,
-                readMapFromFile("query_api",
-                        "request/only_model_name.json",
-                        HashMap::class.java) as HashMap<String, Any>)
+        }.`when`(mockAmplifyDataStorePlugin).query(
+            anyString(), any(QueryOptions::class.java),
+            any<Consumer<Iterator<Model>>>(),
+            any<Consumer<DataStoreException>>()
+        )
+        flutterPlugin.onQuery(
+            mockResult,
+            readMapFromFile(
+                "query_api",
+                "request/only_model_name.json",
+                HashMap::class.java
+            ) as HashMap<String, Any>
+        )
         verify(mockResult, times(1)).success(
-                readMapFromFile("query_api",
-                        "response/2_results.json",
-                        List::class.java))
+            readMapFromFile(
+                "query_api",
+                "response/2_results.json",
+                List::class.java
+            )
+        )
     }
 
     @Test
     fun test_query_with_predicates_success_zero_result() {
         val queryOptions =
-                Where.matches(field("post.id").eq("123").or(field("rating").ge(4).and(not(
-                        field("created").eq("2020-02-20T20:20:20-08:00")))))
-                        .paginated(Page.startingAt(2).withLimit(8))
-                        .sorted(field("post.id").ascending(), field("created").descending())
+            Where.matches(
+                field("post.id").eq("123").or(
+                    field("rating").ge(4).and(
+                        not(
+                            field("created").eq("2020-02-20T20:20:20-08:00")
+                        )
+                    )
+                )
+            )
+                .paginated(Page.startingAt(2).withLimit(8))
+                .sorted(field("post.id").ascending(), field("created").descending())
 
         doAnswer { invocation: InvocationOnMock ->
             assertEquals("Post", invocation.arguments[0])
             assertEquals(queryOptions, invocation.arguments[1])
             (invocation.arguments[2] as Consumer<Iterator<Model>>).accept(
-                    emptyList<SerializedModel>().iterator())
+                emptyList<SerializedModel>().iterator()
+            )
             null
         }.`when`(mockAmplifyDataStorePlugin).query(
-                anyString(),
-                any(QueryOptions::class.java),
-                any<Consumer<Iterator<Model>>>(),
-                any<Consumer<DataStoreException>>())
-        flutterPlugin.onQuery(mockResult,
-                readMapFromFile("query_api",
-                        "request/model_name_with_all_query_parameters.json",
-                        HashMap::class.java) as HashMap<String, Any>)
+            anyString(),
+            any(QueryOptions::class.java),
+            any<Consumer<Iterator<Model>>>(),
+            any<Consumer<DataStoreException>>()
+        )
+        flutterPlugin.onQuery(
+            mockResult,
+            readMapFromFile(
+                "query_api",
+                "request/model_name_with_all_query_parameters.json",
+                HashMap::class.java
+            ) as HashMap<String, Any>
+        )
         verify(mockResult, times(1)).success(emptyList<FlutterSerializedModel>())
     }
 
     @Test
     fun test_query_api_error() {
-        val testRequest: HashMap<String, Any> = (readMapFromFile("query_api",
-                "request/only_model_name.json",
-                HashMap::class.java) as HashMap<String, Any>)
+        val testRequest: HashMap<String, Any> = (readMapFromFile(
+            "query_api",
+            "request/only_model_name.json",
+            HashMap::class.java
+        ) as HashMap<String, Any>)
 
         doAnswer { invocation: InvocationOnMock ->
             assertEquals("Post", invocation.arguments[0])
             assertEquals(Where.matchesAll(), invocation.arguments[1])
             (invocation.arguments[3] as Consumer<DataStoreException>).accept(
-                    dataStoreException)
+                dataStoreException
+            )
             null
         }.`when`(mockAmplifyDataStorePlugin).query(
-                anyString(),
-                any(QueryOptions::class.java),
-                any<Consumer<Iterator<Model>>>(),
-                any<Consumer<DataStoreException>>())
+            anyString(),
+            any(QueryOptions::class.java),
+            any<Consumer<Iterator<Model>>>(),
+            any<Consumer<DataStoreException>>()
+        )
 
         flutterPlugin.onQuery(mockResult, testRequest)
 
         verify(mockResult, times(1)).error(
-                "DataStoreException",
-                ExceptionMessages.defaultFallbackExceptionMessage,
-                mapOf(
-                        "message" to "Some useful exception message",
-                        "recoverySuggestion" to "Some useful recovery message")
+            "DataStoreException",
+            ExceptionMessages.defaultFallbackExceptionMessage,
+            mapOf(
+                "message" to "Some useful exception message",
+                "recoverySuggestion" to "Some useful recovery message"
+            )
         )
     }
 
@@ -248,46 +357,51 @@ class AmplifyDataStorePluginTest {
 
         verifyNoInteractions(mockAmplifyDataStorePlugin)
         verify(mockResult, times(1)).error(
-                "DataStoreException",
-                ExceptionMessages.defaultFallbackExceptionMessage,
-                mapOf(
-                        "message" to ExceptionMessages.missingExceptionMessage,
-                        "recoverySuggestion" to ExceptionMessages.missingRecoverySuggestion,
-                        "underlyingException" to "kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String")
+            "DataStoreException",
+            ExceptionMessages.defaultFallbackExceptionMessage,
+            mapOf(
+                "message" to ExceptionMessages.missingExceptionMessage,
+                "recoverySuggestion" to ExceptionMessages.missingRecoverySuggestion,
+                "underlyingException" to "kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String"
+            )
         )
     }
 
     @Test
     fun test_delete_success_result_no_predicates() {
-        val testRequest: HashMap<String, Any> = (readMapFromFile("delete_api",
-                "request/instance_no_predicate.json",
-                HashMap::class.java) as HashMap<String, Any>)
+        val testRequest: HashMap<String, Any> = (readMapFromFile(
+            "delete_api",
+            "request/instance_no_predicate.json",
+            HashMap::class.java
+        ) as HashMap<String, Any>)
 
         val serializedModelData: HashMap<String, Any> =
-                testRequest["serializedModel"] as HashMap<String, Any>
+            testRequest["serializedModel"] as HashMap<String, Any>
 
         val serializedModel = SerializedModel.builder()
-                .serializedData(serializedModelData)
-                .modelSchema(modelSchema)
-                .build()
+            .serializedData(serializedModelData)
+            .modelSchema(modelSchema)
+            .build()
 
         val dataStoreItemChange = DataStoreItemChange.builder<SerializedModel>()
-                .item(serializedModel)
-                .initiator(DataStoreItemChange.Initiator.LOCAL)
-                .itemClass(SerializedModel::class.java)
-                .type(DataStoreItemChange.Type.DELETE)
-                .build()
+            .item(serializedModel)
+            .initiator(DataStoreItemChange.Initiator.LOCAL)
+            .itemClass(SerializedModel::class.java)
+            .type(DataStoreItemChange.Type.DELETE)
+            .build()
 
         doAnswer { invocation: InvocationOnMock ->
             assertEquals(serializedModel, invocation.arguments[0])
             (invocation.arguments[1] as Consumer<DataStoreItemChange<SerializedModel>>).accept(
-                    dataStoreItemChange)
+                dataStoreItemChange
+            )
             null as Void?
         }.`when`(mockAmplifyDataStorePlugin).delete(
-                any<SerializedModel>(),
-                any<
-                        Consumer<DataStoreItemChange<SerializedModel>>>(),
-                any<Consumer<DataStoreException>>())
+            any<SerializedModel>(),
+            any<
+                    Consumer<DataStoreItemChange<SerializedModel>>>(),
+            any<Consumer<DataStoreException>>()
+        )
 
         flutterPlugin.onDelete(mockResult, testRequest)
 
@@ -297,37 +411,42 @@ class AmplifyDataStorePluginTest {
     @Test
     fun test_delete_api_error() {
 
-        val testRequest: HashMap<String, Any> = (readMapFromFile("delete_api",
-                "request/instance_no_predicate.json",
-                HashMap::class.java) as HashMap<String, Any>)
+        val testRequest: HashMap<String, Any> = (readMapFromFile(
+            "delete_api",
+            "request/instance_no_predicate.json",
+            HashMap::class.java
+        ) as HashMap<String, Any>)
 
         val serializedModelData: HashMap<String, Any> =
-                testRequest["serializedModel"] as HashMap<String, Any>
+            testRequest["serializedModel"] as HashMap<String, Any>
 
         val serializedModel = SerializedModel.builder()
-                .serializedData(serializedModelData)
-                .modelSchema(modelSchema)
-                .build()
+            .serializedData(serializedModelData)
+            .modelSchema(modelSchema)
+            .build()
 
         doAnswer { invocation: InvocationOnMock ->
             assertEquals(serializedModel, invocation.arguments[0])
             (invocation.arguments[2] as Consumer<DataStoreException>).accept(
-                    dataStoreException)
+                dataStoreException
+            )
             null as Void?
         }.`when`(mockAmplifyDataStorePlugin).delete(
-                any<SerializedModel>(),
-                any<
-                        Consumer<DataStoreItemChange<SerializedModel>>>(),
-                any<Consumer<DataStoreException>>())
+            any<SerializedModel>(),
+            any<
+                    Consumer<DataStoreItemChange<SerializedModel>>>(),
+            any<Consumer<DataStoreException>>()
+        )
 
         flutterPlugin.onDelete(mockResult, testRequest)
 
         verify(mockResult, times(1)).error(
-                "DataStoreException",
-                ExceptionMessages.defaultFallbackExceptionMessage,
-                mapOf(
-                        "message" to "Some useful exception message",
-                        "recoverySuggestion" to "Some useful recovery message")
+            "DataStoreException",
+            ExceptionMessages.defaultFallbackExceptionMessage,
+            mapOf(
+                "message" to "Some useful exception message",
+                "recoverySuggestion" to "Some useful recovery message"
+            )
         )
     }
 
@@ -339,48 +458,53 @@ class AmplifyDataStorePluginTest {
 
         verifyNoInteractions(mockAmplifyDataStorePlugin)
         verify(mockResult, times(1)).error(
-                "DataStoreException",
-                ExceptionMessages.defaultFallbackExceptionMessage,
-                mapOf(
-                        "message" to ExceptionMessages.missingExceptionMessage,
-                        "recoverySuggestion" to ExceptionMessages.missingRecoverySuggestion,
-                        "underlyingException" to "kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String")
+            "DataStoreException",
+            ExceptionMessages.defaultFallbackExceptionMessage,
+            mapOf(
+                "message" to ExceptionMessages.missingExceptionMessage,
+                "recoverySuggestion" to ExceptionMessages.missingRecoverySuggestion,
+                "underlyingException" to "kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String"
+            )
         )
     }
 
     @Test
     fun test_save_success_result_no_predicates() {
-        val testRequest: HashMap<String, Any> = (readMapFromFile("save_api",
-                "request/instance_without_predicate.json",
-                HashMap::class.java) as HashMap<String, Any>)
+        val testRequest: HashMap<String, Any> = (readMapFromFile(
+            "save_api",
+            "request/instance_without_predicate.json",
+            HashMap::class.java
+        ) as HashMap<String, Any>)
 
         val serializedModelData: HashMap<String, Any> =
-                testRequest["serializedModel"] as HashMap<String, Any>
+            testRequest["serializedModel"] as HashMap<String, Any>
 
         val serializedModel = SerializedModel.builder()
-                .serializedData(serializedModelData)
-                .modelSchema(modelSchema)
-                .build()
+            .serializedData(serializedModelData)
+            .modelSchema(modelSchema)
+            .build()
 
         val dataStoreItemChange = DataStoreItemChange.builder<SerializedModel>()
-                .item(serializedModel)
-                .initiator(DataStoreItemChange.Initiator.LOCAL)
-                .itemClass(SerializedModel::class.java)
-                .type(DataStoreItemChange.Type.CREATE)
-                .build()
+            .item(serializedModel)
+            .initiator(DataStoreItemChange.Initiator.LOCAL)
+            .itemClass(SerializedModel::class.java)
+            .type(DataStoreItemChange.Type.CREATE)
+            .build()
 
         doAnswer { invocation: InvocationOnMock ->
             assertEquals(serializedModel, invocation.arguments[0])
             assertEquals(QueryPredicates.all(), invocation.arguments[1])
             (invocation.arguments[2] as Consumer<DataStoreItemChange<SerializedModel>>).accept(
-                    dataStoreItemChange)
+                dataStoreItemChange
+            )
             null as Void?
         }.`when`(mockAmplifyDataStorePlugin).save(
-                any<SerializedModel>(),
-                any<QueryPredicate>(),
-                any<
-                        Consumer<DataStoreItemChange<SerializedModel>>>(),
-                any<Consumer<DataStoreException>>())
+            any<SerializedModel>(),
+            any<QueryPredicate>(),
+            any<
+                    Consumer<DataStoreItemChange<SerializedModel>>>(),
+            any<Consumer<DataStoreException>>()
+        )
 
         flutterPlugin.onSave(mockResult, testRequest)
 
@@ -390,38 +514,43 @@ class AmplifyDataStorePluginTest {
     @Test
     fun test_save_api_error() {
 
-        val testRequest: HashMap<String, Any> = (readMapFromFile("save_api",
-                "request/instance_without_predicate.json",
-                HashMap::class.java) as HashMap<String, Any>)
+        val testRequest: HashMap<String, Any> = (readMapFromFile(
+            "save_api",
+            "request/instance_without_predicate.json",
+            HashMap::class.java
+        ) as HashMap<String, Any>)
 
         val serializedModelData: HashMap<String, Any> =
-                testRequest["serializedModel"] as HashMap<String, Any>
+            testRequest["serializedModel"] as HashMap<String, Any>
 
         val serializedModel = SerializedModel.builder()
-                .serializedData(serializedModelData)
-                .modelSchema(modelSchema)
-                .build()
+            .serializedData(serializedModelData)
+            .modelSchema(modelSchema)
+            .build()
 
         doAnswer { invocation: InvocationOnMock ->
             assertEquals(serializedModel, invocation.arguments[0])
             assertEquals(QueryPredicates.all(), invocation.arguments[1])
             (invocation.arguments[3] as Consumer<DataStoreException>).accept(
-                    dataStoreException)
+                dataStoreException
+            )
             null as Void?
         }.`when`(mockAmplifyDataStorePlugin).save(
-                any<SerializedModel>(),
-                any<QueryPredicate>(),
-                any<Consumer<DataStoreItemChange<SerializedModel>>>(),
-                any<Consumer<DataStoreException>>())
+            any<SerializedModel>(),
+            any<QueryPredicate>(),
+            any<Consumer<DataStoreItemChange<SerializedModel>>>(),
+            any<Consumer<DataStoreException>>()
+        )
 
         flutterPlugin.onSave(mockResult, testRequest)
 
         verify(mockResult, times(1)).error(
-                "DataStoreException",
-                ExceptionMessages.defaultFallbackExceptionMessage,
-                mapOf(
-                        "message" to "Some useful exception message",
-                        "recoverySuggestion" to "Some useful recovery message")
+            "DataStoreException",
+            ExceptionMessages.defaultFallbackExceptionMessage,
+            mapOf(
+                "message" to "Some useful exception message",
+                "recoverySuggestion" to "Some useful recovery message"
+            )
         )
     }
 
@@ -433,17 +562,19 @@ class AmplifyDataStorePluginTest {
 
         verifyNoInteractions(mockAmplifyDataStorePlugin)
         verify(mockResult, times(1)).error(
-                "DataStoreException",
-                ExceptionMessages.defaultFallbackExceptionMessage,
-                mapOf(
-                        "message" to ExceptionMessages.missingExceptionMessage,
-                        "recoverySuggestion" to ExceptionMessages.missingRecoverySuggestion,
-                        "underlyingException" to "kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String")
+            "DataStoreException",
+            ExceptionMessages.defaultFallbackExceptionMessage,
+            mapOf(
+                "message" to ExceptionMessages.missingExceptionMessage,
+                "recoverySuggestion" to ExceptionMessages.missingRecoverySuggestion,
+                "underlyingException" to "kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String"
+            )
         )
     }
 
     @Test
     fun test_observe_success_event() {
+<<<<<<< HEAD
         flutterPlugin = AmplifyDataStorePlugin(eventHandler = mockStreamHandler,
                 hubEventHandler = mockHubHandler)
         val eventData: HashMap<String, Any> = (readMapFromFile("observe_api",
@@ -453,26 +584,45 @@ class AmplifyDataStorePluginTest {
                 "title" to "Title 2",
                 "rating" to 0,
                 "created" to Temporal.DateTime("2020-02-20T20:20:20-08:00"))
+=======
+        flutterPlugin = AmplifyDataStorePlugin(
+            eventHandler = mockStreamHandler,
+            hubEventHandler = mockHubHandler
+        )
+        val eventData: HashMap<String, Any> = (readMapFromFile(
+            "observe_api",
+            "post_type_success_event.json",
+            HashMap::class.java
+        ) as HashMap<String, Any>)
+        val modelData = mapOf(
+            "id" to "43036c6b-8044-4309-bddc-262b6c686026",
+            "title" to "Title 2",
+            "created" to Temporal.DateTime("2020-02-20T20:20:20-08:00")
+        )
+>>>>>>> 9c88b30 (feat(datastore): Add selective sync)
         val instance = SerializedModel.builder()
-                .serializedData(modelData)
-                .modelSchema(modelSchema)
-                .build()
+            .serializedData(modelData)
+            .modelSchema(modelSchema)
+            .build()
 
         val dataStoreItemChange = DataStoreItemChange.builder<SerializedModel>()
-                .item(instance)
-                .initiator(DataStoreItemChange.Initiator.LOCAL)
-                .itemClass(SerializedModel::class.java)
-                .type(DataStoreItemChange.Type.CREATE)
-                .build()
+            .item(instance)
+            .initiator(DataStoreItemChange.Initiator.LOCAL)
+            .itemClass(SerializedModel::class.java)
+            .type(DataStoreItemChange.Type.CREATE)
+            .build()
 
         doAnswer { invocation: InvocationOnMock ->
             (invocation.arguments[1] as Consumer<DataStoreItemChange<SerializedModel>>).accept(
-                    dataStoreItemChange)
+                dataStoreItemChange
+            )
             null
-        }.`when`(mockAmplifyDataStorePlugin).observe(any<Consumer<Cancelable>>(),
-                any<Consumer<DataStoreItemChange<out Model>>>(),
-                any<Consumer<DataStoreException>>(),
-                any<Action>())
+        }.`when`(mockAmplifyDataStorePlugin).observe(
+            any<Consumer<Cancelable>>(),
+            any<Consumer<DataStoreItemChange<out Model>>>(),
+            any<Consumer<DataStoreException>>(),
+            any<Action>()
+        )
 
         flutterPlugin.onSetUpObserve(mockResult)
 
@@ -482,26 +632,32 @@ class AmplifyDataStorePluginTest {
 
     @Test
     fun test_observe_error_event() {
-        flutterPlugin = AmplifyDataStorePlugin(eventHandler = mockStreamHandler,
-                hubEventHandler = mockHubHandler)
+        flutterPlugin = AmplifyDataStorePlugin(
+            eventHandler = mockStreamHandler,
+            hubEventHandler = mockHubHandler
+        )
 
         doAnswer { invocation: InvocationOnMock ->
             (invocation.arguments[2] as Consumer<DataStoreException>).accept(
-                    dataStoreException)
+                dataStoreException
+            )
             null
-        }.`when`(mockAmplifyDataStorePlugin).observe(any<Consumer<Cancelable>>(),
-                any<Consumer<DataStoreItemChange<out Model>>>(),
-                any<Consumer<DataStoreException>>(),
-                any<Action>())
+        }.`when`(mockAmplifyDataStorePlugin).observe(
+            any<Consumer<Cancelable>>(),
+            any<Consumer<DataStoreItemChange<out Model>>>(),
+            any<Consumer<DataStoreException>>(),
+            any<Action>()
+        )
 
         flutterPlugin.onSetUpObserve(mockResult)
 
         verify(mockResult, times(1)).success(true)
         verify(mockStreamHandler, times(1)).error(
-                "DataStoreException",
-                mapOf(
-                        "message" to "Some useful exception message",
-                        "recoverySuggestion" to "Some useful recovery message")
+            "DataStoreException",
+            mapOf(
+                "message" to "Some useful exception message",
+                "recoverySuggestion" to "Some useful recovery message"
+            )
         )
     }
 
@@ -511,7 +667,7 @@ class AmplifyDataStorePluginTest {
             (invocation.arguments[0] as Action).call()
             null as Void?
         }.`when`(mockAmplifyDataStorePlugin)
-                .clear(any<Action>(), any<Consumer<DataStoreException>>())
+            .clear(any<Action>(), any<Consumer<DataStoreException>>())
 
         flutterPlugin.onClear(mockResult)
 
@@ -523,46 +679,52 @@ class AmplifyDataStorePluginTest {
 
         doAnswer { invocation: InvocationOnMock ->
             (invocation.arguments[1] as Consumer<DataStoreException>).accept(
-                    dataStoreException)
+                dataStoreException
+            )
             null as Void?
         }.`when`(mockAmplifyDataStorePlugin)
-                .clear(any<Action>(), any<Consumer<DataStoreException>>())
+            .clear(any<Action>(), any<Consumer<DataStoreException>>())
 
         flutterPlugin.onClear(mockResult)
 
         verify(mockResult, times(1)).error(
-                "DataStoreException",
-                ExceptionMessages.defaultFallbackExceptionMessage,
-                mapOf(
-                        "message" to "Some useful exception message",
-                        "recoverySuggestion" to "Some useful recovery message")
+            "DataStoreException",
+            ExceptionMessages.defaultFallbackExceptionMessage,
+            mapOf(
+                "message" to "Some useful exception message",
+                "recoverySuggestion" to "Some useful recovery message"
+            )
         )
     }
 
     @Test
     fun test_nested_model_deserialization() {
         val nestedSerializedModelInput = mapOf<String, Any>(
-                "id" to "af9cfa64-1ea9-46d6-b9e2-8203179d5392",
-                "name" to "A brilliant Post",
-                "rating" to 5,
-                "blog" to mapOf<String, Any>(
-                        "name" to "Amazing Blog",
-                        "id" to "8cb7d5a5-435d-4632-a890-90ed0c6107f5"
-                ) as HashMap<String, Any>
+            "id" to "af9cfa64-1ea9-46d6-b9e2-8203179d5392",
+            "name" to "A brilliant Post",
+            "rating" to 5,
+            "blog" to mapOf<String, Any>(
+                "name" to "Amazing Blog",
+                "id" to "8cb7d5a5-435d-4632-a890-90ed0c6107f5"
+            ) as HashMap<String, Any>
         ) as HashMap<String, Any>
 
         val nestedSerializedModelOutput = mapOf(
-                "id" to "af9cfa64-1ea9-46d6-b9e2-8203179d5392",
-                "name" to "A brilliant Post",
-                "rating" to 5,
-                "blog" to SerializedModel.builder().serializedData(mapOf<String, Any>(
-                        "name" to "Amazing Blog",
-                        "id" to "8cb7d5a5-435d-4632-a890-90ed0c6107f5"
-                ) as HashMap<String, Any>).modelSchema(null).build()
+            "id" to "af9cfa64-1ea9-46d6-b9e2-8203179d5392",
+            "name" to "A brilliant Post",
+            "rating" to 5,
+            "blog" to SerializedModel.builder().serializedData(
+                mapOf<String, Any>(
+                    "name" to "Amazing Blog",
+                    "id" to "8cb7d5a5-435d-4632-a890-90ed0c6107f5"
+                ) as HashMap<String, Any>
+            ).modelSchema(null).build()
         )
 
-        assertEquals(nestedSerializedModelOutput,
-                flutterPlugin.deserializeNestedModels(nestedSerializedModelInput))
+        assertEquals(
+            nestedSerializedModelOutput,
+            flutterPlugin.deserializeNestedModels(nestedSerializedModelInput)
+        )
     }
 
     private fun setFinalStatic(field: Field, newValue: Any?) {

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/SchemaData.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/SchemaData.kt
@@ -21,9 +21,8 @@ import com.amplifyframework.core.model.Model
 import com.amplifyframework.core.model.ModelAssociation
 import com.amplifyframework.core.model.ModelField
 import com.amplifyframework.core.model.ModelSchema
-import com.amplifyframework.core.model.temporal.Temporal
 import com.amplifyframework.core.model.SerializedModel
-
+import com.amplifyframework.core.model.temporal.Temporal
 
 val postSchema = ModelSchema.builder()
         .name("Post")

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -22,12 +22,13 @@ import Combine
 import amplify_core
 
 public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
-
+    
     private let bridge: DataStoreBridge
     private let flutterModelRegistration: FlutterModels
     var observeSubscription: AnyCancellable?
     private let dataStoreObserveEventStreamHandler: DataStoreObserveEventStreamHandler?
     private let dataStoreHubEventStreamHandler: DataStoreHubEventStreamHandler?
+    
     init(bridge: DataStoreBridge = DataStoreBridge(),
          flutterModelRegistration: FlutterModels = FlutterModels(),
          dataStoreObserveEventStreamHandler: DataStoreObserveEventStreamHandler = DataStoreObserveEventStreamHandler(),
@@ -37,7 +38,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
         self.dataStoreObserveEventStreamHandler = dataStoreObserveEventStreamHandler
         self.dataStoreHubEventStreamHandler = dataStoreHubEventStreamHandler
     }
-
+    
     public static func register(with registrar: FlutterPluginRegistrar) {
         let instance = SwiftAmplifyDataStorePlugin()
         let channel = FlutterMethodChannel(name: "com.amazonaws.amplify/datastore", binaryMessenger: registrar.messenger())
@@ -47,7 +48,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
         hubChannel.setStreamHandler(instance.dataStoreHubEventStreamHandler)
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
-
+    
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         var arguments: [String: Any] = [:]
         do {
@@ -59,7 +60,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
                                                               flutterResult: result)
             return
         }
-
+        
         switch call.method {
         case "configureDataStore":
             onConfigureDataStore(args: arguments, result: result)
@@ -77,36 +78,63 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
             result(FlutterMethodNotImplemented)
         }
     }
-
+    
     private func onConfigureDataStore(args: [String: Any], result: @escaping FlutterResult) {
-
+        
         guard let modelSchemaList = args["modelSchemas"] as? [[String: Any]] else {
             result(false)
             return //TODO
         }
-
+        
+        let syncExpressionList = args["syncExpressions"] as! [[String: Any]]
         let syncInterval = args["syncInterval"] as? Double ?? DataStoreConfiguration.defaultSyncInterval
         let syncMaxRecords = args["syncMaxRecords"] as? UInt ?? DataStoreConfiguration.defaultSyncMaxRecords
         let syncPageSize = args["syncPageSize"] as? UInt ?? DataStoreConfiguration.defaultSyncPageSize
-
+        let controller = UIApplication.shared.windows.first { $0.isKeyWindow }!.rootViewController as! FlutterViewController
+        let channel = FlutterMethodChannel(name: "com.amazonaws.amplify/datastore", binaryMessenger: controller.binaryMessenger)
+        
         do {
-
+            
+            
             let modelSchemas: [ModelSchema] = try modelSchemaList.map {
                 try FlutterModelSchema.init(serializedData: $0).convertToNativeModelSchema()
             }
-
+            
             modelSchemas.forEach { (modelSchema) in
                 flutterModelRegistration.addModelSchema(modelName: modelSchema.name, modelSchema: modelSchema)
             }
-
+            
+            let syncExpressions: [DataStoreSyncExpression] = try syncExpressionList.map { syncExpression in
+                let id = syncExpression["id"] as! String
+                let modelName = syncExpression["modelName"] as! String
+                let queryPredicate = try QueryPredicateBuilder.fromSerializedMap(syncExpression["queryPredicate"] as? [String: Any])
+                let modelSchema = flutterModelRegistration.modelSchemas[modelName]
+                return DataStoreSyncExpression.syncExpression(modelSchema!) {
+                    var resolvedQueryPredicate = queryPredicate
+                    let semaphore = DispatchSemaphore(value: 0)
+                    channel.invokeMethod("resolveQueryPredicate", arguments: id) { result in
+                        do {
+                            resolvedQueryPredicate = try QueryPredicateBuilder.fromSerializedMap(result as? [String: Any])
+                        } catch {
+                            print("Failed to resolve query predicate. Reverting to original query predicate.")
+                        }
+                        semaphore.signal()
+                    }
+                    semaphore.wait()
+                    return resolvedQueryPredicate
+                }
+            }
+            
             self.dataStoreHubEventStreamHandler?.registerModelsForHub(flutterModels: flutterModelRegistration)
-
+            
             let dataStorePlugin = AWSDataStorePlugin(modelRegistration: flutterModelRegistration,
-                configuration: .custom(
-                    syncInterval: syncInterval,
-                    syncMaxRecords: syncMaxRecords,
-                    syncPageSize: syncPageSize))
+                                                     configuration: .custom(
+                                                        syncInterval: syncInterval,
+                                                        syncMaxRecords: syncMaxRecords,
+                                                        syncPageSize: syncPageSize,
+                                                        syncExpressions: syncExpressions))
             try Amplify.add(plugin: dataStorePlugin)
+            
             Amplify.Logging.logLevel = .info
             print("Amplify configured with DataStore plugin")
             result(true)
@@ -143,11 +171,11 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
             }
             return
         }
-
+        
     }
-
+    
     func onQuery(args: [String: Any], flutterResult: @escaping FlutterResult) {
-
+        
         do {
             let modelName = try FlutterDataStoreRequestUtils.getModelName(methodChannelArguments: args)
             let modelSchema = try FlutterDataStoreRequestUtils.getModelSchema(modelSchemas: flutterModelRegistration.modelSchemas, modelName: modelName)
@@ -185,17 +213,17 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
                                                               flutterResult: flutterResult)
         }
     }
-
+    
     func onSave(args: [String: Any], flutterResult: @escaping FlutterResult) {
-
+        
         do {
             let modelName = try FlutterDataStoreRequestUtils.getModelName(methodChannelArguments: args)
             let modelSchema = try FlutterDataStoreRequestUtils.getModelSchema(modelSchemas: flutterModelRegistration.modelSchemas, modelName: modelName)
             let serializedModelData = try FlutterDataStoreRequestUtils.getSerializedModelData(methodChannelArguments: args)
             let modelID = try FlutterDataStoreRequestUtils.getModelID(serializedModelData: serializedModelData)
-
+            
             let serializedModel = FlutterSerializedModel(id: modelID, map: try FlutterDataStoreRequestUtils.getJSONValue(serializedModelData))
-
+            
             try bridge.onSave(
                 serializedModel: serializedModel,
                 modelSchema: modelSchema
@@ -224,16 +252,16 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
                                                               flutterResult: flutterResult)
         }
     }
-
+    
     func onDelete(args: [String: Any], flutterResult: @escaping FlutterResult) {
         do {
             let modelName = try FlutterDataStoreRequestUtils.getModelName(methodChannelArguments: args)
             let modelSchema = try FlutterDataStoreRequestUtils.getModelSchema(modelSchemas: flutterModelRegistration.modelSchemas, modelName: modelName)
             let serializedModelData = try FlutterDataStoreRequestUtils.getSerializedModelData(methodChannelArguments: args)
             let modelID = try FlutterDataStoreRequestUtils.getModelID(serializedModelData: serializedModelData)
-
+            
             let serializedModel = FlutterSerializedModel(id: modelID, map: try FlutterDataStoreRequestUtils.getJSONValue(serializedModelData))
-
+            
             try bridge.onDelete(
                 serializedModel: serializedModel,
                 modelSchema: modelSchema) { (result) in
@@ -246,7 +274,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
                     flutterResult(nil)
                 }
             }
-
+            
         }
         catch let error as DataStoreError {
             print("Failed to parse delete arguments with \(error)")
@@ -261,7 +289,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
             return
         }
     }
-
+    
     public func onSetUpObserve(flutterResult: @escaping FlutterResult) {
         do {
             observeSubscription = try observeSubscription ?? bridge.onObserve().sink { completion in
@@ -274,7 +302,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
                 case .finished:
                     print("finished")
                 }
-
+                
             } receiveValue: { (mutationEvent) in
                 do {
                     let serializedEvent = try mutationEvent.decodeModel(as: FlutterSerializedModel.self)
@@ -301,7 +329,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
         }
         flutterResult(nil)
     }
-
+    
     func onClear(flutterResult: @escaping FlutterResult) {
         do {
             try bridge.onClear() {(result) in
@@ -327,7 +355,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
                                                               flutterResult: flutterResult)
         }
     }
-
+    
     private func checkArguments(args: Any) throws -> [String: Any] {
         guard let res = args as? [String: Any] else {
             throw DataStoreError.decodingError("Flutter method call arguments are not a map.",
@@ -335,7 +363,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
         }
         return res;
     }
-
+    
     // TODO: Remove once all configure is moved to the bridge
     func getPlugin() throws -> AWSDataStorePlugin {
         return try Amplify.DataStore.getPlugin(for: "awsDataStorePlugin") as! AWSDataStorePlugin

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -30,19 +30,23 @@ class AmplifyDataStore extends DataStorePluginInterface {
   /// Constructs an AmplifyDataStore plugin with mandatory [modelProvider]
   /// and optional datastore configuration properties including
   ///
+  /// [syncExpressions]: list of sync expressions to filter datastore sync against
+  ///
   /// [syncInterval]: datastore syncing interval (in seconds)
   ///
   /// [syncMaxRecords]: max number of records to sync
   ///
   /// [syncPageSize]: page size to sync
-  AmplifyDataStore(
-      {required ModelProviderInterface modelProvider,
-      int? syncInterval,
-      int? syncMaxRecords,
-      int? syncPageSize})
-      : super(
+  AmplifyDataStore({
+    required ModelProviderInterface modelProvider,
+    List<DataStoreSyncExpression> syncExpressions = const [],
+    int? syncInterval,
+    int? syncMaxRecords,
+    int? syncPageSize,
+  }) : super(
             token: _token,
             modelProvider: modelProvider,
+            syncExpressions: syncExpressions,
             syncInterval: syncInterval,
             syncMaxRecords: syncMaxRecords,
             syncPageSize: syncPageSize);
@@ -64,11 +68,13 @@ class AmplifyDataStore extends DataStorePluginInterface {
   }
 
   @override
-  Future<void> configureDataStore(
-      {ModelProviderInterface? modelProvider,
-      int? syncInterval,
-      int? syncMaxRecords,
-      int? syncPageSize}) async {
+  Future<void> configureDataStore({
+    ModelProviderInterface? modelProvider,
+    List<DataStoreSyncExpression>? syncExpressions,
+    int? syncInterval,
+    int? syncMaxRecords,
+    int? syncPageSize,
+  }) async {
     ModelProviderInterface provider = modelProvider ?? this.modelProvider!;
     if (provider.modelSchemas.isEmpty) {
       throw DataStoreException('No modelProvider or modelSchemas found',
@@ -77,10 +83,12 @@ class AmplifyDataStore extends DataStorePluginInterface {
     }
     streamWrapper.registerModelsForHub(provider);
     return _instance.configureDataStore(
-        modelProvider: provider,
-        syncInterval: this.syncInterval,
-        syncMaxRecords: this.syncMaxRecords,
-        syncPageSize: this.syncPageSize);
+      modelProvider: provider,
+      syncExpressions: this.syncExpressions,
+      syncInterval: this.syncInterval,
+      syncMaxRecords: this.syncMaxRecords,
+      syncPageSize: this.syncPageSize,
+    );
   }
 
   @override

--- a/packages/amplify_datastore/lib/method_channel_datastore.dart
+++ b/packages/amplify_datastore/lib/method_channel_datastore.dart
@@ -32,21 +32,42 @@ class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
   /// configurations. This needs to happen before Amplify.configure() can be
   /// called.
   @override
-  Future<void> configureDataStore(
-      {ModelProviderInterface? modelProvider,
-      int? syncInterval,
-      int? syncMaxRecords,
-      int? syncPageSize}) async {
+  Future<void> configureDataStore({
+    ModelProviderInterface? modelProvider,
+    List<DataStoreSyncExpression>? syncExpressions = const [],
+    int? syncInterval,
+    int? syncMaxRecords,
+    int? syncPageSize,
+  }) async {
+    _channel.setMethodCallHandler((MethodCall call) async {
+      switch (call.method) {
+        case 'resolveQueryPredicate':
+          String? id = call.arguments;
+          if (id == null) {
+            throw ArgumentError(
+                'resolveQueryPredicate must be called with an id');
+          }
+          return syncExpressions!
+              .firstWhere((syncExpression) => syncExpression.id == id)
+              .resolveQueryPredicate()
+              .serializeAsMap();
+        default:
+          throw UnimplementedError('${call.method} has not been implemented.');
+      }
+    });
     try {
       return await _channel
           .invokeMethod('configureDataStore', <String, dynamic>{
-        'modelSchemas': modelProvider!.modelSchemas
+        'modelSchemas': modelProvider?.modelSchemas
             .map((schema) => schema.toMap())
             .toList(),
-        'modelProviderVersion': modelProvider.version,
+        'modelProviderVersion': modelProvider?.version,
+        'syncExpressions': syncExpressions!
+            .map((syncExpression) => syncExpression.toMap())
+            .toList(),
         'syncInterval': syncInterval,
         'syncMaxRecords': syncMaxRecords,
-        'syncPageSize': syncPageSize
+        'syncPageSize': syncPageSize,
       });
     } on PlatformException catch (e) {
       if (e.code == "AmplifyAlreadyConfiguredException") {

--- a/packages/amplify_datastore/test/resources/sync_expressions/blog_name.json
+++ b/packages/amplify_datastore/test/resources/sync_expressions/blog_name.json
@@ -1,0 +1,12 @@
+{
+  "modelName": "Blog",
+  "queryPredicate": {
+    "queryPredicateOperation": {
+      "field": "name",
+      "fieldOperator": {
+        "operatorName": "equal",
+        "value": "foo"
+      }
+    }
+  }
+}

--- a/packages/amplify_datastore/test/resources/sync_expressions/post_title.json
+++ b/packages/amplify_datastore/test/resources/sync_expressions/post_title.json
@@ -1,0 +1,12 @@
+{
+  "modelName": "Post",
+  "queryPredicate": {
+    "queryPredicateOperation": {
+      "field": "title",
+      "fieldOperator": {
+        "operatorName": "equal",
+        "value": "bar"
+      }
+    }
+  }
+}

--- a/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
@@ -22,29 +22,31 @@ import 'package:amplify_core/types/index.dart';
 import 'package:meta/meta.dart';
 
 import 'src/types/models/model.dart';
-import 'src/types/query/query_field.dart';
 import 'src/types/models/subscription_event.dart';
+import 'src/types/sync/DataStoreSyncExpression.dart';
+import 'src/types/query/query_field.dart';
 
 export 'src/types/models/model.dart';
-export 'src/types/models/model_schema.dart';
-export 'src/types/query/query_field.dart';
 export 'src/types/models/model_field.dart';
-export 'src/types/models/model_field_type.dart';
-export 'src/types/models/model_schema_definition.dart';
 export 'src/types/models/model_field_definition.dart';
-export 'src/types/models/uuid.dart';
+export 'src/types/models/model_field_type.dart';
 export 'src/types/models/model_provider.dart';
-export 'src/types/models/auth_rule.dart';
-
+export 'src/types/models/model_schema.dart';
+export 'src/types/models/model_schema_definition.dart';
+export 'src/types/models/subscription_event.dart';
+export 'src/types/models/uuid.dart';
+export 'src/types/query/query_field.dart';
 export 'src/types/temporal/datetime_parse.dart';
 export 'src/types/utils/parsers.dart';
-export 'src/types/models/subscription_event.dart';
 
 export 'src/publicTypes.dart';
 
 abstract class DataStorePluginInterface extends AmplifyPluginInterface {
   /// modelProvider
   ModelProviderInterface? modelProvider;
+
+  /// list of sync expressions to filter datastore sync against
+  List<DataStoreSyncExpression>? syncExpressions;
 
   /// Datastore sync interval (in seconds)
   int? syncInterval;
@@ -56,13 +58,14 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
   int? syncPageSize;
 
   /// Constructs an AmplifyPlatform.
-  DataStorePluginInterface(
-      {required Object token,
-      required this.modelProvider,
-      this.syncInterval,
-      this.syncMaxRecords,
-      this.syncPageSize})
-      : super(token: token);
+  DataStorePluginInterface({
+    required Object token,
+    required this.modelProvider,
+    this.syncExpressions,
+    this.syncInterval,
+    this.syncMaxRecords,
+    this.syncPageSize,
+  }) : super(token: token);
 
   /// Internal use constructor
   @protected

--- a/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
@@ -26,6 +26,7 @@ import 'src/types/models/subscription_event.dart';
 import 'src/types/sync/DataStoreSyncExpression.dart';
 import 'src/types/query/query_field.dart';
 
+export 'src/types/models/auth_rule.dart';
 export 'src/types/models/model.dart';
 export 'src/types/models/model_field.dart';
 export 'src/types/models/model_field_definition.dart';
@@ -85,11 +86,13 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
   /// [syncMaxRecords]: max number of records to sync
   ///
   /// [syncPageSize]: page size to sync
-  Future<void> configureDataStore(
-      {required ModelProviderInterface modelProvider,
-      int? syncInterval,
-      int? syncMaxRecords,
-      int? syncPageSize}) {
+  Future<void> configureDataStore({
+    required ModelProviderInterface modelProvider,
+    List<DataStoreSyncExpression>? syncExpressions,
+    int? syncInterval,
+    int? syncMaxRecords,
+    int? syncPageSize,
+  }) {
     throw UnimplementedError('configureDataStore() has not been implemented.');
   }
 

--- a/packages/amplify_datastore_plugin_interface/lib/src/publicTypes.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/publicTypes.dart
@@ -1,9 +1,8 @@
+export 'types/exception/DataStoreException.dart';
+export 'types/exception/DataStoreExceptionMessages.dart';
+export 'types/query/query_field.dart';
+export 'types/sync/DataStoreSyncExpression.dart';
 export 'types/temporal/temporal_date.dart';
 export 'types/temporal/temporal_time.dart';
 export 'types/temporal/temporal_datetime.dart';
 export 'types/temporal/temporal_timestamp.dart';
-
-export 'types/exception/DataStoreException.dart';
-export 'types/exception/DataStoreExceptionMessages.dart';
-
-export 'types/query/query_field.dart';

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/sync/DataStoreSyncExpression.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/sync/DataStoreSyncExpression.dart
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_datastore_plugin_interface/src/types/models/model.dart';
+import 'package:amplify_datastore_plugin_interface/src/types/query/query_field.dart';
+
+/// Sync expression to configure DataStore plugin with. These expressions
+/// include query predicates which specify filters for selectively persisting a
+/// subset of data to the local device
+class DataStoreSyncExpression {
+  /// A unique id for this sync expression
+  final String id;
+  final ModelType _modelType;
+  final QueryPredicate Function() _queryPredicateResolver;
+
+  /// Default constructor
+  DataStoreSyncExpression(this._modelType, this._queryPredicateResolver)
+      : id = UUID.getUUID();
+
+  /// Returns the result of the query predicate resolver
+  QueryPredicate resolveQueryPredicate() => _queryPredicateResolver();
+
+  /// Returns a map representation of this sync expression as it is needed by
+  /// native platforms
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'modelName': _modelType.modelName(),
+      'queryPredicate': _queryPredicateResolver().serializeAsMap()
+    };
+  }
+}


### PR DESCRIPTION
#298

*Description of changes:*
Currently, DataStore downloads the entire contents of your cloud data source to local device by default when using Amplify Flutter. In comparison, customers of native Amplify Android and iOS SDKs are able to configure DataStore to selectively persist only a subset of data instead.

This PR adds selective sync to Amplify Flutter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
