### PR TITLE
feat(amplify_api): GraphQL Response Decoding

### DIFF
--- a/packages/amplify_api/lib/method_channel_api.dart
+++ b/packages/amplify_api/lib/method_channel_api.dart
@@ -16,6 +16,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:amplify_api/src/graphql/graphql_response_decoder.dart';
 import 'package:amplify_core/types/index.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/foundation.dart';
@@ -159,8 +160,8 @@ class AmplifyAPIMethodChannel extends AmplifyAPI {
             AmplifyExceptionMessages.nullReturnedFromMethodChannel);
       final errors = _deserializeGraphQLResponseErrors(result);
 
-      GraphQLResponse<T> response =
-          GraphQLResponse<T>(data: result['data'] ?? '', errors: errors);
+      GraphQLResponse<T> response = GraphQLResponseDecoder.instance
+          .decode<T>(request: request, data: result['data'], errors: errors);
 
       return response;
     } on PlatformException catch (e) {

--- a/packages/amplify_api/lib/src/graphql/graphql_request_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/graphql_request_factory.dart
@@ -161,7 +161,7 @@ class GraphQLRequestFactory {
     String requestName = "$requestOperationVal$name";
     // e.g. query getBlog($id: ID!, $content: String) { getBlog(id: $id, content: $content) { id name createdAt } }
     String document =
-        '''$requestTypeVal $requestOperationVal$name${documentInputs.upper} { $requestOperationVal$name${documentInputs.lower} { $fields } }''';
+        '''$requestTypeVal $requestName${documentInputs.upper} { $requestName${documentInputs.lower} { $fields } }''';
 
     // TODO: convert model to variable input for non-get operations
     Map<String, dynamic> variables =
@@ -171,6 +171,6 @@ class GraphQLRequestFactory {
         document: document,
         variables: variables,
         modelType: modelType,
-        decodePath: "$requestName");
+        decodePath: requestName);
   }
 }

--- a/packages/amplify_api/lib/src/graphql/graphql_response_decoder.dart
+++ b/packages/amplify_api/lib/src/graphql/graphql_response_decoder.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+
+import 'package:amplify_api/amplify_api.dart';
+
+class GraphQLResponseDecoder {
+  // Singleton methods/properties
+  // usage: GraphQLResponseDecoder.instance;
+  GraphQLResponseDecoder._();
+
+  static final GraphQLResponseDecoder _instance = GraphQLResponseDecoder._();
+
+  static GraphQLResponseDecoder get instance => _instance;
+
+  GraphQLResponse<T> decode<T>(
+      {required GraphQLRequest request,
+      required String data,
+      required List<GraphQLResponseError> errors}) {
+    // if no ModelType fallback to default
+    if (request.modelType == null) {
+      return GraphQLResponse<T>(data: data as T, errors: errors);
+    }
+
+    if (request.decodePath == null) {
+      throw ApiException('No decodePath found',
+          recoverySuggestion: 'Include decodePath when creating a request');
+    }
+
+    Map<String, dynamic> dataJson = json.decode(data);
+    request.decodePath!.split(".").forEach((element) {
+      dataJson = dataJson[element];
+    });
+
+    T decodedData = request.modelType!.fromJson(dataJson) as T;
+
+    return GraphQLResponse<T>(data: decodedData, errors: errors);
+  }
+}

--- a/packages/amplify_api/test/amplify_api_query_test.dart
+++ b/packages/amplify_api/test/amplify_api_query_test.dart
@@ -18,10 +18,13 @@ import 'package:amplify_api_plugin_interface/amplify_api_plugin_interface.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'resources/Blog.dart';
+import 'resources/ModelProvider.dart';
+
 void main() {
   const MethodChannel apiChannel = MethodChannel('com.amazonaws.amplify/api');
 
-  AmplifyAPI api = AmplifyAPI();
+  AmplifyAPI api = AmplifyAPI(modelProvider: ModelProvider.instance);
 
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -76,6 +79,30 @@ void main() {
 
     var response = await operation.response;
     expect(response.data, queryResult.toString());
+  });
+
+  test('Query Model Helpers executes correctly in the happy case', () async {
+    final String id = UUID.getUUID();
+    var queryResult = '''{
+      "getBlog": {
+        "createdAt": "2021-07-21T22:23:33.707Z",
+        "id": "$id",
+        "name": "Test App Blog"
+      }
+    }''';
+
+    apiChannel.setMockMethodCallHandler((MethodCall methodCall) async {
+      return {'data': queryResult.toString(), 'errors': []};
+    });
+
+    GraphQLRequest<Blog> req = ModelQueries.get<Blog>(Blog.classType, id);
+
+    var operation = await api.query<Blog>(request: req);
+
+    var response = await operation.response;
+
+    expect(response.data, isA<Blog>());
+    expect(response.data.id, id);
   });
 
   test(

--- a/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLRequest.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLRequest.dart
@@ -13,14 +13,22 @@
  * permissions and limitations under the License.
  */
 
-import '../UUID.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+
+import '../UUID.dart' as API_UUID;
 
 class GraphQLRequest<T> {
   String document;
   Map<String, dynamic> variables;
-  String cancelToken = UUID.getUUID();
+  String cancelToken = API_UUID.UUID.getUUID();
+  String? decodePath;
+  ModelType? modelType;
 
-  GraphQLRequest({required this.document, this.variables = const {}});
+  GraphQLRequest(
+      {required this.document,
+      this.variables = const {},
+      this.decodePath = null,
+      this.modelType = null}) {}
 
   Map<String, dynamic> serializeAsMap() {
     final Map<String, dynamic> result = <String, dynamic>{};

--- a/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLRequest.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLRequest.dart
@@ -13,8 +13,10 @@
  * permissions and limitations under the License.
  */
 
+// TODO: Datastore dependencies temporarily added in API. Eventually they should be moved to core or otherwise reconciled to avoid duplication.
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 
+// TODO: Remove alias when Datastore dependency is removed
 import '../UUID.dart' as API_UUID;
 
 class GraphQLRequest<T> {
@@ -27,8 +29,8 @@ class GraphQLRequest<T> {
   GraphQLRequest(
       {required this.document,
       this.variables = const {},
-      this.decodePath = null,
-      this.modelType = null}) {}
+      this.decodePath,
+      this.modelType}) {}
 
   Map<String, dynamic> serializeAsMap() {
     final Map<String, dynamic> result = <String, dynamic>{};


### PR DESCRIPTION
*Issue #, if available:*
Partial implementation of GraphQL model helper feature #308. 

*Problem Statement:*
Developers should be able to use types specified to the Model helpers when a response is returned by the API.

*Description of changes:*
This provides a type safe experience when using the Model based helpers. The Dart compiler will recognize and enforce Model types. For example: 

Before: 
```Dart
Amplify.API.query<String>(request:  ModelQueries.get<String>(Blog.classType, id));
```
After:
```Dart
Amplify.API.query<Blog>(request: ModelQueries.get<Blog>(Blog.classType, id));
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
