### PR TITLE
fix(authenticator): remove the label from verify user screen and display email first

### DIFF
--- a/packages/amplify_authenticator/lib/src/l10n/input_resolver.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/input_resolver.dart
@@ -327,6 +327,9 @@ class InputResolverKey {
     InputResolverKeyType.title,
     field: InputField.usernameType,
   );
+
+  String resolve(BuildContext context, InputResolver inputResolver) =>
+      inputResolver.resolve(context, this);
 }
 
 class InputResolver extends Resolver<InputResolverKey> {

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_radio_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_radio_field.dart
@@ -16,7 +16,7 @@ mixin AuthenticatorRadioField<FieldType, FieldValue,
   @override
   Widget buildFormField(BuildContext context) {
     final inputResolver = stringResolver.inputs;
-    onChanged.call(selectionValue!);
+    if (selectionValue != null) onChanged(selectionValue!);
     return Column(
       children: <Widget>[
         for (var selection in selections)
@@ -37,7 +37,7 @@ mixin AuthenticatorRadioField<FieldType, FieldValue,
                 setState(() {
                   selectionValue = value;
                 });
-                onChanged.call(selectionValue!);
+                if (selectionValue != null) onChanged(selectionValue!);
               },
               activeColor: Colors.green,
             ),

--- a/packages/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -70,11 +70,7 @@ abstract class AuthenticatorFormField<FieldType, FieldValue,
     this.title,
     this.hintText,
     FormFieldValidator<FieldValue>? validator,
-  })  : assert(
-          titleKey != null || title != null,
-          'Either title or titleKey must be provided',
-        ),
-        validatorOverride = validator,
+  })  : validatorOverride = validator,
         super(key: key);
 
   /// Resolver key for the title
@@ -172,15 +168,15 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
   @override
   Widget build(BuildContext context) {
     final inputResolver = stringResolver.inputs;
-    final String title = widget.title == null
-        ? inputResolver.resolve(context, widget.titleKey!)
-        : widget.title!;
+    final String? title =
+        widget.title ?? widget.titleKey?.resolve(context, inputResolver);
+
     return Container(
       margin: FormFieldConstants.marginBottom,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Text(title),
+          if (title is String) Text(title),
           const Padding(padding: FormFieldConstants.gap),
           buildFormField(context),
           if (companionWidget != null) companionWidget!,

--- a/packages/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -176,7 +176,7 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          if (title is String) Text(title),
+          if (title != null) Text(title),
           const Padding(padding: FormFieldConstants.gap),
           buildFormField(context),
           if (companionWidget != null) companionWidget!,

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/verify_user_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/verify_user_form_field.dart
@@ -158,8 +158,6 @@ class _VerifyUserRadioField extends VerifyUserFormField<UsernameAttribute> {
   _VerifyAttributeFieldState createState() => _VerifyAttributeFieldState();
 }
 
-UsernameAttribute _default = UsernameAttribute.email;
-
 class _VerifyAttributeFieldState
     extends _VerifyUserFormFieldState<UsernameAttribute>
     with AuthenticatorRadioField {
@@ -183,14 +181,9 @@ class _VerifyAttributeFieldState
             value: UsernameAttribute.phoneNumber,
           )
       ];
-      _default = _inputSelections[0].value;
+      selectionValue = _inputSelections.first.value;
     }
     super.didChangeDependencies();
-  }
-
-  @override
-  UsernameAttribute? get initialValue {
-    return UsernameAttribute.email;
   }
 
   @override
@@ -204,5 +197,5 @@ class _VerifyAttributeFieldState
   }
 
   @override
-  UsernameAttribute? selectionValue = _default;
+  UsernameAttribute? selectionValue;
 }

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/verify_user_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/verify_user_form_field.dart
@@ -170,7 +170,8 @@ class _VerifyAttributeFieldState
     final _authState = InheritedAuthBloc.of(context).currentState;
     _inputSelections = [];
     if (_authState is VerifyUserFlow) {
-      final List<String> _unverifiedKeys = _authState.unverifiedAttributeKeys;
+      final List<String> _unverifiedKeys = _authState.unverifiedAttributeKeys
+        ..sort();
       for (var key in _unverifiedKeys) {
         switch (key) {
           case 'email':

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/verify_user_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/verify_user_form_field.dart
@@ -163,32 +163,27 @@ UsernameAttribute _default = UsernameAttribute.email;
 class _VerifyAttributeFieldState
     extends _VerifyUserFormFieldState<UsernameAttribute>
     with AuthenticatorRadioField {
-  List<InputSelection> _inputSelections = [];
+  List<InputSelection<UsernameAttribute>> _inputSelections = [];
 
   @override
   void didChangeDependencies() {
     final _authState = InheritedAuthBloc.of(context).currentState;
     _inputSelections = [];
     if (_authState is VerifyUserFlow) {
-      final List<String> _unverifiedKeys = _authState.unverifiedAttributeKeys
-        ..sort();
-      for (var key in _unverifiedKeys) {
-        switch (key) {
-          case 'email':
-            _inputSelections.add(const InputSelection<UsernameAttribute>(
-              label: InputResolverKey.emailTitle,
-              value: UsernameAttribute.email,
-            ));
-            break;
-          case 'phone_number':
-            _inputSelections.add(const InputSelection<UsernameAttribute>(
-              label: InputResolverKey.phoneNumberTitle,
-              value: UsernameAttribute.phoneNumber,
-            ));
-            break;
-        }
-        _default = _inputSelections[0].value;
-      }
+      final List<String> _unverifiedKeys = _authState.unverifiedAttributeKeys;
+      _inputSelections = [
+        if (_unverifiedKeys.contains('email'))
+          const InputSelection<UsernameAttribute>(
+            label: InputResolverKey.emailTitle,
+            value: UsernameAttribute.email,
+          ),
+        if (_unverifiedKeys.contains('phone_number'))
+          const InputSelection<UsernameAttribute>(
+            label: InputResolverKey.phoneNumberTitle,
+            value: UsernameAttribute.phoneNumber,
+          )
+      ];
+      _default = _inputSelections[0].value;
     }
     super.didChangeDependencies();
   }

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/verify_user_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/verify_user_form_field.dart
@@ -47,8 +47,6 @@ abstract class VerifyUserFormField<FieldValue> extends AuthenticatorFormField<
   }) =>
       _VerifyUserRadioField(
         key: keyUnverifiedAttributes,
-        titleKey: InputResolverKey.usernameTitle,
-        hintTextKey: InputResolverKey.usernameHint,
         field: VerifyAttributeField.verify,
         validator: validator,
       );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- removes the title from the verify user screen
- updates the ordering so that email always displays before phone
- properly sets the default attribute

**Before**
<img width="332" alt="Screen Shot 2021-11-09 at 9 55 00 AM" src="https://user-images.githubusercontent.com/20613561/140956282-8d6e58d0-ac22-4ba9-8264-a040f6890428.png">


**After**
<img width="332" alt="Screen Shot 2021-11-09 at 10 18 22 AM" src="https://user-images.githubusercontent.com/20613561/140954600-2850ea4b-d8ae-41a4-a94a-3d7fc87edce9.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
