### PR TITLE
fix(datastore): configure function triggers initial sync unexpectedly

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -395,6 +395,11 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
     }
 
     fun onSetUpObserve(flutterResult: Result) {
+        if (this::observeCancelable.isInitialized) {
+            flutterResult.success(true)
+            return
+        }
+
         val plugin = Amplify.DataStore.getPlugin("awsDataStorePlugin") as AWSDataStorePlugin
 
         plugin.observe(

--- a/packages/amplify_datastore/test/amplify_datastore_observe_test.dart
+++ b/packages/amplify_datastore/test/amplify_datastore_observe_test.dart
@@ -39,14 +39,10 @@ void main() {
     dataStoreChannel.setMockMethodCallHandler(null);
   });
 
-  test('configure sets up the observe event channel', () async {
+  test('observe a valid model type and receive an item ', () async {
     dataStoreChannel.setMockMethodCallHandler((MethodCall methodCall) async {
       expect("setUpObserve", methodCall.method);
     });
-    dataStore.configure(configuration: '');
-  });
-
-  test('observe a valid model type and receive an item ', () async {
     var json =
         await getJsonFromFile('observe_api/post_type_success_event.json');
     eventChannel.setMockMethodCallHandler((MethodCall methodCall) async {
@@ -69,6 +65,9 @@ void main() {
   });
 
   test('observe a model type, but event is for different model type', () async {
+    dataStoreChannel.setMockMethodCallHandler((MethodCall methodCall) async {
+      expect("setUpObserve", methodCall.method);
+    });
     var json =
         await getJsonFromFile('observe_api/blog_type_success_event.json');
     eventChannel.setMockMethodCallHandler((MethodCall methodCall) async {


### PR DESCRIPTION
*Issue #, if available:* #736

*Description of changes:*

Originally below code is executed within `DataStore.configure`.

```
_channel.invokeMethod('setUpObserve', {})
```

This method channel call invokes `observe()` method of native DataStore plugins, which triggers `API_SYNC`. This behavior is undesired especially when data model authorization requires valid user session.

Moving the method call to each DataStore operation process, the actually logic of `setUpObserve` will only be invoked once.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
