### PR TITLE
fix(api): support enums in query predicates for model helpers

### DIFF
--- a/packages/api/amplify_api/lib/src/graphql/graphql_request_factory.dart
+++ b/packages/api/amplify_api/lib/src/graphql/graphql_request_factory.dart
@@ -341,7 +341,8 @@ String _getGraphQLFilterExpression(QueryFieldOperatorType operatorType) {
   return result;
 }
 
-/// Convert Temporal* and DateTime values to string if needed; otherwise return unchanged.
+/// Convert Temporal*, DateTime and enum values to string if needed.
+/// Otherwise return unchanged.
 dynamic _getSerializedValue(dynamic value) {
   if (value is TemporalDateTime ||
       value is TemporalDate ||
@@ -351,6 +352,9 @@ dynamic _getSerializedValue(dynamic value) {
   }
   if (value is DateTime) {
     return _getSerializedValue(TemporalDateTime(value));
+  }
+  if (value is Enum) {
+    return describeEnum(value);
   }
   return value;
 }

--- a/packages/api/amplify_api/test/query_predicate_graphql_filter_test.dart
+++ b/packages/api/amplify_api/test/query_predicate_graphql_filter_test.dart
@@ -2,6 +2,7 @@ import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_api/src/graphql/graphql_request_factory.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_test/test_models/ModelProvider.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 enum Size { SMALL, MEDIUM, LARGE }
@@ -217,7 +218,7 @@ void main() {
       // expect this predicate to translate as follows.
       final queryPredicate = Post.TITLE.eq(Size.MEDIUM);
       final expectedFilter = {
-        'title': {'eq': 'MEDIUM'}
+        'title': {'eq': describeEnum(Size.MEDIUM)}
       };
 
       _testQueryPredicateTranslation(queryPredicate, expectedFilter,

--- a/packages/api/amplify_api/test/query_predicate_graphql_filter_test.dart
+++ b/packages/api/amplify_api/test/query_predicate_graphql_filter_test.dart
@@ -4,6 +4,8 @@ import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_test/test_models/ModelProvider.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+enum Size { SMALL, MEDIUM, LARGE }
+
 void main() {
   group('queryPredicateToGraphQLFilter()', () {
     // needed to fetch the schema from within the helper
@@ -204,6 +206,18 @@ void main() {
       final queryPredicate = Post.BLOG.eq(blogId);
       final expectedFilter = {
         'blogID': {'eq': blogId}
+      };
+
+      _testQueryPredicateTranslation(queryPredicate, expectedFilter,
+          modelType: Post.classType);
+    });
+
+    test('query with enum should serialize to string', () {
+      // Note: enums are not actually in the codegen model. Nonetheless, we
+      // expect this predicate to translate as follows.
+      final queryPredicate = Post.TITLE.eq(Size.MEDIUM);
+      final expectedFilter = {
+        'title': {'eq': 'MEDIUM'}
       };
 
       _testQueryPredicateTranslation(queryPredicate, expectedFilter,


### PR DESCRIPTION
Issue #1567 

Model helpers for GraphQL accepts query predicates for some requests. The predicates get serialized into JSON objects which are included as request variables at runtime. There is a nasty error in the library when someone passes an enum into the query predicates. This small PR just calls `describeEnum` to convert them to a string.

Note that there is still a CLI issue at play here https://github.com/aws-amplify/amplify-cli/issues/10370 which makes the compiled schema look for int values instead of strings. That has been identified as a bug and this PR fixes the amplify-flutter end of it and will work if either a) the bug in CLI is fixed b) the appsync compiled schema is manually modified to accept strings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
