### PR TITLE
bug(analytics): Force session start

### DIFF
--- a/packages/amplify_analytics_pinpoint/android/src/main/AndroidManifest.xml
+++ b/packages/amplify_analytics_pinpoint/android/src/main/AndroidManifest.xml
@@ -1,3 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.amazonaws.amplify.amplify_analytics_pinpoint">
+    package="com.amazonaws.amplify.amplify_analytics_pinpoint">
+
+    <application>
+        <activity
+            android:name=".EmptyActivity"
+            android:exported="false" />
+    </application>
+
 </manifest>

--- a/packages/amplify_analytics_pinpoint/android/src/main/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/AmplifyAnalyticsPinpointPlugin.kt
+++ b/packages/amplify_analytics_pinpoint/android/src/main/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/AmplifyAnalyticsPinpointPlugin.kt
@@ -56,7 +56,9 @@ class AmplifyAnalyticsPinpointPlugin : FlutterPlugin, ActivityAware, MethodCallH
             "addPlugin" ->
                 AmplifyAnalyticsBridge.addPlugin(result, context)
             "startSession" -> {
-                // Hack: The AutoSessionTracker in the Pinpoint plugin listens for lifecycle changes and
+                // TODO: Update AutoSessionTracker logic to support Flutter.
+                //
+                // The AutoSessionTracker in the Pinpoint plugin listens for lifecycle changes and
                 // starts and stops session tracking accordingly. It is registered during the call
                 // to Amplify.configure. In native Android apps, this call is made before launching
                 // the main activity and thus receives the initial onResume event, kicking off session

--- a/packages/amplify_analytics_pinpoint/android/src/main/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/AmplifyAnalyticsPinpointPlugin.kt
+++ b/packages/amplify_analytics_pinpoint/android/src/main/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/AmplifyAnalyticsPinpointPlugin.kt
@@ -16,11 +16,9 @@
 package com.amazonaws.amplify.amplify_analytics_pinpoint
 
 import android.app.Activity
-import android.app.Application
 import android.content.Context
-import android.util.Log
+import android.content.Intent
 import androidx.annotation.NonNull
-import com.amplifyframework.analytics.pinpoint.AWSPinpointAnalyticsPlugin
 import com.amplifyframework.core.Amplify
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -29,36 +27,26 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 
-public class AmplifyAnalyticsPinpointPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
+class AmplifyAnalyticsPinpointPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
 
     private lateinit var channel: MethodChannel
     private var mainActivity: Activity? = null
     private lateinit var context: Context
 
     override fun onAttachedToEngine(
-            @NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        @NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding
+    ) {
 
-        channel = MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(),
-                "com.amazonaws.amplify/analytics_pinpoint")
+        channel = MethodChannel(flutterPluginBinding.binaryMessenger,
+            "com.amazonaws.amplify/analytics_pinpoint")
         channel.setMethodCallHandler(this)
-        context = flutterPluginBinding.applicationContext;
+        context = flutterPluginBinding.applicationContext
     }
 
-    // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-    // pre-Flutter-1.12 Android projects.
     companion object {
         const val TAG = "AmplifyAnalyticsPinpointPlugin"
         val LOG = Amplify.Logging.forNamespace("amplify:flutter:analytics_pinpoint")
-
-        @JvmStatic
-        fun registerWith(registrar: Registrar) {
-            val channel =
-                    MethodChannel(registrar.messenger(), "com.amazonaws.amplify/analytics_pinpoint")
-            Amplify.addPlugin(AWSPinpointAnalyticsPlugin(registrar.activity().application))
-            LOG.info("Added AnalyticsPinpoint plugin")
-        }
     }
 
     // Handle methods received via MethodChannel
