### PR TITLE
chore: set min flutter version to '>1.20.0' in packages where set to …

### DIFF
--- a/packages/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/amplify_analytics_pinpoint/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.2.1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_analytics_pinpoint
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ^1.20.0
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:

--- a/packages/amplify_api/pubspec.yaml
+++ b/packages/amplify_api/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/ampl
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ^1.20.0
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:

--- a/packages/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/amplify_auth_cognito/example/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0 <2.0.0"
+  flutter: ">=2.2.0"
 
 dependencies:
   flutter:
@@ -35,10 +35,6 @@ dev_dependencies:
     sdk: flutter
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
-
-# Needed to avoid conflict for integration tests until flutter driver has null safe version of crypto https://github.com/flutter/flutter/issues/77282
-dependency_overrides:
-  crypto: ^3.0.0
 
 # The following section is specific to Flutter.
 flutter:

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/ampl
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:

--- a/packages/amplify_storage_s3/pubspec.yaml
+++ b/packages/amplify_storage_s3/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.2.1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_storage_s3
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ^1.10.0
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
*Description of changes:* Set min flutter version to '>1.20.0' in packages where set to something else. There were some warnings during publishing last release that in some places is set to things like ^1.20.0 which is incorrect bc has upper bounds.

Long-term, maybe should be changed to '>=2.0.0' bc I think these packages really only work on flutter 2+, but this PR at least just makes them consistent and does not have an upper bound.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
