### PR TITLE
chore!(api): run background thread when cancel operation

### DIFF
--- a/packages/api/amplify_api_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApi.kt
+++ b/packages/api/amplify_api_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApi.kt
@@ -15,6 +15,8 @@
 
 package com.amazonaws.amplify.amplify_api
 
+import android.content.Context
+import android.os.AsyncTask
 import android.os.Handler
 import android.os.Looper
 import androidx.annotation.NonNull
@@ -149,8 +151,12 @@ class AmplifyApi : FlutterPlugin, MethodCallHandler {
         cancelToken: String
     ) {
         if (OperationsManager.containsOperation(cancelToken)) {
-            OperationsManager.cancelOperation(cancelToken)
-            flutterResult.success("Operation Canceled")
+            AsyncTask.execute {
+                OperationsManager.cancelOperation(cancelToken)
+                handler.post {
+                    flutterResult.success("Operation Canceled")
+                }
+            }
         } else {
             flutterResult.error(
                 "AmplifyAPI-CancelError",


### PR DESCRIPTION
1. **Issue**:
- When cancel multiple operation at the same time, android main thread will be freeze
2. **Description of changes:**
- Improvement: Use async task to execute the cancel job in background thread