### PR TITLE
fix(amplify_authenticator): trims strings for password confirmation diffs

### DIFF
--- a/packages/amplify_authenticator/lib/src/state/authenticator_state.dart
+++ b/packages/amplify_authenticator/lib/src/state/authenticator_state.dart
@@ -105,7 +105,7 @@ class AuthenticatorState extends ChangeNotifier {
   String get password => _password;
 
   set password(String value) {
-    _password = value;
+    _password = value.trim();
     notifyListeners();
   }
 
@@ -157,7 +157,7 @@ class AuthenticatorState extends ChangeNotifier {
   String get newPassword => _newPassword;
 
   set newPassword(String value) {
-    _newPassword = value;
+    _newPassword = value.trim();
     notifyListeners();
   }
 

--- a/packages/amplify_authenticator/lib/src/utils/validators.dart
+++ b/packages/amplify_authenticator/lib/src/utils/validators.dart
@@ -112,7 +112,7 @@ FormFieldValidator<String> validatePasswordConfirmation(
         context,
         InputResolverKey.passwordConfirmationEmpty,
       );
-    } else if (getPassword().trim() != passwordConfirmation.trim()) {
+    } else if (getPassword() != passwordConfirmation.trim()) {
       return inputResolver.resolve(
           context, InputResolverKey.passwordsDoNotMatch);
     }

--- a/packages/amplify_authenticator/lib/src/utils/validators.dart
+++ b/packages/amplify_authenticator/lib/src/utils/validators.dart
@@ -112,7 +112,7 @@ FormFieldValidator<String> validatePasswordConfirmation(
         context,
         InputResolverKey.passwordConfirmationEmpty,
       );
-    } else if (getPassword() != passwordConfirmation) {
+    } else if (getPassword().trim() != passwordConfirmation.trim()) {
       return inputResolver.resolve(
           context, InputResolverKey.passwordsDoNotMatch);
     }


### PR DESCRIPTION
*Issue #, if available:*
This PR potentially fixed #1592, but we will need additional feedback from the customer to confirm. The change is valid regardless of whether it fixes this particular issue.

*Description of changes:*
Trims strings in password confirmation comparison.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
