### PR TITLE
fix: email/phonenumber username not persisted to next component

### DIFF
--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -27,20 +27,7 @@ mixin AuthenticatorUsernameField<FieldType,
     on AuthenticatorFormFieldState<FieldType, UsernameInput, T> {
   @override
   UsernameInput? get initialValue {
-    String? username;
-    switch (selectedUsernameType) {
-      case UsernameType.username:
-        username = state.username;
-        break;
-      case UsernameType.email:
-        username = state.getAttribute(CognitoUserAttributeKey.email);
-        break;
-      case UsernameType.phoneNumber:
-        username = state.getAttribute(CognitoUserAttributeKey.phoneNumber);
-        break;
-    }
-
-    return UsernameInput(type: selectedUsernameType, username: username ?? '');
+    return UsernameInput(type: selectedUsernameType, username: state.username);
   }
 
   @override


### PR DESCRIPTION
*Description of changes:*
This PR addresses a case in which the customer creates a signup form in which the username is a phone or email, and the value is expected to be persisted to the next confirmSignUpScreen. 

Currently, the persistence only works if the customer ALSO uses a secondary attribute field to capture the email or phone (again), because the state for these values are not set by the username `onChanged` method, yet the username field's `initialValue` getter attempts to retrieve them (email or phone) from state when setting the initial value of the new username field.

An alternative to this fix (which changes the initialValue getter) might be to update the email/phone state values in the username fields `onChanged`. 

I am not 100% sure that either of these are the correct solution (I'm not super familiar with all of the username code), but this at least fixes the failing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
