### PR TITLE
Datastore support nullable lists

### DIFF
--- a/packages/amplify_datastore/example/lib/main.dart
+++ b/packages/amplify_datastore/example/lib/main.dart
@@ -148,6 +148,128 @@ class _MyAppState extends State<MyApp> {
     });
   }
 
+  void test() {
+    testSaveNullableListString();
+    // testQueryNullableListString();
+
+    //testSaveNullableListEnum();
+    //testQueryNullableListEnum();
+
+    //testSaveNullableListModel();
+    //testQueryNullableListModel();
+  }
+
+  void testSaveNullableListString() async {
+    try {
+      // Test empty case
+      var listTest =
+          TestNullableListsString(requiredList: [], requiredListOfRequired: []);
+      await Amplify.DataStore.save(listTest);
+
+      // Test partial empty case
+      listTest = TestNullableListsString(
+          list: [],
+          requiredList: [],
+          requiredListOfRequired: [],
+          listOfRequired: []);
+      await Amplify.DataStore.save(listTest);
+
+      // Test storing data
+      listTest = TestNullableListsString(
+          list: [null, "listTestString"],
+          requiredList: [null, "requiredListTestString"],
+          requiredListOfRequired: ["requiredListOfRequiredString"],
+          listOfRequired: ["listOfRequiredString"]);
+      await Amplify.DataStore.save(listTest);
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  void testSaveNullableListEnum() async {
+    try {
+      // Test empty case
+      var listTest =
+          TestNullableListsEnum(requiredList: [], requiredListOfRequired: []);
+      await Amplify.DataStore.save(listTest);
+
+      // Test partial empty case
+      listTest = TestNullableListsEnum(
+          list: [],
+          requiredList: [],
+          requiredListOfRequired: [],
+          listOfRequired: []);
+      await Amplify.DataStore.save(listTest);
+
+      // Test storing data
+      listTest = TestNullableListsEnum(
+          list: [null, TestEnum.maybe],
+          requiredList: [null, TestEnum.maybe],
+          requiredListOfRequired: [TestEnum.maybe],
+          listOfRequired: [TestEnum.maybe]);
+      await Amplify.DataStore.save(listTest);
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  void testSaveNullableListModel() async {
+    try {
+      // Test empty case
+      var listTest =
+          TestNullableListsModel(requiredList: [], requiredListOfRequired: []);
+      await Amplify.DataStore.save(listTest);
+
+      // Test partial empty case
+      listTest = TestNullableListsModel(
+          list: [],
+          requiredList: [],
+          requiredListOfRequired: [],
+          listOfRequired: []);
+      await Amplify.DataStore.save(listTest);
+
+      // Test storing data
+      Post post = Post(
+          title: "test post", rating: 999, created: TemporalDateTime.now());
+
+      listTest = TestNullableListsModel(
+          list: [null, post],
+          requiredList: [null, post],
+          requiredListOfRequired: [post],
+          listOfRequired: [post]);
+      await Amplify.DataStore.save(listTest);
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  void testQueryNullableListString() async {
+    // get all comments
+    print("\n\ntestQueryNullableListString\n");
+    (await Amplify.DataStore.query(TestNullableListsString.classType))
+        .forEach((element) {
+      print(element.toString());
+    });
+  }
+
+  void testQueryNullableListEnum() async {
+    // get all comments
+    print("\n\ntestQueryNullableListEnum\n");
+    (await Amplify.DataStore.query(TestNullableListsEnum.classType))
+        .forEach((element) {
+      print(element.toString());
+    });
+  }
+
+  void testQueryNullableListModel() async {
+    // get all comments
+    print("\n\ntestQueryNullableListModel\n");
+    (await Amplify.DataStore.query(TestNullableListsModel.classType))
+        .forEach((element) {
+      print(element.toString());
+    });
+  }
+
   void listenToHub() {
     setState(() {
       hubSubscription = Amplify.Hub.listen([HubChannel.DataStore], (msg) {
@@ -356,6 +478,8 @@ class _MyAppState extends State<MyApp> {
         body: Column(
           children: <Widget>[
             Padding(padding: EdgeInsets.all(10.0)),
+
+            ElevatedButton(onPressed: test, child: Text("click")),
 
             // Row for saving blog
             addBlogWidget(_nameController, _isAmplifyConfigured, saveBlog),

--- a/packages/amplify_datastore/example/lib/models/ModelProvider.dart
+++ b/packages/amplify_datastore/example/lib/models/ModelProvider.dart
@@ -26,6 +26,9 @@ import 'HasManyModel.dart';
 import 'HasOneModel.dart';
 import 'Post.dart';
 import 'PostAuthComplex.dart';
+import 'TestNullableListsEnum.dart';
+import 'TestNullableListsModel.dart';
+import 'TestNullableListsString.dart';
 
 export 'AllTypeModel.dart';
 export 'AllTypeOptionalModel.dart';
@@ -38,6 +41,9 @@ export 'HasOneModel.dart';
 export 'Post.dart';
 export 'PostAuthComplex.dart';
 export 'TestEnum.dart';
+export 'TestNullableListsEnum.dart';
+export 'TestNullableListsModel.dart';
+export 'TestNullableListsString.dart';
 
 class ModelProvider implements ModelProviderInterface {
   @override
@@ -53,7 +59,10 @@ class ModelProvider implements ModelProviderInterface {
     HasManyModel.schema,
     HasOneModel.schema,
     Post.schema,
-    PostAuthComplex.schema
+    PostAuthComplex.schema,
+    TestNullableListsEnum.schema,
+    TestNullableListsModel.schema,
+    TestNullableListsString.schema
   ];
   static final ModelProvider _instance = ModelProvider();
 
@@ -109,6 +118,21 @@ class ModelProvider implements ModelProviderInterface {
       case "PostAuthComplex":
         {
           return PostAuthComplex.classType;
+        }
+        break;
+      case "TestNullableListsEnum":
+        {
+          return TestNullableListsEnum.classType;
+        }
+        break;
+      case "TestNullableListsModel":
+        {
+          return TestNullableListsModel.classType;
+        }
+        break;
+      case "TestNullableListsString":
+        {
+          return TestNullableListsString.classType;
         }
         break;
       default:

--- a/packages/amplify_datastore/example/lib/models/TestNullableListsEnum.dart
+++ b/packages/amplify_datastore/example/lib/models/TestNullableListsEnum.dart
@@ -25,8 +25,8 @@ import 'package:flutter/foundation.dart';
 class TestNullableListsEnum extends Model {
   static const classType = const _TestNullableListsEnumModelType();
   final String id;
-  final List<TestEnum>? _list;
-  final List<TestEnum>? _requiredList;
+  final List<TestEnum?>? _list;
+  final List<TestEnum?>? _requiredList;
   final List<TestEnum>? _requiredListOfRequired;
   final List<TestEnum>? _listOfRequired;
 
@@ -38,11 +38,11 @@ class TestNullableListsEnum extends Model {
     return id;
   }
 
-  List<TestEnum>? get list {
+  List<TestEnum?>? get list {
     return _list;
   }
 
-  List<TestEnum> get requiredList {
+  List<TestEnum?> get requiredList {
     try {
       return _requiredList!;
     } catch (e) {
@@ -85,22 +85,16 @@ class TestNullableListsEnum extends Model {
 
   factory TestNullableListsEnum(
       {String? id,
-      List<TestEnum>? list,
-      required List<TestEnum> requiredList,
+      List<TestEnum?>? list,
+      required List<TestEnum?> requiredList,
       required List<TestEnum> requiredListOfRequired,
       List<TestEnum>? listOfRequired}) {
     return TestNullableListsEnum._internal(
         id: id == null ? UUID.getUUID() : id,
-        list: list != null ? List<TestEnum>.unmodifiable(list) : list,
-        requiredList: requiredList != null
-            ? List<TestEnum>.unmodifiable(requiredList)
-            : requiredList,
-        requiredListOfRequired: requiredListOfRequired != null
-            ? List<TestEnum>.unmodifiable(requiredListOfRequired)
-            : requiredListOfRequired,
-        listOfRequired: listOfRequired != null
-            ? List<TestEnum>.unmodifiable(listOfRequired)
-            : listOfRequired);
+        list: list,
+        requiredList: requiredList,
+        requiredListOfRequired: requiredListOfRequired,
+        listOfRequired: listOfRequired);
   }
 
   bool equals(Object other) {
@@ -154,8 +148,8 @@ class TestNullableListsEnum extends Model {
 
   TestNullableListsEnum copyWith(
       {String? id,
-      List<TestEnum>? list,
-      List<TestEnum>? requiredList,
+      List<TestEnum?>? list,
+      List<TestEnum?>? requiredList,
       List<TestEnum>? requiredListOfRequired,
       List<TestEnum>? listOfRequired}) {
     return TestNullableListsEnum(
@@ -171,12 +165,12 @@ class TestNullableListsEnum extends Model {
       : id = json['id'],
         _list = json['list'] is List
             ? (json['list'] as List)
-                .map((e) => enumFromString<TestEnum>(e, TestEnum.values)!)
+                .map((e) => enumFromString<TestEnum>(e, TestEnum.values))
                 .toList()
             : null,
         _requiredList = json['requiredList'] is List
             ? (json['requiredList'] as List)
-                .map((e) => enumFromString<TestEnum>(e, TestEnum.values)!)
+                .map((e) => enumFromString<TestEnum>(e, TestEnum.values))
                 .toList()
             : null,
         _requiredListOfRequired = json['requiredListOfRequired'] is List
@@ -192,11 +186,11 @@ class TestNullableListsEnum extends Model {
 
   Map<String, dynamic> toJson() => {
         'id': id,
-        'list': _list?.map((e) => enumToString(e))?.toList(),
-        'requiredList': _requiredList?.map((e) => enumToString(e))?.toList(),
+        'list': _list?.map((e) => enumToString(e)).toList(),
+        'requiredList': _requiredList?.map((e) => enumToString(e)).toList(),
         'requiredListOfRequired':
-            _requiredListOfRequired?.map((e) => enumToString(e))?.toList(),
-        'listOfRequired': _listOfRequired?.map((e) => enumToString(e))?.toList()
+            _requiredListOfRequired?.map((e) => enumToString(e)).toList(),
+        'listOfRequired': _listOfRequired?.map((e) => enumToString(e)).toList()
       };
 
   static final QueryField ID =

--- a/packages/amplify_datastore/example/lib/models/TestNullableListsEnum.dart
+++ b/packages/amplify_datastore/example/lib/models/TestNullableListsEnum.dart
@@ -1,0 +1,254 @@
+/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// ignore_for_file: public_member_api_docs
+
+import 'ModelProvider.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+
+/** This is an auto generated class representing the TestNullableListsEnum type in your schema. */
+@immutable
+class TestNullableListsEnum extends Model {
+  static const classType = const _TestNullableListsEnumModelType();
+  final String id;
+  final List<TestEnum>? _list;
+  final List<TestEnum>? _requiredList;
+  final List<TestEnum>? _requiredListOfRequired;
+  final List<TestEnum>? _listOfRequired;
+
+  @override
+  getInstanceType() => classType;
+
+  @override
+  String getId() {
+    return id;
+  }
+
+  List<TestEnum>? get list {
+    return _list;
+  }
+
+  List<TestEnum> get requiredList {
+    try {
+      return _requiredList!;
+    } catch (e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion: DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString());
+    }
+  }
+
+  List<TestEnum> get requiredListOfRequired {
+    try {
+      return _requiredListOfRequired!;
+    } catch (e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion: DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString());
+    }
+  }
+
+  List<TestEnum>? get listOfRequired {
+    return _listOfRequired;
+  }
+
+  const TestNullableListsEnum._internal(
+      {required this.id,
+      list,
+      required requiredList,
+      required requiredListOfRequired,
+      listOfRequired})
+      : _list = list,
+        _requiredList = requiredList,
+        _requiredListOfRequired = requiredListOfRequired,
+        _listOfRequired = listOfRequired;
+
+  factory TestNullableListsEnum(
+      {String? id,
+      List<TestEnum>? list,
+      required List<TestEnum> requiredList,
+      required List<TestEnum> requiredListOfRequired,
+      List<TestEnum>? listOfRequired}) {
+    return TestNullableListsEnum._internal(
+        id: id == null ? UUID.getUUID() : id,
+        list: list != null ? List<TestEnum>.unmodifiable(list) : list,
+        requiredList: requiredList != null
+            ? List<TestEnum>.unmodifiable(requiredList)
+            : requiredList,
+        requiredListOfRequired: requiredListOfRequired != null
+            ? List<TestEnum>.unmodifiable(requiredListOfRequired)
+            : requiredListOfRequired,
+        listOfRequired: listOfRequired != null
+            ? List<TestEnum>.unmodifiable(listOfRequired)
+            : listOfRequired);
+  }
+
+  bool equals(Object other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TestNullableListsEnum &&
+        id == other.id &&
+        DeepCollectionEquality().equals(_list, other._list) &&
+        DeepCollectionEquality().equals(_requiredList, other._requiredList) &&
+        DeepCollectionEquality()
+            .equals(_requiredListOfRequired, other._requiredListOfRequired) &&
+        DeepCollectionEquality().equals(_listOfRequired, other._listOfRequired);
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+
+    buffer.write("TestNullableListsEnum {");
+    buffer.write("id=" + "$id" + ", ");
+    buffer.write("list=" +
+        (_list != null
+            ? _list!.map((e) => enumToString(e)).toString()
+            : "null") +
+        ", ");
+    buffer.write("requiredList=" +
+        (_requiredList != null
+            ? _requiredList!.map((e) => enumToString(e)).toString()
+            : "null") +
+        ", ");
+    buffer.write("requiredListOfRequired=" +
+        (_requiredListOfRequired != null
+            ? _requiredListOfRequired!.map((e) => enumToString(e)).toString()
+            : "null") +
+        ", ");
+    buffer.write("listOfRequired=" +
+        (_listOfRequired != null
+            ? _listOfRequired!.map((e) => enumToString(e)).toString()
+            : "null"));
+    buffer.write("}");
+
+    return buffer.toString();
+  }
+
+  TestNullableListsEnum copyWith(
+      {String? id,
+      List<TestEnum>? list,
+      List<TestEnum>? requiredList,
+      List<TestEnum>? requiredListOfRequired,
+      List<TestEnum>? listOfRequired}) {
+    return TestNullableListsEnum(
+        id: id ?? this.id,
+        list: list ?? this.list,
+        requiredList: requiredList ?? this.requiredList,
+        requiredListOfRequired:
+            requiredListOfRequired ?? this.requiredListOfRequired,
+        listOfRequired: listOfRequired ?? this.listOfRequired);
+  }
+
+  TestNullableListsEnum.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        _list = json['list'] is List
+            ? (json['list'] as List)
+                .map((e) => enumFromString<TestEnum>(e, TestEnum.values)!)
+                .toList()
+            : null,
+        _requiredList = json['requiredList'] is List
+            ? (json['requiredList'] as List)
+                .map((e) => enumFromString<TestEnum>(e, TestEnum.values)!)
+                .toList()
+            : null,
+        _requiredListOfRequired = json['requiredListOfRequired'] is List
+            ? (json['requiredListOfRequired'] as List)
+                .map((e) => enumFromString<TestEnum>(e, TestEnum.values)!)
+                .toList()
+            : null,
+        _listOfRequired = json['listOfRequired'] is List
+            ? (json['listOfRequired'] as List)
+                .map((e) => enumFromString<TestEnum>(e, TestEnum.values)!)
+                .toList()
+            : null;
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'list': _list?.map((e) => enumToString(e))?.toList(),
+        'requiredList': _requiredList?.map((e) => enumToString(e))?.toList(),
+        'requiredListOfRequired':
+            _requiredListOfRequired?.map((e) => enumToString(e))?.toList(),
+        'listOfRequired': _listOfRequired?.map((e) => enumToString(e))?.toList()
+      };
+
+  static final QueryField ID =
+      QueryField(fieldName: "testNullableListsEnum.id");
+  static final QueryField LIST = QueryField(fieldName: "list");
+  static final QueryField REQUIREDLIST = QueryField(fieldName: "requiredList");
+  static final QueryField REQUIREDLISTOFREQUIRED =
+      QueryField(fieldName: "requiredListOfRequired");
+  static final QueryField LISTOFREQUIRED =
+      QueryField(fieldName: "listOfRequired");
+  static var schema =
+      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = "TestNullableListsEnum";
+    modelSchemaDefinition.pluralName = "TestNullableListsEnums";
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestNullableListsEnum.LIST,
+        isRequired: false,
+        isArray: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.collection,
+            ofModelName: describeEnum(ModelFieldTypeEnum.enumeration))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestNullableListsEnum.REQUIREDLIST,
+        isRequired: true,
+        isArray: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.collection,
+            ofModelName: describeEnum(ModelFieldTypeEnum.enumeration))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestNullableListsEnum.REQUIREDLISTOFREQUIRED,
+        isRequired: true,
+        isArray: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.collection,
+            ofModelName: describeEnum(ModelFieldTypeEnum.enumeration))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestNullableListsEnum.LISTOFREQUIRED,
+        isRequired: false,
+        isArray: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.collection,
+            ofModelName: describeEnum(ModelFieldTypeEnum.enumeration))));
+  });
+}
+
+class _TestNullableListsEnumModelType extends ModelType<TestNullableListsEnum> {
+  const _TestNullableListsEnumModelType();
+
+  @override
+  TestNullableListsEnum fromJson(Map<String, dynamic> jsonData) {
+    return TestNullableListsEnum.fromJson(jsonData);
+  }
+}

--- a/packages/amplify_datastore/example/lib/models/TestNullableListsModel.dart
+++ b/packages/amplify_datastore/example/lib/models/TestNullableListsModel.dart
@@ -25,8 +25,8 @@ import 'package:flutter/foundation.dart';
 class TestNullableListsModel extends Model {
   static const classType = const _TestNullableListsModelModelType();
   final String id;
-  final List<Post>? _list;
-  final List<Post>? _requiredList;
+  final List<Post?>? _list;
+  final List<Post?>? _requiredList;
   final List<Post>? _requiredListOfRequired;
   final List<Post>? _listOfRequired;
 
@@ -38,11 +38,11 @@ class TestNullableListsModel extends Model {
     return id;
   }
 
-  List<Post>? get list {
+  List<Post?>? get list {
     return _list;
   }
 
-  List<Post> get requiredList {
+  List<Post?> get requiredList {
     try {
       return _requiredList!;
     } catch (e) {
@@ -85,22 +85,16 @@ class TestNullableListsModel extends Model {
 
   factory TestNullableListsModel(
       {String? id,
-      List<Post>? list,
-      required List<Post> requiredList,
+      List<Post?>? list,
+      required List<Post?> requiredList,
       required List<Post> requiredListOfRequired,
       List<Post>? listOfRequired}) {
     return TestNullableListsModel._internal(
         id: id == null ? UUID.getUUID() : id,
-        list: list != null ? List<Post>.unmodifiable(list) : list,
-        requiredList: requiredList != null
-            ? List<Post>.unmodifiable(requiredList)
-            : requiredList,
-        requiredListOfRequired: requiredListOfRequired != null
-            ? List<Post>.unmodifiable(requiredListOfRequired)
-            : requiredListOfRequired,
-        listOfRequired: listOfRequired != null
-            ? List<Post>.unmodifiable(listOfRequired)
-            : listOfRequired);
+        list: list,
+        requiredList: requiredList,
+        requiredListOfRequired: requiredListOfRequired,
+        listOfRequired: listOfRequired);
   }
 
   bool equals(Object other) {
@@ -128,6 +122,27 @@ class TestNullableListsModel extends Model {
 
     buffer.write("TestNullableListsModel {");
     buffer.write("id=" + "$id");
+    buffer.write("list=" +
+        (_list != null
+            ? _list!.map((e) => e != null ? e.toString() : "null").toString()
+            : "null") +
+        ", ");
+    buffer.write("requiredList=" +
+        (_requiredList != null
+            ? _requiredList!
+                .map((e) => e != null ? e.toString() : "null")
+                .toString()
+            : "null") +
+        ", ");
+    buffer.write("requiredListOfRequired=" +
+        (_requiredListOfRequired != null
+            ? _requiredListOfRequired!.map((e) => e.toString()).toString()
+            : "null") +
+        ", ");
+    buffer.write("listOfRequired=" +
+        (_listOfRequired != null
+            ? _listOfRequired!.map((e) => e.toString()).toString()
+            : "null"));
     buffer.write("}");
 
     return buffer.toString();
@@ -135,8 +150,8 @@ class TestNullableListsModel extends Model {
 
   TestNullableListsModel copyWith(
       {String? id,
-      List<Post>? list,
-      List<Post>? requiredList,
+      List<Post?>? list,
+      List<Post?>? requiredList,
       List<Post>? requiredListOfRequired,
       List<Post>? listOfRequired}) {
     return TestNullableListsModel(
@@ -181,11 +196,11 @@ class TestNullableListsModel extends Model {
 
   Map<String, dynamic> toJson() => {
         'id': id,
-        'list': _list?.map((e) => e?.toJson())?.toList(),
-        'requiredList': _requiredList?.map((e) => e?.toJson())?.toList(),
+        'list': _list?.map((e) => e?.toJson()).toList(),
+        'requiredList': _requiredList?.map((e) => e?.toJson()).toList(),
         'requiredListOfRequired':
-            _requiredListOfRequired?.map((e) => e?.toJson())?.toList(),
-        'listOfRequired': _listOfRequired?.map((e) => e?.toJson())?.toList()
+            _requiredListOfRequired?.map((e) => e.toJson()).toList(),
+        'listOfRequired': _listOfRequired?.map((e) => e.toJson()).toList()
       };
 
   static final QueryField ID =

--- a/packages/amplify_datastore/example/lib/models/TestNullableListsModel.dart
+++ b/packages/amplify_datastore/example/lib/models/TestNullableListsModel.dart
@@ -1,0 +1,250 @@
+/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// ignore_for_file: public_member_api_docs
+
+import 'ModelProvider.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+
+/** This is an auto generated class representing the TestNullableListsModel type in your schema. */
+@immutable
+class TestNullableListsModel extends Model {
+  static const classType = const _TestNullableListsModelModelType();
+  final String id;
+  final List<Post>? _list;
+  final List<Post>? _requiredList;
+  final List<Post>? _requiredListOfRequired;
+  final List<Post>? _listOfRequired;
+
+  @override
+  getInstanceType() => classType;
+
+  @override
+  String getId() {
+    return id;
+  }
+
+  List<Post>? get list {
+    return _list;
+  }
+
+  List<Post> get requiredList {
+    try {
+      return _requiredList!;
+    } catch (e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion: DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString());
+    }
+  }
+
+  List<Post> get requiredListOfRequired {
+    try {
+      return _requiredListOfRequired!;
+    } catch (e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion: DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString());
+    }
+  }
+
+  List<Post>? get listOfRequired {
+    return _listOfRequired;
+  }
+
+  const TestNullableListsModel._internal(
+      {required this.id,
+      list,
+      required requiredList,
+      required requiredListOfRequired,
+      listOfRequired})
+      : _list = list,
+        _requiredList = requiredList,
+        _requiredListOfRequired = requiredListOfRequired,
+        _listOfRequired = listOfRequired;
+
+  factory TestNullableListsModel(
+      {String? id,
+      List<Post>? list,
+      required List<Post> requiredList,
+      required List<Post> requiredListOfRequired,
+      List<Post>? listOfRequired}) {
+    return TestNullableListsModel._internal(
+        id: id == null ? UUID.getUUID() : id,
+        list: list != null ? List<Post>.unmodifiable(list) : list,
+        requiredList: requiredList != null
+            ? List<Post>.unmodifiable(requiredList)
+            : requiredList,
+        requiredListOfRequired: requiredListOfRequired != null
+            ? List<Post>.unmodifiable(requiredListOfRequired)
+            : requiredListOfRequired,
+        listOfRequired: listOfRequired != null
+            ? List<Post>.unmodifiable(listOfRequired)
+            : listOfRequired);
+  }
+
+  bool equals(Object other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TestNullableListsModel &&
+        id == other.id &&
+        DeepCollectionEquality().equals(_list, other._list) &&
+        DeepCollectionEquality().equals(_requiredList, other._requiredList) &&
+        DeepCollectionEquality()
+            .equals(_requiredListOfRequired, other._requiredListOfRequired) &&
+        DeepCollectionEquality().equals(_listOfRequired, other._listOfRequired);
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+
+    buffer.write("TestNullableListsModel {");
+    buffer.write("id=" + "$id");
+    buffer.write("}");
+
+    return buffer.toString();
+  }
+
+  TestNullableListsModel copyWith(
+      {String? id,
+      List<Post>? list,
+      List<Post>? requiredList,
+      List<Post>? requiredListOfRequired,
+      List<Post>? listOfRequired}) {
+    return TestNullableListsModel(
+        id: id ?? this.id,
+        list: list ?? this.list,
+        requiredList: requiredList ?? this.requiredList,
+        requiredListOfRequired:
+            requiredListOfRequired ?? this.requiredListOfRequired,
+        listOfRequired: listOfRequired ?? this.listOfRequired);
+  }
+
+  TestNullableListsModel.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        _list = json['list'] is List
+            ? (json['list'] as List)
+                .where((e) => e?['serializedData'] != null)
+                .map((e) => Post.fromJson(
+                    new Map<String, dynamic>.from(e['serializedData'])))
+                .toList()
+            : null,
+        _requiredList = json['requiredList'] is List
+            ? (json['requiredList'] as List)
+                .where((e) => e?['serializedData'] != null)
+                .map((e) => Post.fromJson(
+                    new Map<String, dynamic>.from(e['serializedData'])))
+                .toList()
+            : null,
+        _requiredListOfRequired = json['requiredListOfRequired'] is List
+            ? (json['requiredListOfRequired'] as List)
+                .where((e) => e?['serializedData'] != null)
+                .map((e) => Post.fromJson(
+                    new Map<String, dynamic>.from(e['serializedData'])))
+                .toList()
+            : null,
+        _listOfRequired = json['listOfRequired'] is List
+            ? (json['listOfRequired'] as List)
+                .where((e) => e?['serializedData'] != null)
+                .map((e) => Post.fromJson(
+                    new Map<String, dynamic>.from(e['serializedData'])))
+                .toList()
+            : null;
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'list': _list?.map((e) => e?.toJson())?.toList(),
+        'requiredList': _requiredList?.map((e) => e?.toJson())?.toList(),
+        'requiredListOfRequired':
+            _requiredListOfRequired?.map((e) => e?.toJson())?.toList(),
+        'listOfRequired': _listOfRequired?.map((e) => e?.toJson())?.toList()
+      };
+
+  static final QueryField ID =
+      QueryField(fieldName: "testNullableListsModel.id");
+  static final QueryField LIST = QueryField(
+      fieldName: "list",
+      fieldType: ModelFieldType(ModelFieldTypeEnum.model,
+          ofModelName: (Post).toString()));
+  static final QueryField REQUIREDLIST = QueryField(
+      fieldName: "requiredList",
+      fieldType: ModelFieldType(ModelFieldTypeEnum.model,
+          ofModelName: (Post).toString()));
+  static final QueryField REQUIREDLISTOFREQUIRED = QueryField(
+      fieldName: "requiredListOfRequired",
+      fieldType: ModelFieldType(ModelFieldTypeEnum.model,
+          ofModelName: (Post).toString()));
+  static final QueryField LISTOFREQUIRED = QueryField(
+      fieldName: "listOfRequired",
+      fieldType: ModelFieldType(ModelFieldTypeEnum.model,
+          ofModelName: (Post).toString()));
+  static var schema =
+      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = "TestNullableListsModel";
+    modelSchemaDefinition.pluralName = "TestNullableListsModels";
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.hasMany(
+        key: TestNullableListsModel.LIST,
+        isRequired: false,
+        ofModelName: (Post).toString(),
+        associatedKey: Post.BLOG));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.hasMany(
+        key: TestNullableListsModel.REQUIREDLIST,
+        isRequired: false,
+        ofModelName: (Post).toString(),
+        associatedKey: Post.BLOG));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.hasMany(
+        key: TestNullableListsModel.REQUIREDLISTOFREQUIRED,
+        isRequired: true,
+        ofModelName: (Post).toString(),
+        associatedKey: Post.BLOG));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.hasMany(
+        key: TestNullableListsModel.LISTOFREQUIRED,
+        isRequired: true,
+        ofModelName: (Post).toString(),
+        associatedKey: Post.BLOG));
+  });
+}
+
+class _TestNullableListsModelModelType
+    extends ModelType<TestNullableListsModel> {
+  const _TestNullableListsModelModelType();
+
+  @override
+  TestNullableListsModel fromJson(Map<String, dynamic> jsonData) {
+    return TestNullableListsModel.fromJson(jsonData);
+  }
+}

--- a/packages/amplify_datastore/example/lib/models/TestNullableListsString.dart
+++ b/packages/amplify_datastore/example/lib/models/TestNullableListsString.dart
@@ -25,8 +25,8 @@ class TestNullableListsString extends Model {
   static const classType = const _TestNullableListsStringModelType();
   final String id;
   final List<String?>? _list;
-  final List<String?> _requiredList;
-  final List<String> _requiredListOfRequired;
+  final List<String?>? _requiredList;
+  final List<String>? _requiredListOfRequired;
   final List<String>? _listOfRequired;
 
   @override
@@ -91,12 +91,8 @@ class TestNullableListsString extends Model {
     return TestNullableListsString._internal(
         id: id == null ? UUID.getUUID() : id,
         list: list,
-        requiredList: requiredList != null
-            ? List<String?>.unmodifiable(requiredList)
-            : requiredList,
-        requiredListOfRequired: requiredListOfRequired != null
-            ? List<String>.unmodifiable(requiredListOfRequired)
-            : requiredListOfRequired,
+        requiredList: requiredList,
+        requiredListOfRequired: requiredListOfRequired,
         listOfRequired: listOfRequired);
   }
 
@@ -127,11 +123,11 @@ class TestNullableListsString extends Model {
     buffer.write("id=" + "$id" + ", ");
     buffer.write("list=" + (_list != null ? _list!.toString() : "null") + ", ");
     buffer.write("requiredList=" +
-        (_requiredList != null ? _requiredList!.toString() : "null") +
+        (_requiredList != null ? _requiredList.toString() : "null") +
         ", ");
     buffer.write("requiredListOfRequired=" +
         (_requiredListOfRequired != null
-            ? _requiredListOfRequired!.toString()
+            ? _requiredListOfRequired.toString()
             : "null") +
         ", ");
     buffer.write("listOfRequired=" +

--- a/packages/amplify_datastore/example/lib/models/TestNullableListsString.dart
+++ b/packages/amplify_datastore/example/lib/models/TestNullableListsString.dart
@@ -24,9 +24,9 @@ import 'package:flutter/foundation.dart';
 class TestNullableListsString extends Model {
   static const classType = const _TestNullableListsStringModelType();
   final String id;
-  final List<String>? _list;
-  final List<String>? _requiredList;
-  final List<String>? _requiredListOfRequired;
+  final List<String?>? _list;
+  final List<String?> _requiredList;
+  final List<String> _requiredListOfRequired;
   final List<String>? _listOfRequired;
 
   @override
@@ -37,11 +37,11 @@ class TestNullableListsString extends Model {
     return id;
   }
 
-  List<String>? get list {
+  List<String?>? get list {
     return _list;
   }
 
-  List<String> get requiredList {
+  List<String?> get requiredList {
     try {
       return _requiredList!;
     } catch (e) {
@@ -84,22 +84,20 @@ class TestNullableListsString extends Model {
 
   factory TestNullableListsString(
       {String? id,
-      List<String>? list,
-      required List<String> requiredList,
+      List<String?>? list,
+      required List<String?> requiredList,
       required List<String> requiredListOfRequired,
       List<String>? listOfRequired}) {
     return TestNullableListsString._internal(
         id: id == null ? UUID.getUUID() : id,
-        list: list != null ? List<String>.unmodifiable(list) : list,
+        list: list,
         requiredList: requiredList != null
-            ? List<String>.unmodifiable(requiredList)
+            ? List<String?>.unmodifiable(requiredList)
             : requiredList,
         requiredListOfRequired: requiredListOfRequired != null
             ? List<String>.unmodifiable(requiredListOfRequired)
             : requiredListOfRequired,
-        listOfRequired: listOfRequired != null
-            ? List<String>.unmodifiable(listOfRequired)
-            : listOfRequired);
+        listOfRequired: listOfRequired);
   }
 
   bool equals(Object other) {
@@ -145,8 +143,8 @@ class TestNullableListsString extends Model {
 
   TestNullableListsString copyWith(
       {String? id,
-      List<String>? list,
-      List<String>? requiredList,
+      List<String?>? list,
+      List<String?>? requiredList,
       List<String>? requiredListOfRequired,
       List<String>? listOfRequired}) {
     return TestNullableListsString(
@@ -160,8 +158,8 @@ class TestNullableListsString extends Model {
 
   TestNullableListsString.fromJson(Map<String, dynamic> json)
       : id = json['id'],
-        _list = json['list']?.cast<String>(),
-        _requiredList = json['requiredList']?.cast<String>(),
+        _list = json['list']?.cast<String?>(),
+        _requiredList = json['requiredList']?.cast<String?>(),
         _requiredListOfRequired =
             json['requiredListOfRequired']?.cast<String>(),
         _listOfRequired = json['listOfRequired']?.cast<String>();

--- a/packages/amplify_datastore/example/lib/models/TestNullableListsString.dart
+++ b/packages/amplify_datastore/example/lib/models/TestNullableListsString.dart
@@ -1,0 +1,230 @@
+/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// ignore_for_file: public_member_api_docs
+
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+
+/** This is an auto generated class representing the TestNullableListsString type in your schema. */
+@immutable
+class TestNullableListsString extends Model {
+  static const classType = const _TestNullableListsStringModelType();
+  final String id;
+  final List<String>? _list;
+  final List<String>? _requiredList;
+  final List<String>? _requiredListOfRequired;
+  final List<String>? _listOfRequired;
+
+  @override
+  getInstanceType() => classType;
+
+  @override
+  String getId() {
+    return id;
+  }
+
+  List<String>? get list {
+    return _list;
+  }
+
+  List<String> get requiredList {
+    try {
+      return _requiredList!;
+    } catch (e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion: DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString());
+    }
+  }
+
+  List<String> get requiredListOfRequired {
+    try {
+      return _requiredListOfRequired!;
+    } catch (e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion: DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString());
+    }
+  }
+
+  List<String>? get listOfRequired {
+    return _listOfRequired;
+  }
+
+  const TestNullableListsString._internal(
+      {required this.id,
+      list,
+      required requiredList,
+      required requiredListOfRequired,
+      listOfRequired})
+      : _list = list,
+        _requiredList = requiredList,
+        _requiredListOfRequired = requiredListOfRequired,
+        _listOfRequired = listOfRequired;
+
+  factory TestNullableListsString(
+      {String? id,
+      List<String>? list,
+      required List<String> requiredList,
+      required List<String> requiredListOfRequired,
+      List<String>? listOfRequired}) {
+    return TestNullableListsString._internal(
+        id: id == null ? UUID.getUUID() : id,
+        list: list != null ? List<String>.unmodifiable(list) : list,
+        requiredList: requiredList != null
+            ? List<String>.unmodifiable(requiredList)
+            : requiredList,
+        requiredListOfRequired: requiredListOfRequired != null
+            ? List<String>.unmodifiable(requiredListOfRequired)
+            : requiredListOfRequired,
+        listOfRequired: listOfRequired != null
+            ? List<String>.unmodifiable(listOfRequired)
+            : listOfRequired);
+  }
+
+  bool equals(Object other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TestNullableListsString &&
+        id == other.id &&
+        DeepCollectionEquality().equals(_list, other._list) &&
+        DeepCollectionEquality().equals(_requiredList, other._requiredList) &&
+        DeepCollectionEquality()
+            .equals(_requiredListOfRequired, other._requiredListOfRequired) &&
+        DeepCollectionEquality().equals(_listOfRequired, other._listOfRequired);
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+
+    buffer.write("TestNullableListsString {");
+    buffer.write("id=" + "$id" + ", ");
+    buffer.write("list=" + (_list != null ? _list!.toString() : "null") + ", ");
+    buffer.write("requiredList=" +
+        (_requiredList != null ? _requiredList!.toString() : "null") +
+        ", ");
+    buffer.write("requiredListOfRequired=" +
+        (_requiredListOfRequired != null
+            ? _requiredListOfRequired!.toString()
+            : "null") +
+        ", ");
+    buffer.write("listOfRequired=" +
+        (_listOfRequired != null ? _listOfRequired!.toString() : "null"));
+    buffer.write("}");
+
+    return buffer.toString();
+  }
+
+  TestNullableListsString copyWith(
+      {String? id,
+      List<String>? list,
+      List<String>? requiredList,
+      List<String>? requiredListOfRequired,
+      List<String>? listOfRequired}) {
+    return TestNullableListsString(
+        id: id ?? this.id,
+        list: list ?? this.list,
+        requiredList: requiredList ?? this.requiredList,
+        requiredListOfRequired:
+            requiredListOfRequired ?? this.requiredListOfRequired,
+        listOfRequired: listOfRequired ?? this.listOfRequired);
+  }
+
+  TestNullableListsString.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        _list = json['list']?.cast<String>(),
+        _requiredList = json['requiredList']?.cast<String>(),
+        _requiredListOfRequired =
+            json['requiredListOfRequired']?.cast<String>(),
+        _listOfRequired = json['listOfRequired']?.cast<String>();
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'list': _list,
+        'requiredList': _requiredList,
+        'requiredListOfRequired': _requiredListOfRequired,
+        'listOfRequired': _listOfRequired
+      };
+
+  static final QueryField ID =
+      QueryField(fieldName: "testNullableListsString.id");
+  static final QueryField LIST = QueryField(fieldName: "list");
+  static final QueryField REQUIREDLIST = QueryField(fieldName: "requiredList");
+  static final QueryField REQUIREDLISTOFREQUIRED =
+      QueryField(fieldName: "requiredListOfRequired");
+  static final QueryField LISTOFREQUIRED =
+      QueryField(fieldName: "listOfRequired");
+  static var schema =
+      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = "TestNullableListsString";
+    modelSchemaDefinition.pluralName = "TestNullableListsStrings";
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestNullableListsString.LIST,
+        isRequired: false,
+        isArray: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.collection,
+            ofModelName: describeEnum(ModelFieldTypeEnum.string))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestNullableListsString.REQUIREDLIST,
+        isRequired: true,
+        isArray: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.collection,
+            ofModelName: describeEnum(ModelFieldTypeEnum.string))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestNullableListsString.REQUIREDLISTOFREQUIRED,
+        isRequired: true,
+        isArray: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.collection,
+            ofModelName: describeEnum(ModelFieldTypeEnum.string))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestNullableListsString.LISTOFREQUIRED,
+        isRequired: false,
+        isArray: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.collection,
+            ofModelName: describeEnum(ModelFieldTypeEnum.string))));
+  });
+}
+
+class _TestNullableListsStringModelType
+    extends ModelType<TestNullableListsString> {
+  const _TestNullableListsStringModelType();
+
+  @override
+  TestNullableListsString fromJson(Map<String, dynamic> jsonData) {
+    return TestNullableListsString.fromJson(jsonData);
+  }
+}

--- a/packages/amplify_datastore_plugin_interface/test/amplify_modelType_test.dart
+++ b/packages/amplify_datastore_plugin_interface/test/amplify_modelType_test.dart
@@ -71,4 +71,82 @@ void main() {
       }
     };
   });
+
+  // Test toJson and fromJson of nullable lists
+
+  test(
+      'TestNullableListsString.classType with min parameters generates proper json from serializedMap modelschema',
+      () async {
+    Map<String, dynamic> inputMap = {
+      "id": "3",
+      "modelName": "TestNullableListsString",
+      "serializedData": {
+        "id": "3",
+        "requiredList": [],
+        "requiredListOfRequired": [],
+      }
+    };
+
+    expect(
+        TestNullableListsString.classType.fromSerializedMap(inputMap).toJson(),
+        {
+          "id": "3",
+          "list": null,
+          "requiredList": [],
+          "requiredListOfRequired": [],
+          "listOfRequired": null
+        });
+  });
+
+  test(
+      'TestNullableListsString.classType with empty lists generates proper json from serializedMap modelschema',
+      () async {
+    Map<String, dynamic> inputMap = {
+      "id": "4",
+      "modelName": "TestNullableListsString",
+      "serializedData": {
+        "id": "4",
+        "list": [],
+        "requiredList": [],
+        "requiredListOfRequired": [],
+        "listOfRequired": []
+      }
+    };
+
+    expect(
+        TestNullableListsString.classType.fromSerializedMap(inputMap).toJson(),
+        {
+          "id": "4",
+          "list": [],
+          "requiredList": [],
+          "requiredListOfRequired": [],
+          "listOfRequired": []
+        });
+  });
+
+  test(
+      'TestNullableListsString.classType with nullable values generates proper json from serializedMap modelschema',
+      () async {
+    Map<String, dynamic> inputMap = {
+      "id": "5",
+      "modelName": "TestNullableListsString",
+      "serializedData": {
+        "id": "5",
+        "list": [null, "listTestString"],
+        "requiredList": [null, "requiredListTestString"],
+        "requiredListOfRequired": ["requiredListOfRequiredString"],
+        "listOfRequired": ["listOfRequiredString"]
+      }
+    };
+
+    expect(
+        TestNullableListsString.classType.fromSerializedMap(inputMap).toJson(),
+        {
+          "id": "5",
+          "list": [null, "listTestString"],
+          "requiredList": [null, "requiredListTestString"],
+          "requiredListOfRequired": ["requiredListOfRequiredString"],
+          "listOfRequired": ["listOfRequiredString"]
+        });
+  });
 }

--- a/packages/amplify_datastore_plugin_interface/test/amplify_modelschema_to_map_test.dart
+++ b/packages/amplify_datastore_plugin_interface/test/amplify_modelschema_to_map_test.dart
@@ -186,4 +186,48 @@ void main() {
       }
     });
   });
+
+  test(
+      'TestNullableListsString codegen model generates modelschema with proper fields',
+      () async {
+    ModelSchema testNullableListsString = TestNullableListsString.schema;
+    Map<String, dynamic> map = testNullableListsString.toMap();
+
+    expect(map, {
+      'name': 'TestNullableListsString',
+      'pluralName': 'TestNullableListsStrings',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'fieldType': 'string'},
+          'isRequired': true,
+          'isArray': false
+        },
+        'list': {
+          'name': 'list',
+          'type': {'fieldType': 'collection', 'ofModelName': 'string'},
+          'isRequired': false,
+          'isArray': true
+        },
+        'requiredList': {
+          'name': 'requiredList',
+          'type': {'fieldType': 'collection', 'ofModelName': 'string'},
+          'isRequired': true,
+          'isArray': true
+        },
+        'requiredListOfRequired': {
+          'name': 'requiredListOfRequired',
+          'type': {'fieldType': 'collection', 'ofModelName': 'string'},
+          'isRequired': true,
+          'isArray': true
+        },
+        'listOfRequired': {
+          'name': 'listOfRequired',
+          'type': {'fieldType': 'collection', 'ofModelName': 'string'},
+          'isRequired': false,
+          'isArray': true
+        }
+      }
+    });
+  });
 }

--- a/packages/amplify_datastore_plugin_interface/test/testData/ModelProvider.dart
+++ b/packages/amplify_datastore_plugin_interface/test/testData/ModelProvider.dart
@@ -20,11 +20,13 @@ import 'Blog.dart';
 import 'Comment.dart';
 import 'Post.dart';
 import 'PostAuthComplex.dart';
+import 'TestNullableListsString.dart';
 
 export 'Blog.dart';
 export 'Comment.dart';
 export 'Post.dart';
 export 'PostAuthComplex.dart';
+export 'TestNullableListsString.dart';
 
 class ModelProvider implements ModelProviderInterface {
   @override
@@ -34,7 +36,8 @@ class ModelProvider implements ModelProviderInterface {
     Blog.schema,
     Comment.schema,
     Post.schema,
-    PostAuthComplex.schema
+    PostAuthComplex.schema,
+    TestNullableListsString.schema
   ];
   static final ModelProvider _instance = ModelProvider();
 
@@ -60,6 +63,11 @@ class ModelProvider implements ModelProviderInterface {
       case "PostAuthComplex":
         {
           return PostAuthComplex.classType;
+        }
+        break;
+      case "TestNullableListsString":
+        {
+          return TestNullableListsString.classType;
         }
         break;
       default:

--- a/packages/amplify_datastore_plugin_interface/test/testData/TestNullableListsString.dart
+++ b/packages/amplify_datastore_plugin_interface/test/testData/TestNullableListsString.dart
@@ -1,0 +1,224 @@
+/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// ignore_for_file: public_member_api_docs
+
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+
+/** This is an auto generated class representing the TestNullableListsString type in your schema. */
+@immutable
+class TestNullableListsString extends Model {
+  static const classType = const _TestNullableListsStringModelType();
+  final String id;
+  final List<String?>? _list;
+  final List<String?>? _requiredList;
+  final List<String>? _requiredListOfRequired;
+  final List<String>? _listOfRequired;
+
+  @override
+  getInstanceType() => classType;
+
+  @override
+  String getId() {
+    return id;
+  }
+
+  List<String?>? get list {
+    return _list;
+  }
+
+  List<String?> get requiredList {
+    try {
+      return _requiredList!;
+    } catch (e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion: DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString());
+    }
+  }
+
+  List<String> get requiredListOfRequired {
+    try {
+      return _requiredListOfRequired!;
+    } catch (e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion: DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString());
+    }
+  }
+
+  List<String>? get listOfRequired {
+    return _listOfRequired;
+  }
+
+  const TestNullableListsString._internal(
+      {required this.id,
+      list,
+      required requiredList,
+      required requiredListOfRequired,
+      listOfRequired})
+      : _list = list,
+        _requiredList = requiredList,
+        _requiredListOfRequired = requiredListOfRequired,
+        _listOfRequired = listOfRequired;
+
+  factory TestNullableListsString(
+      {String? id,
+      List<String?>? list,
+      required List<String?> requiredList,
+      required List<String> requiredListOfRequired,
+      List<String>? listOfRequired}) {
+    return TestNullableListsString._internal(
+        id: id == null ? UUID.getUUID() : id,
+        list: list,
+        requiredList: requiredList,
+        requiredListOfRequired: requiredListOfRequired,
+        listOfRequired: listOfRequired);
+  }
+
+  bool equals(Object other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TestNullableListsString &&
+        id == other.id &&
+        DeepCollectionEquality().equals(_list, other._list) &&
+        DeepCollectionEquality().equals(_requiredList, other._requiredList) &&
+        DeepCollectionEquality()
+            .equals(_requiredListOfRequired, other._requiredListOfRequired) &&
+        DeepCollectionEquality().equals(_listOfRequired, other._listOfRequired);
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+
+    buffer.write("TestNullableListsString {");
+    buffer.write("id=" + "$id" + ", ");
+    buffer.write("list=" + (_list != null ? _list!.toString() : "null") + ", ");
+    buffer.write("requiredList=" +
+        (_requiredList != null ? _requiredList.toString() : "null") +
+        ", ");
+    buffer.write("requiredListOfRequired=" +
+        (_requiredListOfRequired != null
+            ? _requiredListOfRequired.toString()
+            : "null") +
+        ", ");
+    buffer.write("listOfRequired=" +
+        (_listOfRequired != null ? _listOfRequired!.toString() : "null"));
+    buffer.write("}");
+
+    return buffer.toString();
+  }
+
+  TestNullableListsString copyWith(
+      {String? id,
+      List<String?>? list,
+      List<String?>? requiredList,
+      List<String>? requiredListOfRequired,
+      List<String>? listOfRequired}) {
+    return TestNullableListsString(
+        id: id ?? this.id,
+        list: list ?? this.list,
+        requiredList: requiredList ?? this.requiredList,
+        requiredListOfRequired:
+            requiredListOfRequired ?? this.requiredListOfRequired,
+        listOfRequired: listOfRequired ?? this.listOfRequired);
+  }
+
+  TestNullableListsString.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        _list = json['list']?.cast<String?>(),
+        _requiredList = json['requiredList']?.cast<String?>(),
+        _requiredListOfRequired =
+            json['requiredListOfRequired']?.cast<String>(),
+        _listOfRequired = json['listOfRequired']?.cast<String>();
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'list': _list,
+        'requiredList': _requiredList,
+        'requiredListOfRequired': _requiredListOfRequired,
+        'listOfRequired': _listOfRequired
+      };
+
+  static final QueryField ID =
+      QueryField(fieldName: "testNullableListsString.id");
+  static final QueryField LIST = QueryField(fieldName: "list");
+  static final QueryField REQUIREDLIST = QueryField(fieldName: "requiredList");
+  static final QueryField REQUIREDLISTOFREQUIRED =
+      QueryField(fieldName: "requiredListOfRequired");
+  static final QueryField LISTOFREQUIRED =
+      QueryField(fieldName: "listOfRequired");
+  static var schema =
+      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = "TestNullableListsString";
+    modelSchemaDefinition.pluralName = "TestNullableListsStrings";
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestNullableListsString.LIST,
+        isRequired: false,
+        isArray: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.collection,
+            ofModelName: describeEnum(ModelFieldTypeEnum.string))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestNullableListsString.REQUIREDLIST,
+        isRequired: true,
+        isArray: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.collection,
+            ofModelName: describeEnum(ModelFieldTypeEnum.string))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestNullableListsString.REQUIREDLISTOFREQUIRED,
+        isRequired: true,
+        isArray: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.collection,
+            ofModelName: describeEnum(ModelFieldTypeEnum.string))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestNullableListsString.LISTOFREQUIRED,
+        isRequired: false,
+        isArray: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.collection,
+            ofModelName: describeEnum(ModelFieldTypeEnum.string))));
+  });
+}
+
+class _TestNullableListsStringModelType
+    extends ModelType<TestNullableListsString> {
+  const _TestNullableListsStringModelType();
+
+  @override
+  TestNullableListsString fromJson(Map<String, dynamic> jsonData) {
+    return TestNullableListsString.fromJson(jsonData);
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Support nullable lists types.  The main changes will be in the Dart codegen models which will be generated differently to allow for lists of nullable types.  We are still working to finalize what the codegen models will look like. 

Testing on Android works.  iOS is not working currently. 

Also need to remove testing code on main.dart 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
