### PR TITLE
fix(api): 0.3.0 fixes

### DIFF
--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApiPlugin.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApiPlugin.kt
@@ -80,7 +80,7 @@ class AmplifyApiPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, _result: Result) {
         val methodName = call.method
         val result = AtomicResult(_result, call.method)
-        val arguments: Map<String, Any> = call.arguments as Map<String, Any>
+        val arguments: Map<String, Any> = (call.arguments as? Map<*, *>)?.cast() ?: mapOf()
 
         if (methodName == "cancel") {
             onCancel(result, (call.arguments as String))

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApiPlugin.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApiPlugin.kt
@@ -23,10 +23,12 @@ import androidx.annotation.VisibleForTesting
 import com.amazonaws.amplify.amplify_api.auth.FlutterAuthProviders
 import com.amazonaws.amplify.amplify_api.rest_api.FlutterRestApi
 import com.amazonaws.amplify.amplify_core.AtomicResult
+import com.amazonaws.amplify.amplify_core.cast
 import com.amazonaws.amplify.amplify_core.exception.ExceptionUtil.Companion.createSerializedUnrecognizedError
 import com.amazonaws.amplify.amplify_core.exception.ExceptionUtil.Companion.handleAddPluginException
 import com.amazonaws.amplify.amplify_core.exception.ExceptionUtil.Companion.postExceptionToFlutterChannel
 import com.amplifyframework.api.aws.AWSApiPlugin
+import com.amplifyframework.api.aws.AuthorizationType
 import com.amplifyframework.core.Amplify
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.EventChannel
@@ -78,16 +80,20 @@ class AmplifyApiPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, _result: Result) {
         val methodName = call.method
         val result = AtomicResult(_result, call.method)
+        val arguments: Map<String, Any> = call.arguments as Map<String, Any>
 
         if (methodName == "cancel") {
             onCancel(result, (call.arguments as String))
             return
         } else if (methodName == "addPlugin") {
             try {
+                val authProvidersList: List<String> =
+                    (arguments["authProviders"] as List<*>?)?.cast() ?: listOf()
+                val authProviders = authProvidersList.map { AuthorizationType.valueOf(it) }
                 Amplify.addPlugin(
                     AWSApiPlugin
                         .builder()
-                        .apiAuthProviders(FlutterAuthProviders(channel).factory)
+                        .apiAuthProviders(FlutterAuthProviders(authProviders, channel).factory)
                         .build()
                 )
                 logger.info("Added API plugin")
@@ -99,7 +105,7 @@ class AmplifyApiPlugin : FlutterPlugin, MethodCallHandler {
         }
 
         try {
-            val arguments: Map<String, Any> = call.arguments as Map<String, Any>
+
 
             when (call.method) {
                 "get" -> FlutterRestApi.get(result, arguments)

--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/auth/FlutterAuthProvider.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/auth/FlutterAuthProvider.kt
@@ -28,7 +28,10 @@ import kotlinx.coroutines.*
 /**
  * Manages the shared state of all [FlutterAuthProvider] instances.
  */
-class FlutterAuthProviders(private val methodChannel: MethodChannel) {
+class FlutterAuthProviders(
+    private val authProviders: List<AuthorizationType>,
+    private val methodChannel: MethodChannel
+) {
 
     private companion object {
         /**
@@ -51,11 +54,15 @@ class FlutterAuthProviders(private val methodChannel: MethodChannel) {
      * A factory of [FlutterAuthProvider] instances.
      */
     val factory: ApiAuthProviders by lazy {
-        ApiAuthProviders
-            .Builder()
-            .functionAuthProvider(FlutterAuthProvider(this, AuthorizationType.AWS_LAMBDA))
-            .oidcAuthProvider(FlutterAuthProvider(this, AuthorizationType.OPENID_CONNECT))
-            .build()
+        val authProviders = this.authProviders.toSet()
+        val builder = ApiAuthProviders.Builder()
+        if (authProviders.contains(AuthorizationType.AWS_LAMBDA)) {
+            builder.functionAuthProvider(FlutterAuthProvider(this, AuthorizationType.AWS_LAMBDA))
+        }
+        if (authProviders.contains(AuthorizationType.OPENID_CONNECT)) {
+            builder.oidcAuthProvider(FlutterAuthProvider(this, AuthorizationType.OPENID_CONNECT))
+        }
+        builder.build()
     }
 
     /**

--- a/packages/amplify_api/ios/Classes/Auth/FlutterAuthProvider.swift
+++ b/packages/amplify_api/ios/Classes/Auth/FlutterAuthProvider.swift
@@ -77,12 +77,24 @@ class FlutterAuthProviders: APIAuthProviderFactory {
 
         return token ?? unknownError
     }
+    
+    private let authProviders: Set<AWSAuthorizationType>
+    
+    init(_ authProviders: [AWSAuthorizationType]) {
+        self.authProviders = Set(authProviders)
+    }
 
     override func oidcAuthProvider() -> AmplifyOIDCAuthProvider? {
+        guard authProviders.contains(.openIDConnect) else {
+            return nil
+        }
         return FlutterAuthProvider(type: .openIDConnect)
     }
 
     override func functionAuthProvider() -> AmplifyFunctionAuthProvider? {
+        guard authProviders.contains(.function) else {
+            return nil
+        }
         return FlutterAuthProvider(type: .function)
     }
 }

--- a/packages/amplify_api/ios/Classes/Auth/FlutterAuthProvider.swift
+++ b/packages/amplify_api/ios/Classes/Auth/FlutterAuthProvider.swift
@@ -77,9 +77,9 @@ class FlutterAuthProviders: APIAuthProviderFactory {
 
         return token ?? unknownError
     }
-    
+
     private let authProviders: Set<AWSAuthorizationType>
-    
+
     init(_ authProviders: [AWSAuthorizationType]) {
         self.authProviders = Set(authProviders)
     }

--- a/packages/amplify_api/ios/Classes/SwiftAmplifyApiPlugin.swift
+++ b/packages/amplify_api/ios/Classes/SwiftAmplifyApiPlugin.swift
@@ -61,7 +61,7 @@ public class SwiftAmplifyApiPlugin: NSObject, FlutterPlugin {
             }
 
             let arguments = try FlutterApiRequest.getMap(args: callArgs)
-            
+
             if method == "addPlugin"{
                 let authProvidersList = arguments["authProviders"] as? [String] ?? []
                 let authProviders = authProvidersList.compactMap {

--- a/packages/amplify_api/ios/Classes/SwiftAmplifyApiPlugin.swift
+++ b/packages/amplify_api/ios/Classes/SwiftAmplifyApiPlugin.swift
@@ -58,12 +58,18 @@ public class SwiftAmplifyApiPlugin: NSObject, FlutterPlugin {
                 let cancelToken = try FlutterApiRequest.getCancelToken(args: callArgs)
                 onCancel(flutterResult: result, cancelToken: cancelToken)
                 return
-            } else if method == "addPlugin"{
-                addPlugin(result: result)
-                return
             }
 
             let arguments = try FlutterApiRequest.getMap(args: callArgs)
+            
+            if method == "addPlugin"{
+                let authProvidersList = arguments["authProviders"] as? [String] ?? []
+                let authProviders = authProvidersList.compactMap {
+                    AWSAuthorizationType(rawValue: $0)
+                }
+                addPlugin(authProviders: authProviders, result: result)
+                return
+            }
 
             try innerHandle(method: method, arguments: arguments, result: result)
         } catch {
@@ -72,12 +78,12 @@ public class SwiftAmplifyApiPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    private func addPlugin(result: FlutterResult) {
+    private func addPlugin(authProviders: [AWSAuthorizationType], result: FlutterResult) {
         do {
             try Amplify.add(
                 plugin: AWSAPIPlugin(
                     sessionFactory: FlutterURLSessionBehaviorFactory(),
-                    apiAuthProviderFactory: FlutterAuthProviders()))
+                    apiAuthProviderFactory: FlutterAuthProviders(authProviders)))
             result(true)
         } catch let apiError as APIError {
             ErrorUtil.postErrorToFlutterChannel(

--- a/packages/amplify_api/lib/src/method_channel_api.dart
+++ b/packages/amplify_api/lib/src/method_channel_api.dart
@@ -83,7 +83,10 @@ class AmplifyAPIMethodChannel extends AmplifyAPI {
   Future<void> addPlugin() async {
     try {
       setupAuthProviders();
-      await _channel.invokeMethod<void>('addPlugin');
+      await _channel.invokeMethod<void>('addPlugin', {
+        'authProviders':
+            _authProviders.keys.map((key) => key.rawValue).toList(),
+      });
     } on PlatformException catch (e) {
       if (e.code == 'AmplifyAlreadyConfiguredException') {
         throw const AmplifyAlreadyConfiguredException(

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterAuthRule.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterAuthRule.kt
@@ -30,7 +30,8 @@ data class FlutterAuthRule(val map: Map<String, Any>) {
     private val groupsField: String? = map["groupsField"] as String?
     private val operations: List<ModelOperation>? =
         (map["operations"] as List<String>?)?.map { stringToModelOperation(it) }
-    private val authProvider: AuthStrategy.Provider? = stringToAuthStrategyProvider(map["provider"] as String?)
+    private val authProvider: AuthStrategy.Provider =
+        stringToAuthStrategyProvider(map["provider"] as String?) ?: authStrategy.defaultAuthProvider
 
     private fun stringToAuthStrategy(string: String): AuthStrategy {
         return when (string) {
@@ -68,9 +69,7 @@ data class FlutterAuthRule(val map: Map<String, Any>) {
         val builder: AuthRule.Builder = AuthRule.builder()
             .authStrategy(authStrategy)
 
-        if (authProvider != null) {
-            builder.authProvider(authProvider)
-        }
+        builder.authProvider(authProvider)
 
         if (groups != null && groups.isNotEmpty()) {
             builder.groups(groups)


### PR DESCRIPTION
*Issue #, if available:*
- API auth providers triggering false positives internally (no OIDC/Lambda provider but native SDK thinks there is)
- Need default auth rule provider on Android to prevent null exception crash

*Description of changes:*
- Pass registered auth providers to `addPlugin`
- Fallback to default auth provider for rule strategy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
