### PR TITLE
chore(aws): Bump min SDK version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,16 +37,93 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; Dart dev; PKGS: packages/aws_common, packages/aws_signature_v4; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; Dart 2.15.0; PKGS: packages/aws_common, packages/aws_signature_v4/example; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v3
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_common-packages/aws_signature_v4;commands:format-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0;packages:packages/aws_common-packages/aws_signature_v4/example;commands:format-analyze_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_common-packages/aws_signature_v4
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0;packages:packages/aws_common-packages/aws_signature_v4/example
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.3
+        with:
+          sdk: "2.15.0"
+      - id: checkout
+        uses: actions/checkout@v3.0.0
+      - id: packages_aws_common_pub_upgrade
+        name: packages/aws_common; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/aws_common
+        run: dart pub upgrade
+      - name: "packages/aws_common; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.packages_aws_common_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_common
+        run: "dart format --output=none --set-exit-if-changed ."
+      - name: "packages/aws_common; dart analyze --fatal-infos ."
+        if: "always() && steps.packages_aws_common_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_common
+        run: dart analyze --fatal-infos .
+      - id: packages_aws_signature_v4_example_pub_upgrade
+        name: packages/aws_signature_v4/example; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4/example
+        run: dart pub upgrade
+      - name: "packages/aws_signature_v4/example; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.packages_aws_signature_v4_example_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4/example
+        run: "dart format --output=none --set-exit-if-changed ."
+      - name: "packages/aws_signature_v4/example; dart analyze --fatal-infos ."
+        if: "always() && steps.packages_aws_signature_v4_example_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4/example
+        run: dart analyze --fatal-infos .
+  job_003:
+    name: "analyze_and_format; Dart 2.15.0; PKG: packages/aws_signature_v4; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos lib test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v3
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0;packages:packages/aws_signature_v4;commands:format-analyze_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0;packages:packages/aws_signature_v4
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.3
+        with:
+          sdk: "2.15.0"
+      - id: checkout
+        uses: actions/checkout@v3.0.0
+      - id: packages_aws_signature_v4_pub_upgrade
+        name: packages/aws_signature_v4; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4
+        run: dart pub upgrade
+      - name: "packages/aws_signature_v4; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4
+        run: "dart format --output=none --set-exit-if-changed ."
+      - name: "packages/aws_signature_v4; dart analyze --fatal-infos lib test"
+        if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4
+        run: dart analyze --fatal-infos lib test
+  job_004:
+    name: "analyze_and_format; Dart dev; PKGS: packages/aws_common, packages/aws_signature_v4/example; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v3
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_common-packages/aws_signature_v4/example;commands:format-analyze_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_common-packages/aws_signature_v4/example
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -68,6 +145,38 @@ jobs:
         if: "always() && steps.packages_aws_common_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_common
         run: dart analyze --fatal-infos .
+      - id: packages_aws_signature_v4_example_pub_upgrade
+        name: packages/aws_signature_v4/example; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4/example
+        run: dart pub upgrade
+      - name: "packages/aws_signature_v4/example; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.packages_aws_signature_v4_example_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4/example
+        run: "dart format --output=none --set-exit-if-changed ."
+      - name: "packages/aws_signature_v4/example; dart analyze --fatal-infos ."
+        if: "always() && steps.packages_aws_signature_v4_example_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4/example
+        run: dart analyze --fatal-infos .
+  job_005:
+    name: "analyze_and_format; Dart dev; PKG: packages/aws_signature_v4; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos lib test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v3
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_signature_v4;commands:format-analyze_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_signature_v4
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.3
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@v3.0.0
       - id: packages_aws_signature_v4_pub_upgrade
         name: packages/aws_signature_v4; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -77,21 +186,21 @@ jobs:
         if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_signature_v4
         run: "dart format --output=none --set-exit-if-changed ."
-      - name: "packages/aws_signature_v4; dart analyze --fatal-infos ."
+      - name: "packages/aws_signature_v4; dart analyze --fatal-infos lib test"
         if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_signature_v4
-        run: dart analyze --fatal-infos .
-  job_003:
-    name: "analyze_and_format; Dart stable; PKGS: packages/aws_common, packages/aws_signature_v4; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+        run: dart analyze --fatal-infos lib test
+  job_006:
+    name: "analyze_and_format; Dart stable; PKGS: packages/aws_common, packages/aws_signature_v4/example; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v3
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aws_common-packages/aws_signature_v4;commands:format-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aws_common-packages/aws_signature_v4/example;commands:format-analyze_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aws_common-packages/aws_signature_v4
+            os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aws_common-packages/aws_signature_v4/example
             os:ubuntu-latest;pub-cache-hosted;sdk:stable
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -113,6 +222,38 @@ jobs:
         if: "always() && steps.packages_aws_common_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_common
         run: dart analyze --fatal-infos .
