### PR TITLE
fix(auth): Credential refresh on sign in

### DIFF
--- a/packages/amplify_core/lib/src/state_machine/state_machine.dart
+++ b/packages/amplify_core/lib/src/state_machine/state_machine.dart
@@ -22,7 +22,7 @@ import 'package:meta/meta.dart';
 @optionalTypeArgs
 abstract class Dispatcher<E extends StateMachineEvent> {
   /// Dispatches an event.
-  void dispatch(E event);
+  FutureOr<void> dispatch(E event);
 }
 
 /// Interface for emitting a state from a state machine.

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/auth_plugin_credentials_provider.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/auth_plugin_credentials_provider.dart
@@ -76,7 +76,7 @@ class AuthPluginCredentialsProviderImpl extends AuthPluginCredentialsProvider {
     // or refresh existing ones if needed, but do not initiate an
     // unauthenticated session since that should be handled via an explicit call
     // to `fetchAuthSession`.
-    _dispatcher.dispatch(
+    await _dispatcher.dispatch(
       const FetchAuthSessionEvent.fetch(
         CognitoSessionOptions(getAWSCredentials: false),
       ),

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
@@ -54,6 +54,9 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
 
   /// Gets the latest fetchAuthSession result.
   Future<FetchAuthSessionSuccess?> getLatestResult() async {
+    // Wait for any pending events to be processed and their initial states to
+    // fire.
+    await Future<void>.delayed(Duration.zero);
     final fetchState = await stream.startWith(currentState).firstWhere((state) {
       return state is FetchAuthSessionSuccess ||
           state is FetchAuthSessionFailure;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -495,7 +495,7 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState> {
   }
 
   /// Adds the session info from [result] to the user.
-  String _saveAuthResult(AuthenticationResultType result) {
+  Future<String> _saveAuthResult(AuthenticationResultType result) async {
     final accessToken = result.accessToken;
     final refreshToken = result.refreshToken;
     final idToken = result.idToken;
@@ -528,20 +528,24 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState> {
       ),
     );
 
-    // Clear anonymous credentials, if there were any.
+    // Clear anonymous credentials, if there were any, and fetch authenticated
+    // credentials.
     if (hasIdentityPool) {
       dispatch(
         CredentialStoreEvent.clearCredentials(
           CognitoIdentityPoolKeys(identityPoolConfig!),
         ),
       );
-    }
 
-    dispatch(
-      const FetchAuthSessionEvent.fetch(
-        CognitoSessionOptions(getAWSCredentials: true),
-      ),
-    );
+      await dispatch(
+        const FetchAuthSessionEvent.fetch(
+          CognitoSessionOptions(getAWSCredentials: true),
+        ),
+      );
+
+      // Wait for above to propagate and complete successfully.
+      await expect(FetchAuthSessionStateMachine.type).getLatestResult();
+    }
 
     return accessToken;
   }
@@ -641,7 +645,7 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState> {
     // Only when authenticationResult is set is the flow considered complete.
     final authenticationResult = _authenticationResult;
     if (authenticationResult != null) {
-      final accessToken = _saveAuthResult(authenticationResult);
+      final accessToken = await _saveAuthResult(authenticationResult);
       final newDeviceMetadata = authenticationResult.newDeviceMetadata;
       if (newDeviceMetadata != null &&
           // ConfirmDevice API requires an identity pool
@@ -651,7 +655,7 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState> {
           ..deviceKey = newDeviceMetadata.deviceKey;
 
         await _createDevice(
-          authenticationResult.accessToken!,
+          accessToken,
           newDeviceMetadata,
         );
 


### PR DESCRIPTION
Fixes issue where multiple successive calls to `fetchAuthSession` were not being sequenced properly due to the state machine needing two event loops to process an event. This is by design but was not accurately captured in the sign in and fetch auth session state machines.

---

**Stack**:
- #1712
- #1711
- #1707
- #1706
- #1702


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*