### PR TITLE
feat(auth): Configuration + credential store state machine

### DIFF
--- a/packages/amplify_core/lib/src/state_machine/state_machine.dart
+++ b/packages/amplify_core/lib/src/state_machine/state_machine.dart
@@ -117,7 +117,7 @@ abstract class StateMachineManager<E extends StateMachineEvent>
 
   /// Dispatches an event to the appropriate state machine.
   @override
-  Future<void> dispatch(E event);
+  FutureOr<void> dispatch(E event);
 
   /// Closes the state machine manager and all state machines.
   @override
@@ -321,7 +321,7 @@ abstract class StateMachine<Event extends StateMachineEvent,
 
   /// Dispatches an event to the state machine.
   @override
-  Future<void> dispatch(StateMachineEvent event) => _manager.dispatch(event);
+  FutureOr<void> dispatch(StateMachineEvent event) => _manager.dispatch(event);
 
   /// Closes the state machine and all stream controllers.
   @override

--- a/packages/amplify_core/lib/src/types/auth/auth_device.dart
+++ b/packages/amplify_core/lib/src/types/auth/auth_device.dart
@@ -16,12 +16,12 @@
 import 'package:aws_common/aws_common.dart';
 import 'package:meta/meta.dart';
 
-/// {@template amplify_auth_cognito_dart.auth_device}
+/// {@template amplify_auth_cognito.auth_device}
 /// Common interface for devices tracked by an authentication provider.
 /// {@endtemplate}
 @immutable
 abstract class AuthDevice with AWSSerializable {
-  /// {@macro amplify_auth_cognito_dart.auth_device}
+  /// {@macro amplify_auth_cognito.auth_device}
   const AuthDevice();
 
   /// Device unique identifier.

--- a/packages/auth/amplify_auth_cognito/example/lib/main.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/main.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:amplify_api/amplify_api.dart';
@@ -43,7 +44,9 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> _configure() async {
     try {
-      await Amplify.addPlugin(AmplifyAPI());
+      if (!zIsWeb && (Platform.isAndroid || Platform.isIOS)) {
+        await Amplify.addPlugin(AmplifyAPI());
+      }
       await Amplify.addPlugin(AmplifyAuthCognito());
       await Amplify.configure(amplifyconfig);
       safePrint('Successfully configured Amplify');

--- a/packages/auth/amplify_auth_cognito/example/pubspec_overrides.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec_overrides.yaml
@@ -22,6 +22,10 @@ dependency_overrides:
     path: ../../../amplify/amplify_flutter_ios
   amplify_flutter_android:
     path: ../../../amplify/amplify_flutter_android
+  amplify_secure_storage:
+    path: ../../../secure_storage/amplify_secure_storage
+  amplify_secure_storage_dart:
+    path: ../../../secure_storage/amplify_secure_storage_dart
   aws_common:
     path: ../../../aws_common
   aws_signature_v4:

--- a/packages/auth/amplify_auth_cognito/lib/amplify_auth_cognito.dart
+++ b/packages/auth/amplify_auth_cognito/lib/amplify_auth_cognito.dart
@@ -44,6 +44,8 @@ export 'src/model/signup/cognito_sign_up_options.dart';
 export 'src/model/signup/cognito_sign_up_result.dart';
 export 'src/model/signup/cognito_sign_up_step.dart';
 
+export 'src/state/cognito_state_machine.dart';
+
 // State Machine
 export 'src/state/event/auth_event.dart';
 export 'src/state/event/credential_store_event.dart';

--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -17,14 +17,74 @@ import 'dart:io';
 
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_auth_cognito/src/native_auth_plugin.dart';
+import 'package:amplify_auth_cognito/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_secure_storage/amplify_secure_storage.dart';
+import 'package:meta/meta.dart';
+import 'package:stream_transform/stream_transform.dart';
 
 /// {@template amplify_auth_cognito.amplify_auth_cognito}
 /// The AWS Cognito implementation of the Amplify Auth category.
 /// {@endtemplate}
 class AmplifyAuthCognito extends AuthPluginInterface implements Closeable {
+  /// {@macro amplify_auth_cognito.amplify_auth_cognito}
+  AmplifyAuthCognito({
+    SecureStorageInterface? credentialStorage,
+  }) : _credentialStorage = credentialStorage;
+
+  /// The on-device credential storage for the Auth category.
+  ///
+  /// Defaults to an instance of [AmplifySecureStorage] with a scope of "auth".
+  final SecureStorageInterface? _credentialStorage;
+
+  CognitoAuthStateMachine _stateMachine = CognitoAuthStateMachine();
+
+  @visibleForTesting
+  set stateMachine(CognitoAuthStateMachine stateMachine) {
+    if (!zDebugMode) throw StateError('Can only be called in tests');
+    _stateMachine = stateMachine;
+  }
+
+  Future<void> _init() async {
+    final credentialStorage = _credentialStorage ??
+        AmplifySecureStorage(
+          config: const AmplifySecureStorageConfig(
+            packageId: 'com.amplify', // TODO(dnys1): Remove
+            scope: 'auth',
+          ),
+        );
+    _stateMachine.addInstance<SecureStorageInterface>(credentialStorage);
+  }
+
   @override
   Future<void> configure({AmplifyConfig? config}) async {
+    if (config == null) {
+      throw const AuthException('No Cognito plugin config detected');
+    }
+    if (_stateMachine.getOrCreate(AuthStateMachine.type).currentState.type !=
+        AuthStateType.notConfigured) {
+      throw const AmplifyAlreadyConfiguredException(
+        'Amplify has already been configured and re-configuration is not supported.',
+        recoverySuggestion:
+            'Check if Amplify is already configured using Amplify.isConfigured.',
+      );
+    }
+
+    await _init();
+    _stateMachine.dispatch(AuthEvent.configure(config));
+
+    await for (final state in _stateMachine.stream.whereType<AuthState>()) {
+      switch (state.type) {
+        case AuthStateType.notConfigured:
+        case AuthStateType.configuring:
+          continue;
+        case AuthStateType.configured:
+          return;
+        case AuthStateType.failure:
+          throw (state as AuthFailure).exception;
+      }
+    }
+
     // Configure this plugin to act as a native iOS/Android plugin.
     if (!zIsWeb && (Platform.isAndroid || Platform.isIOS)) {
       final nativePlugin = _NativeAmplifyAuthCognito(this);

--- a/packages/auth/amplify_auth_cognito/lib/src/credentials/cognito_keys.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/credentials/cognito_keys.dart
@@ -1,0 +1,177 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@internal
+library amplify_auth_cognito.credentials.cognito_keys;
+
+import 'dart:collection';
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:meta/meta.dart';
+
+/// Discrete keys stored for Cognito User Pool operations in secure storage.
+enum CognitoUserPoolKey {
+  /// The access token, serialized as a JWT.
+  accessToken,
+
+  /// The refresh token.
+  refreshToken,
+
+  /// The ID token, serialized as a JWT.
+  idToken,
+
+  /// The user ID.
+  userSub,
+
+  /// The device key.
+  deviceKey,
+
+  /// The device group key.
+  deviceGroupKey,
+}
+
+/// Discrete keys stored for Cognito Identity Pool operations in secure storage.
+enum CognitoIdentityPoolKey {
+  /// AWS Access Key ID
+  accessKeyId,
+
+  /// AWS Secret Access Key
+  secretAccessKey,
+
+  /// AWS Session Token
+  sessionToken,
+
+  /// AWS Credentials Expiration, encoded using ISO 8601.
+  expiration,
+
+  /// AWS Identity ID.
+  identityId,
+}
+
+/// Discrete keys stored for Hosted UI operations in secure storage.
+enum HostedUiKey {
+  /// The access token, serialized as a JWT.
+  accessToken,
+
+  /// The refresh token.
+  refreshToken,
+
+  /// The ID token, serialized as a JWT.
+  idToken,
+
+  /// The OAuth state string.
+  state,
+
+  /// The OAuth code verifier.
+  codeVerifier,
+
+  /// The OIDC nonce value.
+  nonce,
+}
+
+/// {@template amplify_auth_cognito.cognito_identity_pool_keys}
+/// Enumerates and iterates over the keys stored in secure storage by
+/// Cognito Identity Pool operations.
+/// {@endtemplate}
+class CognitoIdentityPoolKeys extends CognitoKeys<CognitoIdentityPoolKey> {
+  /// {@macro amplify_auth_cognito.cognito_identity_pool_keys}
+  const CognitoIdentityPoolKeys(this.config);
+
+  /// The Cognito identity pool configuration, used to determine the key
+  /// prefixes.
+  final CognitoIdentityCredentialsProvider config;
+
+  @override
+  List<CognitoIdentityPoolKey> get _values => CognitoIdentityPoolKey.values;
+
+  @override
+  String get prefix => config.poolId;
+}
+
+/// {@template amplify_auth_cognito.cognito_user_pool_keys}
+/// Enumerates and iterates over the keys stored in secure storage by
+/// Cognito User Pool operations.
+/// {@endtemplate}
+class CognitoUserPoolKeys extends CognitoKeys<CognitoUserPoolKey> {
+  /// {@macro amplify_auth_cognito.cognito_user_pool_keys}
+  const CognitoUserPoolKeys(this.config);
+
+  /// The Cognito user pool configuration, used to determine the key prefixes.
+  final CognitoUserPoolConfig config;
+
+  @override
+  List<CognitoUserPoolKey> get _values => CognitoUserPoolKey.values;
+
+  @override
+  String get prefix => config.appClientId;
+}
+
+/// {@template amplify_auth_cognito.hosted_ui_keys}
+/// Enumerates and iterates over the keys stored in secure storage by
+/// Cognito Hosted UI operations.
+/// {@endtemplate}
+class HostedUiKeys extends CognitoKeys<HostedUiKey> {
+  /// {@macro amplify_auth_cognito.hosted_ui_keys}
+  const HostedUiKeys(this.config);
+
+  /// The Cognito OAuth configuration, used to determine the key prefixes.
+  final CognitoOAuthConfig config;
+
+  @override
+  List<HostedUiKey> get _values => HostedUiKey.values;
+
+  @override
+  String get prefix => '${config.appClientId}.hostedUi';
+}
+
+/// {@template amplify_auth_cognito.cognito_keys}
+/// Iterable secure storage keys.
+/// {@endtemplate}
+abstract class CognitoKeys<Key extends Enum> extends IterableBase<String> {
+  /// {@macro amplify_auth_cognito.cognito_keys}
+  const CognitoKeys();
+
+  /// Enum values of the key type.
+  List<Key> get _values;
+
+  /// The prefix to use for keys.
+  String get prefix;
+
+  /// Retrieves the storage identifier for [key].
+  String operator [](Key key) => '$prefix.${key.name}';
+
+  @override
+  Iterator<String> get iterator => _CognitoKeysIterator(this);
+}
+
+class _CognitoKeysIterator<Key extends Enum> implements Iterator<String> {
+  _CognitoKeysIterator(this._keys);
+
+  final CognitoKeys<Key> _keys;
+
+  /// Current index of iteration.
+  int _currentIndex = -1;
+
+  @override
+  String get current {
+    if (_currentIndex < 0) {
+      throw StateError('Must call moveNext first');
+    }
+    final currentKey = _keys._values[_currentIndex];
+    return _keys[currentKey];
+  }
+
+  @override
+  bool moveNext() => ++_currentIndex < _keys._values.length;
+}

--- a/packages/auth/amplify_auth_cognito/lib/src/model/hosted_ui/oauth_parameters.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/model/hosted_ui/oauth_parameters.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library amplify_auth_cognito_dart.hostedui.oauth_parameters;
+library amplify_auth_cognito.hostedui.oauth_parameters;
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:built_collection/built_collection.dart';
@@ -183,14 +183,14 @@ class OAuthErrorCode extends EnumClass {
       _$oAuthErrorCodeSerializer;
 }
 
-/// {@template amplify_auth_cognito_dart.oauth_parameters}
+/// {@template amplify_auth_cognito.oauth_parameters}
 /// Query parameters of the OAuth redirect.
 ///
 /// [Reference](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2)
 /// {@endtemplate}
 abstract class OAuthParameters
     implements Built<OAuthParameters, OAuthParametersBuilder> {
-  /// {@macro amplify_auth_cognito_dart.oauth_parameters}
+  /// {@macro amplify_auth_cognito.oauth_parameters}
   factory OAuthParameters([void Function(OAuthParametersBuilder) updates]) =
       _$OAuthParameters;
   OAuthParameters._();

--- a/packages/auth/amplify_auth_cognito/lib/src/model/hosted_ui/oauth_parameters.g.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/model/hosted_ui/oauth_parameters.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of amplify_auth_cognito_dart.hostedui.oauth_parameters;
+part of amplify_auth_cognito.hostedui.oauth_parameters;
 
 // **************************************************************************
 // BuiltValueGenerator

--- a/packages/auth/amplify_auth_cognito/lib/src/state/cognito_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/state/cognito_state_machine.dart
@@ -1,0 +1,62 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
+
+import 'state.dart';
+
+/// Default state machine builders for [CognitoAuthStateMachine].
+@visibleForTesting
+final stateMachineBuilders = <StateMachineToken, StateMachineBuilder>{
+  AuthStateMachine.type: AuthStateMachine.new,
+  CredentialStoreStateMachine.type: CredentialStoreStateMachine.new,
+};
+
+/// Default defaultDependencies for [CognitoAuthStateMachine].
+@visibleForTesting
+final defaultDependencies = <Token, DependencyBuilder>{
+  const Token<http.Client>(): http.Client.new,
+};
+
+/// {@template amplify_auth_cognito.cognito_auth_state_machine}
+/// The state machine for managing auth state and relevant work.
+/// {@endtemplate}
+class CognitoAuthStateMachine extends StateMachineManager {
+  /// {@macro amplify_auth_cognito.cognito_auth_state_machine}
+  CognitoAuthStateMachine({
+    DependencyManager? dependencyManager,
+  }) : super(
+          stateMachineBuilders,
+          dependencyManager ?? DependencyManager(defaultDependencies),
+        );
+
+  @override
+  FutureOr<void> dispatch(StateMachineEvent<dynamic> event) async {
+    try {
+      if (event is AuthEvent) {
+        return getOrCreate(AuthStateMachine.type).add(event);
+      } else if (event is CredentialStoreEvent) {
+        return getOrCreate(CredentialStoreStateMachine.type).add(event);
+      }
+      throw StateError('Unhandled event: $event');
+    } finally {
+      // Allow propogation of event
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+}

--- a/packages/auth/amplify_auth_cognito/lib/src/state/event/hosted_ui_event.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/state/event/hosted_ui_event.dart
@@ -17,28 +17,28 @@ import 'package:amplify_core/amplify_core.dart';
 
 /// Discrete event types of the hosted UI state machine.
 enum HostedUiEventType {
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_configure}
+  /// {@macro amplify_auth_cognito.hosted_ui_configure}
   configure,
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_found_state}
+  /// {@macro amplify_auth_cognito.hosted_ui_found_state}
   foundState,
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_sign_in}
+  /// {@macro amplify_auth_cognito.hosted_ui_sign_in}
   signIn,
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_cancel_sign_in}
+  /// {@macro amplify_auth_cognito.hosted_ui_cancel_sign_in}
   cancelSignIn,
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_exchange}
+  /// {@macro amplify_auth_cognito.hosted_ui_exchange}
   exchange,
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_sign_out}
+  /// {@macro amplify_auth_cognito.hosted_ui_sign_out}
   signOut,
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_succeeded}
+  /// {@macro amplify_auth_cognito.hosted_ui_succeeded}
   succeeded,
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_failed}
+  /// {@macro amplify_auth_cognito.hosted_ui_failed}
   failed,
 }
 
@@ -46,49 +46,49 @@ enum HostedUiEventType {
 abstract class HostedUiEvent extends StateMachineEvent<HostedUiEventType> {
   const HostedUiEvent._();
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_configure}
+  /// {@macro amplify_auth_cognito.hosted_ui_configure}
   const factory HostedUiEvent.configure() = HostedUiConfigure;
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_found_state}
+  /// {@macro amplify_auth_cognito.hosted_ui_found_state}
   const factory HostedUiEvent.foundState({
     required String state,
     required String codeVerifier,
   }) = HostedUiFoundState;
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_sign_in}
+  /// {@macro amplify_auth_cognito.hosted_ui_sign_in}
   const factory HostedUiEvent.signIn({
     CognitoSignInWithWebUIOptions options,
     AuthProvider? provider,
     Uri? redirectUri,
   }) = HostedUiSignIn;
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_cancel_sign_in}
+  /// {@macro amplify_auth_cognito.hosted_ui_cancel_sign_in}
   const factory HostedUiEvent.cancelSignIn() = HostedUiCancelSignIn;
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_exchange}
+  /// {@macro amplify_auth_cognito.hosted_ui_exchange}
   const factory HostedUiEvent.exchange(OAuthParameters parameters) =
       HostedUiExchange;
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_sign_out}
+  /// {@macro amplify_auth_cognito.hosted_ui_sign_out}
   const factory HostedUiEvent.signOut() = HostedUiSignOut;
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_succeeded}
+  /// {@macro amplify_auth_cognito.hosted_ui_succeeded}
   const factory HostedUiEvent.succeeded(
     CognitoUserPoolTokens tokens,
   ) = HostedUiSucceeded;
 
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_failed}
+  /// {@macro amplify_auth_cognito.hosted_ui_failed}
   const factory HostedUiEvent.failed(Exception exception) = HostedUiFailed;
 
   @override
   String get runtimeTypeName => 'HostedUiEvent';
 }
 
