### PR TITLE
graphql helpers: slight refactor to datastore interface QueryFieldOpe…

### DIFF
--- a/packages/amplify_datastore_plugin_interface/lib/src/types/query/query_field_operators.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/query/query_field_operators.dart
@@ -66,10 +66,10 @@ abstract class QueryFieldOperator {
   }
 }
 
-abstract class QueryFieldOperatorSimpleValue<T> extends QueryFieldOperator {
+abstract class QueryFieldOperatorSingleValue<T> extends QueryFieldOperator {
   final T value;
 
-  const QueryFieldOperatorSimpleValue(this.value, QueryFieldOperatorType type)
+  const QueryFieldOperatorSingleValue(this.value, QueryFieldOperatorType type)
       : super(type);
 
   @override
@@ -78,36 +78,36 @@ abstract class QueryFieldOperatorSimpleValue<T> extends QueryFieldOperator {
   }
 }
 
-class EqualQueryOperator<T> extends QueryFieldOperatorSimpleValue<T> {
+class EqualQueryOperator<T> extends QueryFieldOperatorSingleValue<T> {
   const EqualQueryOperator(value) : super(value, QueryFieldOperatorType.equal);
 }
 
-class NotEqualQueryOperator<T> extends QueryFieldOperatorSimpleValue<T> {
+class NotEqualQueryOperator<T> extends QueryFieldOperatorSingleValue<T> {
   const NotEqualQueryOperator(value)
       : super(value, QueryFieldOperatorType.not_equal);
 }
 
-class LessOrEqualQueryOperator<T> extends QueryFieldOperatorSimpleValue<T> {
+class LessOrEqualQueryOperator<T> extends QueryFieldOperatorSingleValue<T> {
   const LessOrEqualQueryOperator(value)
       : super(value, QueryFieldOperatorType.less_or_equal);
 }
 
-class LessThanQueryOperator<T> extends QueryFieldOperatorSimpleValue<T> {
+class LessThanQueryOperator<T> extends QueryFieldOperatorSingleValue<T> {
   const LessThanQueryOperator(value)
       : super(value, QueryFieldOperatorType.less_than);
 }
 
-class GreaterOrEqualQueryOperator<T> extends QueryFieldOperatorSimpleValue<T> {
+class GreaterOrEqualQueryOperator<T> extends QueryFieldOperatorSingleValue<T> {
   const GreaterOrEqualQueryOperator(value)
       : super(value, QueryFieldOperatorType.greater_or_equal);
 }
 
-class GreaterThanQueryOperator<T> extends QueryFieldOperatorSimpleValue<T> {
+class GreaterThanQueryOperator<T> extends QueryFieldOperatorSingleValue<T> {
   const GreaterThanQueryOperator(value)
       : super(value, QueryFieldOperatorType.greater_than);
 }
 
-class ContainsQueryOperator<T> extends QueryFieldOperatorSimpleValue<T> {
+class ContainsQueryOperator<T> extends QueryFieldOperatorSingleValue<T> {
   const ContainsQueryOperator(value)
       : super(value, QueryFieldOperatorType.contains);
 }
@@ -129,7 +129,7 @@ class BetweenQueryOperator<T> extends QueryFieldOperator {
   }
 }
 
-class BeginsWithQueryOperator extends QueryFieldOperatorSimpleValue<String> {
+class BeginsWithQueryOperator extends QueryFieldOperatorSingleValue<String> {
   const BeginsWithQueryOperator(String value)
       : super(value, QueryFieldOperatorType.begins_with);
 }


### PR DESCRIPTION
This PR is a small refactor to the `QueryFieldOperator` class that has no user-facing change. It adds the abstract class `QueryFieldOperatorSingleValue<T>` which is then used to extend all the `QueryFieldOperator` classes except between. Before this change, all the `QueryFieldOperator` classes (e.g. `NotEqualQueryOperator`) extend the `QueryFieldOperator` class and repeat a definition for a field `value` of type `<T>` as well as serialization logic. The only exception is between, which does not have a single value, and instead has a start and end. This PR adds the new abstract class and lets all the individual operators except contains inherit that definition. The benefit is there is only a single place that the value field, as well as serialization method.

This will later become useful when translating the query predicates to graphql queries, because we can do

```
if (queryFieldOperator is QueryFieldOperatorSingleValue) {
  print(queryFieldOperator.value);
}

```

Without this new abstract class, the above block needs to be re-written for equal, not equal, less than, etc...

I ran the datastore integration tests here on android and ios, passed fine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
