### PR TITLE
fix(datastore): Query nested model causes column not found sql error

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -214,7 +214,8 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         var queryOptions: QueryOptions
         try {
             modelName = request["modelName"] as String
-            queryOptions = QueryOptionsBuilder.fromSerializedMap(request)
+            val modelSchema = modelProvider.modelSchemas().getValue(modelName)
+            queryOptions = QueryOptionsBuilder.fromSerializedMap(request, modelSchema)
         } catch (e: Exception) {
             handler.post {
                 postExceptionToFlutterChannel(

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryOptionsBuilder.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryOptionsBuilder.kt
@@ -28,7 +28,7 @@ class QueryOptionsBuilder {
 
     companion object {
         @JvmStatic
-        fun fromSerializedMap(request: Map<String, Any>?, modelSchema: ModelSchema? = null): QueryOptions {
+        fun fromSerializedMap(request: Map<String, Any>?, modelSchema: ModelSchema): QueryOptions {
             var queryOptions: QueryOptions = Where.matchesAll()
             if (request == null) {
                 return queryOptions

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryOptionsBuilder.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryOptionsBuilder.kt
@@ -33,11 +33,14 @@ class QueryOptionsBuilder {
                 return queryOptions
             }
             var queryPredicate: QueryPredicate? = QueryPredicateBuilder.fromSerializedMap(
-                    request["queryPredicate"].safeCastToMap())
+                request["queryPredicate"].safeCastToMap()
+            )
             var querySortInput: List<QuerySortBy>? = QuerySortBuilder.fromSerializedList(
-                    request["querySort"].safeCastToList())
+                request["querySort"].safeCastToList()
+            )
             var queryPagination: QueryPaginationInput? = QueryPaginationBuilder.fromSerializedMap(
-                    request["queryPagination"].safeCastToMap())
+                request["queryPagination"].safeCastToMap()
+            )
 
             if (queryPredicate != null) {
                 queryOptions = queryOptions.matches(queryPredicate)

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryOptionsBuilder.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryOptionsBuilder.kt
@@ -17,6 +17,7 @@ package com.amazonaws.amplify.amplify_datastore.types.query
 
 import com.amazonaws.amplify.amplify_datastore.util.safeCastToList
 import com.amazonaws.amplify.amplify_datastore.util.safeCastToMap
+import com.amplifyframework.core.model.ModelSchema
 import com.amplifyframework.core.model.query.QueryOptions
 import com.amplifyframework.core.model.query.QueryPaginationInput
 import com.amplifyframework.core.model.query.QuerySortBy
@@ -27,13 +28,14 @@ class QueryOptionsBuilder {
 
     companion object {
         @JvmStatic
-        fun fromSerializedMap(request: Map<String, Any>?): QueryOptions {
+        fun fromSerializedMap(request: Map<String, Any>?, modelSchema: ModelSchema? = null): QueryOptions {
             var queryOptions: QueryOptions = Where.matchesAll()
             if (request == null) {
                 return queryOptions
             }
             var queryPredicate: QueryPredicate? = QueryPredicateBuilder.fromSerializedMap(
-                request["queryPredicate"].safeCastToMap()
+                request["queryPredicate"].safeCastToMap(),
+                modelSchema
             )
             var querySortInput: List<QuerySortBy>? = QuerySortBuilder.fromSerializedList(
                 request["querySort"].safeCastToList()

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
@@ -18,6 +18,7 @@ package com.amazonaws.amplify.amplify_datastore.types.query
 import com.amazonaws.amplify.amplify_datastore.util.safeCastToList
 import com.amazonaws.amplify.amplify_datastore.util.safeCastToMap
 import com.amplifyframework.core.model.ModelSchema
+import com.amplifyframework.core.model.annotations.BelongsTo
 import com.amplifyframework.core.model.query.predicate.QueryField
 import com.amplifyframework.core.model.query.predicate.QueryPredicate
 import com.amplifyframework.core.model.query.predicate.QueryPredicateGroup
@@ -41,7 +42,11 @@ class QueryPredicateBuilder {
                 var field = queryPredicateOperationMap["field"] as String
 
                 if (modelSchema?.associations?.containsKey(field) == true) {
-                    field = modelSchema.associations.getValue(field).targetName
+                    val association = modelSchema.associations.getValue(field);
+
+                    if (BelongsTo::class.java.simpleName.equals(association.name)) {
+                        field = modelSchema.associations.getValue(field).targetName
+                    }
                 }
 
                 val queryField: QueryField = QueryField.field(field)

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
@@ -32,10 +32,12 @@ class QueryPredicateBuilder {
             }
 
             if (serializedMap.containsKey("queryPredicateOperation")) {
-                val queryPredicateOperationMap: Map<String, Any> = serializedMap["queryPredicateOperation"].safeCastToMap()!!
+                val queryPredicateOperationMap: Map<String, Any> =
+                    serializedMap["queryPredicateOperation"].safeCastToMap()!!
                 val field = queryPredicateOperationMap["field"] as String
                 val queryField: QueryField = QueryField.field(field)
-                val queryFieldOperatorMap: Map<String, Any> = queryPredicateOperationMap["fieldOperator"].safeCastToMap()!!
+                val queryFieldOperatorMap: Map<String, Any> =
+                    queryPredicateOperationMap["fieldOperator"].safeCastToMap()!!
                 val operand: Any? = queryFieldOperatorMap["value"]
                 when (queryFieldOperatorMap["operatorName"]) {
                     "equal" -> return queryField.eq(operand)
@@ -46,20 +48,21 @@ class QueryPredicateBuilder {
                     "greater_than" -> return queryField.gt(operand as Comparable<Any?>?)
                     "contains" -> return queryField.contains(operand as String)
                     "between" -> return queryField.between(
-                            queryFieldOperatorMap["start"] as Comparable<Any?>?,
-                            queryFieldOperatorMap["end"] as Comparable<Any?>?)
+                        queryFieldOperatorMap["start"] as Comparable<Any?>?,
+                        queryFieldOperatorMap["end"] as Comparable<Any?>?
+                    )
                     "begins_with" -> return queryField.beginsWith(operand as String)
                 }
             }
 
             if (serializedMap.containsKey("queryPredicateGroup")) {
-                val queryPredicateGroupMap : Map<String, Any> =
-                        serializedMap["queryPredicateGroup"].safeCastToMap()!!
+                val queryPredicateGroupMap: Map<String, Any> =
+                    serializedMap["queryPredicateGroup"].safeCastToMap()!!
                 var predicates: List<QueryPredicate> =
-                        queryPredicateGroupMap["predicates"].safeCastToList<Map<String, Any>>()
-                                ?.map { queryPredicate ->
-                                    fromSerializedMap(queryPredicate)!!
-                                }!!
+                    queryPredicateGroupMap["predicates"].safeCastToList<Map<String, Any>>()
+                        ?.map { queryPredicate ->
+                            fromSerializedMap(queryPredicate)!!
+                        }!!
                 var resultQueryPredicate: QueryPredicateGroup? = null
                 // The first predicate in the list is either predicateOperation or predicateGroup. We need
                 // to know which one so that we can cast it appropriately and call the `and` or `not` method
@@ -67,12 +70,12 @@ class QueryPredicateBuilder {
                     when (queryPredicateGroupMap["type"]) {
                         "and" -> {
                             resultQueryPredicate =
-                                    (predicates[0] as QueryPredicateOperation<*>).and(predicates[1])
+                                (predicates[0] as QueryPredicateOperation<*>).and(predicates[1])
                             predicates = predicates.drop(2)
                         }
                         "or" -> {
                             resultQueryPredicate =
-                                    (predicates[0] as QueryPredicateOperation<*>).or(predicates[1])
+                                (predicates[0] as QueryPredicateOperation<*>).or(predicates[1])
                             predicates = predicates.drop(2)
                         }
                         "not" -> {
@@ -100,11 +103,12 @@ class QueryPredicateBuilder {
                         // Not operator cannot contain a list of predicates, but just one.
                         if (predicates.isNotEmpty()) {
                             throw IllegalArgumentException(
-                                    "More than one predicates added in the `not` queryPredicate operation." +
-                                            " Predicates Size: " + predicates.size)
+                                "More than one predicates added in the `not` queryPredicate operation." +
+                                        " Predicates Size: " + predicates.size
+                            )
                         }
                         resultQueryPredicate =
-                                QueryPredicateGroup.not(resultQueryPredicate as QueryPredicateGroup)
+                            QueryPredicateGroup.not(resultQueryPredicate as QueryPredicateGroup)
                     }
                 }
 

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
@@ -17,6 +17,7 @@ package com.amazonaws.amplify.amplify_datastore.types.query
 
 import com.amazonaws.amplify.amplify_datastore.util.safeCastToList
 import com.amazonaws.amplify.amplify_datastore.util.safeCastToMap
+import com.amplifyframework.core.model.ModelSchema
 import com.amplifyframework.core.model.query.predicate.QueryField
 import com.amplifyframework.core.model.query.predicate.QueryPredicate
 import com.amplifyframework.core.model.query.predicate.QueryPredicateGroup
@@ -26,7 +27,7 @@ import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation.n
 class QueryPredicateBuilder {
     companion object {
         @JvmStatic
-        fun fromSerializedMap(serializedMap: Map<String, Any>?): QueryPredicate? {
+        fun fromSerializedMap(serializedMap: Map<String, Any>?, modelSchema: ModelSchema? = null): QueryPredicate? {
             if (serializedMap == null) {
                 return null
             }
@@ -34,7 +35,12 @@ class QueryPredicateBuilder {
             if (serializedMap.containsKey("queryPredicateOperation")) {
                 val queryPredicateOperationMap: Map<String, Any> =
                     serializedMap["queryPredicateOperation"].safeCastToMap()!!
-                val field = queryPredicateOperationMap["field"] as String
+                var field = queryPredicateOperationMap["field"] as String
+
+                if (modelSchema?.associations?.containsKey(field) == true) {
+                    field = modelSchema.associations.getValue(field).targetName
+                }
+
                 val queryField: QueryField = QueryField.field(field)
                 val queryFieldOperatorMap: Map<String, Any> =
                     queryPredicateOperationMap["fieldOperator"].safeCastToMap()!!

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
@@ -26,8 +26,11 @@ import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation.n
 
 class QueryPredicateBuilder {
     companion object {
+        /**
+         * Use only within [QueryOptionsBuilder]
+         */
         @JvmStatic
-        fun fromSerializedMap(serializedMap: Map<String, Any>?, modelSchema: ModelSchema? = null): QueryPredicate? {
+        fun fromSerializedMap(serializedMap: Map<String, Any>?, modelSchema: ModelSchema?): QueryPredicate? {
             if (serializedMap == null) {
                 return null
             }
@@ -67,7 +70,7 @@ class QueryPredicateBuilder {
                 var predicates: List<QueryPredicate> =
                     queryPredicateGroupMap["predicates"].safeCastToList<Map<String, Any>>()
                         ?.map { queryPredicate ->
-                            fromSerializedMap(queryPredicate)!!
+                            fromSerializedMap(queryPredicate, modelSchema)!!
                         }!!
                 var resultQueryPredicate: QueryPredicateGroup? = null
                 // The first predicate in the list is either predicateOperation or predicateGroup. We need
@@ -122,6 +125,11 @@ class QueryPredicateBuilder {
             }
 
             return null
+        }
+
+        @JvmStatic
+        fun fromSerializedMap(serializedMap: Map<String, Any>?): QueryPredicate? {
+            return fromSerializedMap(serializedMap, null)
         }
     }
 }

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilderTest.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilderTest.kt
@@ -15,6 +15,7 @@
 
 package com.amazonaws.amplify.amplify_datastore.types.query
 
+import com.amazonaws.amplify.amplify_datastore.postSchema
 import com.amazonaws.amplify.amplify_datastore.readMapFromFile
 import com.amplifyframework.core.model.query.predicate.QueryField
 import com.amplifyframework.core.model.query.predicate.QueryPredicateGroup
@@ -27,6 +28,7 @@ class QueryPredicateBuilderTest {
     private val title: QueryField = QueryField.field("title")
     private val rating: QueryField = QueryField.field("rating")
     private val created: QueryField = QueryField.field("created")
+    private val blogID: QueryField = QueryField.field("blogID")
 
     @Test
     fun test_when_id_not_equals() {
@@ -126,6 +128,21 @@ class QueryPredicateBuilderTest {
                     "negate_complex_predicate.json",
                     HashMap::class.java
                 ) as HashMap<String, Any>
+            )
+        )
+    }
+
+    @Test
+    fun test_lookup_query_field_from_relation() {
+        Assert.assertEquals(
+            blogID.eq("123"),
+            QueryPredicateBuilder.fromSerializedMap(
+                readMapFromFile(
+                    "query_predicate",
+                    "relation_field_lookup.json",
+                    HashMap::class.java
+                ) as HashMap<String, Any>,
+                postSchema
             )
         )
     }

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilderTest.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilderTest.kt
@@ -31,73 +31,102 @@ class QueryPredicateBuilderTest {
     @Test
     fun test_when_id_not_equals() {
         Assert.assertEquals(
-                id.ne("123"),
-                QueryPredicateBuilder.fromSerializedMap(
-                        readMapFromFile("query_predicate", "id_not_equals.json",
-                                        HashMap::class.java) as HashMap<String, Any>))
+            id.ne("123"),
+            QueryPredicateBuilder.fromSerializedMap(
+                readMapFromFile(
+                    "query_predicate", "id_not_equals.json",
+                    HashMap::class.java
+                ) as HashMap<String, Any>
+            )
+        )
     }
 
     @Test
     fun test_when_rating_greater_or_equal() {
         Assert.assertEquals(
-                rating.ge(4),
-                QueryPredicateBuilder.fromSerializedMap(
-                        readMapFromFile("query_predicate",
-                                        "rating_greater_or_equal.json",
-                                        HashMap::class.java) as HashMap<String, Any>))
+            rating.ge(4),
+            QueryPredicateBuilder.fromSerializedMap(
+                readMapFromFile(
+                    "query_predicate",
+                    "rating_greater_or_equal.json",
+                    HashMap::class.java
+                ) as HashMap<String, Any>
+            )
+        )
     }
 
     @Test
     fun test_complex_nested_and_or() {
         Assert.assertEquals(
-                rating.le(4).and(id.contains("abc").or(title.beginsWith("def"))),
-                QueryPredicateBuilder.fromSerializedMap(
-                        readMapFromFile("query_predicate",
-                                        "complex_nested.json",
-                                        HashMap::class.java) as HashMap<String, Any>))
+            rating.le(4).and(id.contains("abc").or(title.beginsWith("def"))),
+            QueryPredicateBuilder.fromSerializedMap(
+                readMapFromFile(
+                    "query_predicate",
+                    "complex_nested.json",
+                    HashMap::class.java
+                ) as HashMap<String, Any>
+            )
+        )
     }
 
     @Test
     fun test_when_group_with_only_and() {
         Assert.assertEquals(
-                rating.between(1, 4)
-                        .and(id.contains("abc"))
-                        .and(title.beginsWith("def"))
-                        .and(created.eq("2020-02-20T20:20:20-08:00")),
-                QueryPredicateBuilder.fromSerializedMap(
-                        readMapFromFile("query_predicate",
-                                        "group_with_only_and.json",
-                                        HashMap::class.java) as HashMap<String, Any>))
+            rating.between(1, 4)
+                .and(id.contains("abc"))
+                .and(title.beginsWith("def"))
+                .and(created.eq("2020-02-20T20:20:20-08:00")),
+            QueryPredicateBuilder.fromSerializedMap(
+                readMapFromFile(
+                    "query_predicate",
+                    "group_with_only_and.json",
+                    HashMap::class.java
+                ) as HashMap<String, Any>
+            )
+        )
     }
 
     @Test
     fun test_when_mixed_and_or() {
         Assert.assertEquals(
-                rating.lt(4).and(id.contains("abc")).or(title.contains("def")),
-                QueryPredicateBuilder.fromSerializedMap(
-                        readMapFromFile("query_predicate",
-                                        "group_mixed_and_or.json",
-                                        HashMap::class.java) as HashMap<String, Any>))
+            rating.lt(4).and(id.contains("abc")).or(title.contains("def")),
+            QueryPredicateBuilder.fromSerializedMap(
+                readMapFromFile(
+                    "query_predicate",
+                    "group_mixed_and_or.json",
+                    HashMap::class.java
+                ) as HashMap<String, Any>
+            )
+        )
     }
 
     @Test
     fun test_when_rating_gt_but_not_eq() {
         Assert.assertEquals(
-                rating.gt(4).and(not(rating.eq(1))),
-                QueryPredicateBuilder.fromSerializedMap(
-                        readMapFromFile("query_predicate",
-                                        "mixed_with_not.json",
-                                        HashMap::class.java) as HashMap<String, Any>))
+            rating.gt(4).and(not(rating.eq(1))),
+            QueryPredicateBuilder.fromSerializedMap(
+                readMapFromFile(
+                    "query_predicate",
+                    "mixed_with_not.json",
+                    HashMap::class.java
+                ) as HashMap<String, Any>
+            )
+        )
     }
 
     @Test
     fun test_when_negate_complex_predicate() {
         Assert.assertEquals(
-                QueryPredicateGroup.not(
-                        rating.eq(1).and(rating.eq(4).or(title.contains("crap")))),
-                QueryPredicateBuilder.fromSerializedMap(
-                        readMapFromFile("query_predicate",
-                                        "negate_complex_predicate.json",
-                                        HashMap::class.java) as HashMap<String, Any>))
+            QueryPredicateGroup.not(
+                rating.eq(1).and(rating.eq(4).or(title.contains("crap")))
+            ),
+            QueryPredicateBuilder.fromSerializedMap(
+                readMapFromFile(
+                    "query_predicate",
+                    "negate_complex_predicate.json",
+                    HashMap::class.java
+                ) as HashMap<String, Any>
+            )
+        )
     }
 }

--- a/packages/amplify_datastore/test/resources/query_predicate/relation_field_lookup.json
+++ b/packages/amplify_datastore/test/resources/query_predicate/relation_field_lookup.json
@@ -1,0 +1,6 @@
+{
+  "queryPredicateOperation": {
+    "field": "blog",
+    "fieldOperator": { "operatorName": "equal", "value": "123" }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:* #444

*Description of changes:*

1. Passing query predicate corresponding `modelSchema` to `QueryPredicateBuilder.fromSerialziedMap`
2. If predicate field is a nested model, replace it with the actual model field 

Note: the [second commit](https://github.com/aws-amplify/amplify-flutter/commit/22057609c7816d08fab5a74b56f09a8e61bb6d3c) in this PR presents the actual code change

e.g. run below query 

```dart
final res = await Amplify.DataStore.query(Post.classType,
    where: Post.BLOG.eq("5eff14cf-9a67-4fe3-8457-11a30f5e3a86"));
print(res);
```

with schema

```graphql
type Post @model @key(name: "byBlog", fields: ["blogID"]) {
  id: ID!
  title: String!
  rating: Int!
  created: AWSDateTime
  blogID: ID!
  blog: Blog @connection(fields: ["blogID"])
  comments: [Comment] @connection(keyName: "byPost", fields: ["id"])
}
```

Before the change, query fails in Android due to SQL error: `no such a column: blog`, while the query is running correctly in iOS.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
