### PR TITLE
fix(auth): Remove duplicate AtomicResult

### DIFF
--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/device/DeviceHandler.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/device/DeviceHandler.kt
@@ -49,7 +49,7 @@ class DeviceHandler(private val errorHandler: AuthErrorHandler) :
     private val scope = CoroutineScope(Dispatchers.IO) + CoroutineName("DeviceHandler")
 
     @Suppress("UNCHECKED_CAST")
-    override fun onMethodCall(call: MethodCall, _result: MethodChannel.Result) {
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {
             "fetchDevices" -> fetchDevices(result)
             "rememberDevice" -> rememberDevice(result)

--- a/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/device/DeviceHandler.kt
+++ b/packages/amplify_auth_cognito/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/device/DeviceHandler.kt
@@ -50,7 +50,6 @@ class DeviceHandler(private val errorHandler: AuthErrorHandler) :
 
     @Suppress("UNCHECKED_CAST")
     override fun onMethodCall(call: MethodCall, _result: MethodChannel.Result) {
-        val result = AtomicResult(_result, call.method)
         when (call.method) {
             "fetchDevices" -> fetchDevices(result)
             "rememberDevice" -> rememberDevice(result)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- There is a duplicate AtomicResult in the DeviceHandler. The result being passed in is already an AtomicResult.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
