### PR TITLE
feat(datastore): Custom Error Handler

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -15,6 +15,7 @@
 
 package com.amazonaws.amplify.amplify_datastore
 
+import android.database.DefaultDatabaseErrorHandler
 import android.os.Handler
 import android.os.Looper
 import androidx.annotation.NonNull
@@ -39,6 +40,7 @@ import com.amplifyframework.core.model.query.QueryOptions
 import com.amplifyframework.core.model.query.predicate.QueryPredicates
 import com.amplifyframework.datastore.AWSDataStorePlugin
 import com.amplifyframework.datastore.DataStoreConfiguration
+import com.amplifyframework.datastore.DataStoreErrorHandler
 import com.amplifyframework.datastore.DataStoreException
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.EventChannel
@@ -162,6 +164,18 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         }
 
         val dataStoreConfigurationBuilder = DataStoreConfiguration.builder()
+
+        if(request["hasCustomErrorHandler"] as Boolean) {
+            var handler = DataStoreErrorHandler {
+                val args = hashMapOf(
+                        "errorCode" to "DataStoreException",
+                        "errorMessage" to ExceptionMessages.defaultFallbackExceptionMessage,
+                        "details" to createSerializedError(it)
+                )
+                channel.invokeMethod("errorHandler", args)
+            }
+            dataStoreConfigurationBuilder.errorHandler(handler!!)
+        }
 
         modelProvider.setVersion(request["modelProviderVersion"] as String)
         val defaultDataStoreConfiguration = DataStoreConfiguration.defaults()

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -165,7 +165,7 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
 
         val dataStoreConfigurationBuilder = DataStoreConfiguration.builder()
 
