### PR TITLE
feat(amplify_authenticator): update view with hub listener on signout

### DIFF
--- a/packages/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/amplify_authenticator/lib/amplify_authenticator.dart
@@ -316,7 +316,6 @@ class _AuthenticatorState extends State<Authenticator> {
     _subscribeToInfoMessages();
     _subscribeToSuccessEvents();
     _waitForConfiguration();
-    _setUpHubSubscription();
   }
 
   void _subscribeToExceptions() {
@@ -397,18 +396,6 @@ class _AuthenticatorState extends State<Authenticator> {
     _successSub = _stateMachineBloc.stream.listen((state) {
       if (state is Authenticated) {
         ScaffoldMessenger.of(context).removeCurrentMaterialBanner();
-      }
-    });
-  }
-
-  Future<void> _setUpHubSubscription() async {
-    // the stream does not exist until configuration is complete
-    await Amplify.asyncConfig;
-    _hubSubscription = Amplify.Hub.listen([HubChannel.Auth], (event) {
-      switch (event.eventName) {
-        case 'SIGNED_OUT':
-          _stateMachineBloc.add(const AuthChangeScreen(AuthScreen.signin));
-          break;
       }
     });
   }

--- a/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -30,6 +30,8 @@ abstract class AuthService {
 
   Future<void> signOut();
 
+  StreamSubscription? hubListener(void Function(HubEvent event) listener);
+
   Future<SignUpResult> signUp(
     String username,
     String password,
@@ -146,6 +148,11 @@ class AmplifyAuthService implements AuthService {
   @override
   Future<void> signOut() {
     return Amplify.Auth.signOut();
+  }
+
+  @override
+  StreamSubscription? hubListener(void Function(HubEvent event) listener) {
+    return Amplify.Hub.listen([HubChannel.Auth], listener);
   }
 
   @override


### PR DESCRIPTION
*Description of changes:*
Uses hub to register a signout auth event in the customer app by listening for external signout events from hub.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
