### PR TITLE
chore: make .gitignore more specific for amplify dirs and tweak integ…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ Podfile.lock
 
 
 # amplify resources from example apps
-amplify/
+**/example/amplify/
 
 dist/
 node_modules/

--- a/melos.yaml
+++ b/melos.yaml
@@ -37,18 +37,10 @@ scripts:
       - Requires running Android and iOS simulators.
 
   test:integration:android:
-    run: melos exec "flutter drive --no-pub --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d sdk"
-    select-package:
-      file-exists:
-        - integration_test/main_test.dart
-      scope: "*example*"
+    run: melos exec -c 1 --scope="*example*" --file-exists="integration_test/main_test.dart" "flutter drive --no-pub --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d sdk"
 
   test:integration:ios:
-    run: melos exec "flutter drive --no-pub --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d iPhone"
-    select-package:
-      file-exists:
-        - integration_test/main_test.dart
-      scope: "*example*"
+    run: melos exec -c 1 --scope="*example*" --file-exists="integration_test/main_test.dart" "flutter drive --no-pub --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d iPhone"
 
   provision_integration_test_resources:
     run: melos exec "./tool/provision_integration_test_resources.sh"


### PR DESCRIPTION
*Description of changes:*

* Make a line in .gitignore more specific as I believe it is ignoring files too aggressively.
* There is also a tweak to the melos tasks for integration tests. I learned they do not work as expected when there are multiple packages with integration tests in that it then prompts the user to choose which package, which then causes issues when trying to automatically do all. The change makes it do them all one at a time with no further prompt.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
