### PR TITLE
fix(aws_signature_v4): Various fixes

### DIFF
--- a/packages/aws_signature_v4/lib/src/configuration/service_configuration.dart
+++ b/packages/aws_signature_v4/lib/src/configuration/service_configuration.dart
@@ -19,10 +19,6 @@ import 'package:aws_signature_v4/aws_signature_v4.dart';
 import 'package:aws_signature_v4/src/version.dart';
 import 'package:meta/meta.dart';
 
-/// Zone flag to change inclusion of user agent header.
-@visibleForTesting
-const zIncludeUserAgent = #_includeUserAgent;
-
 /// {@template aws_signature_v4.service_configuration}
 /// A description of an [AWSSigV4Signer] configuration.
 /// {@endtemplate}
@@ -146,7 +142,8 @@ class BaseServiceConfiguration extends ServiceConfiguration {
     });
 
     // Add user agent header
-    if (Zone.current[zIncludeUserAgent] ?? true) {
+    final isSigningTest = Zone.current[zSigningTest] as bool? ?? false;
+    if (!isSigningTest) {
       const userAgent = 'aws-sdk-dart/$packageVersion';
       headers.update(
         zIsWeb ? AWSHeaders.amzUserAgent : AWSHeaders.userAgent,

--- a/packages/aws_signature_v4/lib/src/configuration/service_configuration.dart
+++ b/packages/aws_signature_v4/lib/src/configuration/service_configuration.dart
@@ -42,14 +42,27 @@ abstract class ServiceConfiguration {
   const ServiceConfiguration._({
     bool? normalizePath,
     bool? omitSessionToken,
+    bool? doubleEncodePathSegments,
   })  : normalizePath = normalizePath ?? true,
-        omitSessionToken = omitSessionToken ?? false;
+        omitSessionToken = omitSessionToken ?? false,
+        doubleEncodePathSegments = doubleEncodePathSegments ?? true;
 
   /// Whether to normalize paths in the canonical request.
+  ///
+  /// Defaults to `true`.
   final bool normalizePath;
 
   /// Whether to omit the session token during signing.
+  ///
+  /// Defaults to `false`.
   final bool omitSessionToken;
+
+  /// Whether path segments should be encoded twice.
+  ///
+  /// If `false`, path segments are only encoded once.
+  ///
+  /// Defaults to `true`.
+  final bool doubleEncodePathSegments;
 
   /// Applies service-specific keys to [headers] for signed header requests.
   @mustCallSuper
@@ -106,9 +119,11 @@ class BaseServiceConfiguration extends ServiceConfiguration {
   const BaseServiceConfiguration({
     bool? normalizePath,
     bool? omitSessionToken,
+    bool? doubleEncodePathSegments,
   }) : super._(
           normalizePath: normalizePath,
           omitSessionToken: omitSessionToken,
+          doubleEncodePathSegments: doubleEncodePathSegments,
         );
 
   @override

--- a/packages/aws_signature_v4/lib/src/configuration/services/s3.dart
+++ b/packages/aws_signature_v4/lib/src/configuration/services/s3.dart
@@ -77,6 +77,7 @@ class S3ServiceConfiguration extends BaseServiceConfiguration {
         super(
           normalizePath: false,
           omitSessionToken: false,
+          doubleEncodePathSegments: false,
         );
 
   int _calculateContentLength(AWSBaseHttpRequest request, int decodedLength) {

--- a/packages/aws_signature_v4/lib/src/configuration/services/s3.dart
+++ b/packages/aws_signature_v4/lib/src/configuration/services/s3.dart
@@ -50,8 +50,12 @@ class S3ServiceConfiguration extends BaseServiceConfiguration {
   // 64 KB is the recommended chunk size.
   static const int _defaultChunkSize = 64 * 1024;
 
-  static const _chunkedPayloadSeedHash = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD';
-  static const _unsignedChunkedPayloadSeedHash = 'UNSIGNED-PAYLOAD';
+  /// The seed hash used for chunked requests.
+  static const chunkedPayloadSeedHash = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD';
+
+  /// The hash sent for unsigned payloads.
+  static const unsignedPayloadHash = 'UNSIGNED-PAYLOAD';
+
   static final _sigSep = Uint8List.fromList(';chunk-signature='.codeUnits);
   static final _sep = Uint8List.fromList('\r\n'.codeUnits);
 
@@ -73,14 +77,18 @@ class S3ServiceConfiguration extends BaseServiceConfiguration {
     this.chunked = false,
     int chunkSize = _defaultChunkSize,
     this.encoding = S3PayloadEncoding.none,
-  })  : chunkSize = max(chunkSize, _minChunkSize),
+  })  : assert(
+          signPayload || !chunked,
+          'S3 does not accept unsigned, chunked payloads',
+        ),
+        chunkSize = max(chunkSize, _minChunkSize),
         super(
           normalizePath: false,
           omitSessionToken: false,
           doubleEncodePathSegments: false,
         );
 
-  int _calculateContentLength(AWSBaseHttpRequest request, int decodedLength) {
+  int _calculateContentLength(int decodedLength) {
     var chunkedLength = 0;
     var metadataLength = 0;
     var numChunks = (decodedLength / chunkSize).ceil() + 1;
@@ -120,10 +128,8 @@ class S3ServiceConfiguration extends BaseServiceConfiguration {
 
       if (encoding == S3PayloadEncoding.none) {
         headers[AWSHeaders.contentEncoding] = 'aws-chunked';
-        headers[AWSHeaders.contentLength] = _calculateContentLength(
-          request,
-          contentLength,
-        ).toString();
+        headers[AWSHeaders.contentLength] =
+            _calculateContentLength(contentLength).toString();
       } else {
         headers[AWSHeaders.contentEncoding] = 'aws-chunked,${encoding.value}';
       }
@@ -141,10 +147,11 @@ class S3ServiceConfiguration extends BaseServiceConfiguration {
     AWSBaseHttpRequest request, {
     required bool presignedUrl,
   }) async {
-    if (chunked || presignedUrl) {
-      return hashPayloadSync(request, presignedUrl: presignedUrl);
+    // Only unchunked, signed requests are hashed as other services would be.
+    if (signPayload && !chunked) {
+      return super.hashPayload(request, presignedUrl: presignedUrl);
     }
-    return super.hashPayload(request, presignedUrl: presignedUrl);
+    return hashPayloadSync(request, presignedUrl: presignedUrl);
   }
 
   @override
@@ -152,14 +159,11 @@ class S3ServiceConfiguration extends BaseServiceConfiguration {
     AWSBaseHttpRequest request, {
     required bool presignedUrl,
   }) {
-    if (presignedUrl) {
-      return _unsignedChunkedPayloadSeedHash;
+    if (presignedUrl || !signPayload) {
+      return unsignedPayloadHash;
     }
     if (chunked) {
-      if (signPayload) {
-        return _chunkedPayloadSeedHash;
-      }
-      return _unsignedChunkedPayloadSeedHash;
+      return chunkedPayloadSeedHash;
     }
     return super.hashPayloadSync(request, presignedUrl: presignedUrl);
   }

--- a/packages/aws_signature_v4/lib/src/configuration/services/s3.dart
+++ b/packages/aws_signature_v4/lib/src/configuration/services/s3.dart
@@ -138,7 +138,7 @@ class S3ServiceConfiguration extends BaseServiceConfiguration {
     if (signPayload) {
       headers[AWSHeaders.contentSHA256] = payloadHash;
     } else {
-      headers[AWSHeaders.contentSHA256] = 'UNSIGNED-PAYLOAD';
+      headers[AWSHeaders.contentSHA256] = unsignedPayloadHash;
     }
   }
 

--- a/packages/aws_signature_v4/lib/src/configuration/services/s3.dart
+++ b/packages/aws_signature_v4/lib/src/configuration/services/s3.dart
@@ -75,7 +75,7 @@ class S3ServiceConfiguration extends BaseServiceConfiguration {
     this.encoding = S3PayloadEncoding.none,
   })  : chunkSize = max(chunkSize, _minChunkSize),
         super(
-          normalizePath: true,
+          normalizePath: false,
           omitSessionToken: false,
         );
 

--- a/packages/aws_signature_v4/lib/src/configuration/services/s3.dart
+++ b/packages/aws_signature_v4/lib/src/configuration/services/s3.dart
@@ -74,7 +74,7 @@ class S3ServiceConfiguration extends BaseServiceConfiguration {
   /// {@macro aws_signature_v4.s3_service_configuration}
   S3ServiceConfiguration({
     this.signPayload = true,
-    this.chunked = false,
+    this.chunked = true,
     int chunkSize = _defaultChunkSize,
     this.encoding = S3PayloadEncoding.none,
   })  : assert(

--- a/packages/aws_signature_v4/lib/src/request/canonical_request/canonical_path.dart
+++ b/packages/aws_signature_v4/lib/src/request/canonical_request/canonical_path.dart
@@ -1,0 +1,48 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of 'canonical_request.dart';
+
+/// Helper methods for canonicalizing paths of a [CanonicalRequest].
+abstract class CanonicalPath {
+  CanonicalPath._();
+
+  /// Returns the normalized path with double-encoded path segments.
+  ///
+  /// Uses [url] to normalize the path.
+  static String canonicalize(
+    final String path, {
+    required ServiceConfiguration serviceConfiguration,
+  }) {
+    var canonicalPath = path;
+
+    // `normalize` removes leading and trailing slashes which should be
+    // preserved.
+    if (serviceConfiguration.normalizePath) {
+      canonicalPath = url.normalize(canonicalPath);
+      if (path.endsWith('/')) {
+        canonicalPath = canonicalPath.ensureEndsWith('/');
+      }
+      canonicalPath = canonicalPath.ensureStartsWith('/');
+    }
+
+    return canonicalPath.split('/').map((segment) {
+      segment = _safeEncode(segment);
+      if (serviceConfiguration.doubleEncodePathSegments) {
+        segment = Uri.encodeComponent(segment);
+      }
+      return segment;
+    }).join('/');
+  }
+}

--- a/packages/aws_signature_v4/lib/src/request/canonical_request/canonical_request.dart
+++ b/packages/aws_signature_v4/lib/src/request/canonical_request/canonical_request.dart
@@ -23,6 +23,7 @@ import 'package:crypto/crypto.dart';
 import 'package:path/path.dart';
 
 part 'canonical_headers.dart';
+part 'canonical_path.dart';
 part 'canonical_query_parameters.dart';
 part 'signed_headers.dart';
 part 'canonical_request_util.dart';
@@ -38,9 +39,9 @@ class CanonicalRequest {
   final AWSCredentialScope credentialScope;
 
   /// The canonicalized request path.
-  late final String canonicalPath = _canonicalPath(
-    request,
-    normalizePath: normalizePath,
+  late final String canonicalPath = CanonicalPath.canonicalize(
+    request.path,
+    serviceConfiguration: serviceConfiguration,
   );
 
   /// The request query parameters, with AWS values added, if necessary.
@@ -210,26 +211,6 @@ class CanonicalRequest {
   })  : normalizePath = serviceConfiguration.normalizePath,
         omitSessionTokenFromSigning = serviceConfiguration.omitSessionToken,
         expiresIn = expiresIn?.inSeconds;
-
-  /// Returns the normalized path with double-encoded path segments.
-  ///
-  /// Uses [url] to normalize the path.
-  static String _canonicalPath(
-    AWSBaseHttpRequest request, {
-    required bool normalizePath,
-  }) {
-    var path = normalizePath ? url.normalize(request.path) : request.path;
-
-    // `normalize` removes leading and trailing slashes which should be preserved.
-    if (normalizePath) {
-      if (request.path.endsWith('/')) {
-        path = path.ensureEndsWith('/');
-      }
-      path = path.ensureStartsWith('/');
-    }
-
-    return path.split('/').map(Uri.encodeComponent).join('/');
-  }
 
   /// Creates the canonical request string.
   @override

--- a/packages/aws_signature_v4/test/build_verify_test.dart
+++ b/packages/aws_signature_v4/test/build_verify_test.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 @TestOn('vm')
+@Tags(['build'])
 
 import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart';

--- a/packages/aws_signature_v4/test/c_test_suite/request_parser.dart
+++ b/packages/aws_signature_v4/test/c_test_suite/request_parser.dart
@@ -96,11 +96,11 @@ class SignerRequestParser {
       }
 
       // Concatenate values for the same key with a ','
-      headers.update(
-        key,
-        (currValue) => currValue + ',' + value,
-        ifAbsent: () => value,
-      );
+      if (headers.containsKey(key)) {
+        headers[key] = '${headers[key]},$value';
+      } else {
+        headers[key] = value;
+      }
 
       // Skip to the next key line
       lineNo = headerLines.indexWhere((el) => el.contains(':'), nextLineNo);

--- a/packages/aws_signature_v4/test/c_test_suite/test_data.dart
+++ b/packages/aws_signature_v4/test/c_test_suite/test_data.dart
@@ -140,6 +140,10 @@ class SignerTest {
             BaseServiceConfiguration(
               normalizePath: context.normalize,
               omitSessionToken: context.omitSessionToken,
+
+              // Although most SigV4 services expect double encoding, the C
+              // tests expect single encoding like S3.
+              doubleEncodePathSegments: false,
             );
 
   factory SignerTest.fromJson(Map<String, Object?> json) {

--- a/packages/aws_signature_v4/test/c_test_suite/test_data.dart
+++ b/packages/aws_signature_v4/test/c_test_suite/test_data.dart
@@ -143,6 +143,7 @@ class SignerTest {
 
               // Although most SigV4 services expect double encoding, the C
               // tests expect single encoding like S3.
+              // https://github.com/awslabs/aws-c-auth/issues/162
               doubleEncodePathSegments: false,
             );
 

--- a/packages/aws_signature_v4/test/common.dart
+++ b/packages/aws_signature_v4/test/common.dart
@@ -12,21 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
+import 'package:aws_common/aws_common.dart';
 import 'package:aws_signature_v4/aws_signature_v4.dart';
-import 'package:test/scaffolding.dart';
 
-import 'testdata/multiple_chunks_testdata.dart';
-
-// From: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html#example-signature-calculations-streaming
-
-void main() {
-  group('S3 Multiple Chunks', () {
-    test('PUT Object', () {
-      runZoned(putObjectTest.run, zoneValues: {
-        zSigningTest: true,
-      });
-    });
-  });
-}
+const dummyCredentials = AWSCredentials('accessKeyId', 'secretAccessKey');
+final dummyCredentialScope =
+    AWSCredentialScope(region: 'us-east-1', service: AWSService.iam);

--- a/packages/aws_signature_v4/test/headers_test.dart
+++ b/packages/aws_signature_v4/test/headers_test.dart
@@ -1,0 +1,82 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:aws_common/aws_common.dart';
+import 'package:aws_signature_v4/aws_signature_v4.dart';
+import 'package:test/test.dart';
+
+import 'common.dart';
+
+void main() {
+  group('Headers', () {
+    const signer = AWSSigV4Signer(
+      credentialsProvider: AWSCredentialsProvider(dummyCredentials),
+    );
+    final request = AWSHttpRequest.post(
+      Uri.https('example.com', '/'),
+      body: utf8.encode('hello'),
+      headers: const {
+        AWSHeaders.contentLength: '5',
+      },
+    );
+    final signedRequest = signer.signSync(
+      request,
+      credentialScope: dummyCredentialScope,
+    );
+    final signedHeaders = CaseInsensitiveMap(
+      signedRequest.canonicalRequest.canonicalHeaders,
+    );
+    final sentHeaders = signedRequest.headers;
+
+    test('Host, Content-Length unset by signer (web)', () {
+      expect(
+        signedHeaders,
+        contains(AWSHeaders.host),
+      );
+      expect(
+        signedHeaders,
+        contains(AWSHeaders.contentLength),
+      );
+      expect(
+        sentHeaders,
+        isNot(contains(AWSHeaders.host)),
+      );
+      expect(
+        sentHeaders,
+        isNot(contains(AWSHeaders.contentLength)),
+      );
+    }, testOn: 'browser');
+
+    test('Host, Content-Length set by signer (vm)', () {
+      expect(
+        signedHeaders,
+        contains(AWSHeaders.host),
+      );
+      expect(
+        signedHeaders,
+        contains(AWSHeaders.contentLength),
+      );
+      expect(
+        sentHeaders,
+        contains(AWSHeaders.host),
+      );
+      expect(
+        sentHeaders,
+        contains(AWSHeaders.contentLength),
+      );
+    }, testOn: 'vm');
+  });
+}

--- a/packages/aws_signature_v4/test/s3/s3_service_configuration_test.dart
+++ b/packages/aws_signature_v4/test/s3/s3_service_configuration_test.dart
@@ -1,0 +1,88 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:aws_common/aws_common.dart';
+import 'package:aws_signature_v4/aws_signature_v4.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const bodyHash =
+      '44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072';
+  AWSBaseHttpRequest createRequest() => AWSHttpRequest(
+        method: AWSHttpMethod.put,
+        uri: Uri.https(
+          'examplebucket.s3.amazonaws.com',
+          r'/test$file.text',
+        ),
+        body: 'Welcome to Amazon S3.'.codeUnits,
+      );
+
+  Future<void> expectHash({
+    required bool signPayload,
+    required bool chunked,
+    required Matcher expected,
+  }) async {
+    final serviceConfiguration = S3ServiceConfiguration(
+      signPayload: signPayload,
+      chunked: chunked,
+    );
+    final payloadHash = await serviceConfiguration.hashPayload(
+      createRequest(),
+      presignedUrl: false,
+    );
+    final syncPayloadHash = serviceConfiguration.hashPayloadSync(
+      createRequest(),
+      presignedUrl: false,
+    );
+
+    expect(payloadHash, expected);
+    expect(syncPayloadHash, expected);
+  }
+
+  group('S3ServiceConfiguration', () {
+    test('signPayload=true chunked=true', () {
+      expectHash(
+        signPayload: true,
+        chunked: true,
+        expected: equals(S3ServiceConfiguration.chunkedPayloadSeedHash),
+      );
+    });
+
+    test('signPayload=true chunked=false', () {
+      expectHash(
+        signPayload: true,
+        chunked: false,
+        expected: equals(bodyHash),
+      );
+    });
+
+    test('signPayload=false chunked=false', () {
+      expectHash(
+        signPayload: false,
+        chunked: false,
+        expected: equals(S3ServiceConfiguration.unsignedPayloadHash),
+      );
+    });
+
+    test('signPayload=false chunked=true', () {
+      expect(
+        () => S3ServiceConfiguration(
+          signPayload: false,
+          chunked: true,
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+}

--- a/packages/aws_signature_v4/test/s3/single_chunk_test.dart
+++ b/packages/aws_signature_v4/test/s3/single_chunk_test.dart
@@ -27,7 +27,7 @@ void main() {
       for (var signerTest in testCases) {
         test(signerTest.name, () {
           runZoned(signerTest.run, zoneValues: {
-            zIncludeUserAgent: false,
+            zSigningTest: true,
           });
         });
       }

--- a/packages/aws_signature_v4/test/s3/testdata/multiple_chunks_testdata.dart
+++ b/packages/aws_signature_v4/test/s3/testdata/multiple_chunks_testdata.dart
@@ -93,7 +93,9 @@ final putObjectTest = SignerTest(
     headers: {
       'x-amz-storage-class': 'REDUCED_REDUNDANCY',
     },
-    body: chunks,
+    body: Stream.multi(
+      (controller) => controller.addStream(chunks),
+    ),
     contentLength: 66560,
   ),
   headerTestData: putObjectTestData,

--- a/packages/aws_signature_v4/test/s3/testdata/single_chunk_testdata.dart
+++ b/packages/aws_signature_v4/test/s3/testdata/single_chunk_testdata.dart
@@ -20,7 +20,10 @@ import '../../c_test_suite/test_data.dart';
 
 import 'util.dart';
 
-final serviceConfiguration = S3ServiceConfiguration();
+final serviceConfiguration = S3ServiceConfiguration(
+  signPayload: true,
+  chunked: false,
+);
 
 final testCases = <SignerTest>[
   getObjectTest,

--- a/packages/aws_signature_v4/test/service_configuration_test.dart
+++ b/packages/aws_signature_v4/test/service_configuration_test.dart
@@ -1,0 +1,68 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:aws_signature_v4/aws_signature_v4.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const unencodedPath = r'/spaced path/test$file.txt';
+  const encodedPath = '/spaced%20path/test%24file.txt';
+  const doubleEncodedPath = '/spaced%2520path/test%2524file.txt';
+
+  group('ServiceConfiguration', () {
+    group('base', () {
+      const serviceConfiguration = BaseServiceConfiguration();
+
+      test('double encodes path segments', () {
+        expect(
+          CanonicalPath.canonicalize(
+            unencodedPath,
+            serviceConfiguration: serviceConfiguration,
+          ),
+          doubleEncodedPath,
+        );
+
+        expect(
+          CanonicalPath.canonicalize(
+            encodedPath,
+            serviceConfiguration: serviceConfiguration,
+          ),
+          doubleEncodedPath,
+        );
+      });
+    });
+
+    group('s3', () {
+      final serviceConfiguration = S3ServiceConfiguration();
+
+      test('single encodes path segments', () {
+        expect(
+          CanonicalPath.canonicalize(
+            unencodedPath,
+            serviceConfiguration: serviceConfiguration,
+          ),
+          encodedPath,
+        );
+
+        expect(
+          CanonicalPath.canonicalize(
+            encodedPath,
+            serviceConfiguration: serviceConfiguration,
+          ),
+          encodedPath,
+        );
+      });
+    });
+  });
+}

--- a/packages/aws_signature_v4/test/signer_html_test.dart
+++ b/packages/aws_signature_v4/test/signer_html_test.dart
@@ -38,7 +38,7 @@ Future<void> main() async {
           SignerTest.fromJson((jsonDecode(testCaseJson) as Map).cast());
       safePrint('Running test: ${signerTest.name}');
       await runZoned(signerTest.run, zoneValues: {
-        zIncludeUserAgent: false,
+        zSigningTest: true,
       });
     }
   });

--- a/packages/aws_signature_v4/test/streamed_request_test.dart
+++ b/packages/aws_signature_v4/test/streamed_request_test.dart
@@ -20,14 +20,14 @@ import 'package:http/http.dart';
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
-const _dummyCredentials = AWSCredentials('accessKeyId', 'secretAccessKey');
+import 'common.dart';
 
 void main() {
   final uri = Uri.parse('https://example.com');
 
   group('AWSStreamedHttpRequest', () {
     const signer = AWSSigV4Signer(
-      credentialsProvider: AWSCredentialsProvider(_dummyCredentials),
+      credentialsProvider: AWSCredentialsProvider(dummyCredentials),
     );
     final mockClient = MockHttpClient();
     Stream<List<int>> makeBody() => Stream.fromIterable([


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixes a problem with S3 path normalization (S3 paths should be un-normalized)
- Fixes a problem with S3 path encoding. S3 path segments should be encoded once, every other service expects double-encoding. The confusion was that the test suite expects single-encoding like S3.
- Fixes a problem with S3 options (chunked/signPayload). Adds tests to verify permutations work as expected.
- Removes `Host` and `Content-Length` headers on Web after signing to prevent browser errors warning against setting these manually


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
