### PR TITLE
fix(datastore): remove default pagination behavior on iOS

### DIFF
--- a/packages/amplify_datastore/example/integration_test/query_test/pagination_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/pagination_test.dart
@@ -77,12 +77,9 @@ void main() {
 
     testWidgets('should default to no pagination if none is provided',
         (WidgetTester tester) async {
-      var blogs = await Amplify.DataStore.query(
-        Blog.classType,
-        sortBy: [Blog.NAME.ascending()],
-      );
+      var blogs = await Amplify.DataStore.query(Blog.classType);
       expect(blogs.length, models.length);
-      expect(blogs, orderedEquals(sortedModels));
+      expect(blogs, unorderedEquals(models));
     });
 
     testWidgets('should default to a page size of 100',

--- a/packages/amplify_datastore/example/integration_test/query_test/pagination_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/pagination_test.dart
@@ -75,6 +75,16 @@ void main() {
       expect(blogs, isEmpty);
     });
 
+    testWidgets('should default to no pagination if none is provided',
+        (WidgetTester tester) async {
+      var blogs = await Amplify.DataStore.query(
+        Blog.classType,
+        sortBy: [Blog.NAME.ascending()],
+      );
+      expect(blogs.length, 1000);
+      expect(blogs, orderedEquals(sortedModels));
+    });
+
     testWidgets('should default to a page size of 100',
         (WidgetTester tester) async {
       var blogs = await Amplify.DataStore.query(

--- a/packages/amplify_datastore/example/integration_test/query_test/pagination_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/pagination_test.dart
@@ -81,7 +81,7 @@ void main() {
         Blog.classType,
         sortBy: [Blog.NAME.ascending()],
       );
-      expect(blogs.length, 1000);
+      expect(blogs.length, models.length);
       expect(blogs, orderedEquals(sortedModels));
     });
 

--- a/packages/amplify_datastore/example/ios/unit_tests/DataStorePluginUnitTests.swift
+++ b/packages/amplify_datastore/example/ios/unit_tests/DataStorePluginUnitTests.swift
@@ -114,7 +114,7 @@ class DataStorePluginUnitTests: XCTestCase {
                 XCTAssertEqual(testSchema.name, modelSchema.name)
                 XCTAssertEqual( QueryPredicateConstant.all, predicate as! QueryPredicateConstant)
                 XCTAssertNil(sortInput)
-                XCTAssertEqual(QueryPaginationInput.firstPage, paginationInput)
+                XCTAssertNil(paginationInput)
 
                 // Return errors from the mock
                 completion(.failure(causedBy: DataStoreError.invalidCondition("test error", "test recovery suggestion", nil)))

--- a/packages/amplify_datastore/example/ios/unit_tests/QueryPaginationUnitTests.swift
+++ b/packages/amplify_datastore/example/ios/unit_tests/QueryPaginationUnitTests.swift
@@ -48,9 +48,8 @@ class QueryPaginationBuilderUnitTests: XCTestCase {
         XCTAssertEqual(expected, actual)
     }
     
-    func test_when_no_input_given_results_in_first_page() throws {
-        let expected : QueryPaginationInput = QueryPaginationInput.firstPage
+    func test_when_no_input_given_results_in_no_pagination() throws {
         let actual = QueryPaginationBuilder.fromSerializedMap(nil)
-        XCTAssertEqual(expected, actual)
+        XCTAssertNil(actual)
     }
 }

--- a/packages/amplify_datastore/ios/Classes/types/query/QueryPaginationBuilder.swift
+++ b/packages/amplify_datastore/ios/Classes/types/query/QueryPaginationBuilder.swift
@@ -18,7 +18,7 @@ import Amplify
 
 public class QueryPaginationBuilder {
    
-    static func fromSerializedMap(_ serializedMap: [String: Any]?) -> QueryPaginationInput {
+    static func fromSerializedMap(_ serializedMap: [String: Any]?) -> QueryPaginationInput? {
         var page: UInt = 0, limit: UInt = QueryPaginationInput.defaultLimit;
         if let data = serializedMap {
             if let pageInput = (data["page"] as? Int) {
@@ -27,7 +27,9 @@ public class QueryPaginationBuilder {
             if let limitInput = (data["limit"] as? Int) {
                 limit = UInt(limitInput)
             }
+            return QueryPaginationInput.page(page, limit: limit)
+        } else {
+            return nil
         }
-        return QueryPaginationInput.page(page, limit: limit)
     }
 }

--- a/packages/amplify_datastore/ios/Classes/types/query/QueryPaginationBuilder.swift
+++ b/packages/amplify_datastore/ios/Classes/types/query/QueryPaginationBuilder.swift
@@ -19,8 +19,8 @@ import Amplify
 public class QueryPaginationBuilder {
    
     static func fromSerializedMap(_ serializedMap: [String: Any]?) -> QueryPaginationInput? {
-        var page: UInt = 0, limit: UInt = QueryPaginationInput.defaultLimit;
         if let data = serializedMap {
+            var page: UInt = 0, limit: UInt = QueryPaginationInput.defaultLimit;
             if let pageInput = (data["page"] as? Int) {
                 page = UInt(pageInput)
             }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/891

*Description of changes:*
- remove the default behavior in QueryPaginationBuilder on iOS to use a page of 0 and a limit of 100

Amplify-flutter, Amplify-iOS, and Amplify-Android all allow for null/nil page sizes in the `query()` API. Amplify-iOS and Amplify-iOS do not provide any default behavior if null/nil is provided. Currently in Amplify-flutter there are default values used on iOS, but not Android.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
