### PR TITLE
chore: add canary workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,181 @@
 version: 2.1
 
+orbs:
+  # Using inline orb for now
+  getting-started-smoke-test:
+    orbs:
+      macos: circleci/macos@2.2.0
+      android: circleci/android@2.0.3
+      flutter-orb: circleci/flutter@1.1.0
+
+    executors:
+      mac-executor:
+        macos:
+          xcode: 13.2.1
+        resource_class: large
+
+      android-executor:
+        machine:
+          image: android:202102-01
+        resource_class: large
+
+    commands:
+      run-with-retry:
+        description: Run command with retry
+        parameters:
+          label:
+            description: Display name
+            type: string
+          command:
+            description: Command to run
+            type: string
+          retry-count:
+            description: Number of retry
+            type: integer
+            default: 3
+          sleep:
+            description: Wait duration until next retry
+            type: integer
+            default: 5
+          no_output_timeout:
+            description: Elapsed time the command can run without output
+            type: string
+            default: 10m
+        steps:
+          - run:
+              name: << parameters.label >>
+              command: |
+                retry() {
+                  MAX_RETRY=<< parameters.retry-count >>
+                  n=0
+                  until [ $n -ge $MAX_RETRY ]
+                  do
+                      << parameters.command >> && break
+                      n=$[$n+1]
+                      sleep << parameters.sleep >>
+                  done
+                  if [ $n -ge $MAX_RETRY ]; then
+                    echo "failed: ${@}" >&2
+                    exit 1
+                  fi
+                }
+                retry
+              no_output_timeout: << parameters.no_output_timeout >>
+      install-flutter:
+        description: Install Flutter and set up paths.
+        parameters:
+          flutter_branch:
+            description: Flutter branch or version tag.
+            type: string
+            default: stable
+        steps:
+          - run:
+              name: Set up Flutter
+              command: |
+                echo 'export FLUTTER_HOME=${HOME}/sdks/flutter' >> $BASH_ENV
+                echo 'export FLUTTER_BRANCH=<< parameters.flutter_branch >>' >> $BASH_ENV
+                echo 'export FLUTTER_ROOT=${FLUTTER_HOME}' >> $BASH_ENV
+                echo 'export PATH=${PATH}:${FLUTTER_HOME}/bin:${FLUTTER_HOME}/bin/cache/dart-sdk/bin:${HOME}/.pub-cache/bin:${FLUTTER_HOME}/.pub-cache/bin' >> $BASH_ENV
+                source $BASH_ENV
+                git clone --branch ${FLUTTER_BRANCH} https://github.com/flutter/flutter.git ${FLUTTER_HOME}
+                (yes || true) | flutter doctor --android-licenses && flutter doctor
+                flutter precache
+      setup-amplify-flutter-project:
+        description: Setup Amplify project
+        steps:
+          - run-with-retry:
+              label: Setting up dependences
+              command: flutter pub add amplify_flutter && flutter pub add amplify_datastore && flutter pub add amplify_storage_s3 && flutter pub add amplify_analytics_pinpoint && flutter pub add amplify_auth_cognito && flutter pub add amplify_api
+              no_output_timeout: 5m
+          - run:
+              name: Adding integration_test package
+              command: 'sed -i -e "s/dev_dependencies:/dev_dependencies:\n  integration_test:\n    sdk: flutter/" ./pubspec.yaml && cat ./pubspec.yaml'
+          - run:
+              name: Update outdated dependences
+              command: flutter pub upgrade --major-versions
+          - run:
+              name: Adding amplifyconfig file
+              command: mv canaries/dummy_amplifyconfiguration.dart canaries/amplifyconfiguration.dart && cp canaries/amplifyconfiguration.dart amplified_todo/lib
+              working_directory: ~/flutter-canaries/
+          - run:
+              name: Adding test code
+              command: cp canaries/main.dart amplified_todo/lib && cp -r canaries/integration_test amplified_todo/integration_test && cp -r canaries/models amplified_todo/lib/models
+              working_directory: ~/flutter-canaries/
+
+
+    jobs:
+      flutter-android:
+        parameters:
+          flutter-version:
+            type: string
+        executor:
+          name: android/android-machine
+          resource-class: large
+          tag: 2021.10.1
+        working_directory: ~/flutter-canaries/amplified_todo
+        steps:
+          - checkout:
+              path: ~/flutter-canaries
+          - install-flutter:
+              flutter_branch: << parameters.flutter-version >>
+          - run:
+              name: Setting up project
+              command: cd ../ && flutter create amplified_todo
+          - run:
+              name: Update Android version
+              command: sed -i -e "s/minSdkVersion .*/minSdkVersion 21/" ./android/app/build.gradle && cat ./android/app/build.gradle
+          - setup-amplify-flutter-project
+          - flutter-orb/install_android_gradle:
+              app-dir: ./
+          - android/create-avd:
+              avd-name: flutter
+              install: true
+              system-image: system-images;android-29;default;x86
+          - android/start-emulator:
+              avd-name: flutter
+              post-emulator-launch-assemble-command: ls -lrt
+              restore-gradle-cache-find-args: ./android -name 'build.gradle'
+          - run-with-retry:
+              label: Run Flutter Build
+              command: flutter build apk --debug
+              no_output_timeout: 20m
+          - run-with-retry:
+              label: Run Flutter Tests
+              command: flutter test integration_test
+              no_output_timeout: 1h
+              retry-count: 5
+
+      flutter-ios:
+        parameters:
+          flutter-version:
+            type: string
+        executor: mac-executor
+        working_directory: ~/flutter-canaries/amplified_todo
+        steps:
+          - checkout:
+              path: ~/flutter-canaries
+          - macos/preboot-simulator:
+              device: iPhone 13
+              version: "15.2"
+          - install-flutter:
+              flutter_branch: << parameters.flutter-version >>
+          - run:
+              name: Setting up project
+              command: cd ../ && flutter create amplified_todo
+          - setup-amplify-flutter-project
+          - run:
+              name: Update ios version
+              command: sed -i -e "s/# platform .*/platform :ios, '13.0'/" ./ios/Podfile && cat ./ios/Podfile
+          - run-with-retry:
+              label: Run Flutter Build
+              command: flutter build ios --debug --simulator
+              no_output_timeout: 20m
+          - run-with-retry:
+              label: Run Flutter Tests
+              command: flutter test integration_test
+              no_output_timeout: 20m
+
+
 executors:
   docker-executor:
     docker:
