### PR TITLE
fix: remove scaffold if state is authenticated

### DIFF
--- a/packages/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/amplify_authenticator/lib/amplify_authenticator.dart
@@ -350,30 +350,33 @@ class _AuthenticatorBody extends StatelessWidget {
     final userAppTheme = Theme.of(context);
     return Theme(
       data: useAmplifyTheme ? AmplifyTheme.theme : userAppTheme,
-      child: Scaffold(
-        backgroundColor: AmplifyColors.backgroundPrimary,
-        body: StreamBuilder(
-          stream: stateMachineBloc.stream,
-          builder: (context, snapshot) {
-            final state = snapshot.data ?? const AuthLoading();
-            final Widget screen;
-            if (state is AuthLoading || state is AuthLoaded) {
-              screen = const LoadingScreen();
-            } else if (state is Authenticated) {
-              return Theme(data: userAppTheme, child: child);
-            } else if (state is AuthFlow) {
-              screen = AuthenticatorScreen(screen: state.screen);
-            } else {
-              screen = const AuthenticatorScreen.signin();
-            }
+      child: StreamBuilder(
+        stream: stateMachineBloc.stream,
+        builder: (context, snapshot) {
+          final state = snapshot.data ?? const AuthLoading();
 
-            return Center(
+          if (state is Authenticated) {
+            return Theme(data: userAppTheme, child: child);
+          }
+
+          final Widget screen;
+          if (state is AuthLoading || state is AuthLoaded) {
+            screen = const LoadingScreen();
+          } else if (state is AuthFlow) {
+            screen = AuthenticatorScreen(screen: state.screen);
+          } else {
+            screen = const AuthenticatorScreen.signin();
+          }
+
+          return Scaffold(
+            backgroundColor: AmplifyColors.backgroundPrimary,
+            body: Center(
               child: SingleChildScrollView(
                 child: screen,
               ),
-            );
-          },
-        ),
+            ),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
### *Issue #, if available:*

*Description of changes:*
- remove scaffold from the widget tree if state == authenticated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
