### PR TITLE
fix(datastore): fix temporal date/time query predicates

### DIFF
--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_query_predicate_test.dart
@@ -41,14 +41,8 @@ void main() {
     var models =
         dates.map((date) => DateTypeModel(value: TemporalDate(date))).toList();
 
-    // non-null models used for all tests
-    var nonNullModels = models.where((e) => e.value != null).toList();
-
     // distinct list of values in the test models
-    var values = models.map((e) => e.value).toSet().toList();
-
-    // distinct list of non-null values in the test models
-    var nonNullValues = values.whereType<TemporalDate>().toList();
+    var values = models.map((e) => e.value!).toSet().toList();
 
     setUpAll(() async {
       await configureDataStore();
@@ -59,7 +53,7 @@ void main() {
     });
     testWidgets('eq()', (WidgetTester tester) async {
       // test against all values
-      for (var value in nonNullValues) {
+      for (var value in values) {
         var expectedModels =
             models.where((model) => model.value == value).toList();
         await testQueryPredicate<DateTypeModel>(
@@ -71,9 +65,9 @@ void main() {
 
     testWidgets('ne()', (WidgetTester tester) async {
       // test against all values
-      for (var value in nonNullValues) {
+      for (var value in values) {
         var expectedModels =
-            nonNullModels.where((model) => model.value != value).toList();
+            models.where((model) => model.value != value).toList();
         await testQueryPredicate<DateTypeModel>(
           queryPredicate: DateTypeModel.VALUE.ne(value),
           expectedModels: expectedModels,
@@ -82,11 +76,10 @@ void main() {
     });
 
     testWidgets('lt()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
-            .where((model) => model.value!.compareTo(value) < 0)
-            .toList();
+      // test against all values
+      for (var value in values) {
+        var expectedModels =
+            models.where((model) => model.value!.compareTo(value) < 0).toList();
         await testQueryPredicate<DateTypeModel>(
           queryPredicate: DateTypeModel.VALUE.lt(value),
           expectedModels: expectedModels,
@@ -95,9 +88,9 @@ void main() {
     });
 
     testWidgets('le()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
+      // test against all values
+      for (var value in values) {
+        var expectedModels = models
             .where((model) => model.value!.compareTo(value) <= 0)
             .toList();
         await testQueryPredicate<DateTypeModel>(
@@ -108,11 +101,10 @@ void main() {
     });
 
     testWidgets('gt()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
-            .where((model) => model.value!.compareTo(value) > 0)
-            .toList();
+      // test against all values
+      for (var value in values) {
+        var expectedModels =
+            models.where((model) => model.value!.compareTo(value) > 0).toList();
         await testQueryPredicate<DateTypeModel>(
           queryPredicate: DateTypeModel.VALUE.gt(value),
           expectedModels: expectedModels,
@@ -121,9 +113,9 @@ void main() {
     });
 
     testWidgets('ge()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
+      // test against all values
+      for (var value in values) {
+        var expectedModels = models
             .where((model) => model.value!.compareTo(value) >= 0)
             .toList();
         await testQueryPredicate<DateTypeModel>(
@@ -137,7 +129,7 @@ void main() {
       // test with partial match
       var partialMatchStart = models[1].value!;
       var partialMatchEnd = models[3].value!;
-      var rangeMatchModels = nonNullModels
+      var rangeMatchModels = models
           .where((model) => model.value!.compareTo(partialMatchStart) >= 0)
           .where((model) => model.value!.compareTo(partialMatchEnd) <= 0)
           .toList();

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_query_predicate_test.dart
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_datastore/amplify_datastore.dart';
+import 'package:amplify_datastore_example/models/ModelProvider.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:amplify_flutter/amplify.dart';
+
+import '../../utils/query_predicate_utils.dart';
+import '../../utils/setup_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('type AWS Date', () {
+    // models used for all tests
+    var models = [
+      DateTypeModel(value: TemporalDate(DateTime(2020, 1, 1))),
+      DateTypeModel(value: TemporalDate(DateTime(2020, 1, 2))),
+      DateTypeModel(value: TemporalDate(DateTime(2020, 2, 1))),
+    ];
+
+    // non-null models used for all tests
+    var nonNullModels = models.where((e) => e.value != null).toList();
+
+    // distinct list of values in the test models
+    var values = models.map((e) => e.value).toSet().toList();
+
+    // distinct list of non-null values in the test models
+    var nonNullValues = values.whereType<TemporalDate>().toList();
+
+    setUpAll(() async {
+      await configureDataStore();
+      await clearDataStore();
+      for (var model in models) {
+        await Amplify.DataStore.save(model);
+      }
+    });
+    testWidgets('eq()', (WidgetTester tester) async {
+      // test against all values
+      for (var value in nonNullValues) {
+        var expectedModels =
+            models.where((model) => model.value == value).toList();
+        await testQueryPredicate<DateTypeModel>(
+          queryPredicate: DateTypeModel.VALUE.eq(value.getDateTime()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('ne()', (WidgetTester tester) async {
+      // test against all values
+      for (var value in nonNullValues) {
+        var expectedModels =
+            nonNullModels.where((model) => model.value != value).toList();
+        await testQueryPredicate<DateTypeModel>(
+          queryPredicate: DateTypeModel.VALUE.ne(value.getDateTime()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('lt()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) < 0)
+            .toList();
+        await testQueryPredicate<DateTypeModel>(
+          queryPredicate: DateTypeModel.VALUE.lt(value.getDateTime()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('le()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) <= 0)
+            .toList();
+        await testQueryPredicate<DateTypeModel>(
+          queryPredicate: DateTypeModel.VALUE.le(value.getDateTime()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('gt()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) > 0)
+            .toList();
+        await testQueryPredicate<DateTypeModel>(
+          queryPredicate: DateTypeModel.VALUE.gt(value.getDateTime()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('ge()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) >= 0)
+            .toList();
+        await testQueryPredicate<DateTypeModel>(
+          queryPredicate: DateTypeModel.VALUE.ge(value.getDateTime()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('between()', (WidgetTester tester) async {
+      // test with partial match
+      var partialMatchStart = models[1].value!;
+      var partialMatchEnd = models[2].value!;
+      var rangeMatchModels = nonNullModels
+          .where((model) => model.value!.compareTo(partialMatchStart) >= 0)
+          .where((model) => model.value!.compareTo(partialMatchEnd) <= 0)
+          .toList();
+      // verify that the test is testing a partial match
+      expect(rangeMatchModels.length, greaterThanOrEqualTo(1));
+      await testQueryPredicate<DateTypeModel>(
+        queryPredicate: DateTypeModel.VALUE.between(
+            partialMatchStart.getDateTime(), partialMatchEnd.getDateTime()),
+        expectedModels: rangeMatchModels,
+      );
+    });
+  });
+}

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_query_predicate_test.dart
@@ -26,12 +26,20 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('type AWS Date', () {
-    // models used for all tests
-    var models = [
-      DateTypeModel(value: TemporalDate(DateTime(2020, 1, 1))),
-      DateTypeModel(value: TemporalDate(DateTime(2020, 1, 2))),
-      DateTypeModel(value: TemporalDate(DateTime(2020, 2, 1))),
+    // dates users for all tests
+    var dates = [
+      DateTime.fromMillisecondsSinceEpoch(0),
+      DateTime(1970),
+      DateTime(2020, 1, 1),
+      DateTime(2020, 1, 1),
+      DateTime(2020, 1, 2),
+      DateTime(2020, 2, 1),
+      DateTime(2020, 12, 31, 23, 59, 59),
     ];
+
+    // models used for all tests
+    var models =
+        dates.map((date) => DateTypeModel(value: TemporalDate(date))).toList();
 
     // non-null models used for all tests
     var nonNullModels = models.where((e) => e.value != null).toList();
@@ -55,7 +63,7 @@ void main() {
         var expectedModels =
             models.where((model) => model.value == value).toList();
         await testQueryPredicate<DateTypeModel>(
-          queryPredicate: DateTypeModel.VALUE.eq(value.getDateTime()),
+          queryPredicate: DateTypeModel.VALUE.eq(value),
           expectedModels: expectedModels,
         );
       }
@@ -67,7 +75,7 @@ void main() {
         var expectedModels =
             nonNullModels.where((model) => model.value != value).toList();
         await testQueryPredicate<DateTypeModel>(
-          queryPredicate: DateTypeModel.VALUE.ne(value.getDateTime()),
+          queryPredicate: DateTypeModel.VALUE.ne(value),
           expectedModels: expectedModels,
         );
       }
@@ -80,7 +88,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) < 0)
             .toList();
         await testQueryPredicate<DateTypeModel>(
-          queryPredicate: DateTypeModel.VALUE.lt(value.getDateTime()),
+          queryPredicate: DateTypeModel.VALUE.lt(value),
           expectedModels: expectedModels,
         );
       }
@@ -93,7 +101,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) <= 0)
             .toList();
         await testQueryPredicate<DateTypeModel>(
-          queryPredicate: DateTypeModel.VALUE.le(value.getDateTime()),
+          queryPredicate: DateTypeModel.VALUE.le(value),
           expectedModels: expectedModels,
         );
       }
@@ -106,7 +114,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) > 0)
             .toList();
         await testQueryPredicate<DateTypeModel>(
-          queryPredicate: DateTypeModel.VALUE.gt(value.getDateTime()),
+          queryPredicate: DateTypeModel.VALUE.gt(value),
           expectedModels: expectedModels,
         );
       }
@@ -119,7 +127,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) >= 0)
             .toList();
         await testQueryPredicate<DateTypeModel>(
-          queryPredicate: DateTypeModel.VALUE.ge(value.getDateTime()),
+          queryPredicate: DateTypeModel.VALUE.ge(value),
           expectedModels: expectedModels,
         );
       }
@@ -128,16 +136,19 @@ void main() {
     testWidgets('between()', (WidgetTester tester) async {
       // test with partial match
       var partialMatchStart = models[1].value!;
-      var partialMatchEnd = models[2].value!;
+      var partialMatchEnd = models[3].value!;
       var rangeMatchModels = nonNullModels
           .where((model) => model.value!.compareTo(partialMatchStart) >= 0)
           .where((model) => model.value!.compareTo(partialMatchEnd) <= 0)
           .toList();
+
       // verify that the test is testing a partial match
       expect(rangeMatchModels.length, greaterThanOrEqualTo(1));
       await testQueryPredicate<DateTypeModel>(
         queryPredicate: DateTypeModel.VALUE.between(
-            partialMatchStart.getDateTime(), partialMatchEnd.getDateTime()),
+          partialMatchStart,
+          partialMatchEnd,
+        ),
         expectedModels: rangeMatchModels,
       );
     });

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_time_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_time_query_predicate_test.dart
@@ -47,14 +47,8 @@ void main() {
         .map((date) => DateTimeTypeModel(value: TemporalDateTime(date)))
         .toList();
 
-    // non-null models used for all tests
-    var nonNullModels = models.where((e) => e.value != null).toList();
-
     // distinct list of values in the test models
-    var values = models.map((e) => e.value).toSet().toList();
-
-    // distinct list of non-null values in the test models
-    var nonNullValues = values.whereType<TemporalDateTime>().toList();
+    var values = models.map((e) => e.value!).toSet().toList();
 
     setUpAll(() async {
       await configureDataStore();
@@ -65,7 +59,7 @@ void main() {
     });
     testWidgets('eq()', (WidgetTester tester) async {
       // test against all values
-      for (var value in nonNullValues) {
+      for (var value in values) {
         var expectedModels =
             models.where((model) => model.value == value).toList();
         await testQueryPredicate<DateTimeTypeModel>(
@@ -77,9 +71,9 @@ void main() {
 
     testWidgets('ne()', (WidgetTester tester) async {
       // test against all values
-      for (var value in nonNullValues) {
+      for (var value in values) {
         var expectedModels =
-            nonNullModels.where((model) => model.value != value).toList();
+            models.where((model) => model.value != value).toList();
         await testQueryPredicate<DateTimeTypeModel>(
           queryPredicate: DateTimeTypeModel.VALUE.ne(value),
           expectedModels: expectedModels,
@@ -88,11 +82,10 @@ void main() {
     });
 
     testWidgets('lt()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
-            .where((model) => model.value!.compareTo(value) < 0)
-            .toList();
+      // test against all values
+      for (var value in values) {
+        var expectedModels =
+            models.where((model) => model.value!.compareTo(value) < 0).toList();
         await testQueryPredicate<DateTimeTypeModel>(
           queryPredicate: DateTimeTypeModel.VALUE.lt(value),
           expectedModels: expectedModels,
@@ -101,9 +94,9 @@ void main() {
     });
 
     testWidgets('le()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
+      // test against all values
+      for (var value in values) {
+        var expectedModels = models
             .where((model) => model.value!.compareTo(value) <= 0)
             .toList();
         await testQueryPredicate<DateTimeTypeModel>(
@@ -114,11 +107,10 @@ void main() {
     });
 
     testWidgets('gt()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
-            .where((model) => model.value!.compareTo(value) > 0)
-            .toList();
+      // test against all values
+      for (var value in values) {
+        var expectedModels =
+            models.where((model) => model.value!.compareTo(value) > 0).toList();
         await testQueryPredicate<DateTimeTypeModel>(
           queryPredicate: DateTimeTypeModel.VALUE.gt(value),
           expectedModels: expectedModels,
@@ -127,9 +119,9 @@ void main() {
     });
 
     testWidgets('ge()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
+      // test against all values
+      for (var value in values) {
+        var expectedModels = models
             .where((model) => model.value!.compareTo(value) >= 0)
             .toList();
         await testQueryPredicate<DateTimeTypeModel>(
@@ -143,7 +135,7 @@ void main() {
       // test with partial match
       var partialMatchStart = models[1].value!;
       var partialMatchEnd = models[3].value!;
-      var rangeMatchModels = nonNullModels
+      var rangeMatchModels = models
           .where((model) => model.value!.compareTo(partialMatchStart) >= 0)
           .where((model) => model.value!.compareTo(partialMatchEnd) <= 0)
           .toList();

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_time_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_time_query_predicate_test.dart
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_datastore/amplify_datastore.dart';
+import 'package:amplify_datastore_example/models/ModelProvider.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:amplify_flutter/amplify.dart';
+
+import '../../utils/query_predicate_utils.dart';
+import '../../utils/setup_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('type AWS DateTime', () {
+    // models used for all tests
+    var models = [
+      DateTimeTypeModel(value: TemporalDateTime(DateTime(2020, 1, 1))),
+      DateTimeTypeModel(value: TemporalDateTime(DateTime(2020, 1, 2))),
+      DateTimeTypeModel(value: TemporalDateTime(DateTime(2020, 2, 1))),
+    ];
+
+    // non-null models used for all tests
+    var nonNullModels = models.where((e) => e.value != null).toList();
+
+    // distinct list of values in the test models
+    var values = models.map((e) => e.value).toSet().toList();
+
+    // distinct list of non-null values in the test models
+    var nonNullValues = values.whereType<TemporalDateTime>().toList();
+
+    setUpAll(() async {
+      await configureDataStore();
+      await clearDataStore();
+      for (var model in models) {
+        await Amplify.DataStore.save(model);
+      }
+    });
+    testWidgets('eq()', (WidgetTester tester) async {
+      // test against all values
+      for (var value in nonNullValues) {
+        var expectedModels =
+            models.where((model) => model.value == value).toList();
+        await testQueryPredicate<DateTimeTypeModel>(
+          queryPredicate: DateTimeTypeModel.VALUE.eq(value.getDateTimeInUtc()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('ne()', (WidgetTester tester) async {
+      // test against all values
+      for (var value in nonNullValues) {
+        var expectedModels =
+            nonNullModels.where((model) => model.value != value).toList();
+        await testQueryPredicate<DateTimeTypeModel>(
+          queryPredicate: DateTimeTypeModel.VALUE.ne(value.getDateTimeInUtc()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('lt()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) < 0)
+            .toList();
+        await testQueryPredicate<DateTimeTypeModel>(
+          queryPredicate: DateTimeTypeModel.VALUE.lt(value.getDateTimeInUtc()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('le()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) <= 0)
+            .toList();
+        await testQueryPredicate<DateTimeTypeModel>(
+          queryPredicate: DateTimeTypeModel.VALUE.le(value.getDateTimeInUtc()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('gt()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) > 0)
+            .toList();
+        await testQueryPredicate<DateTimeTypeModel>(
+          queryPredicate: DateTimeTypeModel.VALUE.gt(value.getDateTimeInUtc()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('ge()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) >= 0)
+            .toList();
+        await testQueryPredicate<DateTimeTypeModel>(
+          queryPredicate: DateTimeTypeModel.VALUE.ge(value.getDateTimeInUtc()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('between()', (WidgetTester tester) async {
+      // test with partial match
+      var partialMatchStart = models[1].value!;
+      var partialMatchEnd = models[2].value!;
+      var rangeMatchModels = nonNullModels
+          .where((model) => model.value!.compareTo(partialMatchStart) >= 0)
+          .where((model) => model.value!.compareTo(partialMatchEnd) <= 0)
+          .toList();
+      // verify that the test is testing a partial match
+      expect(rangeMatchModels.length, greaterThanOrEqualTo(1));
+      await testQueryPredicate<DateTimeTypeModel>(
+        queryPredicate: DateTimeTypeModel.VALUE.between(
+            partialMatchStart.getDateTimeInUtc(),
+            partialMatchEnd.getDateTimeInUtc()),
+        expectedModels: rangeMatchModels,
+      );
+    });
+  });
+}

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_time_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_time_query_predicate_test.dart
@@ -34,10 +34,8 @@ void main() {
       DateTime(2020, 1, 1, 10, 30),
       DateTime(2020, 1, 1, 11, 30),
       DateTime(2020, 1, 1, 11, 30, 45),
-      // TemporalDateTime values with milliseconds & microseconds are not parsed correctly on Android
-      // see: https://github.com/aws-amplify/amplify-flutter/issues/817
-      // DateTime(2020, 1, 1, 11, 30, 45, 100),
-      // DateTime(2020, 1, 1, 11, 30, 45, 100, 250),
+      DateTime(2020, 1, 1, 11, 30, 45, 100),
+      DateTime(2020, 1, 1, 11, 30, 45, 100, 250),
       DateTime(2020, 1, 1),
       DateTime(2020, 1, 2),
       DateTime(2020, 2, 1),

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_time_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_date_time_query_predicate_test.dart
@@ -26,12 +26,28 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('type AWS DateTime', () {
-    // models used for all tests
-    var models = [
-      DateTimeTypeModel(value: TemporalDateTime(DateTime(2020, 1, 1))),
-      DateTimeTypeModel(value: TemporalDateTime(DateTime(2020, 1, 2))),
-      DateTimeTypeModel(value: TemporalDateTime(DateTime(2020, 2, 1))),
+    // dates users for all tests
+    var dates = [
+      DateTime.fromMillisecondsSinceEpoch(0),
+      DateTime(1970),
+      DateTime(2020, 1, 1),
+      DateTime(2020, 1, 1, 10, 30),
+      DateTime(2020, 1, 1, 11, 30),
+      DateTime(2020, 1, 1, 11, 30, 45),
+      // TemporalDateTime values with milliseconds & microseconds are not parsed correctly on Android
+      // see: https://github.com/aws-amplify/amplify-flutter/issues/817
+      // DateTime(2020, 1, 1, 11, 30, 45, 100),
+      // DateTime(2020, 1, 1, 11, 30, 45, 100, 250),
+      DateTime(2020, 1, 1),
+      DateTime(2020, 1, 2),
+      DateTime(2020, 2, 1),
+      DateTime(2020, 12, 31, 23, 59, 59),
     ];
+
+    // models used for all tests
+    var models = dates
+        .map((date) => DateTimeTypeModel(value: TemporalDateTime(date)))
+        .toList();
 
     // non-null models used for all tests
     var nonNullModels = models.where((e) => e.value != null).toList();
@@ -55,7 +71,7 @@ void main() {
         var expectedModels =
             models.where((model) => model.value == value).toList();
         await testQueryPredicate<DateTimeTypeModel>(
-          queryPredicate: DateTimeTypeModel.VALUE.eq(value.getDateTimeInUtc()),
+          queryPredicate: DateTimeTypeModel.VALUE.eq(value),
           expectedModels: expectedModels,
         );
       }
@@ -67,7 +83,7 @@ void main() {
         var expectedModels =
             nonNullModels.where((model) => model.value != value).toList();
         await testQueryPredicate<DateTimeTypeModel>(
-          queryPredicate: DateTimeTypeModel.VALUE.ne(value.getDateTimeInUtc()),
+          queryPredicate: DateTimeTypeModel.VALUE.ne(value),
           expectedModels: expectedModels,
         );
       }
@@ -80,7 +96,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) < 0)
             .toList();
         await testQueryPredicate<DateTimeTypeModel>(
-          queryPredicate: DateTimeTypeModel.VALUE.lt(value.getDateTimeInUtc()),
+          queryPredicate: DateTimeTypeModel.VALUE.lt(value),
           expectedModels: expectedModels,
         );
       }
@@ -93,7 +109,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) <= 0)
             .toList();
         await testQueryPredicate<DateTimeTypeModel>(
-          queryPredicate: DateTimeTypeModel.VALUE.le(value.getDateTimeInUtc()),
+          queryPredicate: DateTimeTypeModel.VALUE.le(value),
           expectedModels: expectedModels,
         );
       }
@@ -106,7 +122,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) > 0)
             .toList();
         await testQueryPredicate<DateTimeTypeModel>(
-          queryPredicate: DateTimeTypeModel.VALUE.gt(value.getDateTimeInUtc()),
+          queryPredicate: DateTimeTypeModel.VALUE.gt(value),
           expectedModels: expectedModels,
         );
       }
@@ -119,7 +135,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) >= 0)
             .toList();
         await testQueryPredicate<DateTimeTypeModel>(
-          queryPredicate: DateTimeTypeModel.VALUE.ge(value.getDateTimeInUtc()),
+          queryPredicate: DateTimeTypeModel.VALUE.ge(value),
           expectedModels: expectedModels,
         );
       }
@@ -128,17 +144,19 @@ void main() {
     testWidgets('between()', (WidgetTester tester) async {
       // test with partial match
       var partialMatchStart = models[1].value!;
-      var partialMatchEnd = models[2].value!;
+      var partialMatchEnd = models[3].value!;
       var rangeMatchModels = nonNullModels
           .where((model) => model.value!.compareTo(partialMatchStart) >= 0)
           .where((model) => model.value!.compareTo(partialMatchEnd) <= 0)
           .toList();
+
       // verify that the test is testing a partial match
       expect(rangeMatchModels.length, greaterThanOrEqualTo(1));
       await testQueryPredicate<DateTimeTypeModel>(
         queryPredicate: DateTimeTypeModel.VALUE.between(
-            partialMatchStart.getDateTimeInUtc(),
-            partialMatchEnd.getDateTimeInUtc()),
+          partialMatchStart,
+          partialMatchEnd,
+        ),
         expectedModels: rangeMatchModels,
       );
     });

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
@@ -34,10 +34,8 @@ void main() {
       DateTime(2020, 1, 1, 11, 30),
       DateTime(2020, 1, 1, 11, 30, 30),
       DateTime(2020, 1, 1, 11, 30, 45),
-      // TemporalDateTime values with milliseconds & microseconds are not parsed correctly on Android
-      // see: https://github.com/aws-amplify/amplify-flutter/issues/817
-      // DateTime(2020, 1, 1, 11, 30, 45, 100),
-      // DateTime(2020, 1, 1, 11, 30, 45, 100, 250),
+      DateTime(2020, 1, 1, 11, 30, 45, 100),
+      DateTime(2020, 1, 1, 11, 30, 45, 100, 250),
       DateTime(2020, 1, 1, 23, 59, 59),
     ];
 

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
@@ -43,14 +43,8 @@ void main() {
     var models =
         dates.map((date) => TimeTypeModel(value: TemporalTime(date))).toList();
 
-    // non-null models used for all tests
-    var nonNullModels = models.where((e) => e.value != null).toList();
-
     // distinct list of values in the test models
-    var values = models.map((e) => e.value).toSet().toList();
-
-    // distinct list of non-null values in the test models
-    var nonNullValues = values.whereType<TemporalTime>().toList();
+    var values = models.map((e) => e.value!).toSet().toList();
 
     setUpAll(() async {
       await configureDataStore();
@@ -61,7 +55,7 @@ void main() {
     });
     testWidgets('eq()', (WidgetTester tester) async {
       // test against all values
-      for (var value in nonNullValues) {
+      for (var value in values) {
         var expectedModels =
             models.where((model) => model.value == value).toList();
         await testQueryPredicate<TimeTypeModel>(
@@ -73,9 +67,9 @@ void main() {
 
     testWidgets('ne()', (WidgetTester tester) async {
       // test against all values
-      for (var value in nonNullValues) {
+      for (var value in values) {
         var expectedModels =
-            nonNullModels.where((model) => model.value != value).toList();
+            models.where((model) => model.value != value).toList();
         await testQueryPredicate<TimeTypeModel>(
           queryPredicate: TimeTypeModel.VALUE.ne(value),
           expectedModels: expectedModels,
@@ -84,11 +78,10 @@ void main() {
     });
 
     testWidgets('lt()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
-            .where((model) => model.value!.compareTo(value) < 0)
-            .toList();
+      // test against all values
+      for (var value in values) {
+        var expectedModels =
+            models.where((model) => model.value!.compareTo(value) < 0).toList();
         await testQueryPredicate<TimeTypeModel>(
           queryPredicate: TimeTypeModel.VALUE.lt(value),
           expectedModels: expectedModels,
@@ -97,9 +90,9 @@ void main() {
     });
 
     testWidgets('le()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
+      // test against all values
+      for (var value in values) {
+        var expectedModels = models
             .where((model) => model.value!.compareTo(value) <= 0)
             .toList();
         await testQueryPredicate<TimeTypeModel>(
@@ -110,11 +103,10 @@ void main() {
     });
 
     testWidgets('gt()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
-            .where((model) => model.value!.compareTo(value) > 0)
-            .toList();
+      // test against all values
+      for (var value in values) {
+        var expectedModels =
+            models.where((model) => model.value!.compareTo(value) > 0).toList();
         await testQueryPredicate<TimeTypeModel>(
           queryPredicate: TimeTypeModel.VALUE.gt(value),
           expectedModels: expectedModels,
@@ -123,9 +115,9 @@ void main() {
     });
 
     testWidgets('ge()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
+      // test against all values
+      for (var value in values) {
+        var expectedModels = models
             .where((model) => model.value!.compareTo(value) >= 0)
             .toList();
         await testQueryPredicate<TimeTypeModel>(
@@ -139,7 +131,7 @@ void main() {
       // test with partial match
       var partialMatchStart = models[1].value!;
       var partialMatchEnd = models[2].value!;
-      var rangeMatchModels = nonNullModels
+      var rangeMatchModels = models
           .where((model) => model.value!.compareTo(partialMatchStart) >= 0)
           .where((model) => model.value!.compareTo(partialMatchEnd) <= 0)
           .toList();

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_datastore/amplify_datastore.dart';
+import 'package:amplify_datastore_example/models/ModelProvider.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:amplify_flutter/amplify.dart';
+
+import '../../utils/query_predicate_utils.dart';
+import '../../utils/setup_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('type AWS Time', () {
+    // models used for all tests
+    var models = [
+      TimeTypeModel(value: TemporalTime(DateTime(2020, 1, 1))),
+      TimeTypeModel(value: TemporalTime(DateTime(2020, 1, 2))),
+      TimeTypeModel(value: TemporalTime(DateTime(2020, 2, 1))),
+    ];
+
+    // non-null models used for all tests
+    var nonNullModels = models.where((e) => e.value != null).toList();
+
+    // distinct list of values in the test models
+    var values = models.map((e) => e.value).toSet().toList();
+
+    // distinct list of non-null values in the test models
+    var nonNullValues = values.whereType<TemporalTime>().toList();
+
+    setUpAll(() async {
+      await configureDataStore();
+      await clearDataStore();
+      for (var model in models) {
+        await Amplify.DataStore.save(model);
+      }
+    });
+    testWidgets('eq()', (WidgetTester tester) async {
+      // test against all values
+      for (var value in nonNullValues) {
+        var expectedModels =
+            models.where((model) => model.value == value).toList();
+        await testQueryPredicate<TimeTypeModel>(
+          queryPredicate: TimeTypeModel.VALUE.eq(value.getDateTime()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('ne()', (WidgetTester tester) async {
+      // test against all values
+      for (var value in nonNullValues) {
+        var expectedModels =
+            nonNullModels.where((model) => model.value != value).toList();
+        await testQueryPredicate<TimeTypeModel>(
+          queryPredicate: TimeTypeModel.VALUE.ne(value.getDateTime()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('lt()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) < 0)
+            .toList();
+        await testQueryPredicate<TimeTypeModel>(
+          queryPredicate: TimeTypeModel.VALUE.lt(value.getDateTime()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('le()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) <= 0)
+            .toList();
+        await testQueryPredicate<TimeTypeModel>(
+          queryPredicate: TimeTypeModel.VALUE.le(value.getDateTime()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('gt()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) > 0)
+            .toList();
+        await testQueryPredicate<TimeTypeModel>(
+          queryPredicate: TimeTypeModel.VALUE.gt(value.getDateTime()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('ge()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) >= 0)
+            .toList();
+        await testQueryPredicate<TimeTypeModel>(
+          queryPredicate: TimeTypeModel.VALUE.ge(value.getDateTime()),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('between()', (WidgetTester tester) async {
+      // test with partial match
+      var partialMatchStart = models[1].value!;
+      var partialMatchEnd = models[2].value!;
+      var rangeMatchModels = nonNullModels
+          .where((model) => model.value!.compareTo(partialMatchStart) >= 0)
+          .where((model) => model.value!.compareTo(partialMatchEnd) <= 0)
+          .toList();
+      // verify that the test is testing a partial match
+      expect(rangeMatchModels.length, greaterThanOrEqualTo(1));
+      await testQueryPredicate<TimeTypeModel>(
+        queryPredicate: TimeTypeModel.VALUE.between(
+            partialMatchStart.getDateTime(), partialMatchEnd.getDateTime()),
+        expectedModels: rangeMatchModels,
+      );
+    });
+  });
+}

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
@@ -26,12 +26,24 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('type AWS Time', () {
-    // models used for all tests
-    var models = [
-      TimeTypeModel(value: TemporalTime(DateTime(2020, 1, 1))),
-      TimeTypeModel(value: TemporalTime(DateTime(2020, 1, 2))),
-      TimeTypeModel(value: TemporalTime(DateTime(2020, 2, 1))),
+    // dates users for all tests
+    var dates = [
+      DateTime.fromMillisecondsSinceEpoch(0),
+      DateTime(2020, 1, 1),
+      DateTime(2020, 1, 1, 10, 30),
+      DateTime(2020, 1, 1, 11, 30),
+      DateTime(2020, 1, 1, 11, 30, 30),
+      DateTime(2020, 1, 1, 11, 30, 45),
+      // TemporalDateTime values with milliseconds & microseconds are not parsed correctly on Android
+      // see: https://github.com/aws-amplify/amplify-flutter/issues/817
+      // DateTime(2020, 1, 1, 11, 30, 45, 100),
+      // DateTime(2020, 1, 1, 11, 30, 45, 100, 250),
+      DateTime(2020, 1, 1, 23, 59, 59),
     ];
+
+    // models used for all tests
+    var models =
+        dates.map((date) => TimeTypeModel(value: TemporalTime(date))).toList();
 
     // non-null models used for all tests
     var nonNullModels = models.where((e) => e.value != null).toList();
@@ -55,7 +67,7 @@ void main() {
         var expectedModels =
             models.where((model) => model.value == value).toList();
         await testQueryPredicate<TimeTypeModel>(
-          queryPredicate: TimeTypeModel.VALUE.eq(value.getDateTime()),
+          queryPredicate: TimeTypeModel.VALUE.eq(value),
           expectedModels: expectedModels,
         );
       }
@@ -67,7 +79,7 @@ void main() {
         var expectedModels =
             nonNullModels.where((model) => model.value != value).toList();
         await testQueryPredicate<TimeTypeModel>(
-          queryPredicate: TimeTypeModel.VALUE.ne(value.getDateTime()),
+          queryPredicate: TimeTypeModel.VALUE.ne(value),
           expectedModels: expectedModels,
         );
       }
@@ -80,7 +92,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) < 0)
             .toList();
         await testQueryPredicate<TimeTypeModel>(
-          queryPredicate: TimeTypeModel.VALUE.lt(value.getDateTime()),
+          queryPredicate: TimeTypeModel.VALUE.lt(value),
           expectedModels: expectedModels,
         );
       }
@@ -93,7 +105,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) <= 0)
             .toList();
         await testQueryPredicate<TimeTypeModel>(
-          queryPredicate: TimeTypeModel.VALUE.le(value.getDateTime()),
+          queryPredicate: TimeTypeModel.VALUE.le(value),
           expectedModels: expectedModels,
         );
       }
@@ -106,7 +118,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) > 0)
             .toList();
         await testQueryPredicate<TimeTypeModel>(
-          queryPredicate: TimeTypeModel.VALUE.gt(value.getDateTime()),
+          queryPredicate: TimeTypeModel.VALUE.gt(value),
           expectedModels: expectedModels,
         );
       }
@@ -119,7 +131,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) >= 0)
             .toList();
         await testQueryPredicate<TimeTypeModel>(
-          queryPredicate: TimeTypeModel.VALUE.ge(value.getDateTime()),
+          queryPredicate: TimeTypeModel.VALUE.ge(value),
           expectedModels: expectedModels,
         );
       }
@@ -136,8 +148,8 @@ void main() {
       // verify that the test is testing a partial match
       expect(rangeMatchModels.length, greaterThanOrEqualTo(1));
       await testQueryPredicate<TimeTypeModel>(
-        queryPredicate: TimeTypeModel.VALUE.between(
-            partialMatchStart.getDateTime(), partialMatchEnd.getDateTime()),
+        queryPredicate:
+            TimeTypeModel.VALUE.between(partialMatchStart, partialMatchEnd),
         expectedModels: rangeMatchModels,
       );
     });

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_timestamp_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_timestamp_query_predicate_test.dart
@@ -26,12 +26,23 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('type AWS Timestamp', () {
-    // models used for all tests
-    var models = [
-      TimestampTypeModel(value: TemporalTimestamp(DateTime(2020, 1, 1))),
-      TimestampTypeModel(value: TemporalTimestamp(DateTime(2020, 1, 2))),
-      TimestampTypeModel(value: TemporalTimestamp(DateTime(2020, 2, 1))),
+    // dates users for all tests
+    var dates = [
+      DateTime.fromMillisecondsSinceEpoch(0),
+      DateTime(2020, 1, 1),
+      DateTime(2020, 1, 1, 10, 30),
+      DateTime(2020, 1, 1, 11, 30),
+      DateTime(2020, 1, 1, 11, 30, 30),
+      DateTime(2020, 1, 1, 11, 30, 45),
+      DateTime(2020, 1, 1, 11, 30, 45, 100),
+      DateTime(2020, 1, 1, 11, 30, 45, 100, 250),
+      DateTime(2020, 1, 1, 23, 59, 59),
     ];
+
+    // models used for all tests
+    var models = dates
+        .map((date) => TimestampTypeModel(value: TemporalTimestamp(date)))
+        .toList();
 
     // non-null models used for all tests
     var nonNullModels = models.where((e) => e.value != null).toList();
@@ -55,8 +66,7 @@ void main() {
         var expectedModels =
             models.where((model) => model.value == value).toList();
         await testQueryPredicate<TimestampTypeModel>(
-          queryPredicate: TimestampTypeModel.VALUE.eq(
-              DateTime.fromMillisecondsSinceEpoch(value.toSeconds() * 1000)),
+          queryPredicate: TimestampTypeModel.VALUE.eq(value),
           expectedModels: expectedModels,
         );
       }
@@ -68,8 +78,7 @@ void main() {
         var expectedModels =
             nonNullModels.where((model) => model.value != value).toList();
         await testQueryPredicate<TimestampTypeModel>(
-          queryPredicate: TimestampTypeModel.VALUE.ne(
-              DateTime.fromMillisecondsSinceEpoch(value.toSeconds() * 1000)),
+          queryPredicate: TimestampTypeModel.VALUE.ne(value),
           expectedModels: expectedModels,
         );
       }
@@ -82,8 +91,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) < 0)
             .toList();
         await testQueryPredicate<TimestampTypeModel>(
-          queryPredicate: TimestampTypeModel.VALUE.lt(
-              DateTime.fromMillisecondsSinceEpoch(value.toSeconds() * 1000)),
+          queryPredicate: TimestampTypeModel.VALUE.lt(value),
           expectedModels: expectedModels,
         );
       }
@@ -96,8 +104,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) <= 0)
             .toList();
         await testQueryPredicate<TimestampTypeModel>(
-          queryPredicate: TimestampTypeModel.VALUE.le(
-              DateTime.fromMillisecondsSinceEpoch(value.toSeconds() * 1000)),
+          queryPredicate: TimestampTypeModel.VALUE.le(value),
           expectedModels: expectedModels,
         );
       }
@@ -110,8 +117,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) > 0)
             .toList();
         await testQueryPredicate<TimestampTypeModel>(
-          queryPredicate: TimestampTypeModel.VALUE.gt(
-              DateTime.fromMillisecondsSinceEpoch(value.toSeconds() * 1000)),
+          queryPredicate: TimestampTypeModel.VALUE.gt(value),
           expectedModels: expectedModels,
         );
       }
@@ -124,8 +130,7 @@ void main() {
             .where((model) => model.value!.compareTo(value) >= 0)
             .toList();
         await testQueryPredicate<TimestampTypeModel>(
-          queryPredicate: TimestampTypeModel.VALUE.ge(
-              DateTime.fromMillisecondsSinceEpoch(value.toSeconds() * 1000)),
+          queryPredicate: TimestampTypeModel.VALUE.ge(value),
           expectedModels: expectedModels,
         );
       }
@@ -143,10 +148,8 @@ void main() {
       expect(rangeMatchModels.length, greaterThanOrEqualTo(1));
       await testQueryPredicate<TimestampTypeModel>(
         queryPredicate: TimestampTypeModel.VALUE.between(
-          DateTime.fromMillisecondsSinceEpoch(
-              partialMatchStart.toSeconds() * 1000),
-          DateTime.fromMillisecondsSinceEpoch(
-              partialMatchEnd.toSeconds() * 1000),
+          partialMatchStart,
+          partialMatchEnd,
         ),
         expectedModels: rangeMatchModels,
       );

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_timestamp_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_timestamp_query_predicate_test.dart
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_datastore/amplify_datastore.dart';
+import 'package:amplify_datastore_example/models/ModelProvider.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:amplify_flutter/amplify.dart';
+
+import '../../utils/query_predicate_utils.dart';
+import '../../utils/setup_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('type AWS Timestamp', () {
+    // models used for all tests
+    var models = [
+      TimestampTypeModel(value: TemporalTimestamp(DateTime(2020, 1, 1))),
+      TimestampTypeModel(value: TemporalTimestamp(DateTime(2020, 1, 2))),
+      TimestampTypeModel(value: TemporalTimestamp(DateTime(2020, 2, 1))),
+    ];
+
+    // non-null models used for all tests
+    var nonNullModels = models.where((e) => e.value != null).toList();
+
+    // distinct list of values in the test models
+    var values = models.map((e) => e.value).toSet().toList();
+
+    // distinct list of non-null values in the test models
+    var nonNullValues = values.whereType<TemporalTimestamp>().toList();
+
+    setUpAll(() async {
+      await configureDataStore();
+      await clearDataStore();
+      for (var model in models) {
+        await Amplify.DataStore.save(model);
+      }
+    });
+    testWidgets('eq()', (WidgetTester tester) async {
+      // test against all values
+      for (var value in nonNullValues) {
+        var expectedModels =
+            models.where((model) => model.value == value).toList();
+        await testQueryPredicate<TimestampTypeModel>(
+          queryPredicate: TimestampTypeModel.VALUE.eq(
+              DateTime.fromMillisecondsSinceEpoch(value.toSeconds() * 1000)),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('ne()', (WidgetTester tester) async {
+      // test against all values
+      for (var value in nonNullValues) {
+        var expectedModels =
+            nonNullModels.where((model) => model.value != value).toList();
+        await testQueryPredicate<TimestampTypeModel>(
+          queryPredicate: TimestampTypeModel.VALUE.ne(
+              DateTime.fromMillisecondsSinceEpoch(value.toSeconds() * 1000)),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('lt()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) < 0)
+            .toList();
+        await testQueryPredicate<TimestampTypeModel>(
+          queryPredicate: TimestampTypeModel.VALUE.lt(
+              DateTime.fromMillisecondsSinceEpoch(value.toSeconds() * 1000)),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('le()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) <= 0)
+            .toList();
+        await testQueryPredicate<TimestampTypeModel>(
+          queryPredicate: TimestampTypeModel.VALUE.le(
+              DateTime.fromMillisecondsSinceEpoch(value.toSeconds() * 1000)),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('gt()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) > 0)
+            .toList();
+        await testQueryPredicate<TimestampTypeModel>(
+          queryPredicate: TimestampTypeModel.VALUE.gt(
+              DateTime.fromMillisecondsSinceEpoch(value.toSeconds() * 1000)),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('ge()', (WidgetTester tester) async {
+      // test against all (non-null) values
+      for (var value in nonNullValues) {
+        var expectedModels = nonNullModels
+            .where((model) => model.value!.compareTo(value) >= 0)
+            .toList();
+        await testQueryPredicate<TimestampTypeModel>(
+          queryPredicate: TimestampTypeModel.VALUE.ge(
+              DateTime.fromMillisecondsSinceEpoch(value.toSeconds() * 1000)),
+          expectedModels: expectedModels,
+        );
+      }
+    });
+
+    testWidgets('between()', (WidgetTester tester) async {
+      // test with partial match
+      var partialMatchStart = models[1].value!;
+      var partialMatchEnd = models[2].value!;
+      var rangeMatchModels = nonNullModels
+          .where((model) => model.value!.compareTo(partialMatchStart) >= 0)
+          .where((model) => model.value!.compareTo(partialMatchEnd) <= 0)
+          .toList();
+      // verify that the test is testing a partial match
+      expect(rangeMatchModels.length, greaterThanOrEqualTo(1));
+      await testQueryPredicate<TimestampTypeModel>(
+        queryPredicate: TimestampTypeModel.VALUE.between(
+          DateTime.fromMillisecondsSinceEpoch(
+              partialMatchStart.toSeconds() * 1000),
+          DateTime.fromMillisecondsSinceEpoch(
+              partialMatchEnd.toSeconds() * 1000),
+        ),
+        expectedModels: rangeMatchModels,
+      );
+    });
+  });
+}

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_timestamp_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_timestamp_query_predicate_test.dart
@@ -44,14 +44,8 @@ void main() {
         .map((date) => TimestampTypeModel(value: TemporalTimestamp(date)))
         .toList();
 
-    // non-null models used for all tests
-    var nonNullModels = models.where((e) => e.value != null).toList();
-
     // distinct list of values in the test models
-    var values = models.map((e) => e.value).toSet().toList();
-
-    // distinct list of non-null values in the test models
-    var nonNullValues = values.whereType<TemporalTimestamp>().toList();
+    var values = models.map((e) => e.value!).toSet().toList();
 
     setUpAll(() async {
       await configureDataStore();
@@ -62,7 +56,7 @@ void main() {
     });
     testWidgets('eq()', (WidgetTester tester) async {
       // test against all values
-      for (var value in nonNullValues) {
+      for (var value in values) {
         var expectedModels =
             models.where((model) => model.value == value).toList();
         await testQueryPredicate<TimestampTypeModel>(
@@ -74,9 +68,9 @@ void main() {
 
     testWidgets('ne()', (WidgetTester tester) async {
       // test against all values
-      for (var value in nonNullValues) {
+      for (var value in values) {
         var expectedModels =
-            nonNullModels.where((model) => model.value != value).toList();
+            models.where((model) => model.value != value).toList();
         await testQueryPredicate<TimestampTypeModel>(
           queryPredicate: TimestampTypeModel.VALUE.ne(value),
           expectedModels: expectedModels,
@@ -85,11 +79,10 @@ void main() {
     });
 
     testWidgets('lt()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
-            .where((model) => model.value!.compareTo(value) < 0)
-            .toList();
+      // test against all values
+      for (var value in values) {
+        var expectedModels =
+            models.where((model) => model.value!.compareTo(value) < 0).toList();
         await testQueryPredicate<TimestampTypeModel>(
           queryPredicate: TimestampTypeModel.VALUE.lt(value),
           expectedModels: expectedModels,
@@ -98,9 +91,9 @@ void main() {
     });
 
     testWidgets('le()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
+      // test against all values
+      for (var value in values) {
+        var expectedModels = models
             .where((model) => model.value!.compareTo(value) <= 0)
             .toList();
         await testQueryPredicate<TimestampTypeModel>(
@@ -111,11 +104,10 @@ void main() {
     });
 
     testWidgets('gt()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
-            .where((model) => model.value!.compareTo(value) > 0)
-            .toList();
+      // test against all values
+      for (var value in values) {
+        var expectedModels =
+            models.where((model) => model.value!.compareTo(value) > 0).toList();
         await testQueryPredicate<TimestampTypeModel>(
           queryPredicate: TimestampTypeModel.VALUE.gt(value),
           expectedModels: expectedModels,
@@ -124,9 +116,9 @@ void main() {
     });
 
     testWidgets('ge()', (WidgetTester tester) async {
-      // test against all (non-null) values
-      for (var value in nonNullValues) {
-        var expectedModels = nonNullModels
+      // test against all values
+      for (var value in values) {
+        var expectedModels = models
             .where((model) => model.value!.compareTo(value) >= 0)
             .toList();
         await testQueryPredicate<TimestampTypeModel>(
@@ -140,7 +132,7 @@ void main() {
       // test with partial match
       var partialMatchStart = models[1].value!;
       var partialMatchEnd = models[2].value!;
-      var rangeMatchModels = nonNullModels
+      var rangeMatchModels = models
           .where((model) => model.value!.compareTo(partialMatchStart) >= 0)
           .where((model) => model.value!.compareTo(partialMatchEnd) <= 0)
           .toList();

--- a/packages/amplify_datastore/test/query_predicate_test.dart
+++ b/packages/amplify_datastore/test/query_predicate_test.dart
@@ -143,27 +143,27 @@ void main() {
       rating: 1000,
     );
 
-    test('equals', () async {
+    test('equals', () {
       QueryPredicate testPredicate = Post.LIKECOUNT.eq(1);
       expect(testPredicate.evaluate(post1), isTrue);
       expect(testPredicate.evaluate(post2), isFalse);
       expect(testPredicate.evaluate(post4), isFalse);
     });
-    test('not equals', () async {
+    test('not equals', () {
       QueryPredicate testPredicate = Post.LIKECOUNT.ne(1);
       expect(testPredicate.evaluate(post1), isFalse);
       expect(testPredicate.evaluate(post2), isTrue);
       expect(testPredicate.evaluate(post4), isTrue);
     });
 
-    test('less than', () async {
+    test('less than', () {
       QueryPredicate testPredicate = Post.LIKECOUNT.lt(5);
       expect(testPredicate.evaluate(post1), isTrue);
       expect(testPredicate.evaluate(post2), isFalse);
       expect(testPredicate.evaluate(post4), isFalse);
     });
 
-    test('less than or equal', () async {
+    test('less than or equal', () {
       QueryPredicate testPredicate = Post.LIKECOUNT.le(10);
       expect(testPredicate.evaluate(post1), isTrue);
       expect(testPredicate.evaluate(post2), isTrue);
@@ -171,14 +171,14 @@ void main() {
       expect(testPredicate.evaluate(post4), isFalse);
     });
 
-    test('greater than', () async {
+    test('greater than', () {
       QueryPredicate testPredicate = Post.LIKECOUNT.gt(5);
       expect(testPredicate.evaluate(post1), isFalse);
       expect(testPredicate.evaluate(post2), isTrue);
       expect(testPredicate.evaluate(post4), isFalse);
     });
 
-    test('greater than or equal', () async {
+    test('greater than or equal', () {
       QueryPredicate testPredicate = Post.LIKECOUNT.ge(10);
       expect(testPredicate.evaluate(post1), isFalse);
       expect(testPredicate.evaluate(post2), isTrue);
@@ -186,7 +186,7 @@ void main() {
       expect(testPredicate.evaluate(post4), isFalse);
     });
 
-    test('between', () async {
+    test('between', () {
       QueryPredicate testPredicate = Post.LIKECOUNT.between(5, 100);
       expect(testPredicate.evaluate(post1), isFalse);
       expect(testPredicate.evaluate(post2), isTrue);
@@ -194,26 +194,26 @@ void main() {
       expect(testPredicate.evaluate(post4), isFalse);
     });
 
-    test('contains', () async {
+    test('contains', () {
       QueryPredicate testPredicate = Post.TITLE.contains("one");
       expect(testPredicate.evaluate(post1), isTrue);
       expect(testPredicate.evaluate(post2), isFalse);
     });
 
-    test('beginsWith', () async {
+    test('beginsWith', () {
       QueryPredicate testPredicate = Post.TITLE.beginsWith("post o");
       expect(testPredicate.evaluate(post1), isTrue);
       expect(testPredicate.evaluate(post2), isFalse);
     });
 
-    test('and', () async {
+    test('and', () {
       QueryPredicate testPredicate =
           Post.TITLE.contains("post") & Post.RATING.lt(10);
       expect(testPredicate.evaluate(post1), isTrue);
       expect(testPredicate.evaluate(post2), isFalse);
     });
 
-    test('or', () async {
+    test('or', () {
       QueryPredicate testPredicate =
           Post.TITLE.contains("two") | Post.RATING.lt(10);
       expect(testPredicate.evaluate(post1), isTrue);
@@ -221,10 +221,18 @@ void main() {
       expect(testPredicate.evaluate(post3), isFalse);
     });
 
-    test('not', () async {
+    test('not', () {
       QueryPredicate testPredicate = not(Post.RATING.lt(5));
       expect(testPredicate.evaluate(post1), isFalse);
       expect(testPredicate.evaluate(post2), isTrue);
+    });
+
+    test('Temporal type', () {
+      QueryPredicate testPredicate = Post.CREATED.lt(TemporalDateTime(
+        DateTime(2020, 01, 01, 12, 00),
+      ));
+      expect(testPredicate.evaluate(post1), isTrue);
+      expect(testPredicate.evaluate(post2), isFalse);
     });
   });
 }

--- a/packages/amplify_datastore/test/query_predicate_test.dart
+++ b/packages/amplify_datastore/test/query_predicate_test.dart
@@ -105,6 +105,15 @@ void main() {
       expect(testPredicate.serializeAsMap(),
           await getJsonFromFile('bool_and_double_operands.json'));
     });
+
+    test('when value is a temporal type', () async {
+      QueryPredicate testPredicate = Post.CREATED.eq(
+        TemporalDateTime(DateTime.utc(2020, 01, 01)),
+      );
+
+      expect(testPredicate.serializeAsMap(),
+          await getJsonFromFile('temporal_predicate.json'));
+    });
   });
 
   group('query predicate comparison', () {

--- a/packages/amplify_datastore/test/resources/query_predicate/temporal_predicate.json
+++ b/packages/amplify_datastore/test/resources/query_predicate/temporal_predicate.json
@@ -1,0 +1,9 @@
+{
+  "queryPredicateOperation": {
+    "field": "created",
+    "fieldOperator": {
+      "operatorName": "equal",
+      "value": "2020-01-01T00:00:00Z"
+    }
+  }
+}

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/query/query_field.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/query/query_field.dart
@@ -17,6 +17,7 @@ library query_field;
 
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:amplify_datastore_plugin_interface/src/types/models/model_field_type.dart';
+import 'package:flutter/foundation.dart';
 import '../temporal/datetime_parse.dart';
 import '../utils/parsers.dart';
 

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/query/query_field_operators.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/query/query_field_operators.dart
@@ -55,7 +55,10 @@ abstract class QueryFieldOperator<T> {
 
   /// check the type of [value] and invoke corresponding serialize method
   dynamic serializeDynamicValue(dynamic value) {
-    if (value is TemporalDate) {
+    // DateTime is deprecated and will be removed in the next major version
+    if (value is DateTime) {
+      return value.toDateTimeIso8601String();
+    } else if (value is TemporalDate) {
       return value.format();
     } else if (value is TemporalDateTime) {
       return value.format();

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/query/query_field_operators.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/query/query_field_operators.dart
@@ -57,6 +57,11 @@ abstract class QueryFieldOperator<T> {
   dynamic serializeDynamicValue(dynamic value) {
     // DateTime is deprecated and will be removed in the next major version
     if (value is DateTime) {
+      if (kDebugMode) {
+        print(
+          'WARNING: Using DateTime types in a QueryPredicate is deprecated. Use a Temporal Date/Time Type instead.',
+        );
+      }
       return value.toDateTimeIso8601String();
     } else if (value is TemporalDate) {
       return value.format();

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/query/query_field_operators.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/query/query_field_operators.dart
@@ -87,7 +87,8 @@ class EqualQueryOperator<T> extends QueryFieldOperator<T> {
 
   @override
   bool evaluate(T? other) {
-    return other == value;
+    var serializedValue = serializeDynamicValue(value);
+    return other == serializedValue;
   }
 
   @override
@@ -105,7 +106,8 @@ class NotEqualQueryOperator<T> extends QueryFieldOperator<T> {
 
   @override
   bool evaluate(T? other) {
-    return other != value;
+    var serializedValue = serializeDynamicValue(value);
+    return other != serializedValue;
   }
 
   @override
@@ -127,7 +129,8 @@ class LessOrEqualQueryOperator<T extends Comparable>
     if (other == null) {
       return false;
     }
-    return other.compareTo(value) <= 0;
+    var serializedValue = serializeDynamicValue(value);
+    return other.compareTo(serializedValue) <= 0;
   }
 
   @override
@@ -149,7 +152,8 @@ class LessThanQueryOperator<T extends Comparable>
     if (other == null) {
       return false;
     }
-    return other.compareTo(value) < 0;
+    var serializedValue = serializeDynamicValue(value);
+    return other.compareTo(serializedValue) < 0;
   }
 
   @override
@@ -171,7 +175,8 @@ class GreaterOrEqualQueryOperator<T extends Comparable>
     if (other == null) {
       return false;
     }
-    return other.compareTo(value) >= 0;
+    var serializedValue = serializeDynamicValue(value);
+    return other.compareTo(serializedValue) >= 0;
   }
 
   @override
@@ -193,7 +198,8 @@ class GreaterThanQueryOperator<T extends Comparable>
     if (other == null) {
       return false;
     }
-    return other.compareTo(value) > 0;
+    var serializedValue = serializeDynamicValue(value);
+    return other.compareTo(serializedValue) > 0;
   }
 
   @override
@@ -236,7 +242,10 @@ class BetweenQueryOperator<T extends Comparable> extends QueryFieldOperator<T> {
     if (other == null) {
       return false;
     }
-    return other.compareTo(start) >= 0 && other.compareTo(end) <= 0;
+    var serializedStart = serializeDynamicValue(start);
+    var serializedEnd = serializeDynamicValue(end);
+    return other.compareTo(serializedStart) >= 0 &&
+        other.compareTo(serializedEnd) <= 0;
   }
 
   @override

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/query/query_field_operators.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/query/query_field_operators.dart
@@ -55,11 +55,15 @@ abstract class QueryFieldOperator<T> {
 
   /// check the type of [value] and invoke corresponding serialize method
   dynamic serializeDynamicValue(dynamic value) {
-    if (value is DateTime) {
-      return value.toDateTimeIso8601String();
-    }
-
-    if (isEnum(value)) {
+    if (value is TemporalDate) {
+      return value.format();
+    } else if (value is TemporalDateTime) {
+      return value.format();
+    } else if (value is TemporalTime) {
+      return value.format();
+    } else if (value is TemporalTimestamp) {
+      return value.toSeconds();
+    } else if (isEnum(value)) {
       return enumToString(value);
     }
 
@@ -231,8 +235,8 @@ class BetweenQueryOperator<T extends Comparable> extends QueryFieldOperator<T> {
   Map<String, dynamic> serializeAsMap() {
     return <String, dynamic>{
       'operatorName': QueryFieldOperatorType.between.toShortString(),
-      'start': start,
-      'end': end
+      'start': serializeDynamicValue(start),
+      'end': serializeDynamicValue(end)
     };
   }
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/837

*Description of changes:*
- serialize temporal date/time types in query predicates
- add unit test for the new serialization
- add integ tests for all temporal date/time types

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
