### PR TITLE
chore(api): Add API response headers/status

### DIFF
--- a/packages/amplify_api/android/build.gradle
+++ b/packages/amplify_api/android/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation "com.amplifyframework:aws-api-appsync:1.19.0"
 
     testImplementation 'junit:junit:4.13'
-    testImplementation 'org.mockito:mockito-core:3.1.0'
+    testImplementation 'org.mockito:mockito-core:3.10.0'
     testImplementation 'org.mockito:mockito-inline:3.1.0'
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'org.robolectric:robolectric:4.3.1'

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/rest_api/FlutterSerializedRestResponse.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/rest_api/FlutterSerializedRestResponse.kt
@@ -18,11 +18,15 @@ package com.amazonaws.amplify.amplify_api.rest_api
 import com.amplifyframework.api.rest.RestResponse
 
 data class FlutterSerializedRestResponse(private var raw: RestResponse) {
-    val data: ByteArray = raw.data.rawBytes
+    private val statusCode: Int = raw.code.hashCode()
+    private val headers: Map<String, String>? = raw.headers
+    private val data: ByteArray? = raw.data.rawBytes
 
-    fun toValueMap(): Map<String, Any> {
+    fun toValueMap(): Map<String, Any?> {
         return mapOf(
-                "data" to data
+            "statusCode" to statusCode,
+            "headers" to headers,
+            "data" to data
         )
     }
 }

--- a/packages/amplify_api/android/src/test/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApiRestTest.kt
+++ b/packages/amplify_api/android/src/test/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApiRestTest.kt
@@ -16,7 +16,6 @@
 package com.amazonaws.amplify.amplify_api
 
 
-import com.amazonaws.amplify.amplify_api.rest_api.FlutterSerializedRestResponse
 import com.amazonaws.amplify.amplify_core.exception.ExceptionMessages
 import com.amplifyframework.api.ApiCategory
 import com.amplifyframework.api.ApiException
@@ -53,7 +52,6 @@ class AmplifyApiRestTest {
     fun setup() {
         flutterPlugin = AmplifyApiPlugin()
         setFinalStatic(Amplify::class.java.getDeclaredField("API"), mockApi)
-        ResponseSerializationTests.suite()
     }
 
     @Test
@@ -101,11 +99,11 @@ class AmplifyApiRestTest {
         )
 
         verify(mockResult).success(
-                mapOf(
+            mapOf(
                 "statusCode" to statusCode,
                 "headers" to headers,
-                        "data" to restResponse.data.rawBytes
-                )
+                "data" to restResponse.data.rawBytes
+            )
         )
 
     }
@@ -183,11 +181,11 @@ class AmplifyApiRestTest {
          */
 
         verify(mockResult).success(
-                mapOf(
+            mapOf(
                 "statusCode" to statusCode,
                 "headers" to headers,
-                        "data" to restResponse.data.rawBytes
-                )
+                "data" to restResponse.data.rawBytes
+            )
         )
 
     }
@@ -226,11 +224,11 @@ class AmplifyApiRestTest {
         )
 
         verify(mockResult).success(
-                mapOf(
+            mapOf(
                 "statusCode" to statusCode,
                 "headers" to headers,
-                        "data" to restResponse.data.rawBytes
-                )
+                "data" to restResponse.data.rawBytes
+            )
         )
 
     }
@@ -266,11 +264,11 @@ class AmplifyApiRestTest {
         )
 
         verify(mockResult).success(
-                mapOf(
+            mapOf(
                 "statusCode" to statusCode,
                 "headers" to headers,
-                        "data" to restResponse.data.rawBytes
-                )
+                "data" to restResponse.data.rawBytes
+            )
         )
 
     }
@@ -309,11 +307,11 @@ class AmplifyApiRestTest {
         )
 
         verify(mockResult, times(1)).success(
-                mapOf(
+            mapOf(
                 "statusCode" to statusCode,
                 "headers" to headers,
                 "data" to restResponse.data.rawBytes
-                )
+            )
         )
 
     }

