### PR TITLE
fix(amplify_authenticator): remove use of onInverseSurface to support older flutter versions

### DIFF
--- a/packages/amplify_authenticator/lib/src/widgets/authenticator_banner.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/authenticator_banner.dart
@@ -44,14 +44,12 @@ SnackBar createSnackBar(
   required StatusType type,
   required Widget content,
 }) {
-  final ThemeData theme = Theme.of(context);
-  final bool isDark = theme.brightness == Brightness.dark;
+  final theme = Theme.of(context);
 
-  // this uses the text style by default, and falls back on the color scheme.
-  // this mimics logic within the SnackBar that sets the backgroundColor.
-  // see SnackBarThemeData.backgroundColor
-  final foregroundColor = theme.snackBarTheme.contentTextStyle?.color ??
-      (isDark ? theme.colorScheme.surface : theme.colorScheme.onSurface);
+  // if contentTextStyle is null, colorScheme.surface is used as a fallback
+  // since SnackBarThemeData.backgroundColor uses colorScheme.onSurface as a fall back
+  final foregroundColor =
+      theme.snackBarTheme.contentTextStyle?.color ?? theme.colorScheme.surface;
 
   return SnackBar(
     key: keyAuthenticatorBanner,

--- a/packages/amplify_authenticator/lib/src/widgets/authenticator_banner.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/authenticator_banner.dart
@@ -44,9 +44,15 @@ SnackBar createSnackBar(
   required StatusType type,
   required Widget content,
 }) {
-  final theme = Theme.of(context);
+  final ThemeData theme = Theme.of(context);
+  final bool isDark = theme.brightness == Brightness.dark;
+
+  // this uses the text style by default, and falls back on the color scheme.
+  // this mimics logic within the SnackBar that sets the backgroundColor.
+  // see SnackBarThemeData.backgroundColor
   final foregroundColor = theme.snackBarTheme.contentTextStyle?.color ??
-      theme.colorScheme.onInverseSurface;
+      (isDark ? theme.colorScheme.surface : theme.colorScheme.onSurface);
+
   return SnackBar(
     key: keyAuthenticatorBanner,
     content: Row(

--- a/packages/amplify_authenticator/pubspec.yaml
+++ b/packages/amplify_authenticator/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/aws-amplify/amplify-flutter/tree/release-candidate/
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=2.0.0"
 
 dependencies:
   amplify_auth_cognito: ">=0.3.0 <0.5.0"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/1381

*Description of changes:*
- Remove use of onInverseSurface to support flutter versions prior to 2.10.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
