### PR TITLE
chore: refactor model mutation processing in QuerySnapshot

### DIFF
--- a/packages/amplify_datastore_plugin_interface/lib/src/types/models/query_snapshot.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/models/query_snapshot.dart
@@ -31,7 +31,8 @@ class QuerySnapshot<T extends Model> {
   // A list of models sorted according to the value provided for sortBy
   final SortedList<T> _sortedList;
 
-  // A Set of modelIds, used to
+  // A map of models in the sorted list, used to effeciently perform
+  // lookups on the list by model id
   final Map<String, T> _models;
 
   /// A list of models from the local store at the time that the snapshot was generated

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/models/sorted_list.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/models/sorted_list.dart
@@ -72,24 +72,28 @@ class SortedList<E> with ListMixin<E> {
       add(item);
       return;
     }
-    int insertIndex = _findInsertionIndex(item);
+    int insertIndex = _findIndex(item);
     insert(insertIndex, item);
   }
 
   /// Updates an item in the list, maintaining the sort order
-  void updateAtSorted(int index, E item) {
+  void updateSorted(E oldItem, E newItem) {
     if (this._compare == null) {
-      this[index] = item;
+      int index = this.indexOf(oldItem);
+      this[index] = newItem;
     } else {
+      int index = this._findIndex(oldItem);
       removeAt(index);
-      addSorted(item);
+      addSorted(newItem);
     }
   }
 
-  /// Finds the index to insert the [item] at
+  /// Finds the index of the given item
+  /// if the item is not in the list, the appropriate
+  /// index to insert the [item] at will be returned
   ///
   /// O(log(n)) time complexity
-  int _findInsertionIndex(E item) {
+  int _findIndex(E item) {
     int low = 0;
     int high = _items.length;
 

--- a/packages/amplify_datastore_plugin_interface/test/sorted_list_test.dart
+++ b/packages/amplify_datastore_plugin_interface/test/sorted_list_test.dart
@@ -48,15 +48,15 @@ void main() {
       });
     });
 
-    group('updateAt()', () {
+    group('updateSorted()', () {
       test('updates the item and maintains the sort order', () {
         List<int> items = [1, 2, 3, 7, 10];
         SortedList<int> sortedList = SortedList.fromPresortedList(
           items: items,
           compare: (a, b) => a.compareTo(b),
         );
-        sortedList.updateAtSorted(1, 5);
-        sortedList.updateAtSorted(4, 1);
+        sortedList.updateSorted(2, 5);
+        sortedList.updateSorted(10, 1);
 
         var expectedItems = [1, 1, 3, 5, 7];
         expect(sortedList.toList(), orderedEquals(expectedItems));
@@ -66,8 +66,8 @@ void main() {
           () {
         List<int> items = [1, 2, 3, 7, 10];
         SortedList<int> sortedList = SortedList.fromPresortedList(items: items);
-        sortedList.updateAtSorted(1, 5);
-        sortedList.updateAtSorted(4, 1);
+        sortedList.updateSorted(2, 5);
+        sortedList.updateSorted(10, 1);
 
         var expectedItems = [1, 5, 3, 7, 1];
         expect(sortedList.toList(), orderedEquals(expectedItems));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There are two goals of this PR:
1. Improve code readability for QuerySnapshot.withSubscriptionEvent().
2. Improve efficiency of processing mutation events, specifically in cases where the mutation doesn't result in a new QuerySnapshot (due to a query predicate). This PR removes a call to `list.indexWhere()` that was running on each mutation. The purpose of this was to lookup a model in the cached data by ID. In place of this, a map of models is cached and updated, which reflects the models in the list. Lookups on the map are O(1), opposed to O(n) for lookups in the list. With the updates, processing mutations that do not result in a new snapshot should no longer depend on the size of the snapshot. The time to process mutations that _do_ result in a new snapshot will likely increase due to the need to clone/update the map each time. 

*Perf Testing*

The theoretical performance impacts were validated via performance testing on an iPhone 11 in profile mode. A data set of ~7,000 Posts were synced to the device, with a query predicate that would result in about half of the 7,000 models resulting in a new QuerySnapshot. This is intended to simulate a high TPS scenario in which many of the mutations do not result in new QuerySnapshots.

Below are the details. With the changes, the amount of time it takes to process a mutation that doesn't result in a new snapshot is constant (does not depend on snapshot size). The amount of time it takes to process a snapshot that _does_ result in a new QuerySnapshot is increased as expected.

Avg time below is the average amount of time it took to process one model mutation event.

| Snapshot size 	| Mutation Result 	| Avg time (main branch) 	| Avg time (w/ PR changes) 	|
|---------------	|-----------------	|------------------------	|--------------------------	|
| ~100 items    	| No new snapshot 	| ~0.010 ms              	| ~0.010 ms                	|
| 5,000+ items  	| No new snapshot 	| **~0.250 ms**              	| **~0.010 ms**                	|
| ~100 items    	| New Snapshot    	| ~0.015 ms              	| ~0.020 ms                	|
| 5,000+ items  	| New Snapshot    	| ~0.250 ms              	| ~0.500 ms                	|

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
