### PR TITLE
fix(datastore): DataTime value comparison is inaccurate

### DIFF
--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/query_predicate_test.dart
@@ -23,6 +23,8 @@ import 'boolean_query_predicate_test.dart' as boolean_query_predicate_tests;
 import 'enum_query_predicate_test.dart' as enum_query_predicate_tests;
 import 'compound_query_predicate_test.dart' as compound_query_predicate_tests;
 import 'aws_date_query_predicate_test.dart' as aws_date_query_predicate_test;
+import 'aws_date_time_query_predicate_test.dart'
+    as aws_date_time_query_predicate_test;
 import 'aws_time_query_predicate_test.dart' as aws_time_query_predicate_test;
 import 'aws_timestamp_query_predicate_test.dart'
     as aws_timestamp_query_predicate_tests;
@@ -38,9 +40,7 @@ void main() async {
     enum_query_predicate_tests.main();
     compound_query_predicate_tests.main();
     aws_date_query_predicate_test.main();
-    // TODO: enable AWSDateTime test suite when this issue gets resolved:
-    //  https://github.com/aws-amplify/amplify-flutter/issues/1245
-    // aws_date_time_query_predicate_test.main();
+    aws_date_time_query_predicate_test.main();
     aws_time_query_predicate_test.main();
     aws_timestamp_query_predicate_tests.main();
   });

--- a/packages/amplify_datastore_plugin_interface/lib/src/types/temporal/temporal_datetime.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/src/types/temporal/temporal_datetime.dart
@@ -60,7 +60,7 @@ class TemporalDateTime implements Comparable<TemporalDateTime> {
         dateTime.microsecond);
 
     if (offset.inDays > 0) {
-      throw new Exception("Cannot have an offset in days (hh:mm:ss)");
+      throw Exception("Cannot have an offset in days (hh:mm:ss)");
     }
 
     _offset = offset;
@@ -75,7 +75,7 @@ class TemporalDateTime implements Comparable<TemporalDateTime> {
   ///     +hh:mm
   ///     +hh:mm:ss
   TemporalDateTime.fromString(String iso8601String) {
-    RegExp regExp = new RegExp(
+    RegExp regExp = RegExp(
         r'^([0-9]{4}-[0-1][0-9]-[0-3][0-9]T[0-2][0-9]:[0-5][0-9](:[0-5][0-9](\.([0-9]{1,9}))?)?)((z|Z)|((\+|-)[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?))',
         caseSensitive: false,
         multiLine: false);
@@ -90,7 +90,7 @@ class TemporalDateTime implements Comparable<TemporalDateTime> {
     }
 
     if (regexString != iso8601String) {
-      throw new Exception("invalid string input");
+      throw Exception("invalid string input");
     }
 
     // Extract Time
@@ -141,9 +141,9 @@ class TemporalDateTime implements Comparable<TemporalDateTime> {
     buffer.write(isoString.substring(0, isoString.length - 4));
 
     int totalMicroseconds = _nanoseconds + Temporal.getNanoseconds(_dateTime);
-    if (totalMicroseconds > 0) {
-      buffer.write("." + totalMicroseconds.toString().padLeft(9, "0"));
-    }
+    // ensure DateTime strings stored in SQLite are in the same format
+    // which ensures string comparison based DataTime comparison accurate
+    buffer.write("." + totalMicroseconds.toString().padLeft(9, "0"));
 
     if (_offset != null) {
       if (_offset!.inSeconds == 0) {

--- a/packages/amplify_datastore_plugin_interface/test/amplify_temporal_datetime_test.dart
+++ b/packages/amplify_datastore_plugin_interface/test/amplify_temporal_datetime_test.dart
@@ -46,7 +46,7 @@ void main() {
 
     expect(time.getOffset(), Duration());
     expect(time.getDateTimeInUtc(), DateTime.utc(1995, 05, 03, 03, 30));
-    expect(time.format(), "1995-05-03T03:30:00Z");
+    expect(time.format(), "1995-05-03T03:30:00.000000000Z");
   });
 
   test('AWSDateTime from string YYYY-MM-DDThh:mm:ssZ success', () async {
@@ -54,7 +54,7 @@ void main() {
 
     expect(time.getOffset(), Duration());
     expect(time.getDateTimeInUtc(), DateTime.utc(1995, 05, 03, 03, 30, 25));
-    expect(time.format(), "1995-05-03T03:30:25Z");
+    expect(time.format(), "1995-05-03T03:30:25.000000000Z");
   });
 
   test('AWSDateTime from string YYYY-MM-DDThh:mm:ss.sssZ success', () async {
@@ -74,7 +74,7 @@ void main() {
 
     expect(time.getOffset(), duration);
     expect(time.getDateTimeInUtc(), DateTime.utc(1995, 05, 03, 03, 30));
-    expect(time.format(), "1995-05-03T03:30:00+03:25");
+    expect(time.format(), "1995-05-03T03:30:00.000000000+03:25");
   });
 
   test('AWSDateTime from string YYYY-MM-DDThh:mm-hh:mm success', () async {
@@ -84,7 +84,7 @@ void main() {
 
     expect(time.getOffset(), duration);
     expect(time.getDateTimeInUtc(), DateTime.utc(1995, 05, 03, 03, 30));
-    expect(time.format(), "1995-05-03T03:30:00-03:25");
+    expect(time.format(), "1995-05-03T03:30:00.000000000-03:25");
   });
 
   test('AWSDateTime from string YYYY-MM-DDThh:mm+hh:mm:ss success', () async {
@@ -94,7 +94,7 @@ void main() {
 
     expect(time.getOffset(), duration);
     expect(time.getDateTimeInUtc(), DateTime.utc(1995, 05, 03, 03, 30));
-    expect(time.format(), "1995-05-03T03:30:00+03:25:55");
+    expect(time.format(), "1995-05-03T03:30:00.000000000+03:25:55");
   });
 
   test('AWSDateTime from string YYYY-MM-DDThh:mm:ss+hh:mm:ss success',
@@ -105,7 +105,7 @@ void main() {
 
     expect(time.getOffset(), duration);
     expect(time.getDateTimeInUtc(), DateTime.utc(1995, 05, 03, 03, 30, 25));
-    expect(time.format(), "1995-05-03T03:30:25+03:25:55");
+    expect(time.format(), "1995-05-03T03:30:25.000000000+03:25:55");
   });
 
   test('AWSDateTime from string YYYY-MM-DDThh:mm:ss.sss+hh:mm:ss success',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Always `padLeft` for 9 digits to ensure string comparison based DateTime comparison produce accurate results

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