@@ -50,6 +226,7 @@ commands:
           name: Install tuneup
           command: |
             flutter pub global activate tuneup
+
 jobs:
   format_flutter:
     executor: docker-executor
@@ -198,10 +375,16 @@ releasable_branches: &releasable_branches
 
 workflows:
   test_deploy:
+    # Tells CircleCI to skip this workflow when the pipeline is triggered by the scheduled source,
+    # i.e. when the canaries workflow executes
+    # https://circleci.com/docs/2.0/scheduled-pipelines/#workflows-filtering
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - format_flutter
       - analyze_flutter
-      # TODO: Enable pub_analysis after https://github.com/dart-lang/pana/issues/1020 is 
+      # TODO: Enable pub_analysis after https://github.com/dart-lang/pana/issues/1020 is
       # resolved or these are updated to run against unpub
       # - pub_analysis:
       #     matrix:
@@ -222,35 +405,51 @@ workflows:
             parameters:
               plugin:
                 [
-                  "amplify_analytics_pinpoint",
-                  "amplify_api",
-                  "amplify_auth_cognito",
-                  "amplify_authenticator",
-                  "amplify_core",
-                  "amplify_datastore",
-                  "amplify_flutter",
-                  "amplify_storage_s3"
+                    "amplify_analytics_pinpoint",
+                    "amplify_api",
+                    "amplify_auth_cognito",
+                    "amplify_authenticator",
+                    "amplify_core",
+                    "amplify_datastore",
+                    "amplify_flutter",
+                    "amplify_storage_s3"
                 ]
       - unit_test_android:
           matrix:
             parameters:
               plugin:
                 [
-                  "amplify_analytics_pinpoint",
-                  "amplify_api",
-                  "amplify_auth_cognito",
-                  "amplify_core",
-                  "amplify_datastore",
-                  "amplify_flutter",
+                    "amplify_analytics_pinpoint",
+                    "amplify_api",
+                    "amplify_auth_cognito",
+                    "amplify_core",
+                    "amplify_datastore",
+                    "amplify_flutter",
                 ]
       - unit_test_ios:
           matrix:
             parameters:
               plugin:
                 [
-                  "amplify_analytics_pinpoint",
-                  "amplify_api",
-                  "amplify_auth_cognito",
-                  "amplify_datastore",
-                  "amplify_flutter",
+                    "amplify_analytics_pinpoint",
+                    "amplify_api",
+                    "amplify_auth_cognito",
+                    "amplify_datastore",
+                    "amplify_flutter",
                 ]
