### PR TITLE
Graphql helpers query pred updated

### DIFF
--- a/packages/amplify_api/example/integration_test/graphql_tests.dart
+++ b/packages/amplify_api/example/integration_test/graphql_tests.dart
@@ -145,6 +145,23 @@ void main() {
       expect(data.items, containsAll(blogs));
     });
 
+    testWidgets(
+        'getRequestForNextResult should produce next page of results from first response',
+        (WidgetTester tester) async {
+      const limit = 1;
+      var firstReq = ModelQueries.list<Blog>(Blog.classType,
+          modelPagination: ModelPagination(limit: limit));
+      var firstRes = await Amplify.API.query(request: firstReq).response;
+      var firstData = firstRes.data;
+      expect(firstData.items.length, limit);
+      expect(firstData.hasNextResult(), true);
+      var secondReq = firstData.getRequestForNextResult();
+      var secondRes = await Amplify.API.query(request: secondReq).response;
+      var secondData = secondRes.data;
+      expect(secondData.items.length, limit);
+      expect(secondData.items[0].id, isNot(firstData.items[0].id));
+    });
+
     // Mutations
     testWidgets('should CREATE a blog with Model helper',
         (WidgetTester tester) async {

--- a/packages/amplify_api/lib/src/graphql/graphql_request_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/graphql_request_factory.dart
@@ -187,4 +187,13 @@ class GraphQLRequestFactory {
         modelType: modelType,
         decodePath: decodePath);
   }
+
+  Map<String, dynamic> buildVariables(
+      {int? limit, String? nextToken, QueryPredicate? queryPredicate}) {
+    return <String, dynamic>{
+      'filter': null, // TODO: handle query predicates
+      'limit': limit,
+      'nextToken': nextToken
+    };
+  }
 }

--- a/packages/amplify_api/lib/src/graphql/graphql_response_decoder.dart
+++ b/packages/amplify_api/lib/src/graphql/graphql_response_decoder.dart
@@ -54,9 +54,11 @@ class GraphQLResponseDecoder {
           recoverySuggestion:
               "Current GraphQLResponse is non-nullable, please ensure item exists before fetching");
     }
+    if (request.variables['limit'] != null) {
+      dataJson?['limit'] = request.variables['limit'];
+    }
 
     T decodedData = request.modelType!.fromJson(dataJson!) as T;
-
     return GraphQLResponse<T>(data: decodedData, errors: errors);
   }
 }

