### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/packages/amplify_analytics_pinpoint/android/build.gradle
+++ b/packages/amplify_analytics_pinpoint/android/build.gradle
@@ -67,8 +67,8 @@ dependencies {
     api amplifyCore
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.28.3-rc'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.28.3-rc'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.29.1'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.29.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'
     testImplementation 'org.mockito:mockito-inline:3.10.0'

--- a/packages/amplify_analytics_pinpoint/ios/amplify_analytics_pinpoint.podspec
+++ b/packages/amplify_analytics_pinpoint/ios/amplify_analytics_pinpoint.podspec
@@ -17,8 +17,8 @@ This code is the iOS part of the Amplify Flutter Pinpoint Analytics Plugin.  The
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.15.5'
-  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '~> 1.15.5'
+  s.dependency 'Amplify', '1.15.6'
+  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.15.6'
   s.dependency 'amplify_core'
   s.dependency 'SwiftLint'
   s.dependency 'SwiftFormat/CLI'

--- a/packages/amplify_api/android/build.gradle
+++ b/packages/amplify_api/android/build.gradle
@@ -65,8 +65,8 @@ dependencies {
     api amplifyCore
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.amplifyframework:aws-api:1.28.3-rc"
-    implementation "com.amplifyframework:aws-api-appsync:1.28.3-rc"
+    implementation "com.amplifyframework:aws-api:1.29.1"
+    implementation "com.amplifyframework:aws-api-appsync:1.29.1"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 
     testImplementation 'junit:junit:4.13.2'

--- a/packages/amplify_api/ios/amplify_api.podspec
+++ b/packages/amplify_api/ios/amplify_api.podspec
@@ -17,8 +17,8 @@ The API module for Amplify Flutter.
   s.source           = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.15.5'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '~> 1.15.5'
+  s.dependency 'Amplify', '1.15.6'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.15.6'
   s.dependency 'amplify_core'
   s.dependency 'SwiftLint'
   s.dependency 'SwiftFormat/CLI'

--- a/packages/amplify_auth_cognito/android/build.gradle
+++ b/packages/amplify_auth_cognito/android/build.gradle
@@ -61,7 +61,7 @@ android {
 dependencies {
     api amplifyCore
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:aws-auth-cognito:1.28.3-rc'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.29.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'
     testImplementation 'org.mockito:mockito-inline:3.10.0'

--- a/packages/amplify_auth_cognito/ios/amplify_auth_cognito.podspec
+++ b/packages/amplify_auth_cognito/ios/amplify_auth_cognito.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.15.5'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '~> 1.15.5'
+  s.dependency 'Amplify', '1.15.6'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.15.6'
   s.dependency 'ObjectMapper'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'

--- a/packages/amplify_core/android/build.gradle
+++ b/packages/amplify_core/android/build.gradle
@@ -69,7 +69,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:core:1.28.3-rc'
+    implementation 'com.amplifyframework:core:1.29.1'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -62,8 +62,8 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.amplifyframework:aws-datastore:1.28.3-rc"
-    implementation "com.amplifyframework:aws-api-appsync:1.28.3-rc"
+    implementation "com.amplifyframework:aws-datastore:1.29.1"
+    implementation "com.amplifyframework:aws-api-appsync:1.29.1"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'
     testImplementation 'org.mockito:mockito-inline:3.10.0'

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,8 +15,8 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.15.5'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '~> 1.15.5'
+  s.dependency 'Amplify', '1.15.6'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.15.6'
   s.dependency 'amplify_core'
   s.platform = :ios, '13.0'
 

--- a/packages/amplify_flutter/android/build.gradle
+++ b/packages/amplify_flutter/android/build.gradle
@@ -65,7 +65,7 @@ android {
 
 dependencies {
     api amplifyCore
-    implementation 'com.amplifyframework:core:1.28.3-rc'
+    implementation 'com.amplifyframework:core:1.29.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 
@@ -75,6 +75,6 @@ dependencies {
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'com.google.code.gson:gson:2.8.6'
-    testImplementation 'com.amplifyframework:aws-auth-cognito:1.28.3-rc'
+    testImplementation 'com.amplifyframework:aws-auth-cognito:1.29.1'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9'
 }

--- a/packages/amplify_flutter/ios/amplify_flutter.podspec
+++ b/packages/amplify_flutter/ios/amplify_flutter.podspec
@@ -17,9 +17,9 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.15.5'
-  s.dependency 'AWSPluginsCore', '~> 1.15.5'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '~> 1.15.5'
+  s.dependency 'Amplify', '1.15.6'
+  s.dependency 'AWSPluginsCore', '1.15.6'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.15.6'
   s.dependency 'amplify_core'
   s.dependency 'SwiftLint'
   s.dependency 'SwiftFormat/CLI'

--- a/packages/amplify_storage_s3/android/build.gradle
+++ b/packages/amplify_storage_s3/android/build.gradle
@@ -49,5 +49,5 @@ android {
 dependencies {
     api amplifyCore
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:aws-storage-s3:1.28.3-rc'
+    implementation 'com.amplifyframework:aws-storage-s3:1.29.1'
 }

--- a/packages/amplify_storage_s3/ios/amplify_storage_s3.podspec
+++ b/packages/amplify_storage_s3/ios/amplify_storage_s3.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '~> 1.15.5'
-  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '~> 1.15.5'
+  s.dependency 'Amplify', '1.15.6'
+  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.15.6'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
- amplify-android to 1.29.1
- amplify-ios pin to 1.15.6

*Issue #, if available:*

*Description of changes:*

Upgrade amplify-ios and amplify-android version to bring in `ModelSyncMetadata` table migration for DataStore plugin.

NOTE: the upgraded versions are not the latest versions but the minimum version required to migrate `ModelSyncMetadata` table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
