### PR TITLE
feat(amplify_flutter): allow customers to override AmplifyClass methods

### DIFF
--- a/packages/amplify_flutter/lib/amplify_flutter.dart
+++ b/packages/amplify_flutter/lib/amplify_flutter.dart
@@ -37,6 +37,10 @@ export 'src/utils/json.dart';
 export 'src/utils/serializable.dart';
 
 /// Top level singleton Amplify object.
-final AmplifyClass Amplify = AmplifyClass.protected();
+AmplifyClass get Amplify => AmplifyClass.instance;
+
+set Amplify(AmplifyClass amplifyClass) {
+  AmplifyClass.instance = amplifyClass;
+}
 
 // ignore_for_file: non_constant_identifier_names

--- a/packages/amplify_flutter/lib/amplify_flutter.dart
+++ b/packages/amplify_flutter/lib/amplify_flutter.dart
@@ -19,6 +19,9 @@ import 'src/amplify_impl.dart';
 
 export 'package:amplify_core/amplify_core.dart';
 
+// amplify class
+export 'src/amplify_impl.dart';
+
 // Config
 export 'src/config/amplify_config.dart';
 export 'src/config/amplify_plugin_config.dart' hide UnknownPluginConfigFactory;
@@ -28,7 +31,6 @@ export 'src/config/api/api_config.dart';
 export 'src/config/auth/auth_config.dart';
 export 'src/config/config_map.dart';
 export 'src/config/storage/storage_config.dart';
-
 // Utilities
 export 'src/utils/equatable.dart';
 export 'src/utils/json.dart';

