### PR TITLE
fix(analytics): adds flutter sdk to example apps

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint_android/example/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_android/example/pubspec.yaml
@@ -6,10 +6,12 @@ description: Test bed for amplify_analytics_pinpoint_android
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.2.0"
 
 dependencies:
+  flutter:
+    sdk: flutter
   amplify_analytics_pinpoint_android:
     # When depending on this package from a real application you should use:
     #   amplify_analytics_pinpoint: ^x.y.z

--- a/packages/analytics/amplify_analytics_pinpoint_ios/example/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_ios/example/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
   flutter: ">=2.2.0"
 
 dependencies:
+  flutter:
+    sdk: flutter
   amplify_analytics_pinpoint_ios:
     # When depending on this package from a real application you should use:
     #   amplify_analytics_pinpoint: ^x.y.z


### PR DESCRIPTION
*Description of changes:*
Adds the flutter sdk as dependency to analytics example apps.

Fixes the following melos error:
```terminal
Running "flutter pub get" in workspace packages...
Note: this may take a while in large workspaces such as this one.
  ✓ amplify_analytics_pinpoint
    └> packages/analytics/amplify_analytics_pinpoint
  ✓ amplify_analytics_pinpoint_android
    └> packages/analytics/amplify_analytics_pinpoint_android
  - amplify_analytics_pinpoint_android_example
    └> packages/analytics/amplify_analytics_pinpoint_android/example
    └> Failed to install.

Resolving dependencies...
Because amplify_analytics_pinpoint_android_example requires the Flutter SDK, version solving failed.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
