### PR TITLE
fix: "Reply already submitted" crashes

### DIFF
--- a/packages/amplify_analytics_pinpoint/android/src/main/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/AmplifyAnalyticsPinpointPlugin.kt
+++ b/packages/amplify_analytics_pinpoint/android/src/main/kotlin/com/amazonaws/amplify/amplify_analytics_pinpoint/AmplifyAnalyticsPinpointPlugin.kt
@@ -19,6 +19,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.annotation.NonNull
+import com.amazonaws.amplify.amplify_core.AtomicResult
 import com.amplifyframework.core.Amplify
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -51,7 +52,8 @@ class AmplifyAnalyticsPinpointPlugin : FlutterPlugin, ActivityAware, MethodCallH
     }
 
     // Handle methods received via MethodChannel
-    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
+    override fun onMethodCall(@NonNull call: MethodCall, @NonNull _result: Result) {
+        val result = AtomicResult(_result, call.method)
 
         when (call.method) {
             "addPlugin" ->

--- a/packages/amplify_analytics_pinpoint/ios/Classes/SwiftAmplifyAnalyticsPinpointPlugin.swift
+++ b/packages/amplify_analytics_pinpoint/ios/Classes/SwiftAmplifyAnalyticsPinpointPlugin.swift
@@ -17,6 +17,7 @@ import Flutter
 import UIKit
 import Amplify
 import AmplifyPlugins
+import amplify_core
 
 public class SwiftAmplifyAnalyticsPinpointPlugin: NSObject, FlutterPlugin {
     private let bridge: AnalyticsBridge
@@ -36,6 +37,8 @@ public class SwiftAmplifyAnalyticsPinpointPlugin: NSObject, FlutterPlugin {
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let result = AtomicResult(result, call.method)
+
         innerHandle(method: call.method, callArgs: call.arguments as Any?, result: result)
     }
 

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApiPlugin.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApiPlugin.kt
@@ -22,6 +22,7 @@ import androidx.annotation.NonNull
 import androidx.annotation.VisibleForTesting
 import com.amazonaws.amplify.amplify_api.auth.FlutterAuthProviders
 import com.amazonaws.amplify.amplify_api.rest_api.FlutterRestApi
+import com.amazonaws.amplify.amplify_core.AtomicResult
 import com.amazonaws.amplify.amplify_core.exception.ExceptionUtil.Companion.createSerializedUnrecognizedError
 import com.amazonaws.amplify.amplify_core.exception.ExceptionUtil.Companion.handleAddPluginException
 import com.amazonaws.amplify.amplify_core.exception.ExceptionUtil.Companion.postExceptionToFlutterChannel
@@ -74,8 +75,9 @@ class AmplifyApiPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun onMethodCall(call: MethodCall, result: Result) {
+    override fun onMethodCall(call: MethodCall, _result: Result) {
         val methodName = call.method
+        val result = AtomicResult(_result, call.method)
 
         if (methodName == "cancel") {
             onCancel(result, (call.arguments as String))

--- a/packages/amplify_api/ios/Classes/SwiftAmplifyApiPlugin.swift
+++ b/packages/amplify_api/ios/Classes/SwiftAmplifyApiPlugin.swift
@@ -46,6 +46,8 @@ public class SwiftAmplifyApiPlugin: NSObject, FlutterPlugin {
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let result = AtomicResult(result, call.method)
+
         innerHandle(method: call.method, callArgs: call.arguments as Any, result: result)
     }
 

--- a/packages/amplify_auth_cognito/android/build.gradle
+++ b/packages/amplify_auth_cognito/android/build.gradle
@@ -67,5 +67,4 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:3.10.0'
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.robolectric:robolectric:4.3.1'
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9'
 }

--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
@@ -52,6 +52,7 @@ import com.amazonaws.amplify.amplify_auth_cognito.types.FlutterResendUserAttribu
 import com.amazonaws.amplify.amplify_auth_cognito.types.FlutterSignOutRequest
 import com.amazonaws.amplify.amplify_core.exception.ExceptionUtil.Companion.handleAddPluginException
 import com.amazonaws.amplify.amplify_auth_cognito.utils.isRedirectActivityDeclared
+import com.amazonaws.amplify.amplify_core.AtomicResult
 import com.amplifyframework.auth.AuthException
 import com.amplifyframework.auth.AuthProvider
 import com.amplifyframework.auth.AuthSession
@@ -151,7 +152,9 @@ public class AuthCognito : FlutterPlugin, ActivityAware, MethodCallHandler, Plug
     return args as HashMap<String, Any>
   };
 
-  override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
+  override fun onMethodCall(@NonNull call: MethodCall, @NonNull _result: Result) {
+
+    val result = AtomicResult(_result, call.method)
 
     if(call.method == "addPlugin"){
       try {

--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/device/DeviceHandler.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/device/DeviceHandler.kt
@@ -15,7 +15,7 @@
 package com.amazonaws.amplify.amplify_auth_cognito.device
 
 import com.amazonaws.amplify.amplify_auth_cognito.AuthErrorHandler
-import com.amazonaws.amplify.amplify_auth_cognito.base.AtomicResult
+import com.amazonaws.amplify.amplify_core.AtomicResult
 import com.amazonaws.mobile.client.AWSMobileClient
 import com.amazonaws.mobile.client.Callback
 import com.amazonaws.mobile.client.results.ListDevicesResult

--- a/packages/amplify_auth_cognito/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/amplify_auth_cognito/example/ios/Runner.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		26AECB412893A7A959622364 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE1727BF3FA0D464713D41A3 /* Pods_Runner.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		4BD33A9326B483830051B8AC /* AtomicResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD33A9226B483830051B8AC /* AtomicResultTests.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		9674FCEAE95127916BA4C1B4 /* Pods_unit_tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D2AB19942AD94335DB089EE /* Pods_unit_tests.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -44,7 +43,6 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3D23EF9D73AD2AD9798E569E /* Pods-amplify_auth_cognito_exampleTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-amplify_auth_cognito_exampleTests.profile.xcconfig"; path = "Target Support Files/Pods-amplify_auth_cognito_exampleTests/Pods-amplify_auth_cognito_exampleTests.profile.xcconfig"; sourceTree = "<group>"; };
 		3D2AB19942AD94335DB089EE /* Pods_unit_tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_unit_tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4BD33A9226B483830051B8AC /* AtomicResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicResultTests.swift; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		77E8D0F580AB656481259C9E /* Pods-amplify_auth_cognito_exampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-amplify_auth_cognito_exampleTests.release.xcconfig"; path = "Target Support Files/Pods-amplify_auth_cognito_exampleTests/Pods-amplify_auth_cognito_exampleTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -143,7 +141,6 @@
 			children = (
 				9C3D802725C1F52600728B7B /* amplify_auth_error_handling_tests.swift */,
 				9C404086251AA2430036C5FE /* MockAuthSession.swift */,
-				4BD33A9226B483830051B8AC /* AtomicResultTests.swift */,
 				B43589BC2581AA9600789DEE /* amplify_auth_cognito_tests.swift */,
 				9CEFDF1625113C2F001481FC /* Info.plist */,
 				9CC45C2325A4F7E90055E103 /* amplify_auth_cognito_hub_tests.swift */,
@@ -404,7 +401,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9C3D802825C1F52600728B7B /* amplify_auth_error_handling_tests.swift in Sources */,
-				4BD33A9326B483830051B8AC /* AtomicResultTests.swift in Sources */,
 				9CC45C2425A4F7E90055E103 /* amplify_auth_cognito_hub_tests.swift in Sources */,
 				9C404087251AA2430036C5FE /* MockAuthSession.swift in Sources */,
 				9C3D802B25C1F82800728B7B /* MockErrorConstants.swift in Sources */,

--- a/packages/amplify_auth_cognito/ios/Classes/Device/DeviceHandler.swift
+++ b/packages/amplify_auth_cognito/ios/Classes/Device/DeviceHandler.swift
@@ -17,6 +17,7 @@ import Foundation
 import Flutter
 import Amplify
 import AmplifyPlugins
+import amplify_core
 
 /// Handles calls to the Devices API.
 struct DeviceHandler {
@@ -43,7 +44,6 @@ struct DeviceHandler {
     func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard DeviceHandler.canHandle(call.method) else { return }
         
-        let result = AtomicResult(result)
         do {
             switch call.method {
             case "rememberDevice":

--- a/packages/amplify_auth_cognito/ios/Classes/SwiftAuthCognito.swift
+++ b/packages/amplify_auth_cognito/ios/Classes/SwiftAuthCognito.swift
@@ -65,6 +65,8 @@ public class SwiftAuthCognito: NSObject, FlutterPlugin {
     }
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let result = AtomicResult(result, call.method)
+
         if(call.method == "addPlugin"){
             do {
                 try Amplify.add(plugin: AWSCognitoAuthPlugin() )

--- a/packages/amplify_core/android/build.gradle
+++ b/packages/amplify_core/android/build.gradle
@@ -50,6 +50,7 @@ android {
     testOptions {
         unitTests {
             includeAndroidResources = true
+            returnDefaultValues = true
         }
     }
     buildTypes {

--- a/packages/amplify_core/android/build.gradle
+++ b/packages/amplify_core/android/build.gradle
@@ -63,11 +63,14 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.amplifyframework:core:1.28.2'
     implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9'
+
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'
     testImplementation 'org.mockito:mockito-inline:3.10.0'
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9'
 }
 
 apply plugin: 'org.jlleitschuh.gradle.ktlint'

--- a/packages/amplify_core/android/src/main/kotlin/com/amazonaws/amplify/amplify_core/AtomicResult.kt
+++ b/packages/amplify_core/android/src/main/kotlin/com/amazonaws/amplify/amplify_core/AtomicResult.kt
@@ -12,7 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package com.amazonaws.amplify.amplify_auth_cognito.base
+package com.amazonaws.amplify.amplify_core
 
 import io.flutter.Log
 import io.flutter.plugin.common.MethodChannel

--- a/packages/amplify_core/android/src/test/kotlin/com/amazonaws/amplify/amplify_core/AtomicResultTest.kt
+++ b/packages/amplify_core/android/src/test/kotlin/com/amazonaws/amplify/amplify_core/AtomicResultTest.kt
@@ -12,7 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package com.amazonaws.amplify.amplify_auth_cognito.base
+package com.amazonaws.amplify.amplify_core
 
 import io.flutter.plugin.common.MethodChannel
 import kotlinx.coroutines.Dispatchers

--- a/packages/amplify_core/android/src/test/kotlin/com/amazonaws/amplify/amplify_core/CoroutineTestRule.kt
+++ b/packages/amplify_core/android/src/test/kotlin/com/amazonaws/amplify/amplify_core/CoroutineTestRule.kt
@@ -12,7 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package com.amazonaws.amplify.amplify_auth_cognito.base
+package com.amazonaws.amplify.amplify_core
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/packages/amplify_core/ios/Classes/Support/AtomicResult.swift
+++ b/packages/amplify_core/ios/Classes/Support/AtomicResult.swift
@@ -16,23 +16,30 @@
 import Foundation
 
 /// Thread-safe wrapper for [FlutterResult]. Prevents multiple replies and automically posts results to the main thread.
-func AtomicResult(_ result: @escaping FlutterResult) -> FlutterResult {
-    return atomicResult(result).send
+public func AtomicResult(_ result: @escaping FlutterResult, _ methodName: String) -> FlutterResult {
+    return atomicResult(result, methodName).send
 }
 
 private class atomicResult {
     let result: FlutterResult
     
+    /// The method call which initiated this result.
+    let methodName: String
+    
     /// Whether a reply has already been sent.
     var isSent = false
     
-    init(_ result: @escaping FlutterResult) {
+    init(_ result: @escaping FlutterResult, _ methodName: String) {
         self.result = result
+        self.methodName = methodName
     }
     
     func send(_ value: Any?) {
         DispatchQueue.main.async { [self] in
-            guard !isSent else { return }
+            guard !isSent else {
+                NSLog("AtomicResult(%@): Attempted to send value after initial reply", methodName)
+                return
+            }
             result(value)
             isSent = true
         }

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -19,6 +19,7 @@ import android.os.Handler
 import android.os.Looper
 import androidx.annotation.NonNull
 import androidx.annotation.VisibleForTesting
+import com.amazonaws.amplify.amplify_core.AtomicResult
 import com.amazonaws.amplify.amplify_core.exception.ExceptionMessages
 import com.amazonaws.amplify.amplify_core.exception.ExceptionUtil.Companion.createSerializedError
 import com.amazonaws.amplify.amplify_core.exception.ExceptionUtil.Companion.createSerializedUnrecognizedError
@@ -99,7 +100,8 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         LOG.info("Initiated DataStore plugin")
     }
 
-    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
+    override fun onMethodCall(@NonNull call: MethodCall, @NonNull _result: Result) {
+        val result = AtomicResult(_result, call.method)
         var data: Map<String, Any> = HashMap()
         try {
             if (call.arguments != null) {

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -51,6 +51,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
     }
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let result = AtomicResult(result, call.method)
         var arguments: [String: Any] = [:]
         do {
             if(call.arguments != nil) {

--- a/packages/amplify_flutter/android/src/main/kotlin/com/amazonaws/amplify/Amplify.kt
+++ b/packages/amplify_flutter/android/src/main/kotlin/com/amazonaws/amplify/Amplify.kt
@@ -21,6 +21,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import androidx.annotation.NonNull
+import com.amazonaws.amplify.amplify_core.AtomicResult
 import com.amazonaws.amplify.amplify_core.exception.ExceptionUtil.Companion.createSerializedError
 import com.amazonaws.amplify.amplify_core.exception.ExceptionUtil.Companion.postExceptionToFlutterChannel
 import com.amplifyframework.AmplifyException
@@ -67,8 +68,9 @@ class Amplify(
         }
     }
 
-    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-
+    override fun onMethodCall(@NonNull call: MethodCall, @NonNull _result: Result) {
+        val result = AtomicResult(_result, call.method)
+        
         when (call.method) {
             "configure" ->
                 try {

--- a/packages/amplify_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/amplify_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0D197502BD59DBEF93D65436 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E32443345238838F59C230ED /* Pods_Runner.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		4BE11A56273ADE200085B0A5 /* AtomicResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE11A55273ADE200085B0A5 /* AtomicResultTests.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		89CF7883E32A148B466DB6EE /* Pods_unit_tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B23243B049084B0B0D59CDFA /* Pods_unit_tests.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -37,6 +38,7 @@
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		2013AFA741F195A766DAEE21 /* Pods-unit_tests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-unit_tests.profile.xcconfig"; path = "Target Support Files/Pods-unit_tests/Pods-unit_tests.profile.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		4BE11A55273ADE200085B0A5 /* AtomicResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicResultTests.swift; sourceTree = "<group>"; };
 		55AAAAF3DD54E1727852F736 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		709E5110B3B116EC5F857110 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 			children = (
 				B454F8AC2593CCBF00CA6E09 /* amplify_flutter_exampleTests.swift */,
 				B454F8B02593CCCA00CA6E09 /* Info.plist */,
+				4BE11A55273ADE200085B0A5 /* AtomicResultTests.swift */,
 				B44F26FE25CDF1F700B05C07 /* MockAnalyticsCategoryPlugin.swift */,
 			);
 			path = unit_tests;
@@ -386,6 +389,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B454F8AD2593CCBF00CA6E09 /* amplify_flutter_exampleTests.swift in Sources */,
+				4BE11A56273ADE200085B0A5 /* AtomicResultTests.swift in Sources */,
 				B44F26FF25CDF1F700B05C07 /* MockAnalyticsCategoryPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/packages/amplify_flutter/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/packages/amplify_flutter/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/packages/amplify_flutter/example/ios/unit_tests/AtomicResultTests.swift
+++ b/packages/amplify_flutter/example/ios/unit_tests/AtomicResultTests.swift
@@ -1,13 +1,21 @@
-//
-//  AtomicResultTests.swift
-//  unit_tests
-//
-//  Created by Nys, Dillon on 7/30/21.
-//
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 
 import XCTest
 import Flutter
-@testable import amplify_auth_cognito
+import amplify_core
 
 class AtomicResultTests: XCTestCase {
     
@@ -28,7 +36,7 @@ class AtomicResultTests: XCTestCase {
             }
             XCTAssertEqual(strValue, expected)
         }
-        let atomicResult = AtomicResult(result)
+        let atomicResult = AtomicResult(result, #function)
         atomicResult(expected)
         waitForExpectations(timeout: 1)
     }
@@ -44,7 +52,7 @@ class AtomicResultTests: XCTestCase {
             }
             XCTAssertEqual(errValue, expected)
         }
-        let atomicResult = AtomicResult(result)
+        let atomicResult = AtomicResult(result, #function)
         atomicResult(expected)
         waitForExpectations(timeout: 0.1)
     }
@@ -53,7 +61,7 @@ class AtomicResultTests: XCTestCase {
         let result: FlutterResult = { _ in
             OSAtomicIncrement32(&self.counter)
         }
-        let atomicResult = AtomicResult(result)
+        let atomicResult = AtomicResult(result, #function)
         atomicResult(nil)
         atomicResult(nil)
         let exp = expectation(description: #function)
@@ -68,7 +76,7 @@ class AtomicResultTests: XCTestCase {
         let result: FlutterResult = { _ in
             OSAtomicIncrement32(&self.counter)
         }
-        let atomicResult = AtomicResult(result)
+        let atomicResult = AtomicResult(result, #function)
         
         DispatchQueue.global().sync {
             DispatchQueue.concurrentPerform(iterations: 1000) { i in

--- a/packages/amplify_flutter/ios/Classes/SwiftAmplify.swift
+++ b/packages/amplify_flutter/ios/Classes/SwiftAmplify.swift
@@ -29,6 +29,8 @@ public class SwiftAmplify: NSObject, FlutterPlugin {
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let result = AtomicResult(result, call.method)
+
         switch call.method {
         case "configure":
             let arguments = call.arguments as! Dictionary<String, AnyObject>

--- a/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/AmplifyStorageS3Plugin.kt
+++ b/packages/amplify_storage_s3/android/src/main/kotlin/com/amazonaws/amplify/amplify_storage_s3/AmplifyStorageS3Plugin.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.src.main.kotlin.com.amazonaws.amplify.amplify_storage_s3.types.TransferProgressStreamHandler
 import android.util.Log
 import androidx.annotation.NonNull
+import com.amazonaws.amplify.amplify_core.AtomicResult
 import com.amazonaws.amplify.amplify_core.exception.ExceptionUtil.Companion.handleAddPluginException
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.storage.s3.AWSS3StoragePlugin
@@ -55,7 +56,9 @@ class AmplifyStorageS3Plugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         transferProgressEventChannel.setStreamHandler(transferProgressStreamHandler);
     }
 
-    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
+    override fun onMethodCall(@NonNull call: MethodCall, @NonNull _result: Result) {
+        val result = AtomicResult(_result, call.method)
+
         if(call.method == "addPlugin"){
             try {
                 Amplify.addPlugin(AWSS3StoragePlugin())

--- a/packages/amplify_storage_s3/ios/Classes/SwiftAmplifyStorageS3Plugin.swift
+++ b/packages/amplify_storage_s3/ios/Classes/SwiftAmplifyStorageS3Plugin.swift
@@ -33,7 +33,7 @@ public class SwiftAmplifyStorageS3Plugin: NSObject, FlutterPlugin {
     }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    print("In handle for method \(call.method)")
+    let result = AtomicResult(result, call.method)
 
     if(call.method == "addPlugin"){
         do {


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-amplify/amplify-flutter/issues/1022
- https://github.com/aws-amplify/amplify-flutter/issues/791
- https://github.com/aws-amplify/amplify-flutter/issues/340
- https://github.com/aws-amplify/amplify-flutter/issues/140

*Description of changes:*
- Long overdue migration to AtomicResult to prevent "reply already submitted" crashes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
