### PR TITLE
chore(authenticator): Prefer private session for iOS

### DIFF
--- a/packages/amplify_auth_cognito/lib/src/CognitoSignIn/CognitoSignInWithWebUIOptions.dart
+++ b/packages/amplify_auth_cognito/lib/src/CognitoSignIn/CognitoSignInWithWebUIOptions.dart
@@ -22,9 +22,9 @@ class CognitoSignInWithWebUIOptions extends SignInWithWebUIOptions {
   /// Note that this value internally sets `prefersEphemeralWebBrowserSession` in ASWebAuthenticationSession.
   /// As per Apple documentation, Whether the request is honored depends on the user’s default web browser.
   /// Safari always honors the request.
-  /// {@endtemplate}
   ///
   /// Defaults to `false`.
+  /// {@endtemplate}
   final bool isPreferPrivateSession;
   const CognitoSignInWithWebUIOptions({this.isPreferPrivateSession = false});
   @override

--- a/packages/amplify_auth_cognito/lib/src/CognitoSignIn/CognitoSignInWithWebUIOptions.dart
+++ b/packages/amplify_auth_cognito/lib/src/CognitoSignIn/CognitoSignInWithWebUIOptions.dart
@@ -22,9 +22,9 @@ class CognitoSignInWithWebUIOptions extends SignInWithWebUIOptions {
   /// Note that this value internally sets `prefersEphemeralWebBrowserSession` in ASWebAuthenticationSession.
   /// As per Apple documentation, Whether the request is honored depends on the user’s default web browser.
   /// Safari always honors the request.
+  /// {@endtemplate}
   ///
   /// Defaults to `false`.
-  /// {@endtemplate}
   final bool isPreferPrivateSession;
   const CognitoSignInWithWebUIOptions({this.isPreferPrivateSession = false});
   @override

--- a/packages/amplify_auth_cognito/lib/src/CognitoSignIn/CognitoSignInWithWebUIOptions.dart
+++ b/packages/amplify_auth_cognito/lib/src/CognitoSignIn/CognitoSignInWithWebUIOptions.dart
@@ -16,6 +16,7 @@
 import 'package:amplify_auth_plugin_interface/amplify_auth_plugin_interface.dart';
 
 class CognitoSignInWithWebUIOptions extends SignInWithWebUIOptions {
+  /// {@template amplify_auth_plugin_interface.cognito_sign_in_with_web_ui_options}
   /// iOS-only: Starts the webUI signin in a private browser session, if supported by the current browser.
   ///
   /// Note that this value internally sets `prefersEphemeralWebBrowserSession` in ASWebAuthenticationSession.
@@ -23,6 +24,7 @@ class CognitoSignInWithWebUIOptions extends SignInWithWebUIOptions {
   /// Safari always honors the request.
   ///
   /// Defaults to `false`.
+  /// {@endtemplate}
   final bool isPreferPrivateSession;
   const CognitoSignInWithWebUIOptions({this.isPreferPrivateSession = false});
   @override

--- a/packages/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/amplify_authenticator/lib/amplify_authenticator.dart
@@ -17,6 +17,7 @@ library amplify_authenticator;
 
 import 'dart:async';
 
+import 'package:amplify_auth_plugin_interface/amplify_auth_plugin_interface.dart';
 import 'package:amplify_authenticator/src/blocs/auth/auth_bloc.dart';
 import 'package:amplify_authenticator/src/constants/authenticator_constants.dart';
 import 'package:amplify_authenticator/src/enums/enums.dart';
@@ -106,6 +107,7 @@ class Authenticator extends StatefulWidget {
     this.useAmplifyTheme = false,
     this.onException,
     this.exceptionBannerLocation = ExceptionBannerLocation.auto,
+    this.preferPrivateSession = false,
   }) : super(key: key) {
     this.signInForm = signInForm ?? SignInForm();
     this.signUpForm = signUpForm ?? SignUpForm();
@@ -201,6 +203,9 @@ class Authenticator extends StatefulWidget {
   /// {@macro amplify_authenticator.exception_banner_location}
   final ExceptionBannerLocation exceptionBannerLocation;
 
+  /// {@macro amplify_auth_plugin_interface.cognito_sign_in_with_web_ui_options}
+  final bool preferPrivateSession;
+
   /// This widget will be displayed after a user has signed in.
   final Widget child;
 
@@ -218,6 +223,8 @@ class Authenticator extends StatefulWidget {
         ObjectFlagProperty<ExceptionHandler?>.has('onException', onException));
     properties.add(EnumProperty<ExceptionBannerLocation>(
         'exceptionBannerLocation', exceptionBannerLocation));
+    properties.add(DiagnosticsProperty<bool>(
+        'preferPrivateSession', preferPrivateSession));
   }
 }
 
@@ -235,8 +242,10 @@ class _AuthenticatorState extends State<Authenticator> {
   @override
   void initState() {
     super.initState();
-    _stateMachineBloc = StateMachineBloc(authService: _authService)
-      ..add(const AuthLoad());
+    _stateMachineBloc = StateMachineBloc(
+      authService: _authService,
+      preferPrivateSession: widget.preferPrivateSession,
+    )..add(const AuthLoad());
     _viewModel = AuthViewModel(_stateMachineBloc);
     _subscribeToExceptions();
     _subscribeToInfoMessages();

--- a/packages/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/amplify_authenticator/lib/amplify_authenticator.dart
@@ -107,7 +107,7 @@ class Authenticator extends StatefulWidget {
     this.useAmplifyTheme = false,
     this.onException,
     this.exceptionBannerLocation = ExceptionBannerLocation.auto,
-    this.preferPrivateSession = false,
+    this.preferPrivateSession = true,
   }) : super(key: key) {
     this.signInForm = signInForm ?? SignInForm();
     this.signUpForm = signUpForm ?? SignUpForm();
@@ -204,6 +204,8 @@ class Authenticator extends StatefulWidget {
   final ExceptionBannerLocation exceptionBannerLocation;
 
   /// {@macro amplify_auth_plugin_interface.cognito_sign_in_with_web_ui_options}
+  ///
+  /// Defaults to `true`.
   final bool preferPrivateSession;
 
   /// This widget will be displayed after a user has signed in.

--- a/packages/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/amplify_authenticator/lib/amplify_authenticator.dart
@@ -107,7 +107,7 @@ class Authenticator extends StatefulWidget {
     this.useAmplifyTheme = false,
     this.onException,
     this.exceptionBannerLocation = ExceptionBannerLocation.auto,
-    this.preferPrivateSession = true,
+    this.preferPrivateSession = false,
   }) : super(key: key) {
     this.signInForm = signInForm ?? SignInForm();
     this.signUpForm = signUpForm ?? SignUpForm();
@@ -204,8 +204,6 @@ class Authenticator extends StatefulWidget {
   final ExceptionBannerLocation exceptionBannerLocation;
 
   /// {@macro amplify_auth_plugin_interface.cognito_sign_in_with_web_ui_options}
-  ///
-  /// Defaults to `true`.
   final bool preferPrivateSession;
 
   /// This widget will be displayed after a user has signed in.

--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -33,6 +33,7 @@ part 'auth_state.dart';
 /// {@endtemplate}
 class StateMachineBloc {
   final AuthService _authService;
+  final bool preferPrivateSession;
 
   /// State controller.
   final StreamController<AuthState> _authStateController =
@@ -61,6 +62,7 @@ class StateMachineBloc {
   /// {@macro authenticator.state_machine_bloc}
   StateMachineBloc({
     required AuthService authService,
+    required this.preferPrivateSession,
   }) : _authService = authService {
     _subscription =
         _authEventStream.asyncExpand(_eventTransformer).listen((state) {
@@ -267,7 +269,10 @@ class StateMachineBloc {
           data.password,
         );
       } else if (data is AuthSocialSignInData) {
-        result = await _authService.signInWithProvider(data.provider);
+        result = await _authService.signInWithProvider(
+          data.provider,
+          preferPrivateSession: preferPrivateSession,
+        );
       } else {
         throw StateError('Bad sign in data: $data');
       }

--- a/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -24,7 +24,10 @@ import 'package:collection/src/iterable_extensions.dart';
 abstract class AuthService {
   Future<SignInResult> signIn(String username, String password);
 
-  Future<SignInResult> signInWithProvider(AuthProvider provider);
+  Future<SignInResult> signInWithProvider(
+    AuthProvider provider, {
+    required bool preferPrivateSession,
+  });
 
   Future<void> signOut();
 
@@ -87,7 +90,7 @@ class AmplifyAuthService implements AuthService {
   @override
   Future<SignInResult> signInWithProvider(
     AuthProvider provider, {
-    bool preferPrivateSession = false,
+    required bool preferPrivateSession,
   }) {
     return Amplify.Auth.signInWithWebUI(
       provider: provider,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add option for `preferPrivateSession` - default to `true` within Authenticator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