-/// {@template amplify_auth_cognito_dart.hosted_ui_configure}
+/// {@template amplify_auth_cognito.hosted_ui_configure}
 /// Configure the hosted UI flow for use.
 /// {@endtemplate}
 class HostedUiConfigure extends HostedUiEvent {
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_configure}
+  /// {@macro amplify_auth_cognito.hosted_ui_configure}
   const HostedUiConfigure() : super._();
 
   @override
@@ -98,11 +98,11 @@ class HostedUiConfigure extends HostedUiEvent {
   HostedUiEventType get type => HostedUiEventType.configure;
 }
 
-/// {@template amplify_auth_cognito_dart.hosted_ui_found_state}
+/// {@template amplify_auth_cognito.hosted_ui_found_state}
 /// The hosted UI flow was found to be in a partially complete state.
 /// {@endtemplate}
 class HostedUiFoundState extends HostedUiEvent {
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_found_state}
+  /// {@macro amplify_auth_cognito.hosted_ui_found_state}
   const HostedUiFoundState({
     required this.state,
     required this.codeVerifier,
@@ -121,11 +121,11 @@ class HostedUiFoundState extends HostedUiEvent {
   HostedUiEventType get type => HostedUiEventType.foundState;
 }
 
-/// {@template amplify_auth_cognito_dart.hosted_ui_sign_in}
+/// {@template amplify_auth_cognito.hosted_ui_sign_in}
 /// Sign in via the hosted UI flow.
 /// {@endtemplate}
 class HostedUiSignIn extends HostedUiEvent {
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_sign_in}
+  /// {@macro amplify_auth_cognito.hosted_ui_sign_in}
   const HostedUiSignIn({
     this.options = const CognitoSignInWithWebUIOptions(),
     this.provider,
@@ -155,11 +155,11 @@ class HostedUiSignIn extends HostedUiEvent {
   HostedUiEventType get type => HostedUiEventType.signIn;
 }
 
-/// {@template amplify_auth_cognito_dart.hosted_ui_cancel_sign_in}
+/// {@template amplify_auth_cognito.hosted_ui_cancel_sign_in}
 /// Cancels the hosted UI flow.
 /// {@endtemplate}
 class HostedUiCancelSignIn extends HostedUiEvent {
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_cancel_sign_in}
+  /// {@macro amplify_auth_cognito.hosted_ui_cancel_sign_in}
   const HostedUiCancelSignIn() : super._();
 
   @override
@@ -177,11 +177,11 @@ class HostedUiCancelSignIn extends HostedUiEvent {
   }
 }
 
-/// {@template amplify_auth_cognito_dart.hosted_ui_exchange}
+/// {@template amplify_auth_cognito.hosted_ui_exchange}
 /// Perform the `exchange` portion of the hosted UI flow.
 /// {@endtemplate}
 class HostedUiExchange extends HostedUiEvent {
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_exchange}
+  /// {@macro amplify_auth_cognito.hosted_ui_exchange}
   const HostedUiExchange(this.parameters) : super._();
 
   /// The query parameters returned from the call to `authorize`.
@@ -194,11 +194,11 @@ class HostedUiExchange extends HostedUiEvent {
   HostedUiEventType get type => HostedUiEventType.exchange;
 }
 
-/// {@template amplify_auth_cognito_dart.hosted_ui_sign_out}
+/// {@template amplify_auth_cognito.hosted_ui_sign_out}
 /// Signs out a user who signed in with the Hosted UI flow.
 /// {@endtemplate}
 class HostedUiSignOut extends HostedUiEvent {
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_sign_out}
+  /// {@macro amplify_auth_cognito.hosted_ui_sign_out}
   const HostedUiSignOut() : super._();
 
   @override
@@ -227,11 +227,11 @@ class HostedUiSignOut extends HostedUiEvent {
   }
 }
 
-/// {@template amplify_auth_cognito_dart.hosted_ui_succeeded}
+/// {@template amplify_auth_cognito.hosted_ui_succeeded}
 /// The user successfully logged in via the hosted UI flow.
 /// {@endtemplate}
 class HostedUiSucceeded extends HostedUiEvent {
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_succeeded}
+  /// {@macro amplify_auth_cognito.hosted_ui_succeeded}
   const HostedUiSucceeded(this.tokens) : super._();
 
   /// The tokens retrieved via the hosted UI flow.
@@ -244,11 +244,11 @@ class HostedUiSucceeded extends HostedUiEvent {
   HostedUiEventType get type => HostedUiEventType.succeeded;
 }
 
-/// {@template amplify_auth_cognito_dart.hosted_ui_failed}
+/// {@template amplify_auth_cognito.hosted_ui_failed}
 /// The Hosted UI flow failed with an [exception].
 /// {@endtemplate}
 class HostedUiFailed extends HostedUiEvent with ErrorEvent {
-  /// {@macro amplify_auth_cognito_dart.hosted_ui_failed}
+  /// {@macro amplify_auth_cognito.hosted_ui_failed}
   const HostedUiFailed(this.exception) : super._();
 
   /// The Hosted UI exception.

--- a/packages/auth/amplify_auth_cognito/lib/src/state/machines/auth_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/state/machines/auth_state_machine.dart
@@ -1,0 +1,112 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:amplify_auth_cognito/src/model/auth_configuration.dart';
+import 'package:amplify_auth_cognito/src/sdk/cognito_identity.dart';
+import 'package:amplify_auth_cognito/src/sdk/cognito_identity_provider.dart';
+import 'package:amplify_auth_cognito/src/state/machines/generated/auth_state_machine_base.dart';
+import 'package:amplify_auth_cognito/src/state/state.dart';
+import 'package:amplify_auth_cognito/src/util/credentials_providers.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_signature_v4/aws_signature_v4.dart';
+
+/// {@template amplify_auth_cognito.auth_state_machine}
+/// Manages configuration of the Auth category.
+/// {@endtemplate}
+class AuthStateMachine extends AuthStateMachineBase {
+  /// {@macro amplify_auth_cognito.auth_state_machine}
+  AuthStateMachine(super.manager);
+
+  /// The [AuthStateMachine] type.
+  static const type =
+      StateMachineToken<AuthEvent, AuthState, AuthStateMachine>();
+
+  /// The AWS credentials provider, using cached credentials.
+  late final AWSCredentialsProvider credentialsProvider =
+      InlineCredentialsProvider(() async {
+    throw UnimplementedError();
+  });
+
+  @override
+  Future<void> onConfigure(AuthConfigure event) async {
+    // InitializeAuthConfiguration
+    final cognitoConfig = event.config.auth?.awsPlugin;
+    if (cognitoConfig == null) {
+      throw const AuthException('No Cognito plugin config available');
+    }
+    addInstance(cognitoConfig);
+    final config = AuthConfiguration.fromConfig(cognitoConfig);
+    addInstance(config);
+
+    final waiters = <Future<void>>[];
+    final userPoolConfig = config.userPoolConfig;
+    if (userPoolConfig != null) {
+      addInstance(userPoolConfig);
+      addInstance(
+        CognitoIdentityProviderClient(
+          region: userPoolConfig.region,
+          credentialsProvider: credentialsProvider,
+        ),
+      );
+    }
+
+    final identityPoolConfig = config.identityPoolConfig;
+    if (identityPoolConfig != null) {
+      addInstance(identityPoolConfig);
+      addInstance(
+        CognitoIdentityClient(
+          region: identityPoolConfig.region,
+          credentialsProvider: const AnonymousCredentialsProvider(),
+        ),
+      );
+    }
+
+    dispatch(const CredentialStoreEvent.loadCredentialStore());
+
+    final credentialStoreConfigured = Completer<void>.sync();
+    subscribeTo(CredentialStoreStateMachine.type, (state) {
+      if (state is CredentialStoreSuccess &&
+          !credentialStoreConfigured.isCompleted) {
+        credentialStoreConfigured.complete();
+      }
+      if (state is CredentialStoreFailure &&
+          !credentialStoreConfigured.isCompleted) {
+        credentialStoreConfigured.completeError(state.exception);
+      }
+    });
+    waiters.add(credentialStoreConfigured.future);
+
+    unawaited(_waitForConfiguration(cognitoConfig, waiters));
+  }
+
+  Future<void> _waitForConfiguration(
+    CognitoPluginConfig config,
+    List<Future<void>> futures,
+  ) async {
+    try {
+      await Future.wait<void>(futures, eagerError: true);
+      dispatch(AuthEvent.configureSucceeded(config));
+    } on Exception catch (e) {
+      dispatch(AuthEvent.configureFailed(AuthException.fromException(e)));
+    }
+  }
+
+  @override
+  Future<void> onConfigureSucceeded(AuthConfigureSucceeded event) async {}
+
+  @override
+  Future<void> onConfigureFailed(AuthConfigureFailed event) async {}
+}

--- a/packages/auth/amplify_auth_cognito/lib/src/state/machines/credential_store_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/state/machines/credential_store_state_machine.dart
@@ -1,0 +1,337 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:amplify_auth_cognito/src/credentials/cognito_keys.dart';
+import 'package:amplify_auth_cognito/src/jwt/jwt.dart';
+import 'package:amplify_auth_cognito/src/model/auth_configuration.dart';
+import 'package:amplify_auth_cognito/src/model/cognito_device_secrets.dart';
+import 'package:amplify_auth_cognito/src/state/machines/generated/credential_store_state_machine_base.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_secure_storage/amplify_secure_storage.dart';
+import 'package:stream_transform/stream_transform.dart';
+
+/// {@template amplify_auth_cognito.auth_store_state_machine}
+/// Manages the loading and storing of auth configuration data.
+/// {@endtemplate}
+class CredentialStoreStateMachine extends CredentialStoreStateMachineBase {
+  /// {@macro amplify_auth_cognito.auth_store_state_machine}
+  CredentialStoreStateMachine(super.manager);
+
+  /// The [CredentialStoreStateMachine] type.
+  static const type = StateMachineToken<CredentialStoreEvent,
+      CredentialStoreState, CredentialStoreStateMachine>();
+
+  SecureStorageInterface get _secureStorage => getOrCreate();
+
+  /// Gets the current credentials result.
+  Future<CredentialStoreSuccess> getCredentialsResult() async {
+    // Wait for any pending events to be processed and their initial states to
+    // fire. Helps protect against the case where we call `credentialStoreMachine.clear()`
+    // in the same loop as `credentialStoreMachine.get()`, we want the second
+    // call to fail.
+    await Future<void>.delayed(Duration.zero);
+    final credentialsState = await stream.startWith(currentState).firstWhere(
+          (state) =>
+              state is CredentialStoreFailure ||
+              state is CredentialStoreSuccess,
+        );
+    if (credentialsState is CredentialStoreFailure) {
+      throw credentialsState.exception;
+    }
+    return credentialsState as CredentialStoreSuccess;
+  }
+
+  /// Loads the credential store from storage and emits the resulting values.
+  Future<void> _loadCredentialStore() async {
+    final authConfig = expect<AuthConfiguration>();
+
+    CognitoUserPoolTokens? userPoolTokens;
+    CognitoDeviceSecrets? deviceSecrets;
+    final userPoolConfig = authConfig.userPoolConfig;
+    if (userPoolConfig != null) {
+      final keys = CognitoUserPoolKeys(userPoolConfig);
+      final accessToken = await _secureStorage.read(
+        key: keys[CognitoUserPoolKey.accessToken],
+      );
+      final refreshToken = await _secureStorage.read(
+        key: keys[CognitoUserPoolKey.refreshToken],
+      );
+      final idToken = await _secureStorage.read(
+        key: keys[CognitoUserPoolKey.idToken],
+      );
+      if (accessToken != null && refreshToken != null && idToken != null) {
+        userPoolTokens = CognitoUserPoolTokens(
+          (b) => b
+            ..signInMethod = CognitoSignInMethod.default$
+            ..accessToken = JsonWebToken.parse(accessToken)
+            ..refreshToken = refreshToken
+            ..idToken = JsonWebToken.parse(idToken),
+        );
+      }
+
+      final deviceKey = await _secureStorage.read(
+        key: keys[CognitoUserPoolKey.deviceKey],
+      );
+      final deviceGroupKey = await _secureStorage.read(
+        key: keys[CognitoUserPoolKey.deviceGroupKey],
+      );
+      if (deviceKey != null && deviceGroupKey != null) {
+        deviceSecrets = CognitoDeviceSecrets(
+          (b) => b
+            ..deviceKey = deviceKey
+            ..deviceGroupKey = deviceGroupKey,
+        );
+      }
+    }
+
+    final hostedUiConfig = authConfig.hostedUiConfig;
+    if (hostedUiConfig != null) {
+      final keys = HostedUiKeys(hostedUiConfig);
+      final accessToken = await _secureStorage.read(
+        key: keys[HostedUiKey.accessToken],
+      );
+      final refreshToken = await _secureStorage.read(
+        key: keys[HostedUiKey.refreshToken],
+      );
+      final idToken = await _secureStorage.read(
+        key: keys[HostedUiKey.idToken],
+      );
+      if (accessToken != null && refreshToken != null && idToken != null) {
+        userPoolTokens = CognitoUserPoolTokens(
+          (b) => b
+            ..signInMethod = CognitoSignInMethod.hostedUi
+            ..accessToken = JsonWebToken.parse(accessToken)
+            ..refreshToken = refreshToken
+            ..idToken = JsonWebToken.parse(idToken),
+        );
+      }
+    }
+
+    String? identityId;
+    AWSCredentials? awsCredentials;
+    final identityPoolConfig = authConfig.identityPoolConfig;
+    if (identityPoolConfig != null) {
+      final keys = CognitoIdentityPoolKeys(identityPoolConfig);
+      identityId = await _secureStorage.read(
+        key: keys[CognitoIdentityPoolKey.identityId],
+      );
+      final accessKeyId = await _secureStorage.read(
+        key: keys[CognitoIdentityPoolKey.accessKeyId],
+      );
+      final secretAccessKey = await _secureStorage.read(
+        key: keys[CognitoIdentityPoolKey.secretAccessKey],
+      );
+      final sessionToken = await _secureStorage.read(
+        key: keys[CognitoIdentityPoolKey.sessionToken],
+      );
+      final expirationStr = await _secureStorage.read(
+        key: keys[CognitoIdentityPoolKey.expiration],
+      );
+      if (accessKeyId != null && secretAccessKey != null) {
+        DateTime? expiration;
+        if (expirationStr != null) {
+          expiration = DateTime.tryParse(expirationStr);
+        }
+        awsCredentials = AWSCredentials(
+          accessKeyId,
+          secretAccessKey,
+          sessionToken,
+          expiration,
+        );
+      }
+    }
+
+    emit(
+      CredentialStoreState.success(
+        userPoolTokens: userPoolTokens,
+        identityId: identityId,
+        awsCredentials: awsCredentials,
+        deviceSecrets: deviceSecrets,
+      ),
+    );
+  }
+
+  @override
+  Future<void> onLoadCredentialStore(
+    CredentialStoreLoadCredentialStore event,
+  ) async {
+    await _loadCredentialStore();
+  }
+
+  @override
+  Future<void> onMigrateLegacyCredentialStore(
+    CredentialStoreMigrateLegacyCredentialStore event,
+  ) async {
+    // TODO(Jordan-Nelson): Implement migration flow
+    emit(const CredentialStoreState.success());
+  }
+
+  @override
+  Future<void> onStoreCredentials(
+    CredentialStoreStoreCredentials event,
+  ) async {
+    final authConfig = expect<AuthConfiguration>();
+
+    final userPoolConfig = authConfig.userPoolConfig;
+    if (userPoolConfig != null) {
+      final keys = CognitoUserPoolKeys(userPoolConfig);
+      final userPoolTokens = event.userPoolTokens;
+      if (userPoolTokens != null &&
+          userPoolTokens.signInMethod == CognitoSignInMethod.default$) {
+        _secureStorage
+          ..write(
+            key: keys[CognitoUserPoolKey.accessToken],
+            value: userPoolTokens.accessToken.raw,
+          )
+          ..write(
+            key: keys[CognitoUserPoolKey.refreshToken],
+            value: userPoolTokens.refreshToken,
+          )
+          ..write(
+            key: keys[CognitoUserPoolKey.idToken],
+            value: userPoolTokens.idToken.raw,
+          );
+      }
+
+      final deviceSecrets = event.deviceSecrets;
+      if (deviceSecrets != null) {
+        _secureStorage
+          ..write(
+            key: keys[CognitoUserPoolKey.deviceKey],
+            value: deviceSecrets.deviceKey,
+          )
+          ..write(
+            key: keys[CognitoUserPoolKey.deviceGroupKey],
+            value: deviceSecrets.deviceGroupKey,
+          );
+      }
+    }
+
+    final hostedUiConfig = authConfig.hostedUiConfig;
+    if (hostedUiConfig != null) {
+      final keys = HostedUiKeys(hostedUiConfig);
+      final userPoolTokens = event.userPoolTokens;
+      if (userPoolTokens != null &&
+          userPoolTokens.signInMethod == CognitoSignInMethod.hostedUi) {
+        _secureStorage
+          ..write(
+            key: keys[HostedUiKey.accessToken],
+            value: userPoolTokens.accessToken.raw,
+          )
+          ..write(
+            key: keys[HostedUiKey.refreshToken],
+            value: userPoolTokens.refreshToken,
+          )
+          ..write(
+            key: keys[HostedUiKey.idToken],
+            value: userPoolTokens.idToken.raw,
+          );
+      }
+    }
+
+    final identityPoolConfig = authConfig.identityPoolConfig;
+    if (identityPoolConfig != null) {
+      final keys = CognitoIdentityPoolKeys(identityPoolConfig);
+      final identityId = event.identityId;
+      if (identityId != null) {
+        _secureStorage.write(
+          key: keys[CognitoIdentityPoolKey.identityId],
+          value: identityId,
+        );
+      }
+      final awsCredentials = event.awsCredentials;
+      if (awsCredentials != null) {
+        _secureStorage
+          ..write(
+            key: keys[CognitoIdentityPoolKey.accessKeyId],
+            value: awsCredentials.accessKeyId,
+          )
+          ..write(
+            key: keys[CognitoIdentityPoolKey.secretAccessKey],
+            value: awsCredentials.secretAccessKey,
+          );
+        final sessionToken = awsCredentials.sessionToken;
+        if (sessionToken != null) {
+          _secureStorage.write(
+            key: keys[CognitoIdentityPoolKey.sessionToken],
+            value: sessionToken,
+          );
+        } else {
+          _secureStorage.delete(
+            key: keys[CognitoIdentityPoolKey.sessionToken],
+          );
+        }
+        final expiration = awsCredentials.expiration;
+        if (expiration != null) {
+          _secureStorage.write(
+            key: keys[CognitoIdentityPoolKey.expiration],
+            value: expiration.toIso8601String(),
+          );
+        } else {
+          _secureStorage.delete(
+            key: keys[CognitoIdentityPoolKey.expiration],
+          );
+        }
+      }
+    }
+
+    await _loadCredentialStore();
+  }
+
+  @override
+  Future<void> onClearCredentials(
+    CredentialStoreClearCredentials event,
+  ) async {
+    final authConfig = expect<AuthConfiguration>();
+
+    final clearKeys = event.keys;
+    bool shouldDelete(String key) =>
+        clearKeys.isEmpty || clearKeys.contains(key);
+
+    final userPoolConfig = authConfig.userPoolConfig;
+    if (userPoolConfig != null) {
+      final userPoolKeys = CognitoUserPoolKeys(userPoolConfig);
+      for (final key in userPoolKeys) {
+        if (shouldDelete(key)) {
+          _secureStorage.delete(key: key);
+        }
+      }
+    }
+
+    final hostedUiConfig = authConfig.hostedUiConfig;
+    if (hostedUiConfig != null) {
+      final hostedUiKeys = HostedUiKeys(hostedUiConfig);
+      for (final key in hostedUiKeys) {
+        if (shouldDelete(key)) {
+          _secureStorage.delete(key: key);
+        }
+      }
+    }
+
+    final identityPoolConfig = authConfig.identityPoolConfig;
+    if (identityPoolConfig != null) {
+      final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig);
+      for (final key in identityPoolKeys) {
+        if (shouldDelete(key)) {
+          _secureStorage.delete(key: key);
+        }
+      }
+    }
+
+    await _loadCredentialStore();
+  }
+}

--- a/packages/auth/amplify_auth_cognito/lib/src/state/state.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/state/state.dart
@@ -1,0 +1,41 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@internal
+
+/// Internal auth state machine code.
+library amplify_auth_cognito.state;
+
+import 'package:meta/meta.dart';
+
+export 'event/auth_event.dart';
+export 'event/credential_store_event.dart';
+export 'event/fetch_auth_session_event.dart';
+export 'event/hosted_ui_event.dart';
+export 'event/sign_in_event.dart';
+export 'event/sign_up_event.dart';
+
+export 'machines/auth_state_machine.dart';
+export 'machines/credential_store_state_machine.dart';
+// export 'machines/fetch_auth_session_state_machine.dart';
+// export 'machines/hosted_ui_state_machine.dart';
+// export 'machines/sign_in_state_machine.dart';
+// export 'machines/sign_up_state_machine.dart';
+
+export 'state/auth_state.dart';
+export 'state/credential_store_state.dart';
+export 'state/fetch_auth_session_state.dart';
+export 'state/hosted_ui_state.dart';
+export 'state/sign_in_state.dart';
+export 'state/sign_up_state.dart';

--- a/packages/auth/amplify_auth_cognito/lib/src/util/credentials_providers.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/util/credentials_providers.dart
@@ -1,0 +1,47 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@internal
+library amplify_auth_cognito.util.credentials_providers;
+
+import 'dart:async';
+
+import 'package:aws_signature_v4/aws_signature_v4.dart';
+import 'package:meta/meta.dart';
+
+/// {@template amplify_auth_cognito.anonymous_credentials_provider}
+/// Creates a credentials provider with no credentials.
+/// {@endtemplate}
+class AnonymousCredentialsProvider implements AWSCredentialsProvider {
+  /// {@macro amplify_auth_cognito.anonymous_credentials_provider}
+  const AnonymousCredentialsProvider();
+
+  @override
+  FutureOr<AWSCredentials> retrieve() {
+    throw Exception();
+  }
+}
+
+/// {@template amplify_auth_cognito.inline_credentials_provider}
+/// Creates a credentials provider using a closure.
+/// {@endtemplate}
+class InlineCredentialsProvider implements AWSCredentialsProvider {
+  /// {@macro amplify_auth_cognito.inline_credentials_provider}
+  const InlineCredentialsProvider(this._retrieve);
+
+  final FutureOr<AWSCredentials> Function() _retrieve;
+
+  @override
+  FutureOr<AWSCredentials> retrieve() => _retrieve();
+}

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   amplify_auth_cognito_ios: 0.5.0
   amplify_auth_plugin_interface: 0.5.0
   amplify_core: 0.5.0
+  amplify_secure_storage: ^0.1.0
   aws_common: ^0.1.0
   aws_signature_v4: ^0.1.0
   built_collection: ^5.0.0
@@ -25,6 +26,7 @@ dependencies:
   json_annotation: ^4.4.0
   meta: ^1.7.0
   oauth2: ^2.0.0
+  path: ^1.8.0
   plugin_platform_interface: ^2.0.0
   smithy:
     hosted: https://pub.dillonnys.com
@@ -32,6 +34,7 @@ dependencies:
   smithy_aws:
     hosted: https://pub.dillonnys.com
     version: ^0.5.0
+  stream_transform: ^2.0.0
 
 dev_dependencies:
   amplify_lints:

--- a/packages/auth/amplify_auth_cognito/pubspec_overrides.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec_overrides.yaml
@@ -6,6 +6,10 @@
 dependency_overrides:
   amplify_core:
     path: ../../amplify_core
+  amplify_secure_storage:
+    path: ../../secure_storage/amplify_secure_storage
+  amplify_secure_storage_dart:
+    path: ../../secure_storage/amplify_secure_storage_dart
   aws_common:
     path: ../../aws_common
   aws_signature_v4:

--- a/packages/auth/amplify_auth_cognito/test/common/mock_config.dart
+++ b/packages/auth/amplify_auth_cognito/test/common/mock_config.dart
@@ -1,0 +1,101 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_auth_cognito/src/credentials/cognito_keys.dart';
+import 'package:amplify_auth_cognito/src/jwt/jwt.dart';
+import 'package:amplify_auth_cognito/src/model/auth_configuration.dart';
+import 'package:amplify_core/amplify_core.dart';
+
+const testUserPoolId = 'us-east-1_userPoolId';
+const testAppClientId = 'appClientId';
+const testIdentityPoolId = 'identityPoolId';
+const testRegion = 'region';
+const scopes = ['profile'];
+const redirectUri = 'http://localhost:9999';
+const webDomain = 'example.com';
+const hostedUiConfig = CognitoOAuthConfig(
+  appClientId: testAppClientId,
+  scopes: scopes,
+  signInRedirectUri: redirectUri,
+  signOutRedirectUri: redirectUri,
+  webDomain: webDomain,
+);
+
+const userPoolOnlyConfig = AmplifyConfig(
+  auth: AuthConfig(
+    plugins: {
+      CognitoPluginConfig.pluginKey: CognitoPluginConfig(
+        cognitoUserPool: AWSConfigMap({
+          'Default': CognitoUserPoolConfig(
+            poolId: testUserPoolId,
+            appClientId: testAppClientId,
+            region: testRegion,
+          ),
+        }),
+      ),
+    },
+  ),
+);
+const mockConfig = AmplifyConfig(
+  auth: AuthConfig(
+    plugins: {
+      CognitoPluginConfig.pluginKey: CognitoPluginConfig(
+        auth: AWSConfigMap({
+          'Default': CognitoAuthConfig(
+            oAuth: hostedUiConfig,
+          ),
+        }),
+        cognitoUserPool: AWSConfigMap({
+          'Default': CognitoUserPoolConfig(
+            poolId: testUserPoolId,
+            appClientId: testAppClientId,
+            region: testRegion,
+          ),
+        }),
+        credentialsProvider: CredentialsProviders({
+          'CognitoIdentity': AWSConfigMap({
+            'Default': CognitoIdentityCredentialsProvider(
+              poolId: testIdentityPoolId,
+              region: testRegion,
+            ),
+          }),
+        }),
+      ),
+    },
+  ),
+);
+
+final accessToken = JsonWebToken(
+  header: const JsonWebHeader(algorithm: Algorithm.hmacSha256),
+  claims: JsonWebClaims(subject: userSub, expiration: expiration),
+  signature: const [],
+);
+const refreshToken = 'refreshToken';
+const idToken = JsonWebToken(
+  header: JsonWebHeader(algorithm: Algorithm.hmacSha256),
+  claims: JsonWebClaims(subject: userSub),
+  signature: [],
+);
+const userSub = 'userSub';
+const accessKeyId = 'accessKeyId';
+const secretAccessKey = 'secretAccessKey';
+const sessionToken = 'sessionToken';
+final expiration = DateTime.utc(2100, 1, 1);
+const identityId = 'identityId';
+
+final authConfig = AuthConfiguration.fromConfig(mockConfig.auth!.awsPlugin!);
+final userPoolConfig = authConfig.userPoolConfig!;
+final identityPoolConfig = authConfig.identityPoolConfig!;
+final userPoolKeys = CognitoUserPoolKeys(userPoolConfig);
+final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig);

--- a/packages/auth/amplify_auth_cognito/test/common/mock_secure_storage.dart
+++ b/packages/auth/amplify_auth_cognito/test/common/mock_secure_storage.dart
@@ -1,0 +1,97 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_auth_cognito/src/credentials/cognito_keys.dart';
+import 'package:amplify_secure_storage/amplify_secure_storage.dart';
+
+import 'mock_config.dart';
+
+class MockSecureStorage implements SecureStorageInterface {
+  final Map<String, String> _storage = {};
+
+  @override
+  void delete({required String key}) => _storage.remove(key);
+
+  @override
+  String? read({required String key}) => _storage[key];
+
+  @override
+  void write({required String key, required String value}) =>
+      _storage[key] = value;
+}
+
+void seedStorage(
+  SecureStorageInterface secureStorage, {
+  CognitoUserPoolKeys? userPoolKeys,
+  CognitoIdentityPoolKeys? identityPoolKeys,
+  HostedUiKeys? hostedUiKeys,
+}) {
+  if (userPoolKeys != null) {
+    secureStorage
+      ..write(
+        key: userPoolKeys[CognitoUserPoolKey.accessToken],
+        value: accessToken.raw,
+      )
+      ..write(
+        key: userPoolKeys[CognitoUserPoolKey.refreshToken],
+        value: refreshToken,
+      )
+      ..write(
+        key: userPoolKeys[CognitoUserPoolKey.idToken],
+        value: idToken.raw,
+      )
+      ..write(
+        key: userPoolKeys[CognitoUserPoolKey.userSub],
+        value: userSub,
+      );
+  }
+  if (identityPoolKeys != null) {
+    secureStorage
+      ..write(
+        key: identityPoolKeys[CognitoIdentityPoolKey.accessKeyId],
+        value: accessKeyId,
+      )
+      ..write(
+        key: identityPoolKeys[CognitoIdentityPoolKey.secretAccessKey],
+        value: secretAccessKey,
+      )
+      ..write(
+        key: identityPoolKeys[CognitoIdentityPoolKey.sessionToken],
+        value: sessionToken,
+      )
+      ..write(
+        key: identityPoolKeys[CognitoIdentityPoolKey.expiration],
+        value: expiration.toIso8601String(),
+      )
+      ..write(
+        key: identityPoolKeys[CognitoIdentityPoolKey.identityId],
+        value: identityId,
+      );
+  }
+  if (hostedUiKeys != null) {
+    secureStorage
+      ..write(
+        key: hostedUiKeys[HostedUiKey.accessToken],
+        value: accessToken.raw,
+      )
+      ..write(
+        key: hostedUiKeys[HostedUiKey.refreshToken],
+        value: refreshToken,
+      )
+      ..write(
+        key: hostedUiKeys[HostedUiKey.idToken],
+        value: idToken.raw,
+      );
+  }
+}

--- a/packages/auth/amplify_auth_cognito/test/state/auth_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito/test/state/auth_state_machine_test.dart
@@ -1,0 +1,120 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:amplify_auth_cognito/src/state/state.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_secure_storage/amplify_secure_storage.dart';
+import 'package:stream_transform/stream_transform.dart';
+import 'package:test/test.dart';
+
+import '../common/mock_config.dart';
+import '../common/mock_secure_storage.dart';
+
+const badConfig = AmplifyConfig();
+
+void main() {
+  late CognitoAuthStateMachine stateMachine;
+  late SecureStorageInterface secureStorage;
+
+  group('AuthStateMachine', () {
+    setUp(() {
+      stateMachine = CognitoAuthStateMachine();
+      secureStorage = MockSecureStorage();
+      stateMachine.addInstance(secureStorage);
+    });
+
+    test('configure succeeds', () async {
+      final authStateMachine = stateMachine.getOrCreate(AuthStateMachine.type);
+
+      stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+      await expectLater(
+        authStateMachine.stream.startWith(authStateMachine.currentState),
+        emitsInOrder(<Matcher>[
+          isA<AuthNotConfigured>(),
+          isA<AuthConfiguring>(),
+          isA<AuthConfigured>(),
+        ]),
+      );
+
+      await stateMachine.close();
+    });
+
+    test('configure fails', () async {
+      final authStateMachine = stateMachine.getOrCreate(AuthStateMachine.type);
+
+      stateMachine.dispatch(const AuthEvent.configure(badConfig));
+      await expectLater(
+        authStateMachine.stream.startWith(authStateMachine.currentState),
+        emitsInOrder(<Matcher>[
+          isA<AuthNotConfigured>(),
+          isA<AuthConfiguring>(),
+          isA<AuthFailure>(),
+        ]),
+      );
+
+      await stateMachine.close();
+    });
+
+    test('retry configure succeeds', () async {
+      final authStateMachine = stateMachine.getOrCreate(AuthStateMachine.type);
+
+      stateMachine.dispatch(const AuthEvent.configure(badConfig));
+      await expectLater(
+        authStateMachine.stream.startWith(authStateMachine.currentState),
+        emitsInOrder(<Matcher>[
+          isA<AuthNotConfigured>(),
+          isA<AuthConfiguring>(),
+          isA<AuthFailure>(),
+        ]),
+      );
+
+      stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+      await expectLater(
+        authStateMachine.stream.startWith(authStateMachine.currentState),
+        emitsInOrder(<Matcher>[
+          isA<AuthFailure>(),
+          isA<AuthConfiguring>(),
+          isA<AuthConfigured>(),
+        ]),
+      );
+
+      await stateMachine.close();
+    });
+
+    test('multiple configures are ignored', () async {
+      final authStateMachine = stateMachine.getOrCreate(AuthStateMachine.type);
+
+      stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+      await expectLater(
+        authStateMachine.stream.startWith(authStateMachine.currentState),
+        emitsInOrder(<Matcher>[
+          isA<AuthNotConfigured>(),
+          isA<AuthConfiguring>(),
+          isA<AuthConfigured>(),
+        ]),
+      );
+
+      stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+      expect(
+        authStateMachine.stream,
+        emitsDone,
+      );
+
+      await stateMachine.close();
+    });
+  });
+}
+
+// ignore_for_file: close_sinks

--- a/packages/auth/amplify_auth_cognito/test/state/credential_store_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito/test/state/credential_store_state_machine_test.dart
@@ -1,0 +1,346 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:amplify_auth_cognito/src/credentials/cognito_keys.dart';
+import 'package:amplify_auth_cognito/src/state/state.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_secure_storage/amplify_secure_storage.dart';
+import 'package:stream_transform/stream_transform.dart';
+import 'package:test/test.dart';
+
+import '../common/mock_config.dart';
+import '../common/mock_secure_storage.dart';
+
+void main() {
+  test('CognitoKeys', () {
+    expect(userPoolKeys, hasLength(CognitoUserPoolKey.values.length));
+    expect(identityPoolKeys, hasLength(CognitoIdentityPoolKey.values.length));
+  });
+
+  group('CredentialStoreStateMachine', () {
+    late DependencyManager manager;
+    late CognitoAuthStateMachine stateMachine;
+    late SecureStorageInterface secureStorage;
+
+    setUp(() {
+      secureStorage = MockSecureStorage();
+      manager = DependencyManager()
+        ..addInstance(secureStorage)
+        ..addInstance(mockConfig)
+        ..addInstance(authConfig);
+      stateMachine = CognitoAuthStateMachine(dependencyManager: manager);
+    });
+
+    // Load an empty credential store.
+    test('loadCredentialStore (empty)', () async {
+      stateMachine.dispatch(
+        const CredentialStoreEvent.loadCredentialStore(),
+      );
+
+      final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
+      await expectLater(
+        sm.stream.startWith(sm.currentState),
+        emitsInOrder(<Matcher>[
+          isA<CredentialStoreNotConfigured>(),
+          isA<CredentialStoreLoadingStoredCredentials>(),
+          isA<CredentialStoreSuccess>(),
+        ]),
+      );
+
+      await stateMachine.close();
+    });
+
+    // Load a credential store which is already seeded.
+    test('loadCredentialStore', () async {
+      seedStorage(
+        secureStorage,
+        userPoolKeys: userPoolKeys,
+        identityPoolKeys: identityPoolKeys,
+      );
+      stateMachine.dispatch(
+        const CredentialStoreEvent.loadCredentialStore(),
+      );
+
+      final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
+      await expectLater(
+        sm.stream.startWith(sm.currentState),
+        emitsInOrder(<Matcher>[
+          isA<CredentialStoreNotConfigured>(),
+          isA<CredentialStoreLoadingStoredCredentials>(),
+          isA<CredentialStoreSuccess>(),
+        ]),
+      );
+
+      final result = await sm.getCredentialsResult();
+      expect(result.awsCredentials, isNotNull);
+      expect(result.awsCredentials?.accessKeyId, accessKeyId);
+      expect(result.awsCredentials?.secretAccessKey, secretAccessKey);
+      expect(result.awsCredentials?.sessionToken, sessionToken);
+      expect(result.awsCredentials?.expiration, expiration);
+      expect(result.identityId, identityId);
+      expect(result.userPoolTokens, isNotNull);
+      expect(result.userPoolTokens?.accessToken, accessToken);
+      expect(result.userPoolTokens?.refreshToken, refreshToken);
+      expect(result.userPoolTokens?.idToken, idToken);
+
+      await stateMachine.close();
+    });
+
+    group('storeCredentials', () {
+      test('all', () async {
+        stateMachine.dispatch(
+          const CredentialStoreEvent.loadCredentialStore(),
+        );
+
+        final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
+        await expectLater(
+          sm.stream.startWith(sm.currentState),
+          emitsInOrder(<Matcher>[
+            isA<CredentialStoreNotConfigured>(),
+            isA<CredentialStoreLoadingStoredCredentials>(),
+            isA<CredentialStoreSuccess>(),
+          ]),
+        );
+
+        final storeCredentialsEvent = CredentialStoreEvent.storeCredentials(
+          awsCredentials: AWSCredentials(
+            accessKeyId,
+            secretAccessKey,
+            sessionToken,
+            expiration,
+          ),
+          identityId: identityId,
+          userPoolTokens: CognitoUserPoolTokens(
+            (b) => b
+              ..accessToken = accessToken
+              ..refreshToken = refreshToken
+              ..idToken = idToken,
+          ),
+        );
+        stateMachine.dispatch(storeCredentialsEvent);
+
+        await expectLater(
+          sm.stream.startWith(sm.currentState),
+          emitsInOrder(<Matcher>[
+            isA<CredentialStoreSuccess>(),
+            isA<CredentialStoreStoringCredentials>(),
+            isA<CredentialStoreSuccess>(),
+          ]),
+        );
+
+        final result = await sm.getCredentialsResult();
+        expect(result.awsCredentials, isNotNull);
+        expect(result.awsCredentials?.accessKeyId, accessKeyId);
+        expect(result.awsCredentials?.secretAccessKey, secretAccessKey);
+        expect(result.awsCredentials?.sessionToken, sessionToken);
+        expect(result.awsCredentials?.expiration, expiration);
+        expect(result.identityId, identityId);
+        expect(result.userPoolTokens, isNotNull);
+        expect(result.userPoolTokens?.accessToken, accessToken);
+        expect(result.userPoolTokens?.refreshToken, refreshToken);
+        expect(result.userPoolTokens?.idToken, idToken);
+
+        await stateMachine.close();
+      });
+
+      test('partial', () async {
+        seedStorage(
+          secureStorage,
+          userPoolKeys: userPoolKeys,
+          identityPoolKeys: identityPoolKeys,
+        );
+        stateMachine.dispatch(
+          const CredentialStoreEvent.loadCredentialStore(),
+        );
+
+        final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
+        await expectLater(
+          sm.stream.startWith(sm.currentState),
+          emitsInOrder(<Matcher>[
+            isA<CredentialStoreNotConfigured>(),
+            isA<CredentialStoreLoadingStoredCredentials>(),
+            isA<CredentialStoreSuccess>(),
+          ]),
+        );
+
+        stateMachine.dispatch(
+          const CredentialStoreEvent.storeCredentials(
+            identityId: identityId,
+          ),
+        );
+        await expectLater(
+          sm.stream.startWith(sm.currentState),
+          emitsInOrder(<Matcher>[
+            isA<CredentialStoreSuccess>(),
+            isA<CredentialStoreStoringCredentials>(),
+            isA<CredentialStoreSuccess>(),
+          ]),
+        );
+
+        final result = await sm.getCredentialsResult();
+        expect(result.awsCredentials, isNotNull);
+        expect(result.awsCredentials?.accessKeyId, accessKeyId);
+        expect(result.awsCredentials?.secretAccessKey, secretAccessKey);
+        expect(result.awsCredentials?.sessionToken, sessionToken);
+        expect(result.awsCredentials?.expiration, expiration);
+        expect(result.identityId, identityId);
+        expect(result.userPoolTokens, isNotNull);
+        expect(result.userPoolTokens?.accessToken, accessToken);
+        expect(result.userPoolTokens?.refreshToken, refreshToken);
+        expect(result.userPoolTokens?.idToken, idToken);
+
+        await stateMachine.close();
+      });
+
+      test('overwrite', () async {
+        seedStorage(
+          secureStorage,
+          userPoolKeys: userPoolKeys,
+          identityPoolKeys: identityPoolKeys,
+        );
+        stateMachine.dispatch(
+          const CredentialStoreEvent.loadCredentialStore(),
+        );
+
+        final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
+        await expectLater(
+          sm.stream.startWith(sm.currentState),
+          emitsInOrder(<Matcher>[
+            isA<CredentialStoreNotConfigured>(),
+            isA<CredentialStoreLoadingStoredCredentials>(),
+            isA<CredentialStoreSuccess>(),
+          ]),
+        );
+
+        const newAccessKeyId = 'newAccessKeyId';
+        const newSecretAccessKey = 'newSecretAccessKey';
+        const newCredentials = AWSCredentials(
+          newAccessKeyId,
+          newSecretAccessKey,
+        );
+        stateMachine.dispatch(
+          const CredentialStoreEvent.storeCredentials(
+            awsCredentials: newCredentials,
+          ),
+        );
+        await expectLater(
+          sm.stream.startWith(sm.currentState),
+          emitsInOrder(<Matcher>[
+            isA<CredentialStoreSuccess>(),
+            isA<CredentialStoreStoringCredentials>(),
+            isA<CredentialStoreSuccess>(),
+          ]),
+        );
+
+        final result = await sm.getCredentialsResult();
+        expect(result.awsCredentials, isNotNull);
+        expect(result.awsCredentials?.accessKeyId, newAccessKeyId);
+        expect(result.awsCredentials?.secretAccessKey, newSecretAccessKey);
+        expect(result.awsCredentials?.sessionToken, isNull);
+        expect(result.awsCredentials?.expiration, isNull);
+
+        await stateMachine.close();
+      });
+    });
+
+    group('clearCredentials', () {
+      test('all', () async {
+        seedStorage(
+          secureStorage,
+          userPoolKeys: userPoolKeys,
+          identityPoolKeys: identityPoolKeys,
+        );
+        stateMachine.dispatch(
+          const CredentialStoreEvent.loadCredentialStore(),
+        );
+
+        final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
+        await expectLater(
+          sm.stream.startWith(sm.currentState),
+          emitsInOrder(<Matcher>[
+            isA<CredentialStoreNotConfigured>(),
+            isA<CredentialStoreLoadingStoredCredentials>(),
+            isA<CredentialStoreSuccess>(),
+          ]),
+        );
+
+        stateMachine.dispatch(
+          const CredentialStoreEvent.clearCredentials(),
+        );
+
+        await expectLater(
+          sm.stream.startWith(sm.currentState),
+          emitsInOrder(<Matcher>[
+            isA<CredentialStoreSuccess>(),
+            isA<CredentialStoreClearingCredentials>(),
+            isA<CredentialStoreSuccess>(),
+          ]),
+        );
+
+        final result = await sm.getCredentialsResult();
+        expect(result.awsCredentials, isNull);
+        expect(result.identityId, isNull);
+        expect(result.userPoolTokens, isNull);
+
+        await stateMachine.close();
+      });
+
+      test('partial', () async {
+        seedStorage(
+          secureStorage,
+          userPoolKeys: userPoolKeys,
+          identityPoolKeys: identityPoolKeys,
+        );
+        stateMachine.dispatch(
+          const CredentialStoreEvent.loadCredentialStore(),
+        );
+
+        final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
+        await expectLater(
+          sm.stream.startWith(sm.currentState),
+          emitsInOrder(<Matcher>[
+            isA<CredentialStoreNotConfigured>(),
+            isA<CredentialStoreLoadingStoredCredentials>(),
+            isA<CredentialStoreSuccess>(),
+          ]),
+        );
+
+        stateMachine.dispatch(
+          CredentialStoreEvent.clearCredentials(
+            identityPoolKeys,
+          ),
+        );
+
+        await expectLater(
+          sm.stream.startWith(sm.currentState),
+          emitsInOrder(<Matcher>[
+            isA<CredentialStoreSuccess>(),
+            isA<CredentialStoreClearingCredentials>(),
+            isA<CredentialStoreSuccess>(),
+          ]),
+        );
+
+        final result = await sm.getCredentialsResult();
+        expect(result.awsCredentials, isNull);
+        expect(result.identityId, isNull);
+        expect(result.userPoolTokens, isNotNull);
+
+        await stateMachine.close();
+      });
+    });
+  });
+}
+
+// ignore_for_file: close_sinks

--- a/packages/secure_storage/amplify_secure_storage/lib/amplify_secure_storage.dart
+++ b/packages/secure_storage/amplify_secure_storage/lib/amplify_secure_storage.dart
@@ -14,5 +14,6 @@
 
 library amplify_secure_storage;
 
+export 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 export 'src/amplify_secure_storage.vm.dart'
     if (dart.library.html) 'src/amplify_secure_storage.web.dart';

--- a/packages/secure_storage/amplify_secure_storage/lib/src/amplify_secure_storage.android.dart
+++ b/packages/secure_storage/amplify_secure_storage/lib/src/amplify_secure_storage.android.dart
@@ -17,9 +17,6 @@ import 'dart:async';
 import 'package:amplify_secure_storage/src/messages.g.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 
-export 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart'
-    show AmplifySecureStorageConfig;
-
 class AmplifySecureStorageAndroid extends AmplifySecureStorageInterface {
   const AmplifySecureStorageAndroid({
     required AmplifySecureStorageConfig config,

--- a/packages/secure_storage/amplify_secure_storage/lib/src/amplify_secure_storage.vm.dart
+++ b/packages/secure_storage/amplify_secure_storage/lib/src/amplify_secure_storage.vm.dart
@@ -18,9 +18,6 @@ import 'dart:io';
 import 'package:amplify_secure_storage/src/amplify_secure_storage.android.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 
-export 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart'
-    show AmplifySecureStorageConfig;
-
 /// {@template amplify_secure_storage.amplify_secure_storage}
 /// The default Secure Storage implementation used in Amplify packages.
 /// {@endtemplate}

--- a/packages/secure_storage/amplify_secure_storage/lib/src/amplify_secure_storage.web.dart
+++ b/packages/secure_storage/amplify_secure_storage/lib/src/amplify_secure_storage.web.dart
@@ -16,9 +16,6 @@ import 'dart:async';
 
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 
-export 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart'
-    show AmplifySecureStorageConfig;
-
 /// {@macro amplify_secure_storage.amplify_secure_storage}
 class AmplifySecureStorage extends AmplifySecureStorageInterface {
   /// {@macro amplify_secure_storage.amplify_secure_storage}


### PR DESCRIPTION
Introduces Dart-only category configuration and credential storage via the state machine

---

**Stack**:
- #1642
- #1639
- #1625


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*