### PR TITLE
fix: bumps ios version and bumps api AuthProvider timeout

### DIFF
--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/auth/FlutterAuthProvider.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/auth/FlutterAuthProvider.kt
@@ -35,7 +35,7 @@ class FlutterAuthProviders(
         /**
          * Timeout on a single [getToken] call.
          */
-        const val getTokenTimeoutMillis = 2000L
+        const val getTokenTimeoutMillis = 4000L
 
         /**
          * Logger tag.

--- a/packages/amplify_api/ios/Classes/Auth/FlutterAuthProvider.swift
+++ b/packages/amplify_api/ios/Classes/Auth/FlutterAuthProvider.swift
@@ -64,7 +64,7 @@ class FlutterAuthProviders: APIAuthProviderFactory {
                 }
             }
 
-            let timeout: DispatchTimeInterval = .seconds(2)
+            let timeout: DispatchTimeInterval = .seconds(4)
             let waitResult = completer.wait(timeout: .now() + timeout)
             if waitResult == .timedOut {
                 token = .failure(APIError.operationError(

--- a/packages/amplify_api/ios/amplify_api.podspec
+++ b/packages/amplify_api/ios/amplify_api.podspec
@@ -17,8 +17,8 @@ The API module for Amplify Flutter.
   s.source           = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.22.3'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.22.3'
+  s.dependency 'Amplify', '1.23.0'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.23.0'
   s.dependency 'amplify_core'
   s.dependency 'SwiftLint'
   s.dependency 'SwiftFormat/CLI'

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,8 +15,8 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.22.3'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.22.3'
+  s.dependency 'Amplify', '1.23.0'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.23.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '13.0'
 

--- a/packages/amplify_flutter/ios/amplify_flutter.podspec
+++ b/packages/amplify_flutter/ios/amplify_flutter.podspec
@@ -17,9 +17,9 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.22.3'
-  s.dependency 'AWSPluginsCore', '1.22.3'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.22.3'
+  s.dependency 'Amplify', '1.23.0'
+  s.dependency 'AWSPluginsCore', '1.23.0'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.23.0'
   s.dependency 'amplify_core'
   s.dependency 'SwiftLint'
   s.dependency 'SwiftFormat/CLI'

--- a/packages/analytics/amplify_analytics_pinpoint_ios/ios/amplify_analytics_pinpoint_ios.podspec
+++ b/packages/analytics/amplify_analytics_pinpoint_ios/ios/amplify_analytics_pinpoint_ios.podspec
@@ -15,8 +15,8 @@ This code is the iOS part of the Amplify Flutter Pinpoint Analytics Plugin.  The
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.22.3'
-  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.22.3'
+  s.dependency 'Amplify', '1.23.0'
+  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.23.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
+++ b/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.22.3'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.22.3'
+  s.dependency 'Amplify', '1.23.0'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.23.0'
   s.dependency 'ObjectMapper'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'

--- a/packages/storage/amplify_storage_s3_ios/ios/amplify_storage_s3_ios.podspec
+++ b/packages/storage/amplify_storage_s3_ios/ios/amplify_storage_s3_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.22.3'
-  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.22.3'
+  s.dependency 'Amplify', '1.23.0'
+  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.23.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
*Issue #, if available:*
#1512 
#1504

*Description of changes:*
Includes an amplify-ios version bump to support XCode 12; bumps timeout in API's AuthProvider.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
