### PR TITLE
fix(amplify_authenticator): updates username on switch state

### DIFF
--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -133,9 +133,15 @@ mixin AuthenticatorUsernameField<FieldType,
                           useEmail.value = val;
                         });
 
-                        // Clear current username value, but not the underlying
-                        // attribute values.
-                        viewModel.setUsername('');
+                        // Reset current username value to align with the current switch state.
+                        String newUsername = val
+                            ? viewModel.getAttribute(
+                                    CognitoUserAttributeKey.email) ??
+                                ''
+                            : viewModel.getAttribute(
+                                    CognitoUserAttributeKey.phoneNumber) ??
+                                '';
+                        viewModel.setUsername(newUsername);
                       },
                     ),
                     const Icon(Icons.email),


### PR DESCRIPTION
*Issue #, if available:*
The username mixin is resetting username to `''` on a change of state in the swich component, but the user may have already input their email and phone. This results in empty username being sent to the signUp API.

*Description of changes:*
Updates viewModel.username with the attribute corresponding to the switch state (falls back to empty string).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
