### PR TITLE
fix: create newPassword field for confirm sign up

### DIFF
--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -152,7 +152,7 @@ class StateMachineBloc {
   ) async* {
     try {
       var result = await _authService.confirmSignIn(
-        code: data.code,
+        confirmationValue: data.confirmationValue,
         attributes: data.attributes,
       );
 

--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_data.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_data.dart
@@ -101,11 +101,11 @@ class AuthUpdatePasswordData {
 
 class AuthConfirmSignInData {
   AuthConfirmSignInData({
-    required this.code,
+    required this.confirmationValue,
     this.attributes = const {},
   });
 
-  final String code;
+  final String confirmationValue;
   final Map<String, String> attributes;
 }
 

--- a/packages/amplify_authenticator/lib/src/enums/confirm_signin_types.dart
+++ b/packages/amplify_authenticator/lib/src/enums/confirm_signin_types.dart
@@ -18,6 +18,7 @@ import 'package:flutter/foundation.dart';
 enum ConfirmSignInField {
   code,
   password,
+  newPassword,
   address,
   birthdate,
   email,

--- a/packages/amplify_authenticator/lib/src/keys.dart
+++ b/packages/amplify_authenticator/lib/src/keys.dart
@@ -68,6 +68,8 @@ const keyCodeConfirmSignUpFormfield = Key('codeConfirmSignUpFormField');
 const keyCodeConfirmSignInFormfield = Key('codeConfirmSignUpFormField');
 const keyUsernameConfirmSignInFormfield = Key('usernameConfirmSignInFormField');
 const keyPasswordConfirmSignInFormField = Key('passwordConfirmSignInFormField');
+const keyNewPasswordConfirmSignInFormField =
+    Key('newPasswordConfirmSignInFormField');
 const keyAddressConfirmSignInFormField = Key('addresslConfirmSignInFormField');
 const keyBirthdateConfirmSignInFormField =
     Key('birthdateConfirmSignInFormField');

--- a/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations.dart
@@ -120,6 +120,12 @@ abstract class AuthenticatorInputLocalizations {
   /// **'Password'**
   String get password;
 
+  /// User's chosen new password.
+  ///
+  /// In en, this message translates to:
+  /// **'New Password'**
+  String get newPassword;
+
   /// Confirmation of user's chosen password.
   ///
   /// In en, this message translates to:

--- a/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations_en.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations_en.dart
@@ -30,6 +30,9 @@ class AuthenticatorInputLocalizationsEn
   String get password => 'Password';
 
   @override
+  String get newPassword => 'New Password';
+
+  @override
   String get passwordConfirmation => 'Confirm Password';
 
   @override

--- a/packages/amplify_authenticator/lib/src/l10n/input_resolver.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/input_resolver.dart
@@ -22,6 +22,7 @@ import 'resolver.dart';
 enum InputField {
   username,
   password,
+  newPassword,
   passwordConfirmation,
   verificationCode,
   address,
@@ -81,6 +82,10 @@ class InputResolverKey {
   static const passwordEmpty = InputResolverKey._(
     InputResolverKeyType.empty,
     field: InputField.password,
+  );
+  static const newPasswordHint = InputResolverKey._(
+    InputResolverKeyType.hint,
+    field: InputField.newPassword,
   );
   static const passwordConfirmationTitle = InputResolverKey._(
     InputResolverKeyType.title,
@@ -333,6 +338,8 @@ class InputResolver extends Resolver<InputResolverKey> {
         return AuthenticatorLocalizations.inputsOf(context).username;
       case InputField.password:
         return AuthenticatorLocalizations.inputsOf(context).password;
+      case InputField.newPassword:
+        return AuthenticatorLocalizations.inputsOf(context).newPassword;
       case InputField.passwordConfirmation:
         return AuthenticatorLocalizations.inputsOf(context)
             .passwordConfirmation;

--- a/packages/amplify_authenticator/lib/src/l10n/src/inputs/inputs_en.arb
+++ b/packages/amplify_authenticator/lib/src/l10n/src/inputs/inputs_en.arb
@@ -9,6 +9,10 @@
     "@password": {
         "description": "User's chosen password."
     },
+    "newPassword": "New Password",
+    "@newPassword": {
+        "description": "User's chosen new password."
+    },
     "passwordConfirmation": "Confirm Password",
     "@passwordConfirmation": {
         "description": "Confirmation of user's chosen password."

--- a/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -49,7 +49,7 @@ abstract class AuthService {
   );
 
   Future<SignInResult> confirmSignIn({
-    required String code,
+    required String confirmationValue,
     Map<String, String>? attributes,
   });
 
@@ -123,11 +123,11 @@ class AmplifyAuthService implements AuthService {
 
   @override
   Future<SignInResult> confirmSignIn({
-    required String code,
+    required String confirmationValue,
     Map<String, String>? attributes,
   }) {
     return Amplify.Auth.confirmSignIn(
-      confirmationValue: code,
+      confirmationValue: confirmationValue,
       options: CognitoConfirmSignInOptions(userAttributes: attributes),
     );
   }

--- a/packages/amplify_authenticator/lib/src/state/auth_viewmodel.dart
+++ b/packages/amplify_authenticator/lib/src/state/auth_viewmodel.dart
@@ -214,13 +214,28 @@ class AuthViewModel extends ChangeNotifier {
 
   // Auth calls
 
-  Future<void> confirmSignIn() async {
+  Future<void> confirmSignInMFA() async {
     if (!formKey.currentState!.validate()) {
       return;
     }
     setBusy(true);
     var confirm = AuthConfirmSignInData(
-      code: _confirmationCode.trim(),
+      confirmationValue: _confirmationCode.trim(),
+      attributes: _authAttributes,
+    );
+
+    authBloc.add(AuthConfirmSignIn(confirm, rememberDevice: rememberDevice));
+    await _nextBlocEvent();
+    setBusy(false);
+  }
+
+  Future<void> confirmSignInNewPassword() async {
+    if (!formKey.currentState!.validate()) {
+      return;
+    }
+    setBusy(true);
+    var confirm = AuthConfirmSignInData(
+      confirmationValue: _newPassword.trim(),
       attributes: _authAttributes,
     );
 

--- a/packages/amplify_authenticator/lib/src/widgets/button.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/button.dart
@@ -247,7 +247,7 @@ class ConfirmSignInMFAButton extends AuthenticatorElevatedButton {
 
   @override
   void onPressed(BuildContext context, AuthViewModel viewModel) =>
-      viewModel.confirmSignIn();
+      viewModel.confirmSignInMFA();
 }
 
 // SignOutButton should not inherit from AuthenticatorButton, since we override
@@ -519,7 +519,7 @@ class ConfirmSignInNewPasswordButton extends AuthenticatorElevatedButton {
 
   @override
   void onPressed(BuildContext context, AuthViewModel viewModel) =>
-      viewModel.confirmSignIn();
+      viewModel.confirmSignInNewPassword();
 }
 
 class VerifyUserButton extends AuthenticatorElevatedButton {

--- a/packages/amplify_authenticator/lib/src/widgets/form.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form.dart
@@ -398,7 +398,7 @@ class ConfirmSignInNewPasswordForm
   }) : this.custom(
           key: key,
           fields: [
-            ConfirmSignInFormField.password(),
+            ConfirmSignInFormField.newPassword(),
           ],
         );
 

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/confirm_sign_in_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/confirm_sign_in_form_field.dart
@@ -49,10 +49,23 @@ abstract class ConfirmSignInFormField<FieldValue>
     FormFieldValidator<String>? validator,
   }) =>
       _ConfirmSignInTextField(
-        key: key ?? keyPasswordConfirmSignUpFormfield,
+        key: key ?? keyPasswordConfirmSignInFormField,
         titleKey: InputResolverKey.passwordTitle,
         hintTextKey: InputResolverKey.passwordHint,
         field: ConfirmSignInField.password,
+        validator: validator,
+      );
+
+  /// Creates a new password component.
+  static ConfirmSignInFormField newPassword({
+    Key? key,
+    FormFieldValidator<String>? validator,
+  }) =>
+      _ConfirmSignInTextField(
+        key: key ?? keyNewPasswordConfirmSignInFormField,
+        titleKey: InputResolverKey.passwordTitle,
+        hintTextKey: InputResolverKey.newPasswordHint,
+        field: ConfirmSignInField.newPassword,
         validator: validator,
       );
 
@@ -99,6 +112,7 @@ abstract class _ConfirmSignInFormFieldState<FieldValue>
   bool get obscureText {
     switch (widget.field) {
       case ConfirmSignInField.password:
+      case ConfirmSignInField.newPassword:
         return true;
       default:
         return false;
@@ -111,6 +125,7 @@ abstract class _ConfirmSignInFormFieldState<FieldValue>
       case ConfirmSignInField.code:
         return TextInputType.number;
       case ConfirmSignInField.password:
+      case ConfirmSignInField.newPassword:
         return TextInputType.visiblePassword;
       case ConfirmSignInField.address:
         return TextInputType.streetAddress;
@@ -137,6 +152,7 @@ abstract class _ConfirmSignInFormFieldState<FieldValue>
   Widget? get suffixIcon {
     switch (widget.field) {
       case ConfirmSignInField.password:
+      case ConfirmSignInField.newPassword:
         return visibilityToggle;
       default:
         return null;
@@ -178,6 +194,8 @@ class _ConfirmSignInTextFieldState extends _ConfirmSignInFormFieldState<String>
         return viewModel.confirmationCode;
       case ConfirmSignInField.password:
         return viewModel.password;
+      case ConfirmSignInField.newPassword:
+        return viewModel.newPassword;
       case ConfirmSignInField.address:
       case ConfirmSignInField.birthdate:
       case ConfirmSignInField.email:
@@ -201,7 +219,9 @@ class _ConfirmSignInTextFieldState extends _ConfirmSignInFormFieldState<String>
       case ConfirmSignInField.code:
         return viewModel.setConfirmationCode;
       case ConfirmSignInField.password:
-        return viewModel.setConfirmationCode;
+        return viewModel.setPassword;
+      case ConfirmSignInField.newPassword:
+        return viewModel.setNewPassword;
       case ConfirmSignInField.address:
         return viewModel.setAddress;
       case ConfirmSignInField.birthdate:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- create a newPassword field for confirm sign up
- separate MFA confirm sign up and force password reset confirm sign up
- update the language for the hint text


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
