### PR TITLE
fix(dataStore): update in memory sorts and filters for IDs

### DIFF
--- a/packages/amplify_core/lib/src/types/query/query_field.dart
+++ b/packages/amplify_core/lib/src/types/query/query_field.dart
@@ -16,6 +16,7 @@
 library query_field;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/query/query_utils.dart';
 import 'package:flutter/foundation.dart';
 
 part 'query_field_operators.dart';

--- a/packages/amplify_core/lib/src/types/query/query_predicate.dart
+++ b/packages/amplify_core/lib/src/types/query/query_predicate.dart
@@ -69,8 +69,9 @@ class QueryPredicateOperation extends QueryPredicate {
 
   @override
   bool evaluate(Model model) {
+    String fieldName = getFieldName(field);
     //ignore:implicit_dynamic_variable
-    var value = model.toJson()[field];
+    var value = model.toJson()[fieldName];
     return queryFieldOperator.evaluate(value);
   }
 

--- a/packages/amplify_core/lib/src/types/query/query_sort.dart
+++ b/packages/amplify_core/lib/src/types/query/query_sort.dart
@@ -32,8 +32,9 @@ class QuerySortBy {
   const QuerySortBy({required this.order, required this.field});
 
   int compare<T extends Model>(T a, T b) {
-    dynamic valueA = a.toJson()[field];
-    dynamic valueB = b.toJson()[field];
+    String fieldName = getFieldName(field);
+    dynamic valueA = a.toJson()[fieldName];
+    dynamic valueB = b.toJson()[fieldName];
     int orderMultiplier = order == QuerySortOrder.ascending ? 1 : -1;
     if (valueA == null || valueB == null) {
       return orderMultiplier * _compareNull(valueA, valueB);

--- a/packages/amplify_core/lib/src/types/query/query_utils.dart
+++ b/packages/amplify_core/lib/src/types/query/query_utils.dart
@@ -13,10 +13,10 @@
  * permissions and limitations under the License.
  */
 
-/// Removes the model name that is pre-pended to field names.
+/// Removes the model name that is pre-pended to id fields.
 ///
 /// ID fields are named `<Model_Name>.<Field_Name>`, for example "blog.id".
 /// This util will remove the model name and return just the field name ("id").
 String getFieldName(String fieldName) {
-  return fieldName.contains('.') ? fieldName.split('.').last : fieldName;
+  return fieldName.endsWith('.id') ? 'id' : fieldName;
 }

--- a/packages/amplify_core/lib/src/types/query/query_utils.dart
+++ b/packages/amplify_core/lib/src/types/query/query_utils.dart
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/// Removes the model name that is pre-pended to field names.
+///
+/// ID fields are named `<Model_Name>.<Field_Name>`, for example "blog.id".
+/// This util will remove the model name and return just the field name ("id").
+String getFieldName(String fieldName) {
+  return fieldName.contains('.') ? fieldName.split('.').last : fieldName;
+}

--- a/packages/amplify_datastore/test/query_predicate_test.dart
+++ b/packages/amplify_datastore/test/query_predicate_test.dart
@@ -161,6 +161,13 @@ void main() {
       expect(testPredicate.evaluate(post2), isFalse);
       expect(testPredicate.evaluate(post4), isFalse);
     });
+
+    test('equals (ID)', () {
+      QueryPredicate testPredicate = Post.ID.eq(post2.id);
+      expect(testPredicate.evaluate(post1), isFalse);
+      expect(testPredicate.evaluate(post2), isTrue);
+      expect(testPredicate.evaluate(post4), isFalse);
+    });
     test('not equals', () {
       QueryPredicate testPredicate = Post.LIKECOUNT.ne(1);
       expect(testPredicate.evaluate(post1), isFalse);

--- a/packages/amplify_datastore/test/query_predicate_test.dart
+++ b/packages/amplify_datastore/test/query_predicate_test.dart
@@ -168,6 +168,7 @@ void main() {
       expect(testPredicate.evaluate(post2), isTrue);
       expect(testPredicate.evaluate(post4), isFalse);
     });
+
     test('not equals', () {
       QueryPredicate testPredicate = Post.LIKECOUNT.ne(1);
       expect(testPredicate.evaluate(post1), isFalse);

--- a/packages/amplify_datastore/test/query_sort_test.dart
+++ b/packages/amplify_datastore/test/query_sort_test.dart
@@ -53,12 +53,14 @@ void main() {
 
   group('compare', () {
     Post post1 = Post(
+      id: '123e4567-e89b-12d3-a456-426614174000',
       title: 'post1',
       rating: 1,
       created: TemporalDateTime(DateTime(2020, 01, 01, 10, 30)),
     );
 
     Post post2 = Post(
+      id: '123e4567-e89b-12d3-a456-426614174001',
       title: 'post2',
       rating: 2,
       created: TemporalDateTime(DateTime(2020, 01, 01, 12, 30)),
@@ -71,6 +73,19 @@ void main() {
     Post post4 = post1.copyWith(likeCount: 1);
 
     Post post4Copy = post4.copyWith();
+
+    test('should compare ID fields', () {
+      QuerySortBy sortByAsc = Post.ID.ascending();
+      QuerySortBy sortByDesc = Post.ID.descending();
+
+      expect(sortByAsc.compare(post1, post2), -1);
+      expect(sortByAsc.compare(post2, post1), 1);
+      expect(sortByAsc.compare(post2, post2Copy), 0);
+
+      expect(sortByDesc.compare(post1, post2), 1);
+      expect(sortByDesc.compare(post2, post1), -1);
+      expect(sortByDesc.compare(post2, post2Copy), 0);
+    });
 
     test('should compare int fields', () {
       QuerySortBy sortByAsc = Post.RATING.ascending();


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/1594

*Description of changes:*
- remove model name from ID fields for in-memory field comparisons

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