-        if(request["hasCustomErrorHandler"] as Boolean) {
+        if( (request["hasErrorHandler"] as? Boolean? == true) ) {
             var handler = DataStoreErrorHandler {
                 val args = hashMapOf(
                         "errorCode" to "DataStoreException",

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -15,7 +15,6 @@
 
 package com.amazonaws.amplify.amplify_datastore
 
-import android.database.DefaultDatabaseErrorHandler
 import android.os.Handler
 import android.os.Looper
 import androidx.annotation.NonNull
@@ -165,8 +164,9 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
 
         val dataStoreConfigurationBuilder = DataStoreConfiguration.builder()
 
-        if( (request["hasErrorHandler"] as? Boolean? == true) ) {
-            var handler = DataStoreErrorHandler {
+        var errorHandler : DataStoreErrorHandler;
+        errorHandler = if( (request["hasErrorHandler"] as? Boolean? == true) ) {
+            DataStoreErrorHandler {
                 val args = hashMapOf(
                         "errorCode" to "DataStoreException",
                         "errorMessage" to ExceptionMessages.defaultFallbackExceptionMessage,
@@ -174,8 +174,13 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
                 )
                 channel.invokeMethod("errorHandler", args)
             }
-            dataStoreConfigurationBuilder.errorHandler(handler!!)
         }
+        else {
+            DataStoreErrorHandler {
+                LOG.error(it.toString())
+            }
+        }
+        dataStoreConfigurationBuilder.errorHandler(errorHandler)
 
         modelProvider.setVersion(request["modelProviderVersion"] as String)
         val defaultDataStoreConfiguration = DataStoreConfiguration.defaults()

--- a/packages/amplify_datastore/example/lib/main.dart
+++ b/packages/amplify_datastore/example/lib/main.dart
@@ -88,7 +88,7 @@ class _MyAppState extends State<MyApp> {
       datastorePlugin = AmplifyDataStore(
         modelProvider: ModelProvider.instance,
         errorHandler: ((error) =>
-            {print("Custom ErrorHandler result: " + error.toString())}),
+            {print("Custom ErrorHandler received: " + error.toString())}),
       );
       await Amplify.addPlugin(datastorePlugin);
 

--- a/packages/amplify_datastore/example/lib/main.dart
+++ b/packages/amplify_datastore/example/lib/main.dart
@@ -85,7 +85,11 @@ class _MyAppState extends State<MyApp> {
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> initPlatformState() async {
     try {
-      datastorePlugin = AmplifyDataStore(modelProvider: ModelProvider.instance);
+      datastorePlugin = AmplifyDataStore(
+        modelProvider: ModelProvider.instance,
+        errorHandler: ((error) =>
+            {print("Custom ErrorHandler result: " + error.toString())}),
+      );
       await Amplify.addPlugin(datastorePlugin);
 
       // Configure

--- a/packages/amplify_datastore/ios/Classes/FlutterDataStoreErrorHandler.swift
+++ b/packages/amplify_datastore/ios/Classes/FlutterDataStoreErrorHandler.swift
@@ -26,7 +26,7 @@ class FlutterDataStoreErrorHandler {
                                             details: FlutterDataStoreErrorHandler.createSerializedError(error: error))
     }
     
-    static func createSerializedError(error: DataStoreError) -> Dictionary<String, String> {
+    static func createSerializedError(error: AmplifyError) -> Dictionary<String, String> {
         return createSerializedError(message: error.errorDescription,
                                      recoverySuggestion: error.recoverySuggestion,
                                      underlyingError: error.underlyingError?.localizedDescription)

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -126,7 +126,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
             
 
             var errorHandler: DataStoreErrorHandler
-            if( args["hasCustomErrorHandler"] as! Bool ){
+            if( (args["hasErrorHandler"] as? Bool) == true ){
                 errorHandler = { error in
                     let map : [String:Any] = [
                         "errorCode" : "DataStoreException",

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -126,7 +126,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
             
 
             var errorHandler: DataStoreErrorHandler
-            if( (args["hasErrorHandler"] as? Bool) == true ){
+            if((args["hasErrorHandler"] as? Bool) == true) {
                 errorHandler = { error in
                     let map : [String:Any] = [
                         "errorCode" : "DataStoreException",
@@ -135,8 +135,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
                     ]
                     self.channel!.invokeMethod("errorHandler", arguments: args)
                 }
-            }
-            else{
+            } else {
                 errorHandler = { error in
                     Amplify.Logging.error(error: error)
                 }
@@ -153,7 +152,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
             
             Amplify.Logging.logLevel = .info
             print("Amplify configured with DataStore plugin")
-            result(true)            
+            result(true)
         } catch ModelSchemaError.parse(let className, let fieldName, let desiredType){
             FlutterDataStoreErrorHandler.handleDataStoreError(
                 error: DataStoreError.decodingError(

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -15,6 +15,7 @@
 
 import 'dart:async';
 
+import 'package:amplify_core/types/exception/AmplifyException.dart';
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:meta/meta.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
@@ -39,6 +40,7 @@ class AmplifyDataStore extends DataStorePluginInterface {
   /// [syncPageSize]: page size to sync
   AmplifyDataStore({
     required ModelProviderInterface modelProvider,
+    Function(AmplifyException)? errorHandler,
     List<DataStoreSyncExpression> syncExpressions = const [],
     int? syncInterval,
     int? syncMaxRecords,
@@ -46,6 +48,7 @@ class AmplifyDataStore extends DataStorePluginInterface {
   }) : super(
           token: _token,
           modelProvider: modelProvider,
+          errorHandler: errorHandler,
           syncExpressions: syncExpressions,
           syncInterval: syncInterval,
           syncMaxRecords: syncMaxRecords,
@@ -71,6 +74,7 @@ class AmplifyDataStore extends DataStorePluginInterface {
   @override
   Future<void> configureDataStore({
     ModelProviderInterface? modelProvider,
+    Function(AmplifyException)? errorHandler,
     List<DataStoreSyncExpression>? syncExpressions,
     int? syncInterval,
     int? syncMaxRecords,
@@ -85,6 +89,7 @@ class AmplifyDataStore extends DataStorePluginInterface {
     streamWrapper.registerModelsForHub(provider);
     return _instance.configureDataStore(
       modelProvider: provider,
+      errorHandler: errorHandler ?? this.errorHandler,
       syncExpressions: this.syncExpressions,
       syncInterval: this.syncInterval,
       syncMaxRecords: this.syncMaxRecords,

--- a/packages/amplify_datastore/lib/method_channel_datastore.dart
+++ b/packages/amplify_datastore/lib/method_channel_datastore.dart
@@ -88,7 +88,7 @@ class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
         'modelSchemas': modelProvider?.modelSchemas
             .map((schema) => schema.toMap())
             .toList(),
-        'hasCustomErrorHandler': errorHandler != null,
+        'hasErrorHandler': errorHandler != null,
         'modelProviderVersion': modelProvider?.version,
         'syncExpressions': syncExpressions!
             .map((syncExpression) => syncExpression.toMap())

--- a/packages/amplify_datastore/lib/method_channel_datastore.dart
+++ b/packages/amplify_datastore/lib/method_channel_datastore.dart
@@ -27,6 +27,9 @@ const MethodChannel _channel = MethodChannel('com.amazonaws.amplify/datastore');
 class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
   dynamic _allModelsStreamFromMethodChannel = null;
 
+  List<DataStoreSyncExpression>? _syncExpressions;
+  Function(AmplifyException)? _errorHandler;
+
   ObserveQueryExecutor _observeQueryExecutor = ObserveQueryExecutor(
     dataStoreEventStream:
         AmplifyDataStore.streamWrapper.datastoreStreamController.stream,
@@ -35,39 +38,57 @@ class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
   /// Internal use constructor
   AmplifyDataStoreMethodChannel() : super.tokenOnly();
 
+  // Receives calls from Native
+  Future<dynamic> _methodCallHandler(MethodCall call) async {
+    switch (call.method) {
+      case 'resolveQueryPredicate':
+        String? id = call.arguments;
+        if (id == null) {
+          throw ArgumentError(
+              'resolveQueryPredicate must be called with an id');
+        }
+        return _syncExpressions!
+            .firstWhere((syncExpression) => syncExpression.id == id)
+            .resolveQueryPredicate()
+            .serializeAsMap();
+
+      case 'errorHandler':
+        Map<String, dynamic> arguments =
+            Map<String, dynamic>.from(call.arguments);
+        _errorHandler!(_deserializeExceptionFromMap(arguments));
+        break;
+
+      case 'conflictHandler':
+        break;
+
+      default:
+        throw UnimplementedError('${call.method} has not been implemented.');
+    }
+  }
+
   /// This method instantiates the native DataStore plugins with plugin
   /// configurations. This needs to happen before Amplify.configure() can be
   /// called.
   @override
   Future<void> configureDataStore({
     ModelProviderInterface? modelProvider,
+    Function(AmplifyException)? errorHandler,
     List<DataStoreSyncExpression>? syncExpressions,
     int? syncInterval,
     int? syncMaxRecords,
     int? syncPageSize,
   }) async {
-    _channel.setMethodCallHandler((MethodCall call) async {
-      switch (call.method) {
-        case 'resolveQueryPredicate':
-          String? id = call.arguments;
-          if (id == null) {
-            throw ArgumentError(
-                'resolveQueryPredicate must be called with an id');
-          }
-          return syncExpressions!
-              .firstWhere((syncExpression) => syncExpression.id == id)
-              .resolveQueryPredicate()
-              .serializeAsMap();
-        default:
-          throw UnimplementedError('${call.method} has not been implemented.');
-      }
-    });
+    _channel.setMethodCallHandler(_methodCallHandler);
     try {
+      _syncExpressions = syncExpressions;
+      _errorHandler = errorHandler;
+
       return await _channel
           .invokeMethod('configureDataStore', <String, dynamic>{
         'modelSchemas': modelProvider?.modelSchemas
             .map((schema) => schema.toMap())
             .toList(),
+        'hasCustomErrorHandler': errorHandler != null,
         'modelProviderVersion': modelProvider?.version,
         'syncExpressions': syncExpressions!
             .map((syncExpression) => syncExpression.toMap())
@@ -229,6 +250,23 @@ class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
     Map<String, dynamic> serializedItem =
         Map<String, dynamic>.from(serializedEvent["item"]);
     return serializedItem["modelName"] as String;
+  }
+
+  AmplifyException _deserializeExceptionFromMap(Map<String, dynamic> e) {
+    if (e['errorCode'] == 'DataStoreException') {
+      return DataStoreException.fromMap(Map<String, String>.from(e['details']));
+    } else if (e['errorCode'] == 'AmplifyAlreadyConfiguredException') {
+      return AmplifyAlreadyConfiguredException.fromMap(
+          Map<String, String>.from(e['details']));
+    } else {
+      // This shouldn't happen. All exceptions coming from platform for
+      // amplify_datastore should have a known code. Throw an unknown error.
+      return DataStoreException(
+          AmplifyExceptionMessages.missingExceptionMessage,
+          recoverySuggestion:
+              AmplifyExceptionMessages.missingRecoverySuggestion,
+          underlyingException: e.toString());
+    }
   }
 
   AmplifyException _deserializeException(PlatformException e) {

--- a/packages/amplify_datastore/test/amplify_datastore_custom_error_handler_test.dart
+++ b/packages/amplify_datastore/test/amplify_datastore_custom_error_handler_test.dart
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_core/types/index.dart';
+import 'package:amplify_datastore/amplify_datastore.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'test_models/ModelProvider.dart';
+
+// Utilized from: https://github.com/flutter/flutter/issues/63465 #CyrilHu
+// For mocking Native -> Dart
+extension MockMethodChannel on MethodChannel {
+  Future<void> invokeMockMethod(String method, dynamic arguments) async {
+    const codec = StandardMethodCodec();
+    final data = codec.encodeMethodCall(MethodCall(method, arguments));
+
+    return ServicesBinding.instance?.defaultBinaryMessenger
+        .handlePlatformMessage(
+      name,
+      data,
+      (ByteData? data) {},
+    );
+  }
+}
+
+void main() {
+  const MethodChannel dataStoreChannel =
+      MethodChannel('com.amazonaws.amplify/datastore');
+
+  AmplifyException? receivedException;
+
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    dataStoreChannel.setMockMethodCallHandler((MethodCall methodCall) async {});
+    AmplifyDataStore dataStore = AmplifyDataStore(
+        modelProvider: ModelProvider.instance,
+        errorHandler: (exception) => {receivedException = exception});
+    return dataStore.configureDataStore();
+  });
+
+  test(
+      'DataStoreException from MethodChannel is properly serialized and called',
+      () async {
+    await dataStoreChannel.invokeMockMethod("errorHandler", {
+      'errorCode': 'DataStoreException',
+      'errorMessage': 'ErrorMessage',
+      'details': {
+        'message': 'message',
+        'recoverySuggestion': 'recoverySuggestion',
+        'underlyingException': 'underlyingException'
+      }
+    });
+    expect(
+        receivedException,
+        DataStoreException.fromMap({
+          'message': 'message',
+          'recoverySuggestion': 'recoverySuggestion',
+          'underlyingException': 'underlyingException'
+        }));
+  });
+
+  test(
+      'Unknown DataStoreException from MethodChannel is properly serialized and called',
+      () async {
+    await dataStoreChannel
+        .invokeMockMethod("errorHandler", {'badErrorFormat': 'badErrorFormat'});
+    expect(
+        receivedException,
+        DataStoreException(AmplifyExceptionMessages.missingExceptionMessage,
+            recoverySuggestion:
+                AmplifyExceptionMessages.missingRecoverySuggestion,
+            underlyingException:
+                {'badErrorFormat': 'badErrorFormat'}.toString()));
+  });
+}

--- a/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
@@ -86,13 +86,13 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
   /// Configure AmplifyDataStore plugin with mandatory [modelProvider]
   /// and optional DataStore configuration properties including
   ///
-  /// [errorHandler]: custom error handler code executed when DataStore encounters an unhandled error during its background operations
+  /// [errorHandler]: Custom error handler function that may receive an [AmplifyException] object when DataStore encounters an unhandled error during its background operations
   ///
   /// [syncInterval]: DataStore syncing interval (in seconds)
   ///
-  /// [syncMaxRecords]: max number of records to sync
+  /// [syncMaxRecords]: Max number of records to sync
   ///
-  /// [syncPageSize]: page size to sync
+  /// [syncPageSize]: Page size to sync
   Future<void> configureDataStore(
       {required ModelProviderInterface modelProvider,
       Function(AmplifyException)? errorHandler,

--- a/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
@@ -47,6 +47,9 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
   /// modelProvider
   ModelProviderInterface? modelProvider;
 
+  // errorHandler
+  Function(AmplifyException)? errorHandler;
+
   /// list of sync expressions to filter datastore sync against
   List<DataStoreSyncExpression>? syncExpressions;
 
@@ -63,6 +66,7 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
   DataStorePluginInterface({
     required Object token,
     required this.modelProvider,
+    this.errorHandler,
     this.syncExpressions,
     this.syncInterval,
     this.syncMaxRecords,
@@ -80,15 +84,18 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
   }
 
   /// Configure AmplifyDataStore plugin with mandatory [modelProvider]
-  /// and optional datastore configuration properties including
+  /// and optional DataStore configuration properties including
   ///
-  /// [syncInterval]: datastore syncing interval (in seconds)
+  /// [errorHandler]: custom error handler code executed when DataStore encounters an unhandled error during its background operations
+  ///
+  /// [syncInterval]: DataStore syncing interval (in seconds)
   ///
   /// [syncMaxRecords]: max number of records to sync
   ///
   /// [syncPageSize]: page size to sync
   Future<void> configureDataStore(
       {required ModelProviderInterface modelProvider,
+      Function(AmplifyException)? errorHandler,
       int? syncInterval,
       int? syncMaxRecords,
       int? syncPageSize}) {

--- a/packages/amplify_flutter/lib/categories/amplify_datastore_category.dart
+++ b/packages/amplify_flutter/lib/categories/amplify_datastore_category.dart
@@ -34,7 +34,9 @@ class DataStoreCategory {
         // Extra step to configure datastore specifically.
         // Note: The native datastore plugins are not added
         // in the `onAttachedToEngine` but rather in the `configure()
-        await plugin.configureDataStore(modelProvider: plugin.modelProvider!, errorHandler: plugin.errorHandler);
+        await plugin.configureDataStore(
+            modelProvider: plugin.modelProvider!,
+            errorHandler: plugin.errorHandler);
         plugins.add(plugin);
       } on AmplifyAlreadyConfiguredException {
         plugins.add(plugin);

--- a/packages/amplify_flutter/lib/categories/amplify_datastore_category.dart
+++ b/packages/amplify_flutter/lib/categories/amplify_datastore_category.dart
@@ -34,7 +34,7 @@ class DataStoreCategory {
         // Extra step to configure datastore specifically.
         // Note: The native datastore plugins are not added
         // in the `onAttachedToEngine` but rather in the `configure()
-        await plugin.configureDataStore(modelProvider: plugin.modelProvider!);
+        await plugin.configureDataStore(modelProvider: plugin.modelProvider!, errorHandler: plugin.errorHandler);
         plugins.add(plugin);
       } on AmplifyAlreadyConfiguredException {
         plugins.add(plugin);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Custom ErrorHandler support 

I haven't written integration tests for this.  Should be a small code change but a bit tricky to figure out as I don't know how to trigger the Datastore Exceptions that would in turn trigger the custom error handler (I've just manually triggered it from native atm) 

Update November 8: 

We should include integration tests for this code change in a separate PR.  Writing integration tests will require enabling cloud sync and thus reworking all existing integration tests in Datastore as well.  Given ongoing talks with native teams, I might also need to enable Auth as well to trigger the edge case that would get the custom error callback to be called in the first place.  As this could require significantly more time and is outside scope of original task I plan to tackle this in a separate line of work.  There are already unit tests for this feature though. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
