### PR TITLE
chore: bump amplify-ios to 1.22.0

### DIFF
--- a/packages/amplify_api/ios/amplify_api.podspec
+++ b/packages/amplify_api/ios/amplify_api.podspec
@@ -17,8 +17,8 @@ The API module for Amplify Flutter.
   s.source           = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.19.0'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.19.0'
+  s.dependency 'Amplify', '1.22.0'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.22.0'
   s.dependency 'amplify_core'
   s.dependency 'SwiftLint'
   s.dependency 'SwiftFormat/CLI'

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,8 +15,8 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.19.0'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.19.0'
+  s.dependency 'Amplify', '1.22.0'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.22.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '13.0'
 

--- a/packages/amplify_flutter/ios/amplify_flutter.podspec
+++ b/packages/amplify_flutter/ios/amplify_flutter.podspec
@@ -17,9 +17,9 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.19.0'
-  s.dependency 'AWSPluginsCore', '1.19.0'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.19.0'
+  s.dependency 'Amplify', '1.22.0'
+  s.dependency 'AWSPluginsCore', '1.22.0'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.22.0'
   s.dependency 'amplify_core'
   s.dependency 'SwiftLint'
   s.dependency 'SwiftFormat/CLI'

--- a/packages/analytics/amplify_analytics_pinpoint_ios/ios/amplify_analytics_pinpoint_ios.podspec
+++ b/packages/analytics/amplify_analytics_pinpoint_ios/ios/amplify_analytics_pinpoint_ios.podspec
@@ -15,8 +15,8 @@ This code is the iOS part of the Amplify Flutter Pinpoint Analytics Plugin.  The
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.19.0'
-  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.19.0'
+  s.dependency 'Amplify', '1.22.0'
+  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.22.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
+++ b/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.19.0'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.19.0'
+  s.dependency 'Amplify', '1.22.0'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.22.0'
   s.dependency 'ObjectMapper'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'

--- a/packages/storage/amplify_storage_s3_android/.gitignore
+++ b/packages/storage/amplify_storage_s3_android/.gitignore
@@ -1,0 +1,48 @@
+# See https://dart.dev/guides/libraries/private-files
+
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+build/
+
+# Code coverage
+coverage/
+
+# Android related
+**/android/**/gradle-wrapper.jar
+**/android/.gradle
+**/android/captures/
+**/android/gradlew
+**/android/gradlew.bat
+**/android/local.properties
+**/android/**/GeneratedPluginRegistrant.java
+
+# Exceptions to above rules.
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages

--- a/packages/storage/amplify_storage_s3_ios/.gitignore
+++ b/packages/storage/amplify_storage_s3_ios/.gitignore
@@ -1,0 +1,66 @@
+# See https://dart.dev/guides/libraries/private-files
+
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+build/
+
+# Code coverage
+coverage/
+
+# iOS related
+DerivedData/
+build/
+GeneratedPluginRegistrant.h
+GeneratedPluginRegistrant.m
+
+.generated/
+
+*.pbxuser
+*.mode1v3
+*.mode2v3
+*.perspectivev3
+
+!default.pbxuser
+!default.mode1v3
+!default.mode2v3
+!default.perspectivev3
+
+xcuserdata
+
+*.moved-aside
+
+*.pyc
+*sync/
+Icon?
+.tags*
+
+/Flutter/Generated.xcconfig
+/Flutter/flutter_export_environment.sh

--- a/packages/storage/amplify_storage_s3_ios/ios/amplify_storage_s3_ios.podspec
+++ b/packages/storage/amplify_storage_s3_ios/ios/amplify_storage_s3_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.19.0'
-  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.19.0'
+  s.dependency 'Amplify', '1.22.0'
+  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.22.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump amplify-ios to version [1.22.0](https://github.com/aws-amplify/amplify-ios/releases/tag/v1.22.0).
Also add missing `.gitignore` files for `storage` packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
