### PR TITLE
chore: refactor labels to use TextFormField InputDecoration

### DIFF
--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
 */
 
-import 'package:amplify_authenticator/src/state/inherited_config.dart';
 import 'package:amplify_authenticator/src/theme/amplify_theme.dart';
 import 'package:amplify_authenticator/src/widgets/form_field.dart';
 import 'package:flutter/material.dart';

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
 */
 
+import 'package:amplify_authenticator/src/state/inherited_config.dart';
 import 'package:amplify_authenticator/src/theme/amplify_theme.dart';
 import 'package:amplify_authenticator/src/widgets/form_field.dart';
 import 'package:flutter/material.dart';
@@ -44,6 +45,7 @@ mixin AuthenticatorDateField<FieldType,
 
   @override
   Widget buildFormField(BuildContext context) {
+    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
     final inputResolver = stringResolver.inputs;
     final hintText = widget.hintText == null
         ? inputResolver.resolve(context, widget.hintTextKey!)
@@ -81,6 +83,9 @@ mixin AuthenticatorDateField<FieldType,
           onPressed: _pickTime,
         ),
         errorMaxLines: errorMaxLines,
+        labelText: useAmplifyTheme
+            ? null
+            : widget.title ?? widget.titleKey?.resolve(context, inputResolver),
         hintText: hintText,
       ),
       keyboardType: TextInputType.datetime,

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
@@ -45,18 +45,10 @@ mixin AuthenticatorDateField<FieldType,
 
   @override
   Widget buildFormField(BuildContext context) {
-    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
     final inputResolver = stringResolver.inputs;
     final hintText = widget.hintText == null
         ? inputResolver.resolve(context, widget.hintTextKey!)
         : widget.hintText!;
-    String? labelText = useAmplifyTheme
-        ? null
-        : widget.title ?? widget.titleKey?.resolve(context, inputResolver);
-    if (labelText != null) {
-      labelText =
-          isOptional ? inputResolver.optional(context, labelText) : labelText;
-    }
 
     DateTime now = DateTime.now();
     Future<void> _pickTime() async {

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
 */
 
+import 'package:amplify_authenticator/src/state/inherited_config.dart';
 import 'package:amplify_authenticator/src/theme/amplify_theme.dart';
 import 'package:amplify_authenticator/src/widgets/form_field.dart';
 import 'package:flutter/material.dart';
@@ -44,6 +45,7 @@ mixin AuthenticatorDateField<FieldType,
 
   @override
   Widget buildFormField(BuildContext context) {
+    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
     final inputResolver = stringResolver.inputs;
     final hintText = widget.hintText == null
         ? inputResolver.resolve(context, widget.hintTextKey!)
@@ -81,7 +83,7 @@ mixin AuthenticatorDateField<FieldType,
           onPressed: _pickTime,
         ),
         errorMaxLines: errorMaxLines,
-        labelText: labelText,
+        labelText: useAmplifyTheme ? null : labelText,
         hintText: hintText,
       ),
       keyboardType: TextInputType.datetime,

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
@@ -50,6 +50,13 @@ mixin AuthenticatorDateField<FieldType,
     final hintText = widget.hintText == null
         ? inputResolver.resolve(context, widget.hintTextKey!)
         : widget.hintText!;
+    String? labelText = useAmplifyTheme
+        ? null
+        : widget.title ?? widget.titleKey?.resolve(context, inputResolver);
+    if (labelText != null) {
+      labelText =
+          isOptional ? inputResolver.optional(context, labelText) : labelText;
+    }
 
     DateTime now = DateTime.now();
     Future<void> _pickTime() async {
@@ -83,9 +90,7 @@ mixin AuthenticatorDateField<FieldType,
           onPressed: _pickTime,
         ),
         errorMaxLines: errorMaxLines,
-        labelText: useAmplifyTheme
-            ? null
-            : widget.title ?? widget.titleKey?.resolve(context, inputResolver),
+        labelText: labelText,
         hintText: hintText,
       ),
       keyboardType: TextInputType.datetime,

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
 */
 
+import 'package:amplify_authenticator/src/state/inherited_config.dart';
 import 'package:amplify_authenticator/src/theme/amplify_theme.dart';
 import 'package:amplify_authenticator/src/widgets/form.dart';
 import 'package:amplify_authenticator/src/widgets/form_field.dart';
