### PR TITLE
feat(datastore): MultiAuth support in DataStore

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -163,8 +163,11 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         val syncExpressions: List<Map<String, Any>> =
             request["syncExpressions"].safeCastToList() ?: emptyList()
         val defaultDataStoreConfiguration = DataStoreConfiguration.defaults()
-        val authModeStrategy = request["authModeStrategy"] as String
-        val authModeStrategyType = AuthModeStrategyType.valueOf(authModeStrategy.toUpperCase(Locale.ROOT))
+        val authModeStrategy = request["authModeStrategy"] as? String
+        val authModeStrategyType = if (authModeStrategy == null)
+            AuthModeStrategyType.DEFAULT
+        else
+            AuthModeStrategyType.valueOf(authModeStrategy.toUpperCase(Locale.ROOT))
         val syncInterval: Long =
             (request["syncInterval"] as? Int)?.toLong()
                 ?: defaultDataStoreConfiguration.syncIntervalInMinutes

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -33,6 +33,7 @@ import com.amazonaws.amplify.amplify_datastore.types.query.QueryOptionsBuilder
 import com.amazonaws.amplify.amplify_datastore.types.query.QueryPredicateBuilder
 import com.amazonaws.amplify.amplify_datastore.util.safeCastToList
 import com.amazonaws.amplify.amplify_datastore.util.safeCastToMap
+import com.amplifyframework.api.aws.AuthModeStrategyType
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.async.Cancelable
 import com.amplifyframework.core.model.CustomTypeSchema
@@ -162,6 +163,8 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         val syncExpressions: List<Map<String, Any>> =
             request["syncExpressions"].safeCastToList() ?: emptyList()
         val defaultDataStoreConfiguration = DataStoreConfiguration.defaults()
+        val authModeStrategy = request["authModeStrategy"] as String
+        val authModeStrategyType = AuthModeStrategyType.valueOf(authModeStrategy.toUpperCase(Locale.ROOT))
         val syncInterval: Long =
             (request["syncInterval"] as? Int)?.toLong()
                 ?: defaultDataStoreConfiguration.syncIntervalInMinutes
@@ -205,6 +208,7 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
         val dataStorePlugin = AWSDataStorePlugin
             .builder()
             .modelProvider(modelProvider)