--- a/packages/amplify_api/android/src/test/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApiRestTest.kt
+++ b/packages/amplify_api/android/src/test/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApiRestTest.kt
@@ -16,14 +16,13 @@
 package com.amazonaws.amplify.amplify_api
 
 
-import com.amazonaws.amplify.amplify_api.AmplifyApiPlugin
+import com.amazonaws.amplify.amplify_api.rest_api.FlutterSerializedRestResponse
+import com.amazonaws.amplify.amplify_core.exception.ExceptionMessages
 import com.amplifyframework.api.ApiCategory
 import com.amplifyframework.api.ApiException
-import com.amplifyframework.api.aws.AWSApiPlugin
 import com.amplifyframework.api.rest.RestOperation
 import com.amplifyframework.api.rest.RestOptions
 import com.amplifyframework.api.rest.RestResponse
-
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.Consumer
 import io.flutter.plugin.common.MethodCall
@@ -34,15 +33,11 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.mockito.Mockito.*
-import org.mockito.invocation.InvocationOnMock
 import org.robolectric.RobolectricTestRunner
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
-import com.amazonaws.amplify.amplify_core.exception.ExceptionMessages
-import com.amplifyframework.AmplifyException
 
 
 @RunWith(RobolectricTestRunner::class)
@@ -58,13 +53,18 @@ class AmplifyApiRestTest {
     fun setup() {
         flutterPlugin = AmplifyApiPlugin()
         setFinalStatic(Amplify::class.java.getDeclaredField("API"), mockApi)
+        ResponseSerializationTests.suite()
     }
 
     @Test
     fun test_get_returns_success(){
 
-        var data = getSuccessData
-        var restResponse = RestResponse(200, null, data)
+        val statusCode = 200
+        val headers = mapOf(
+            "key" to "value"
+        )
+        val data = getSuccessData
+        val restResponse = RestResponse(statusCode, headers, data)
 
         Mockito.doAnswer { invocation ->
             (invocation.arguments[1] as Consumer<RestResponse>).accept(
@@ -76,7 +76,7 @@ class AmplifyApiRestTest {
                 any(),
                 any())
 
-        var arguments : Map<String, Any> = mapOf(
+        val arguments : Map<String, Any> = mapOf(
                 "restOptions" to mapOf(
                     "path" to "/items"
                 ),
@@ -102,6 +102,8 @@ class AmplifyApiRestTest {
 
         verify(mockResult).success(
                 mapOf(
+                "statusCode" to statusCode,
+                "headers" to headers,
                         "data" to restResponse.data.rawBytes
                 )
         )
@@ -111,10 +113,14 @@ class AmplifyApiRestTest {
     @Test
     fun test_post_returns_success(){
 
-        var body = toStoreData
-        var data = postSuccessData
+        val statusCode = 200
+        val headers = mapOf(
+            "key" to "value"
+        )
+        val body = toStoreData
+        val data = postSuccessData
 
-        var restResponse = RestResponse(200, null, data)
+        val restResponse = RestResponse(statusCode, headers, data)
 
         Mockito.doAnswer { invocation ->
             (invocation.arguments[2] as Consumer<RestResponse>).accept(
@@ -127,7 +133,7 @@ class AmplifyApiRestTest {
                 any(),
                 any())
 
-        var arguments : Map<String, Any> = mapOf(
+        val arguments : Map<String, Any> = mapOf(
                 "restOptions" to mapOf(
                         "path" to "/items",
                         "body" to body,
@@ -178,6 +184,8 @@ class AmplifyApiRestTest {
 
         verify(mockResult).success(
                 mapOf(
+                "statusCode" to statusCode,
+                "headers" to headers,
                         "data" to restResponse.data.rawBytes
                 )
         )
@@ -187,10 +195,12 @@ class AmplifyApiRestTest {
     @Test
     fun test_put_all_inputs_returns_success(){
 
-        var body = toStoreData
-        var data = putSuccessData
+        val statusCode = 200
+        val headers = null
+        val body = toStoreData
+        val data = putSuccessData
 
-        var restResponse = RestResponse(200, null, data)
+        val restResponse = RestResponse(statusCode, headers, data)
 
         Mockito.doAnswer { invocation ->
             (invocation.arguments[1] as Consumer<RestResponse>).accept(
@@ -202,7 +212,7 @@ class AmplifyApiRestTest {
                 any(),
                 any())
 
-        var arguments : Map<String, Any> = mapOf(
+        val arguments : Map<String, Any> = mapOf(
                 "restOptions" to mapOf(
                         "path" to "/items",
                         "body" to body
@@ -217,6 +227,8 @@ class AmplifyApiRestTest {
 
         verify(mockResult).success(
                 mapOf(
+                "statusCode" to statusCode,
+                "headers" to headers,
                         "data" to restResponse.data.rawBytes
                 )
         )
@@ -226,8 +238,10 @@ class AmplifyApiRestTest {
     @Test
     fun test_delete_returns_success(){
 
-        var data = deleteSuccessData
-        var restResponse = RestResponse(200, null, data)
+        val statusCode = 200
+        val headers = null
+        val data = deleteSuccessData
+        val restResponse = RestResponse(statusCode, headers, data)
 
         Mockito.doAnswer { invocation ->
             (invocation.arguments[1] as Consumer<RestResponse>).accept(
@@ -239,7 +253,7 @@ class AmplifyApiRestTest {
                 any(),
                 any())
 
-        var arguments : Map<String, Any> = mapOf(
+        val arguments : Map<String, Any> = mapOf(
                 "restOptions" to mapOf(
                         "path" to "/items"
                 ),
@@ -253,6 +267,8 @@ class AmplifyApiRestTest {
 
         verify(mockResult).success(
                 mapOf(
+                "statusCode" to statusCode,
+                "headers" to headers,
                         "data" to restResponse.data.rawBytes
                 )
         )
@@ -263,8 +279,12 @@ class AmplifyApiRestTest {
     @Test
     fun test_get_status_code_error(){
 
-        var data = getFailedData
-        var restResponse = RestResponse(400, null, data)
+        val statusCode = 400
+        val headers = mapOf(
+            "key" to "value"
+        )
+        val data = getFailedData
+        val restResponse = RestResponse(statusCode, headers, data)
 
         Mockito.doAnswer { invocation ->
             (invocation.arguments[1] as Consumer<RestResponse>).accept(
@@ -276,7 +296,7 @@ class AmplifyApiRestTest {
                 any(),
                 any())
 
-        var arguments : Map<String, Any> = mapOf(
+        val arguments : Map<String, Any> = mapOf(
                 "restOptions" to mapOf(
                         "path" to "/items"
                 ),
@@ -288,17 +308,11 @@ class AmplifyApiRestTest {
                 mockResult
         )
 
-        verify(mockResult, times(1)).error(
-                "ApiException",
-                ExceptionMessages.defaultFallbackExceptionMessage,
+        verify(mockResult, times(1)).success(
                 mapOf(
-                        "recoverySuggestion" to """
-                    The metadata associated with the response is contained in the HTTPURLResponse.
-                    For more information on HTTP status codes, take a look at
-                    https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
-                    """,
-                        "message" to "The HTTP response status code is [400].",
-                        "httpStatusCode" to "400"
+                "statusCode" to statusCode,
+                "headers" to headers,
+                "data" to restResponse.data.rawBytes
                 )
         )
 
@@ -308,8 +322,8 @@ class AmplifyApiRestTest {
     @Test
     fun test_get_invalid_input_map_error(){
 
-        var data = getFailedData
-        var restResponse = RestResponse(400, null, data)
+        val data = getFailedData
+        val restResponse = RestResponse(400, null, data)
 
         Mockito.doAnswer { invocation ->
             (invocation.arguments[1] as Consumer<RestResponse>).accept(
@@ -321,7 +335,7 @@ class AmplifyApiRestTest {
                 any(),
                 any())
 
-        var arguments : Map<String, Any> = mapOf(
+        val arguments : Map<String, Any> = mapOf(
         )
 
         flutterPlugin.onMethodCall(
@@ -456,7 +470,6 @@ class AmplifyApiRestTest {
                 "Operation does not exist"
         )
     }
-
 
     private fun setFinalStatic(field: Field, newValue: Any?) {
         field.isAccessible = true

--- a/packages/amplify_api/example/.gitignore
+++ b/packages/amplify_api/example/.gitignore
@@ -57,6 +57,7 @@ node_modules/
 aws-exports.js
 awsconfiguration.json
 amplifyconfiguration.json
+amplifyconfiguration.dart
 amplify-build-config.json
 amplify-gradle-config.json
 amplifytools.xcconfig

--- a/packages/amplify_api/example/lib/rest_api_view.dart
+++ b/packages/amplify_api/example/lib/rest_api_view.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'dart:typed_data';
+import 'dart:convert';
 
 import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_flutter/amplify.dart';
@@ -40,16 +40,17 @@ class _RestApiViewState extends State<RestApiView> {
   void onPutPressed() async {
     try {
       RestOperation restOperation = Amplify.API.put(
-          restOptions: RestOptions(
-              path: _apiPathController.text,
-              body:
-                  Uint8List.fromList("{\"name\":\"Mow the lawn\"}".codeUnits)));
+        restOptions: RestOptions(
+          path: _apiPathController.text,
+          body: utf8.encode('{"name":"Mow the lawn"}'),
+        ),
+      );
 
       _lastRestOperation = restOperation;
       RestResponse response = await restOperation.response;
 
       print("Put SUCCESS");
-      print(new String.fromCharCodes(response.data));
+      print(response);
     } on Exception catch (e) {
       print("Put FAILED");
       print(e);
@@ -59,16 +60,17 @@ class _RestApiViewState extends State<RestApiView> {
   void onPostPressed() async {
     try {
       RestOperation restOperation = Amplify.API.post(
-          restOptions: RestOptions(
-              path: _apiPathController.text,
-              body:
-                  Uint8List.fromList("{\"name\":\"Mow the lawn\"}".codeUnits)));
+        restOptions: RestOptions(
+          path: _apiPathController.text,
+          body: utf8.encode('{"name":"Mow the lawn"}'),
+        ),
+      );
 
       _lastRestOperation = restOperation;
       RestResponse response = await restOperation.response;
 
       print("Post SUCCESS");
-      print(new String.fromCharCodes(response.data));
+      print(response);
     } on Exception catch (e) {
       print("Post FAILED");
       print(e);
@@ -86,7 +88,7 @@ class _RestApiViewState extends State<RestApiView> {
       RestResponse response = await restOperation.response;
 
       print("Get SUCCESS");
-      print(new String.fromCharCodes(response.data));
+      print(response);
     } on ApiException catch (e) {
       print("Get FAILED");
       print(e.toString());
@@ -95,14 +97,15 @@ class _RestApiViewState extends State<RestApiView> {
 
   void onDeletePressed() async {
     try {
-      RestOperation restOperation = Amplify.API
-          .delete(restOptions: RestOptions(path: _apiPathController.text));
+      RestOperation restOperation = Amplify.API.delete(
+        restOptions: RestOptions(path: _apiPathController.text),
+      );
 
       _lastRestOperation = restOperation;
       RestResponse response = await restOperation.response;
 
       print("Delete SUCCESS");
-      print(new String.fromCharCodes(response.data));
+      print(response);
     } on Exception catch (e) {
       print("Delete FAILED");
       print(e);
@@ -121,15 +124,14 @@ class _RestApiViewState extends State<RestApiView> {
   void onHeadPressed() async {
     try {
       RestOperation restOperation = Amplify.API.head(
-          restOptions: RestOptions(
-        path: _apiPathController.text,
-      ));
+        restOptions: RestOptions(path: _apiPathController.text),
+      );
 
       _lastRestOperation = restOperation;
       RestResponse response = await restOperation.response;
 
       print("Head SUCCESS");
-      print(new String.fromCharCodes(response.data));
+      print(response);
     } on ApiException catch (e) {
       print("Head FAILED");
       print(e.toString());
@@ -139,15 +141,14 @@ class _RestApiViewState extends State<RestApiView> {
   void onPatchPressed() async {
     try {
       RestOperation restOperation = Amplify.API.patch(
-          restOptions: RestOptions(
-        path: _apiPathController.text,
-      ));
+        restOptions: RestOptions(path: _apiPathController.text),
+      );
 
       _lastRestOperation = restOperation;
       RestResponse response = await restOperation.response;
 
       print("Patch SUCCESS");
-      print(new String.fromCharCodes(response.data));
+      print(response);
     } on ApiException catch (e) {
       print("Patch FAILED");
       print(e.toString());

--- a/packages/amplify_api/ios/Classes/FlutterSerializedRestResponse.swift
+++ b/packages/amplify_api/ios/Classes/FlutterSerializedRestResponse.swift
@@ -26,7 +26,7 @@ public struct FlutterSerializedRestResponse {
     init(statusCode: Int = 200, headers: [AnyHashable: Any]?, data: Data?) {
         let stringHeaders = headers?
             .filter { $0.key is String }
-            .compactMapValues { $0 as? String } as! [String: String]
+            .compactMapValues { $0 as? String } as? [String: String]
         self.statusCode = statusCode
         self.headers = stringHeaders
         self.data = data

--- a/packages/amplify_api/ios/Classes/FlutterSerializedRestResponse.swift
+++ b/packages/amplify_api/ios/Classes/FlutterSerializedRestResponse.swift
@@ -23,7 +23,7 @@ public struct FlutterSerializedRestResponse {
     private var headers: [String: String]?
     private var data: Data?
     
-    init(statusCode: Int = 200, headers: [AnyHashable: Any]?, data: Data?) {
+    init(statusCode: Int, headers: [AnyHashable: Any]?, data: Data?) {
         let stringHeaders = headers?
             .filter { $0.key is String }
             .compactMapValues { $0 as? String } as? [String: String]

--- a/packages/amplify_api/ios/Classes/FlutterSerializedRestResponse.swift
+++ b/packages/amplify_api/ios/Classes/FlutterSerializedRestResponse.swift
@@ -19,14 +19,22 @@ import Amplify
 
 public struct FlutterSerializedRestResponse {
     
-    private var data: Data
+    private var statusCode: Int
+    private var headers: [AnyHashable: Any]?
+    private var data: Data?
     
-    init(data: Data) {
+    init(statusCode: Int = 200, headers: [AnyHashable: Any]?, data: Data?) {
+        self.statusCode = statusCode
+        self.headers = headers
         self.data = data
     }
     
-    func toValueMap() -> [String: Any] {
-        return [ "data" : data ]
+    func toValueMap() -> [String: Any?] {
+        return [
+            "statusCode": statusCode,
+            "headers": headers,
+            "data" : data
+        ]
     }
 
     

--- a/packages/amplify_api/ios/Classes/FlutterSerializedRestResponse.swift
+++ b/packages/amplify_api/ios/Classes/FlutterSerializedRestResponse.swift
@@ -20,12 +20,15 @@ import Amplify
 public struct FlutterSerializedRestResponse {
     
     private var statusCode: Int
-    private var headers: [AnyHashable: Any]?
+    private var headers: [String: String]?
     private var data: Data?
     
     init(statusCode: Int = 200, headers: [AnyHashable: Any]?, data: Data?) {
+        let stringHeaders = headers?
+            .filter { $0.key is String }
+            .compactMapValues { $0 as? String } as! [String: String]
         self.statusCode = statusCode
-        self.headers = headers
+        self.headers = stringHeaders
         self.data = data
     }
     

--- a/packages/amplify_api/lib/method_channel_api.dart
+++ b/packages/amplify_api/lib/method_channel_api.dart
@@ -220,16 +220,12 @@ class AmplifyAPIMethodChannel extends AmplifyAPI {
   }
 
   RestResponse _formatRestResponse(Map<String, dynamic> res) {
-    try {
-      return RestResponse(data: res["data"] as Uint8List);
-    }
-    // This shouldn't happen.  RestResponse should be properly formatted from native
-    on Exception catch (e) {
-      throw ApiException(AmplifyExceptionMessages.missingExceptionMessage,
-          recoverySuggestion:
-              AmplifyExceptionMessages.missingRecoverySuggestion,
-          underlyingException: e.toString());
-    }
+    final headers = res['headers'] as Map?;
+    return RestResponse(
+      data: res["data"] as Uint8List?,
+      headers: headers == null ? null : Map<String, String>.from(headers),
+      statusCode: res['statusCode'] as int,
+    );
   }
 
   @override

--- a/packages/amplify_api/test/amplify_rest_api_methods_test.dart
+++ b/packages/amplify_api/test/amplify_rest_api_methods_test.dart
@@ -20,6 +20,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:amplify_api/amplify_api.dart';
 
+const statusOK = 200;
+
 void main() {
   const MethodChannel apiChannel = MethodChannel('com.amazonaws.amplify/api');
 
@@ -47,7 +49,7 @@ void main() {
         expect(restOptions["queryParameters"], queryParameters);
         expect(restOptions["headers"], headers);
 
-        return {"data": responseData};
+        return {"data": responseData, 'statusCode': statusOK};
       }
     });
 
@@ -84,7 +86,7 @@ void main() {
         expect(restOptions["queryParameters"], queryParameters);
         expect(restOptions["headers"], headers);
 
-        return {"data": responseData};
+        return {"data": responseData, 'statusCode': statusOK};
       }
     });
 
@@ -110,7 +112,7 @@ void main() {
         Map<dynamic, dynamic> restOptions = methodCall.arguments["restOptions"];
         expect(restOptions["path"], "/items");
 
-        return {"data": responseData};
+        return {"data": responseData, 'statusCode': statusOK};
       }
     });
 
@@ -133,7 +135,7 @@ void main() {
         Map<dynamic, dynamic> restOptions = methodCall.arguments["restOptions"];
         expect(restOptions["path"], "/items");
 
-        return {"data": responseData};
+        return {"data": responseData, 'statusCode': statusOK};
       }
     });
 
@@ -253,7 +255,7 @@ void main() {
       if (methodCall.method == "get") {
         Map<dynamic, dynamic> restOptions = methodCall.arguments["restOptions"];
         expect(restOptions["path"], "/items");
-        return {"data": responseData};
+        return {"data": responseData, 'statusCode': statusOK};
       }
     });
 

--- a/packages/amplify_api_plugin_interface/lib/src/RestAPI/RestResponse.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/RestAPI/RestResponse.dart
@@ -13,9 +13,37 @@
  * permissions and limitations under the License.
  */
 
+import 'dart:convert';
 import 'dart:typed_data';
 
+/// An HTTP response from a REST API.
 class RestResponse {
-  Uint8List data;
-  RestResponse({required this.data});
+  /// The response status code.
+  final int statusCode;
+
+  /// The response headers.
+  ///
+  /// Will be `null` if unavailable from the platform.
+  final Map<String, String>? headers;
+
+  /// The response body bytes.
+  final Uint8List data;
+
+  /// The decoded body (using UTF-8).
+  ///
+  /// For custom processing, use [data] to get the raw body bytes.
+  late final String body;
+
+  RestResponse({
+    required Uint8List? data,
+    required this.headers,
+    required this.statusCode,
+  }) : data = data ?? Uint8List(0) {
+    body = utf8.decode(this.data, allowMalformed: true);
+  }
+
+  @override
+  String toString() {
+    return 'RestResponse{ statusCode=$statusCode, headers=$headers, body="$body" }';
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*
- #688 
- #612 

*Description of changes:*
- Add `statusCode` and `headers` to `RestResponse`
- Do not throw `ApiException` on HTTP 4xx/5xx anymore. Instead, return `RestResponse`

_Limitations_:
- Currently, `headers` are only available on iOS for successful calls (2xx?).
- Getting the `statusCode` on Android is a little hacky and could benefit from a public getter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
