### PR TITLE
fix(datastore): cannot saving boolean as integer in SQLite

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterModelFieldType.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterModelFieldType.kt
@@ -64,7 +64,7 @@ data class FlutterModelFieldType(val map: Map<String, Any>) {
             "dateTime" -> Temporal.DateTime::class.java
             "time" -> Temporal.Time::class.java
             "timestamp" -> Temporal.Timestamp::class.java
-            "bool" -> Boolean::class.java
+            "bool" -> Boolean::class.javaObjectType
             "enumeration" -> String::class.java
             "model" -> Model::class.java
             "collection" -> List::class.java


### PR DESCRIPTION
*Issue #, if available:* #752

*Description of changes:*

Convert `bool` filed type to java `Boolean` object type instead of Kotlin primitive `Boolean` type. 

Reason: amplify-android uses Java `Boolean` class but not expecting Kotlin primitive boolean. This will let amplify-android correctly create boolean value column with `integer` type, and further to fix the issue described in #752

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
