### PR TITLE
fix(datastore): Hub memory usage

### DIFF
--- a/packages/amplify_datastore/ios/Classes/DataStoreHubEventStreamHandler.swift
+++ b/packages/amplify_datastore/ios/Classes/DataStoreHubEventStreamHandler.swift
@@ -53,6 +53,7 @@ public class DataStoreHubEventStreamHandler: NSObject, FlutterStreamHandler {
         // Replay events. On hot restart, `onListen` is called again with a new listener. However,
         // DataStore will not re-emit events such as ready and modelSynced. As a result, this info
         // is lost on the Flutter side unless we replay the history prior to the hot restart.
+        #if DEBUG
         if !eventHistory.isEmpty {
             eventGuard.lock()
             defer { eventGuard.unlock() }
@@ -62,10 +63,15 @@ public class DataStoreHubEventStreamHandler: NSObject, FlutterStreamHandler {
                 }
             }
         }
+        #endif
         token = Amplify.Hub.listen(to: .dataStore) { [unowned self] (payload) in
+            #if DEBUG
             eventGuard.lock()
             defer { eventGuard.unlock() }
-            eventHistory.append(payload)
+            if replayableEvents.contains(payload.eventName) {
+                eventHistory.append(payload)
+            }
+            #endif
             sendPayload(payload)
         }
     }

--- a/packages/amplify_datastore/ios/Classes/DataStoreHubEventStreamHandler.swift
+++ b/packages/amplify_datastore/ios/Classes/DataStoreHubEventStreamHandler.swift
@@ -58,9 +58,7 @@ public class DataStoreHubEventStreamHandler: NSObject, FlutterStreamHandler {
             eventGuard.lock()
             defer { eventGuard.unlock() }
             for payload in eventHistory {
-                if replayableEvents.contains(payload.eventName) {
-                    sendPayload(payload)
-                }
+                sendPayload(payload)
             }
         }
         #endif


### PR DESCRIPTION
*Issue #, if available:*
- Hub history tracking is consuming too much memory

*Description of changes:*
- Only store necessary hub events
- Disable for release mode

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
