### PR TITLE
feat(amplify_api): GraphQL Helpers Integration Tests

### DIFF
--- a/packages/amplify_api/example/integration_test/graph_ql_tests.dart
+++ b/packages/amplify_api/example/integration_test/graph_ql_tests.dart
@@ -12,24 +12,83 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 import 'package:integration_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:amplify_flutter/amplify.dart';
 import 'package:amplify_api/amplify_api.dart';
 import 'dart:convert';
-
 import 'package:amplify_api_example/amplifyconfiguration.dart';
+
+import 'resources/Blog.dart';
+import 'resources/ModelProvider.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  List<Blog> blogIds = [];
 
+  // utility to query blogs and return length
   group('GraphQL', () {
+    // declare utility to delete all blogs async
+    Future<bool> deleteBlog(String id) async {
+      String graphQLDocument = '''mutation deleteBlog(\$id: ID!) {
+          deleteBlog(input: {id: \$id}) {
+            id
+            name
+            createdAt
+          }
+        }''';
+      var req =
+          GraphQLRequest(document: graphQLDocument, variables: {"id": id});
+
+      var operation = await Amplify.API.mutate(request: req);
+
+      var response = await operation.response;
+      Map data = jsonDecode(response.data);
+
+      return true;
+    }
+
+    Future<bool> deleteAllBlogs() async {
+      blogIds.forEach((e) async {
+        await deleteBlog(e.id);
+      });
+      return true;
+    }
+
+    // declare utility which creates blog with title as parameter
+    Future<Blog> addBlog(String name) async {
+      String graphQLDocument = '''mutation createBlog(\$name: String!) {
+        createBlog(input: {name: \$name}) {
+          id
+          name
+          createdAt
+        }
+      }''';
+
+      var _r = await Amplify.API.mutate(
+          request: GraphQLRequest(
+              document: graphQLDocument, variables: {"name": name}));
+
+      var response = await _r.response;
+      Map data = jsonDecode(response.data);
+      Blog blog = Blog.fromJson(data["createBlog"]);
+      blogIds.add(blog);
+      return blog;
+    }
+
     setUpAll(() async {
       if (!Amplify.isConfigured) {
-        await Amplify.addPlugins([AmplifyAPI()]);
+        await Amplify.addPlugins(
+            [AmplifyAPI(modelProvider: ModelProvider.instance)]);
         await Amplify.configure(amplifyconfig);
       }
+      if (blogIds.length == 0) {
+        await deleteAllBlogs();
+      }
+    });
+
+    tearDownAll(() async {
+      await deleteAllBlogs();
     });
 
     testWidgets('should fetch', (WidgetTester tester) async {
@@ -44,12 +103,94 @@ void main() {
           }
         }
       }''';
-
       var _r = await Amplify.API
           .query<String>(request: GraphQLRequest(document: graphQLDocument));
       var response = await _r.response;
       Map data = jsonDecode(response.data);
       expect(data[listBlogs][items], hasLength(greaterThanOrEqualTo(0)));
+    });
+
+    // Queries
+    testWidgets('should GET a blog with Model helper',
+        (WidgetTester tester) async {
+      String name = "Integration Test Blog to fetch";
+      Blog blog = await addBlog(name);
+
+      var req = ModelQueries.get(Blog.classType, blog.id);
+      var _r = await Amplify.API.query(request: req);
+
+      var res = await _r.response;
+      Blog data = res.data;
+
+      expect(data.name, name);
+    });
+
+    testWidgets('should LIST blogs with Model helper',
+        (WidgetTester tester) async {
+      String blog_1_name = "Integration Test Blog 1";
+      String blog_2_name = "Integration Test Blog 2";
+      String blog_3_name = "Integration Test Blog 3";
+      Blog blog_1 = await addBlog(blog_1_name);
+      Blog blog_2 = await addBlog(blog_2_name);
+      Blog blog_3 = await addBlog(blog_3_name);
+
+      var req = ModelQueries.list<Blog>(Blog.classType);
+      var _r = await Amplify.API.query(request: req);
+
+      var res = await _r.response;
+      var data = res.data;
+
+      expect(data.items.length, greaterThanOrEqualTo(3));
+    });
+
+    // Mutations
+    testWidgets('should CREATE a blog with Model helper',
+        (WidgetTester tester) async {
+      String name = "Integration Test Blog - create";
+      Blog blog = Blog(name: name);
+
+      blog = blog.copyWith(name: name);
+      var req = ModelMutations.create(blog);
+
+      var _r = await Amplify.API.mutate(request: req);
+
+      var res = await _r.response;
+      Blog data = res.data;
+
+      blogIds.add(data);
+
+      expect(data.name, name);
+    });
+
+    testWidgets('should UPDATE a blog with Model helper',
+        (WidgetTester tester) async {
+      String oldName = "Integration Test Blog to update";
+      String newName = "Integration Test Blog - updated";
+      Blog blog = await addBlog(oldName);
+
+      blog = blog.copyWith(name: newName);
+
+      var req = ModelMutations.update(blog);
+      var _r = await Amplify.API.mutate(request: req);
+
+      var res = await _r.response;
+      Blog data = res.data;
+
+      expect(data.name, newName);
+    });
+
+    testWidgets('should DELETE a blog with Model helper',
+        (WidgetTester tester) async {
+      String name = "Integration Test Blog - delete";
+      Blog blog = await addBlog(name);
+
+      var req = ModelMutations.delete(blog);
+      var _r = await Amplify.API.mutate(request: req);
+
+      var res = await _r.response;
+      Blog data = res.data;
+
+      expect(data.name, name);
     });
   });
 }

--- a/packages/amplify_api/example/integration_test/main_test.dart
+++ b/packages/amplify_api/example/integration_test/main_test.dart
@@ -20,13 +20,15 @@ import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_api_example/amplifyconfiguration.dart';
 
 import 'graph_ql_tests.dart' as graph_ql_tests;
+import 'resources/ModelProvider.dart';
 
 void main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('amplify_api', () {
     setUpAll(() async {
-      await Amplify.addPlugins([AmplifyAPI()]);
+      await Amplify.addPlugins(
+          [AmplifyAPI(modelProvider: ModelProvider.instance)]);
       await Amplify.configure(amplifyconfig);
     });
 

--- a/packages/amplify_api/example/integration_test/resources/Blog.dart
+++ b/packages/amplify_api/example/integration_test/resources/Blog.dart
@@ -1,0 +1,140 @@
+/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// ignore_for_file: public_member_api_docs
+
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:flutter/foundation.dart';
+
+/** This is an auto generated class representing the Blog type in your schema. */
+@immutable
+class Blog extends Model {
+  static const classType = const _BlogModelType();
+  final String id;
+  final String? _name;
+  final TemporalDateTime? _createdAt;
+
+  @override
+  getInstanceType() => classType;
+
+  @override
+  String getId() {
+    return id;
+  }
+
+  String get name {
+    try {
+      return _name!;
+    } catch (e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion: DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString());
+    }
+  }
+
+  TemporalDateTime? get createdAt {
+    return _createdAt;
+  }
+
+  const Blog._internal({required this.id, required name, createdAt})
+      : _name = name,
+        _createdAt = createdAt;
+
+  factory Blog(
+      {String? id, required String name, TemporalDateTime? createdAt}) {
+    return Blog._internal(
+        id: id == null ? UUID.getUUID() : id, name: name, createdAt: createdAt);
+  }
+
+  bool equals(Object other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Blog &&
+        id == other.id &&
+        _name == other._name &&
+        _createdAt == other._createdAt;
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+
+    buffer.write("Blog {");
+    buffer.write("id=" + "$id" + ", ");
+    buffer.write("name=" + "$_name" + ", ");
+    buffer.write(
+        "createdAt=" + (_createdAt != null ? _createdAt!.format() : "null"));
+    buffer.write("}");
+
+    return buffer.toString();
+  }
+
+  Blog copyWith({String? id, String? name, TemporalDateTime? createdAt}) {
+    return Blog(
+        id: id ?? this.id,
+        name: name ?? this.name,
+        createdAt: createdAt ?? this.createdAt);
+  }
+
+  Blog.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        _name = json['name'],
+        _createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null;
+
+  Map<String, dynamic> toJson() =>
+      {'id': id, 'name': _name, 'createdAt': _createdAt?.format()};
+
+  static final QueryField ID = QueryField(fieldName: "blog.id");
+  static final QueryField NAME = QueryField(fieldName: "name");
+  static final QueryField CREATEDAT = QueryField(fieldName: "createdAt");
+  static var schema =
+      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = "Blog";
+    modelSchemaDefinition.pluralName = "Blogs";
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Blog.NAME,
+        isRequired: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Blog.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+  });
+}
+
+class _BlogModelType extends ModelType<Blog> {
+  const _BlogModelType();
+
+  @override
+  Blog fromJson(Map<String, dynamic> jsonData) {
+    return Blog.fromJson(jsonData);
+  }
+}

--- a/packages/amplify_api/example/integration_test/resources/ModelProvider.dart
+++ b/packages/amplify_api/example/integration_test/resources/ModelProvider.dart
@@ -1,0 +1,47 @@
+/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// ignore_for_file: public_member_api_docs
+
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'Blog.dart';
+
+export 'Blog.dart';
+
+class ModelProvider implements ModelProviderInterface {
+  @override
+  String version = "6c3e54d8511f1242fe2f4eef5967cda6";
+  @override
+  List<ModelSchema> modelSchemas = [Blog.schema];
+  static final ModelProvider _instance = ModelProvider();
+
+  static ModelProvider get instance => _instance;
+
+  ModelType getModelTypeByModelName(String modelName) {
+    switch (modelName) {
+      case "Blog":
+        {
+          return Blog.classType;
+        }
+        break;
+      default:
+        {
+          throw Exception(
+              "Failed to find model in model provider for model name: " +
+                  modelName);
+        }
+    }
+  }
+}

--- a/packages/amplify_api/example/pubspec.yaml
+++ b/packages/amplify_api/example/pubspec.yaml
@@ -15,7 +15,8 @@ dependencies:
 
   amplify_auth_cognito:
     path: ../../amplify_auth_cognito
-  amplify_datastore_plugin_interface: 0.2.0
+  amplify_datastore_plugin_interface:
+    path: ../../amplify_datastore_plugin_interface
 
   amplify_api:
     # When depending on this package from a real application you should use:

--- a/packages/amplify_api/example/pubspec.yaml
+++ b/packages/amplify_api/example/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
 
   amplify_auth_cognito:
     path: ../../amplify_auth_cognito
+  amplify_datastore_plugin_interface: 0.2.0
 
   amplify_api:
     # When depending on this package from a real application you should use:

--- a/packages/amplify_api/lib/src/graphql/graphql_response_decoder.dart
+++ b/packages/amplify_api/lib/src/graphql/graphql_response_decoder.dart
@@ -39,7 +39,7 @@ class GraphQLResponseDecoder {
     }
 
     request.decodePath!.split(".").forEach((element) {
-      if (dataJson![element] == null) {
+      if (!dataJson!.containsKey(element)) {
         throw ApiException(
             'decodePath did not match the structure of the JSON response',
             recoverySuggestion:
@@ -47,6 +47,13 @@ class GraphQLResponseDecoder {
       }
       dataJson = dataJson![element];
     });
+
+    if (dataJson == null) {
+      // TODO: T data is non-nullable, need to handle valid null response
+      throw ApiException('response from app sync was "null"',
+          recoverySuggestion:
+              "Current GraphQLResponse is non-nullable, please insure item exists before fetching");
+    }
 
     T decodedData = request.modelType!.fromJson(dataJson!) as T;
 

--- a/packages/amplify_api/lib/src/graphql/graphql_response_decoder.dart
+++ b/packages/amplify_api/lib/src/graphql/graphql_response_decoder.dart
@@ -17,7 +17,7 @@ class GraphQLResponseDecoder {
       required List<GraphQLResponseError> errors}) {
     // if no ModelType fallback to default
     if (request.modelType == null) {
-      if (T == String) {
+      if (T == String || T == dynamic) {
         return GraphQLResponse(
             data: data as T, errors: errors); // <T> is implied
       } else {

--- a/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/model_mutations_factory.dart
@@ -14,7 +14,7 @@ class ModelMutationsFactory extends ModelMutationsInterface {
 
   @override
   GraphQLRequest<T> create<T extends Model>(T model) {
-    Map<String, dynamic> variables = model.toJson();
+    Map<String, dynamic> variables = {"input": model.toJson()};
 
     return GraphQLRequestFactory.instance.buildRequest(
         model: model,
@@ -32,7 +32,9 @@ class ModelMutationsFactory extends ModelMutationsInterface {
   @override
   GraphQLRequest<T> deleteById<T extends Model>(
       ModelType<T> modelType, String id) {
-    Map<String, dynamic> variables = {"id": id};
+    Map<String, dynamic> variables = {
+      "input": {"id": id}
+    };
 
     return GraphQLRequestFactory.instance.buildRequest(
         variables: variables,
@@ -43,7 +45,7 @@ class ModelMutationsFactory extends ModelMutationsInterface {
 
   @override
   GraphQLRequest<T> update<T extends Model>(T model, {QueryPredicate? where}) {
-    Map<String, dynamic> variables = model.toJson();
+    Map<String, dynamic> variables = {"input": model.toJson()};
 
     return GraphQLRequestFactory.instance.buildRequest(
         model: model,

--- a/packages/amplify_api/test/graphql_helpers_test.dart
+++ b/packages/amplify_api/test/graphql_helpers_test.dart
@@ -15,10 +15,10 @@
 
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart'
     as DataStore;
-import 'package:flutter/foundation.dart';
 import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_api/src/graphql/graphql_response_decoder.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:collection/collection.dart';
 
 import 'resources/Blog.dart';
 import 'resources/ModelProvider.dart';
@@ -36,7 +36,8 @@ void main() {
         GraphQLRequest<Blog> req = ModelQueries.get<Blog>(Blog.classType, id);
 
         expect(req.document, expected);
-        expect(mapEquals(req.variables, {'id': id}), isTrue);
+        expect(
+            DeepCollectionEquality().equals(req.variables, {'id': id}), isTrue);
         expect(req.modelType, Blog.classType);
         expect(req.decodePath, "getBlog");
       });
@@ -160,15 +161,17 @@ void main() {
         final createdAt = DataStore.TemporalDateTime.fromString(time);
 
         Blog blog = Blog(id: id, name: name, createdAt: createdAt);
-
-        final expectedVars = {'id': id, 'name': name, "createdAt": time};
+        final expectedVars = {
+          "input": {'id': id, 'name': name, "createdAt": time}
+        };
         final expectedDoc =
             r"mutation createBlog($input: CreateBlogInput!, $condition:  ModelBlogConditionInput) { createBlog(input: $input, condition: $condition) { id name createdAt } }";
 
         GraphQLRequest<Blog> req = ModelMutations.create<Blog>(blog);
 
         expect(req.document, expectedDoc);
-        expect(mapEquals(req.variables, expectedVars), isTrue);
+        expect(DeepCollectionEquality().equals(req.variables, expectedVars),
+            isTrue);
         expect(req.modelType, Blog.classType);
         expect(req.decodePath, "createBlog");
       });
@@ -181,14 +184,17 @@ void main() {
 
         Blog blog = Blog(id: id, name: name, createdAt: createdAt);
 
-        final expectedVars = {'id': id};
+        final expectedVars = {
+          "input": {'id': id}
+        };
         final expectedDoc =
             r"mutation deleteBlog($input: DeleteBlogInput!, $condition:  ModelBlogConditionInput) { deleteBlog(input: $input, condition: $condition) { id name createdAt } }";
 
         GraphQLRequest<Blog> req = ModelMutations.delete<Blog>(blog);
 
         expect(req.document, expectedDoc);
-        expect(mapEquals(req.variables, expectedVars), isTrue);
+        expect(DeepCollectionEquality().equals(req.variables, expectedVars),
+            isTrue);
         expect(req.modelType, Blog.classType);
         expect(req.decodePath, "deleteBlog");
       });
@@ -196,7 +202,9 @@ void main() {
       test("ModelMutations.deleteById() should build a valid request", () {
         final id = UUID.getUUID();
 
-        final expectedVars = {'id': id};
+        final expectedVars = {
+          "input": {'id': id}
+        };
         final expectedDoc =
             r"mutation deleteBlog($input: DeleteBlogInput!, $condition:  ModelBlogConditionInput) { deleteBlog(input: $input, condition: $condition) { id name createdAt } }";
 
@@ -204,7 +212,8 @@ void main() {
             ModelMutations.deleteById<Blog>(Blog.classType, id);
 
         expect(req.document, expectedDoc);
-        expect(mapEquals(req.variables, expectedVars), isTrue);
+        expect(DeepCollectionEquality().equals(req.variables, expectedVars),
+            isTrue);
         expect(req.modelType, Blog.classType);
         expect(req.decodePath, "deleteBlog");
       });
@@ -217,14 +226,17 @@ void main() {
 
         Blog blog = Blog(id: id, name: name, createdAt: createdAt);
 
-        final expectedVars = {'id': id, 'name': name, "createdAt": time};
+        final expectedVars = {
+          "input": {'id': id, 'name': name, "createdAt": time}
+        };
         final expectedDoc =
             r"mutation updateBlog($input: UpdateBlogInput!, $condition:  ModelBlogConditionInput) { updateBlog(input: $input, condition: $condition) { id name createdAt } }";
 
         GraphQLRequest<Blog> req = ModelMutations.update<Blog>(blog);
 
         expect(req.document, expectedDoc);
-        expect(mapEquals(req.variables, expectedVars), isTrue);
+        expect(DeepCollectionEquality().equals(req.variables, expectedVars),
+            isTrue);
         expect(req.modelType, Blog.classType);
         expect(req.decodePath, "updateBlog");
       });
@@ -237,14 +249,17 @@ void main() {
 
         Blog blog = Blog(id: id, name: name, createdAt: createdAt);
 
-        final expectedVars = {'id': id, 'name': name, "createdAt": time};
+        final expectedVars = {
+          "input": {'id': id, 'name': name, "createdAt": time}
+        };
         final expectedDoc =
             r"mutation updateBlog($input: UpdateBlogInput!, $condition:  ModelBlogConditionInput) { updateBlog(input: $input, condition: $condition) { id name createdAt } }";
 
         GraphQLRequest<Blog> req = ModelMutations.update<Blog>(blog);
 
         expect(req.document, expectedDoc);
-        expect(mapEquals(req.variables, expectedVars), isTrue);
+        expect(DeepCollectionEquality().equals(req.variables, expectedVars),
+            isTrue);
         expect(req.modelType, Blog.classType);
         expect(req.decodePath, "updateBlog");
       });


### PR DESCRIPTION
*Issue #, if available:*
Partial implementation of GraphQL model helper feature #308. 

*Description of changes:*
This PR introduces integration tests to validate the GraphQL helpers against a real endpoint. Includes tests for: `get`, `list`, `create`, `update`, and `delete`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