+  # Scheduled smoke test workflow
+  # Jobs are pulled from the getting-started-smoke-test inline orb defined above
+  canaries:
+#    when:
+#      and:
+#        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+#        - equal: [ "Canaries", << pipeline.schedule.name >> ]
+    jobs:
+      - getting-started-smoke-test/flutter-android:
+          matrix:
+            parameters:
+              flutter-version: [ "stable", "beta" ]
+      - getting-started-smoke-test/flutter-ios:
+          matrix:
+            parameters:
+              flutter-version: [ "stable", "beta" ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,6 @@ orbs:
               command: cp canaries/main.dart amplified_todo/lib && cp -r canaries/integration_test amplified_todo/integration_test && cp -r canaries/models amplified_todo/lib/models
               working_directory: ~/flutter-canaries/
 
-
     jobs:
       flutter-android:
         parameters:
@@ -154,6 +153,9 @@ orbs:
         steps:
           - checkout:
               path: ~/flutter-canaries
+          - run:
+              name: Install gnu-sed
+              command: brew install gnu-sed
           - macos/preboot-simulator:
               device: iPhone 13
               version: "15.2"
@@ -163,6 +165,9 @@ orbs:
               name: Setting up project
               command: cd ../ && flutter create amplified_todo
           - setup-amplify-flutter-project
+          - run:
+              name: Removing IPHONEOS_DEPLOYMENT_TARGET from build_settings
+              command: cd ios && gsed -i "/flutter_additional_ios_build_settings(target)/ a \    target.build_configurations.each do |config|\n      config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'\n    end" Podfile
           - run:
               name: Update ios version
               command: sed -i -e "s/# platform .*/platform :ios, '13.0'/" ./ios/Podfile && cat ./ios/Podfile
@@ -440,10 +445,10 @@ workflows:
   # Scheduled smoke test workflow
   # Jobs are pulled from the getting-started-smoke-test inline orb defined above
   canaries:
-#    when:
-#      and:
-#        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-#        - equal: [ "Canaries", << pipeline.schedule.name >> ]
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "Canaries", << pipeline.schedule.name >> ]
     jobs:
       - getting-started-smoke-test/flutter-android:
           matrix:

--- a/canaries/dummy_amplifyconfiguration.dart
+++ b/canaries/dummy_amplifyconfiguration.dart
@@ -1,0 +1,4 @@
+const amplifyconfig = ''' {
+    "UserAgent": "aws-amplify-cli/2.0",
+    "Version": "1.0"
+}''';

--- a/canaries/integration_test/app_test.dart
+++ b/canaries/integration_test/app_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:amplified_todo/main.dart' as app;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('end-to-end test', () {
+    testWidgets('tap on the floating action button, verify counter',
+            (tester) async {
+          app.main();
+          await tester.pumpAndSettle();
+
+          // Verify the counter starts at 0.
+          expect(find.text('0'), findsOneWidget);
+
+          // Finds the floating action button to tap on.
+          final Finder fab = find.byTooltip('Increment');
+
+          // Emulate a tap on the floating action button.
+          await tester.tap(fab);
+
+          // Trigger a frame.
+          await tester.pumpAndSettle();
+
+          // Verify the counter increments by 1.
+          expect(find.text('1'), findsOneWidget);
+        });
+  });
+}

