### PR TITLE
fix(datastore): Android TemporalTime Save Issue

### DIFF
--- a/packages/amplify_datastore/example/integration_test/model_type_test.dart
+++ b/packages/amplify_datastore/example/integration_test/model_type_test.dart
@@ -168,9 +168,7 @@ void main() {
         DateTime(2020, 01, 01, 00, 00, 00),
         DateTime(2020, 01, 01, 23, 59, 59),
         DateTime(2999, 12, 31, 23, 59, 59),
-        // TemporalDateTime values with milliseconds & microseconds are not parsed correctly on Android
-        // see: https://github.com/aws-amplify/amplify-flutter/issues/817
-        // DateTime(2999, 12, 31, 23, 59, 59, 999, 999),
+        DateTime(2999, 12, 31, 23, 59, 59, 999, 999),
       ];
       var models = values
           .map((value) => DateTimeTypeModel(value: TemporalDateTime(value)))
@@ -212,9 +210,7 @@ void main() {
         DateTime(2020, 01, 01, 00, 00, 00),
         DateTime(2020, 01, 01, 23, 59, 59),
         DateTime(2999, 12, 31, 23, 59, 59),
-        // TemporalTime values with milliseconds & microseconds are not parsed correctly on Android
-        // see: https://github.com/aws-amplify/amplify-flutter/issues/817
-        // DateTime(2999, 12, 31, 23, 59, 59, 999, 999),
+        DateTime(2999, 12, 31, 23, 59, 59, 999, 999),
       ];
       var models = values
           .map((value) => TimeTypeModel(value: TemporalTime(value)))

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/temporal/temporal_datetime.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/temporal/temporal_datetime.dart
@@ -99,7 +99,7 @@ class TemporalDateTime implements Comparable<TemporalDateTime> {
     // Parse cannot take a YYYY-MM-DD as UTC!
     DateTime dateTime = DateTime.parse(match.group(1)!.split(".")[0]);
 
-    int totalNanoseconds = Temporal.getIntOr0(match.group(4));
+    int totalNanoseconds = Temporal.getIntOr0(match.group(4)?.padRight(9, "0"));
     int milliseconds = totalNanoseconds ~/ 1000000;
     int microseconds = (totalNanoseconds ~/ 1000) % 1000;
     _nanoseconds = totalNanoseconds % 1000;

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/temporal/temporal_time.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/temporal/temporal_time.dart
@@ -88,7 +88,7 @@ class TemporalTime implements Comparable<TemporalTime> {
     int minutes = int.parse(match.group(2)!);
     int seconds = Temporal.getIntOr0(match.group(4));
 
-    int totalNanoseconds = Temporal.getIntOr0(match.group(6));
+    int totalNanoseconds = Temporal.getIntOr0(match.group(6)?.padRight(9, "0"));
     int milliseconds = totalNanoseconds ~/ 1000000;
     int microseconds = (totalNanoseconds ~/ 1000) % 1000;
     _nanoseconds = totalNanoseconds % 1000;

--- a/packages/amplify_datastore_plugin_interface/test/amplify_temporal_datetime_test.dart
+++ b/packages/amplify_datastore_plugin_interface/test/amplify_temporal_datetime_test.dart
@@ -128,9 +128,9 @@ void main() {
     Duration duration = Duration(hours: 3, minutes: 25, seconds: 55);
 
     expect(time.getOffset(), duration);
-    expect(
-        time.getDateTimeInUtc(), DateTime.utc(1995, 05, 03, 03, 30, 25, 0, 99));
-    expect(time.format(), "1995-05-03T03:30:25.000099999+03:25:55");
+    expect(time.getDateTimeInUtc(),
+        DateTime.utc(1995, 05, 03, 03, 30, 25, 999, 990));
+    expect(time.format(), "1995-05-03T03:30:25.999990000+03:25:55");
   });
 
   test('AWSDateTime from offset with single digit duration', () async {


### PR DESCRIPTION
Add padding in fromString method for TemporalDateTime and TemporalTime to replace trailing “0”s removed by Android.

Fixes issues: 

https://github.com/aws-amplify/amplify-flutter/issues/817
https://github.com/aws-amplify/amplify-flutter/issues/579




Fix suggested by @martinzuccotti

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
