### PR TITLE
chore: revert 0.3.3 version bump

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -25,10 +25,10 @@ dependencies:
   flutter:
     sdk: flutter
   file_picker: ^4.0.0
-  amplify_flutter: 0.3.3
-  amplify_analytics_pinpoint: 0.3.3
-  amplify_auth_cognito: 0.3.3
-  amplify_storage_s3: 0.3.3
+  amplify_flutter: 0.3.2
+  amplify_analytics_pinpoint: 0.3.2
+  amplify_auth_cognito: 0.3.2
+  amplify_storage_s3: 0.3.2
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3

--- a/packages/amplify_analytics_pinpoint/CHANGELOG.md
+++ b/packages/amplify_analytics_pinpoint/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-- fix: updates for latest flutter and dart versions (#1333)
-
 ## 0.3.2 (2022-01-21)
 
 - chore: bump amplify-android to 1.31.2

--- a/packages/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/amplify_analytics_pinpoint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint
 description: The Amplify Flutter Analytics category plugin using the AWS Pinpoint provider.
-version: 0.3.3
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_analytics_pinpoint
 
 environment:
@@ -8,8 +8,8 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  amplify_analytics_plugin_interface: 0.3.3
-  amplify_core: 0.3.3
+  amplify_analytics_plugin_interface: 0.3.2
+  amplify_core: 0.3.2
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.0

--- a/packages/amplify_analytics_plugin_interface/CHANGELOG.md
+++ b/packages/amplify_analytics_plugin_interface/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-- fix: updates for latest flutter and dart versions (#1333)
-
 ## 0.3.2 (2022-01-21)
 
 - chore: bump amplify-android to 1.31.2

--- a/packages/amplify_analytics_plugin_interface/pubspec.yaml
+++ b/packages/amplify_analytics_plugin_interface/pubspec.yaml
@@ -1,13 +1,13 @@
 name: amplify_analytics_plugin_interface
 description: The platform interface for the analytics module of Amplify Flutter.
-version: 0.3.3
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_analytics_plugin_interface
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  amplify_core: 0.3.3
+  amplify_core: 0.3.2
   flutter:
     sdk: flutter
   meta: ^1.1.8

--- a/packages/amplify_api/CHANGELOG.md
+++ b/packages/amplify_api/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-- fix: updates for latest flutter and dart versions (#1333)
-
 ## 0.3.2 (2022-01-21)
 
 - chore: bump amplify-android to 1.31.2

--- a/packages/amplify_api/pubspec.yaml
+++ b/packages/amplify_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api
 description: The Amplify Flutter API category plugin, supporting GraphQL and REST operations.
-version: 0.3.3
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_api
 
 environment:
@@ -8,8 +8,8 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  amplify_api_plugin_interface: 0.3.3
-  amplify_core: 0.3.3
+  amplify_api_plugin_interface: 0.3.2
+  amplify_core: 0.3.2
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.0

--- a/packages/amplify_api_plugin_interface/CHANGELOG.md
+++ b/packages/amplify_api_plugin_interface/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-- fix: updates for latest flutter and dart versions (#1333)
-
 ## 0.3.2 (2022-01-21)
 
 - chore: bump amplify-android to 1.31.2

--- a/packages/amplify_api_plugin_interface/pubspec.yaml
+++ b/packages/amplify_api_plugin_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_plugin_interface
 description: The platform interface for the API module of Amplify Flutter.
-version: 0.3.3
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_api_plugin_interface
 
 environment:
@@ -8,7 +8,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  amplify_core: 0.3.3
+  amplify_core: 0.3.2
   collection: ^1.15.0
   flutter:
     sdk: flutter

--- a/packages/amplify_auth_cognito/CHANGELOG.md
+++ b/packages/amplify_auth_cognito/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-- fix: updates for latest flutter and dart versions (#1333)
-
 ## 0.3.2 (2022-01-21)
 
 - feat: add deleteUser API for iOS

--- a/packages/amplify_auth_cognito/pubspec.yaml
+++ b/packages/amplify_auth_cognito/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito
 description: The Amplify Flutter Auth category plugin using the AWS Cognito provider.
-version: 0.3.3
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_auth_cognito
 
 environment:
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_auth_plugin_interface: 0.3.3
-  amplify_core: 0.3.3
+  amplify_auth_plugin_interface: 0.3.2
+  amplify_core: 0.3.2
   collection: ^1.15.0
   plugin_platform_interface: ^2.0.0
 

--- a/packages/amplify_auth_plugin_interface/CHANGELOG.md
+++ b/packages/amplify_auth_plugin_interface/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-- fix: updates for latest flutter and dart versions (#1333)
-
 ## 0.3.2 (2022-01-21)
 
 - feat: add deleteUser API for iOS

--- a/packages/amplify_auth_plugin_interface/pubspec.yaml
+++ b/packages/amplify_auth_plugin_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_plugin_interface
 description: The platform interface for the auth module of Amplify Flutter.
-version: 0.3.3
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_auth_plugin_interface
 
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.1.8
-  amplify_core: 0.3.3
+  amplify_core: 0.3.2
 
 dev_dependencies:
   amplify_test:

--- a/packages/amplify_core/CHANGELOG.md
+++ b/packages/amplify_core/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-- fix: updates for latest flutter and dart versions (#1333)
-
 ## 0.3.2 (2022-01-21)
 
 - chore: bump amplify-android to 1.31.2

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_core
 description: The base package containing common types and utilities that are shared across the Amplify Flutter packages.
-version: 0.3.3
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_core
 
 environment:

--- a/packages/amplify_datastore/CHANGELOG.md
+++ b/packages/amplify_datastore/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-- fix: Hub memory usage (#1201)
-- chore: Export hub event types (#1330)
-- fix: updates for latest flutter and dart versions (#1333)
-
 ## 0.3.2 (2022-01-21)
 
 - chore: bump amplify-android to 1.31.2

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore
 description: The Amplify Flutter DataStore category plugin, providing a queryable, on-device data store.
-version: 0.3.3
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_datastore
 
 environment:
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_datastore_plugin_interface: 0.3.3
-  amplify_core: 0.3.3
+  amplify_datastore_plugin_interface: 0.3.2
+  amplify_core: 0.3.2
   plugin_platform_interface: ^2.0.0
   meta: ^1.1.8
   collection: ^1.14.13

--- a/packages/amplify_datastore_plugin_interface/CHANGELOG.md
+++ b/packages/amplify_datastore_plugin_interface/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-- fix: updates for latest flutter and dart versions (#1333)
-
 ## 0.3.2 (2022-01-21)
 
 - chore: bump amplify-android to 1.31.2

--- a/packages/amplify_datastore_plugin_interface/pubspec.yaml
+++ b/packages/amplify_datastore_plugin_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore_plugin_interface
 description: The platform interface for the DataStore module of Amplify Flutter.
-version: 0.3.3
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_datastore_plugin_interface
 
 environment:
@@ -14,7 +14,7 @@ dependencies:
   collection: ^1.15.0
   date_time_format: ^2.0.1
   uuid: ^3.0.1
-  amplify_core: 0.3.3
+  amplify_core: 0.3.2
 
 dev_dependencies:
   amplify_test:

--- a/packages/amplify_flutter/CHANGELOG.md
+++ b/packages/amplify_flutter/CHANGELOG.md
@@ -1,19 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-### Fixes
-
-- fix(amplify_flutter): Password settings parsing (#1323)
-- fix(amplify_datastore): Hub memory usage (#1201)
-- fix(amplify_flutter): updates for latest flutter and dart versions #1333
-
-### Features
-
-- feat(amplify_flutter): allow customers to override AmplifyClass methods (#1325)
-
-### Chores
-
-- chore(amplify_datastore): Export hub event types (#1330)
-
 ## 0.3.2 (2022-01-21)
 
 - chore: bump amplify-android to 1.31.2

--- a/packages/amplify_flutter/lib/src/method_channel_amplify.dart
+++ b/packages/amplify_flutter/lib/src/method_channel_amplify.dart
@@ -167,6 +167,6 @@ class MethodChannelAmplify extends AmplifyClass {
   }
 
   String _getVersion() {
-    return '0.3.3';
+    return '0.3.2';
   }
 }

--- a/packages/amplify_flutter/pubspec.yaml
+++ b/packages/amplify_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter
 description: The top level Flutter package for the AWS Amplify libraries.
-version: 0.3.3
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_flutter
 
 environment:
@@ -8,12 +8,12 @@ environment:
   flutter: ">=2.0.0"
 
 dependencies:
-  amplify_analytics_plugin_interface: 0.3.3
-  amplify_api_plugin_interface: 0.3.3
-  amplify_auth_plugin_interface: 0.3.3
-  amplify_core: 0.3.3
-  amplify_datastore_plugin_interface: 0.3.3
-  amplify_storage_plugin_interface: 0.3.3
+  amplify_analytics_plugin_interface: 0.3.2
+  amplify_api_plugin_interface: 0.3.2
+  amplify_auth_plugin_interface: 0.3.2
+  amplify_core: 0.3.2
+  amplify_datastore_plugin_interface: 0.3.2
+  amplify_storage_plugin_interface: 0.3.2
   collection: ^1.15.0
   flutter:
     sdk: flutter
@@ -47,12 +47,12 @@ dependencies:
 #     path: ../amplify_storage_s3
 
 dev_dependencies:
-  amplify_analytics_pinpoint: 0.3.3
-  amplify_api: 0.3.3
-  amplify_auth_cognito: 0.3.3
-  amplify_datastore: 0.3.3
+  amplify_analytics_pinpoint: 0.3.2
+  amplify_api: 0.3.2
+  amplify_auth_cognito: 0.3.2
+  amplify_datastore: 0.3.2
   amplify_lints: ^1.0.0
-  amplify_storage_s3: 0.3.3
+  amplify_storage_s3: 0.3.2
   amplify_test:
     path: ../amplify_test
   build_runner: ^2.0.0

--- a/packages/amplify_lints/CHANGELOG.md
+++ b/packages/amplify_lints/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-- fix: updates for latest flutter and dart versions (#1333)
-
 ## 1.1.0
 
 ### Chores

--- a/packages/amplify_storage_plugin_interface/CHANGELOG.md
+++ b/packages/amplify_storage_plugin_interface/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-- fix: updates for latest flutter and dart versions (#1333)
-
 ## 0.3.2 (2022-01-21)
 
 - chore: bump amplify-android to 1.31.2

--- a/packages/amplify_storage_plugin_interface/pubspec.yaml
+++ b/packages/amplify_storage_plugin_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_plugin_interface
 description: The platform interface for the storage module of Amplify Flutter.
-version: 0.3.3
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_storage_plugin_interface
 
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.1.8
-  amplify_core: 0.3.3
+  amplify_core: 0.3.2
 
 dev_dependencies:
   amplify_test:

--- a/packages/amplify_storage_s3/CHANGELOG.md
+++ b/packages/amplify_storage_s3/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.3.3 (2022-02-04)
-
-- fix: updates for latest flutter and dart versions (#1333)
-
 ## 0.3.2 (2022-01-21)
 
 - chore: bump amplify-android to 1.31.2

--- a/packages/amplify_storage_s3/pubspec.yaml
+++ b/packages/amplify_storage_s3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3
 description: The Amplify Flutter Storage category plugin using the AWS S3 provider.
-version: 0.3.3
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_storage_s3
 
 environment:
@@ -10,9 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_storage_plugin_interface: 0.3.3
+  amplify_storage_plugin_interface: 0.3.2
   plugin_platform_interface: ^2.0.0
-  amplify_core: 0.3.3
+  amplify_core: 0.3.2
 
 dev_dependencies:
   amplify_test:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- revert the changes made for amplify_flutter 0.3.3 version bump. This reverts the changes from 117191e8656b6bee66df08f6d81e5d0f5a22678c, with the exception of the authenticator version bump and logs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
