### PR TITLE
fix(core): Implement Result in AtomicResult

### DIFF
--- a/packages/amplify_core/android/src/main/kotlin/com/amazonaws/amplify/amplify_core/AtomicResult.kt
+++ b/packages/amplify_core/android/src/main/kotlin/com/amazonaws/amplify/amplify_core/AtomicResult.kt
@@ -51,7 +51,7 @@ class AtomicResult(private val result: MethodChannel.Result, private val operati
         }
     }
 
-    override fun error(errorCode: String?, errorMessage: String?, errorDetails: Any?) {
+    override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
         scope.launch {
             if (isSent.getAndSet(true)) {
                 Log.w(

--- a/packages/amplify_core/android/src/test/kotlin/com/amazonaws/amplify/amplify_core/AtomicResultTest.kt
+++ b/packages/amplify_core/android/src/test/kotlin/com/amazonaws/amplify/amplify_core/AtomicResultTest.kt
@@ -46,8 +46,8 @@ class AtomicResultTest {
     @Test
     fun errorIsForwarded() = coroutinesTestRule.testDispatcher.runBlockingTest {
         val atomicResult = AtomicResult(mockResult, "errorIsForwarded")
-        atomicResult.error(null, null, null)
-        verify(mockResult).error(null, null, null)
+        atomicResult.error("", null, null)
+        verify(mockResult).error("", null, null)
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/1396

The issue is that the CX is using Flutter master and they just recently updated the annotations on the `Result` interface to make `errorCode` non-null.

The same error has been experienced in Firebase and seems to be due to how Kotlin assumes every Java type is nullable unless explicitly marked with the `@NonNull` annotation. 
- https://github.com/flutter/engine/pull/31530
- https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20firebase_abstract_method_smoke_test/25243/overview

*Description of changes:*
- Make `errorCode` non-null to match new Java interface: https://github.com/flutter/engine/blame/main/shell/platform/android/io/flutter/plugin/common/MethodChannel.java#L217

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
