### PR TITLE
fix(authenticator): allow second signin attempt on web

### DIFF
--- a/packages/amplify_authenticator/example/integration_test/sign_in_with_username_test.dart
+++ b/packages/amplify_authenticator/example/integration_test/sign_in_with_username_test.dart
@@ -190,7 +190,7 @@ void main() {
     // And I click the "Sign in" button
     await signInPage.submitSignIn();
 
-    /// Then I see UserNotFound exception bannder
+    /// Then I see UserNotFound exception banner
     await signInPage.expectUserNotFound();
 
     // Then I type the correct username
@@ -198,6 +198,9 @@ void main() {
 
     // Then I type the correct password
     await signInPage.enterPassword(password);
+
+    // And I click the "Sign in" button
+    await signInPage.submitSignIn();
 
     // And I click the "Sign in" button
     await signInPage.expectAuthenticated();

--- a/packages/amplify_authenticator/example/integration_test/sign_in_with_username_test.dart
+++ b/packages/amplify_authenticator/example/integration_test/sign_in_with_username_test.dart
@@ -16,7 +16,6 @@
 // This test follows the Amplify UI feature "sign-in-with-username"
 // https://github.com/aws-amplify/amplify-ui/blob/main/packages/e2e/features/ui/components/authenticator/sign-up-with-username.feature
 
-import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
@@ -165,5 +164,42 @@ void main() {
       await confirmSignInPage.expectConfirmSignInNewPasswordIsPresent();
       confirmSignInPage.expectNewPasswordIsPresent();
     });
+  });
+
+  testWidgets(
+      'Sign in with confirmed credentials after a failed attempt with bad credentials',
+      (tester) async {
+    final username = generateUsername();
+    final password = generatePassword();
+    await adminCreateUser(
+      username,
+      password,
+      autoConfirm: true,
+      verifyAttributes: true,
+    );
+    await loadAuthenticator(tester: tester, authenticator: authenticator);
+    SignInPage signInPage = SignInPage(tester: tester);
+    signInPage.expectUsername();
+
+    // When I type my "username"
+    await signInPage.enterUsername('bad_username');
+
+    // And I type my bad password
+    await signInPage.enterPassword(password);
+
+    // And I click the "Sign in" button
+    await signInPage.submitSignIn();
+
+    /// Then I see UserNotFound exception bannder
+    await signInPage.expectUserNotFound();
+
+    // Then I type the correct username
+    await signInPage.enterUsername(username);
+
+    // Then I type the correct password
+    await signInPage.enterPassword(password);
+
+    // And I click the "Sign in" button
+    await signInPage.expectAuthenticated();
   });
 }

--- a/packages/amplify_authenticator/example/integration_test/sign_in_with_username_test.dart
+++ b/packages/amplify_authenticator/example/integration_test/sign_in_with_username_test.dart
@@ -202,7 +202,7 @@ void main() {
     // And I click the "Sign in" button
     await signInPage.submitSignIn();
 
-    // And I click the "Sign in" button
+    // Then I am signed in
     await signInPage.expectAuthenticated();
   });
 }

--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -122,6 +122,7 @@ class StateMachineBloc {
     yield const LoadingState();
     await Amplify.asyncConfig;
     yield* _isValidSession();
+    yield* const Stream.empty();
   }
 
   Stream<AuthState> _isValidSession() async* {
@@ -325,11 +326,10 @@ class StateMachineBloc {
         e.message,
         showBanner: !e.message.contains('cancelled'),
       ));
-      yield UnauthenticatedState.signIn;
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e.toString()));
-      yield UnauthenticatedState.signIn;
     }
+    yield* const Stream.empty();
   }
 
   Stream<AuthState> _checkUserVerification() async* {
@@ -380,6 +380,7 @@ class StateMachineBloc {
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e.toString()));
     }
+    yield* const Stream.empty();
   }
 
   Stream<AuthState> _confirmSignUp(AuthConfirmSignUpData data) async* {
@@ -396,6 +397,7 @@ class StateMachineBloc {
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e.toString()));
     }
+    yield* const Stream.empty();
   }
 
   Stream<AuthState> _signOut() async* {
@@ -407,6 +409,7 @@ class StateMachineBloc {
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e.toString()));
     }