@@ -67,6 +55,24 @@ public class AmplifyAnalyticsPinpointPlugin : FlutterPlugin, ActivityAware, Meth
         when (call.method) {
             "addPlugin" ->
                 AmplifyAnalyticsBridge.addPlugin(result, context)
+            "startSession" -> {
+                // Hack: The AutoSessionTracker in the Pinpoint plugin listens for lifecycle changes and
+                // starts and stops session tracking accordingly. It is registered during the call
+                // to Amplify.configure. In native Android apps, this call is made before launching
+                // the main activity and thus receives the initial onResume event, kicking off session
+                // tracking. However, in Flutter, the call to Amplify.configure is made sometime later.
+                // The initial onResume call is not received by the AutoSessionTracker, and no session
+                // tracking occurs.
+                //
+                // The startSession/stopSession calls made by the AutoSessionTracker are not available
+                // via the escape hatch, the AWS SDK, or reflection, so this hack must be used to
+                // force an onPause/onResume cycle.
+                //
+                // This method is invoked in the Flutter SDK just after Amplify.configure.
+                val intent = Intent(mainActivity, EmptyActivity::class.java)
+                mainActivity?.startActivity(intent)
+                result.success(null)
+            }
             "recordEvent" ->
                 AmplifyAnalyticsBridge.recordEvent(call.arguments, result)
             "flushEvents" ->

--- a/packages/amplify_analytics_pinpoint/android/src/main/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/EmptyActivity.kt
+++ b/packages/amplify_analytics_pinpoint/android/src/main/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/EmptyActivity.kt
@@ -1,0 +1,13 @@
+package com.amazonaws.amplify.amplify_analytics_pinpoint
+
+import android.app.Activity
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+
+/// Empty activity used to force lifecycle events in the user's app.
+class EmptyActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        finish()
+    }
+}

--- a/packages/amplify_analytics_pinpoint/ios/Classes/SwiftAmplifyAnalyticsPinpointPlugin.swift
+++ b/packages/amplify_analytics_pinpoint/ios/Classes/SwiftAmplifyAnalyticsPinpointPlugin.swift
@@ -42,6 +42,9 @@ public class SwiftAmplifyAnalyticsPinpointPlugin: NSObject, FlutterPlugin {
         switch method{
             case "addPlugin":
                 FlutterAnalytics.addPlugin(result: result)
+            case "sessionStart":
+                // No-op
+                result(nil)
             case "recordEvent":
                 FlutterAnalytics.record(arguments: callArgs, result: result, bridge: bridge)
             case "flushEvents":

--- a/packages/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
+++ b/packages/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
@@ -78,8 +78,6 @@ class AmplifyAnalyticsPinpoint extends AnalyticsPluginInterface {
     return _instance.identifyUser(userId: userId, userProfile: userProfile);
   }
 
-  // Internal
-
   @override
   Future<void> onConfigure() {
     return _instance.onConfigure();

--- a/packages/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
+++ b/packages/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
@@ -77,4 +77,11 @@ class AmplifyAnalyticsPinpoint extends AnalyticsPluginInterface {
       required AnalyticsUserProfile userProfile}) async {
     return _instance.identifyUser(userId: userId, userProfile: userProfile);
   }
+
+  // Internal
+
+  @override
+  Future<void> onConfigure() {
+    return _instance.onConfigure();
+  }
 }

--- a/packages/amplify_analytics_pinpoint/lib/method_channel_amplify.dart
+++ b/packages/amplify_analytics_pinpoint/lib/method_channel_amplify.dart
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+import 'dart:io';
+
 import 'package:amplify_analytics_plugin_interface/amplify_analytics_plugin_interface.dart';
 import 'package:amplify_core/types/exception/AmplifyException.dart';
 import 'package:amplify_core/types/exception/AmplifyExceptionMessages.dart';
@@ -38,6 +40,17 @@ class AmplifyAnalyticsPinpointMethodChannel extends AmplifyAnalyticsPinpoint {
       } else {
         throw AmplifyException.fromMap(Map<String, String>.from(e.details));
       }
+    }
+  }
+
+  @override
+  Future<void> onConfigure() async {
+    try {
+      if (Platform.isAndroid) {
+        await _channel.invokeMethod('startSession');
+      }
+    } on Exception {
+      // TODO: log, but should not happen
     }
   }
 

