### PR TITLE
fix(amplify_authenticator): Makes SignUpField.custom hintText required

### DIFF
--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/sign_up_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/sign_up_form_field.dart
@@ -245,7 +245,7 @@ abstract class SignUpFormField<FieldValue> extends AuthenticatorFormField<
     Key? key,
     required String title,
     required String attributeKey,
-    String? hintText,
+    required String hintText,
     FormFieldValidator<String>? validator,
   }) =>
       _SignUpTextField(


### PR DESCRIPTION
*Description of changes:*
Makes SignUpField.custom hintText required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
