### PR TITLE
chore: update flutter analysis to throw an error for depend_on_refere…

### DIFF
--- a/packages/amplify_lints/lib/dart.yaml
+++ b/packages/amplify_lints/lib/dart.yaml
@@ -3,6 +3,8 @@ include: package:lints/recommended.yaml
 analyzer:
   strong-mode:
     implicit-dynamic: false
+  errors:
+    depend_on_referenced_packages: error               # To prevent issues publishing.
 
 linter:
   rules:

--- a/packages/amplify_lints/lib/flutter_lib.yaml
+++ b/packages/amplify_lints/lib/flutter_lib.yaml
@@ -3,6 +3,8 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   strong-mode:
     implicit-dynamic: false
+  errors:
+    depend_on_referenced_packages: error               # To prevent issues publishing.
 
 linter:
   rules:


### PR DESCRIPTION
*Description of changes:*

We currently have a lint rule for depend_on_referenced_packages, which basically gives info warning if your code imports something that is not in the pubspec for that plugin. When that dependency is transitive, it will compile, but will throw an error when you publish on pubspec.

To prevent that, this PR makes it an error that will cause analysis to fail.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
