### PR TITLE
chore(ci): Update melos configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
       - run:
           name: Install and set up melos
           command: |
-            flutter pub global activate melos 1.3.0
+            flutter pub global activate melos 2.3.0
             melos bootstrap
   activate_pana:
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.2.1
+# Created with package:mono_repo v6.2.2
 name: Dart Lint
 on:
   push:
@@ -31,9 +31,9 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.2.1
+        run: dart pub global activate mono_repo 6.2.2
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
@@ -54,7 +54,7 @@ jobs:
         with:
           sdk: "2.15.0"
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_common_pub_upgrade
         name: packages/aws_common; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -99,7 +99,7 @@ jobs:
         with:
           sdk: "2.15.0"
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_signature_v4_pub_upgrade
         name: packages/aws_signature_v4; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -131,7 +131,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_common_pub_upgrade
         name: packages/aws_common; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -176,7 +176,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_signature_v4_pub_upgrade
         name: packages/aws_signature_v4; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -208,7 +208,7 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_common_pub_upgrade
         name: packages/aws_common; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -253,7 +253,7 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_signature_v4_pub_upgrade
         name: packages/aws_signature_v4; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.2.1
+# Created with package:mono_repo v6.2.2
 name: Test
 on:
   push:
@@ -33,7 +33,7 @@ jobs:
         with:
           sdk: "2.15.0"
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_common_pub_upgrade
         name: packages/aws_common; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -65,7 +65,7 @@ jobs:
         with:
           sdk: "2.15.0"
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_signature_v4_pub_upgrade
         name: packages/aws_signature_v4; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -97,7 +97,7 @@ jobs:
         with:
           sdk: "2.15.0"
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_signature_v4_pub_upgrade
         name: packages/aws_signature_v4; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -133,7 +133,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_common_pub_upgrade
         name: packages/aws_common; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -165,7 +165,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_signature_v4_pub_upgrade
         name: packages/aws_signature_v4; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -197,7 +197,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_signature_v4_pub_upgrade
         name: packages/aws_signature_v4; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -233,7 +233,7 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_common_pub_upgrade
         name: packages/aws_common; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -265,7 +265,7 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_signature_v4_pub_upgrade
         name: packages/aws_signature_v4; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -297,7 +297,7 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - id: packages_aws_signature_v4_pub_upgrade
         name: packages/aws_signature_v4; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 **/ios/.symlinks/
 **/android/.settings/
 pubspec.lock
+pubspec_overrides.yaml
 Podfile.lock
 *.iml
 *.jar
@@ -18,7 +19,6 @@ Podfile.lock
 
 # IDEs
 .idea/
-.vscode/
 .atom/
 .idea/
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "dart.runPubGetOnPubspecChanges": false,
   "files.insertFinalNewline": true
 }

--- a/melos.yaml
+++ b/melos.yaml
@@ -12,6 +12,7 @@ ignore:
 command:
   bootstrap:
     usePubspecOverrides: true
+    runPubGetInParallel: false
 
 scripts:
   setup_tuneup: >

--- a/melos.yaml
+++ b/melos.yaml
@@ -9,6 +9,10 @@ packages:
 ignore:
   - synthetic_package
 
+command:
+  bootstrap:
+    usePubspecOverrides: true
+
 scripts:
   setup_tuneup: >
     flutter pub global activate tuneup
@@ -348,8 +352,8 @@ scripts:
     description: Run "pod repo update" and then updates amplify related pods. Intended for use after amplify iOS version has been updated.
 
   postbootstrap: |
-    melos run copy_dummy_config && \
-    melos run packages:fix
+    melos run copy_dummy_config
+
   postclean: >
     melos exec -- \
       rm -rf ./build ./android/.gradle ./ios/.symlinks ./ios/Pods ./ios/Podfile.lock

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -23,31 +23,6 @@ dependencies:
   meta: ^1.7.0
   plugin_platform_interface: ^2.0.0
 
-## Uncomment to run `flutter pub run build_runner` (cannot use Melos).
-# dependency_overrides:
-#   amplify_analytics_pinpoint:
-#     path: ../amplify_analytics_pinpoint
-#   amplify_analytics_plugin_interface:
-#     path: ../amplify_analytics_plugin_interface
-#   amplify_api:
-#     path: ../amplify_api
-#   amplify_api_plugin_interface:
-#     path: ../amplify_api_plugin_interface
-#   amplify_auth_cognito:
-#     path: ../amplify_auth_cognito
-#   amplify_auth_plugin_interface:
-#     path: ../amplify_auth_plugin_interface
-#   amplify_core:
-#     path: ../amplify_core
-#   amplify_datastore:
-#     path: ../amplify_datastore
-#   amplify_datastore_plugin_interface:
-#     path: ../amplify_datastore_plugin_interface
-#   amplify_storage_plugin_interface:
-#     path: ../amplify_storage_plugin_interface
-#   amplify_storage_s3:
-#     path: ../amplify_storage_s3
-
 dev_dependencies:
   amplify_analytics_pinpoint: 0.4.3
   amplify_api: 0.4.3

--- a/packages/aws_common/pubspec_overrides.yaml
+++ b/packages/aws_common/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: amplify_lints
+dependency_overrides:
+  amplify_lints:
+    path: ../amplify_lints

--- a/packages/aws_signature_v4/example/pubspec.yaml
+++ b/packages/aws_signature_v4/example/pubspec.yaml
@@ -14,10 +14,6 @@ dependencies:
   http: ^0.13.0
   path: ^1.8.0
 
-dependency_overrides:
-  aws_common:
-    path: ../../aws_common
-
 dev_dependencies:
   amplify_lints: ^1.0.0
   build_runner: ^2.0.0

--- a/packages/aws_signature_v4/example/pubspec_overrides.yaml
+++ b/packages/aws_signature_v4/example/pubspec_overrides.yaml
@@ -1,0 +1,8 @@
+# melos_managed_dependency_overrides: amplify_lints,aws_common,aws_signature_v4
+dependency_overrides:
+  amplify_lints:
+    path: ../../amplify_lints
+  aws_common:
+    path: ../../aws_common
+  aws_signature_v4:
+    path: ..

--- a/packages/aws_signature_v4/pubspec.yaml
+++ b/packages/aws_signature_v4/pubspec.yaml
@@ -18,10 +18,6 @@ dependencies:
   meta: ^1.0.0
   path: ^1.8.0
 
-dependency_overrides:
-  aws_common:
-    path: ../aws_common
-
 dev_dependencies:
   amplify_lints: ^1.0.0
   args: ^2.2.0

--- a/packages/aws_signature_v4/pubspec_overrides.yaml
+++ b/packages/aws_signature_v4/pubspec_overrides.yaml
@@ -1,0 +1,6 @@
+# melos_managed_dependency_overrides: amplify_lints,aws_common
+dependency_overrides:
+  amplify_lints:
+    path: ../amplify_lints
+  aws_common:
+    path: ../aws_common

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.2.1
+# Created with package:mono_repo v6.2.2
 
 # Support built in commands on windows out of the box.
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change takes advantage of a new feature in `pub` called `pubspec_overrides` which allows for local overrides to the `pubspec.yaml` while developing without affecting publishing. This works by not checking in the `pubspec_overrides.yaml` file. As of the latest melos version, it will automatically generate this file for you.

The benefit of this approach is that `dart`/`flutter pub get` will correctly work now! 🎉

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
