### PR TITLE
fix(storage): Storage.list crash on null "options"

### DIFF
--- a/packages/amplify_storage_s3/example/.gitignore
+++ b/packages/amplify_storage_s3/example/.gitignore
@@ -42,7 +42,7 @@ app.*.map.json
 # Exceptions to above rules.
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 
-#amplify
+#amplify-do-not-edit-begin
 amplify/\#current-cloud-backend
 amplify/.config/local-*
 amplify/logs
@@ -61,3 +61,5 @@ amplify-build-config.json
 amplify-gradle-config.json
 amplifytools.xcconfig
 .secret-*
+**.sample
+#amplify-do-not-edit-end

--- a/packages/amplify_storage_s3/ios/Classes/AmplifyStorageOperations.swift
+++ b/packages/amplify_storage_s3/ios/Classes/AmplifyStorageOperations.swift
@@ -90,28 +90,23 @@ public class AmplifyStorageOperations {
     }
     
     public static func list(flutterResult: @escaping FlutterResult, request: Dictionary<String, AnyObject>){
-        do {
-            try FlutterListRequest.validate(request: request)
-            let req = FlutterListRequest(request: request)
-            _ = Amplify.Storage.list(options: req.options,
-                 resultListener: {event in
-                    switch event{
-                    case .success(let result):
-                        var listResultDictionary = [String:Any]();
-                        var storageItemList = [[String:Any]]();
-                        for item in result.items {
-                            let storageItemDictionary = getStorageItemDictionary(item: item)
-                            storageItemList.append(storageItemDictionary)
-                        }
-                        listResultDictionary["items"] = storageItemList
-                        flutterResult(listResultDictionary);
-                    case.failure(let storageError):
-                        prepareError(flutterResult: flutterResult, error: storageError)
+        let req = FlutterListRequest(request: request)
+        _ = Amplify.Storage.list(options: req.options,
+             resultListener: {event in
+                switch event{
+                case .success(let result):
+                    var listResultDictionary = [String:Any]();
+                    var storageItemList = [[String:Any]]();
+                    for item in result.items {
+                        let storageItemDictionary = getStorageItemDictionary(item: item)
+                        storageItemList.append(storageItemDictionary)
                     }
-             })
-        } catch {
-            prepareError(flutterResult: flutterResult, error: error)
-        }
+                    listResultDictionary["items"] = storageItemList
+                    flutterResult(listResultDictionary);
+                case.failure(let storageError):
+                    prepareError(flutterResult: flutterResult, error: storageError)
+                }
+         })
     }
     
     internal static func downloadFile(flutterResult: @escaping FlutterResult, request: Dictionary<String, AnyObject>, transferProgressStreamHandler : TransferProgressStreamHandler){

--- a/packages/amplify_storage_s3/ios/Classes/FlutterListRequest.swift
+++ b/packages/amplify_storage_s3/ios/Classes/FlutterListRequest.swift
@@ -18,41 +18,30 @@ import Amplify
 import amplify_core
 
 struct FlutterListRequest {
-    var options: StorageListRequest.Options?
-    init(request: Dictionary<String, AnyObject>) {
-        self.options = setOptions(request: request)
+    static private let validationErrorMessage = "List request malformed."
+    
+    let options: StorageListRequest.Options
+
+    init(request: [String: Any?]) {
+        self.options = FlutterListRequest.parseOptions(request: request)
     }
 
-    static func validate(request: Dictionary<String, AnyObject>) throws {
-        let validationErrorMessage = "List request malformed."
-        if !(request["path"] is String?) {
-            throw InvalidRequestError.storage(comment: validationErrorMessage,
-                                              suggestion: String(format: ErrorMessages.missingAttribute, "path"))
-        }
-    }
-    
-    private func setOptions(request: Dictionary<String, AnyObject>) -> StorageListRequest.Options? {
+    private static func parseOptions(request: [String: Any?]) -> StorageListRequest.Options {
+        var accessLevel = StorageAccessLevel.guest
+        var targetIdentityId: String? = nil
+        let path = request["path"] as? String
         
-        if(request["options"] != nil || request["path"] != nil) {
-            let requestOptions = request["options"] as! Dictionary<String, AnyObject>
-            //Default options
-            var accessLevel = StorageAccessLevel.guest
-            var targetIdentityId: String? = nil
-            let path: String? = request["path"] as! String?
-            
-            for(key,value) in requestOptions {
-                switch key {
-                case "accessLevel":
-                    accessLevel = StorageAccessLevel(rawValue: value as! String) ?? accessLevel
-                case "targetIdentityId":
-                    targetIdentityId = value as? String
-                default:
-                    print("Received unexpected option: \(key)")
-                }
+        if let options = request["options"] as? [String: Any?] {
+            if let accessValueLevel = options["accessLevel"] as? String,
+               let storageAccessLevel = StorageAccessLevel(rawValue: accessValueLevel) {
+                accessLevel = storageAccessLevel
             }
-            return StorageListRequest.Options(accessLevel: accessLevel, targetIdentityId: targetIdentityId, path: path)
+            targetIdentityId = options["targetIdentityId"] as? String
         }
-        return nil
+        
+        return StorageListRequest.Options(accessLevel: accessLevel,
+                                          targetIdentityId: targetIdentityId,
+                                          path: path)
     }
     
 }

--- a/packages/amplify_storage_s3/ios/Classes/FlutterListRequest.swift
+++ b/packages/amplify_storage_s3/ios/Classes/FlutterListRequest.swift
@@ -18,8 +18,7 @@ import Amplify
 import amplify_core
 
 struct FlutterListRequest {
-    static private let validationErrorMessage = "List request malformed."
-    
+
     let options: StorageListRequest.Options
 
     init(request: [String: Any?]) {


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-amplify/amplify-flutter/issues/1059

Issue: Omitting the `options` cause a crash on iOS due to improper null checks

*Description of changes:*
- Fix crash on null "options" dict
- Remove validation which did not do anything

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
