### PR TITLE
fix(aws_signature_v4): Presign Min/Max Expirations

### DIFF
--- a/packages/aws_signature_v4/example/bin/example.dart
+++ b/packages/aws_signature_v4/example/bin/example.dart
@@ -162,13 +162,22 @@ Future<void> main(List<String> args) async {
       AWSHeaders.host: host,
     },
   );
-  final Uri signedUrl = await signer.presign(
+
+  final Uri signedUrl1Sec = await signer.presign(
     urlRequest,
     credentialScope: scope,
     serviceConfiguration: serviceConfiguration,
-    expiresIn: const Duration(minutes: 10),
+    expiresIn: const Duration(seconds: 1),
   );
-  stdout.writeln('Download URL: $signedUrl');
+  stdout.writeln('Download URL for 1 second: $signedUrl1Sec');
+
+  final Uri signedUrl7Days = await signer.presign(
+    urlRequest,
+    credentialScope: scope,
+    serviceConfiguration: serviceConfiguration,
+    expiresIn: const Duration(days: 7),
+  );
+  stdout.writeln('Download URL for 7 days: $signedUrl7Days');
 }
 
 /// Exits the script with an [error].

--- a/packages/aws_signature_v4/example/bin/example.dart
+++ b/packages/aws_signature_v4/example/bin/example.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: omit_local_variable_types
+
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
@@ -36,34 +38,47 @@ Future<void> main(List<String> args) async {
   const bucketArg = 'bucket';
   const regionArg = 'region';
 
-  argParser.addOption(accessKeyIdArg,
-      abbr: 'a', valueHelp: $awsAccessKeyId, mandatory: false);
-  argParser.addOption(secretAccessKeyArg,
-      abbr: 's', valueHelp: $awsSecretAccessKey, mandatory: false);
-  argParser.addOption(sessionTokenArg,
-      abbr: 't', valueHelp: $awsSessionToken, mandatory: false);
-  argParser.addOption(
-    bucketArg,
-    abbr: 'b',
-    help: 'The name of the bucket to create',
-    valueHelp: 'BUCKET',
-    mandatory: false,
-  );
-  argParser.addOption(
-    regionArg,
-    abbr: 'r',
-    help: 'The region of the bucket',
-    valueHelp: 'REGION',
-    mandatory: true,
-  );
+  argParser
+    ..addOption(
+      accessKeyIdArg,
+      abbr: 'a',
+      valueHelp: $awsAccessKeyId,
+      mandatory: false,
+    )
+    ..addOption(
+      secretAccessKeyArg,
+      abbr: 's',
+      valueHelp: $awsSecretAccessKey,
+      mandatory: false,
+    )
+    ..addOption(
+      sessionTokenArg,
+      abbr: 't',
+      valueHelp: $awsSessionToken,
+      mandatory: false,
+    )
+    ..addOption(
+      bucketArg,
+      abbr: 'b',
+      help: 'The name of the bucket to create',
+      valueHelp: 'BUCKET',
+      mandatory: false,
+    )
+    ..addOption(
+      regionArg,
+      abbr: 'r',
+      help: 'The region of the bucket',
+      valueHelp: 'REGION',
+      mandatory: true,
+    );
 
   final parsedArgs = argParser.parse(args);
-  final String? accessKeyId =
-      Platform.environment[$awsAccessKeyId] ?? parsedArgs[accessKeyIdArg];
+  final String? accessKeyId = Platform.environment[$awsAccessKeyId] ??
+      parsedArgs[accessKeyIdArg] as String?;
   final String? secretAccessKey = Platform.environment[$awsSecretAccessKey] ??
-      parsedArgs[secretAccessKeyArg];
-  final String? sessionToken =
-      Platform.environment[$awsSessionToken] ?? parsedArgs[sessionTokenArg];
+      parsedArgs[secretAccessKeyArg] as String?;
+  final String? sessionToken = Platform.environment[$awsSessionToken] ??
+      parsedArgs[sessionTokenArg] as String?;
 
   if (accessKeyId == null || secretAccessKey == null) {
     exitWithError('No AWS credentials found');
@@ -95,11 +110,13 @@ Future<void> main(List<String> args) async {
   final ServiceConfiguration serviceConfiguration = S3ServiceConfiguration();
 
   // Create the bucket
-  final List<int> createBody = utf8.encode('''
+  final List<int> createBody = utf8.encode(
+    '''
 <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 <LocationConstraint>$region</LocationConstraint>
 </CreateBucketConfiguration>
-''');
+''',
+  );
   final AWSHttpRequest createRequest = AWSHttpRequest.put(
     Uri.https(host, '/'),
     body: createBody,
@@ -162,22 +179,13 @@ Future<void> main(List<String> args) async {
       AWSHeaders.host: host,
     },
   );
-
-  final Uri signedUrl1Sec = await signer.presign(
+  final Uri signedUrl = await signer.presign(
     urlRequest,
     credentialScope: scope,
     serviceConfiguration: serviceConfiguration,
-    expiresIn: const Duration(seconds: 1),
+    expiresIn: const Duration(minutes: 10),
   );
-  stdout.writeln('Download URL for 1 second: $signedUrl1Sec');
-
-  final Uri signedUrl7Days = await signer.presign(
-    urlRequest,
-    credentialScope: scope,
-    serviceConfiguration: serviceConfiguration,
-    expiresIn: const Duration(days: 7),
-  );
-  stdout.writeln('Download URL for 7 days: $signedUrl7Days');
+  stdout.writeln('Download URL: $signedUrl');
 }
 
 /// Exits the script with an [error].

--- a/packages/aws_signature_v4/lib/src/request/canonical_request/canonical_request.dart
+++ b/packages/aws_signature_v4/lib/src/request/canonical_request/canonical_request.dart
@@ -25,8 +25,8 @@ import 'package:path/path.dart';
 part 'canonical_headers.dart';
 part 'canonical_path.dart';
 part 'canonical_query_parameters.dart';
-part 'signed_headers.dart';
 part 'canonical_request_util.dart';
+part 'signed_headers.dart';
 
 /// {@template aws_signature_v4.canonical_request}
 /// A canonicalized request, used for signing via the SigV4 signing process.
@@ -164,8 +164,8 @@ class CanonicalRequest {
 
     // Per https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
     assert(
-      expiresIn > const Duration(seconds: 1) &&
-          expiresIn < const Duration(days: 7),
+      expiresIn >= const Duration(seconds: 1) &&
+          expiresIn <= const Duration(days: 7),
       'Expiration must be greater than 1 second and less than 7 days',
     );
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

According to the [doc]( https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html), minimum exp value is one second, and maximum exp value is 7 days. 

- change `>` to `>=` and `<` to `<=`
- modify examples to print seven days and one second link

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
