### PR TITLE
chore: upgrade amplify-android 1.24.1

### DIFF
--- a/packages/amplify_analytics_pinpoint/android/build.gradle
+++ b/packages/amplify_analytics_pinpoint/android/build.gradle
@@ -64,8 +64,8 @@ dependencies {
     api amplifyCore
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.24.0'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.24.0'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.24.1'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.24.1'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.mockito:mockito-inline:3.1.0'

--- a/packages/amplify_api/android/build.gradle
+++ b/packages/amplify_api/android/build.gradle
@@ -58,8 +58,8 @@ dependencies {
     api amplifyCore
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.amplifyframework:aws-api:1.24.0"
-    implementation "com.amplifyframework:aws-api-appsync:1.24.0"
+    implementation "com.amplifyframework:aws-api:1.24.1"
+    implementation "com.amplifyframework:aws-api-appsync:1.24.1"
     implementation 'androidx.test.ext:junit-ktx:1.1.3'
 
     testImplementation 'junit:junit:4.13'

--- a/packages/amplify_auth_cognito/android/build.gradle
+++ b/packages/amplify_auth_cognito/android/build.gradle
@@ -62,7 +62,7 @@ android {
 dependencies {
     api amplifyCore
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:aws-auth-cognito:1.24.0'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.24.1'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.10.0'
     testImplementation 'org.mockito:mockito-inline:3.1.0'

--- a/packages/amplify_core/android/build.gradle
+++ b/packages/amplify_core/android/build.gradle
@@ -61,7 +61,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:core:1.24.0'
+    implementation 'com.amplifyframework:core:1.24.1'
     implementation 'com.google.code.gson:gson:2.8.6'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -57,8 +57,8 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.amplifyframework:aws-datastore:1.24.0"
-    implementation "com.amplifyframework:aws-api-appsync:1.24.0"
+    implementation "com.amplifyframework:aws-datastore:1.24.1"
+    implementation "com.amplifyframework:aws-api-appsync:1.24.1"
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.10.0'
     testImplementation 'org.mockito:mockito-inline:3.10.0'

--- a/packages/amplify_flutter/android/build.gradle
+++ b/packages/amplify_flutter/android/build.gradle
@@ -58,7 +58,7 @@ android {
 
 dependencies {
     api amplifyCore
-    implementation 'com.amplifyframework:core:1.24.0'
+    implementation 'com.amplifyframework:core:1.24.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'
@@ -66,5 +66,5 @@ dependencies {
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'com.google.code.gson:gson:2.8.6'
-    testImplementation 'com.amplifyframework:aws-auth-cognito:1.24.0'
+    testImplementation 'com.amplifyframework:aws-auth-cognito:1.24.1'
 }

--- a/packages/amplify_storage_s3/android/build.gradle
+++ b/packages/amplify_storage_s3/android/build.gradle
@@ -49,5 +49,5 @@ android {
 dependencies {
     api amplifyCore
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:aws-storage-s3:1.24.0'
+    implementation 'com.amplifyframework:aws-storage-s3:1.24.1'
 }


### PR DESCRIPTION
*Issue #, if available:* [#511](https://github.com/aws-amplify/amplify-flutter/issues/511)

*Description of changes:*

Upgrade amplify-android to 1.24.1 to integrate the fix for not being able to query by null values.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
