### PR TITLE
feat(amplify_auth_cognito): delete user for Android

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/integration_test/delete_user_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/delete_user_test.dart
@@ -12,7 +12,6 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-import 'dart:io' show Platform;
 import 'package:integration_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
@@ -26,7 +25,7 @@ import 'utils/setup_utils.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  group('deleteUser (iOS)', () {
+  group('deleteUser', () {
     setUpAll(() async {
       await configureAuth(additionalPlugins: [
         AmplifyAPI(),
@@ -34,8 +33,7 @@ void main() {
       await signOutUser();
     });
 
-    testWidgets('should delete a confirmed user on iOS',
-        (WidgetTester tester) async {
+    testWidgets('should delete a confirmed user', (WidgetTester tester) async {
       final username = generateUsername();
       final password = generatePassword();
 
@@ -104,24 +102,5 @@ void main() {
       }
       fail('Expected SignedOutException');
     });
-  }, skip: !Platform.isIOS);
-
-  group('deleteUser (Android)', () {
-    setUpAll(() async {
-      await configureAuth(additionalPlugins: [
-        AmplifyAPI(),
-      ]);
-      await signOutUser();
-    });
-    testWidgets('should throw an UnimplementedError on Android',
-        (WidgetTester tester) async {
-      try {
-        await Amplify.Auth.deleteUser();
-      } catch (e) {
-        expect(e, TypeMatcher<UnimplementedError>());
-        return;
-      }
-      fail('Expected UnimplementedError');
-    });
-  }, skip: !Platform.isAndroid);
+  });
 }

--- a/packages/auth/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   amplify_flutter:
     path: ../../../amplify/amplify_flutter
   amplify_api:
-    path: ../../../amplify_api
+    path: ../../../api/amplify_api
   amplify_auth_cognito:
     # When depending on this package from a real application you should use:
     #   amplify_auth_cognito: ^x.y.z

--- a/packages/auth/amplify_auth_cognito/lib/method_channel_auth_cognito.dart
+++ b/packages/auth/amplify_auth_cognito/lib/method_channel_auth_cognito.dart
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-import 'dart:io' show Platform;
 import 'dart:convert';
 
 import 'package:amplify_core/amplify_core.dart';
@@ -554,11 +553,6 @@ class AmplifyAuthCognitoMethodChannel extends AmplifyAuthCognito {
 
   @override
   Future<void> deleteUser() async {
-    if (!Platform.isIOS) {
-      throw UnimplementedError(
-        'The deleteUser API is currently available on the iOS platform only.',
-      );
-    }
     try {
       await _channel.invokeMethod('deleteUser');
     } on PlatformException catch (e) {

--- a/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
+++ b/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
@@ -203,6 +203,7 @@ public class AuthCognito : FlutterPlugin, ActivityAware, MethodCallHandler, Plug
             "updateUserAttributes" -> onUpdateUserAttributes(result, data)
             "confirmUserAttribute" -> onConfirmUserAttribute(result, data)
             "resendUserAttributeConfirmationCode" -> onResendUserAttributeConfirmationCode(result, data)
+            "deleteUser" -> onDeleteUser(result)
             else -> result.notImplemented()
         }
     }
@@ -552,6 +553,18 @@ public class AuthCognito : FlutterPlugin, ActivityAware, MethodCallHandler, Plug
             errorHandler.prepareGenericException(flutterResult, e)
         }
     }
+
+    private fun onDeleteUser (@NonNull flutterResult: Result) {
+        try {
+            Amplify.Auth.deleteUser(
+                { prepareDeleteResult(flutterResult) },
+                { error -> errorHandler.handleAuthError(flutterResult, error) }
+            );
+        } catch (e: Exception) {
+            errorHandler.prepareGenericException(flutterResult, e)
+        }
+    }
+
 
     fun prepareResendSignUpCodeResult(@NonNull flutterResult: Result, @NonNull result: AuthSignUpResult) {
         var resendData = FlutterResendSignUpCodeResult(result)

--- a/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognitoHubEventStreamHandler.kt
+++ b/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognitoHubEventStreamHandler.kt
@@ -60,6 +60,7 @@ class AuthCognitoHubEventStreamHandler : EventChannel.StreamHandler {
                 when (AuthChannelEventName.valueOf(hubEvent.name)) {
                     AuthChannelEventName.SIGNED_IN,
                     AuthChannelEventName.SIGNED_OUT,
+                    AuthChannelEventName.USER_DELETED,
                     AuthChannelEventName.SESSION_EXPIRED -> {
                         var hubEvent = mapOf("eventName" to hubEvent.name)
                         sendEvent(hubEvent)

--- a/packages/auth/amplify_auth_cognito_android/android/src/test/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AmplifyAuthCognitoHubTest.kt
+++ b/packages/auth/amplify_auth_cognito_android/android/src/test/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AmplifyAuthCognitoHubTest.kt
@@ -131,4 +131,26 @@ class AmplifyAuthCognitoHubTest {
         shadowOf(getMainLooper()).idle()
         verify(hubSpy, times(1)).sendEvent(eventData)
     }
+
+    @Test
+    fun test_hub_userDeleteEvent_event() {
+        val latch = CountDownLatch(1)
+        val realHubHandler = AuthCognitoHubEventStreamHandler(latch)
+
+        flutterPlugin = AuthCognito(realHubHandler, mock(Activity::class.java))
+        var eventData: HashMap<String, Any> = (readMapFromFile("hub",
+            "userDeletedEvent.json",
+            HashMap::class.java) as HashMap<String, Any>)
+
+        var event: HubEvent<*> = HubEvent.create(AuthChannelEventName.USER_DELETED)
+
+        val hubSpy = spy(realHubHandler)
+
+        val token: SubscriptionToken = hubSpy.getHubListener()
+        Amplify.Hub.publish(HubChannel.AUTH, event)
+        Latch.await(latch);
+        Amplify.Hub.unsubscribe(token)
+        shadowOf(getMainLooper()).idle()
+        verify(hubSpy, times(1)).sendEvent(eventData)
+    }
 }

--- a/packages/auth/amplify_auth_cognito_android/android/src/test/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AmplifyAuthCognitoPluginTest.kt
+++ b/packages/auth/amplify_auth_cognito_android/android/src/test/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AmplifyAuthCognitoPluginTest.kt
@@ -1437,6 +1437,26 @@ class AmplifyAuthCognitoPluginTest {
         }
     }
 
+    @Test
+    fun deleteUser_returnsSuccess() {
+        // Arrange
+        doAnswer { invocation: InvocationOnMock ->
+            plugin.prepareDeleteResult(mockResult)
+            null as Void?
+        }.`when`(mockAuth).deleteUser(
+            ArgumentMatchers.any<Action>(),
+            ArgumentMatchers.any<Consumer<AuthException>>()
+        )
+        val call = MethodCall("deleteUser", null)
+
+        // Act
+        plugin.onMethodCall(call, mockResult)
+
+        // Assert
+        verify(mockResult, times(1)).success(null);
+    }
+
+
     private fun setFinalStatic(field: Field, newValue: Any?) {
         field.isAccessible = true
         val modifiersField: Field = Field::class.java.getDeclaredField("modifiers")

--- a/packages/auth/amplify_auth_cognito_ios/test/resources/hub/userDeletedEvent.json
+++ b/packages/auth/amplify_auth_cognito_ios/test/resources/hub/userDeletedEvent.json
@@ -1,0 +1,3 @@
+{
+    "eventName": "USER_DELETED"
+}


### PR DESCRIPTION
*Issue #, if available:*
#1297 

*Description of changes:*
Adds deleteUser API for Android.
Do **NOT** merge until the amplify-android [deleteUser PR ](https://github.com/aws-amplify/amplify-android/pull/1656) has been merged and released, and the build.gradle files for amplify-flutter have received a version bump.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
