### PR TITLE
chore: add github action to lint PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,6 +13,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+        # amannn/action-semantic-pull-request@4.5
+      - uses: amannn/action-semantic-pull-request@6a7ed2d5046cf8a40c60494c83c962343061874a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,18 @@
+# Validates that PR titles follow conventional commits
+name: "PR Title Lint"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Add a GitHub action to lint PR titles according to conventional commits

This was validated in a fork. [See PR 10-14](https://github.com/Jordan-Nelson/amplify-flutter/pulls) for several good PR titles that pass CI and one bad title that fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