+      - id: packages_aws_signature_v4_example_pub_upgrade
+        name: packages/aws_signature_v4/example; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4/example
+        run: dart pub upgrade
+      - name: "packages/aws_signature_v4/example; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.packages_aws_signature_v4_example_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4/example
+        run: "dart format --output=none --set-exit-if-changed ."
+      - name: "packages/aws_signature_v4/example; dart analyze --fatal-infos ."
+        if: "always() && steps.packages_aws_signature_v4_example_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4/example
+        run: dart analyze --fatal-infos .
+  job_007:
+    name: "analyze_and_format; Dart stable; PKG: packages/aws_signature_v4; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos lib test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v3
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aws_signature_v4;commands:format-analyze_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aws_signature_v4
+            os:ubuntu-latest;pub-cache-hosted;sdk:stable
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.3
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v3.0.0
       - id: packages_aws_signature_v4_pub_upgrade
         name: packages/aws_signature_v4; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -122,7 +263,7 @@ jobs:
         if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_signature_v4
         run: "dart format --output=none --set-exit-if-changed ."
-      - name: "packages/aws_signature_v4; dart analyze --fatal-infos ."
+      - name: "packages/aws_signature_v4; dart analyze --fatal-infos lib test"
         if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_signature_v4
-        run: dart analyze --fatal-infos .
+        run: dart analyze --fatal-infos lib test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,106 @@ env:
 
 jobs:
   job_001:
+    name: "unit_test; Dart 2.15.0; PKG: packages/aws_common; `dart test`, `dart test -p chrome`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v3
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0;packages:packages/aws_common;commands:test_0-test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0;packages:packages/aws_common
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.3
+        with:
+          sdk: "2.15.0"
+      - id: checkout
+        uses: actions/checkout@v3.0.0
+      - id: packages_aws_common_pub_upgrade
+        name: packages/aws_common; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/aws_common
+        run: dart pub upgrade
+      - name: packages/aws_common; dart test
+        if: "always() && steps.packages_aws_common_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_common
+        run: dart test
+      - name: "packages/aws_common; dart test -p chrome"
+        if: "always() && steps.packages_aws_common_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_common
+        run: dart test -p chrome
+  job_002:
+    name: "unit_test; Dart 2.15.0; PKG: packages/aws_signature_v4; `git submodule update --init`, `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v3
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0;packages:packages/aws_signature_v4;commands:command-test_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0;packages:packages/aws_signature_v4
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.3
+        with:
+          sdk: "2.15.0"
+      - id: checkout
+        uses: actions/checkout@v3.0.0
+      - id: packages_aws_signature_v4_pub_upgrade
+        name: packages/aws_signature_v4; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4
+        run: dart pub upgrade
+      - name: "packages/aws_signature_v4; git submodule update --init"
+        if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4
+        run: git submodule update --init
+      - name: packages/aws_signature_v4; dart test
+        if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4
+        run: dart test
+  job_003:
+    name: "unit_test; Dart 2.15.0; PKG: packages/aws_signature_v4; `git submodule update --init`, `dart test`, `dart test -p chrome`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v3
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0;packages:packages/aws_signature_v4;commands:command-test_0-test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0;packages:packages/aws_signature_v4
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.15.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.3
+        with:
+          sdk: "2.15.0"
+      - id: checkout
+        uses: actions/checkout@v3.0.0
+      - id: packages_aws_signature_v4_pub_upgrade
+        name: packages/aws_signature_v4; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4
+        run: dart pub upgrade
+      - name: "packages/aws_signature_v4; git submodule update --init"
+        if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4
+        run: git submodule update --init
+      - name: packages/aws_signature_v4; dart test
+        if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4
+        run: dart test
+      - name: "packages/aws_signature_v4; dart test -p chrome"
+        if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/aws_signature_v4
+        run: dart test -p chrome
+  job_004:
     name: "unit_test; Dart dev; PKG: packages/aws_common; `dart test`, `dart test -p chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -47,7 +147,7 @@ jobs:
         if: "always() && steps.packages_aws_common_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_common
         run: dart test -p chrome
-  job_002:
+  job_005:
     name: "unit_test; Dart dev; PKG: packages/aws_signature_v4; `git submodule update --init`, `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -79,7 +179,7 @@ jobs:
         if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_signature_v4
         run: dart test
