### PR TITLE
chore(amplify_authenticator): run unit tests for amplify_authenticato…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,6 +189,7 @@ workflows:
                   "amplify_analytics_pinpoint",
                   "amplify_api",
                   "amplify_auth_cognito",
+                  "amplify_authenticator",
                   "amplify_core",
                   "amplify_datastore",
                   "amplify_datastore_plugin_interface",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,20 @@ toolkit for interacting with AWS backend resources.
 2. [AWS SDK for iOS](https://github.com/aws-amplify/aws-sdk-ios)
 3. [AWS SDK for JavaScript](https://github.com/aws/aws-sdk-js)
 
+## Unit Tests
+
+To run all the flutter unit tests for all plugins:
+
+```bash
+$ melos run test:unit:flutter
+```
+
+or run all unit tests for a given platform
+```bash
+$ melos run test:unit:android
+$ melos run test:unit:ios
+```
+
 ## Integration Tests
 
 In addition to unit tests which mock Amplify API interaction, this repository has integration tests which

--- a/melos.yaml
+++ b/melos.yaml
@@ -33,16 +33,11 @@ scripts:
       flutter build apk --verbose
 
   test:unit:flutter:
-    run: |
-      melos run test:unit:flutter:plugin amplify_analytics_pinpoint && \
-      melos run test:unit:flutter:plugin amplify_api $PWD && \
-      melos run test:unit:flutter:plugin amplify_auth_cognito $PWD && \
-      melos run test:unit:flutter:plugin amplify_core $PWD && \
-      melos run test:unit:flutter:plugin amplify_datastore $PWD && \
-      melos run test:unit:flutter:plugin amplify_datastore_plugin_interface $PWD && \
-      melos run test:unit:flutter:plugin amplify_flutter $PWD && \
-      melos run test:unit:flutter:plugin amplify_storage_plugin_interface $PWD && \
-      melos run test:unit:flutter:plugin amplify_storage_s3 $PWD && exit 0
+    run: melos exec -c 1 "flutter test"
+    description: >
+      Runs flutter unit tests in all plugins and example apps. Manually run only, not in CI
+    select-package:
+      dir-exists: test
 
   test:unit:android:
     run: |


### PR DESCRIPTION
*Description of changes:*

This PR adds flutter unit tests for authenticator to circle CI as they appear to be omitted. There is also a little documentation change and melos modification for running all the tests locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