--- a/packages/amplify_analytics_pinpoint/lib/method_channel_amplify.dart
+++ b/packages/amplify_analytics_pinpoint/lib/method_channel_amplify.dart
@@ -46,9 +46,7 @@ class AmplifyAnalyticsPinpointMethodChannel extends AmplifyAnalyticsPinpoint {
   @override
   Future<void> onConfigure() async {
     try {
-      if (Platform.isAndroid) {
-        await _channel.invokeMethod('startSession');
-      }
+      await _channel.invokeMethod('startSession');
     } on Exception {
       // TODO: log, but should not happen
     }

--- a/packages/amplify_analytics_plugin_interface/lib/amplify_analytics_plugin_interface.dart
+++ b/packages/amplify_analytics_plugin_interface/lib/amplify_analytics_plugin_interface.dart
@@ -18,6 +18,7 @@ library amplify_analytics_plugin_interface;
 import 'dart:async';
 
 import 'package:amplify_core/types/index.dart';
+import 'package:meta/meta.dart';
 
 import 'src/types.dart';
 export 'src/types.dart';
@@ -64,7 +65,6 @@ abstract class AnalyticsPluginInterface extends AmplifyPluginInterface {
     throw UnimplementedError('identifyUser() has not been implemented.');
   }
 
-  // Internal
-
+  @protected
   Future<void> onConfigure() async {}
 }

--- a/packages/amplify_analytics_plugin_interface/lib/amplify_analytics_plugin_interface.dart
+++ b/packages/amplify_analytics_plugin_interface/lib/amplify_analytics_plugin_interface.dart
@@ -63,4 +63,8 @@ abstract class AnalyticsPluginInterface extends AmplifyPluginInterface {
       required AnalyticsUserProfile userProfile}) async {
     throw UnimplementedError('identifyUser() has not been implemented.');
   }
+
+  // Internal
+
+  Future<void> onConfigure() async {}
 }

--- a/packages/amplify_flutter/lib/method_channel_amplify.dart
+++ b/packages/amplify_flutter/lib/method_channel_amplify.dart
@@ -33,6 +33,7 @@ class MethodChannelAmplify extends AmplifyClass {
     );
     if (configured ?? false) {
       await Future.wait(
+          //ignore:invalid_use_of_protected_member
           AnalyticsCategory.plugins.map((plugin) => plugin.onConfigure()));
     }
     return configured;

--- a/packages/amplify_flutter/lib/method_channel_amplify.dart
+++ b/packages/amplify_flutter/lib/method_channel_amplify.dart
@@ -22,13 +22,19 @@ class MethodChannelAmplify extends AmplifyClass {
   MethodChannelAmplify() : super.protected();
 
   @override
-  Future<bool?> _configurePlatforms(String version, String configuration) {
-    return _channel.invokeMethod<bool>(
+  Future<bool?> _configurePlatforms(
+      String version, String configuration) async {
+    final configured = await _channel.invokeMethod<bool>(
       'configure',
       <String, Object>{
         'version': version,
         'configuration': configuration,
       },
     );
+    if (configured ?? false) {
+      await Future.wait(
+          AnalyticsCategory.plugins.map((plugin) => plugin.onConfigure()));
+    }
+    return configured;
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
- Internal ticket: P50379527
- Summary of issue:

The [AutoSessionTracker](https://github.com/aws-amplify/amplify-android/blob/main/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AutoSessionTracker.java) in the Pinpoint plugin listens for lifecycle changes and starts and stops session tracking accordingly. It is registered during the call to `Amplify.configure`. In native Android apps, this call is made before launching the main activity and thus receives the initial onResume event, kicking off session tracking. However, in Flutter, the call to `Amplify.configure` is made sometime later. The initial onResume event is not received by the AutoSessionTracker, and no session tracking occurs.

The startSession/stopSession calls made by the AutoSessionTracker are not available via the escape hatch, the AWS SDK, or reflection, so an onPause/onResume cycle must be forced.

This method is invoked in the Flutter SDK just after `Amplify.configure`.

*Description of changes:*

- Force session start after configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
