### PR TITLE
test(amplify_authenticator): signup with email

### DIFF
--- a/packages/amplify_authenticator/example/integration_test/config.dart
+++ b/packages/amplify_authenticator/example/integration_test/config.dart
@@ -16,14 +16,18 @@
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_flutter/amplify.dart';
 
+import 'envs/auth_with_email.dart' as auth_with_email;
 import 'envs/auth_with_username.dart' as auth_with_username;
 
+/// All envs modeled on:
+/// https://github.com/aws-amplify/amplify-ui/blob/main/examples/angular/src/pages/ui/components/authenticator/
 const environmentsByConfiguration = {
-  // From: https://github.com/aws-amplify/amplify-ui/blob/main/examples/angular/src/pages/ui/components/authenticator/sign-up-with-username/sign-up-with-username.component.ts
+  'ui/components/authenticator/sign-up-with-email': 'auth-with-email',
   'ui/components/authenticator/sign-up-with-username': 'auth-with-username',
 };
 
 const environments = {
+  'auth-with-email': auth_with_email.amplifyconfig,
   'auth-with-username': auth_with_username.amplifyconfig,
 };
 

--- a/packages/amplify_authenticator/example/integration_test/pages/sign_up_page.dart
+++ b/packages/amplify_authenticator/example/integration_test/pages/sign_up_page.dart
@@ -53,13 +53,13 @@ class SignUpPage {
   }
 
   /// Then I see "Username" as an input field
-  void expectUserNameIsPresent() {
+  void expectUserNameIsPresent({String usernameLabel = 'Username'}) {
     // username field is present
     expect(usernameField, findsOneWidget);
     // login type is "username"
     Finder usernameFieldHint = find.descendant(
       of: find.byKey(keyUsernameSignUpFormField),
-      matching: find.text('Username'),
+      matching: find.text(usernameLabel),
     );
     expect(usernameFieldHint, findsOneWidget);
   }

--- a/packages/amplify_authenticator/example/integration_test/sign_up_with_email_test.dart
+++ b/packages/amplify_authenticator/example/integration_test/sign_up_with_email_test.dart
@@ -55,15 +55,6 @@ void main() {
       signUpPage.expectUserNameIsPresent(usernameLabel: 'Email');
     });
 
