### PR TITLE
fix(datastore): Fix DataStore release mode crash (Android)

### DIFF
--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -35,6 +35,11 @@ android {
     }
     defaultConfig {
         minSdkVersion 21
+
+        // TODO: Remove when Gradle can be updated, since
+        // this seems to have been fixed in newer versions
+        // https://stackoverflow.com/a/64506880/12626712
+        consumerProguardFiles 'proguard-rules.pro'
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/amplify_datastore/android/proguard-rules.pro
+++ b/packages/amplify_datastore/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class io.reactivex.rxjava3.** { *; }


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-amplify/amplify-flutter/issues/1048
- https://github.com/aws-amplify/amplify-flutter/issues/828

*Description of changes:*
- Add ProGuard rules to prevent class splitting which causes crashes on startup for DataStore in release mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