--- a/canaries/main.dart
+++ b/canaries/main.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
+import 'package:amplify_analytics_pinpoint/amplify_analytics_pinpoint.dart';
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:amplify_storage_s3/amplify_storage_s3.dart';
+import 'package:amplify_datastore/amplify_datastore.dart';
+import 'package:amplify_api/amplify_api.dart';
+import '/models/ModelProvider.dart';
+import 'amplifyconfiguration.dart';
+
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  // This widget is the root of your application.
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        // This is the theme of your application.
+        //
+        // Try running your application with "flutter run". You'll see the
+        // application has a blue toolbar. Then, without quitting the app, try
+        // changing the primarySwatch below to Colors.green and then invoke
+        // "hot reload" (press "r" in the console where you ran "flutter run",
+        // or simply save your changes to "hot reload" in a Flutter IDE).
+        // Notice that the counter didn't reset back to zero; the application
+        // is not restarted.
+        primarySwatch: Colors.blue,
+      ),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({Key? key, required this.title}) : super(key: key);
+
+  // This widget is the home page of your application. It is stateful, meaning
+  // that it has a State object (defined below) that contains fields that affect
+  // how it looks.
+
+  // This class is the configuration for the state. It holds the values (in this
+  // case the title) provided by the parent (in this case the App widget) and
+  // used by the build method of the State. Fields in a Widget subclass are
+  // always marked "final".
+
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _counter = 0;
+
+  @override
+  void initState() {
+    _configureAmplify();
+    super.initState();
+  }
+
+  void _configureAmplify() async {
+    if(!Amplify.isConfigured) {
+      print("Configuring amplify");
+      AmplifyAuthCognito auth = AmplifyAuthCognito();
+      AmplifyStorageS3 storage = AmplifyStorageS3();
+      AmplifyAnalyticsPinpoint analytics = AmplifyAnalyticsPinpoint();
+      Amplify.addPlugin(AmplifyAPI(modelProvider: ModelProvider.instance));
+      AmplifyDataStore datastorePlugin =
+      AmplifyDataStore(modelProvider: ModelProvider.instance);
+
+      try {
+        await Amplify.addPlugins([auth, storage, analytics, datastorePlugin]);
+        await Amplify.configure(amplifyconfig);
+        print("Done configuring amplify");
+      } on AmplifyException catch (e)  {
+        print(e);
+        print("Expected to fail cause there's no real amplifyconfig file");
+      }
+    }
+  }
+
+  void _incrementCounter() {
+    setState(() {
+      // This call to setState tells the Flutter framework that something has
+      // changed in this State, which causes it to rerun the build method below
+      // so that the display can reflect the updated values. If we changed
+      // _counter without calling setState(), then the build method would not be
+      // called again, and so nothing would appear to happen.
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // This method is rerun every time setState is called, for instance as done
+    // by the _incrementCounter method above.
+    //
+    // The Flutter framework has been optimized to make rerunning build methods
+    // fast, so that you can just rebuild anything that needs updating rather
+    // than having to individually change instances of widgets.
+    return Scaffold(
+      appBar: AppBar(
+        // Here we take the value from the MyHomePage object that was created by
+        // the App.build method, and use it to set our appbar title.
+        title: Text(widget.title),
+      ),
+      body: Center(
+        // Center is a layout widget. It takes a single child and positions it
+        // in the middle of the parent.
+        child: Column(
+          // Column is also a layout widget. It takes a list of children and
+          // arranges them vertically. By default, it sizes itself to fit its
+          // children horizontally, and tries to be as tall as its parent.
+          //
+          // Invoke "debug painting" (press "p" in the console, choose the
+          // "Toggle Debug Paint" action from the Flutter Inspector in Android
+          // Studio, or the "Toggle Debug Paint" command in Visual Studio Code)
+          // to see the wireframe for each widget.
+          //
+          // Column has various properties to control how it sizes itself and
+          // how it positions its children. Here we use mainAxisAlignment to
+          // center the children vertically; the main axis here is the vertical
+          // axis because Columns are vertical (the cross axis would be
+          // horizontal).
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              'You have pushed the button this many times:',
+            ),
+            Text(
+              '$_counter',
+              style: Theme.of(context).textTheme.headline4,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _incrementCounter,
+        tooltip: 'Increment',
+        child: const Icon(Icons.add),
+      ), // This trailing comma makes auto-formatting nicer for build methods.
+    );
+  }
+}

--- a/canaries/models/ModelProvider.dart
+++ b/canaries/models/ModelProvider.dart
@@ -1,0 +1,45 @@
+/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
+
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+
+class ModelProvider implements ModelProviderInterface {
+  @override
+  String version = "f80fece878bf91a76f44577fe599b120";
+  @override
+  List<ModelSchema> modelSchemas = [
+
+  ];
+  static final ModelProvider _instance = ModelProvider();
+  @override
+  List<ModelSchema> customTypeSchemas = [
+
+  ];
+
+  static ModelProvider get instance => _instance;
+
+  @override
+  ModelType<Model> getModelTypeByModelName(String modelName) {
+    // TODO: implement getModelTypeByModelName
+    throw UnimplementedError();
+  }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added canary workflow for getting started workflow(https://docs.amplify.aws/start/q/integration/flutter/). The new circleci job essentially doing the same step as described in the tutorial. 

After merging:
We will set up a trigger to run once a day(https://circleci.com/docs/2.0/scheduled-pipelines/#project-settings)

Note: We are using inline orb for now, we will extract the implementation and put in an actual orb after we've confirmed it runs successfully for couple of days, and when orb's namespace is ready to use

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
