### PR TITLE
chore(amplify_api): add meta as dependency

### DIFF
--- a/packages/amplify_api/pubspec.yaml
+++ b/packages/amplify_api/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   collection: ^1.15.0
   flutter:
     sdk: flutter
+  meta: ^1.3.0
   plugin_platform_interface: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
*Description of changes:*

Adds meta as a direct dependency in amplify_api to prevent a publish-time error about transitive dependencies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
