### PR TITLE
fix(amplify_auth_cognito): remove int.parse from AuthUserAttribute

### DIFF
--- a/packages/amplify_auth_cognito/example/integration_test/user_attributes_test.dart
+++ b/packages/amplify_auth_cognito/example/integration_test/user_attributes_test.dart
@@ -26,7 +26,7 @@ const phoneNumberAttributeKey = CognitoUserAttributeKey.phoneNumber;
 const givenNameAttributeKey = CognitoUserAttributeKey.givenName;
 const emailVerifiedAttributeKey = CognitoUserAttributeKey.emailVerified;
 
-dynamic getAttributeValueFromList(
+String getAttributeValueFromList(
   List<AuthUserAttribute> userAttributes,
   CognitoUserAttributeKey cognitoAttribute,
 ) {

--- a/packages/amplify_auth_cognito/example/lib/Widgets/ConfirmUserAttribute.dart
+++ b/packages/amplify_auth_cognito/example/lib/Widgets/ConfirmUserAttribute.dart
@@ -81,7 +81,7 @@ class _ConfirmUserAttributeState extends State<ConfirmUserAttribute> {
           children: [
             const SizedBox(height: 12),
             TextFormField(
-              initialValue: widget.userAttributeKey.key,
+              initialValue: widget.userAttributeKey.toString(),
               enabled: false,
               decoration: const InputDecoration(
                 labelText: 'Attribute Name',

--- a/packages/amplify_auth_cognito/example/lib/Widgets/UpdateUserAttribute.dart
+++ b/packages/amplify_auth_cognito/example/lib/Widgets/UpdateUserAttribute.dart
@@ -22,7 +22,7 @@ import 'ConfirmUserAttribute.dart';
 
 // ignore_for_file: public_member_api_docs
 class UpdateUserAttributeWidget extends StatefulWidget {
-  final String? userAttributeKey;
+  final CognitoUserAttributeKey? userAttributeKey;
   UpdateUserAttributeWidget({this.userAttributeKey});
 
   @override
@@ -70,7 +70,9 @@ class _UpdateUserAttributeWidgetState extends State<UpdateUserAttributeWidget> {
   @override
   void initState() {
     isNewAttribute = widget.userAttributeKey == null;
-    _keyController = TextEditingController(text: widget.userAttributeKey);
+    _keyController = TextEditingController(
+      text: widget.userAttributeKey.toString(),
+    );
     super.initState();
   }
 

--- a/packages/amplify_auth_cognito/example/lib/Widgets/ViewUserAttributes.dart
+++ b/packages/amplify_auth_cognito/example/lib/Widgets/ViewUserAttributes.dart
@@ -41,7 +41,7 @@ class _ViewUserAttributesState extends State<ViewUserAttributes> {
         SnackBar(backgroundColor: Colors.red[900], content: Text(message)));
   }
 
-  Future _fetchAttributes({bool isRefresh = false}) {
+  Future<void> _fetchAttributes({bool isRefresh = false}) {
     return Amplify.Auth.fetchUserAttributes().then((attributes) {
       setState(() => _userAttributes = attributes
         ..sort((a, b) => a.userAttributeKey.compareTo(b.userAttributeKey)));
@@ -106,14 +106,14 @@ class _ViewUserAttributesState extends State<ViewUserAttributes> {
               child: ListView.builder(
                 itemCount: _userAttributes.length,
                 itemBuilder: (context, index) {
-                  var key = _userAttributes[index].userAttributeKey
-                      as CognitoUserAttributeKey;
-                  var value = _userAttributes[index].value;
-                  var stringValue = value.toString();
+                  AuthUserAttribute atrribute = _userAttributes[index];
+                  CognitoUserAttributeKey userAttributeKey =
+                      atrribute.userAttributeKey as CognitoUserAttributeKey;
+                  String value = atrribute.value;
                   return ListTile(
-                    title: Text(key.key),
-                    subtitle: Text(stringValue),
-                    trailing: key.readOnly
+                    title: Text(userAttributeKey.key),
+                    subtitle: Text(value),
+                    trailing: userAttributeKey.readOnly
                         ? null
                         : IconButton(
                             icon: Icon(Icons.edit),
@@ -122,7 +122,7 @@ class _ViewUserAttributesState extends State<ViewUserAttributes> {
                                 MaterialPageRoute(
                                   builder: (context) =>
                                       UpdateUserAttributeWidget(
-                                    userAttributeKey: key.key,
+                                    userAttributeKey: userAttributeKey.key,
                                   ),
                                 ),
                               );

--- a/packages/amplify_auth_cognito/example/lib/Widgets/ViewUserAttributes.dart
+++ b/packages/amplify_auth_cognito/example/lib/Widgets/ViewUserAttributes.dart
@@ -111,7 +111,7 @@ class _ViewUserAttributesState extends State<ViewUserAttributes> {
                       atrribute.userAttributeKey as CognitoUserAttributeKey;
                   String value = atrribute.value;
                   return ListTile(
-                    title: Text(userAttributeKey.key),
+                    title: Text(userAttributeKey.toString()),
                     subtitle: Text(value),
                     trailing: userAttributeKey.readOnly
                         ? null
@@ -122,7 +122,7 @@ class _ViewUserAttributesState extends State<ViewUserAttributes> {
                                 MaterialPageRoute(
                                   builder: (context) =>
                                       UpdateUserAttributeWidget(
-                                    userAttributeKey: userAttributeKey.key,
+                                    userAttributeKey: userAttributeKey,
                                   ),
                                 ),
                               );

--- a/packages/amplify_auth_cognito/test/amplify_auth_cognito_fetchUserAttributes_test.dart
+++ b/packages/amplify_auth_cognito/test/amplify_auth_cognito_fetchUserAttributes_test.dart
@@ -68,7 +68,7 @@ void main() {
     expect(res[0].value, equals('person'));
     expect(
         res[1].userAttributeKey, equals(CognitoUserAttributeKey.custom('num')));
-    expect(res[1].value, equals(2));
+    expect(res[1].value, equals('2'));
     expect(
       res[2].userAttributeKey,
       equals(

--- a/packages/amplify_auth_plugin_interface/lib/src/Attribute/AuthUserAttribute.dart
+++ b/packages/amplify_auth_plugin_interface/lib/src/Attribute/AuthUserAttribute.dart
@@ -17,19 +17,13 @@ import 'package:amplify_auth_plugin_interface/amplify_auth_plugin_interface.dart
 
 class AuthUserAttribute {
   final UserAttributeKey userAttributeKey;
-  late final Object value;
+  final String value;
 
   /// Creates an object that holds the key and value for a user attribute.
-  AuthUserAttribute({
+  const AuthUserAttribute({
     required this.userAttributeKey,
-    required String value,
-  }) {
-    Object? _value;
-    if (userAttributeKey.key != 'phone_number') {
-      _value = int.tryParse(value);
-    }
-    this.value = _value ?? value;
-  }
+    required this.value,
+  });
 
   // ignore: public_member_api_docs
   Map<String, dynamic> serializeAsMap() {


### PR DESCRIPTION
*Issue #, if available:* #1164

*Description of changes:*
- removes the attempt to convert the attribute value to an int.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
