### PR TITLE
chore(authenticator): Missing exports

### DIFF
--- a/packages/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/amplify_authenticator/lib/amplify_authenticator.dart
@@ -45,6 +45,10 @@ import 'package:amplify_flutter/amplify.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+export 'package:amplify_auth_cognito/amplify_auth_cognito.dart'
+    show AuthProvider;
+export 'package:amplify_flutter/amplify.dart' show PasswordProtectionSettings;
+
 export 'src/enums/enums.dart' show AuthScreen, Gender;
 export 'src/l10n/auth_strings_resolver.dart' hide ButtonResolverKeyType;
 export 'src/models/authenticator_exception.dart';

--- a/packages/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/amplify_authenticator/lib/amplify_authenticator.dart
@@ -47,7 +47,8 @@ import 'package:flutter/material.dart';
 
 export 'package:amplify_auth_cognito/amplify_auth_cognito.dart'
     show AuthProvider;
-export 'package:amplify_flutter/amplify.dart' show PasswordProtectionSettings;
+export 'package:amplify_flutter/amplify.dart'
+    show PasswordProtectionSettings, PasswordPolicyCharacters;
 
 export 'src/enums/enums.dart' show AuthScreen, Gender;
 export 'src/l10n/auth_strings_resolver.dart' hide ButtonResolverKeyType;

--- a/packages/amplify_authenticator/lib/src/l10n/button_resolver.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/button_resolver.dart
@@ -13,8 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
-import 'package:amplify_authenticator/src/enums/enums.dart';
+import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 

--- a/packages/amplify_authenticator/lib/src/l10n/generated/button_localizations.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/button_localizations.dart
@@ -15,7 +15,6 @@
 
 import 'dart:async';
 
-import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';

--- a/packages/amplify_authenticator/lib/src/l10n/generated/button_localizations_en.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/button_localizations_en.dart
@@ -13,9 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_authenticator/amplify_authenticator.dart';
-import 'package:amplify_flutter/amplify.dart';
 
 import 'package:intl/intl.dart' as intl;
 import 'button_localizations.dart';

--- a/packages/amplify_authenticator/lib/src/l10n/generated/country_localizations_en.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/country_localizations_en.dart
@@ -13,9 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_authenticator/amplify_authenticator.dart';
-import 'package:amplify_flutter/amplify.dart';
 
 import 'country_localizations.dart';
 

--- a/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations.dart
@@ -16,7 +16,6 @@
 import 'dart:async';
 
 import 'package:amplify_authenticator/amplify_authenticator.dart';
-import 'package:amplify_flutter/amplify.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:intl/intl.dart' as intl;

--- a/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations_en.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/input_localizations_en.dart
@@ -13,9 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_authenticator/amplify_authenticator.dart';
-import 'package:amplify_flutter/amplify.dart';
 
 import 'package:intl/intl.dart' as intl;
 import 'input_localizations.dart';

--- a/packages/amplify_authenticator/lib/src/l10n/generated/message_localizations_en.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/message_localizations_en.dart
@@ -13,9 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_authenticator/amplify_authenticator.dart';
-import 'package:amplify_flutter/amplify.dart';
 
 import 'message_localizations.dart';
 

--- a/packages/amplify_authenticator/lib/src/l10n/generated/title_localizations_en.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/generated/title_localizations_en.dart
@@ -13,9 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_authenticator/amplify_authenticator.dart';
-import 'package:amplify_flutter/amplify.dart';
 
 import 'title_localizations.dart';
 

--- a/packages/amplify_authenticator/lib/src/l10n/input_resolver.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/input_resolver.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_flutter/amplify.dart';
+import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:flutter/material.dart';
 
 import 'authenticator_localizations.dart';

--- a/packages/amplify_authenticator/lib/src/l10n/title_resolver.dart
+++ b/packages/amplify_authenticator/lib/src/l10n/title_resolver.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_authenticator/src/enums/auth_screen.dart';
+import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:flutter/material.dart';
 
 import 'authenticator_localizations.dart';

--- a/packages/amplify_authenticator/tool/generate_l10n.sh
+++ b/packages/amplify_authenticator/tool/generate_l10n.sh
@@ -16,9 +16,7 @@ HEADER=$(cat <<EOF
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_authenticator/amplify_authenticator.dart';
-import 'package:amplify_flutter/amplify.dart';
 EOF
 )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- All exports needed for localization should be exported (CXs should not need to know where to locate these symbols).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
