### PR TITLE
fix(flutter): Export category interfaces

### DIFF
--- a/packages/amplify_flutter/lib/amplify_flutter.dart
+++ b/packages/amplify_flutter/lib/amplify_flutter.dart
@@ -19,8 +19,11 @@ import 'src/amplify_impl.dart';
 
 export 'package:amplify_core/amplify_core.dart';
 
-// amplify class
+// Amplify interface
 export 'src/amplify_impl.dart';
+
+// Category interfaces
+export 'src/categories/amplify_categories.dart';
 
 // Config
 export 'src/config/amplify_config.dart';
@@ -31,6 +34,7 @@ export 'src/config/api/api_config.dart';
 export 'src/config/auth/auth_config.dart';
 export 'src/config/config_map.dart';
 export 'src/config/storage/storage_config.dart';
+
 // Utilities
 export 'src/utils/equatable.dart';
 export 'src/utils/json.dart';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Exports the category interfaces from `amplify_flutter` which were public pre-0.3.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