+    yield* const Stream.empty();
   }
 
   Stream<AuthState> _verifyUser(AuthVerifyUserData data) async* {
@@ -424,6 +427,7 @@ class StateMachineBloc {
         _exceptionController.add(AuthenticatorException(e.toString()));
       }
     }
+    yield* const Stream.empty();
   }
 
   Stream<AuthState> _confirmVerifyUser(AuthConfirmVerifyUserData data) async* {
@@ -440,6 +444,7 @@ class StateMachineBloc {
         _exceptionController.add(AuthenticatorException(e.toString()));
       }
     }
+    yield* const Stream.empty();
   }
 
   Stream<AuthState> _changeScreen(AuthenticatorStep step) async* {
@@ -457,6 +462,7 @@ class StateMachineBloc {
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e.toString()));
     }
+    yield* const Stream.empty();
   }
 
   Future<void> dispose() {

--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -325,8 +325,10 @@ class StateMachineBloc {
         e.message,
         showBanner: !e.message.contains('cancelled'),
       ));
+      yield UnauthenticatedState.signIn;
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e.toString()));
+      yield UnauthenticatedState.signIn;
     }
   }
 

--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -122,6 +122,8 @@ class StateMachineBloc {
     yield const LoadingState();
     await Amplify.asyncConfig;
     yield* _isValidSession();
+    // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
+    // TODO: investigate broken event handling
     yield* const Stream.empty();
   }
 
@@ -329,6 +331,7 @@ class StateMachineBloc {
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e.toString()));
     }
+    // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
     yield* const Stream.empty();
   }
 
@@ -380,6 +383,7 @@ class StateMachineBloc {
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e.toString()));
     }
+    // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
     yield* const Stream.empty();
   }
 
@@ -397,6 +401,7 @@ class StateMachineBloc {
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e.toString()));
     }
+    // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
     yield* const Stream.empty();
   }
 
@@ -409,6 +414,7 @@ class StateMachineBloc {
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e.toString()));
     }
+    // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
     yield* const Stream.empty();
   }
 
@@ -427,6 +433,7 @@ class StateMachineBloc {
         _exceptionController.add(AuthenticatorException(e.toString()));
       }
     }
+    // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
     yield* const Stream.empty();
   }
 
@@ -444,11 +451,14 @@ class StateMachineBloc {
         _exceptionController.add(AuthenticatorException(e.toString()));
       }
     }
+    // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
     yield* const Stream.empty();
   }
 
   Stream<AuthState> _changeScreen(AuthenticatorStep step) async* {
     yield UnauthenticatedState(step: step);
+    // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
+    yield* const Stream.empty();
   }
 
   Stream<AuthState> _resendSignUpCode(String username) async* {
@@ -462,6 +472,7 @@ class StateMachineBloc {
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e.toString()));
     }
+    // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
     yield* const Stream.empty();
   }
 

--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_in_sign_out_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_in_sign_out_test.dart
@@ -83,6 +83,19 @@ void main() {
       );
     });
 
+    testWidgets('should be able to sign in after a failed attempt',
+        (WidgetTester tester) async {
+      final incorrectUsername = generateUsername();
+      expect(
+        Amplify.Auth.signIn(username: incorrectUsername, password: password),
+        throwsA(isA<UserNotFoundException>()),
+      );
+
+      final res =
+          await Amplify.Auth.signIn(username: username, password: password);
+      expect(res.isSignedIn, true);
+    });
+
     testWidgets(
         'should throw an InvalidStateException if a user is already signed in',
         (WidgetTester tester) async {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_in_sign_out_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_in_sign_out_test.dart
@@ -83,19 +83,6 @@ void main() {
       );
     });
 
-    testWidgets('should be able to sign in after a failed attempt',
-        (WidgetTester tester) async {
-      final incorrectUsername = generateUsername();
-      expect(
-        Amplify.Auth.signIn(username: incorrectUsername, password: password),
-        throwsA(isA<UserNotFoundException>()),
-      );
-
-      final res =
-          await Amplify.Auth.signIn(username: username, password: password);
-      expect(res.isSignedIn, true);
-    });
-
     testWidgets(
         'should throw an InvalidStateException if a user is already signed in',
         (WidgetTester tester) async {


### PR DESCRIPTION
*Issue #, if available:*
The authenticator on web was not allowing a second sign in attempt after a failure, nor was it allowing the 'Forgot Password' button.

*Description of changes:*
This PR yields the UnauthenticatedStep.signIn state after a sign in failure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
