### PR TITLE
feat(amplify_api): GraphQL Mutate Helper - Update

### DIFF
--- a/packages/amplify_api/lib/model_mutations.dart
+++ b/packages/amplify_api/lib/model_mutations.dart
@@ -23,4 +23,8 @@ class ModelMutations {
   static GraphQLRequest<T> create<T extends Model>(T model) {
     return ModelMutationsFactory.instance.create<T>(model);
   }
+
+  static GraphQLRequest<T> update<T extends Model>(T model) {
+    return ModelMutationsFactory.instance.update<T>(model);
+  }
 }

--- a/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
@@ -39,7 +39,13 @@ class ModelMutationsFactory extends ModelMutationsInterface {
 
   @override
   GraphQLRequest<T> update<T extends Model>(T model, {QueryPredicate? where}) {
-    // TODO: implement update
-    throw UnimplementedError();
+    Map<String, dynamic> variables = model.toJson();
+
+    return GraphQLRequestFactory.instance.buildQuery(
+        model: model,
+        variables: variables,
+        modelType: model.getInstanceType(),
+        requestType: GraphQLRequestType.mutation,
+        requestOperation: GraphQLRequestOperation.update);
   }
 }

--- a/packages/amplify_api/test/amplify_api_mutate_test.dart
+++ b/packages/amplify_api/test/amplify_api_mutate_test.dart
@@ -95,6 +95,34 @@ void main() {
     expect(response.data.equals(blog), isTrue);
   });
 
+  test('ModelMutations.update() executes correctly in the happy case',
+      () async {
+    final id = UUID.getUUID();
+    const name = 'Test App Blog';
+    const time = '2020-12-14T19:54:18.733Z';
+    final dateTime = DataStore.TemporalDateTime.fromString(time);
+    final mutationResult = '''{
+      "updateBlog": {
+        "id": "$id",
+        "name": "$name",
+        "createdAt": "$time"
+      }
+    }''';
+
+    apiChannel.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'mutate') {
+        return {'data': mutationResult.toString(), 'errors': []};
+      }
+    });
+
+    Blog blog = Blog(id: id, name: name, createdAt: dateTime);
+
+    var operation =
+        await api.mutate(request: ModelMutations.update<Blog>(blog));
+
+    var response = await operation.response;
+    expect(response.data.equals(blog), isTrue);
+  });
   test(
       'A PlatformException for a failed API call results in the corresponding ApiException',
       () async {

--- a/packages/amplify_api/test/graphql_helpers_test.dart
+++ b/packages/amplify_api/test/graphql_helpers_test.dart
@@ -172,6 +172,26 @@ void main() {
         expect(req.modelType, Blog.classType);
         expect(req.decodePath, "createBlog");
       });
+
+      test("ModelMutations.update() should build a valid request", () {
+        final id = UUID.getUUID();
+        final name = "Test Blog";
+        final time = "2021-08-03T16:39:18.000000651Z";
+        final createdAt = DataStore.TemporalDateTime.fromString(time);
+
+        Blog blog = Blog(id: id, name: name, createdAt: createdAt);
+
+        final expectedVars = {'id': id, 'name': name, "createdAt": time};
+        final expectedDoc =
+            r"mutation updateBlog($input: UpdateBlogInput!, $condition:  ModelBlogConditionInput) { updateBlog(input: $input, condition: $condition) { id name createdAt } }";
+
+        GraphQLRequest<Blog> req = ModelMutations.update<Blog>(blog);
+
+        expect(req.document, expectedDoc);
+        expect(mapEquals(req.variables, expectedVars), isTrue);
+        expect(req.modelType, Blog.classType);
+        expect(req.decodePath, "updateBlog");
+      });
     });
   });
 


### PR DESCRIPTION
*Issue #, if available:*
Partial implementation of GraphQL model helper feature #308. 

*Description of changes:*
This adds `ModelMutations.update()` and relevant unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.