### PR TITLE
chore: remove DateTime.now() from tests

### DIFF
--- a/packages/amplify_datastore/example/integration_test/model_type_test.dart
+++ b/packages/amplify_datastore/example/integration_test/model_type_test.dart
@@ -144,9 +144,9 @@ void main() {
     });
 
     group('List<AWSDate>', () {
-      var now = DateTime.now();
-      var list =
-          List.generate(3, (i) => TemporalDate(now.add(Duration(days: i))));
+      var dateTime = DateTime.parse("2021-11-09T18:53:12.183540Z");
+      var list = List.generate(
+          3, (i) => TemporalDate(dateTime.add(Duration(days: i))));
       var models = List.generate(5, (_) => DateListTypeModel(value: list));
       testModelOperations(models: models);
     });
@@ -186,9 +186,9 @@ void main() {
     });
 
     group('List<AWSDateTime>', () {
-      var now = DateTime.now();
-      var list =
-          List.generate(3, (i) => TemporalDateTime(now.add(Duration(days: i))));
+      var dateTime = DateTime.parse("2021-11-09T18:53:12.183540Z");
+      var list = List.generate(
+          3, (i) => TemporalDateTime(dateTime.add(Duration(days: i))));
       var models = List.generate(5, (_) => DateTimeListTypeModel(value: list));
       testModelOperations(models: models);
     });
@@ -224,9 +224,9 @@ void main() {
     });
 
     group('List<AWSTime>', () {
-      var now = DateTime.now();
-      var list =
-          List.generate(3, (i) => TemporalTime(now.add(Duration(days: i))));
+      var dateTime = DateTime.parse("2021-11-09T18:53:12.183540Z");
+      var list = List.generate(
+          3, (i) => TemporalTime(dateTime.add(Duration(days: i))));
       var models = List.generate(5, (_) => TimeListTypeModel(value: list));
       testModelOperations(models: models);
     });
