### PR TITLE
chore(amplify_datastore): comment for FlutterSerializedModel.swift

### DIFF
--- a/packages/amplify_datastore/ios/Classes/types/model/FlutterSerializedModel.swift
+++ b/packages/amplify_datastore/ios/Classes/types/model/FlutterSerializedModel.swift
@@ -17,6 +17,12 @@ import Flutter
 import Foundation
 import Amplify
 
+/*
+    Helper class to assist with handling serialized data
+    Note: This class is used in amplify-ios serialized model integration tests.
+    Until this code can be properly shared between repositories, this class should be updated
+    in the ios integration tests as needed.
+*/
 struct FlutterSerializedModel: Model, JSONValueHolder {
     public let id: String
 


### PR DESCRIPTION
*Description of changes:*
Adds a note specifying that we are using duplicated code for FlutterSerializedModel.swift in amplify-ios integ tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
