### PR TITLE
fix(secure_storage): make database late initializer

### DIFF
--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_web.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_web.dart
@@ -58,8 +58,8 @@ class AmplifySecureStorageWeb extends AmplifySecureStorageInterface {
         database.createObjectStore(storeName);
       }
     };
-    // TODO: update once https://github.com/dart-lang/sdk/issues/48835 
-    // is resolved in a stable version. setting _database instead of returning 
+    // TODO: update once https://github.com/dart-lang/sdk/issues/48835
+    // is resolved in a stable version. setting _database instead of returning
     // it is a work around.
     _database = await openRequest.future;
   }

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_web.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_web.dart
@@ -58,8 +58,9 @@ class AmplifySecureStorageWeb extends AmplifySecureStorageInterface {
         database.createObjectStore(storeName);
       }
     };
-    // setting _database instead of returning it is a work
-    // around for https://github.com/dart-lang/sdk/issues/48835
+    // TODO: update once https://github.com/dart-lang/sdk/issues/48835 
+    // is resolved in a stable version. setting _database instead of returning 
+    // it is a work around.
     _database = await openRequest.future;
   }
 

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_web.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_web.dart
@@ -36,12 +36,14 @@ class AmplifySecureStorageWeb extends AmplifySecureStorageInterface {
   /// Reference: https://www.w3.org/TR/IndexedDB/#object-store-name
   final storeName = 'default.store';
 
-  late final Future<IDBDatabase> _databaseFuture = _openDatabase();
+  late final Future<void> _databaseOpenEvent = _openDatabase();
+
+  late final IDBDatabase _database;
 
   /// Opens the database and returns it as a future.
   ///
   /// Will throw a [NotAvailableException] if IndexedDB is not supported.
-  Future<IDBDatabase> _openDatabase() async {
+  Future<void> _openDatabase() async {
     if (indexedDB == null) {
       throw const NotAvailableException(
         'IndexedDB is not supported.',
@@ -56,14 +58,15 @@ class AmplifySecureStorageWeb extends AmplifySecureStorageInterface {
         database.createObjectStore(storeName);
       }
     };
-    return openRequest.future;
+    // setting _database instead of returning it is a work
+    // around for https://github.com/dart-lang/sdk/issues/48835
+    _database = await openRequest.future;
   }
 
   /// Returns a new [IDBObjectStore] instance after waiting for initialization
   /// to complete.
-  Future<IDBObjectStore> _getObjectStore() async {
-    final IDBDatabase db = await _databaseFuture;
-    final IDBTransaction transaction = db.transaction(
+  IDBObjectStore _getObjectStore() {
+    final IDBTransaction transaction = _database.transaction(
       storeName,
       mode: IDBTransactionMode.readwrite,
     );
@@ -73,20 +76,23 @@ class AmplifySecureStorageWeb extends AmplifySecureStorageInterface {
 
   @override
   Future<void> write({required String key, required String value}) async {
-    final IDBObjectStore store = await _getObjectStore();
+    await _databaseOpenEvent;
+    final IDBObjectStore store = _getObjectStore();
     await store.put(value, key).future;
   }
 
   @override
   Future<String?> read({required String key}) async {
-    final IDBObjectStore store = await _getObjectStore();
+    await _databaseOpenEvent;
+    final IDBObjectStore store = _getObjectStore();
     final String? value = await store.getObject(key).future;
     return value;
   }
 
   @override
   Future<void> delete({required String key}) async {
-    final IDBObjectStore store = await _getObjectStore();
+    await _databaseOpenEvent;
+    final IDBObjectStore store = _getObjectStore();
     await store.delete(key).future;
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- make `_database` a late initializer rather than returning it as a future

This is a workaround for https://github.com/dart-lang/sdk/issues/48835

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
