### PR TITLE
chore(amplify_api): support custom list type (embedded collection) in…

### DIFF
--- a/packages/amplify_api/example/integration_test/graphql_tests.dart
+++ b/packages/amplify_api/example/integration_test/graphql_tests.dart
@@ -287,7 +287,7 @@ void main() {
 
       testWidgets('should CREATE a blog with Model helper and custom type',
           (WidgetTester tester) async {
-        String name = 'Integration Test Blog - create';
+        String name = 'Integration Test Blog - create, custom type';
         String bucketName = 'Good bucket';
         Blog blog = Blog(
             name: name,
@@ -300,6 +300,27 @@ void main() {
         if (data != null) blogCache.add(data);
 
         expect(data?.file?.bucket, equals(bucketName));
+      });
+
+      testWidgets(
+          'should CREATE a blog with Model helper and nested custom type',
+          (WidgetTester tester) async {
+        String name = 'Integration Test Blog - create, nested custom type';
+        String metaName = 'alpha';
+        Blog blog = Blog(
+            name: name,
+            file: S3Object(
+                bucket: 'nested bucket',
+                region: 'us-west-2',
+                key: 'foo',
+                meta: FileMeta(name: metaName)));
+
+        final req = ModelMutations.create(blog);
+        final res = await Amplify.API.mutate(request: req).response;
+        Blog? data = res.data;
+        if (data != null) blogCache.add(data);
+
+        expect(data?.file?.meta?.name, equals(metaName));
       });
 
       testWidgets('should CREATE a blog with Model helper and custom type list',

--- a/packages/amplify_api/example/integration_test/graphql_tests.dart
+++ b/packages/amplify_api/example/integration_test/graphql_tests.dart
@@ -302,6 +302,22 @@ void main() {
         expect(data?.file?.bucket, equals(bucketName));
       });
 
+      testWidgets('should CREATE a blog with Model helper and custom type list',
+          (WidgetTester tester) async {
+        String name = 'Integration Test Blog - create';
+        String bucketName = 'Good bucket';
+        Blog blog = Blog(name: name, files: [
+          S3Object(bucket: bucketName, region: 'us-west-2', key: 'foo')
+        ]);
+
+        final req = ModelMutations.create(blog);
+        final res = await Amplify.API.mutate(request: req).response;
+        Blog? data = res.data;
+        if (data != null) blogCache.add(data);
+
+        expect(data?.files?[0].bucket, equals(bucketName));
+      });
+
       testWidgets('should CREATE a post (model with parent) with Model helper',
           (WidgetTester tester) async {
         final title = 'Lorem Ipsum Test Post: ${UUID.getUUID()}';

--- a/packages/amplify_api/example/tool/schema.graphql
+++ b/packages/amplify_api/example/tool/schema.graphql
@@ -1,7 +1,12 @@
+type FileMeta {
+  name: String!
+}
+
 type S3Object {
   bucket: String!
   region: String!
   key: String!
+  meta: FileMeta
 }
 
 type Blog @model {

--- a/packages/amplify_api/example/tool/schema.graphql
+++ b/packages/amplify_api/example/tool/schema.graphql
@@ -9,6 +9,7 @@ type Blog @model {
   name: String!
   createdAt: AWSDateTime
   file: S3Object
+  files: [S3Object]
   posts: [Post] @connection(keyName: "byBlog", fields: ["id"])
 }
 

--- a/packages/amplify_api/lib/src/graphql/graphql_request_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/graphql_request_factory.dart
@@ -76,7 +76,8 @@ class GraphQLRequestFactory {
         .where((entry) =>
             entry.value.association == null) // ignore related model fields
         .map((entry) {
-      if (entry.value.type.fieldType == ModelFieldTypeEnum.embedded) {
+      if (entry.value.type.fieldType == ModelFieldTypeEnum.embedded ||
+          entry.value.type.fieldType == ModelFieldTypeEnum.embeddedCollection) {
         final embeddedSchema =
             getModelSchemaByModelName(entry.value.type.ofCustomTypeName!, null);
         final embeddedSelectionSet = _getSelectionSetFromModelSchema(

--- a/packages/amplify_api/lib/src/graphql/utils.dart
+++ b/packages/amplify_api/lib/src/graphql/utils.dart
@@ -115,24 +115,21 @@ Map<String, dynamic> transformAppSyncJsonToModelJson(
     dynamic inputValue = _input[parentField.name];
     if (inputValue != null && ofModelName != null) {
       final parentSchema = getModelSchemaByModelName(ofModelName, null);
-      if (inputValue is Map) {
-        _input.update(
-            parentField.name,
-            (dynamic parentData) => <String, dynamic>{
-                  _serializedData:
-                      transformAppSyncJsonToModelJson(parentData, parentSchema)
-                });
-      } else if (inputValue is List) {
-        // only used for embeddedCollection
-        _input.update(parentField.name, (dynamic parentData) {
-          return (parentData as List)
+      _input.update(parentField.name, (dynamic parentData) {
+        if (parentData is List) {
+          // only used for embeddedCollection
+          return parentData
               .map((dynamic e) => {
                     _serializedData:
                         transformAppSyncJsonToModelJson(e, parentSchema)
                   })
               .toList();
-        });
-      }
+        }
+        return {
+          _serializedData:
+              transformAppSyncJsonToModelJson(parentData, parentSchema)
+        };
+      });
     }
   }
 

--- a/packages/amplify_api/lib/src/graphql/utils.dart
+++ b/packages/amplify_api/lib/src/graphql/utils.dart
@@ -113,7 +113,7 @@ Map<String, dynamic> transformAppSyncJsonToModelJson(
     final ofModelName =
         parentField.type.ofModelName ?? parentField.type.ofCustomTypeName;
     dynamic inputValue = _input[parentField.name];
-    if (inputValue != null && ofModelName != null) {
+    if ((inputValue is Map || inputValue is List) && ofModelName != null) {
       final parentSchema = getModelSchemaByModelName(ofModelName, null);
       _input.update(parentField.name, (dynamic parentData) {
         if (parentData is List) {

--- a/packages/amplify_api/test/amplify_api_query_test.dart
+++ b/packages/amplify_api/test/amplify_api_query_test.dart
@@ -34,7 +34,7 @@ void main() {
   });
 
   const blogSelectionSet =
-      'id name file { bucket region key } createdAt updatedAt';
+      'id name createdAt file { bucket region key } files { bucket region key } updatedAt';
 
   test('Query advanced flow executes correctly in the happy case', () async {
     const queryResult = {

--- a/packages/amplify_api/test/amplify_api_query_test.dart
+++ b/packages/amplify_api/test/amplify_api_query_test.dart
@@ -34,7 +34,7 @@ void main() {
   });
 
   const blogSelectionSet =
-      'id name createdAt file { bucket region key } files { bucket region key } updatedAt';
+      'id name createdAt file { bucket region key meta { name } } files { bucket region key meta { name } } updatedAt';
 
   test('Query advanced flow executes correctly in the happy case', () async {
     const queryResult = {

--- a/packages/amplify_api/test/graphql_helpers_test.dart
+++ b/packages/amplify_api/test/graphql_helpers_test.dart
@@ -25,7 +25,7 @@ void main() {
   group('with ModelProvider', () {
     final AmplifyAPI api = AmplifyAPI(modelProvider: ModelProvider.instance);
     const blogSelectionSet =
-        'id name file { bucket region key } createdAt updatedAt';
+        'id name createdAt file { bucket region key } files { bucket region key } updatedAt';
 
     group('ModelQueries', () {
       test('ModelQueries.get() should build a valid request', () {
@@ -291,7 +291,13 @@ void main() {
 
         Blog blog = Blog(id: id, name: name, createdAt: createdAt);
         final expectedVars = {
-          'input': {'id': id, 'name': name, 'createdAt': time, 'file': null}
+          'input': {
+            'id': id,
+            'name': name,
+            'createdAt': time,
+            'file': null,
+            'files': null
+          }
         };
         const expectedDoc =
             'mutation createBlog(\$input: CreateBlogInput!, \$condition:  ModelBlogConditionInput) { createBlog(input: \$input, condition: \$condition) { $blogSelectionSet } }';
@@ -392,7 +398,13 @@ void main() {
         Blog blog = Blog(id: id, name: name, createdAt: createdAt);
 
         final expectedVars = {
-          'input': {'id': id, 'name': name, 'createdAt': time, 'file': null},
+          'input': {
+            'id': id,
+            'name': name,
+            'createdAt': time,
+            'file': null,
+            'files': null
+          },
           'condition': null
         };
         const expectedDoc =
@@ -451,7 +463,13 @@ void main() {
         final createdAt = TemporalDateTime.fromString(time);
         Blog blog = Blog(id: id, name: name, createdAt: createdAt);
         final expectedVars = {
-          'input': {'id': id, 'name': name, 'createdAt': time, 'file': null},
+          'input': {
+            'id': id,
+            'name': name,
+            'createdAt': time,
+            'file': null,
+            'files': null
+          },
           'condition': {
             'createdAt': {'lt': time}
           }

--- a/packages/amplify_api/test/graphql_helpers_test.dart
+++ b/packages/amplify_api/test/graphql_helpers_test.dart
@@ -25,7 +25,7 @@ void main() {
   group('with ModelProvider', () {
     final AmplifyAPI api = AmplifyAPI(modelProvider: ModelProvider.instance);
     const blogSelectionSet =
-        'id name createdAt file { bucket region key } files { bucket region key } updatedAt';
+        'id name createdAt file { bucket region key meta { name } } files { bucket region key meta { name } } updatedAt';
 
     group('ModelQueries', () {
       test('ModelQueries.get() should build a valid request', () {

--- a/packages/amplify_test/lib/test_models/FileMeta.dart
+++ b/packages/amplify_test/lib/test_models/FileMeta.dart
@@ -1,0 +1,87 @@
+/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code, implicit_dynamic_parameter, implicit_dynamic_map_literal, implicit_dynamic_type
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:flutter/foundation.dart';
+
+/** This is an auto generated class representing the FileMeta type in your schema. */
+@immutable
+class FileMeta {
+  final String? _name;
+
+  String get name {
+    try {
+      return _name!;
+    } catch (e) {
+      throw new AmplifyCodeGenModelException(
+          AmplifyExceptionMessages
+              .codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion: AmplifyExceptionMessages
+              .codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString());
+    }
+  }
+
+  const FileMeta._internal({required name}) : _name = name;
+
+  factory FileMeta({required String name}) {
+    return FileMeta._internal(name: name);
+  }
+
+  bool equals(Object other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is FileMeta && _name == other._name;
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+
+    buffer.write("FileMeta {");
+    buffer.write("name=" + "$_name");
+    buffer.write("}");
+
+    return buffer.toString();
+  }
+
+  FileMeta copyWith({String? name}) {
+    return FileMeta._internal(name: name ?? this.name);
+  }
+
+  FileMeta.fromJson(Map<String, dynamic> json) : _name = json['name'];
+
+  Map<String, dynamic> toJson() => {'name': _name};
+
+  static var schema =
+      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = "FileMeta";
+    modelSchemaDefinition.pluralName = "FileMetas";
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.customTypeField(
+        fieldName: 'name',
+        isRequired: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+  });
+}

--- a/packages/amplify_test/lib/test_models/ModelProvider.dart
+++ b/packages/amplify_test/lib/test_models/ModelProvider.dart
@@ -23,21 +23,23 @@ import 'package:amplify_core/amplify_core.dart';
 import 'Blog.dart';
 import 'Comment.dart';
 import 'Post.dart';
+import 'FileMeta.dart';
 import 'S3Object.dart';
 
 export 'Blog.dart';
 export 'Comment.dart';
+export 'FileMeta.dart';
 export 'Post.dart';
 export 'S3Object.dart';
 
 class ModelProvider implements ModelProviderInterface {
   @override
-  String version = "4364df78ad5b08b91c8e1495d6b1997f";
+  String version = "e22227993ad5df5e265b0d065245b740";
   @override
   List<ModelSchema> modelSchemas = [Blog.schema, Comment.schema, Post.schema];
   static final ModelProvider _instance = ModelProvider();
   @override
-  List<ModelSchema> customTypeSchemas = [S3Object.schema];
+  List<ModelSchema> customTypeSchemas = [FileMeta.schema, S3Object.schema];
 
   static ModelProvider get instance => _instance;
 

--- a/packages/amplify_test/lib/test_models/S3Object.dart
+++ b/packages/amplify_test/lib/test_models/S3Object.dart
@@ -15,6 +15,7 @@
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code, implicit_dynamic_parameter, implicit_dynamic_map_literal, implicit_dynamic_type
 
+import 'ModelProvider.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
@@ -24,6 +25,7 @@ class S3Object {
   final String? _bucket;
   final String? _region;
   final String? _key;
+  final FileMeta? _meta;
 
   String get bucket {
     try {
@@ -64,14 +66,24 @@ class S3Object {
     }
   }
 
-  const S3Object._internal({required bucket, required region, required key})
+  FileMeta? get meta {
+    return _meta;
+  }
+
+  const S3Object._internal(
+      {required bucket, required region, required key, meta})
       : _bucket = bucket,
         _region = region,
-        _key = key;
+        _key = key,
+        _meta = meta;
 
   factory S3Object(
-      {required String bucket, required String region, required String key}) {
-    return S3Object._internal(bucket: bucket, region: region, key: key);
+      {required String bucket,
+      required String region,
+      required String key,
+      FileMeta? meta}) {
+    return S3Object._internal(
+        bucket: bucket, region: region, key: key, meta: meta);
   }
 
   bool equals(Object other) {
@@ -84,7 +96,8 @@ class S3Object {
     return other is S3Object &&
         _bucket == other._bucket &&
         _region == other._region &&
-        _key == other._key;
+        _key == other._key &&
+        _meta == other._meta;
   }
 
   @override
@@ -97,26 +110,37 @@ class S3Object {
     buffer.write("S3Object {");
     buffer.write("bucket=" + "$_bucket" + ", ");
     buffer.write("region=" + "$_region" + ", ");
-    buffer.write("key=" + "$_key");
+    buffer.write("key=" + "$_key" + ", ");
+    buffer.write("meta=" + (_meta != null ? _meta!.toString() : "null"));
     buffer.write("}");
 
     return buffer.toString();
   }
 
-  S3Object copyWith({String? bucket, String? region, String? key}) {
+  S3Object copyWith(
+      {String? bucket, String? region, String? key, FileMeta? meta}) {
     return S3Object._internal(
         bucket: bucket ?? this.bucket,
         region: region ?? this.region,
-        key: key ?? this.key);
+        key: key ?? this.key,
+        meta: meta ?? this.meta);
   }
 
   S3Object.fromJson(Map<String, dynamic> json)
       : _bucket = json['bucket'],
         _region = json['region'],
-        _key = json['key'];
+        _key = json['key'],
+        _meta = json['meta']?['serializedData'] != null
+            ? FileMeta.fromJson(
+                new Map<String, dynamic>.from(json['meta']['serializedData']))
+            : null;
 
-  Map<String, dynamic> toJson() =>
-      {'bucket': _bucket, 'region': _region, 'key': _key};
+  Map<String, dynamic> toJson() => {
+        'bucket': _bucket,
+        'region': _region,
+        'key': _key,
+        'meta': _meta?.toJson()
+      };
 
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -137,5 +161,11 @@ class S3Object {
         fieldName: 'key',
         isRequired: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.embedded(
+        fieldName: 'meta',
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.embedded,
+            ofCustomTypeName: 'FileMeta')));
   });
 }


### PR DESCRIPTION
Some fixes to support custom type list (embedded collection) fields in model-based graphql helpers. Some tests for that, as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
