### PR TITLE
feat(amplify_api): GraphQL Mutate Helper - Create

### DIFF
--- a/packages/amplify_api/lib/amplify_api.dart
+++ b/packages/amplify_api/lib/amplify_api.dart
@@ -21,6 +21,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:meta/meta.dart';
 import './method_channel_api.dart';
 
+export './model_mutations.dart';
 export './model_queries.dart';
 export 'package:amplify_api_plugin_interface/src/types.dart';
 

--- a/packages/amplify_api/lib/model_mutations.dart
+++ b/packages/amplify_api/lib/model_mutations.dart
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_api/amplify_api.dart';
+import 'package:amplify_api/src/graphql/model_mutations_factory.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+
+// This class provides static method calls to enable a simpler DX,
+// while preserving internal interfaces
+class ModelMutations {
+  static GraphQLRequest<T> create<T extends Model>(T model) {
+    return ModelMutationsFactory.instance.create<T>(model);
+  }
+}

--- a/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
@@ -1,0 +1,45 @@
+import 'package:amplify_api/amplify_api.dart';
+import 'package:amplify_api/src/graphql/graphql_request_factory.dart';
+import 'package:amplify_datastore_plugin_interface/src/types/query/query_field.dart';
+import 'package:amplify_datastore_plugin_interface/src/types/models/model.dart';
+
+class ModelMutationsFactory extends ModelMutationsInterface {
+  // Singleton methods/properties
+  // usage: ModelQueriesFactory.instance;
+  ModelMutationsFactory._();
+
+  static final ModelMutationsFactory _instance = ModelMutationsFactory._();
+
+  static ModelMutationsFactory get instance => _instance;
+
+  @override
+  GraphQLRequest<T> create<T extends Model>(T model) {
+    Map<String, dynamic> variables = model.toJson();
+
+    return GraphQLRequestFactory.instance.buildQuery(
+        model: model,
+        variables: variables,
+        modelType: model.getInstanceType(),
+        requestType: GraphQLRequestType.mutation,
+        requestOperation: GraphQLRequestOperation.create);
+  }
+
+  @override
+  GraphQLRequest<T> delete<T extends Model>(T model, {QueryPredicate? where}) {
+    // TODO: implement delete
+    throw UnimplementedError();
+  }
+
+  @override
+  GraphQLRequest<T> deleteById<T extends Model>(
+      ModelType<T> modelType, String id) {
+    // TODO: implement deleteById
+    throw UnimplementedError();
+  }
+
+  @override
+  GraphQLRequest<T> update<T extends Model>(T model, {QueryPredicate? where}) {
+    // TODO: implement update
+    throw UnimplementedError();
+  }
+}

--- a/packages/amplify_api/test/graphql_helpers_test.dart
+++ b/packages/amplify_api/test/graphql_helpers_test.dart
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart'
+    as DataStore;
 import 'package:flutter/foundation.dart';
 import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_api/src/graphql/graphql_response_decoder.dart';
