### PR TITLE
fix: check attribute verification after confirm sign in

### DIFF
--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -169,7 +169,7 @@ class StateMachineBloc {
               );
             }
           }
-          yield const Authenticated();
+          yield* _checkUserVerification();
           break;
         default:
           break;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Check that a user's attributes are verified after confirm sign in. Currently this is only done after sign in, not _confirm_ sign in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
