### PR TITLE
fix(amplify_authenticator): Confirm password field

### DIFF
--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -197,7 +197,7 @@ class StateMachineBloc {
 
           break;
         case 'RESET_PASSWORD':
-          yield AuthFlow(screen: AuthScreen.sendCode);
+          yield AuthFlow(screen: AuthScreen.resetPassword);
           break;
         case 'CONFIRM_SIGN_UP':
           yield AuthFlow(screen: AuthScreen.confirmSignUp);

--- a/packages/amplify_authenticator/lib/src/enums/signup_types.dart
+++ b/packages/amplify_authenticator/lib/src/enums/signup_types.dart
@@ -3,6 +3,7 @@ import 'package:collection/collection.dart';
 enum SignUpType {
   username,
   password,
+  passwordConfirmation,
   address,
   birthdate,
   email,

--- a/packages/amplify_authenticator/lib/src/keys.dart
+++ b/packages/amplify_authenticator/lib/src/keys.dart
@@ -12,6 +12,8 @@ const String keyNewUsernameSignInFormField = 'newUsernameSignInFormField';
 
 const String keyUsernameSignUpFormField = 'usernameSignUpFormField';
 const String keyPasswordSignUpFormField = 'passwordSignUpFormField';
+const String keyPasswordConfirmationSignUpFormField =
+    'keyPasswordConfirmationSignUpFormField';
 const String keyAddressSignUpFormField = 'addresslSignUpFormField';
 const String keyBirthdateSignUpFormField = 'birthdateSignUpFormField';
 const String keyEmailSignUpFormField = 'emailSignUpFormField';

--- a/packages/amplify_authenticator/lib/src/text_customization/input_resolver.dart
+++ b/packages/amplify_authenticator/lib/src/text_customization/input_resolver.dart
@@ -28,6 +28,11 @@ class InputResolver {
   /// Hint of password field
   StringResolver password_hint = (_) => "Enter your password";
 
+  StringResolver password_confirmation_title = (_) => "Confirm Password*";
+
+  /// Hint of password field
+  StringResolver password_confirmation_hint = (_) => "Re-enter your password";
+
   /// Title of email field
   StringResolver email_title = (_) => "Email*";
 

--- a/packages/amplify_authenticator/lib/src/views/signin_viewmodel.dart
+++ b/packages/amplify_authenticator/lib/src/views/signin_viewmodel.dart
@@ -26,6 +26,7 @@ class SignInViewModel extends BaseViewModel {
 
   void setUsername(String value) {
     _username = value;
+    _newUsername = value;
   }
 
   void setPassword(String value) {

--- a/packages/amplify_authenticator/lib/src/views/signup_viewmodel.dart
+++ b/packages/amplify_authenticator/lib/src/views/signup_viewmodel.dart
@@ -15,6 +15,7 @@ class SignUpViewModel extends BaseViewModel {
 
   String? username;
   String? _password;
+  String? _passwordConfirmation;
   String? _address;
   String? _birthdate;
   String? _email;
@@ -42,6 +43,14 @@ class SignUpViewModel extends BaseViewModel {
 
   void setPassword(String value) {
     _password = value;
+  }
+
+  String? get password {
+    return _password;
+  }
+
+  void setPasswordConfirmation(String value) {
+    _passwordConfirmation = value;
   }
 
   void setAddress(String value, String type) {
@@ -136,7 +145,6 @@ class SignUpViewModel extends BaseViewModel {
   }
 
   // Auth calls
-
   Future<void> signUp() async {
     if (!_formKey.currentState!.validate()) {
       return;
@@ -175,6 +183,7 @@ class SignUpViewModel extends BaseViewModel {
 
   void clean() {
     _password = null;
+    _passwordConfirmation = null;
     _address = null;
     _birthdate = null;
     _email = null;

--- a/packages/amplify_authenticator/lib/src/widgets/default_forms.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/default_forms.dart
@@ -62,6 +62,10 @@ class DefaultForms {
               hintText: resolver.inputs.password_hint(_context),
               type: 'password'),
           SignUpFormField(
+              title: resolver.inputs.password_confirmation_title(_context),
+              hintText: resolver.inputs.password_confirmation_hint(_context),
+              type: 'passwordConfirmation'),
+          SignUpFormField(
               title: resolver.inputs.email_title(_context),
               hintText: resolver.inputs.email_hint(_context),
               type: 'email'),

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields.dart
@@ -185,6 +185,17 @@ class SignUpFormField extends StatelessWidget {
     TextInputType _keyboardType = TextInputType.text;
     final SignUpType? _type = fromStringToSignUpType(type);
 
+    /// Special validator using the existing password, executed if a passwordConfirmation field is present
+    /// TODO: Implement a mechanism for customers to access subsets of the viewmodels.
+    String? validatePasswordConfirmation(String? passwordConfirmation) {
+      if (passwordConfirmation == null || passwordConfirmation.isEmpty) {
+        return 'Re-enter your password to confirm';
+      } else if (_signUpViewModel.password != passwordConfirmation) {
+        return 'Passwords do not match';
+      }
+      return null;
+    }
+
     switch (_type) {
       case SignUpType.username:
         _callBack = (String value) {
@@ -204,6 +215,16 @@ class SignUpFormField extends StatelessWidget {
         _obscureText = true;
         _validator = validator ?? validatePassword;
         _key = const Key(keyPasswordSignUpFormField);
+        break;
+      case SignUpType.passwordConfirmation:
+        _callBack = (String value) {
+          _signUpViewModel.setPasswordConfirmation(value);
+          _confirmSignUpViewModel.setPassword(value);
+        };
+        _keyboardType = TextInputType.visiblePassword;
+        _obscureText = true;
+        _validator = validator ?? validatePasswordConfirmation;
+        _key = const Key(keyPasswordConfirmationSignUpFormField);
         break;
       case SignUpType.address:
         _callBack = (String value) => _signUpViewModel.setAddress(value, type);
@@ -320,6 +341,7 @@ class SignUpFormField extends StatelessWidget {
 
         break;
     }
+
     return FormFieldContainer(
         key: _key,
         keyboardType: _keyboardType,


### PR DESCRIPTION
*Description of changes:*
* Adds a passwordConfirmation field and ability to validate against password field.
* Directs user to the widget for resetting a password with a verification code after signing into an account for which a Cognito admin has forced a password reset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
