### PR TITLE
chore: add DS integ test for parent ID query

### DIFF
--- a/packages/amplify_datastore/example/integration_test/query_test/standard_query_operations_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/standard_query_operations_test.dart
@@ -81,5 +81,30 @@ void main() {
       var post = posts[0];
       expect(post.blog!.id, testBlog.id);
     });
+
+    testWidgets('should return the correct records when queried by parent ID',
+        (WidgetTester tester) async {
+      Blog testBlog1 = Blog(name: 'blog one');
+      Blog testBlog2 = Blog(name: 'blog two');
+      Post testPost1 = Post(title: 'post one', rating: 0, blog: testBlog1);
+      Post testPost2 = Post(title: 'post two', rating: 0, blog: testBlog1);
+      Post testPost3 = Post(title: 'post three', rating: 0, blog: testBlog2);
+
+      await Amplify.DataStore.save(testBlog1);
+      await Amplify.DataStore.save(testBlog2);
+      await Amplify.DataStore.save(testPost1);
+      await Amplify.DataStore.save(testPost2);
+      await Amplify.DataStore.save(testPost3);
+
+      var posts = await Amplify.DataStore.query(
+        Post.classType,
+        where: Post.BLOG.eq(testBlog1.id),
+      );
+
+      expect(posts.length, 2);
+      expect(posts.contains(testPost1), isTrue);
+      expect(posts.contains(testPost2), isTrue);
+      expect(posts.contains(testPost3), isFalse);
+    });
   });
 }

--- a/packages/amplify_datastore/example/ios/Runner/Info.plist
+++ b/packages/amplify_datastore/example/ios/Runner/Info.plist
@@ -41,5 +41,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Adds and integ test for querying by the parent ID. We have one [similar to this in API](https://github.com/aws-amplify/amplify-flutter/blob/main/packages/api/amplify_api/example/integration_test/graphql_tests.dart#L247-L262), but nothing in DS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