@@ -24,6 +25,7 @@ mixin AuthenticatorTextField<FieldType,
     on AuthenticatorFormFieldState<FieldType, String, T> {
   @override
   Widget buildFormField(BuildContext context) {
+    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
     final inputResolver = stringResolver.inputs;
     final hintText = widget.hintText == null
         ? widget.hintTextKey?.resolve(context, inputResolver)
@@ -44,6 +46,10 @@ mixin AuthenticatorTextField<FieldType,
           onChanged: onChanged,
           autocorrect: false,
           decoration: InputDecoration(
+            labelText: useAmplifyTheme
+                ? null
+                : widget.title ??
+                    widget.titleKey?.resolve(context, inputResolver),
             prefixIcon: prefix,
             prefixIconConstraints: const BoxConstraints(
               minWidth: 40,
@@ -52,7 +58,7 @@ mixin AuthenticatorTextField<FieldType,
             suffixIcon: suffix,
             errorMaxLines: errorMaxLines,
             hintText: hintText,
-            isDense: true,
+            isDense: useAmplifyTheme ? true : null,
           ),
           maxLength: maxLength,
           maxLengthEnforcement: MaxLengthEnforcement.enforced,

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
 */
 
-import 'package:amplify_authenticator/src/state/inherited_config.dart';
 import 'package:amplify_authenticator/src/theme/amplify_theme.dart';
 import 'package:amplify_authenticator/src/widgets/form.dart';
 import 'package:amplify_authenticator/src/widgets/form_field.dart';
@@ -25,18 +24,10 @@ mixin AuthenticatorTextField<FieldType,
     on AuthenticatorFormFieldState<FieldType, String, T> {
   @override
   Widget buildFormField(BuildContext context) {
-    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
     final inputResolver = stringResolver.inputs;
     final hintText = widget.hintText == null
         ? widget.hintTextKey?.resolve(context, inputResolver)
         : widget.hintText!;
-    String? labelText = useAmplifyTheme
-        ? null
-        : widget.title ?? widget.titleKey?.resolve(context, inputResolver);
-    if (labelText != null) {
-      labelText =
-          isOptional ? inputResolver.optional(context, labelText) : labelText;
-    }
     return ValueListenableBuilder<bool>(
       valueListenable: context
           .findAncestorStateOfType<AuthenticatorFormState>()!
@@ -62,7 +53,6 @@ mixin AuthenticatorTextField<FieldType,
             suffixIcon: suffix,
             errorMaxLines: errorMaxLines,
             hintText: hintText,
-            isDense: useAmplifyTheme ? true : null,
           ),
           maxLength: maxLength,
           maxLengthEnforcement: MaxLengthEnforcement.enforced,

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
@@ -30,6 +30,13 @@ mixin AuthenticatorTextField<FieldType,
     final hintText = widget.hintText == null
         ? widget.hintTextKey?.resolve(context, inputResolver)
         : widget.hintText!;
+    String? labelText = useAmplifyTheme
+        ? null
+        : widget.title ?? widget.titleKey?.resolve(context, inputResolver);
+    if (labelText != null) {
+      labelText =
+          isOptional ? inputResolver.optional(context, labelText) : labelText;
+    }
     return ValueListenableBuilder<bool>(
       valueListenable: context
           .findAncestorStateOfType<AuthenticatorFormState>()!
@@ -46,10 +53,7 @@ mixin AuthenticatorTextField<FieldType,
           onChanged: onChanged,
           autocorrect: false,
           decoration: InputDecoration(
-            labelText: useAmplifyTheme
-                ? null
-                : widget.title ??
-                    widget.titleKey?.resolve(context, inputResolver),
+            labelText: labelText,
             prefixIcon: prefix,
             prefixIconConstraints: const BoxConstraints(
               minWidth: 40,

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
 */
 
+import 'package:amplify_authenticator/src/state/inherited_config.dart';
 import 'package:amplify_authenticator/src/theme/amplify_theme.dart';
 import 'package:amplify_authenticator/src/widgets/form.dart';
 import 'package:amplify_authenticator/src/widgets/form_field.dart';
@@ -24,6 +25,7 @@ mixin AuthenticatorTextField<FieldType,
     on AuthenticatorFormFieldState<FieldType, String, T> {
   @override
   Widget buildFormField(BuildContext context) {
+    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
     final inputResolver = stringResolver.inputs;
     final hintText = widget.hintText == null
         ? widget.hintTextKey?.resolve(context, inputResolver)
@@ -44,7 +46,7 @@ mixin AuthenticatorTextField<FieldType,
           onChanged: onChanged,
           autocorrect: false,
           decoration: InputDecoration(
-            labelText: labelText,
+            labelText: useAmplifyTheme ? null : labelText,
             prefixIcon: prefix,
             prefixIconConstraints: const BoxConstraints(
               minWidth: 40,

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -99,13 +99,17 @@ mixin AuthenticatorUsernameField<FieldType,
   }
 
   @override
-  Widget get labelSuffix {
+  Widget get title {
     final inputResolver = stringResolver.inputs;
     final titleString = inputResolver.resolve(context, titleKey);
-    final labelText = Text(
+    final title = Text(
       isOptional ? inputResolver.optional(context, titleString) : titleString,
     );
+    return title;
+  }
 
+  @override
+  Widget get labelSuffix {
     // Mirrors internal impl. to create an "always active" Switch theme.
     final thumbColor = Theme.of(context).toggleableActiveColor;
     final trackColor = thumbColor.withOpacity(0.5);
@@ -114,7 +118,7 @@ mixin AuthenticatorUsernameField<FieldType,
       case UsernameConfigType.username:
       case UsernameConfigType.email:
       case UsernameConfigType.phoneNumber:
-        return labelText;
+        return title;
       case UsernameConfigType.emailOrPhoneNumber:
       default:
         return SizedBox(
@@ -208,6 +212,7 @@ mixin AuthenticatorUsernameField<FieldType,
         errorMaxLines: errorMaxLines,
         initialValue:
             viewModel.getAttribute(CognitoUserAttributeKey.phoneNumber),
+        useAmplifyTheme: useAmplifyTheme,
       );
     }
     return TextFormField(
@@ -225,9 +230,8 @@ mixin AuthenticatorUsernameField<FieldType,
         prefixIcon: prefix,
         suffixIcon: suffix,
         errorMaxLines: errorMaxLines,
-        labelText: useAmplifyTheme
-            ? null
-            : widget.title ?? widget.titleKey?.resolve(context, inputResolver),
+        labelText:
+            useAmplifyTheme ? null : titleKey.resolve(context, inputResolver),
         hintText: hintText,
         isDense: useAmplifyTheme ? true : null,
       ),

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -206,6 +206,7 @@ mixin AuthenticatorUsernameField<FieldType,
     if (selectedUsernameType == UsernameType.phoneNumber) {
       return AuthenticatorPhoneField<FieldType>(
         field: widget.field,
+        requiredOverride: true,
         onChanged: _onChanged,
         validator: _validator,
         enabled: enabled,

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -109,7 +109,7 @@ mixin AuthenticatorUsernameField<FieldType,
   }
 
   @override
-  Widget? get labelSuffix {
+  Widget? get suffix {
     // Mirrors internal impl. to create an "always active" Switch theme.
     final thumbColor = Theme.of(context).toggleableActiveColor;
     final trackColor = thumbColor.withOpacity(0.5);
@@ -123,6 +123,7 @@ mixin AuthenticatorUsernameField<FieldType,
       default:
         return SizedBox(
           height: 20,
+          width: 100,
           child: IconTheme.merge(
             data: const IconThemeData(size: 16.0),
             child: Row(
@@ -222,6 +223,7 @@ mixin AuthenticatorUsernameField<FieldType,
         initialValue:
             viewModel.getAttribute(CognitoUserAttributeKey.phoneNumber),
         useAmplifyTheme: useAmplifyTheme,
+        suffix: suffix,
       );
     }
     return TextFormField(

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -16,6 +16,7 @@
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_authenticator/src/l10n/auth_strings_resolver.dart';
 import 'package:amplify_authenticator/src/models/username_input.dart';
+import 'package:amplify_authenticator/src/state/inherited_config.dart';
 import 'package:amplify_authenticator/src/theme/amplify_theme.dart';
 import 'package:amplify_authenticator/src/utils/validators.dart';
 import 'package:amplify_authenticator/src/widgets/component.dart';
@@ -98,7 +99,7 @@ mixin AuthenticatorUsernameField<FieldType,
   }
 
   @override
-  Widget get title {
+  Widget get labelSuffix {
     final inputResolver = stringResolver.inputs;
     final titleString = inputResolver.resolve(context, titleKey);
     final labelText = Text(
@@ -118,40 +119,34 @@ mixin AuthenticatorUsernameField<FieldType,
       default:
         return SizedBox(
           height: 20,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              labelText,
-              IconTheme.merge(
-                data: const IconThemeData(size: 16.0),
-                child: Row(
-                  children: [
-                    const Icon(Icons.phone),
-                    Switch(
-                      thumbColor: MaterialStateProperty.all(thumbColor),
-                      trackColor: MaterialStateProperty.all(trackColor),
-                      value: useEmail.value,
-                      onChanged: (val) {
-                        setState(() {
-                          useEmail.value = val;
-                        });
+          child: IconTheme.merge(
+            data: const IconThemeData(size: 16.0),
+            child: Row(
+              children: [
+                const Icon(Icons.phone),
+                Switch(
+                  thumbColor: MaterialStateProperty.all(thumbColor),
+                  trackColor: MaterialStateProperty.all(trackColor),
+                  value: useEmail.value,
+                  onChanged: (val) {
+                    setState(() {
+                      useEmail.value = val;
+                    });
 
-                        // Reset current username value to align with the current switch state.
-                        String newUsername = val
-                            ? viewModel.getAttribute(
-                                    CognitoUserAttributeKey.email) ??
-                                ''
-                            : viewModel.getAttribute(
-                                    CognitoUserAttributeKey.phoneNumber) ??
-                                '';
-                        viewModel.setUsername(newUsername);
-                      },
-                    ),
-                    const Icon(Icons.email),
-                  ],
+                    // Reset current username value to align with the current switch state.
+                    String newUsername = val
+                        ? viewModel
+                                .getAttribute(CognitoUserAttributeKey.email) ??
+                            ''
+                        : viewModel.getAttribute(
+                                CognitoUserAttributeKey.phoneNumber) ??
+                            '';
+                    viewModel.setUsername(newUsername);
+                  },
                 ),
-              ),
-            ],
+                const Icon(Icons.email),
+              ],
+            ),
           ),
         );
     }
@@ -185,6 +180,7 @@ mixin AuthenticatorUsernameField<FieldType,
 
   @override
   Widget buildFormField(BuildContext context) {
+    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
     final inputResolver = stringResolver.inputs;
     final hintText = inputResolver.resolve(context, hintKey);
 
@@ -229,8 +225,11 @@ mixin AuthenticatorUsernameField<FieldType,
         prefixIcon: prefix,
         suffixIcon: suffix,
         errorMaxLines: errorMaxLines,
+        labelText: useAmplifyTheme
+            ? null
+            : widget.title ?? widget.titleKey?.resolve(context, inputResolver),
         hintText: hintText,
-        isDense: true,
+        isDense: useAmplifyTheme ? true : null,
       ),
       keyboardType: keyboardType,
       obscureText: false,

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -99,13 +99,13 @@ mixin AuthenticatorUsernameField<FieldType,
   }
 
   @override
-  Widget get title {
+  Widget get label {
     final inputResolver = stringResolver.inputs;
     final titleString = inputResolver.resolve(context, titleKey);
-    final title = Text(
+    final label = Text(
       isOptional ? inputResolver.optional(context, titleString) : titleString,
     );
-    return title;
+    return label;
   }
 
   @override

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -109,7 +109,7 @@ mixin AuthenticatorUsernameField<FieldType,
   }
 
   @override
-  Widget get labelSuffix {
+  Widget? get labelSuffix {
     // Mirrors internal impl. to create an "always active" Switch theme.
     final thumbColor = Theme.of(context).toggleableActiveColor;
     final trackColor = thumbColor.withOpacity(0.5);
@@ -118,7 +118,7 @@ mixin AuthenticatorUsernameField<FieldType,
       case UsernameConfigType.username:
       case UsernameConfigType.email:
       case UsernameConfigType.phoneNumber:
-        return title;
+        return null;
       case UsernameConfigType.emailOrPhoneNumber:
       default:
         return SizedBox(

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -183,6 +183,16 @@ mixin AuthenticatorUsernameField<FieldType,
   }
 
   @override
+  String? get labelText {
+    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
+    final inputResolver = stringResolver.inputs;
+    String? labelText = useAmplifyTheme
+        ? null
+        : widget.title ?? titleKey.resolve(context, inputResolver);
+    return labelText;
+  }
+
+  @override
   Widget buildFormField(BuildContext context) {
     final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
     final inputResolver = stringResolver.inputs;
@@ -231,10 +241,8 @@ mixin AuthenticatorUsernameField<FieldType,
         prefixIcon: prefix,
         suffixIcon: suffix,
         errorMaxLines: errorMaxLines,
-        labelText:
-            useAmplifyTheme ? null : titleKey.resolve(context, inputResolver),
+        labelText: labelText,
         hintText: hintText,
-        isDense: useAmplifyTheme ? true : null,
       ),
       keyboardType: keyboardType,
       obscureText: false,

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -184,11 +184,9 @@ mixin AuthenticatorUsernameField<FieldType,
 
   @override
   String? get labelText {
-    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
     final inputResolver = stringResolver.inputs;
-    String? labelText = useAmplifyTheme
-        ? null
-        : widget.title ?? titleKey.resolve(context, inputResolver);
+    String? labelText =
+        widget.title ?? titleKey.resolve(context, inputResolver);
     return labelText;
   }
 
@@ -241,7 +239,7 @@ mixin AuthenticatorUsernameField<FieldType,
         prefixIcon: prefix,
         suffixIcon: suffix,
         errorMaxLines: errorMaxLines,
-        labelText: labelText,
+        labelText: useAmplifyTheme ? null : labelText,
         hintText: hintText,
       ),
       keyboardType: keyboardType,

--- a/packages/amplify_authenticator/lib/src/theme/amplify_theme.dart
+++ b/packages/amplify_authenticator/lib/src/theme/amplify_theme.dart
@@ -505,6 +505,7 @@ class AmplifyTheme {
     ),
     focusedBorder: const OutlineInputBorder(),
     border: const OutlineInputBorder(),
+    isDense: true,
   );
 
   static final inputDecorationThemeDark = InputDecorationTheme(
@@ -518,6 +519,7 @@ class AmplifyTheme {
     border: const OutlineInputBorder(
       borderSide: BorderSide(color: AmplifyColors.neutral90),
     ),
+    isDense: true,
   );
 
   static final tabBarTheme = TabBarTheme(

--- a/packages/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -186,20 +186,7 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
   /// The maximum length of the input.
   int? get maxLength => null;
 
-  /// Title widget to use above form field.
-  ///
-  /// Defaults to a [Text] object with the form field's title.
-  Widget? get title {
-    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
-    return useAmplifyTheme && labelText != null ? Text(labelText!) : null;
-  }
-
-  /// a widget to show after the label, right aligned.
-  ///
-  /// Used to display a toggle between username selection
-  Widget? get labelSuffix => null;
-
-  /// Content for the form field's label
+  /// Text content for the form field's label
   String? get labelText {
     final inputResolver = stringResolver.inputs;
     String? labelText =
@@ -210,6 +197,20 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
     }
     return labelText;
   }
+
+  /// Label widget for the form field
+  ///
+  /// Defaults to a [Text] object with the form field's label text.
+  ///
+  /// Displayed above the form field for Amplify Theme, unused for Material Theme
+  Widget? get label => labelText != null ? Text(labelText!) : null;
+
+  /// Widget to show after the label
+  ///
+  /// The labelSuffix will be right aligned with the form field,
+  /// and will be veritcally aligned with the label for Amplify Theme,
+  /// or above the label for Material Theme
+  Widget? get labelSuffix => null;
 
   Widget buildFormField(BuildContext context);
 
@@ -240,10 +241,10 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
                   children: [labelSuffix!],
                   mainAxisAlignment: MainAxisAlignment.end,
                 ),
-              if (useAmplifyTheme && title != null)
+              if (useAmplifyTheme && label != null)
                 DefaultTextStyle(
                   style: titleStyle,
-                  child: title!,
+                  child: label!,
                 ),
               const SizedBox(height: FormFieldConstants.gap),
               buildFormField(context),

--- a/packages/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -214,6 +214,12 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
     return !isRequired;
   }
 
+  /// Margin below the form field
+  EdgeInsetsGeometry? get marginBottom => FormFieldConstants.marginBottom;
+
+  /// Gap between the label and the form field
+  double? get labelGap => FormFieldConstants.gap;
+
   @nonVirtual
   @override
   Widget build(BuildContext context) {
@@ -223,7 +229,7 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
         const TextStyle(fontSize: 16);
 
     return Container(
-      margin: FormFieldConstants.marginBottom,
+      margin: marginBottom,
       child: Stack(
         children: [
           Column(
@@ -234,7 +240,7 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
                   style: titleStyle,
                   child: label!,
                 ),
-              const SizedBox(height: FormFieldConstants.gap),
+              SizedBox(height: labelGap),
               buildFormField(context),
               if (companionWidget != null) companionWidget!,
             ],
@@ -267,5 +273,8 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
     properties.add(IntProperty('maxLength', maxLength));
     properties.add(DiagnosticsProperty<bool>('isOptional', isOptional));
     properties.add(StringProperty('labelText', labelText));
+    properties.add(
+        DiagnosticsProperty<EdgeInsetsGeometry?>('marginBottom', marginBottom));
+    properties.add(DoubleProperty('labelGap', labelGap));
   }
 }

--- a/packages/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -191,7 +191,24 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
   /// Defaults to a [Text] object with the form field's title.
   Widget? get title => null;
 
+  /// a widget to show after the label, right aligned.
+  ///
+  /// Used to display a toggle between username selection
   Widget? get labelSuffix => null;
+
+  /// Content for the form field's label
+  String? get labelText {
+    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
+    final inputResolver = stringResolver.inputs;
+    String? labelText = useAmplifyTheme
+        ? null
+        : widget.title ?? widget.titleKey?.resolve(context, inputResolver);
+    if (labelText != null) {
+      labelText =
+          isOptional ? inputResolver.optional(context, labelText) : labelText;
+    }
+    return labelText;
+  }
 
   Widget buildFormField(BuildContext context);
 
@@ -274,5 +291,6 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
         .add(DiagnosticsProperty<ValueNotifier<bool>>('useEmail', useEmail));
     properties.add(IntProperty('maxLength', maxLength));
     properties.add(DiagnosticsProperty<bool>('isOptional', isOptional));
+    properties.add(StringProperty('labelText', labelText));
   }
 }

--- a/packages/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -189,7 +189,10 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
   /// Title widget to use above form field.
   ///
   /// Defaults to a [Text] object with the form field's title.
-  Widget? get title => null;
+  Widget? get title {
+    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
+    return useAmplifyTheme && labelText != null ? Text(labelText!) : null;
+  }
 
   /// a widget to show after the label, right aligned.
   ///
@@ -198,11 +201,9 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
 
   /// Content for the form field's label
   String? get labelText {
-    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
     final inputResolver = stringResolver.inputs;
-    String? labelText = useAmplifyTheme
-        ? null
-        : widget.title ?? widget.titleKey?.resolve(context, inputResolver);
+    String? labelText =
+        widget.title ?? widget.titleKey?.resolve(context, inputResolver);
     if (labelText != null) {
       labelText =
           isOptional ? inputResolver.optional(context, labelText) : labelText;
@@ -223,19 +224,6 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
   @override
   Widget build(BuildContext context) {
     final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
-    final inputResolver = stringResolver.inputs;
-    Widget? title = useAmplifyTheme ? this.title : null;
-    if (title == null && useAmplifyTheme) {
-      final titleString =
-          widget.title ?? widget.titleKey?.resolve(context, inputResolver);
-      if (titleString != null) {
-        title = Text(
-          isOptional
-              ? inputResolver.optional(context, titleString)
-              : titleString,
-        );
-      }
-    }
     final titleStyle = Theme.of(context).inputDecorationTheme.labelStyle ??
         Theme.of(context).textTheme.subtitle1 ??
         const TextStyle(fontSize: 16);
@@ -252,10 +240,10 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
                   children: [labelSuffix!],
                   mainAxisAlignment: MainAxisAlignment.end,
                 ),
-              if (title != null)
+              if (useAmplifyTheme && title != null)
                 DefaultTextStyle(
                   style: titleStyle,
-                  child: title,
+                  child: title!,
                 ),
               const SizedBox(height: FormFieldConstants.gap),
               buildFormField(context),

--- a/packages/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -31,6 +31,7 @@ import 'package:amplify_authenticator/src/mixins/authenticator_text_field.dart';
 import 'package:amplify_authenticator/src/mixins/authenticator_username_field.dart';
 import 'package:amplify_authenticator/src/models/username_input.dart';
 import 'package:amplify_authenticator/src/state/inherited_auth_bloc.dart';
+import 'package:amplify_authenticator/src/state/inherited_config.dart';
 import 'package:amplify_authenticator/src/state/inherited_forms.dart';
 import 'package:amplify_authenticator/src/utils/country_code.dart';
 import 'package:amplify_authenticator/src/utils/validators.dart';
@@ -190,6 +191,8 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
   /// Defaults to a [Text] object with the form field's title.
   Widget? get title => null;
 
+  Widget? get labelSuffix => null;
+
   Widget buildFormField(BuildContext context);
 
   /// Whether the field is optional, i.e. does not require user input. This is
@@ -202,8 +205,9 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
   @nonVirtual
   @override
   Widget build(BuildContext context) {
+    final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
     final inputResolver = stringResolver.inputs;
-    Widget? title = this.title;
+    Widget? title = useAmplifyTheme ? this.title : null;
     if (title == null) {
       final titleString =
           widget.title ?? widget.titleKey?.resolve(context, inputResolver);
@@ -221,17 +225,23 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
 
     return Container(
       margin: title == null ? EdgeInsets.zero : FormFieldConstants.marginBottom,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          if (title != null)
-            DefaultTextStyle(
-              style: titleStyle,
-              child: title,
-            ),
-          const SizedBox(height: FormFieldConstants.gap),
-          buildFormField(context),
-          if (companionWidget != null) companionWidget!,
+      child: Stack(
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              if (useAmplifyTheme && title != null)
+                DefaultTextStyle(
+                  style: titleStyle,
+                  child: title,
+                ),
+              const SizedBox(height: FormFieldConstants.gap),
+              buildFormField(context),
+              if (companionWidget != null) companionWidget!,
+            ],
+          ),
+          if (labelSuffix != null)
+            Positioned(top: 0, right: 0, child: labelSuffix!),
         ],
       ),
     );

--- a/packages/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -208,7 +208,7 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
     final useAmplifyTheme = InheritedConfig.of(context).useAmplifyTheme;
     final inputResolver = stringResolver.inputs;
     Widget? title = useAmplifyTheme ? this.title : null;
-    if (title == null) {
+    if (title == null && useAmplifyTheme) {
       final titleString =
           widget.title ?? widget.titleKey?.resolve(context, inputResolver);
       if (titleString != null) {
@@ -224,13 +224,18 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
         const TextStyle(fontSize: 16);
 
     return Container(
-      margin: title == null ? EdgeInsets.zero : FormFieldConstants.marginBottom,
+      margin: FormFieldConstants.marginBottom,
       child: Stack(
         children: [
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              if (useAmplifyTheme && title != null)
+              if (!useAmplifyTheme && labelSuffix != null)
+                Row(
+                  children: [labelSuffix!],
+                  mainAxisAlignment: MainAxisAlignment.end,
+                ),
+              if (title != null)
                 DefaultTextStyle(
                   style: titleStyle,
                   child: title,
@@ -240,7 +245,7 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
               if (companionWidget != null) companionWidget!,
             ],
           ),
-          if (labelSuffix != null)
+          if (useAmplifyTheme && labelSuffix != null)
             Positioned(top: 0, right: 0, child: labelSuffix!),
         ],
       ),

--- a/packages/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -205,13 +205,6 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
   /// Displayed above the form field for Amplify Theme, unused for Material Theme
   Widget? get label => labelText != null ? Text(labelText!) : null;
 
-  /// Widget to show after the label
-  ///
-  /// The labelSuffix will be right aligned with the form field,
-  /// and will be veritcally aligned with the label for Amplify Theme,
-  /// or above the label for Material Theme
-  Widget? get labelSuffix => null;
-
   Widget buildFormField(BuildContext context);
 
   /// Whether the field is optional, i.e. does not require user input. This is
@@ -236,11 +229,6 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              if (!useAmplifyTheme && labelSuffix != null)
-                Row(
-                  children: [labelSuffix!],
-                  mainAxisAlignment: MainAxisAlignment.end,
-                ),
               if (useAmplifyTheme && label != null)
                 DefaultTextStyle(
                   style: titleStyle,
@@ -251,8 +239,6 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
               if (companionWidget != null) companionWidget!,
             ],
           ),
-          if (useAmplifyTheme && labelSuffix != null)
-            Positioned(top: 0, right: 0, child: labelSuffix!),
         ],
       ),
     );

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/phone_number_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/phone_number_field.dart
@@ -25,9 +25,11 @@ class AuthenticatorPhoneField<FieldType> extends AuthenticatorFormField<
     this.enabled,
     this.initialValue,
     this.errorMaxLines,
+    required bool useAmplifyTheme,
   }) : super._(
           key: key,
           field: field,
+          titleKey: useAmplifyTheme ? null : InputResolverKey.phoneNumberTitle,
           hintTextKey: InputResolverKey.phoneNumberHint,
         );
 

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/phone_number_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/phone_number_field.dart
@@ -26,6 +26,7 @@ class AuthenticatorPhoneField<FieldType> extends AuthenticatorFormField<
     this.enabled,
     this.initialValue,
     this.errorMaxLines,
+    this.suffix,
     required bool useAmplifyTheme,
   }) : super._(
           key: key,
@@ -40,6 +41,7 @@ class AuthenticatorPhoneField<FieldType> extends AuthenticatorFormField<
   final ValueChanged<String>? onChanged;
   final FormFieldValidator<String?>? validator;
   final int? errorMaxLines;
+  final Widget? suffix;
 
   @override
   _AuthenticatorPhoneFieldState<FieldType> createState() =>
@@ -76,6 +78,9 @@ class _AuthenticatorPhoneFieldState<FieldType>
 
   @override
   int get errorMaxLines => widget.errorMaxLines ?? super.errorMaxLines;
+
+  @override
+  Widget? get suffix => widget.suffix;
 
   @override
   ValueChanged<String> get onChanged => (phoneNumber) {

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/phone_number_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/phone_number_field.dart
@@ -20,6 +20,7 @@ class AuthenticatorPhoneField<FieldType> extends AuthenticatorFormField<
   const AuthenticatorPhoneField({
     Key? key,
     required FieldType field,
+    bool? requiredOverride,
     this.onChanged,
     this.validator,
     this.enabled,
@@ -31,6 +32,7 @@ class AuthenticatorPhoneField<FieldType> extends AuthenticatorFormField<
           field: field,
           titleKey: useAmplifyTheme ? null : InputResolverKey.phoneNumberTitle,
           hintTextKey: InputResolverKey.phoneNumberHint,
+          requiredOverride: requiredOverride,
         );
 
   final bool? enabled;

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/phone_number_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/phone_number_field.dart
@@ -83,6 +83,12 @@ class _AuthenticatorPhoneFieldState<FieldType>
   Widget? get suffix => widget.suffix;
 
   @override
+  EdgeInsetsGeometry? get marginBottom => null;
+
+  @override
+  double? get labelGap => null;
+
+  @override
   ValueChanged<String> get onChanged => (phoneNumber) {
         phoneNumber = formatPhoneNumber(phoneNumber)!;
         return (widget.onChanged ?? super.onChanged)(phoneNumber);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Use label/labelText for material theme


### Screenshots

#### Email OR Phone, Email Selected

**Before**

![Screen Shot 2021-11-23 at 10 59 13 PM](https://user-images.githubusercontent.com/20613561/143173216-93939dd1-b080-49a1-861b-a214ad4e4169.png)

**After**
![Screen Shot 2021-11-23 at 11 01 19 PM](https://user-images.githubusercontent.com/20613561/143173247-98bbe40b-8596-4d72-8bcb-05ce37d5c723.png)

#### Email OR Phone, Phone Selected

**Before**
![Screen Shot 2021-11-23 at 10 59 24 PM](https://user-images.githubusercontent.com/20613561/143173219-819617f9-9f79-4b23-a513-2f392b4e72c2.png)

**After**
![Screen Shot 2021-11-23 at 11 22 21 PM](https://user-images.githubusercontent.com/20613561/143174629-5c155f3f-d791-411f-92eb-086fdb985511.png)

#### Email OR Phone, Phone Selected AND focused

**Before**
![Screen Shot 2021-11-23 at 10 59 38 PM](https://user-images.githubusercontent.com/20613561/143173220-3311a3ca-6230-4f62-8e56-30528403200a.png)

**After**
![Screen Shot 2021-11-23 at 11 22 28 PM](https://user-images.githubusercontent.com/20613561/143174641-0e1c588c-258a-4890-820c-83186dfa7cc1.png)

#### Email only

**Before**
![Screen Shot 2021-11-23 at 11 00 25 PM](https://user-images.githubusercontent.com/20613561/143173222-28b11751-5739-408c-bffd-54abad8f014d.png)


**After**
![Screen Shot 2021-11-23 at 11 03 26 PM](https://user-images.githubusercontent.com/20613561/143173251-dd8934eb-be43-4636-87d8-1a9acf17104d.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
