### PR TITLE
[DRAFT] test(DataStore): multi device integ tests for DataStore

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -42,6 +42,9 @@ scripts:
   test:integration:ios:
     run: melos exec -c 1 --scope="*example*" --file-exists="integration_test/main_test.dart" "flutter drive --no-pub --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d iPhone"
 
+  test:integration:multi_device:
+    run: melos exec -c 1 --scope="*example*" --file-exists="tool/run_multi_device_tests.sh" "./tool/run_multi_device_tests.sh"
+
   provision_integration_test_resources:
     run: melos exec "./tool/provision_integration_test_resources.sh"
     description:

--- a/packages/amplify_datastore/example/integration_test/multi_device/device_1_test.dart
+++ b/packages/amplify_datastore/example/integration_test/multi_device/device_1_test.dart
@@ -20,12 +20,12 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../utils/setup_utils.dart';
 import 'multi_device_utils.dart';
+import 'mutli_device_contants.dart';
 
 void main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  group('save', () {
+  group('DataStore', () {
     setUpAll(() async {
-      setTestId();
       await configureDataStore(cloudSync: true);
       // clear local DB from previous test runs
       await Amplify.DataStore.clear();
@@ -33,12 +33,21 @@ void main() async {
       await waitForDeviceTwoReady();
     });
 
-    testWidgets('should save data', (WidgetTester tester) async {
-      Blog testComment = Blog(name: 'test blog created from device 1');
-      await waitForTestStart(testName: 'should save data');
-      await Amplify.DataStore.save(testComment);
-      await waitForTestEnd(testName: 'should save data');
-      await Amplify.DataStore.delete(testComment);
+    testWidgets(
+        'should save data on device one, and observe data on device two',
+        (WidgetTester tester) async {
+      // wait for device two perform setup (listen to datastore events)
+      await waitForTestStart(testName: testOneName);
+
+      // create blog
+      Blog testBlog = Blog(name: testOneBlogName);
+      await Amplify.DataStore.save(testBlog);
+
+      // wait for device two to complete test
+      await waitForTestEnd(testName: testOneName);
+
+      // cleanup
+      await Amplify.DataStore.delete(testBlog);
     });
   });
 }

--- a/packages/amplify_datastore/example/integration_test/multi_device/device_1_test.dart
+++ b/packages/amplify_datastore/example/integration_test/multi_device/device_1_test.dart
@@ -24,7 +24,7 @@ import 'multi_device_utils.dart';
 void main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   group('save', () {
-    setUp(() async {
+    setUpAll(() async {
       setTestId();
       await configureDataStore(cloudSync: true);
       // clear local DB from previous test runs
@@ -33,12 +33,16 @@ void main() async {
       await waitForDeviceTwoReady();
     });
 
-    testWidgets('should save data', (WidgetTester tester) async {
-      Blog testComment = Blog(name: 'test blog created from device 1');
-      await waitForTestStart(testName: 'should save data');
-      await Amplify.DataStore.save(testComment);
-      await waitForTestEnd(testName: 'should save data');
-      await Amplify.DataStore.delete(testComment);
-    });
+    testWidgets(
+      'should save data',
+      (WidgetTester tester) async {
+        Blog testComment = Blog(name: 'test blog created from device 1');
+        await waitForTestStart(testName: 'should save data');
+        await Amplify.DataStore.save(testComment);
+        await waitForTestEnd(testName: 'should save data');
+        await Amplify.DataStore.delete(testComment);
+      },
+      timeout: Timeout(Duration(seconds: 10)),
+    );
   });
 }

--- a/packages/amplify_datastore/example/integration_test/multi_device/device_1_test.dart
+++ b/packages/amplify_datastore/example/integration_test/multi_device/device_1_test.dart
@@ -33,16 +33,12 @@ void main() async {
       await waitForDeviceTwoReady();
     });
 
-    testWidgets(
-      'should save data',
-      (WidgetTester tester) async {
-        Blog testComment = Blog(name: 'test blog created from device 1');
-        await waitForTestStart(testName: 'should save data');
-        await Amplify.DataStore.save(testComment);
-        await waitForTestEnd(testName: 'should save data');
-        await Amplify.DataStore.delete(testComment);
-      },
-      timeout: Timeout(Duration(seconds: 10)),
-    );
+    testWidgets('should save data', (WidgetTester tester) async {
+      Blog testComment = Blog(name: 'test blog created from device 1');
+      await waitForTestStart(testName: 'should save data');
+      await Amplify.DataStore.save(testComment);
+      await waitForTestEnd(testName: 'should save data');
+      await Amplify.DataStore.delete(testComment);
+    });
   });
 }

--- a/packages/amplify_datastore/example/integration_test/multi_device/device_1_test.dart
+++ b/packages/amplify_datastore/example/integration_test/multi_device/device_1_test.dart
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_datastore_example/models/ModelProvider.dart';
+import 'package:amplify_flutter/amplify.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../utils/setup_utils.dart';
+import 'multi_device_utils.dart';
+
+void main() async {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  group('save', () {
+    setUp(() async {
+      setTestId();
+      await configureDataStore(cloudSync: true);
+      // clear local DB from previous test runs
+      await Amplify.DataStore.clear();
+      await signalDeviceOneReady();
+      await waitForDeviceTwoReady();
+    });
+
+    testWidgets('should save data', (WidgetTester tester) async {
+      Blog testComment = Blog(name: 'test blog created from device 1');
+      await waitForTestStart(testName: 'should save data');
+      await Amplify.DataStore.save(testComment);
+      await waitForTestEnd(testName: 'should save data');
+      await Amplify.DataStore.delete(testComment);
+    });
+  });
+}

--- a/packages/amplify_datastore/example/integration_test/multi_device/device_2_test.dart
+++ b/packages/amplify_datastore/example/integration_test/multi_device/device_2_test.dart
@@ -24,7 +24,7 @@ import 'multi_device_utils.dart';
 void main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   group('save', () {
-    setUp(() async {
+    setUpAll(() async {
       setTestId();
       await configureDataStore(cloudSync: true);
       // clear local DB from previous test runs
@@ -33,14 +33,19 @@ void main() async {
       await signalDeviceTwoReady();
     });
 
-    testWidgets('should save data', (WidgetTester tester) async {
-      var eventFuture = Amplify.DataStore.observe(Blog.classType).firstWhere(
-          (element) => element.item.name == 'test blog created from device 1');
-      await signalTestStart(testName: 'should save data');
-      // test waits for the Blog from device 1 to be created
-      // as long as the test does not timeout, the test will pass
-      await eventFuture;
-      await signalTestEnd(testName: 'should save data');
-    });
+    testWidgets(
+      'should save data',
+      (WidgetTester tester) async {
+        var eventFuture = Amplify.DataStore.observe(Blog.classType).firstWhere(
+            (element) =>
+                element.item.name == 'test blog created from device 1');
+        await signalTestStart(testName: 'should save data');
+        // test waits for the Blog from device 1 to be created
+        // as long as the test does not timeout, the test will pass
+        await eventFuture;
+        await signalTestEnd(testName: 'should save data');
+      },
+      timeout: Timeout(Duration(seconds: 10)),
+    );
   });
 }

--- a/packages/amplify_datastore/example/integration_test/multi_device/device_2_test.dart
+++ b/packages/amplify_datastore/example/integration_test/multi_device/device_2_test.dart
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_datastore_example/models/ModelProvider.dart';
+import 'package:amplify_flutter/amplify.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../utils/setup_utils.dart';
+import 'multi_device_utils.dart';
+
+void main() async {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  group('save', () {
+    setUp(() async {
+      setTestId();
+      await configureDataStore(cloudSync: true);
+      // clear local DB from previous test runs
+      await Amplify.DataStore.clear();
+      await waitForDeviceOneReady();
+      await signalDeviceTwoReady();
+    });
+
+    testWidgets('should save data', (WidgetTester tester) async {
+      var eventFuture = Amplify.DataStore.observe(Blog.classType).firstWhere(
+          (element) => element.item.name == 'test blog created from device 1');
+      await signalTestStart(testName: 'should save data');
+      // test waits for the Blog from device 1 to be created
+      // as long as the test does not timeout, the test will pass
+      await eventFuture;
+      await signalTestEnd(testName: 'should save data');
+    });
+  });
+}

--- a/packages/amplify_datastore/example/integration_test/multi_device/device_2_test.dart
+++ b/packages/amplify_datastore/example/integration_test/multi_device/device_2_test.dart
@@ -41,7 +41,7 @@ void main() async {
                 element.item.name == 'test blog created from device 1');
         await signalTestStart(testName: 'should save data');
         // test waits for the Blog from device 1 to be created
-        // as long as the test does not timeout, the test will pass
+        // the test will pass as long as the event is received before timing out
         await eventFuture;
         await signalTestEnd(testName: 'should save data');
       },

--- a/packages/amplify_datastore/example/integration_test/multi_device/multi_device_utils.dart
+++ b/packages/amplify_datastore/example/integration_test/multi_device/multi_device_utils.dart
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_datastore_example/models/ModelProvider.dart';
+import 'package:amplify_flutter/amplify.dart';
+
+String _testId = '';
+
+/// sets an ID that is available accross all tests instances from
+/// a single test run
+setTestId() {
+  // const is needed for use with String.fromEnvironment
+  const testId = String.fromEnvironment('test_id');
+  _testId = testId;
+  print('test Id set to: $_testId');
+}
+
+/// signal that device one is ready for test execution
+Future<void> signalDeviceOneReady() async {
+  await _createBlogWithName('device 1 ready');
+}
+
+/// signal that device two is ready for test execution
+Future<void> signalDeviceTwoReady() async {
+  await _createBlogWithName('device 2 ready');
+}
+
+/// wait for device one to be ready for device execution
+Future<void> waitForDeviceOneReady() async {
+  return _waitForBlogWithName('device 1 ready');
+}
+
+/// wait for device two to be ready for device execution
+Future<void> waitForDeviceTwoReady() async {
+  return _waitForBlogWithName('device 2 ready');
+}
+
+/// signal that a test with a given name has started
+Future<void> signalTestStart({required String testName}) async {
+  return _createBlogWithName('test start: $testName');
+}
+
+/// wait for a test with a given name to start
+Future<void> waitForTestStart({required String testName}) async {
+  return _waitForBlogWithName('test start: $testName');
+}
+
+/// signal that a test with a given name has ended and can be cleaned up
+Future<void> signalTestEnd({required String testName}) async {
+  return _createBlogWithName('test end: $testName');
+}
+
+/// wait for a test with a given name to end
+Future<void> waitForTestEnd({required String testName}) async {
+  return _waitForBlogWithName('test end: $testName');
+}
+
+/// create a blog with a given name, and prepend the test ID to the name
+Future<void> _createBlogWithName(String name) async {
+  print('Event created: ' + name);
+  Blog blog = Blog(name: '$_testId - $name');
+  await Amplify.DataStore.save(blog);
+}
+
+/// waits for a blog to be created with a given name
+Future<void> _waitForBlogWithName(String name) async {
+  var blogs = await Amplify.DataStore.query(Blog.classType,
+      where: Blog.NAME.eq('$_testId - $name'));
+  if (blogs.length > 0) {
+    print('Event recieved: ' + name);
+    return;
+  } else {
+    await Amplify.DataStore.observe(Blog.classType)
+        .firstWhere((element) => element.item.name == '$_testId - $name');
+    print('Event recieved: ' + name);
+    return;
+  }
+}

--- a/packages/amplify_datastore/example/integration_test/multi_device/mutli_device_contants.dart
+++ b/packages/amplify_datastore/example/integration_test/multi_device/mutli_device_contants.dart
@@ -1,0 +1,8 @@
+import 'multi_device_utils.dart';
+
+const deviceOneReady = 'device one ready';
+const deviceTwoReady = 'device two ready';
+const testOneName = 'test 1';
+
+String testOneBlogName =
+    'test blog created from device 1 for testId: ${testInstance.id}';

--- a/packages/amplify_datastore/example/integration_test/utils/setup_utils.dart
+++ b/packages/amplify_datastore/example/integration_test/utils/setup_utils.dart
@@ -1,13 +1,17 @@
+import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_datastore/amplify_datastore.dart';
 import 'package:amplify_datastore_example/amplifyconfiguration.dart';
 import 'package:amplify_datastore_example/models/ModelProvider.dart';
 import 'package:amplify_flutter/amplify.dart';
 
-Future<void> configureDataStore() async {
+Future<void> configureDataStore({cloudSync = false}) async {
   if (!Amplify.isConfigured) {
     final dataStorePlugin =
         AmplifyDataStore(modelProvider: ModelProvider.instance);
     await Amplify.addPlugins([dataStorePlugin]);
+    if (cloudSync) {
+      await Amplify.addPlugin(AmplifyAPI());
+    }
     await Amplify.configure(amplifyconfig);
   }
 }

--- a/packages/amplify_datastore/example/lib/models/ModelProvider.dart
+++ b/packages/amplify_datastore/example/lib/models/ModelProvider.dart
@@ -19,16 +19,23 @@ import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_inte
 import 'Blog.dart';
 import 'Comment.dart';
 import 'Post.dart';
+import 'TestEvent.dart';
 
 export 'Blog.dart';
 export 'Comment.dart';
 export 'Post.dart';
+export 'TestEvent.dart';
 
 class ModelProvider implements ModelProviderInterface {
   @override
-  String version = "5d57d0339e98a5193251cdde962c0b6e";
+  String version = "1b79f27d8e7c19f0c2b111e305d3defa";
   @override
-  List<ModelSchema> modelSchemas = [Blog.schema, Comment.schema, Post.schema];
+  List<ModelSchema> modelSchemas = [
+    Blog.schema,
+    Comment.schema,
+    Post.schema,
+    TestEvent.schema
+  ];
   static final ModelProvider _instance = ModelProvider();
 
   static ModelProvider get instance => _instance;
@@ -41,6 +48,8 @@ class ModelProvider implements ModelProviderInterface {
         return Comment.classType;
       case "Post":
         return Post.classType;
+      case "TestEvent":
+        return TestEvent.classType;
       default:
         {
           throw Exception(

--- a/packages/amplify_datastore/example/lib/models/TestEvent.dart
+++ b/packages/amplify_datastore/example/lib/models/TestEvent.dart
@@ -1,0 +1,149 @@
+/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// ignore_for_file: public_member_api_docs
+
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:flutter/foundation.dart';
+
+/** This is an auto generated class representing the TestEvent type in your schema. */
+@immutable
+class TestEvent extends Model {
+  static const classType = const _TestEventModelType();
+  final String id;
+  final String? _testRunId;
+  final String? _eventName;
+
+  @override
+  getInstanceType() => classType;
+
+  @override
+  String getId() {
+    return id;
+  }
+
+  String get testRunId {
+    try {
+      return _testRunId!;
+    } catch (e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion: DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString());
+    }
+  }
+
+  String get eventName {
+    try {
+      return _eventName!;
+    } catch (e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion: DataStoreExceptionMessages
+              .codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString());
+    }
+  }
+
+  const TestEvent._internal(
+      {required this.id, required testRunId, required eventName})
+      : _testRunId = testRunId,
+        _eventName = eventName;
+
+  factory TestEvent(
+      {String? id, required String testRunId, required String eventName}) {
+    return TestEvent._internal(
+        id: id == null ? UUID.getUUID() : id,
+        testRunId: testRunId,
+        eventName: eventName);
+  }
+
+  bool equals(Object other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TestEvent &&
+        id == other.id &&
+        _testRunId == other._testRunId &&
+        _eventName == other._eventName;
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+
+    buffer.write("TestEvent {");
+    buffer.write("id=" + "$id" + ", ");
+    buffer.write("testRunId=" + "$_testRunId" + ", ");
+    buffer.write("eventName=" + "$_eventName");
+    buffer.write("}");
+
+    return buffer.toString();
+  }
+
+  TestEvent copyWith({String? id, String? testRunId, String? eventName}) {
+    return TestEvent(
+        id: id ?? this.id,
+        testRunId: testRunId ?? this.testRunId,
+        eventName: eventName ?? this.eventName);
+  }
+
+  TestEvent.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        _testRunId = json['testRunId'],
+        _eventName = json['eventName'];
+
+  Map<String, dynamic> toJson() =>
+      {'id': id, 'testRunId': _testRunId, 'eventName': _eventName};
+
+  static final QueryField ID = QueryField(fieldName: "testEvent.id");
+  static final QueryField TESTRUNID = QueryField(fieldName: "testRunId");
+  static final QueryField EVENTNAME = QueryField(fieldName: "eventName");
+  static var schema =
+      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = "TestEvent";
+    modelSchemaDefinition.pluralName = "TestEvents";
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestEvent.TESTRUNID,
+        isRequired: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestEvent.EVENTNAME,
+        isRequired: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+  });
+}
+
+class _TestEventModelType extends ModelType<TestEvent> {
+  const _TestEventModelType();
+
+  @override
+  TestEvent fromJson(Map<String, dynamic> jsonData) {
+    return TestEvent.fromJson(jsonData);
+  }
+}

--- a/packages/amplify_datastore/example/pubspec.yaml
+++ b/packages/amplify_datastore/example/pubspec.yaml
@@ -20,8 +20,8 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
   # Uncomment the below lines to enable online sync
-  # amplify_api:
-  #   path: ../../amplify_api
+  amplify_api:
+    path: ../../amplify_api
   amplify_flutter:
     path: ../../amplify_flutter
   flutter_driver:

--- a/packages/amplify_datastore/example/tool/run_multi_device_tests.sh
+++ b/packages/amplify_datastore/example/tool/run_multi_device_tests.sh
@@ -1,20 +1,39 @@
 #!/bin/bash
+set -eu
 
-# test_id is used to identify a unique test instance to enable tests to be run in parallel
-# the id is prepended to items saved to the db to avoid conflicting items from other tests
-test_id=$(uuidgen)
+multi_device_test () {
+    # test_id is used to identify a unique test run instance to enable tests to be run in parallel
+    test_id=$(uuidgen)
 
-# test with iPhone and "device 1" and Android as "device 2"
-flutter drive \
---no-pub \
---driver=test_driver/integration_test.dart \
---target=integration_test/multi_device/device_1_test.dart \
---dart-define="test_id=$test_id" \
--d iPhone \
-& \ 
-flutter drive \
---no-pub \
---driver=test_driver/integration_test.dart \
---target=integration_test/multi_device/device_2_test.dart \
---dart-define="test_id=$test_id" \
--d sdk \
+    # list of PIDs from parallel test runs
+    testPids=()
+
+    flutter drive \
+    --no-pub \
+    --driver=test_driver/integration_test.dart \
+    --target=integration_test/multi_device/device_1_test.dart \
+    --dart-define="test_id=$test_id" \
+    -d $1 \
+    & testPids+=($!)
+
+    flutter drive \
+    --no-pub \
+    --driver=test_driver/integration_test.dart \
+    --target=integration_test/multi_device/device_2_test.dart \
+    --dart-define="test_id=$test_id" \
+    -d $2 \
+    & testPids+=($!)
+
+    # wait for each test execution to complete or fail 
+    for pid in "${testPids[@]}"; do
+        wait "$pid"
+    done
+}
+
+
+# test run 1 with iPhone as "device 1" and Android as "device 2"
+multi_device_test iPhone sdk
+
+# test run 2 with Android as "device 1" and iOS as "device 2"
+multi_device_test sdk iPhone
+

--- a/packages/amplify_datastore/example/tool/run_multi_device_tests.sh
+++ b/packages/amplify_datastore/example/tool/run_multi_device_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# test_id is used to identify a unique test instance to enable tests to be run in parallel
+# the id is prepended to items saved to the db to avoid conflicting items from other tests
+test_id=$(uuidgen)
+
+# test with iPhone and "device 1" and Android as "device 2"
+flutter drive \
+--no-pub \
+--driver=test_driver/integration_test.dart \
+--target=integration_test/multi_device/device_1_test.dart \
+--dart-define="test_id=$test_id" \
+-d iPhone \
+& \ 
+flutter drive \
+--no-pub \
+--driver=test_driver/integration_test.dart \
+--target=integration_test/multi_device/device_2_test.dart \
+--dart-define="test_id=$test_id" \
+-d sdk \


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
- add basic multi device test for DataStore

This PR adds a new type of integration test, which will:
- start multiple devices at once
- synchronize test execution between the devices (using datastore)
- perform an action on one device (such as saving a model)
- executes an assertion on another device (such as expecting a model to be present)

The bulk of the logic in this PR is in `multi_device_utils.dart`. This file contains utilities to sync test execution across the devices. More specifically, there are utilities to create a `TestEvent` with a specific testID and test name on one device, and then wait for them event on the other device.

Below shows the test running. The first test run can be seen ~0:59. The second test run can be seen ~1:50. The Android device finished first in the first test run. The test execution if flipped in the second run and the iOS test finishes first in the second test run.

https://user-images.githubusercontent.com/20613561/129624471-e28388f7-0213-43d4-99ce-feba48d65988.mov



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
