### PR TITLE
fix(datastore): delete default predicate causes deletion failure

### DIFF
--- a/packages/amplify_datastore/example/integration_test/save_test.dart
+++ b/packages/amplify_datastore/example/integration_test/save_test.dart
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+import 'package:amplify_datastore/amplify_datastore.dart';
 import 'package:amplify_datastore_example/models/ModelProvider.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -71,12 +72,14 @@ void main() {
       await Amplify.DataStore.save(testBlog);
 
       var updatedBlog = testBlog.copyWith(name: 'changed name');
-      await Amplify.DataStore.save(updatedBlog,
-          where: Blog.NAME.contains("Predicate"));
 
-      var blogs = await Amplify.DataStore.query(Blog.classType);
-      expect(blogs.length, 1);
-      expect(blogs[0].name, originalBlogName);
+      expect(
+          () => Amplify.DataStore.save(updatedBlog,
+              where: Blog.NAME.contains("Predicate")),
+          throwsA(predicate((e) =>
+              e is DataStoreException &&
+              e.message.contains(
+                  "condition did not match existing model instance"))));
     });
 
     testWidgets('predicate should not prevent save for matching model',
@@ -89,7 +92,7 @@ void main() {
       const matchingBlogName = 'matching blog name';
       var updatedBlog = testBlog.copyWith(name: matchingBlogName);
       await Amplify.DataStore.save(updatedBlog,
-          where: Blog.NAME.contains("matching"));
+          where: Blog.NAME.contains("original"));
 
       var blogs = await Amplify.DataStore.query(Blog.classType);
       expect(blogs.length, 1);

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -325,7 +325,8 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
                 modelSchemaRegistry: modelSchemaRegistry,
                 modelName: modelName
             )
-            let queryPredicates = try QueryPredicateBuilder.fromSerializedMap(args["queryPredicate"] as? [String : Any])
+            let queryPredicatesMap = args["queryPredicate"] as? [String : Any];
+            let queryPredicates = queryPredicatesMap != nil ? try QueryPredicateBuilder.fromSerializedMap(queryPredicatesMap) : nil;
             
             let serializedModelData = try FlutterDataStoreRequestUtils.getSerializedModelData(methodChannelArguments: args)
             let modelID = try FlutterDataStoreRequestUtils.getModelID(serializedModelData: serializedModelData)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/1400
*Description of changes:*

For `delete` API, if the query predicate is not provide, leave it as nil and not using `QueryPredicateConstant.all`, which causes the deletion validation query returns all record instead of the record that is with the specific id.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
