### PR TITLE
chore: update amplify pods to 1.15.5

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -131,6 +131,18 @@ scripts:
     melos exec -- \
       flutter analyze --no-fatal-infos --no-fatal-warnings &>/dev/null || true
 
+  pod:repo-update:
+    run: melos exec -c 8 --scope="*example*,sample_app" "(cd ios && pod repo update)"
+    description: runs "pod repo update" in all example apps
+
+  pod:update-amplify:
+    run: melos exec -c 8 --ignore="amplify_core_example" --file-exists="./ios/Podfile.lock" "(cd ios && pod update Amplify AWSPluginsCore AmplifyPlugins)"
+    description: Update amplify pods in projects with a Podfile.lock
+
+  pod:update:
+    run: melos run pod:repo-update && melos run pod:update-amplify
+    description: Run "pod repo update" and then updates amplify related pods. Intended for use after amplify iOS version has been updated.
+
   postbootstrap: |
     melos run copy_dummy_config && \
     melos run packages:fix

--- a/packages/amplify_analytics_pinpoint/ios/amplify_analytics_pinpoint.podspec
+++ b/packages/amplify_analytics_pinpoint/ios/amplify_analytics_pinpoint.podspec
@@ -15,8 +15,8 @@ This code is the iOS part of the Amplify Flutter Pinpoint Analytics Plugin.  The
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.15.3'
-  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '~> 1.15.3'
+  s.dependency 'Amplify', '~> 1.15.5'
+  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '~> 1.15.5'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/amplify_api/ios/amplify_api.podspec
+++ b/packages/amplify_api/ios/amplify_api.podspec
@@ -15,8 +15,8 @@ The API module for Amplify Flutter.
   s.source           = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.15.3'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '~> 1.15.3'
+  s.dependency 'Amplify', '~> 1.15.5'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '~> 1.15.5'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/amplify_auth_cognito/ios/amplify_auth_cognito.podspec
+++ b/packages/amplify_auth_cognito/ios/amplify_auth_cognito.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.15.3'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '~> 1.15.3'
+  s.dependency 'Amplify', '~> 1.15.5'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '~> 1.15.5'
   s.dependency 'ObjectMapper'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,8 +15,8 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.15.3'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '~> 1.15.3'
+  s.dependency 'Amplify', '~> 1.15.5'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '~> 1.15.5'
   s.dependency 'amplify_core'
   s.platform = :ios, '13.0'
 

--- a/packages/amplify_flutter/ios/amplify_flutter.podspec
+++ b/packages/amplify_flutter/ios/amplify_flutter.podspec
@@ -15,9 +15,9 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.15.3'
-  s.dependency 'AWSPluginsCore', '~> 1.15.3'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '~> 1.15.3'
+  s.dependency 'Amplify', '~> 1.15.5'
+  s.dependency 'AWSPluginsCore', '~> 1.15.5'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '~> 1.15.5'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/amplify_storage_s3/ios/amplify_storage_s3.podspec
+++ b/packages/amplify_storage_s3/ios/amplify_storage_s3.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.15.3'
-  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '~> 1.15.3'
+  s.dependency 'Amplify', '~> 1.15.5'
+  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '~> 1.15.5'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- update amplify-ios to 1.15.5 to bring in https://github.com/aws-amplify/amplify-ios/pull/1494
- add melos script intended to be run after updating amplify pod versions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
