### PR TITLE
fix(core): Update QueryPagination page field to default to 0

### DIFF
--- a/packages/amplify_core/lib/src/types/query/query_pagination.dart
+++ b/packages/amplify_core/lib/src/types/query/query_pagination.dart
@@ -16,10 +16,10 @@
 part of 'query_field.dart';
 
 class QueryPagination {
-  final int? page;
+  final int page;
   final int limit;
 
-  const QueryPagination({this.page, this.limit = 100});
+  const QueryPagination({this.page = 0, this.limit = 100});
 
   const QueryPagination.firstPage() : this(page: 0);
 


### PR DESCRIPTION
*Issue #, if available:* #842

*Description of changes:* This PR updates the default constructor for `QueryPagination`s to supply a default value of `0` for the `page` field. The Kotlin version of the `QueryPaginationBuilder` checks to see if the serialized map passed to it contains the `page` key, but since the `serializeAsMap()` method *always* adds the page key, a `NullPointerException` can arise as a result.

Another fix considered was to update the `serializeAsMap()` method to only add the `page` key if page is defined. This would be a reasonable fix but only when coupled with the current `QueryPaginationBuilder` utilities. Opting for the default value would not require the "is the `page` key defined check.
* Also of note - Rather than removing these checks from the utilities, opting to keep them there as they are, in theory, directly usable outside of Flutter method channel context as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
