### PR TITLE
feat: support email & phone in confirm sign in

### DIFF
--- a/packages/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/amplify_authenticator/lib/amplify_authenticator.dart
@@ -100,7 +100,7 @@ class Authenticator extends StatefulWidget {
     Key? key,
     SignInForm? signInForm,
     SignUpForm? signUpForm,
-    ConfirmSignInMFAForm? confirmSignInMFAForm,
+    ConfirmSignInNewPasswordForm? confirmSignInNewPasswordForm,
     this.stringResolver = const AuthStringResolver(),
     required this.child,
     this.useAmplifyTheme = false,
@@ -109,7 +109,8 @@ class Authenticator extends StatefulWidget {
   }) : super(key: key) {
     this.signInForm = signInForm ?? SignInForm();
     this.signUpForm = signUpForm ?? SignUpForm();
-    this.confirmSignInMFAForm = confirmSignInMFAForm ?? ConfirmSignInMFAForm();
+    this.confirmSignInNewPasswordForm =
+        confirmSignInNewPasswordForm ?? ConfirmSignInNewPasswordForm();
   }
 
   /// Whether to use Amplify colors and styles in the Authenticator,
@@ -118,8 +119,8 @@ class Authenticator extends StatefulWidget {
   /// Defaults to `true`.
   final bool useAmplifyTheme;
 
-  /// The form to display when confirming a sign in with MFA.
-  late final ConfirmSignInMFAForm confirmSignInMFAForm;
+  /// The form to display when promted for a password change upon signing in
+  late final ConfirmSignInNewPasswordForm confirmSignInNewPasswordForm;
 
   /// This form will support the following form field types:
   ///    * username
@@ -381,13 +382,14 @@ class _AuthenticatorState extends State<Authenticator> {
             child: InheritedStrings(
               resolver: widget.stringResolver,
               child: InheritedForms(
-                confirmSignInNewPasswordForm: ConfirmSignInNewPasswordForm(),
+                confirmSignInNewPasswordForm:
+                    widget.confirmSignInNewPasswordForm,
                 resetPasswordForm: const ResetPasswordForm(),
                 sendCodeForm: SendCodeForm(),
                 signInForm: widget.signInForm,
                 signUpForm: widget.signUpForm,
                 confirmSignUpForm: ConfirmSignUpForm(),
-                confirmSignInMFAForm: widget.confirmSignInMFAForm,
+                confirmSignInMFAForm: ConfirmSignInMFAForm(),
                 verifyUserForm: VerifyUserForm(),
                 confirmVerifyUserForm: ConfirmVerifyUserForm(),
                 child: _AuthenticatorBody(child: widget.child),

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
@@ -26,7 +26,7 @@ mixin AuthenticatorTextField<FieldType,
   Widget buildFormField(BuildContext context) {
     final inputResolver = stringResolver.inputs;
     final hintText = widget.hintText == null
-        ? inputResolver.resolve(context, widget.hintTextKey!)
+        ? widget.hintTextKey?.resolve(context, inputResolver)
         : widget.hintText!;
     return ValueListenableBuilder<bool>(
       valueListenable: context

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/confirm_sign_in_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/confirm_sign_in_form_field.dart
@@ -33,6 +33,7 @@ abstract class ConfirmSignInFormField<FieldValue>
     String? hintText,
     FormFieldValidator<FieldValue>? validator,
     CognitoUserAttributeKey? customAttributeKey,
+    bool? required,
   })  : _customAttributeKey = customAttributeKey,
         super._(
           key: key,
@@ -42,6 +43,7 @@ abstract class ConfirmSignInFormField<FieldValue>
           title: title,
           hintText: hintText,
           validator: validator,
+          requiredOverride: required,
         );
 
   /// Creates a password component.
@@ -83,6 +85,36 @@ abstract class ConfirmSignInFormField<FieldValue>
         validator: validator,
       );
 
+  /// Creates an email component.
+  static ConfirmSignInFormField email({
+    Key? key,
+    FormFieldValidator<String>? validator,
+    bool? required,
+  }) =>
+      _ConfirmSignInTextField(
+        key: key ?? keyEmailConfirmSignInFormField,
+        titleKey: InputResolverKey.emailTitle,
+        hintTextKey: InputResolverKey.emailHint,
+        field: ConfirmSignInField.email,
+        validator: validator,
+        required: required,
+      );
+
+  /// Creates a phoneNumber component.
+  static ConfirmSignInFormField phoneNumber({
+    Key? key,
+    FormFieldValidator<String>? validator,
+    bool? required,
+  }) =>
+      _ConfirmSignInPhoneField(
+        key: key ?? keyPhoneNumberSignUpFormField,
+        titleKey: InputResolverKey.phoneNumberTitle,
+        hintTextKey: InputResolverKey.phoneNumberHint,
+        field: ConfirmSignInField.phoneNumber,
+        validator: validator,
+        required: required,
+      );
+
   /// Creates a custom attribute component.
   static ConfirmSignInFormField custom({
     Key? key,
@@ -90,6 +122,7 @@ abstract class ConfirmSignInFormField<FieldValue>
     required CognitoUserAttributeKey attributeKey,
     String? hintText,
     FormFieldValidator<String>? validator,
+    bool? required,
   }) =>
       _ConfirmSignInTextField(
         key: key,
@@ -98,6 +131,7 @@ abstract class ConfirmSignInFormField<FieldValue>
         field: ConfirmSignInField.custom,
         validator: validator,
         customAttributeKey: attributeKey,
+        required: required,
       );
 
   // Custom Cognito attribute key.
@@ -217,6 +251,55 @@ abstract class _ConfirmSignInFormFieldState<FieldValue>
   }
 }
 
+class _ConfirmSignInPhoneField extends ConfirmSignInFormField<String> {
+  const _ConfirmSignInPhoneField({
+    Key? key,
+    required ConfirmSignInField field,
+    InputResolverKey? titleKey,
+    InputResolverKey? hintTextKey,
+    String? title,
+    String? hintText,
+    CognitoUserAttributeKey? attributeKey,
+    FormFieldValidator<String>? validator,
+    bool? required,
+  }) : super._(
+          key: key,
+          field: field,
+          titleKey: titleKey,
+          hintTextKey: hintTextKey,
+          title: title,
+          hintText: hintText,
+          validator: validator,
+          customAttributeKey: attributeKey,
+          required: required,
+        );
+
+  @override
+  _ConfirmSignInPhoneFieldState createState() =>
+      _ConfirmSignInPhoneFieldState();
+}
+
+class _ConfirmSignInPhoneFieldState extends _ConfirmSignInTextFieldState
+    with AuthenticatorPhoneFieldMixin {
+  @override
+  String? get initialValue {
+    var _initialValue =
+        viewModel.getAttribute(CognitoUserAttributeKey.phoneNumber);
+    if (_initialValue != null) {
+      _initialValue = displayPhoneNumber(_initialValue);
+    }
+    return _initialValue;
+  }
+
+  @override
+  ValueChanged<String> get onChanged {
+    return (phoneNumber) {
+      phoneNumber = formatPhoneNumber(phoneNumber)!;
+      viewModel.setPhoneNumber(phoneNumber);
+    };
+  }
+}
+
 class _ConfirmSignInTextField extends ConfirmSignInFormField<String> {
   const _ConfirmSignInTextField({
     Key? key,
@@ -227,6 +310,7 @@ class _ConfirmSignInTextField extends ConfirmSignInFormField<String> {
     String? hintText,
     CognitoUserAttributeKey? customAttributeKey,
     FormFieldValidator<String>? validator,
+    bool? required,
   }) : super._(
           key: key,
           field: field,
@@ -236,6 +320,7 @@ class _ConfirmSignInTextField extends ConfirmSignInFormField<String> {
           hintText: hintText,
           customAttributeKey: customAttributeKey,
           validator: validator,
+          required: required,
         );
 
   @override

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/sign_in_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/sign_in_form_field.dart
@@ -31,6 +31,7 @@ abstract class SignInFormField<FieldValue> extends AuthenticatorFormField<
     String? title,
     String? hintText,
     FormFieldValidator<FieldValue>? validator,
+    bool? required,
   }) : super._(
           key: key,
           field: field,
@@ -39,6 +40,7 @@ abstract class SignInFormField<FieldValue> extends AuthenticatorFormField<
           title: title,
           hintText: hintText,
           validator: validator,
+          requiredOverride: required,
         );
 
   /// Creates a username component.
@@ -127,6 +129,7 @@ class _SignInTextField extends SignInFormField<String> {
     String? title,
     String? hintText,
     FormFieldValidator<String>? validator,
+    bool? required,
   }) : super._(
           key: key,
           field: field,
@@ -135,6 +138,7 @@ class _SignInTextField extends SignInFormField<String> {
           title: title,
           hintText: hintText,
           validator: validator,
+          required: required,
         );
 
   @override


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- support the ability to customize the confirm sign in screen
- add email and phone attributes to the confirm sign in screen

With these changes, the following code snippet will produce the screenshot below it.

```dart
final authenticator = Authenticator(
  confirmSignInNewPasswordForm: ConfirmSignInNewPasswordForm.custom(
    fields: [
      ConfirmSignInFormField.email(required: true),
      ConfirmSignInFormField.custom(
          required: true,
          attributeKey: CognitoUserAttributeKey.name,
          title: 'Name',
          hintText: 'Enter your name'),
    ],
  ),
  child: const SignedInScreen(),
);
```

![Screen Shot 2021-11-17 at 10 26 08 AM](https://user-images.githubusercontent.com/20613561/142275694-fda7d6fd-dbd5-4e25-bee6-57f40ed6fad7.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
