### PR TITLE
chore(amplify_api): make data nullable in graphql responses

### DIFF
--- a/packages/amplify_api/example/lib/graphql_api_view.dart
+++ b/packages/amplify_api/example/lib/graphql_api_view.dart
@@ -83,6 +83,7 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
     var response = await operation.response;
     var data = response.data;
     if (data == null) {
+      print('errors: ' + response.errors.toString());
       return;
     }
 
@@ -112,6 +113,7 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
     var response = await operation.response;
     var data = response.data;
     if (data == null) {
+      print('errors: ' + response.errors.toString());
       return;
     }
 

--- a/packages/amplify_api/example/lib/graphql_api_view.dart
+++ b/packages/amplify_api/example/lib/graphql_api_view.dart
@@ -82,6 +82,9 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
 
     var response = await operation.response;
     var data = response.data;
+    if (data == null) {
+      return;
+    }
 
     print('Result data: ' + data);
     setState(() {
@@ -108,6 +111,9 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
 
     var response = await operation.response;
     var data = response.data;
+    if (data == null) {
+      return;
+    }
 
     print('Result data: ' + data);
     setState(() {

--- a/packages/amplify_api/lib/method_channel_api.dart
+++ b/packages/amplify_api/lib/method_channel_api.dart
@@ -213,8 +213,8 @@ class AmplifyAPIMethodChannel extends AmplifyAPI {
       }
       final errors = _deserializeGraphQLResponseErrors(result);
 
-      GraphQLResponse<T> response = GraphQLResponseDecoder.instance.decode<T>(
-          request: request, data: result['data'] ?? '', errors: errors);
+      GraphQLResponse<T> response = GraphQLResponseDecoder.instance
+          .decode<T>(request: request, data: result['data'], errors: errors);
 
       return response;
     } on PlatformException catch (e) {

--- a/packages/amplify_api/lib/src/graphql/graphql_response_decoder.dart
+++ b/packages/amplify_api/lib/src/graphql/graphql_response_decoder.dart
@@ -13,10 +13,14 @@ class GraphQLResponseDecoder {
 
   GraphQLResponse<T> decode<T>(
       {required GraphQLRequest request,
-      required String data,
+      String? data,
       required List<GraphQLResponseError> errors}) {
-    // if no ModelType fallback to default
-    if (request.modelType == null) {
+    if (data == null) {
+      return GraphQLResponse(data: null, errors: errors);
+    }
+    // If no modelType fallback to default (likely String).
+    final modelType = request.modelType;
+    if (modelType == null) {
       if (T == String || T == dynamic) {
         return GraphQLResponse(
             data: data as T, errors: errors); // <T> is implied
@@ -26,26 +30,22 @@ class GraphQLResponseDecoder {
             recoverySuggestion: "Please provide a Model Type or type 'String'");
       }
     }
-
-    if (data == '') {
-      // TODO: T data is non-nullable, need to handle valid null response
-      throw ApiException('response from app sync was "null"',
-          recoverySuggestion:
-              "Current GraphQLResponse is non-nullable, please ensure item exists before fetching");
-    }
+    // From here, it appears this is a response that must be parsed into a non-string object.
 
     if (request.decodePath == null) {
       throw ApiException('No decodePath found',
           recoverySuggestion: 'Include decodePath when creating a request');
     }
 
+    // Even if the data string is not null, it may be a null value shallow
+    // nested in a small JSON object in the `decodePath`. Its structure varies by
+    // platform when null. Unpack the JSON object and null check the result along
+    // the way. If null at any point, return null response.
     Map<String, dynamic>? dataJson = json.decode(data);
     if (dataJson == null) {
-      throw ApiException(
-          'Unable to decode json response, data received was null');
+      return GraphQLResponse(data: null, errors: errors);
     }
-
-    request.decodePath!.split(".").forEach((element) {
+    request.decodePath!.split('.').forEach((element) {
       if (!dataJson!.containsKey(element)) {
         throw ApiException(
             'decodePath did not match the structure of the JSON response',
@@ -54,23 +54,19 @@ class GraphQLResponseDecoder {
       }
       dataJson = dataJson![element];
     });
-
     if (dataJson == null) {
-      // TODO: T data is non-nullable, need to handle valid null response
-      throw ApiException('response from app sync was "null"',
-          recoverySuggestion:
-              "Current GraphQLResponse is non-nullable, please ensure item exists before fetching");
+      return GraphQLResponse(data: null, errors: errors);
     }
 
+    // Found a JSON object to represent the model, parse it using model's fromJSON.
     T decodedData;
-    final modelType = request.modelType;
     if (modelType is PaginatedModelType) {
       Map<String, dynamic>? filter = request.variables['filter'];
       int? limit = request.variables['limit'];
       decodedData =
           modelType.fromJson(dataJson!, limit: limit, filter: filter) as T;
     } else {
-      decodedData = modelType!.fromJson(dataJson!) as T;
+      decodedData = modelType.fromJson(dataJson!) as T;
     }
     return GraphQLResponse<T>(data: decodedData, errors: errors);
   }

--- a/packages/amplify_api/test/amplify_api_mutate_test.dart
+++ b/packages/amplify_api/test/amplify_api_mutate_test.dart
@@ -99,7 +99,7 @@ void main() {
         await api.mutate(request: ModelMutations.create<Blog>(blog));
 
     var response = await operation.response;
-    expect(response.data.equals(blog), isTrue);
+    expect(response.data?.equals(blog), isTrue);
   });
 
   test('ModelMutations.delete() executes correctly in the happy case',

--- a/packages/amplify_api/test/amplify_api_query_test.dart
+++ b/packages/amplify_api/test/amplify_api_query_test.dart
@@ -115,7 +115,7 @@ void main() {
 
     expect(req.document, expectedDoc);
     expect(response.data, isA<Blog>());
-    expect(response.data.id, id);
+    expect(response.data?.id, id);
   });
 
   test('ModelQueries.list Model Helper executes correctly in the happy case',
@@ -163,7 +163,7 @@ void main() {
 
     expect(req.document, expectedDoc);
     expect(response.data, isA<PaginatedResult<Blog>>());
-    expect(response.data.items.length, 4);
+    expect(response.data?.items.length, 4);
   });
 
   test(

--- a/packages/amplify_api/test/graphql_error_test.dart
+++ b/packages/amplify_api/test/graphql_error_test.dart
@@ -49,7 +49,7 @@ void main() {
         )
         .response;
 
-    expect(resp.data, equals(''));
+    expect(resp.data, equals(null));
     expect(resp.errors.single, equals(expected));
   });
 }

--- a/packages/amplify_api/test/graphql_helpers_test.dart
+++ b/packages/amplify_api/test/graphql_helpers_test.dart
@@ -61,7 +61,7 @@ void main() {
             .decode<Blog>(request: req, data: data, errors: errors);
 
         expect(response.data, isA<Blog>());
-        expect(response.data.id, id);
+        expect(response.data?.id, id);
       });
       test('ModelQueries.list() should build a valid request', () async {
         String expected =
@@ -147,8 +147,8 @@ void main() {
                 request: req, data: data, errors: errors);
 
         expect(response.data, isA<PaginatedResult<Blog>>());
-        expect(response.data.items, isA<List<Blog>>());
-        expect(response.data.items.length, 2);
+        expect(response.data?.items, isA<List<Blog>>());
+        expect(response.data?.items.length, 2);
       });
 
       test(
@@ -180,13 +180,13 @@ void main() {
         GraphQLResponse<PaginatedResult<Blog>> response =
             GraphQLResponseDecoder.instance.decode<PaginatedResult<Blog>>(
                 request: req, data: data, errors: errors);
-        expect(response.data.hasNextResult, true);
+        expect(response.data?.hasNextResult, true);
         String expectedDocument =
             r'query listBlogs($filter: ModelBlogFilterInput, $limit: Int, $nextToken: String) { listBlogs(filter: $filter, limit: $limit, nextToken: $nextToken) { items { id name createdAt } nextToken } }';
-        final resultRequest = response.data.requestForNextResult!;
-        expect(resultRequest.document, expectedDocument);
-        expect(resultRequest.variables['nextToken'], response.data.nextToken);
-        expect(resultRequest.variables['limit'], limit);
+        final resultRequest = response.data?.requestForNextResult!;
+        expect(resultRequest?.document, expectedDocument);
+        expect(resultRequest?.variables['nextToken'], response.data?.nextToken);
+        expect(resultRequest?.variables['limit'], limit);
       });
 
       test(
@@ -217,7 +217,7 @@ void main() {
         GraphQLResponse<PaginatedResult<Blog>> response =
             GraphQLResponseDecoder.instance.decode<PaginatedResult<Blog>>(
                 request: req, data: data, errors: errors);
-        expect(response.data.hasNextResult, false);
+        expect(response.data?.hasNextResult, false);
       });
 
       test(
@@ -276,10 +276,10 @@ void main() {
             GraphQLResponseDecoder.instance.decode<PaginatedResult<Blog>>(
                 request: req, data: data, errors: errors);
         Map<String, dynamic> firstRequestFilter = req.variables['filter'];
-        final resultRequest = response.data.requestForNextResult!;
+        final resultRequest = response.data?.requestForNextResult!;
 
-        expect(resultRequest.variables['filter'], firstRequestFilter);
-        expect(resultRequest.variables['filter'], expectedFilter);
+        expect(resultRequest?.variables['filter'], firstRequestFilter);
+        expect(resultRequest?.variables['filter'], expectedFilter);
       });
     });
 

--- a/packages/amplify_api_plugin_interface/lib/src/graphql/graphql_response.dart
+++ b/packages/amplify_api_plugin_interface/lib/src/graphql/graphql_response.dart
@@ -16,11 +16,11 @@
 import '../types.dart';
 
 class GraphQLResponse<T> {
-  final T data;
+  final T? data;
   final List<GraphQLResponseError> errors;
 
   const GraphQLResponse({
-    required this.data,
+    this.data,
     required this.errors,
   });
 }


### PR DESCRIPTION
BREAKING CHANGE: data field nullable in GraphQLResponse

This PR makes the data field nullable in graphql responses for the graphql helper branch. Eventually, it will get merged into release-candidate and go out with 0.3.x release. It has the type change as well as some changes to the decoder for models in API responses, and lots of null check operators in tests (kinda like a user would have to start doing with this change). There is also a small change to the API example app for null checking responses.

To recap reason for this, it's in the Graphql spec that data can be null on responses. AppSync sends null data responses in lots of normal situations, like fetching a blog that does not exist (think 404). For simple string responses, we default to empty string right now, which is not only wrong, but impossible to apply to the situation of a model object. We cannot parse null to a model. The only correct thing to do is forward the null response. 0.3.x will start doing this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