--- a/packages/amplify_api/lib/src/graphql/model_queries_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/model_queries_factory.dart
@@ -43,12 +43,8 @@ class ModelQueriesFactory extends ModelQueriesInterface {
     ModelPagination? modelPagination = const ModelPagination(),
     QueryPredicate? where,
   }) {
-    // ignore: implicit_dynamic_map_literal
-    Map<String, dynamic> variables = {
-      "filter": null, // TODO: handle query predicates
-      "limit": modelPagination?.limit,
-      "nextToken": null // TODO: need to handle nextToken input
-    };
+    final variables = GraphQLRequestFactory.instance
+        .buildVariables(limit: modelPagination?.limit, queryPredicate: where);
 
     return GraphQLRequestFactory.instance.buildRequest<PaginatedResult<T>>(
         modelType: PaginatedModelTypeImpl(modelType),

--- a/packages/amplify_api/lib/src/graphql/paginated_model_type_impl.dart
+++ b/packages/amplify_api/lib/src/graphql/paginated_model_type_impl.dart
@@ -10,7 +10,7 @@ class PaginatedModelTypeImpl<T extends Model> extends PaginatedModelType<T> {
     final itemsJson = jsonData['items'] as List?;
 
     if (itemsJson == null || itemsJson.isEmpty) {
-      return PaginatedResultImpl<T>([], null);
+      return PaginatedResultImpl<T>([], null, null);
     }
 
     final items = itemsJson
@@ -21,7 +21,8 @@ class PaginatedModelTypeImpl<T extends Model> extends PaginatedModelType<T> {
         )
         .toList();
 
-    return PaginatedResultImpl<T>(items, jsonData['nextToken'] as String?);
+    return PaginatedResultImpl<T>(
+        items, jsonData['limit'], jsonData['nextToken'] as String?);
   }
 
   @override

--- a/packages/amplify_api/lib/src/graphql/paginated_result_impl.dart
+++ b/packages/amplify_api/lib/src/graphql/paginated_result_impl.dart
@@ -14,13 +14,14 @@
  */
 
 import 'package:amplify_api/amplify_api.dart';
+import 'package:amplify_api/src/graphql/graphql_request_factory.dart';
 import 'package:amplify_api/src/graphql/paginated_model_type_impl.dart';
 // TODO: Datastore dependencies temporarily added in API. Eventually they should be moved to core or otherwise reconciled to avoid duplication.
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 
 class PaginatedResultImpl<T extends Model> extends PaginatedResult<T> {
-  const PaginatedResultImpl(List<T> items, String? nextToken)
-      : super(items, nextToken);
+  const PaginatedResultImpl(List<T> items, int? limit, String? nextToken)
+      : super(items, limit, nextToken);
 
   @override
   String getId() {
@@ -28,7 +29,30 @@ class PaginatedResultImpl<T extends Model> extends PaginatedResult<T> {
   }
 
   @override
-  PaginatedModelType<T> getInstanceType() {
+  bool hasNextResult() {
+    return limit != null && nextToken != null;
+  }
+
+  @override
+  GraphQLRequest<PaginatedResult<T>> getRequestForNextResult() {
+    if (!hasNextResult()) {
+      throw ApiException('Unable to get request for next page results.',
+          recoverySuggestion:
+              'Make sure you provide a limit to your request and that you expect additional data.');
+    }
+
+    final modelType = _getModelType();
+    final variables = GraphQLRequestFactory.instance
+        .buildVariables(limit: limit, nextToken: nextToken);
+
+    return GraphQLRequestFactory.instance.buildRequest<PaginatedResult<T>>(
+        modelType: PaginatedModelTypeImpl(modelType),
+        variables: variables,
+        requestType: GraphQLRequestType.query,
+        requestOperation: GraphQLRequestOperation.list);
+  }
+
+  ModelType<T> _getModelType() {
     ModelProviderInterface? provider = AmplifyAPI.instance.modelProvider;
     if (provider == null) {
       throw ApiException('No modelProvider found',
@@ -36,10 +60,12 @@ class PaginatedResultImpl<T extends Model> extends PaginatedResult<T> {
               'Pass in a modelProvider instance while instantiating APIPlugin');
     }
 
-    ModelType<T> modelType =
-        provider.getModelTypeByModelName(T.toString()) as ModelType<T>;
+    return provider.getModelTypeByModelName(T.toString()) as ModelType<T>;
+  }
 
-    return PaginatedModelTypeImpl(modelType);
+  @override
+  PaginatedModelType<T> getInstanceType() {
+    return PaginatedModelTypeImpl(_getModelType());
   }
 
   @override

--- a/packages/amplify_api_plugin_interface/lib/src/types/pagination/paginated_result.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/types/pagination/paginated_result.dart
@@ -20,7 +20,16 @@ import '../../types.dart';
 
 abstract class PaginatedResult<T extends Model> extends Model {
   final List<T> items;
+  final int? limit;
   final String? nextToken;
 
-  const PaginatedResult(this.items, this.nextToken);
+  const PaginatedResult(this.items, this.limit, this.nextToken);
+
+  bool hasNextResult() {
+    throw UnimplementedError('hasNextResult not been implemented.');
+  }
+
+  GraphQLRequest<PaginatedResult<T>> getRequestForNextResult() {
+    throw UnimplementedError('getRequestForNextResult not been implemented.');
+  }
 }

--- a/packages/amplify_api_plugin_interface/lib/src/types/pagination/paginated_result.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/types/pagination/paginated_result.dart
@@ -25,11 +25,7 @@ abstract class PaginatedResult<T extends Model> extends Model {
 
   const PaginatedResult(this.items, this.limit, this.nextToken);
 
-  bool hasNextResult() {
-    throw UnimplementedError('hasNextResult not been implemented.');
-  }
+  bool hasNextResult();
 
-  GraphQLRequest<PaginatedResult<T>> getRequestForNextResult() {
-    throw UnimplementedError('getRequestForNextResult not been implemented.');
-  }
+  GraphQLRequest<PaginatedResult<T>> getRequestForNextResult();
 }


### PR DESCRIPTION
This PR adds additional pagination helpers to the graphql helpers branch. Namely, adds `hasNextResult` and `getRequestForNextResult` to paginated result. Users can call these on a graphql response to get requests for additional pages of data.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