-    // Scenario: "Phone Number" is not included
-    testWidgets('"Phone Number" is not included', (tester) async {
-      SignUpPage signUpPage = SignUpPage(tester: tester);
-      SignInPage signInPage = SignInPage(tester: tester);
-      await loadAuthenticator(tester: tester, authenticator: authenticator);
-      await signInPage.navigateToSignUp();
-      signUpPage.expectPhoneIsNotPresent();
-    });
-
     // Scenario: Sign up a new email & password
     testWidgets('Sign up a new email & password', (tester) async {
       SignUpPage signUpPage = SignUpPage(tester: tester);

--- a/packages/amplify_authenticator/example/integration_test/sign_up_with_email_test.dart
+++ b/packages/amplify_authenticator/example/integration_test/sign_up_with_email_test.dart
@@ -13,9 +13,6 @@
  * permissions and limitations under the License.
  */
 
-// This test follows the Amplify UI feature "sign-in-with-username"
-// https://github.com/aws-amplify/amplify-ui/blob/main/packages/e2e/features/ui/components/authenticator/sign-up-with-username.feature
-
 import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -28,6 +25,9 @@ import 'pages/sign_up_page.dart';
 import 'pages/test_utils.dart';
 import 'utils/mock_data.dart';
 
+// This test follows the Amplify UI feature "sign-up-with-email"
+// https://github.com/aws-amplify/amplify-ui/blob/main/packages/e2e/features/ui/components/authenticator/sign-up-with-email.feature
+
 void main() {
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized()
       as IntegrationTestWidgetsFlutterBinding;
@@ -38,42 +38,21 @@ void main() {
     home: Authenticator(child: Container()),
   );
 
-  group('sign-in-with-username', () {
+  group('sign-up-with-email', () {
     // Given I'm running the example "ui/components/authenticator/sign-up-with-username"
     setUpAll(() async {
       await loadConfiguration(
-        'ui/components/authenticator/sign-up-with-username',
+        'ui/components/authenticator/sign-up-with-email',
       );
     });
 
-    // Scenario: Login mechanism set to "username"
-    testWidgets('Login mechanism set to "username"', (tester) async {
+    // Scenario: Login mechanism set to "email"
+    testWidgets('Login mechanism set to "email"', (tester) async {
       SignUpPage signUpPage = SignUpPage(tester: tester);
       SignInPage signInPage = SignInPage(tester: tester);
       await loadAuthenticator(tester: tester, authenticator: authenticator);
       await signInPage.navigateToSignUp();
-      signUpPage.expectUserNameIsPresent();
-    });
-
-    // Scenario: "Preferred Username" is included from `aws_cognito_signup_attributes`
-    testWidgets(
-        '"Preferred Username" is included from aws_cognito_signup_attributes',
-        (tester) async {
-      SignUpPage signUpPage = SignUpPage(tester: tester);
-      SignInPage signInPage = SignInPage(tester: tester);
-      await loadAuthenticator(tester: tester, authenticator: authenticator);
-      await signInPage.navigateToSignUp();
-      signUpPage.expectPreferredUserNameIsPresent();
-    });
-
-    // Scenario: "Email" is included from `aws_cognito_verification_mechanisms`
-    testWidgets('"Email" is included from aws_cognito_verification_mechanisms',
-        (tester) async {
-      SignUpPage signUpPage = SignUpPage(tester: tester);
-      SignInPage signInPage = SignInPage(tester: tester);
-      await loadAuthenticator(tester: tester, authenticator: authenticator);
-      await signInPage.navigateToSignUp();
-      signUpPage.expectEmailIsPresent();
+      signUpPage.expectUserNameIsPresent(usernameLabel: 'Email');
     });
 
     // Scenario: "Phone Number" is not included
@@ -85,8 +64,8 @@ void main() {
       signUpPage.expectPhoneIsNotPresent();
     });
 
-    // Scenario: Sign up a new username & password
-    testWidgets('Sign up a new username & password', (tester) async {
+    // Scenario: Sign up a new email & password
+    testWidgets('Sign up a new email & password', (tester) async {
       SignUpPage signUpPage = SignUpPage(tester: tester);
       SignInPage signInPage = SignInPage(tester: tester);
       ConfirmSignUpPage confirmSignUpPage = ConfirmSignUpPage(tester: tester);
@@ -94,19 +73,16 @@ void main() {
       await loadAuthenticator(tester: tester, authenticator: authenticator);
       await signInPage.navigateToSignUp();
 
-      // TODO: Clarify requirements
-      // Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }'
-      // with fixture "sign-up-with-username"
+      //   // TODO: Clarify requirements
+      //   // Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }'
+      //   // with fixture "sign-up-with-email"
 
-      final username = generateUsername();
+      final username = generateEmail();
       final password = generatePassword();
-      final email = generateEmail();
 
       await signUpPage.enterUsername(username);
       await signUpPage.enterPassword(password);
       await signUpPage.enterPasswordConfirmation(password);
-      await signUpPage.enterEmail(email);
-      await signUpPage.enterPreferredUsername(username);
       await signUpPage.submitSignUp();
 
       await confirmSignUpPage.expectConfirmSignUpIsPresent();
@@ -115,7 +91,7 @@ void main() {
 
     // Scenario: Username field autocompletes username
     // TODO: Clarify requirements
-    // testWidgets('Username field autocompletes username', (tester) async {});
+    // testWidgets('Email field autocompletes username', (tester) async {});
 
     // Scenario: Password fields autocomplete "new-password"
     // TODO: Clarify requirements

--- a/packages/amplify_authenticator/example/integration_test/utils/mock_data.dart
+++ b/packages/amplify_authenticator/example/integration_test/utils/mock_data.dart
@@ -12,7 +12,7 @@ const symbols = '~/`!@#\$%^&\\"\'*(),._?:;{}|<>';
 const String mockPhoneNumber = '+15555551234';
 const String mockCode = '12345';
 
-String generateEmail() => 'flutter-email-${randomNumber()}@test.com';
+String generateEmail() => 'flutter-email-${randomNumber()}@example.com';
 
 String generatePassword() =>
     uuid.v4() +


### PR DESCRIPTION
*Description of changes:*
* Adds sign-up-with-email tests
* Changes generated email domain from test.com to example.com (I believe that test.com is a registered domain, while example.com is reserved)
* Comments out test cases that are in TODO state, so they do not appear as successful tests in output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