-  job_003:
+  job_006:
     name: "unit_test; Dart dev; PKG: packages/aws_signature_v4; `git submodule update --init`, `dart test`, `dart test -p chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -115,7 +215,7 @@ jobs:
         if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_signature_v4
         run: dart test -p chrome
-  job_004:
+  job_007:
     name: "unit_test; Dart stable; PKG: packages/aws_common; `dart test`, `dart test -p chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -147,7 +247,7 @@ jobs:
         if: "always() && steps.packages_aws_common_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_common
         run: dart test -p chrome
-  job_005:
+  job_008:
     name: "unit_test; Dart stable; PKG: packages/aws_signature_v4; `git submodule update --init`, `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -179,7 +279,7 @@ jobs:
         if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_signature_v4
         run: dart test
-  job_006:
+  job_009:
     name: "unit_test; Dart stable; PKG: packages/aws_signature_v4; `git submodule update --init`, `dart test`, `dart test -p chrome`"
     runs-on: ubuntu-latest
     steps:

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/aws-amplify/amplify-flutter/packages/aws_common
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   async: ^2.8.2

--- a/packages/aws_signature_v4/example/mono_pkg.yaml
+++ b/packages/aws_signature_v4/example/mono_pkg.yaml
@@ -8,7 +8,3 @@ stages:
       - group:
           - format
           - analyze: --fatal-infos .
-  - unit_test:
-      - group:
-          - test:
-          - test: -p chrome

--- a/packages/aws_signature_v4/lib/src/signer/aws_signer.dart
+++ b/packages/aws_signature_v4/lib/src/signer/aws_signer.dart
@@ -275,8 +275,7 @@ class AWSSigV4Signer {
         sessionToken != null && canonicalRequest.omitSessionTokenFromSigning;
     if (canonicalRequest.presignedUrl) {
       queryParameters[AWSHeaders.signature] = signature;
-      // TODO(dnys1): Remove second check when package SDK dep is >=2.15.0
-      if (includeSessionToken && sessionToken != null) {
+      if (includeSessionToken) {
         queryParameters[AWSHeaders.securityToken] = sessionToken;
       }
     } else {
@@ -286,8 +285,7 @@ class AWSSigV4Signer {
         signedHeaders: canonicalRequest.signedHeaders,
         signature: signature,
       );
-      // TODO(dnys1): Remove second check when package SDK dep is >=2.15.0
-      if (includeSessionToken && sessionToken != null) {
+      if (includeSessionToken) {
         headers[AWSHeaders.securityToken] = sessionToken;
       }
     }

--- a/packages/aws_signature_v4/mono_pkg.yaml
+++ b/packages/aws_signature_v4/mono_pkg.yaml
@@ -1,4 +1,5 @@
 sdk:
+  - '2.15.0'
   - stable
   - dev
 
@@ -6,7 +7,7 @@ stages:
   - analyze_and_format:
       - group:
           - format
-          - analyze: --fatal-infos .
+          - analyze: --fatal-infos lib test
   - unit_test:
       - group:
           # Pull `aws-c-auth` with the test vectors

--- a/packages/aws_signature_v4/pubspec.yaml
+++ b/packages/aws_signature_v4/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/aws-amplify/amplify-flutter/packages/aws_signature_
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   async: ^2.6.0

--- a/packages/aws_signature_v4/test/build_verify_test.dart
+++ b/packages/aws_signature_v4/test/build_verify_test.dart
@@ -23,5 +23,6 @@ void main() {
     () => expectBuildClean(
       packageRelativeDirectory: 'packages/aws_signature_v4',
     ),
+    timeout: const Timeout(Duration(minutes: 3)),
   );
 }

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -67,9 +67,13 @@ for PKG in ${PKGS}; do
       echo
       echo -e "\033[1mPKG: ${PKG}; TASK: ${TASK}\033[22m"
       case ${TASK} in
-      analyze)
+      analyze_0)
         echo 'dart analyze --fatal-infos .'
         dart analyze --fatal-infos . || EXIT_CODE=$?
+        ;;
+      analyze_1)
+        echo 'dart analyze --fatal-infos lib test'
+        dart analyze --fatal-infos lib test || EXIT_CODE=$?
         ;;
       command)
         echo 'git submodule update --init'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Bumps the minimum SDK version to 2.15 (from 2.12). This is to align with the rest of Amplify Dart.
- Updates mono_repo config for the AWS packages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
