### PR TITLE
chore: bump amplify-android version to 1.35.3

### DIFF
--- a/packages/amplify/amplify_flutter_android/android/build.gradle
+++ b/packages/amplify/amplify_flutter_android/android/build.gradle
@@ -72,7 +72,7 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:core:1.35.1'
+    implementation 'com.amplifyframework:core:1.35.3'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 
     testImplementation 'junit:junit:4.13.2'
@@ -81,6 +81,6 @@ dependencies {
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'com.google.code.gson:gson:2.8.6'
-    testImplementation 'com.amplifyframework:aws-auth-cognito:1.35.1'
+    testImplementation 'com.amplifyframework:aws-auth-cognito:1.35.3'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9'
 }

--- a/packages/amplify_core/android/build.gradle
+++ b/packages/amplify_core/android/build.gradle
@@ -69,7 +69,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.amplifyframework:core:1.35.1'
+    implementation 'com.amplifyframework:core:1.35.3'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -69,8 +69,8 @@ android {
 }
 
 dependencies {
-    implementation "com.amplifyframework:aws-datastore:1.35.1"
-    implementation "com.amplifyframework:aws-api-appsync:1.35.1"
+    implementation "com.amplifyframework:aws-datastore:1.35.3"
+    implementation "com.amplifyframework:aws-api-appsync:1.35.3"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/packages/analytics/amplify_analytics_pinpoint_android/android/build.gradle
+++ b/packages/analytics/amplify_analytics_pinpoint_android/android/build.gradle
@@ -72,8 +72,8 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.35.1'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.35.1'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.35.3'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.35.3'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/packages/api/amplify_api_android/android/build.gradle
+++ b/packages/api/amplify_api_android/android/build.gradle
@@ -72,8 +72,8 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation "com.amplifyframework:aws-api:1.35.1"
-    implementation "com.amplifyframework:aws-api-appsync:1.35.1"
+    implementation "com.amplifyframework:aws-api:1.35.3"
+    implementation "com.amplifyframework:aws-api-appsync:1.35.3"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 
     testImplementation 'junit:junit:4.13.2'

--- a/packages/auth/amplify_auth_cognito_android/android/build.gradle
+++ b/packages/auth/amplify_auth_cognito_android/android/build.gradle
@@ -74,7 +74,7 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:aws-auth-cognito:1.35.1'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.35.3'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/packages/storage/amplify_storage_s3_android/android/build.gradle
+++ b/packages/storage/amplify_storage_s3_android/android/build.gradle
@@ -62,5 +62,5 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:aws-storage-s3:1.35.1'
+    implementation 'com.amplifyframework:aws-storage-s3:1.35.3'
 }


### PR DESCRIPTION
*Issue #, if available:*

#1131 

*Description of changes:*

Bump amplify-android version to [1.35.3](https://github.com/aws-amplify/amplify-android/releases/tag/release_v1.35.3), which include a fix to resolve the issue described in #1131 .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
