### PR TITLE
chore: update integ provision scripts to use AWS profile

### DIFF
--- a/packages/amplify_api/example/tool/provision_integration_test_resources.sh
+++ b/packages/amplify_api/example/tool/provision_integration_test_resources.sh
@@ -2,7 +2,7 @@
 set -e
 IFS='|'
 
-[ "$AWS_PROFILE" ] && profileName="$AWS_PROFILE" || profileName="default";
+profileName=${AWS_PROFILE:-default}
 
 FLUTTERCONFIG="{\
 \"ResDir\":\"./lib/\",\

--- a/packages/amplify_api/example/tool/provision_integration_test_resources.sh
+++ b/packages/amplify_api/example/tool/provision_integration_test_resources.sh
@@ -2,6 +2,8 @@
 set -e
 IFS='|'
 
+[ "$AWS_PROFILE" ] && profileName="$AWS_PROFILE" || profileName="default";
+
 FLUTTERCONFIG="{\
 \"ResDir\":\"./lib/\",\
 }"
@@ -15,6 +17,17 @@ AMPLIFY="{\
 FRONTEND="{\
 \"frontend\":\"flutter\",\
 \"config\":$FLUTTERCONFIG\
+}"
+
+AWSCLOUDFORMATIONCONFIG="{\
+\"configLevel\":\"project\",\
+\"useProfile\":"true",\
+\"profileName\":\"$profileName\",\
+\"region\":\"us-west-2\"\
+}"
+
+PROVIDERS="{\
+\"awscloudformation\":$AWSCLOUDFORMATIONCONFIG\
 }"
 
 # read the request template and the schema
@@ -31,6 +44,7 @@ request="${requestTemplate/<SCHEMA_PLACEHOLDER>/$schema}"
 amplify init \
 --amplify $AMPLIFY \
 --frontend $FRONTEND \
+--providers $PROVIDERS \
 --yes
 echo "$request" | jq -c | amplify add api --headless
 amplify push --yes

--- a/packages/amplify_api/example/tool/provision_integration_test_resources.sh
+++ b/packages/amplify_api/example/tool/provision_integration_test_resources.sh
@@ -21,7 +21,7 @@ FRONTEND="{\
 
 AWSCLOUDFORMATIONCONFIG="{\
 \"configLevel\":\"project\",\
-\"useProfile\":"true",\
+\"useProfile\":\"true\",\
 \"profileName\":\"$profileName\",\
 \"region\":\"us-west-2\"\
 }"

--- a/packages/amplify_datastore/example/tool/provision_integration_test_resources.sh
+++ b/packages/amplify_datastore/example/tool/provision_integration_test_resources.sh
@@ -2,7 +2,7 @@
 set -e
 IFS='|'
 
-[ "$AWS_PROFILE" ] && profileName="$AWS_PROFILE" || profileName="default";
+profileName=${AWS_PROFILE:-default}
 
 FLUTTERCONFIG="{\
 \"ResDir\":\"./lib/\",\

--- a/packages/amplify_datastore/example/tool/provision_integration_test_resources.sh
+++ b/packages/amplify_datastore/example/tool/provision_integration_test_resources.sh
@@ -2,6 +2,8 @@
 set -e
 IFS='|'
 
+[ "$AWS_PROFILE" ] && profileName="$AWS_PROFILE" || profileName="default";
+
 FLUTTERCONFIG="{\
 \"ResDir\":\"./lib/\",\
 }"
@@ -15,6 +17,17 @@ AMPLIFY="{\
 FRONTEND="{\
 \"frontend\":\"flutter\",\
 \"config\":$FLUTTERCONFIG\
+}"
+
+AWSCLOUDFORMATIONCONFIG="{\
+\"configLevel\":\"project\",\
+\"useProfile\":"true",\
+\"profileName\":\"$profileName\",\
+\"region\":\"us-west-2\"\
+}"
+
+PROVIDERS="{\
+\"awscloudformation\":$AWSCLOUDFORMATIONCONFIG\
 }"
 
 # read the request template and the schema
@@ -31,6 +44,7 @@ request="${requestTemplate/<SCHEMA_PLACEHOLDER>/$schema}"
 amplify init \
 --amplify $AMPLIFY \
 --frontend $FRONTEND \
+--providers $PROVIDERS \
 --yes
 echo "$request" | jq -c | amplify add api --headless
 amplify push --yes

--- a/packages/amplify_datastore/example/tool/provision_integration_test_resources.sh
+++ b/packages/amplify_datastore/example/tool/provision_integration_test_resources.sh
@@ -21,7 +21,7 @@ FRONTEND="{\
 
 AWSCLOUDFORMATIONCONFIG="{\
 \"configLevel\":\"project\",\
-\"useProfile\":"true",\
+\"useProfile\":\"true\",\
 \"profileName\":\"$profileName\",\
 \"region\":\"us-west-2\"\
 }"

--- a/packages/auth/amplify_auth_cognito/example/tool/provision_integration_test_resources.sh
+++ b/packages/auth/amplify_auth_cognito/example/tool/provision_integration_test_resources.sh
@@ -2,7 +2,7 @@
 set -e
 IFS='|'
 
-[ "$AWS_PROFILE" ] && profileName="$AWS_PROFILE" || profileName="default";
+profileName=${AWS_PROFILE:-default}
 
 FLUTTERCONFIG="{\
 \"ResDir\":\"./lib/\",\

--- a/packages/auth/amplify_auth_cognito/example/tool/provision_integration_test_resources.sh
+++ b/packages/auth/amplify_auth_cognito/example/tool/provision_integration_test_resources.sh
@@ -21,7 +21,7 @@ FRONTEND="{\
 
 AWSCLOUDFORMATIONCONFIG="{\
 \"configLevel\":\"project\",\
-\"useProfile\":"true",\
+\"useProfile\":\"true\",\
 \"profileName\":\"$profileName\",\
 \"region\":\"us-west-2\"\
 }"


### PR DESCRIPTION
As written, provision scripts for integration test resources assume default profile in local AWS configuration. This PR lets the caller specify the AWS profile with an env variable `AWS_PROFILE`, similar to existing change in auth example script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
