### PR TITLE
chore(auth): remove redundant switch case

### DIFF
--- a/packages/auth/amplify_auth_cognito/lib/amplify_auth_cognito_stream_controller.dart
+++ b/packages/auth/amplify_auth_cognito/lib/amplify_auth_cognito_stream_controller.dart
@@ -49,9 +49,6 @@ _onListen() {
         case "USER_DELETED":
           _authStreamController.add(AuthHubEvent(event["eventName"]));
           break;
-        case "USER_DELETED":
-          _authStreamController.add(AuthHubEvent(event["eventName"]));
-          break;
         default:
           break;
       }


### PR DESCRIPTION
*Description of changes:*
Removes dupe switch case in Auth Hub.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
