### PR TITLE
fix(amplify_api): model helpers, fix for mutations with no parent ID

### DIFF
--- a/packages/amplify_api/lib/src/graphql/graphql_request_factory.dart
+++ b/packages/amplify_api/lib/src/graphql/graphql_request_factory.dart
@@ -299,10 +299,11 @@ class GraphQLRequestFactory {
         .toSet();
     modelJson.removeWhere((key, dynamic value) => fieldsToRemove.contains(key));
     // Assign the parent ID if the model has a parent.
-    // belongsToValue intentionally not null checked here to allow AppSync to throw.
     if (belongsToKey != null && belongsToModelName != null) {
-      modelJson[belongsToKey] = belongsToValue;
       modelJson.remove(belongsToModelName);
+      if (belongsToValue != null) {
+        modelJson[belongsToKey] = belongsToValue;
+      }
     }
 
     return modelJson;

--- a/packages/amplify_api/test/graphql_helpers_test.dart
+++ b/packages/amplify_api/test/graphql_helpers_test.dart
@@ -345,6 +345,17 @@ void main() {
         expect(req.decodePath, 'createPost');
       });
 
+      test(
+          'ModelMutations.create() should not include parent ID in variables if not in model',
+          () {
+        final postId = UUID.getUUID();
+        const title = 'Lorem Ipsum';
+        const rating = 1;
+        Post post = Post(id: postId, title: title, rating: rating);
+        GraphQLRequest<Post> req = ModelMutations.create<Post>(post);
+        expect(req.variables['input'].containsKey('blogID'), isFalse);
+      });
+
       test('ModelMutations.delete() should build a valid request', () {
         final id = UUID.getUUID();
         final name = 'Test Blog';


### PR DESCRIPTION
*Description of changes:*

Model helpers, do not include null parent ID in mutation inputs to allow mutation child without parent ID when schema permits.

I had mistakenly thought that all models with parents required parent ID in mutation due to graphql transformer. However, that was just bc of the schema I was always testing with. Users can make a schema that does not require this. In this situation, parent ID is sent as null in the mutation variables, which causes an appsync error as null not an acceptable value for an ID type.

This PR just checks the value of the parent ID to see if non null before putting in the variables so it can be omitted when the schema permits.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