@@ -23,28 +25,29 @@ import 'resources/ModelProvider.dart';
 
 void main() {
   group('with ModelProvider', () {
-    final AmplifyAPI api = AmplifyAPI(modelProvider: ModelProvider.instance);
+    group('ModelQueries', () {
+      final AmplifyAPI api = AmplifyAPI(modelProvider: ModelProvider.instance);
 
-    test("ModelQueries.get() should build a valid request", () {
-      String id = UUID.getUUID();
-      String expected =
-          r"query getBlog($id: ID!) { getBlog(id: $id) { id name createdAt } }";
+      test("ModelQueries.get() should build a valid request", () {
+        String id = UUID.getUUID();
+        String expected =
+            r"query getBlog($id: ID!) { getBlog(id: $id) { id name createdAt } }";
 
-      GraphQLRequest<Blog> req = ModelQueries.get<Blog>(Blog.classType, id);
+        GraphQLRequest<Blog> req = ModelQueries.get<Blog>(Blog.classType, id);
 
-      expect(req.document, expected);
-      expect(mapEquals(req.variables, {'id': id}), isTrue);
-      expect(req.modelType, Blog.classType);
-      expect(req.decodePath, "getBlog");
-    });
+        expect(req.document, expected);
+        expect(mapEquals(req.variables, {'id': id}), isTrue);
+        expect(req.modelType, Blog.classType);
+        expect(req.decodePath, "getBlog");
+      });
 
-    test(
-        'ModelQueries.get() returns a GraphQLRequest<Blog> when provided a modelType',
-        () async {
-      String id = UUID.getUUID();
-      GraphQLRequest<Blog> req = ModelQueries.get<Blog>(Blog.classType, id);
-      List<GraphQLResponseError> errors = [];
-      String data = '''{
+      test(
+          'ModelQueries.get() returns a GraphQLRequest<Blog> when provided a modelType',
+          () async {
+        String id = UUID.getUUID();
+        GraphQLRequest<Blog> req = ModelQueries.get<Blog>(Blog.classType, id);
+        List<GraphQLResponseError> errors = [];
+        String data = '''{
         "getBlog": {
             "createdAt": "2021-01-01T01:00:00.000000000Z",
             "id": "$id",
@@ -52,54 +55,54 @@ void main() {
         }
     }''';
 
-      GraphQLResponse<Blog> response = GraphQLResponseDecoder.instance
-          .decode<Blog>(request: req, data: data, errors: errors);
+        GraphQLResponse<Blog> response = GraphQLResponseDecoder.instance
+            .decode<Blog>(request: req, data: data, errors: errors);
 
-      expect(response.data, isA<Blog>());
-      expect(response.data.id, id);
-    });
-    test('ModelQueries.list() should build a valid request', () async {
-      String expected =
-          r"query listBlogs($filter: ModelBlogFilterInput, $limit: Int, $nextToken: String) { listBlogs(filter: $filter, limit: $limit, nextToken: $nextToken) { items { id name createdAt } nextToken } }";
+        expect(response.data, isA<Blog>());
+        expect(response.data.id, id);
+      });
+      test('ModelQueries.list() should build a valid request', () async {
+        String expected =
+            r"query listBlogs($filter: ModelBlogFilterInput, $limit: Int, $nextToken: String) { listBlogs(filter: $filter, limit: $limit, nextToken: $nextToken) { items { id name createdAt } nextToken } }";
 
-      GraphQLRequest<PaginatedResult<Blog>> req =
-          ModelQueries.list<Blog>(Blog.classType);
+        GraphQLRequest<PaginatedResult<Blog>> req =
+            ModelQueries.list<Blog>(Blog.classType);
 
-      expect(req.document, expected);
-      expect(req.modelType, isA<PaginatedModelType<Blog>>());
-      expect(req.decodePath, "listBlogs");
-    });
+        expect(req.document, expected);
+        expect(req.modelType, isA<PaginatedModelType<Blog>>());
+        expect(req.decodePath, "listBlogs");
+      });
 
-    test('ModelQueries.list() should build a valid request with pagination',
-        () async {
-      String expected =
-          r"query listBlogs($filter: ModelBlogFilterInput, $limit: Int, $nextToken: String) { listBlogs(filter: $filter, limit: $limit, nextToken: $nextToken) { items { id name createdAt } nextToken } }";
+      test('ModelQueries.list() should build a valid request with pagination',
+          () async {
+        String expected =
+            r"query listBlogs($filter: ModelBlogFilterInput, $limit: Int, $nextToken: String) { listBlogs(filter: $filter, limit: $limit, nextToken: $nextToken) { items { id name createdAt } nextToken } }";
 
-      GraphQLRequest<PaginatedResult<Blog>> req = ModelQueries.list<Blog>(
-          Blog.classType,
-          modelPagination: ModelPagination(limit: 1));
+        GraphQLRequest<PaginatedResult<Blog>> req = ModelQueries.list<Blog>(
+            Blog.classType,
+            modelPagination: ModelPagination(limit: 1));
 
-      expect(req.document, expected);
-      expect(req.modelType, isA<PaginatedModelType<Blog>>());
-      expect(req.variables["limit"], 1);
-      expect(req.decodePath, "listBlogs");
-    });
+        expect(req.document, expected);
+        expect(req.modelType, isA<PaginatedModelType<Blog>>());
+        expect(req.variables["limit"], 1);
+        expect(req.decodePath, "listBlogs");
+      });
 
-    test(
-        'ModelQueries.get() returns a GraphQLRequest<String> when not provided a modelType',
-        () async {
-      String id = UUID.getUUID();
-      String doc = '''query MyQuery {
+      test(
+          'ModelQueries.get() returns a GraphQLRequest<String> when not provided a modelType',
+          () async {
+        String id = UUID.getUUID();
+        String doc = '''query MyQuery {
       getBlog {
         id
         name
         createdAt
       }
     }''';
-      GraphQLRequest<String> req =
-          GraphQLRequest(document: doc, variables: {id: id});
-      List<GraphQLResponseError> errors = [];
-      String data = '''{
+        GraphQLRequest<String> req =
+            GraphQLRequest(document: doc, variables: {id: id});
+        List<GraphQLResponseError> errors = [];
+        String data = '''{
         "getBlog": {
             "createdAt": "2021-01-01T01:00:00.000000000Z",
             "id": "$id",
@@ -107,21 +110,21 @@ void main() {
         }
     }''';
 
-      GraphQLResponse<String> response = GraphQLResponseDecoder.instance
-          .decode<String>(request: req, data: data, errors: errors);
+        GraphQLResponse<String> response = GraphQLResponseDecoder.instance
+            .decode<String>(request: req, data: data, errors: errors);
 
-      expect(response.data, isA<String>());
-    });
+        expect(response.data, isA<String>());
+      });
 
-    test(
-        'ModelQueries.list() returns a GraphQLRequest<PaginatedResult<Blog>> when provided a modelType',
-        () async {
-      GraphQLRequest<PaginatedResult<Blog>> req = ModelQueries.list<Blog>(
-          Blog.classType,
-          modelPagination: ModelPagination(limit: 2));
+      test(
+          'ModelQueries.list() returns a GraphQLRequest<PaginatedResult<Blog>> when provided a modelType',
+          () async {
+        GraphQLRequest<PaginatedResult<Blog>> req = ModelQueries.list<Blog>(
+            Blog.classType,
+            modelPagination: ModelPagination(limit: 2));
 
-      List<GraphQLResponseError> errors = [];
-      String data = '''{
+        List<GraphQLResponseError> errors = [];
+        String data = '''{
           "listBlogs": {
               "items": [
                 {
@@ -139,13 +142,36 @@ void main() {
             }
         }''';
 
-      GraphQLResponse<PaginatedResult<Blog>> response =
-          GraphQLResponseDecoder.instance.decode<PaginatedResult<Blog>>(
-              request: req, data: data, errors: errors);
+        GraphQLResponse<PaginatedResult<Blog>> response =
+            GraphQLResponseDecoder.instance.decode<PaginatedResult<Blog>>(
+                request: req, data: data, errors: errors);
 
-      expect(response.data, isA<PaginatedResult<Blog>>());
-      expect(response.data.items, isA<List<Blog>>());
-      expect(response.data.items.length, 2);
+        expect(response.data, isA<PaginatedResult<Blog>>());
+        expect(response.data.items, isA<List<Blog>>());
+        expect(response.data.items.length, 2);
+      });
+    });
+
+    group('ModelMutations', () {
+      test("ModelMutations.create() should build a valid request", () {
+        final id = UUID.getUUID();
+        final name = "Test Blog";
+        final time = "2021-08-03T16:39:18.000000651Z";
+        final createdAt = DataStore.TemporalDateTime.fromString(time);
+
+        Blog blog = Blog(id: id, name: name, createdAt: createdAt);
+
+        final expectedVars = {'id': id, 'name': name, "createdAt": time};
+        final expectedDoc =
+            r"mutation createBlog($input: CreateBlogInput!, $condition:  ModelBlogConditionInput) { createBlog(input: $input, condition: $condition) { id name createdAt } }";
+
+        GraphQLRequest<Blog> req = ModelMutations.create<Blog>(blog);
+
+        expect(req.document, expectedDoc);
+        expect(mapEquals(req.variables, expectedVars), isTrue);
+        expect(req.modelType, Blog.classType);
+        expect(req.decodePath, "createBlog");
+      });
     });
   });
 


### PR DESCRIPTION
*Issue #, if available:*
Partial implementation of GraphQL model helper feature #308. 

*Description of changes:*
This adds `ModelMutations.create()` and relevant unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.