### PR TITLE
fix(datastore): return null for list field in nested model

### DIFF
--- a/packages/amplify_datastore/ios/Classes/types/model/FlutterSerializedModel.swift
+++ b/packages/amplify_datastore/ios/Classes/types/model/FlutterSerializedModel.swift
@@ -176,7 +176,7 @@ struct FlutterSerializedModel: Model, JSONValueHolder {
             if case .object(let deserializedValue) = value {
                 // If a field that has many models
                 if (deserializedValue["associatedField"] != nil && deserializedValue["associatedId"] != nil) {
-                    result[key] = Array<Any>();
+                    result[key] = nil
                 }
                 // If a field that has one or belongs to a model
                 else if case .string(let modelId) = deserializedValue["id"],


### PR DESCRIPTION
*Issue #, if available:* #834

*Description of changes:*

Return `nil` for a list field in nested models in iOS to align the behavior cross platform.

---- 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
