### PR TITLE
chore: Update iOS deps to 1.14.0

### DIFF
--- a/packages/amplify_analytics_pinpoint/ios/amplify_analytics_pinpoint.podspec
+++ b/packages/amplify_analytics_pinpoint/ios/amplify_analytics_pinpoint.podspec
@@ -15,8 +15,8 @@ This code is the iOS part of the Amplify Flutter Pinpoint Analytics Plugin.  The
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.13.0'
-  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '~> 1.13.0'
+  s.dependency 'Amplify', '~> 1.14.0'
+  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '~> 1.14.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/amplify_api/ios/amplify_api.podspec
+++ b/packages/amplify_api/ios/amplify_api.podspec
@@ -15,8 +15,8 @@ The API module for Amplify Flutter.
   s.source           = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.13.0'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '~> 1.13.0'
+  s.dependency 'Amplify', '~> 1.14.0'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '~> 1.14.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/amplify_auth_cognito/ios/amplify_auth_cognito.podspec
+++ b/packages/amplify_auth_cognito/ios/amplify_auth_cognito.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.13.0'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '~> 1.13.0'
+  s.dependency 'Amplify', '~> 1.14.0'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '~> 1.14.0'
   s.dependency 'ObjectMapper'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,8 +15,8 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.13.0'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '~> 1.13.0'
+  s.dependency 'Amplify', '~> 1.14.0'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '~> 1.14.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '13.0'
 

--- a/packages/amplify_flutter/ios/amplify_flutter.podspec
+++ b/packages/amplify_flutter/ios/amplify_flutter.podspec
@@ -15,9 +15,9 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.13.0'
-  s.dependency 'AWSPluginsCore', '~> 1.13.0'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '~> 1.13.0'
+  s.dependency 'Amplify', '~> 1.14.0'
+  s.dependency 'AWSPluginsCore', '~> 1.14.0'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '~> 1.14.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/amplify_storage_s3/ios/amplify_storage_s3.podspec
+++ b/packages/amplify_storage_s3/ios/amplify_storage_s3.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.13.0'
-  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '~> 1.13.0'
+  s.dependency 'Amplify', '~> 1.14.0'
+  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '~> 1.14.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-amplify/amplify-ios/issues/1387
- https://github.com/aws-amplify/amplify-flutter/issues/935
- https://github.com/aws-amplify/amplify-flutter/issues/936

*Description of changes:*
- Update dependencies to amplify-ios 1.14.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
