### PR TITLE
feat(amplify_api): GraphQL Mutate Helper - Delete

### DIFF
--- a/packages/amplify_api/lib/model_mutations.dart
+++ b/packages/amplify_api/lib/model_mutations.dart
@@ -24,9 +24,9 @@ class ModelMutations {
     return ModelMutationsFactory.instance.create<T>(model);
   }
 
-  static GraphQLRequest<T> deleteById<T extends Model>(
+  static GraphQLRequest<T> delete<T extends Model>(
       ModelType<T> modelType, String id) {
-    return ModelMutationsFactory.instance.deleteById<T>(modelType, id);
+    return ModelMutationsFactory.instance.delete<T>(modelType, id);
   }
 
   static GraphQLRequest<T> update<T extends Model>(T model) {

--- a/packages/amplify_api/lib/model_mutations.dart
+++ b/packages/amplify_api/lib/model_mutations.dart
@@ -24,10 +24,6 @@ class ModelMutations {
     return ModelMutationsFactory.instance.create<T>(model);
   }
 
-  static GraphQLRequest<T> delete<T extends Model>(T model) {
-    return ModelMutationsFactory.instance.delete<T>(model);
-  }
-
   static GraphQLRequest<T> deleteById<T extends Model>(
       ModelType<T> modelType, String id) {
     return ModelMutationsFactory.instance.deleteById<T>(modelType, id);

--- a/packages/amplify_api/lib/model_mutations.dart
+++ b/packages/amplify_api/lib/model_mutations.dart
@@ -24,9 +24,13 @@ class ModelMutations {
     return ModelMutationsFactory.instance.create<T>(model);
   }
 
-  static GraphQLRequest<T> delete<T extends Model>(
+  static GraphQLRequest<T> delete<T extends Model>(T model) {
+    return ModelMutationsFactory.instance.delete<T>(model);
+  }
+
+  static GraphQLRequest<T> deleteById<T extends Model>(
       ModelType<T> modelType, String id) {
-    return ModelMutationsFactory.instance.delete<T>(modelType, id);
+    return ModelMutationsFactory.instance.deleteById<T>(modelType, id);
   }
 
   static GraphQLRequest<T> update<T extends Model>(T model) {

--- a/packages/amplify_api/lib/model_mutations.dart
+++ b/packages/amplify_api/lib/model_mutations.dart
@@ -23,4 +23,13 @@ class ModelMutations {
   static GraphQLRequest<T> create<T extends Model>(T model) {
     return ModelMutationsFactory.instance.create<T>(model);
   }
+
+  static GraphQLRequest<T> delete<T extends Model>(T model) {
+    return ModelMutationsFactory.instance.delete<T>(model);
+  }
+
+  static GraphQLRequest<T> deleteById<T extends Model>(
+      ModelType<T> modelType, String id) {
+    return ModelMutationsFactory.instance.deleteById<T>(modelType, id);
+  }
 }

--- a/packages/amplify_api/lib/src/graphql/graphql_request_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/graphql_request_factory.dart
@@ -147,7 +147,7 @@ class GraphQLRequestFactory {
    *  Example: 
    *    query getBlog($id: ID!, $content: String) { getBlog(id: $id, content: $content) { id name createdAt } }
   */
-  GraphQLRequest<T> buildQuery<T extends Model>(
+  GraphQLRequest<T> buildRequest<T extends Model>(
       {required ModelType modelType,
       Model? model,
       required GraphQLRequestType requestType,

--- a/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
@@ -26,15 +26,19 @@ class ModelMutationsFactory extends ModelMutationsInterface {
 
   @override
   GraphQLRequest<T> delete<T extends Model>(T model, {QueryPredicate? where}) {
-    // TODO: implement delete
-    throw UnimplementedError();
+    return deleteById(model.getInstanceType() as ModelType<T>, model.getId());
   }
 
   @override
   GraphQLRequest<T> deleteById<T extends Model>(
       ModelType<T> modelType, String id) {
-    // TODO: implement deleteById
-    throw UnimplementedError();
+    Map<String, dynamic> variables = {"id": id};
+
+    return GraphQLRequestFactory.instance.buildQuery(
+        variables: variables,
+        modelType: modelType,
+        requestType: GraphQLRequestType.mutation,
+        requestOperation: GraphQLRequestOperation.delete);
   }
 
   @override

--- a/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
@@ -16,7 +16,7 @@ class ModelMutationsFactory extends ModelMutationsInterface {
   GraphQLRequest<T> create<T extends Model>(T model) {
     Map<String, dynamic> variables = model.toJson();
 
-    return GraphQLRequestFactory.instance.buildQuery(
+    return GraphQLRequestFactory.instance.buildRequest(
         model: model,
         variables: variables,
         modelType: model.getInstanceType(),
@@ -25,11 +25,10 @@ class ModelMutationsFactory extends ModelMutationsInterface {
   }
 
   @override
-  GraphQLRequest<T> deleteById<T extends Model>(
-      ModelType<T> modelType, String id) {
+  GraphQLRequest<T> delete<T extends Model>(ModelType<T> modelType, String id) {
     Map<String, dynamic> variables = {"id": id};
 
-    return GraphQLRequestFactory.instance.buildQuery(
+    return GraphQLRequestFactory.instance.buildRequest(
         variables: variables,
         modelType: modelType,
         requestType: GraphQLRequestType.mutation,
@@ -40,7 +39,7 @@ class ModelMutationsFactory extends ModelMutationsInterface {
   GraphQLRequest<T> update<T extends Model>(T model, {QueryPredicate? where}) {
     Map<String, dynamic> variables = model.toJson();
 
-    return GraphQLRequestFactory.instance.buildQuery(
+    return GraphQLRequestFactory.instance.buildRequest(
         model: model,
         variables: variables,
         modelType: model.getInstanceType(),

--- a/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
@@ -25,7 +25,13 @@ class ModelMutationsFactory extends ModelMutationsInterface {
   }
 
   @override
-  GraphQLRequest<T> delete<T extends Model>(ModelType<T> modelType, String id) {
+  GraphQLRequest<T> delete<T extends Model>(T model, {QueryPredicate? where}) {
+    return deleteById(model.getInstanceType() as ModelType<T>, model.getId());
+  }
+
+  @override
+  GraphQLRequest<T> deleteById<T extends Model>(
+      ModelType<T> modelType, String id) {
     Map<String, dynamic> variables = {"id": id};
 
     return GraphQLRequestFactory.instance.buildRequest(

--- a/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
@@ -25,11 +25,6 @@ class ModelMutationsFactory extends ModelMutationsInterface {
   }
 
   @override
-  GraphQLRequest<T> delete<T extends Model>(T model, {QueryPredicate? where}) {
-    return deleteById(model.getInstanceType() as ModelType<T>, model.getId());
-  }
-
-  @override
   GraphQLRequest<T> deleteById<T extends Model>(
       ModelType<T> modelType, String id) {
     Map<String, dynamic> variables = {"id": id};

--- a/packages/amplify_api/lib/src/graphql/model_queries_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/model_queries_factory.dart
@@ -30,7 +30,7 @@ class ModelQueriesFactory extends ModelQueriesInterface {
   @override
   GraphQLRequest<T> get<T extends Model>(ModelType<T> modelType, String id) {
     Map<String, dynamic> variables = {"id": id};
-    return GraphQLRequestFactory.instance.buildQuery<T>(
+    return GraphQLRequestFactory.instance.buildRequest<T>(
         modelType: modelType,
         variables: variables,
         requestType: GraphQLRequestType.query,
@@ -49,7 +49,7 @@ class ModelQueriesFactory extends ModelQueriesInterface {
       "nextToken": null // TODO: need to handle nextToken input
     };
 
-    return GraphQLRequestFactory.instance.buildQuery<PaginatedResult<T>>(
+    return GraphQLRequestFactory.instance.buildRequest<PaginatedResult<T>>(
         modelType: PaginatedModelTypeImpl(modelType),
         variables: variables,
         requestType: GraphQLRequestType.query,

--- a/packages/amplify_api/test/amplify_api_mutate_test.dart
+++ b/packages/amplify_api/test/amplify_api_mutate_test.dart
@@ -118,7 +118,7 @@ void main() {
     Blog blog = Blog(id: id, name: name, createdAt: dateTime);
 
     var operation = await api.mutate(
-        request: ModelMutations.deleteById<Blog>(Blog.classType, blog.id));
+        request: ModelMutations.delete<Blog>(Blog.classType, blog.id));
 
     var response = await operation.response;
     expect(response.data, equals(blog));

--- a/packages/amplify_api/test/amplify_api_mutate_test.dart
+++ b/packages/amplify_api/test/amplify_api_mutate_test.dart
@@ -117,11 +117,11 @@ void main() {
 
     Blog blog = Blog(id: id, name: name, createdAt: dateTime);
 
-    var operation =
-        await api.mutate(request: ModelMutations.delete<Blog>(blog));
+    var operation = await api.mutate(
+        request: ModelMutations.deleteById<Blog>(Blog.classType, blog.id));
 
     var response = await operation.response;
-    expect(response.data.equals(blog), isTrue);
+    expect(response.data, equals(blog));
   });
 
   test(

--- a/packages/amplify_api/test/amplify_api_mutate_test.dart
+++ b/packages/amplify_api/test/amplify_api_mutate_test.dart
@@ -150,7 +150,7 @@ void main() {
         await api.mutate(request: ModelMutations.update<Blog>(blog));
 
     var response = await operation.response;
-    expect(response.data.equals(blog), isTrue);
+    expect(response.data, equals(blog));
   });
 
   test(

--- a/packages/amplify_api/test/amplify_api_mutate_test.dart
+++ b/packages/amplify_api/test/amplify_api_mutate_test.dart
@@ -95,6 +95,35 @@ void main() {
     expect(response.data.equals(blog), isTrue);
   });
 
+  test('ModelMutations.delete() executes correctly in the happy case',
+      () async {
+    final id = UUID.getUUID();
+    const name = 'Test App Blog';
+    const time = '2020-12-14T19:54:18.733Z';
+    final dateTime = DataStore.TemporalDateTime.fromString(time);
+    final mutationResult = '''{
+      "deleteBlog": {
+        "id": "$id",
+        "name": "$name",
+        "createdAt": "$time"
+      }
+    }''';
+
+    apiChannel.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'mutate') {
+        return {'data': mutationResult.toString(), 'errors': []};
+      }
+    });
+
+    Blog blog = Blog(id: id, name: name, createdAt: dateTime);
+
+    var operation =
+        await api.mutate(request: ModelMutations.delete<Blog>(blog));
+
+    var response = await operation.response;
+    expect(response.data.equals(blog), isTrue);
+  });
+
   test(
       'A PlatformException for a failed API call results in the corresponding ApiException',
       () async {

--- a/packages/amplify_api/test/amplify_api_mutate_test.dart
+++ b/packages/amplify_api/test/amplify_api_mutate_test.dart
@@ -117,8 +117,8 @@ void main() {
 
     Blog blog = Blog(id: id, name: name, createdAt: dateTime);
 
-    var operation = await api.mutate(
-        request: ModelMutations.delete<Blog>(Blog.classType, blog.id));
+    var operation =
+        await api.mutate(request: ModelMutations.delete<Blog>(blog));
 
     var response = await operation.response;
     expect(response.data, equals(blog));

--- a/packages/amplify_api/test/graphql_helpers_test.dart
+++ b/packages/amplify_api/test/graphql_helpers_test.dart
@@ -175,18 +175,58 @@ void main() {
 
       test("ModelMutations.delete() should build a valid request", () {
         final id = UUID.getUUID();
+        final name = "Test Blog";
+        final time = "2021-08-03T16:39:18.000000651Z";
+        final createdAt = DataStore.TemporalDateTime.fromString(time);
+
+        Blog blog = Blog(id: id, name: name, createdAt: createdAt);
+
+        final expectedVars = {'id': id};
+        final expectedDoc =
+            r"mutation deleteBlog($input: DeleteBlogInput!, $condition:  ModelBlogConditionInput) { deleteBlog(input: $input, condition: $condition) { id name createdAt } }";
+
+        GraphQLRequest<Blog> req = ModelMutations.delete<Blog>(blog);
+
+        expect(req.document, expectedDoc);
+        expect(mapEquals(req.variables, expectedVars), isTrue);
+        expect(req.modelType, Blog.classType);
+        expect(req.decodePath, "deleteBlog");
+      });
+
+      test("ModelMutations.deleteById() should build a valid request", () {
+        final id = UUID.getUUID();
 
         final expectedVars = {'id': id};
         final expectedDoc =
             r"mutation deleteBlog($input: DeleteBlogInput!, $condition:  ModelBlogConditionInput) { deleteBlog(input: $input, condition: $condition) { id name createdAt } }";
 
         GraphQLRequest<Blog> req =
-            ModelMutations.delete<Blog>(Blog.classType, id);
+            ModelMutations.deleteById<Blog>(Blog.classType, id);
 
         expect(req.document, expectedDoc);
         expect(mapEquals(req.variables, expectedVars), isTrue);
         expect(req.modelType, Blog.classType);
         expect(req.decodePath, "deleteBlog");
+      });
+
+      test("ModelMutations.update() should build a valid request", () {
+        final id = UUID.getUUID();
+        final name = "Test Blog";
+        final time = "2021-08-03T16:39:18.000000651Z";
+        final createdAt = DataStore.TemporalDateTime.fromString(time);
+
+        Blog blog = Blog(id: id, name: name, createdAt: createdAt);
+
+        final expectedVars = {'id': id, 'name': name, "createdAt": time};
+        final expectedDoc =
+            r"mutation updateBlog($input: UpdateBlogInput!, $condition:  ModelBlogConditionInput) { updateBlog(input: $input, condition: $condition) { id name createdAt } }";
+
+        GraphQLRequest<Blog> req = ModelMutations.update<Blog>(blog);
+
+        expect(req.document, expectedDoc);
+        expect(mapEquals(req.variables, expectedVars), isTrue);
+        expect(req.modelType, Blog.classType);
+        expect(req.decodePath, "updateBlog");
       });
 
       test("ModelMutations.update() should build a valid request", () {

--- a/packages/amplify_api/test/graphql_helpers_test.dart
+++ b/packages/amplify_api/test/graphql_helpers_test.dart
@@ -172,6 +172,42 @@ void main() {
         expect(req.modelType, Blog.classType);
         expect(req.decodePath, "createBlog");
       });
+
+      test("ModelMutations.delete() should build a valid request", () {
+        final id = UUID.getUUID();
+        final name = "Test Blog";
+        final time = "2021-08-03T16:39:18.000000651Z";
+        final createdAt = DataStore.TemporalDateTime.fromString(time);
+
+        Blog blog = Blog(id: id, name: name, createdAt: createdAt);
+
+        final expectedVars = {'id': id};
+        final expectedDoc =
+            r"mutation deleteBlog($input: DeleteBlogInput!, $condition:  ModelBlogConditionInput) { deleteBlog(input: $input, condition: $condition) { id name createdAt } }";
+
+        GraphQLRequest<Blog> req = ModelMutations.delete<Blog>(blog);
+
+        expect(req.document, expectedDoc);
+        expect(mapEquals(req.variables, expectedVars), isTrue);
+        expect(req.modelType, Blog.classType);
+        expect(req.decodePath, "deleteBlog");
+      });
+
+      test("ModelMutations.deleteById() should build a valid request", () {
+        final id = UUID.getUUID();
+
+        final expectedVars = {'id': id};
+        final expectedDoc =
+            r"mutation deleteBlog($input: DeleteBlogInput!, $condition:  ModelBlogConditionInput) { deleteBlog(input: $input, condition: $condition) { id name createdAt } }";
+
+        GraphQLRequest<Blog> req =
+            ModelMutations.deleteById<Blog>(Blog.classType, id);
+
+        expect(req.document, expectedDoc);
+        expect(mapEquals(req.variables, expectedVars), isTrue);
+        expect(req.modelType, Blog.classType);
+        expect(req.decodePath, "deleteBlog");
+      });
     });
   });
 

--- a/packages/amplify_api/test/graphql_helpers_test.dart
+++ b/packages/amplify_api/test/graphql_helpers_test.dart
@@ -173,7 +173,7 @@ void main() {
         expect(req.decodePath, "createBlog");
       });
 
-      test("ModelMutations.deleteById() should build a valid request", () {
+      test("ModelMutations.delete() should build a valid request", () {
         final id = UUID.getUUID();
 
         final expectedVars = {'id': id};
@@ -181,7 +181,7 @@ void main() {
             r"mutation deleteBlog($input: DeleteBlogInput!, $condition:  ModelBlogConditionInput) { deleteBlog(input: $input, condition: $condition) { id name createdAt } }";
 
         GraphQLRequest<Blog> req =
-            ModelMutations.deleteById<Blog>(Blog.classType, id);
+            ModelMutations.delete<Blog>(Blog.classType, id);
 
         expect(req.document, expectedDoc);
         expect(mapEquals(req.variables, expectedVars), isTrue);

--- a/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLHelpers.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLHelpers.dart
@@ -37,6 +37,5 @@ abstract class ModelMutationsInterface {
   GraphQLRequest<T> update<T extends Model>(T model, {QueryPredicate? where});
 
   // DeleteById
-  GraphQLRequest<T> deleteById<T extends Model>(
-      ModelType<T> modelType, String id);
+  GraphQLRequest<T> delete<T extends Model>(ModelType<T> modelType, String id);
 }

--- a/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLHelpers.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLHelpers.dart
@@ -36,9 +36,6 @@ abstract class ModelMutationsInterface {
   // Update
   GraphQLRequest<T> update<T extends Model>(T model, {QueryPredicate? where});
 
-  // Delete
-  GraphQLRequest<T> delete<T extends Model>(T model, {QueryPredicate? where});
-
   // DeleteById
   GraphQLRequest<T> deleteById<T extends Model>(
       ModelType<T> modelType, String id);

--- a/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLHelpers.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/GraphQL/GraphQLHelpers.dart
@@ -36,6 +36,10 @@ abstract class ModelMutationsInterface {
   // Update
   GraphQLRequest<T> update<T extends Model>(T model, {QueryPredicate? where});
 
+  // Delete
+  GraphQLRequest<T> delete<T extends Model>(T model, {QueryPredicate? where});
+
   // DeleteById
-  GraphQLRequest<T> delete<T extends Model>(ModelType<T> modelType, String id);
+  GraphQLRequest<T> deleteById<T extends Model>(
+      ModelType<T> modelType, String id);
 }


### PR DESCRIPTION
*Issue #, if available:*
Partial implementation of GraphQL model helper feature #308. 

*Description of changes:*
This adds `ModelMutations.delete()` and relevant unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.