+            .authModeStrategy(authModeStrategyType)
             .dataStoreConfiguration(
                 dataStoreConfigurationBuilder
                     .syncInterval(syncInterval, TimeUnit.MINUTES)

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePluginTest.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePluginTest.kt
@@ -178,7 +178,8 @@ class AmplifyDataStorePluginTest {
             "syncInterval" to mockSyncInterval,
             "syncMaxRecords" to mockSyncMaxRecords,
             "syncPageSize" to mockSyncPageSize,
-            "modelProviderVersion" to "1.0"
+            "modelProviderVersion" to "1.0",
+            "authModeStrategy" to "default"
         )
 
         mockStatic(DataStoreConfiguration::class.java).use { mockedDataStoreConfiguration ->
@@ -231,7 +232,8 @@ class AmplifyDataStorePluginTest {
         val mockRequestWithCustomConfig = mapOf(
             "modelSchemas" to mockModelSchemas,
             "syncExpressions" to mockSyncExpressions,
-            "modelProviderVersion" to "1.0"
+            "modelProviderVersion" to "1.0",
+            "authModeStrategy" to "default"
         )
 
         mockStatic(DataStoreConfiguration::class.java).use { mockedDataStoreConfiguration ->

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -46,6 +46,7 @@ class AmplifyDataStore extends DataStorePluginInterface {
     int? syncInterval,
     int? syncMaxRecords,
     int? syncPageSize,
+    AuthModeStrategy? authModeStrategy,
   }) : super(
           token: _token,
           modelProvider: modelProvider,
@@ -54,6 +55,7 @@ class AmplifyDataStore extends DataStorePluginInterface {
           syncInterval: syncInterval,
           syncMaxRecords: syncMaxRecords,
           syncPageSize: syncPageSize,
+          authModeStrategy: authModeStrategy,
         );
 
   /// Internal use constructor
@@ -80,6 +82,7 @@ class AmplifyDataStore extends DataStorePluginInterface {
     int? syncInterval,
     int? syncMaxRecords,
     int? syncPageSize,
+    AuthModeStrategy? authModeStrategy,
   }) async {
     ModelProviderInterface provider = modelProvider ?? this.modelProvider!;
     if (provider.modelSchemas.isEmpty) {
@@ -95,6 +98,7 @@ class AmplifyDataStore extends DataStorePluginInterface {
       syncInterval: this.syncInterval,
       syncMaxRecords: this.syncMaxRecords,
       syncPageSize: this.syncPageSize,
+      authModeStrategy: this.authModeStrategy,
     );
   }
 

--- a/packages/amplify_datastore/lib/method_channel_datastore.dart
+++ b/packages/amplify_datastore/lib/method_channel_datastore.dart
@@ -76,6 +76,7 @@ class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
     int? syncInterval,
     int? syncMaxRecords,
     int? syncPageSize,
+    AuthModeStrategy? authModeStrategy,
   }) async {
     _channel.setMethodCallHandler(_methodCallHandler);
     try {
@@ -98,6 +99,7 @@ class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
         'syncInterval': syncInterval,
         'syncMaxRecords': syncMaxRecords,
         'syncPageSize': syncPageSize,
+        'authModeStrategy': authModeStrategy!.rawValue,
       });
     } on PlatformException catch (e) {
       if (e.code == "AmplifyAlreadyConfiguredException") {

--- a/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
@@ -21,6 +21,7 @@ import 'package:amplify_datastore_plugin_interface/src/types/models/model_provid
 import 'package:amplify_core/amplify_core.dart';
 import 'package:meta/meta.dart';
 
+import 'src/types/models/auth_mode_strategy.dart';
 import 'src/types/models/model.dart';
 import 'src/types/models/observe_query_throttle_options.dart';
 import 'src/types/models/query_snapshot.dart';
@@ -28,6 +29,7 @@ import 'src/types/models/subscription_event.dart';
 import 'src/types/sync/DataStoreSyncExpression.dart';
 import 'src/types/query/query_field.dart';
 
+export 'src/types/models/auth_mode_strategy.dart';
 export 'src/types/models/auth_rule.dart';
 export 'src/types/models/model.dart';
 export 'src/types/models/model_field.dart';
@@ -62,6 +64,9 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
   /// Datastore page size to sync
   int? syncPageSize;
 
+  /// The strategy for authorizing an API call.
+  final AuthModeStrategy authModeStrategy;
+
   /// Constructs an AmplifyPlatform.
   DataStorePluginInterface({
     required Object token,
@@ -71,12 +76,14 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
     this.syncInterval,
     this.syncMaxRecords,
     this.syncPageSize,
-  }) : super(token: token);
+    AuthModeStrategy? authModeStrategy,
+  })  : authModeStrategy = authModeStrategy ?? AuthModeStrategy.default$,
+        super(token: token);
 
   /// Internal use constructor
   @protected
   DataStorePluginInterface.tokenOnly({required Object token})
-      : super(token: token);
+      : this(token: token, modelProvider: null);
 
   StreamController<HubEvent> get streamController {
     throw UnimplementedError(
@@ -93,12 +100,14 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
   /// [syncMaxRecords]: Max number of records to sync
   ///
   /// [syncPageSize]: Page size to sync
-  Future<void> configureDataStore(
-      {required ModelProviderInterface modelProvider,
-      Function(AmplifyException)? errorHandler,
-      int? syncInterval,
-      int? syncMaxRecords,
-      int? syncPageSize}) {
+  Future<void> configureDataStore({
+    required ModelProviderInterface modelProvider,
+    Function(AmplifyException)? errorHandler,
+    int? syncInterval,
+    int? syncMaxRecords,
+    int? syncPageSize,
+    AuthModeStrategy? authModeStrategy,
+  }) {
     throw UnimplementedError('configureDataStore() has not been implemented.');
   }
 

--- a/packages/amplify_datastore_plugin_interface/lib/src/publicTypes.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/publicTypes.dart
@@ -15,6 +15,7 @@
 
 export 'types/exception/DataStoreException.dart';
 export 'types/exception/DataStoreExceptionMessages.dart';
+export 'types/models/auth_mode_strategy.dart';
 export 'types/models/subscription_event.dart';
 export 'types/models/query_snapshot.dart';
 export 'types/models/observe_query_throttle_options.dart';

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/models/auth_mode_strategy.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/models/auth_mode_strategy.dart
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/// Represents different auth strategies supported by a client
+/// interfacing with an AppSync backend
+enum AuthModeStrategy {
+  /// Default authorization type read from API configuration
+  default$,
+
+  /// Uses schema metadata to create a prioritized list of potential authorization types
+  /// that could be used for a request. The client iterates through that list until one of the
+  /// avaialable types succeeds or all of them fail.
+  multiAuth,
+}
+
+/// Helpers for [AuthModeStrategy].
+extension AuthModeStrategyX on AuthModeStrategy {
+  /// The raw value used for interfacing with iOS/Android SDKs.
+  String get rawValue {
+    switch (this) {
+      case AuthModeStrategy.default$:
+        return 'default';
+      case AuthModeStrategy.multiAuth:
+        return 'multiauth';
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- MultiAuth support in DataStore (introduces flag to native libs)

Usage:

```dart
final datastorePlugin = AmplifyDataStore(
  modelProvider: ModelProvider.instance,
  authModeStrategy: AuthModeStrategy.multiAuth,
);

await Amplify.addPlugin(datastorePlugin);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
