### PR TITLE
fix(amplify_authenticator) uses session for _authLoad

### DIFF
--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -152,13 +152,13 @@ class StateMachineBloc {
         yield AuthFlow.signin;
       }
 
-      /// The [isValidSession] method catches [SignedOutException] and [SessionExpiredException]
-      /// All other exceptions are re-thrown and caught here.
-    } on Exception {
+      /// The [isValidSession] method will only surface a SessonExpiredException,
+      /// as we want to display a banner to alert users. All other exceptions are swallowed.
+    } on SessionExpiredException {
       /// On all Exceptions other than SignedOutException or SessionExpired,
       /// we provide a generic message to the user and surface the SignIn form.
       _exceptionController.add(const AuthenticatorException(
-          'An unknown exception has occurred while parsing the session.'));
+          'Your session has expired. Please sign in.'));
       yield AuthFlow.signin;
     }
   }

--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -167,10 +167,9 @@ class StateMachineBloc {
       _exceptionController
           .add(AuthenticatorException(e.message, showBanner: false));
       yield AuthFlow.signin;
-    } on Exception {
-      _exceptionController.add(const AuthenticatorException(
-          'An unknown exception has occurred when fetching the session',
-          showBanner: false));
+    } on Exception catch (e) {
+      _exceptionController
+          .add(AuthenticatorException(e.toString(), showBanner: false));
       yield AuthFlow.signin;
     }
   }

--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -150,7 +150,7 @@ class StateMachineBloc {
         yield const Authenticated();
       } else {
         /// [isValidSession] returns false if the native platform
-        /// returns a [SignedOutException] or if the native libraries return a valid object but
+        /// returns a [SignedOutException] or if the native libraries return a session object but
         /// UserPool tokens are null (when unauthenticated access is enabled on Identity Pool).
         yield AuthFlow.signin;
       }

--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -145,21 +145,21 @@ class StateMachineBloc {
 
   Stream<AuthState> _isValidSession() async* {
     try {
-      bool isValidSession = await _authService.isValidSession;
+      bool isValidSession = await _authService.isValidSession();
       if (isValidSession) {
         yield const Authenticated();
       } else {
         yield AuthFlow.signin;
       }
-    } on AmplifyException catch (e) {
-      /// On all AmplifyExceptions other than SignedOutException or SessionExpired,
-      /// we provide a message to the user and surface the SignIn form.
-      _exceptionController.add(AuthenticatorException(e.message));
+
+      /// The [isValidSession] method catches [SignedOutException] and [SessionExpiredException]
+      /// All other exceptions are re-thrown and caught here.
+    } on Exception {
+      /// On all Exceptions other than SignedOutException or SessionExpired,
+      /// we provide a generic message to the user and surface the SignIn form.
+      _exceptionController.add(const AuthenticatorException(
+          'An unknown exception has occurred while parsing the session.'));
       yield AuthFlow.signin;
-    } on Exception catch (e) {
-      /// On all other Exceptions we display an an exception and do not
-      /// load the Auththenticator, as the app may be in an unusable state
-      _exceptionController.add(AuthenticatorException(e.toString()));
     }
   }
 

--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -169,7 +169,8 @@ class StateMachineBloc {
     } on AmplifyException catch (e) {
       _exceptionController
           .add(AuthenticatorException(e.message, showBanner: false));
-    } on Exception catch (e) {
+      yield AuthFlow.signin;
+    } on Exception {
       _exceptionController.add(const AuthenticatorException(
           'An unknown exception has occurred when fetching the session',
           showBanner: false));

--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -152,8 +152,8 @@ class StateMachineBloc {
         yield AuthFlow.signin;
       }
     } on AmplifyException catch (e) {
-      /// On all other AmplifyExceptions other than SignedOutException or SessionExpired, we provide a message to the user
-      /// and surface the SignIn form.
+      /// On all AmplifyExceptions other than SignedOutException or SessionExpired,
+      /// we provide a message to the user and surface the SignIn form.
       _exceptionController.add(AuthenticatorException(e.message));
       yield AuthFlow.signin;
     } on Exception catch (e) {

--- a/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -176,12 +176,12 @@ class AmplifyAuthService implements AuthService {
       await Amplify.Auth.fetchAuthSession(
           options: CognitoSessionOptions(getAWSCredentials: true));
       return true;
+
+      /// Surface the SessionExpiredException to the caller so that a banner can be displayed.
     } on SessionExpiredException {
-      return false;
-    } on SignedOutException {
-      return false;
-    } on Exception {
       rethrow;
+    } on Exception {
+      return false;
     }
   }
 

--- a/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -16,6 +16,7 @@
 import 'dart:async';
 
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:amplify_authenticator/src/models/authenticator_exception.dart';
 import 'package:amplify_flutter/amplify.dart';
 import 'package:amplify_flutter/src/config/amplify_config.dart';
 import 'package:collection/collection.dart';
@@ -37,6 +38,8 @@ abstract class AuthService {
   Future<SignUpResult> confirmSignUp(String username, String code);
 
   Future<AuthUser?> get currentUser;
+
+  Future<bool> get isValidSession;
 
   Future<bool> get isLoggedIn;
 
@@ -164,6 +167,21 @@ class AmplifyAuthService implements AuthService {
       return result.isSignedIn;
     } on SignedOutException {
       return false;
+    }
+  }
+
+  @override
+  Future<bool> get isValidSession async {
+    try {
+      await Amplify.Auth.fetchAuthSession(
+          options: CognitoSessionOptions(getAWSCredentials: true));
+      return true;
+    } on SessionExpiredException {
+      return false;
+    } on SignedOutException {
+      return false;
+    } on Exception {
+      rethrow;
     }
   }
 

--- a/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -39,7 +39,7 @@ abstract class AuthService {
 
   Future<AuthUser?> get currentUser;
 
-  Future<bool> get isValidSession;
+  Future<bool> isValidSession();
 
   Future<bool> get isLoggedIn;
 
@@ -171,7 +171,7 @@ class AmplifyAuthService implements AuthService {
   }
 
   @override
-  Future<bool> get isValidSession async {
+  Future<bool> isValidSession() async {
     try {
       await Amplify.Auth.fetchAuthSession(
           options: CognitoSessionOptions(getAWSCredentials: true));

--- a/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -173,9 +173,10 @@ class AmplifyAuthService implements AuthService {
   @override
   Future<bool> isValidSession() async {
     try {
-      await Amplify.Auth.fetchAuthSession(
-          options: CognitoSessionOptions(getAWSCredentials: true));
-      return true;
+      var res = await Amplify.Auth.fetchAuthSession(
+              options: CognitoSessionOptions(getAWSCredentials: true))
+          as CognitoAuthSession;
+      return res.userPoolTokens != null;
     } on SignedOutException {
       return false;
     } on Exception {

--- a/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -176,12 +176,10 @@ class AmplifyAuthService implements AuthService {
       await Amplify.Auth.fetchAuthSession(
           options: CognitoSessionOptions(getAWSCredentials: true));
       return true;
-
-      /// Surface the SessionExpiredException to the caller so that a banner can be displayed.
-    } on SessionExpiredException {
-      rethrow;
-    } on Exception {
+    } on SignedOutException {
       return false;
+    } on Exception {
+      rethrow;
     }
   }
 


### PR DESCRIPTION
*Description of changes:*
With this PR we no longer use getCurrentUser when deciding to display the SignIn form or the customer app, as this method has inconsistent behavior between platforms (on main) and returns an AuthUser even when the session has expired (RC). We now use fetchAuthSession.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