--- a/packages/amplify_flutter/lib/src/amplify_impl.dart
+++ b/packages/amplify_flutter/lib/src/amplify_impl.dart
@@ -164,7 +164,7 @@ class AmplifyClass extends PlatformInterface {
     }
     try {
       await AmplifyClass.instance
-          ._configurePlatforms(_getVersion(), configuration);
+          .configurePlatforms(_getVersion(), configuration);
       _isConfigured = true;
     } on PlatformException catch (e) {
       if (e.code == 'AnalyticsException') {
@@ -204,8 +204,8 @@ class AmplifyClass extends PlatformInterface {
   }
 
   /// Adds the configuration and return true if it was successful.
-  Future<void> _configurePlatforms(String version, String configuration) {
-    throw UnimplementedError('_configurePlatforms() has not been implemented.');
+  Future<void> configurePlatforms(String version, String configuration) {
+    throw UnimplementedError('configurePlatforms() has not been implemented.');
   }
 
   /// Constructs a Core platform.

--- a/packages/amplify_flutter/lib/src/amplify_impl.dart
+++ b/packages/amplify_flutter/lib/src/amplify_impl.dart
@@ -32,12 +32,12 @@ import 'categories/amplify_categories.dart';
 
 part 'method_channel_amplify.dart';
 
-/// This is a private class and customers are not expected to
-/// instantiate an object of this class. Please use top level
-/// `Amplify` singleton object for making calls to methods of this class.
+/// Amplify singleton class.
+///
+/// This class can be extended to create a custom Amplify implementation.
+/// The default Amplify implementation will use method channels, and will
+/// only support iOS and Android platforms.
 class AmplifyClass extends PlatformInterface {
-  AmplifyConfig? _config;
-
   /// The Auth category.
   final AuthCategory Auth = const AuthCategory();
 
@@ -53,12 +53,8 @@ class AmplifyClass extends PlatformInterface {
   /// The API category.
   final APICategory API = const APICategory();
 
-  bool _isConfigured = false;
-
-  // ignore: public_member_api_docs
+  /// The Amplify event hub.
   final AmplifyHub Hub = AmplifyHub();
-
-  final _configCompleter = Completer<AmplifyConfig>();
 
   /// Adds one plugin at a time. Note: this method can only
   /// be called before Amplify has been configured. Customers are expected
@@ -67,71 +63,24 @@ class AmplifyClass extends PlatformInterface {
   /// Throws AmplifyAlreadyConfiguredException if
   /// this method is called after configure (e.g. during hot reload).
   Future<void> addPlugin(AmplifyPluginInterface plugin) async {
-    if (_isConfigured) {
-      throw const AmplifyAlreadyConfiguredException(
-        'Amplify has already been configured and adding plugins after configure is not supported.',
-        recoverySuggestion:
-            'Check if Amplify is already configured using Amplify.isConfigured.',
-      );
-    }
-    try {
-      if (plugin is AuthPluginInterface) {
-        await Auth.addPlugin(plugin);
-        Hub.addChannel(HubChannel.Auth, plugin.streamController);
-      } else if (plugin is AnalyticsPluginInterface) {
-        await Analytics.addPlugin(plugin);
-      } else if (plugin is StoragePluginInterface) {
-        await Storage.addPlugin(plugin);
-      } else if (plugin is DataStorePluginInterface) {
-        try {
-          await DataStore.addPlugin(plugin);
-        } on AmplifyAlreadyConfiguredException {
-          // A new plugin is added in native libraries during `addPlugin`
-          // call for DataStore, which means during an app restart, this
-          // method will throw an exception in android. We will ignore this
-          // like other plugins and move on. Other exceptions fall through.
-        }
-        Hub.addChannel(HubChannel.DataStore, plugin.streamController);
-      } else if (plugin is APIPluginInterface) {
-        await API.addPlugin(plugin);
-      } else {
-        throw AmplifyException(
-            'The type of plugin ' +
-                plugin.runtimeType.toString() +
-                ' is not yet supported in Amplify.',
-            recoverySuggestion:
-                AmplifyExceptionMessages.missingRecoverySuggestion);
-      }
-    } on Exception catch (e) {
-      safePrint('Amplify plugin was not added');
-      throw AmplifyException(
-        'Amplify plugin ' +
-            plugin.runtimeType.toString() +
-            ' was not added successfully.',
-        recoverySuggestion: AmplifyExceptionMessages.missingRecoverySuggestion,
-        underlyingException: e.toString(),
-      );
-    }
+    return instance.addPlugin(plugin);
   }
 
   /// Adds multiple plugins at the same time. Note: this method can only
   /// be called before Amplify has been configured. Customers are expected
   /// to check the configuration state by calling `Amplify.isConfigured`
-  Future<void> addPlugins(List<AmplifyPluginInterface> plugins) =>
-      Future.wait(plugins.map(addPlugin));
+  Future<void> addPlugins(List<AmplifyPluginInterface> plugins) {
+    return instance.addPlugins(plugins);
+  }
 
   /// Returns whether Amplify has been configured or not.
   bool get isConfigured {
-    return _isConfigured;
+    return instance.isConfigured;
   }
 
   /// A future when completes when Amplify has been successfully configured.
   Future<AmplifyConfig> get asyncConfig {
-    return _configCompleter.future;
-  }
-
-  String _getVersion() {
-    return '0.3.2';
+    return instance.asyncConfig;
   }
 
   /// Configures Amplify with the provided configuration string.
@@ -143,69 +92,7 @@ class AmplifyClass extends PlatformInterface {
   /// Throws AmplifyAlreadyConfiguredException if
   /// this method is called again (e.g. during hot reload).
   Future<void> configure(String configuration) async {
-    // Validation #1
-    if (_isConfigured) {
-      throw const AmplifyAlreadyConfiguredException(
-        'Amplify has already been configured and re-configuration is not supported.',
-        recoverySuggestion:
-            'Check if Amplify is already configured using Amplify.isConfigured.',
-      );
-    }
-
-    // Validation #2. Try decoding the json string
-    try {
-      jsonDecode(configuration);
-    } on FormatException catch (e) {
-      throw AmplifyException(
-          'The provided configuration is not a valid json. Check underlyingException.',
-          recoverySuggestion:
-              'Inspect your amplifyconfiguration.dart and ensure that the string is proper json',
-          underlyingException: e.toString());
-    }
-    try {
-      await AmplifyClass.instance
-          .configurePlatforms(_getVersion(), configuration);
-      _isConfigured = true;
-    } on PlatformException catch (e) {
-      if (e.code == 'AnalyticsException') {
-        throw AnalyticsException.fromMap(Map<String, String>.from(e.details));
-      } else if (e.code == 'AmplifyException') {
-        throw AmplifyException.fromMap(Map<String, String>.from(e.details));
-      } else if (e.code == 'AmplifyAlreadyConfiguredException') {
-        _isConfigured = true;
-      } else {
-        // This shouldn't happen. All exceptions coming from platform for
-        // amplify_flutter should have a known code. Throw an unknown error.
-        throw AmplifyException(AmplifyExceptionMessages.missingExceptionMessage,
-            recoverySuggestion:
-                AmplifyExceptionMessages.missingRecoverySuggestion,
-            underlyingException: e.toString());
-      }
-    }
-    await DataStore.configure(configuration);
-
-    if (_isConfigured && !_configCompleter.isCompleted) {
-      _config = _parseConfigJson(configuration);
-      _configCompleter.complete(_config);
-    }
-  }
-
-  /// Parses the [configuration] string into an [AmplifyConfig] object.
-  /// An empty [AmplifyConfig] is returned on exception.
-  AmplifyConfig _parseConfigJson(String configuration) {
-    try {
-      return AmplifyConfig.fromJson(jsonDecode(configuration));
-    } on Exception catch (e) {
-      safePrint(
-        'There was an unexpected problem parsing the amplifyconfiguration.dart file: $e',
-      );
-      return const AmplifyConfig();
-    }
-  }
-
-  /// Adds the configuration and return true if it was successful.
-  Future<void> configurePlatforms(String version, String configuration) {
-    throw UnimplementedError('configurePlatforms() has not been implemented.');
+    return instance.configure(configuration);
   }
 
   /// Constructs a Core platform.
@@ -217,13 +104,13 @@ class AmplifyClass extends PlatformInterface {
 
   static AmplifyClass _instance = MethodChannelAmplify();
 
-  /// The default instance of [AmplifyPlatform] to use.
+  /// The default instance of [AmplifyClass] to use.
   ///
   /// Defaults to [MethodChannelAmplify].
   static AmplifyClass get instance => _instance;
 
   /// Platform-specific plugins should set this with their own platform-specific
-  /// class that extends [AmplifyPlatform] when they register themselves.
+  /// class that extends [AmplifyClass] when they register themselves.
   static set instance(AmplifyClass instance) {
     PlatformInterface.verifyToken(instance, _token);
     _instance = instance;

--- a/packages/amplify_flutter/lib/src/method_channel_amplify.dart
+++ b/packages/amplify_flutter/lib/src/method_channel_amplify.dart
@@ -22,7 +22,7 @@ class MethodChannelAmplify extends AmplifyClass {
   MethodChannelAmplify() : super.protected();
 
   @override
-  Future<void> _configurePlatforms(String version, String configuration) async {
+  Future<void> configurePlatforms(String version, String configuration) async {
     await _channel.invokeMethod<void>(
       'configure',
       <String, Object>{

--- a/packages/amplify_flutter/lib/src/method_channel_amplify.dart
+++ b/packages/amplify_flutter/lib/src/method_channel_amplify.dart
@@ -21,8 +21,125 @@ const MethodChannel _channel = MethodChannel('com.amazonaws.amplify/amplify');
 class MethodChannelAmplify extends AmplifyClass {
   MethodChannelAmplify() : super.protected();
 
+  AmplifyConfig? _config;
+
+  bool _isConfigured = false;
+
+  final _configCompleter = Completer<AmplifyConfig>();
+
   @override
-  Future<void> configurePlatforms(String version, String configuration) async {
+  bool get isConfigured {
+    return _isConfigured;
+  }
+
+  @override
+  Future<AmplifyConfig> get asyncConfig {
+    return _configCompleter.future;
+  }
+
+  @override
+  Future<void> addPlugin(AmplifyPluginInterface plugin) async {
+    if (_isConfigured) {
+      throw const AmplifyAlreadyConfiguredException(
+        'Amplify has already been configured and adding plugins after configure is not supported.',
+        recoverySuggestion:
+            'Check if Amplify is already configured using Amplify.isConfigured.',
+      );
+    }
+    try {
+      if (plugin is AuthPluginInterface) {
+        await Auth.addPlugin(plugin);
+        Hub.addChannel(HubChannel.Auth, plugin.streamController);
+      } else if (plugin is AnalyticsPluginInterface) {
+        await Analytics.addPlugin(plugin);
+      } else if (plugin is StoragePluginInterface) {
+        await Storage.addPlugin(plugin);
+      } else if (plugin is DataStorePluginInterface) {
+        try {
+          await DataStore.addPlugin(plugin);
+        } on AmplifyAlreadyConfiguredException {
+          // A new plugin is added in native libraries during `addPlugin`
+          // call for DataStore, which means during an app restart, this
+          // method will throw an exception in android. We will ignore this
+          // like other plugins and move on. Other exceptions fall through.
+        }
+        Hub.addChannel(HubChannel.DataStore, plugin.streamController);
+      } else if (plugin is APIPluginInterface) {
+        await API.addPlugin(plugin);
+      } else {
+        throw AmplifyException(
+            'The type of plugin ' +
+                plugin.runtimeType.toString() +
+                ' is not yet supported in Amplify.',
+            recoverySuggestion:
+                AmplifyExceptionMessages.missingRecoverySuggestion);
+      }
+    } on Exception catch (e) {
+      safePrint('Amplify plugin was not added');
+      throw AmplifyException(
+        'Amplify plugin ' +
+            plugin.runtimeType.toString() +
+            ' was not added successfully.',
+        recoverySuggestion: AmplifyExceptionMessages.missingRecoverySuggestion,
+        underlyingException: e.toString(),
+      );
+    }
+  }
+
+  @override
+  Future<void> addPlugins(List<AmplifyPluginInterface> plugins) {
+    return Future.wait(plugins.map(addPlugin));
+  }
+
+  @override
+  Future<void> configure(String configuration) async {
+    // Validation #1
+    if (_isConfigured) {
+      throw const AmplifyAlreadyConfiguredException(
+        'Amplify has already been configured and re-configuration is not supported.',
+        recoverySuggestion:
+            'Check if Amplify is already configured using Amplify.isConfigured.',
+      );
+    }
+
+    // Validation #2. Try decoding the json string
+    try {
+      jsonDecode(configuration);
+    } on FormatException catch (e) {
+      throw AmplifyException(
+          'The provided configuration is not a valid json. Check underlyingException.',
+          recoverySuggestion:
+              'Inspect your amplifyconfiguration.dart and ensure that the string is proper json',
+          underlyingException: e.toString());
+    }
+    try {
+      await _configurePlatforms(_getVersion(), configuration);
+      _isConfigured = true;
+    } on PlatformException catch (e) {
+      if (e.code == 'AnalyticsException') {
+        throw AnalyticsException.fromMap(Map<String, String>.from(e.details));
+      } else if (e.code == 'AmplifyException') {
+        throw AmplifyException.fromMap(Map<String, String>.from(e.details));
+      } else if (e.code == 'AmplifyAlreadyConfiguredException') {
+        _isConfigured = true;
+      } else {
+        // This shouldn't happen. All exceptions coming from platform for
+        // amplify_flutter should have a known code. Throw an unknown error.
+        throw AmplifyException(AmplifyExceptionMessages.missingExceptionMessage,
+            recoverySuggestion:
+                AmplifyExceptionMessages.missingRecoverySuggestion,
+            underlyingException: e.toString());
+      }
+    }
+    await DataStore.configure(configuration);
+
+    if (_isConfigured && !_configCompleter.isCompleted) {
+      _config = _parseConfigJson(configuration);
+      _configCompleter.complete(_config);
+    }
+  }
+
+  Future<void> _configurePlatforms(String version, String configuration) async {
     await _channel.invokeMethod<void>(
       'configure',
       <String, Object>{
@@ -34,5 +151,22 @@ class MethodChannelAmplify extends AmplifyClass {
       //ignore:invalid_use_of_protected_member
       AnalyticsCategory.plugins.map((plugin) => plugin.onConfigure()),
     );
+  }
+
+  /// Parses the [configuration] string into an [AmplifyConfig] object.
+  /// An empty [AmplifyConfig] is returned on exception.
+  AmplifyConfig _parseConfigJson(String configuration) {
+    try {
+      return AmplifyConfig.fromJson(jsonDecode(configuration));
+    } on Exception catch (e) {
+      safePrint(
+        'There was an unexpected problem parsing the amplifyconfiguration.dart file: $e',
+      );
+      return const AmplifyConfig();
+    }
+  }
+
+  String _getVersion() {
+    return '0.3.2';
   }
 }

--- a/packages/amplify_flutter/test/amplify_test.dart
+++ b/packages/amplify_flutter/test/amplify_test.dart
@@ -83,6 +83,7 @@ void main() {
     // We want to instantiate a new instance for each test so we start
     // with a fresh state as `Amplify` singleton holds a state.
     amplify = AmplifyClass.protected();
+    AmplifyClass.instance = MethodChannelAmplify();
 
     // We only use Auth and Analytics category for testing this class.
     // Clear out their plugins before each test for a fresh state.

--- a/packages/amplify_flutter/test/amplify_test.dart
+++ b/packages/amplify_flutter/test/amplify_test.dart
@@ -18,7 +18,6 @@ import 'dart:convert';
 import 'package:amplify_analytics_pinpoint/amplify_analytics_pinpoint.dart';
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
-import 'package:amplify_flutter/src/amplify_impl.dart';
 import 'package:amplify_flutter/src/categories/amplify_categories.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
*Issue #, if available:* n/a

*Goal:*
- Allow Amplify Auth to be stubbed for use in the browser, so that a live Amplify Authenticator demo (with a stubbed backend) can be imbedded in the docs website.

*Issue description:*

`AmplifyClass` has a setter for the private `_instance` field. This allows a customer to pass in their own AmplifyClass implementation. However, the instance they pass in isn't used (except in one location, where a private method is invoked, and private methods can't be overridden from outside the lib anyway). This means that customers can technically create their own AmplifyClass implementation, but they can't override any of the methods, which defeats the whole point.

*Description of changes:*
- Move all implementations from AmplifyClass to MethodChannelAmplify.
  - _Note_: I think it is debatable if **all** of the methods belong in the method channel class. We could create a new class, which would  be the default implementation of AmplifyClass, and this class could call through to the method channel class when needed. The pattern of putting all of the implementations in the method channel class is consistent with the other plugins though. I think it is worth revisiting this possibly in the future, but for now we just move them all over.
- Replace all implementation with calls to the appropriate method on the instance

*Example:*

[Here is an example where AmplifyClass is stubbed](https://github.com/Jordan-Nelson/amplify_authenticator_example/blob/main/device_preview_example/lib/stubs/amplify_class_stub.dart) for the purpose of running a (mocked) demo of the Amplify Authenticator in the browser. The implementation here is similar to the implementation in the real class. The key difference is that the method channel is never invoked. This is important because the method channel will not be available in the browser.

A similar stub could be used to allow Amplify.configure() and Amplify.addPlugin() to be called from within a widget/unit tests. Right now those methods can only be called from within integ tests. We had [an issue](https://github.com/aws-amplify/amplify-flutter/issues/1255) opened in the past related to this.

This also would in theory allow a custom to write their own implementation for a platform we don't currently support, although I think that is an unlikely use case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
