### PR TITLE
fix(datastore): cascade delete not working in iOS

### DIFF
--- a/packages/amplify_datastore/example/integration_test/relationship_type_test.dart
+++ b/packages/amplify_datastore/example/integration_test/relationship_type_test.dart
@@ -110,8 +110,9 @@ void main() {
     });
 
     group('BelongsTo', () {
-      var child = ChildModel(name: 'child');
-      var parent = BelongsToModel(name: 'HasOne', child: child);
+      var relationshipParent = ChildModel(name: 'child');
+      var relationshipChild =
+          BelongsToModel(name: 'BelongsTo', child: relationshipParent);
       late Future<SubscriptionEvent<ChildModel>> belongsToEvent;
       late Future<SubscriptionEvent<BelongsToModel>> hasOneEvent;
 
@@ -132,47 +133,48 @@ void main() {
         expect(queriedParents, isEmpty);
       });
 
-      testWidgets('save child', (WidgetTester tester) async {
-        await Amplify.DataStore.save(child);
+      testWidgets('save relationshipParent', (WidgetTester tester) async {
+        await Amplify.DataStore.save(relationshipParent);
         var children = await Amplify.DataStore.query(ChildModel.classType);
         expect(children, isNotEmpty);
       });
 
-      testWidgets('save parent', (WidgetTester tester) async {
-        await Amplify.DataStore.save(parent);
+      testWidgets('save relationshipChild', (WidgetTester tester) async {
+        await Amplify.DataStore.save(relationshipChild);
         var parents = await Amplify.DataStore.query(BelongsToModel.classType);
         expect(parents, isNotEmpty);
       });
 
-      testWidgets('query parent', (WidgetTester tester) async {
+      testWidgets('query relationshipChild', (WidgetTester tester) async {
         var parents = await Amplify.DataStore.query(BelongsToModel.classType);
         var queriedParent = parents.single;
-        expect(queriedParent, parent);
-        expect(queriedParent.child, child);
+        expect(queriedParent, relationshipChild);
+        expect(queriedParent.child, relationshipParent);
       });
 
-      testWidgets('query child', (WidgetTester tester) async {
+      testWidgets('query relationshipParent', (WidgetTester tester) async {
         var children = await Amplify.DataStore.query(ChildModel.classType);
         var queriedChild = children.single;
-        expect(queriedChild, child);
+        expect(queriedChild, relationshipParent);
       });
 
-      testWidgets('observe parent', (WidgetTester tester) async {
+      testWidgets('observe relationshipChild', (WidgetTester tester) async {
         var event = await hasOneEvent;
         var observedParent = event.item;
-        expect(observedParent, parent);
-        expect(observedParent.child, child);
+        expect(observedParent, relationshipChild);
+        expect(observedParent.child, relationshipParent);
       });
 
-      testWidgets('observe child', (WidgetTester tester) async {
+      testWidgets('observe relationshipParent', (WidgetTester tester) async {
         var event = await belongsToEvent;
         var observedChild = event.item;
-        expect(observedChild, child);
+        expect(observedChild, relationshipParent);
       });
 
-      testWidgets('delete child (cascade delete parent)',
+      testWidgets(
+          'delete relationshipParent (cascade delete relationshipChild)',
           (WidgetTester tester) async {
-        await Amplify.DataStore.delete(child);
+        await Amplify.DataStore.delete(relationshipParent);
         var children = await Amplify.DataStore.query(ChildModel.classType);
         expect(children, isEmpty);
         var parent = await Amplify.DataStore.query(BelongsToModel.classType);

--- a/packages/amplify_datastore/example/integration_test/relationship_type_test.dart
+++ b/packages/amplify_datastore/example/integration_test/relationship_type_test.dart
@@ -170,16 +170,13 @@ void main() {
         expect(observedChild, child);
       });
 
-      testWidgets('delete parent', (WidgetTester tester) async {
-        await Amplify.DataStore.delete(parent);
-        var parents = await Amplify.DataStore.query(BelongsToModel.classType);
-        expect(parents, isEmpty);
-      });
-
-      testWidgets('delete child', (WidgetTester tester) async {
+      testWidgets('delete child (cascade delete parent)',
+          (WidgetTester tester) async {
         await Amplify.DataStore.delete(child);
         var children = await Amplify.DataStore.query(ChildModel.classType);
         expect(children, isEmpty);
+        var parent = await Amplify.DataStore.query(BelongsToModel.classType);
+        expect(parent, isEmpty);
       });
     });
 
@@ -266,16 +263,11 @@ void main() {
         }
       });
 
-      testWidgets('delete parent', (WidgetTester tester) async {
+      testWidgets('delete parent (cascade delete children)',
+          (WidgetTester tester) async {
         await Amplify.DataStore.delete(parent);
         var parents = await Amplify.DataStore.query(HasManyModel.classType);
         expect(parents, isEmpty);
-      });
-
-      testWidgets('delete children', (WidgetTester tester) async {
-        for (var child in children) {
-          await Amplify.DataStore.delete(child);
-        }
         var queriedChildren =
             await Amplify.DataStore.query(HasManyChildModel.classType);
         expect(queriedChildren, isEmpty);

--- a/packages/amplify_datastore/example/ios/unit_tests/AmplifySerializedModelUnitTests.swift
+++ b/packages/amplify_datastore/example/ios/unit_tests/AmplifySerializedModelUnitTests.swift
@@ -118,4 +118,37 @@ class AmplifySerializedModelUnitTests: XCTestCase {
         XCTAssertEqual(ourSd["timeType"] as! String , refSd["timeType"] as! String)
         XCTAssertEqual(ourSd["enumType"] as! String , refSd["enumType"] as! String)
     }
+
+    func test_model_registy_decoder_decodes_object() throws {
+        let modelName = "Comment"
+        let testModelId = "123"
+        let testModelContent = "a comment"
+        let jsonString = "{\"id\":\"\(testModelId)\",\"content\":\"\(testModelContent)\"}"
+        let decodedModel = try ModelRegistry.decode(modelName: modelName, from: jsonString)
+        XCTAssertEqual(decodedModel.id, testModelId);
+        let values = (decodedModel as! FlutterSerializedModel).values
+        XCTAssertEqual(values["content"], JSONValue.string(testModelContent))
+    }
+
+    func test_model_registy_decoder_decodes_array_of_object() throws {
+        let modelName = "Comment"
+        let testModelId = "123"
+        let testModelContent = "a comment"
+        let jsonString = "[{\"id\":\"\(testModelId)\",\"content\":\"\(testModelContent)\"}]"
+        let decodedModel = try ModelRegistry.decode(modelName: modelName, from: jsonString)
+        XCTAssertEqual(decodedModel.id, testModelId);
+        let values = (decodedModel as! FlutterSerializedModel).values
+        XCTAssertEqual(values["content"], JSONValue.string(testModelContent))
+    }
+
+    func test_model_registy_decoder_throws_on_invalid_json_input() throws {
+        let modelName = "Comment"
+        let jsonString = "invalid_json_string"
+
+        XCTAssertThrowsError(
+            try ModelRegistry.decode(modelName: modelName, from: jsonString)
+        ) { error in
+            XCTAssertEqual(error is DecodingError, true)
+        }
+    }
 }

--- a/packages/amplify_datastore/example/ios/unit_tests/resources/SchemaData.swift
+++ b/packages/amplify_datastore/example/ios/unit_tests/resources/SchemaData.swift
@@ -131,6 +131,8 @@ struct SchemaData {
             flutterModelRegistration.addModelSchema(modelName: key, modelSchema: value)
         }
 
+        flutterModelRegistration.registerModels(registry: ModelRegistry.self)
+
         return flutterModelRegistration
     }
 }

--- a/packages/amplify_datastore/ios/Classes/FlutterModels.swift
+++ b/packages/amplify_datastore/ios/Classes/FlutterModels.swift
@@ -39,8 +39,15 @@ final public class FlutterModels: AmplifyModelRegistration {
                 // Convert jsonstring to object
                 let data = jsonString.data(using: .utf8)!
                 let jsonValue = try resolvedDecoder.decode(JSONValue.self, from: data)
+                // the json string presents an array of objects
                 if case .array(let jsonArray) = jsonValue,
                    case .object(let jsonObj) = jsonArray[0],
+                   case .string(let id) = jsonObj["id"] {
+                    let model = FlutterSerializedModel(id: id, map: jsonObj)
+                    return model
+                }
+                // the json string presents an object
+                if case .object(let jsonObj) = jsonValue,
                    case .string(let id) = jsonObj["id"] {
                     let model = FlutterSerializedModel(id: id, map: jsonObj)
                     return model

--- a/packages/amplify_datastore/ios/Classes/FlutterModels.swift
+++ b/packages/amplify_datastore/ios/Classes/FlutterModels.swift
@@ -39,15 +39,17 @@ final public class FlutterModels: AmplifyModelRegistration {
                 // Convert jsonstring to object
                 let data = jsonString.data(using: .utf8)!
                 let jsonValue = try resolvedDecoder.decode(JSONValue.self, from: data)
+
+                var jsonObj: [String: JSONValue]?
                 // the json string presents an array of objects
                 if case .array(let jsonArray) = jsonValue,
-                   case .object(let jsonObj) = jsonArray[0],
-                   case .string(let id) = jsonObj["id"] {
-                    let model = FlutterSerializedModel(id: id, map: jsonObj)
-                    return model
+                   case .object(let obj) = jsonArray[0] {
+                    jsonObj = obj
+                } else if case .object(let obj) = jsonValue {
+                    jsonObj = obj
                 }
                 // the json string presents an object
-                if case .object(let jsonObj) = jsonValue,
+                if let jsonObj = jsonObj,
                    case .string(let id) = jsonObj["id"] {
                     let model = FlutterSerializedModel(id: id, map: jsonObj)
                     return model


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/1198

*Description of changes:*

Make the registered model decoder capable to handle decoding json string that presents a single object besides an array of objects.

- Updated relevant integration tests to test the use cases.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