@@ -263,9 +263,9 @@ void main() {
     group(
       'List<AWSTimestamp>',
       () {
-        var now = DateTime.now();
+        var dateTime = DateTime.parse("2021-11-09T18:53:12.183540Z");
         var list = List.generate(
-            3, (i) => TemporalTimestamp(now.add(Duration(days: i))));
+            3, (i) => TemporalTimestamp(dateTime.add(Duration(days: i))));
         var models =
             List.generate(5, (_) => TimestampListTypeModel(value: list));
         testModelOperations(models: models);

--- a/packages/amplify_datastore/example/integration_test/query_test/standard_query_operations_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/standard_query_operations_test.dart
@@ -74,7 +74,7 @@ void main() {
       Post testPost = Post(
         title: 'test post',
         blog: testBlog,
-        created: TemporalDateTime(DateTime.now()),
+        created: TemporalDateTime.fromString("2021-11-09T18:53:12.183540Z"),
         rating: 10,
       );
       await Amplify.DataStore.save(testPost);

--- a/packages/amplify_datastore/test/amplify_datastore_delete_test.dart
+++ b/packages/amplify_datastore/test/amplify_datastore_delete_test.dart
@@ -65,7 +65,8 @@ void main() {
             id: '4281dfba-96c8-4a38-9a8e-35c7e893ea47',
             title: 'test title',
             rating: 0,
-            created: TemporalDateTime.now())),
+            created:
+                TemporalDateTime.fromString("2021-11-09T18:53:12.183540Z"))),
         throwsA(isA<DataStoreException>()
             .having((exception) => exception.message, 'message',
                 'Delete failed for whatever known reason')

--- a/packages/amplify_datastore_plugin_interface/test/amplify_temporal_date_test.dart
+++ b/packages/amplify_datastore_plugin_interface/test/amplify_temporal_date_test.dart
@@ -18,27 +18,30 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('AWSDate from DateTime success', () async {
-    DateTime now = DateTime.now();
+    DateTime dateTime = DateTime.parse("2021-11-09T18:53:12.183540Z");
 
-    TemporalDate awsDate = TemporalDate(now);
-    now = now.toUtc();
+    TemporalDate awsDate = TemporalDate(dateTime);
+    dateTime = dateTime.toUtc();
 
     expect(awsDate.getOffset(), null);
-    expect(awsDate.getDateTime(), DateTime.utc(now.year, now.month, now.day));
-    expect(awsDate.format(), now.toIso8601String().substring(0, 10));
+    expect(awsDate.getDateTime(),
+        DateTime.utc(dateTime.year, dateTime.month, dateTime.day));
+    expect(awsDate.format(), dateTime.toIso8601String().substring(0, 10));
   });
 
   test('AWSDate from DateTime with offset success', () async {
-    DateTime now = DateTime.now();
+    DateTime dateTime = DateTime.parse("2021-11-09T18:53:12.183540Z");
     Duration offset = Duration(hours: 3, minutes: 30);
 
-    TemporalDate awsDate = TemporalDate.withOffset(now, offset);
+    TemporalDate awsDate = TemporalDate.withOffset(dateTime, offset);
 
-    now = now.toUtc();
+    dateTime = dateTime.toUtc();
 
     expect(awsDate.getOffset(), offset);
-    expect(awsDate.getDateTime(), DateTime.utc(now.year, now.month, now.day));
-    expect(awsDate.format(), now.toIso8601String().substring(0, 10) + "+03:30");
+    expect(awsDate.getDateTime(),
+        DateTime.utc(dateTime.year, dateTime.month, dateTime.day));
+    expect(awsDate.format(),
+        dateTime.toIso8601String().substring(0, 10) + "+03:30");
   });
 
   test('AWSDate from string YYYY-MM-DD success', () async {
@@ -85,9 +88,9 @@ void main() {
   });
 
   test('AWSDate with day Duration fails', () async {
+    DateTime dateTime = DateTime.parse("2021-11-09T18:53:12.183540Z");
     Duration duration = Duration(days: 10, hours: 3, minutes: 30, seconds: 30);
-    expect(() => TemporalDate.withOffset(DateTime.now(), duration),
-        throwsException);
+    expect(() => TemporalDate.withOffset(dateTime, duration), throwsException);
   });
 
   test('AWSDate from string YYYY-MM fails', () async {

--- a/packages/amplify_datastore_plugin_interface/test/amplify_temporal_datetime_test.dart
+++ b/packages/amplify_datastore_plugin_interface/test/amplify_temporal_datetime_test.dart
@@ -18,27 +18,27 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('AWSDateTime from DateTime success', () async {
-    DateTime now = DateTime.now();
+    DateTime dateTime = DateTime.parse("2021-11-09T18:53:12.183540Z");
 
-    TemporalDateTime time = TemporalDateTime(now);
-    now = now.toUtc();
+    TemporalDateTime time = TemporalDateTime(dateTime);
+    dateTime = dateTime.toUtc();
 
     expect(time.getOffset(), Duration());
-    expect(time.getDateTimeInUtc(), now);
-    expect(time.format(), now.toIso8601String().substring(0, 26) + "000Z");
+    expect(time.getDateTimeInUtc(), dateTime);
+    expect(time.format(), dateTime.toIso8601String().substring(0, 26) + "000Z");
   });
 
   test('AWSDateTime from DateTime with offset success', () async {
-    DateTime now = DateTime.now();
+    DateTime dateTime = DateTime.parse("2021-11-09T18:53:12.183540Z");
     Duration offset = Duration(hours: 3, minutes: 30);
 
-    TemporalDateTime time = TemporalDateTime.withOffset(now, offset);
-    now = now.toUtc();
+    TemporalDateTime time = TemporalDateTime.withOffset(dateTime, offset);
+    dateTime = dateTime.toUtc();
 
     expect(time.getOffset(), offset);
-    expect(time.getDateTimeInUtc(), now);
+    expect(time.getDateTimeInUtc(), dateTime);
     expect(time.format(),
-        now.toIso8601String().substring(0, 26) + "000" + "+03:30");
+        dateTime.toIso8601String().substring(0, 26) + "000" + "+03:30");
   });
 
   test('AWSDateTime from string YYYY-MM-DDThh:mmZ success', () async {
@@ -134,16 +134,16 @@ void main() {
   });
 
   test('AWSDateTime from offset with single digit duration', () async {
-    DateTime now = DateTime.now();
+    DateTime dateTime = DateTime.parse("2021-11-09T18:53:12.183540Z");
     Duration offset = Duration(hours: 3, minutes: 3, seconds: 03);
 
-    TemporalDateTime time = TemporalDateTime.withOffset(now, offset);
-    now = now.toUtc();
+    TemporalDateTime time = TemporalDateTime.withOffset(dateTime, offset);
+    dateTime = dateTime.toUtc();
 
     expect(time.getOffset(), offset);
-    expect(time.getDateTimeInUtc(), now);
+    expect(time.getDateTimeInUtc(), dateTime);
     expect(time.format(),
-        now.toIso8601String().substring(0, 26) + "000" + "+03:03:03");
+        dateTime.toIso8601String().substring(0, 26) + "000" + "+03:03:03");
   });
 
   test('AWSDateTime from string YYYY-MM-DDThh:mm fails', () async {

--- a/packages/amplify_datastore_plugin_interface/test/amplify_temporal_time_test.dart
+++ b/packages/amplify_datastore_plugin_interface/test/amplify_temporal_time_test.dart
@@ -18,33 +18,33 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('AWSTime from DateTime success', () async {
-    DateTime now = DateTime.now();
+    DateTime dateTime = DateTime.parse("2021-11-09T18:53:12.183540Z");
 
-    TemporalTime time = TemporalTime(now);
-    now = now.toUtc();
+    TemporalTime time = TemporalTime(dateTime);
+    dateTime = dateTime.toUtc();
 
     expect(time.getOffset(), null);
     expect(
         time.getDateTime(),
-        DateTime.utc(1970, 1, 1, now.hour, now.minute, now.second,
-            now.millisecond, now.microsecond));
-    expect(time.format(), now.toIso8601String().substring(11, 26) + "000");
+        DateTime.utc(1970, 1, 1, dateTime.hour, dateTime.minute,
+            dateTime.second, dateTime.millisecond, dateTime.microsecond));
+    expect(time.format(), dateTime.toIso8601String().substring(11, 26) + "000");
   });
 
   test('AWSTime from DateTime with offset success', () async {
-    DateTime now = DateTime.now();
+    DateTime dateTime = DateTime.parse("2021-11-09T18:53:12.183540Z");
     Duration offset = Duration(hours: 3, minutes: 30);
 
-    TemporalTime time = TemporalTime.withOffset(now, offset);
-    now = now.toUtc();
+    TemporalTime time = TemporalTime.withOffset(dateTime, offset);
+    dateTime = dateTime.toUtc();
 
     expect(time.getOffset(), offset);
     expect(
         time.getDateTime(),
-        DateTime.utc(1970, 1, 1, now.hour, now.minute, now.second,
-            now.millisecond, now.microsecond));
+        DateTime.utc(1970, 1, 1, dateTime.hour, dateTime.minute,
+            dateTime.second, dateTime.millisecond, dateTime.microsecond));
     expect(time.format(),
-        now.toIso8601String().substring(11, 26) + "000" + "+03:30");
+        dateTime.toIso8601String().substring(11, 26) + "000" + "+03:30");
   });
 
   test('AWSDate from string hh:mm success', () async {

--- a/packages/amplify_datastore_plugin_interface/test/query_snapshot_test.dart
+++ b/packages/amplify_datastore_plugin_interface/test/query_snapshot_test.dart
@@ -20,6 +20,8 @@ import 'testData/ModelProvider.dart';
 
 void main() {
   group('QuerySnapshot', () {
+    TemporalDateTime _temporalDateTime =
+        TemporalDateTime.fromString("2021-11-09T18:53:12.183540Z");
     group('withSubscriptionEvent()', () {
       group('with no query predicate or sort order', () {
         late List<Blog> blogs;
@@ -325,7 +327,7 @@ void main() {
             (index) => Post(
               title: 'post $index',
               rating: index * 10,
-              created: TemporalDateTime.now(),
+              created: _temporalDateTime,
             ),
           );
           snapshot = QuerySnapshot(
@@ -341,7 +343,7 @@ void main() {
             Post newPost = Post(
               title: 'new post',
               rating: 25,
-              created: TemporalDateTime.now(),
+              created: _temporalDateTime,
             );
 
             SubscriptionEvent<Post> subscriptionEvent = SubscriptionEvent(
@@ -401,7 +403,7 @@ void main() {
             Post updatedPost = Post(
               title: 'new post',
               rating: 25,
-              created: TemporalDateTime.now(),
+              created: _temporalDateTime,
             );
 
             SubscriptionEvent<Post> subscriptionEvent = SubscriptionEvent(
@@ -435,7 +437,7 @@ void main() {
             (index) => Post(
               title: 'post $index',
               rating: index * 10,
-              created: TemporalDateTime.now(),
+              created: _temporalDateTime,
             ),
           );
           snapshot = QuerySnapshot(
@@ -451,25 +453,25 @@ void main() {
             Post newPost1 = Post(
               title: 'new post a',
               rating: 25,
-              created: TemporalDateTime.now(),
+              created: _temporalDateTime,
             );
 
             Post newPost2 = Post(
               title: 'new post a',
               rating: 40,
-              created: TemporalDateTime.now(),
+              created: _temporalDateTime,
             );
 
             Post newPost3 = Post(
               title: 'new post b',
               rating: 25,
-              created: TemporalDateTime.now(),
+              created: _temporalDateTime,
             );
 
             Post newPost4 = Post(
               title: 'new post b',
               rating: 40,
-              created: TemporalDateTime.now(),
+              created: _temporalDateTime,
             );
 
             SubscriptionEvent<Post> subscriptionEvent1 = SubscriptionEvent(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- remove calls to DateTime.now() from tests to prevent flaky tests

Note: I left a call to DateTime.now() in the storage integ tests that check the DateTime of file uploads. I think the use there is reasonable and I don't think there is an easy alternative.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
