### PR TITLE
fix: update confirm password hint text

### DIFF
--- a/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations.dart
@@ -129,7 +129,7 @@ abstract class AuthenticatorInputLocalizations {
   /// Confirmation of user's chosen password.
   ///
   /// In en, this message translates to:
-  /// **'Confirm Password'**
+  /// **'Password'**
   String get passwordConfirmation;
 
   /// User's preferred e-mail address.
@@ -239,6 +239,12 @@ abstract class AuthenticatorInputLocalizations {
   /// In en, this message translates to:
   /// **'Re-enter your {attribute}'**
   String promptRefill(String attribute);
+
+  /// Title to re-enter an optional or required input field, used as the label for text fields.
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm {attribute}'**
+  String titleConfirmation(String attribute);
 
   /// Preamble to list of unment password requirements.
   ///

--- a/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations.dart
@@ -126,12 +126,6 @@ abstract class AuthenticatorInputLocalizations {
   /// **'New Password'**
   String get newPassword;
 
-  /// Confirmation of user's chosen password.
-  ///
-  /// In en, this message translates to:
-  /// **'Password'**
-  String get passwordConfirmation;
-
   /// User's preferred e-mail address.
   ///
   /// In en, this message translates to:
@@ -244,7 +238,7 @@ abstract class AuthenticatorInputLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Confirm {attribute}'**
-  String titleConfirmation(String attribute);
+  String confirmAttribute(String attribute);
 
   /// Preamble to list of unment password requirements.
   ///

--- a/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations_en.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations_en.dart
@@ -33,7 +33,7 @@ class AuthenticatorInputLocalizationsEn
   String get newPassword => 'New Password';
 
   @override
-  String get passwordConfirmation => 'Confirm Password';
+  String get passwordConfirmation => 'Password';
 
   @override
   String get email => 'Email';
@@ -101,6 +101,11 @@ class AuthenticatorInputLocalizationsEn
   @override
   String promptRefill(String attribute) {
     return 'Re-enter your $attribute';
+  }
+
+  @override
+  String titleConfirmation(String attribute) {
+    return 'Confirm $attribute';
   }
 
   @override

--- a/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations_en.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations_en.dart
@@ -33,9 +33,6 @@ class AuthenticatorInputLocalizationsEn
   String get newPassword => 'New Password';
 
   @override
-  String get passwordConfirmation => 'Password';
-
-  @override
   String get email => 'Email';
 
   @override
@@ -104,7 +101,7 @@ class AuthenticatorInputLocalizationsEn
   }
 
   @override
-  String titleConfirmation(String attribute) {
+  String confirmAttribute(String attribute) {
     return 'Confirm $attribute';
   }
 

--- a/packages/amplify_authenticator/lib/src/l10n/input_resolver.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/input_resolver.dart
@@ -371,8 +371,10 @@ class InputResolver extends Resolver<InputResolverKey> {
       case InputField.newPassword:
         return AuthenticatorLocalizations.inputsOf(context).newPassword;
       case InputField.passwordConfirmation:
+        final fieldName =
+            AuthenticatorLocalizations.inputsOf(context).passwordConfirmation;
         return AuthenticatorLocalizations.inputsOf(context)
-            .passwordConfirmation;
+            .titleConfirmation(fieldName);
       case InputField.verificationCode:
         return AuthenticatorLocalizations.inputsOf(context).verificationCode;
       case InputField.address:
@@ -417,12 +419,15 @@ class InputResolver extends Resolver<InputResolverKey> {
   }
 
   String hint(BuildContext context, InputField field) {
-    final fieldName = title(context, field);
-    final lowercasedFieldName = fieldName.toLowerCase();
     if (field == InputField.passwordConfirmation) {
+      final fieldName =
+          AuthenticatorLocalizations.inputsOf(context).passwordConfirmation;
+      final lowercasedFieldName = fieldName.toLowerCase();
       return AuthenticatorLocalizations.inputsOf(context)
           .promptRefill(lowercasedFieldName);
     }
+    final fieldName = title(context, field);
+    final lowercasedFieldName = fieldName.toLowerCase();
     return AuthenticatorLocalizations.inputsOf(context)
         .promptFill(lowercasedFieldName);
   }

--- a/packages/amplify_authenticator/lib/src/l10n/input_resolver.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/input_resolver.dart
@@ -49,6 +49,7 @@ enum InputField {
 enum InputResolverKeyType {
   title,
   hint,
+  confirmHint,
   empty,
   passwordRequirements,
   format,
@@ -99,7 +100,7 @@ class InputResolverKey {
     field: InputField.passwordConfirmation,
   );
   static const passwordConfirmationHint = InputResolverKey._(
-    InputResolverKeyType.hint,
+    InputResolverKeyType.confirmHint,
     field: InputField.passwordConfirmation,
   );
   static const passwordConfirmationEmpty = InputResolverKey._(
@@ -371,10 +372,10 @@ class InputResolver extends Resolver<InputResolverKey> {
       case InputField.newPassword:
         return AuthenticatorLocalizations.inputsOf(context).newPassword;
       case InputField.passwordConfirmation:
-        final fieldName =
-            AuthenticatorLocalizations.inputsOf(context).passwordConfirmation;
+        final attributeName =
+            AuthenticatorLocalizations.inputsOf(context).password;
         return AuthenticatorLocalizations.inputsOf(context)
-            .titleConfirmation(fieldName);
+            .confirmAttribute(attributeName);
       case InputField.verificationCode:
         return AuthenticatorLocalizations.inputsOf(context).verificationCode;
       case InputField.address:
@@ -419,17 +420,17 @@ class InputResolver extends Resolver<InputResolverKey> {
   }
 
   String hint(BuildContext context, InputField field) {
-    if (field == InputField.passwordConfirmation) {
-      final fieldName =
-          AuthenticatorLocalizations.inputsOf(context).passwordConfirmation;
-      final lowercasedFieldName = fieldName.toLowerCase();
-      return AuthenticatorLocalizations.inputsOf(context)
-          .promptRefill(lowercasedFieldName);
-    }
     final fieldName = title(context, field);
     final lowercasedFieldName = fieldName.toLowerCase();
     return AuthenticatorLocalizations.inputsOf(context)
         .promptFill(lowercasedFieldName);
+  }
+
+  String confirmHint(BuildContext context, InputField field) {
+    final fieldName = AuthenticatorLocalizations.inputsOf(context).password;
+    final lowercasedFieldName = fieldName.toLowerCase();
+    return AuthenticatorLocalizations.inputsOf(context)
+        .promptRefill(lowercasedFieldName);
   }
 
   String empty(BuildContext context, InputField field) {
@@ -483,6 +484,8 @@ class InputResolver extends Resolver<InputResolverKey> {
         return title(context, key.field);
       case InputResolverKeyType.hint:
         return hint(context, key.field);
+      case InputResolverKeyType.confirmHint:
+        return confirmHint(context, key.field);
       case InputResolverKeyType.empty:
         return empty(context, key.field);
       case InputResolverKeyType.passwordRequirements:

--- a/packages/amplify_authenticator/lib/src/l10n/src/inputs/inputs_en.arb
+++ b/packages/amplify_authenticator/lib/src/l10n/src/inputs/inputs_en.arb
@@ -13,10 +13,6 @@
     "@newPassword": {
         "description": "User's chosen new password."
     },
-    "passwordConfirmation": "Password",
-    "@passwordConfirmation": {
-        "description": "Confirmation of user's chosen password."
-    },
     "email": "Email",
     "@email": {
         "description": "User's preferred e-mail address.",
@@ -140,8 +136,8 @@
             }
         }
     },
-    "titleConfirmation": "Confirm {attribute}",
-    "@titleConfirmation": {
+    "confirmAttribute": "Confirm {attribute}",
+    "@confirmAttribute": {
         "description": "Title to re-enter an optional or required input field, used as the label for text fields.",
         "placeholders": {
             "attribute": {

--- a/packages/amplify_authenticator/lib/src/l10n/src/inputs/inputs_en.arb
+++ b/packages/amplify_authenticator/lib/src/l10n/src/inputs/inputs_en.arb
@@ -13,7 +13,7 @@
     "@newPassword": {
         "description": "User's chosen new password."
     },
-    "passwordConfirmation": "Confirm Password",
+    "passwordConfirmation": "Password",
     "@passwordConfirmation": {
         "description": "Confirmation of user's chosen password."
     },
@@ -132,6 +132,17 @@
     "promptRefill": "Re-enter your {attribute}",
     "@promptRefill": {
         "description": "Prompt to refill an optional or required input field, used as the placeholder for text fields.",
+        "placeholders": {
+            "attribute": {
+                "type": "String",
+                "example": "username",
+                "description": "The field which can be filled."
+            }
+        }
+    },
+    "titleConfirmation": "Confirm {attribute}",
+    "@titleConfirmation": {
+        "description": "Title to re-enter an optional or required input field, used as the label for text fields.",
         "placeholders": {
             "attribute": {
                 "type": "String",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- update hint text for confirm password. The previous hint text said "Re-enter your _confirm_ password." The new text says "Re-enter your password." See before and after.

**Before**
![Screen Shot 2021-11-17 at 9 00 53 AM](https://user-images.githubusercontent.com/20613561/142217110-b39c5aa9-2ddc-4005-9b7d-c961eda140c7.png)


**After**
![Screen Shot 2021-11-17 at 9 13 58 AM](https://user-images.githubusercontent.com/20613561/142217112-2f3a7b3b-fb84-4228-b5c5-417874a42f4a.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
