### PR TITLE
fix(docs): Update custom pre-sign up handler

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,7 +256,7 @@ When prompted to edit the function now, choose "yes" and add the following code 
 created by the amplify CLI, from [documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-sign-up.html#aws-lambda-triggers-pre-registration-example-2).
 
 ```js
-exports.handler = (event, context, callback) => {
+exports.handler = async event => {
   // Confirm the user
   event.response.autoConfirmUser = true;
 
@@ -271,7 +271,7 @@ exports.handler = (event, context, callback) => {
   }
 
   // Return to Amazon Cognito
-  callback(null, event);
+  return event;
 };
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
- Current pre-sign up trigger does not work in latest CLI. Gives following error:

```
LambdaException(message: Sign up failed, recoverySuggestion: See attached exception for more details., underlyingException: com.amazonaws.services.cognitoidentityprovider.model.UserLambdaValidationException: PreSignUp failed with error callback is not a function. (Service: AmazonCognitoIdentityProvider; Status Code: 400; Error Code: UserLambdaValidationException; Request ID: 21307ea4-f716-4f7f-94d7-aae754d58eb3))
```

*Description of changes:*
- See ex. [here](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreSignup/email-filter-allowlist.js)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
