### PR TITLE
chore: Migrate Dart-only examples

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -147,16 +147,16 @@ jobs:
         working-directory: packages/auth/amplify_auth_cognito
         run: flutter analyze --fatal-infos lib
   job_005:
-    name: "analyze_and_format; Dart dev; PKGS: packages/amplify_core, packages/aws_common, packages/aws_signature_v4/example, packages/secure_storage/amplify_secure_storage_dart, packages/worker_bee/e2e_test, packages/worker_bee/worker_bee, packages/worker_bee/worker_bee_builder; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; Dart dev; PKGS: packages/amplify_core, packages/aws_common, packages/aws_signature_v4/example, packages/example_common, packages/secure_storage/amplify_secure_storage_dart, packages/secure_storage/amplify_secure_storage_dart/example, packages/worker_bee/e2e_test, packages/worker_bee/worker_bee, packages/worker_bee/worker_bee_builder; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/amplify_core-packages/aws_common-packages/aws_signature_v4/example-packages/secure_storage/amplify_secure_storage_dart-packages/worker_bee/e2e_test-packages/worker_bee/worker_bee-packages/worker_bee/worker_bee_builder;commands:format-analyze_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/amplify_core-packages/aws_common-packages/aws_signature_v4/example-packages/example_common-packages/secure_storage/amplify_secure_storage_dart-packages/secure_storage/amplify_secure_storage_dart/example-packages/worker_bee/e2e_test-packages/worker_bee/worker_bee-packages/worker_bee/worker_bee_builder;commands:format-analyze_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/amplify_core-packages/aws_common-packages/aws_signature_v4/example-packages/secure_storage/amplify_secure_storage_dart-packages/worker_bee/e2e_test-packages/worker_bee/worker_bee-packages/worker_bee/worker_bee_builder
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/amplify_core-packages/aws_common-packages/aws_signature_v4/example-packages/example_common-packages/secure_storage/amplify_secure_storage_dart-packages/secure_storage/amplify_secure_storage_dart/example-packages/worker_bee/e2e_test-packages/worker_bee/worker_bee-packages/worker_bee/worker_bee_builder
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -204,6 +204,19 @@ jobs:
         if: "always() && steps.packages_aws_signature_v4_example_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_signature_v4/example
         run: dart analyze --fatal-infos .
+      - id: packages_example_common_pub_upgrade
+        name: packages/example_common; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/example_common
+        run: dart pub upgrade
+      - name: "packages/example_common; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.packages_example_common_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/example_common
+        run: "dart format --output=none --set-exit-if-changed ."
+      - name: "packages/example_common; dart analyze --fatal-infos ."
+        if: "always() && steps.packages_example_common_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/example_common
+        run: dart analyze --fatal-infos .
       - id: packages_secure_storage_amplify_secure_storage_dart_pub_upgrade
         name: packages/secure_storage/amplify_secure_storage_dart; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -216,6 +229,19 @@ jobs:
       - name: "packages/secure_storage/amplify_secure_storage_dart; dart analyze --fatal-infos ."
         if: "always() && steps.packages_secure_storage_amplify_secure_storage_dart_pub_upgrade.conclusion == 'success'"
         working-directory: packages/secure_storage/amplify_secure_storage_dart
+        run: dart analyze --fatal-infos .
+      - id: packages_secure_storage_amplify_secure_storage_dart_example_pub_upgrade
+        name: packages/secure_storage/amplify_secure_storage_dart/example; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/secure_storage/amplify_secure_storage_dart/example
+        run: dart pub upgrade
+      - name: "packages/secure_storage/amplify_secure_storage_dart/example; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.packages_secure_storage_amplify_secure_storage_dart_example_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/secure_storage/amplify_secure_storage_dart/example
+        run: "dart format --output=none --set-exit-if-changed ."
+      - name: "packages/secure_storage/amplify_secure_storage_dart/example; dart analyze --fatal-infos ."
+        if: "always() && steps.packages_secure_storage_amplify_secure_storage_dart_example_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/secure_storage/amplify_secure_storage_dart/example
         run: dart analyze --fatal-infos .
       - id: packages_worker_bee_e2e_test_pub_upgrade
         name: packages/worker_bee/e2e_test; dart pub upgrade
@@ -302,16 +328,16 @@ jobs:
         working-directory: packages/aws_signature_v4
         run: dart analyze --fatal-infos lib test
   job_007:
-    name: "analyze_and_format; Dart stable; PKGS: packages/amplify_core, packages/aws_common, packages/aws_signature_v4/example, packages/secure_storage/amplify_secure_storage_dart, packages/worker_bee/e2e_test, packages/worker_bee/worker_bee, packages/worker_bee/worker_bee_builder; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; Dart stable; PKGS: packages/amplify_core, packages/aws_common, packages/aws_signature_v4/example, packages/example_common, packages/secure_storage/amplify_secure_storage_dart, packages/secure_storage/amplify_secure_storage_dart/example, packages/worker_bee/e2e_test, packages/worker_bee/worker_bee, packages/worker_bee/worker_bee_builder; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/amplify_core-packages/aws_common-packages/aws_signature_v4/example-packages/secure_storage/amplify_secure_storage_dart-packages/worker_bee/e2e_test-packages/worker_bee/worker_bee-packages/worker_bee/worker_bee_builder;commands:format-analyze_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/amplify_core-packages/aws_common-packages/aws_signature_v4/example-packages/example_common-packages/secure_storage/amplify_secure_storage_dart-packages/secure_storage/amplify_secure_storage_dart/example-packages/worker_bee/e2e_test-packages/worker_bee/worker_bee-packages/worker_bee/worker_bee_builder;commands:format-analyze_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/amplify_core-packages/aws_common-packages/aws_signature_v4/example-packages/secure_storage/amplify_secure_storage_dart-packages/worker_bee/e2e_test-packages/worker_bee/worker_bee-packages/worker_bee/worker_bee_builder
+            os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/amplify_core-packages/aws_common-packages/aws_signature_v4/example-packages/example_common-packages/secure_storage/amplify_secure_storage_dart-packages/secure_storage/amplify_secure_storage_dart/example-packages/worker_bee/e2e_test-packages/worker_bee/worker_bee-packages/worker_bee/worker_bee_builder
             os:ubuntu-latest;pub-cache-hosted;sdk:stable
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -359,6 +385,19 @@ jobs:
         if: "always() && steps.packages_aws_signature_v4_example_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_signature_v4/example
         run: dart analyze --fatal-infos .
+      - id: packages_example_common_pub_upgrade
+        name: packages/example_common; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/example_common
+        run: dart pub upgrade
+      - name: "packages/example_common; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.packages_example_common_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/example_common
+        run: "dart format --output=none --set-exit-if-changed ."
+      - name: "packages/example_common; dart analyze --fatal-infos ."
+        if: "always() && steps.packages_example_common_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/example_common
+        run: dart analyze --fatal-infos .
       - id: packages_secure_storage_amplify_secure_storage_dart_pub_upgrade
         name: packages/secure_storage/amplify_secure_storage_dart; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -371,6 +410,19 @@ jobs:
       - name: "packages/secure_storage/amplify_secure_storage_dart; dart analyze --fatal-infos ."
         if: "always() && steps.packages_secure_storage_amplify_secure_storage_dart_pub_upgrade.conclusion == 'success'"
         working-directory: packages/secure_storage/amplify_secure_storage_dart
+        run: dart analyze --fatal-infos .
+      - id: packages_secure_storage_amplify_secure_storage_dart_example_pub_upgrade
+        name: packages/secure_storage/amplify_secure_storage_dart/example; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/secure_storage/amplify_secure_storage_dart/example
+        run: dart pub upgrade
+      - name: "packages/secure_storage/amplify_secure_storage_dart/example; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.packages_secure_storage_amplify_secure_storage_dart_example_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/secure_storage/amplify_secure_storage_dart/example
+        run: "dart format --output=none --set-exit-if-changed ."
+      - name: "packages/secure_storage/amplify_secure_storage_dart/example; dart analyze --fatal-infos ."
+        if: "always() && steps.packages_secure_storage_amplify_secure_storage_dart_example_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/secure_storage/amplify_secure_storage_dart/example
         run: dart analyze --fatal-infos .
       - id: packages_worker_bee_e2e_test_pub_upgrade
         name: packages/worker_bee/e2e_test; dart pub upgrade

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,6 +270,34 @@ jobs:
         working-directory: packages/aws_signature_v4
         run: dart test -p chrome
   job_008:
+    name: "unit_test; linux; Dart dev; PKG: packages/example_common; `dart test -p chrome`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/example_common;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/example_common
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: packages_example_common_pub_upgrade
+        name: packages/example_common; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/example_common
+        run: dart pub upgrade
+      - name: "packages/example_common; dart test -p chrome"
+        if: "always() && steps.packages_example_common_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/example_common
+        run: dart test -p chrome
+  job_009:
     name: "unit_test; linux; Dart dev; PKGS: packages/secure_storage/amplify_secure_storage_dart, packages/worker_bee/e2e_test; `tool/test.sh -p chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -306,7 +334,7 @@ jobs:
         if: "always() && steps.packages_worker_bee_e2e_test_pub_upgrade.conclusion == 'success'"
         working-directory: packages/worker_bee/e2e_test
         run: tool/test.sh -p chrome
-  job_009:
+  job_010:
     name: "unit_test; linux; Dart dev; PKGS: packages/secure_storage/amplify_secure_storage_dart, packages/worker_bee/e2e_test; `tool/test.sh -p firefox`"
     runs-on: ubuntu-latest
     steps:
@@ -343,7 +371,7 @@ jobs:
         if: "always() && steps.packages_worker_bee_e2e_test_pub_upgrade.conclusion == 'success'"
         working-directory: packages/worker_bee/e2e_test
         run: tool/test.sh -p firefox
-  job_010:
+  job_011:
     name: "unit_test; linux; Dart dev; PKG: packages/worker_bee/e2e_test; `dart run build_runner build --delete-conflicting-outputs`, `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -375,7 +403,7 @@ jobs:
         if: "always() && steps.packages_worker_bee_e2e_test_pub_upgrade.conclusion == 'success'"
         working-directory: packages/worker_bee/e2e_test
         run: dart test
-  job_011:
+  job_012:
     name: "unit_test; linux; Dart stable; PKGS: packages/amplify_core, packages/auth/amplify_auth_cognito_dart; `dart --version`, `dart test`, `dart test -p chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -428,7 +456,7 @@ jobs:
         if: "always() && steps.packages_auth_amplify_auth_cognito_dart_pub_upgrade.conclusion == 'success'"
         working-directory: packages/auth/amplify_auth_cognito_dart
         run: dart test -p chrome
-  job_012:
+  job_013:
     name: "unit_test; linux; Dart stable; PKG: packages/aws_common; `dart test`, `dart test -p chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -460,7 +488,7 @@ jobs:
         if: "always() && steps.packages_aws_common_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_common
         run: dart test -p chrome
-  job_013:
+  job_014:
     name: "unit_test; linux; Dart stable; PKG: packages/aws_signature_v4; `git submodule update --init`, `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -492,7 +520,7 @@ jobs:
         if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_signature_v4
         run: dart test
-  job_014:
+  job_015:
     name: "unit_test; linux; Dart stable; PKG: packages/aws_signature_v4; `git submodule update --init`, `dart test`, `dart test -p chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -528,7 +556,35 @@ jobs:
         if: "always() && steps.packages_aws_signature_v4_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_signature_v4
         run: dart test -p chrome
-  job_015:
+  job_016:
+    name: "unit_test; linux; Dart stable; PKG: packages/example_common; `dart test -p chrome`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/example_common;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/example_common
+            os:ubuntu-latest;pub-cache-hosted;sdk:stable
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: packages_example_common_pub_upgrade
+        name: packages/example_common; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/example_common
+        run: dart pub upgrade
+      - name: "packages/example_common; dart test -p chrome"
+        if: "always() && steps.packages_example_common_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/example_common
+        run: dart test -p chrome
+  job_017:
     name: "unit_test; linux; Dart stable; PKGS: packages/secure_storage/amplify_secure_storage_dart, packages/worker_bee/e2e_test; `tool/test.sh -p chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -565,7 +621,7 @@ jobs:
         if: "always() && steps.packages_worker_bee_e2e_test_pub_upgrade.conclusion == 'success'"
         working-directory: packages/worker_bee/e2e_test
         run: tool/test.sh -p chrome
-  job_016:
+  job_018:
     name: "unit_test; linux; Dart stable; PKGS: packages/secure_storage/amplify_secure_storage_dart, packages/worker_bee/e2e_test; `tool/test.sh -p firefox`"
     runs-on: ubuntu-latest
     steps:
@@ -602,7 +658,7 @@ jobs:
         if: "always() && steps.packages_worker_bee_e2e_test_pub_upgrade.conclusion == 'success'"
         working-directory: packages/worker_bee/e2e_test
         run: tool/test.sh -p firefox
-  job_017:
+  job_019:
     name: "unit_test; linux; Dart stable; PKG: packages/worker_bee/e2e_test; `dart run build_runner build --delete-conflicting-outputs`, `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -634,7 +690,7 @@ jobs:
         if: "always() && steps.packages_worker_bee_e2e_test_pub_upgrade.conclusion == 'success'"
         working-directory: packages/worker_bee/e2e_test
         run: dart test
-  job_018:
+  job_020:
     name: "unit_test; macos; Dart dev; PKG: packages/secure_storage/amplify_secure_storage_dart; `dart test`"
     runs-on: macos-latest
     steps:
@@ -662,7 +718,7 @@ jobs:
         if: "always() && steps.packages_secure_storage_amplify_secure_storage_dart_pub_upgrade.conclusion == 'success'"
         working-directory: packages/secure_storage/amplify_secure_storage_dart
         run: dart test
-  job_019:
+  job_021:
     name: "unit_test; macos; Dart stable; PKG: packages/secure_storage/amplify_secure_storage_dart; `dart test`"
     runs-on: macos-latest
     steps:
@@ -690,7 +746,7 @@ jobs:
         if: "always() && steps.packages_secure_storage_amplify_secure_storage_dart_pub_upgrade.conclusion == 'success'"
         working-directory: packages/secure_storage/amplify_secure_storage_dart
         run: dart test
-  job_020:
+  job_022:
     name: "unit_test; windows; Dart dev; PKG: packages/secure_storage/amplify_secure_storage_dart; `dart test`"
     runs-on: windows-latest
     steps:
@@ -708,7 +764,7 @@ jobs:
         if: "always() && steps.packages_secure_storage_amplify_secure_storage_dart_pub_upgrade.conclusion == 'success'"
         working-directory: packages/secure_storage/amplify_secure_storage_dart
         run: dart test
-  job_021:
+  job_023:
     name: "unit_test; windows; Dart stable; PKG: packages/secure_storage/amplify_secure_storage_dart; `dart test`"
     runs-on: windows-latest
     steps:

--- a/packages/auth/amplify_auth_cognito_dart/example/.gitignore
+++ b/packages/auth/amplify_auth_cognito_dart/example/.gitignore
@@ -1,0 +1,30 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build output.
+build/
+
+
+amplify/
+
+#amplify-do-not-edit-begin
+amplify/\#current-cloud-backend
+amplify/.config/local-*
+amplify/logs
+amplify/mock-data
+amplify/backend/amplify-meta.json
+amplify/backend/.temp
+build/
+dist/
+node_modules/
+aws-exports.js
+awsconfiguration.json
+amplifyconfiguration.json
+amplifyconfiguration.dart
+amplify-build-config.json
+amplify-gradle-config.json
+amplifytools.xcconfig
+.secret-*
+**.sample
+#amplify-do-not-edit-end

--- a/packages/auth/amplify_auth_cognito_dart/example/README.md
+++ b/packages/auth/amplify_auth_cognito_dart/example/README.md
@@ -1,0 +1,3 @@
+# Amplify Auth Cognito Dart Example
+
+Example app and testbed for [`amplify_auth_cognito_dart`](../).

--- a/packages/auth/amplify_auth_cognito_dart/example/analysis_options.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/example/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:amplify_lints/app.yaml
+
+analyzer:
+  exclude:
+    - lib/**/*.g.dart

--- a/packages/auth/amplify_auth_cognito_dart/example/bin/example.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/bin/example.dart
@@ -1,0 +1,174 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
+import 'package:cognito_example/amplifyconfiguration.dart';
+import 'package:cognito_example/common.dart';
+
+Future<void> main() async {
+  try {
+    await Amplify.addPlugin(
+      // ignore: invalid_use_of_protected_member
+      AmplifyAuthCognitoDart(
+        credentialStorage: AmplifySecureStorageDart(
+          config: AmplifySecureStorageConfig(
+            scope: 'auth',
+            macOSOptions: MacOSSecureStorageOptions(useDataProtection: false),
+          ),
+        ),
+      )..stateMachine.stream.listen(safePrint),
+    );
+    await Amplify.configure(amplifyconfig);
+  } on Exception catch (e) {
+    stderr.writeln('Could not configure: $e');
+    exit(1);
+  }
+  final username = prompt(
+    'Enter your username (or type "amazon" to login with Amazon): ',
+  );
+
+  if (username == 'amazon') {
+    try {
+      await hostedSignIn(provider: AuthProvider.amazon);
+    } on Object catch (e, st) {
+      exitError(e, st);
+    }
+  } else {
+    final password = prompt('Enter your password: ');
+    stdout.writeln('Logging in...');
+    try {
+      var res = await signIn(
+        username: username,
+        password: password,
+      );
+      while (!res.isSignedIn) {
+        res = await _processSignInResult(
+          res,
+          username: username,
+          password: password,
+        );
+      }
+    } on Object catch (e, st) {
+      exitError(e, st);
+    }
+  }
+
+  stdout
+    ..writeln('Successfully logged in')
+    ..writeln();
+
+  try {
+    final session = await fetchAuthSession();
+    stdout
+      ..writeln('Session Details')
+      ..writeln('---------------')
+      ..writeln('Access Token: ${session.userPoolTokens?.accessToken}')
+      ..writeln('Refresh Token: ${session.userPoolTokens?.refreshToken}')
+      ..writeln('ID Token: ${session.userPoolTokens?.idToken}')
+      ..writeln();
+
+    final attributes = await fetchUserAttributes();
+    stdout
+      ..writeln('User Attributes')
+      ..writeln('---------------');
+    for (final attribute in attributes) {
+      stdout.writeln('${attribute.userAttributeKey}: ${attribute.value}');
+    }
+    stdout.writeln();
+
+    final devices = await fetchDevices();
+    stdout
+      ..writeln('Devices')
+      ..writeln('-------');
+    if (devices.isEmpty) {
+      stdout.writeln('No devices');
+    } else {
+      for (final device in devices) {
+        stdout.writeln(
+          '${device.name ?? device.id}: '
+          '${device.asCognitoDevice.attributes}',
+        );
+      }
+    }
+    stdout.writeln();
+  } on Object catch (e, st) {
+    exitError(e, st);
+  }
+}
+
+Never exitError(Object error, [StackTrace? stackTrace]) {
+  stderr.writeln(error);
+  stderr.writeln(stackTrace);
+  exit(1);
+}
+
+Future<SignInResult> _processSignInResult(
+  SignInResult result, {
+  required String username,
+  required String password,
+}) async {
+  final nextStep = result.nextStep?.signInStep;
+  final missingAttributes =
+      result.nextStep?.missingAttributes.cast<CognitoUserAttributeKey>() ??
+          const [];
+  switch (nextStep) {
+    case 'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE':
+    case 'CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE':
+      final confirmationCode = prompt('Enter your confirmation code: ');
+      return confirmSignIn(confirmationCode);
+    case 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD':
+      final userAttributes = <CognitoUserAttributeKey, String>{};
+      for (final missingAttribute in missingAttributes) {
+        final attributeValue = prompt(
+          'Enter value for attribute ($missingAttribute): ',
+        );
+        userAttributes[missingAttribute] = attributeValue;
+      }
+      final newPassword = prompt('Enter your new password: ');
+      return confirmSignIn(
+        newPassword,
+        userAttributes: userAttributes,
+      );
+    case 'RESET_PASSWORD':
+      final result = await resetPassword(username: username);
+      stdout
+        ..writeln('You must reset your password.')
+        ..writeln(result);
+      final newPassword = prompt('Enter your new password: ');
+      final confirmationCode = prompt('Enter your confirmation code: ');
+      final confirmResult = await confirmResetPassword(
+        username: username,
+        newPassword: newPassword,
+        confirmationCode: confirmationCode,
+      );
+      stdout.writeln(confirmResult);
+      return signIn(username: username, password: password);
+    default:
+      throw StateError('Unhandled case: $nextStep');
+  }
+}
+
+String prompt(String prompt) {
+  String? value;
+  while (value == null || value.isEmpty) {
+    stdout.write(prompt);
+    value = stdin.readLineSync(encoding: utf8);
+  }
+  return value;
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/lib/common.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/lib/common.dart
@@ -1,0 +1,164 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_core/amplify_core.dart';
+
+import 'amplifyconfiguration.dart';
+
+AmplifyConfig loadConfig() {
+  return AmplifyConfig.fromJson(
+    jsonDecode(amplifyconfig) as Map<String, Object?>,
+  );
+}
+
+Future<SignInResult> signIn({
+  required String username,
+  required String password,
+}) async {
+  return Amplify.Auth.signIn(
+    username: username,
+    password: password,
+  );
+}
+
+Future<SignInResult> hostedSignIn({
+  AuthProvider? provider,
+}) async {
+  return Amplify.Auth.signInWithWebUI(provider: provider);
+}
+
+Future<ResetPasswordResult> forgotPassword({required String username}) {
+  return Amplify.Auth.resetPassword(username: username);
+}
+
+Future<SignInResult> confirmSignIn(
+  String confirmationValue, {
+  Map<CognitoUserAttributeKey, String>? userAttributes,
+}) {
+  return Amplify.Auth.confirmSignIn(
+    confirmationValue: confirmationValue,
+    options: CognitoConfirmSignInOptions(
+      userAttributes: userAttributes,
+    ),
+  );
+}
+
+Future<ResetPasswordResult> resetPassword({
+  required String username,
+}) {
+  return Amplify.Auth.resetPassword(username: username);
+}
+
+Future<UpdatePasswordResult> confirmResetPassword({
+  required String username,
+  required String newPassword,
+  required String confirmationCode,
+}) {
+  return Amplify.Auth.confirmResetPassword(
+    username: username,
+    newPassword: newPassword,
+    confirmationCode: confirmationCode,
+  );
+}
+
+Future<void> changePassword({
+  required String oldPassword,
+  required String newPassword,
+}) async {
+  await Amplify.Auth.updatePassword(
+    oldPassword: oldPassword,
+    newPassword: newPassword,
+  );
+}
+
+Future<CognitoAuthSession> fetchAuthSession() async {
+  final res = await Amplify.Auth.fetchAuthSession(
+    options: const CognitoSessionOptions(
+      getAWSCredentials: true,
+    ),
+  );
+  return res as CognitoAuthSession;
+}
+
+Future<List<AuthUserAttribute>> fetchUserAttributes() async {
+  return Amplify.Auth.fetchUserAttributes();
+}
+
+Future<List<AuthDevice>> fetchDevices() async {
+  return Amplify.Auth.fetchDevices();
+}
+
+Future<void> rememberDevice() async {
+  await Amplify.Auth.rememberDevice();
+}
+
+Future<void> forgetDevice() async {
+  await Amplify.Auth.forgetDevice();
+}
+
+Future<UpdateUserAttributeResult> updateUserAttribute({
+  required UserAttributeKey key,
+  required String value,
+  CognitoUpdateUserAttributeOptions? options,
+}) async {
+  return Amplify.Auth.updateUserAttribute(
+    userAttributeKey: key,
+    value: value,
+    options: options,
+  );
+}
+
+Future<Map<UserAttributeKey, UpdateUserAttributeResult>> updateUserAttributes({
+  required List<AuthUserAttribute> attributes,
+  CognitoUpdateUserAttributesOptions? options,
+}) async {
+  return Amplify.Auth.updateUserAttributes(
+    attributes: attributes,
+    options: options,
+  );
+}
+
+Future<ConfirmUserAttributeResult> confirmUserAttribute({
+  required UserAttributeKey key,
+  required String confirmationCode,
+}) async {
+  return Amplify.Auth.confirmUserAttribute(
+    userAttributeKey: key,
+    confirmationCode: confirmationCode,
+  );
+}
+
+Future<ResendUserAttributeConfirmationCodeResult>
+    resendUserAttributeConfirmationCode({
+  required UserAttributeKey key,
+  CognitoResendUserAttributeConfirmationCodeOptions? options,
+}) async {
+  return Amplify.Auth.resendUserAttributeConfirmationCode(
+    userAttributeKey: key,
+    options: options,
+  );
+}
+
+Future<void> signOut({required bool globalSignOut}) async {
+  await Amplify.Auth.signOut(
+    options: SignOutOptions(globalSignOut: globalSignOut),
+  );
+}
+
+Future<void> deleteUser() async {
+  await Amplify.Auth.deleteUser();
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
@@ -1,0 +1,35 @@
+name: cognito_example
+description: Amplify Auth Cognito for Dart example
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  amplify_auth_cognito_dart:
+    path: ../
+  amplify_core:
+    path: ../../../amplify_core
+  amplify_secure_storage_dart:
+    path: ../../../secure_storage/amplify_secure_storage_dart
+  example_common:
+    path: ../../../example_common
+
+dependency_overrides:
+  amplify_core:
+    path: ../../../amplify_core
+  amplify_secure_storage_dart:
+    path: ../../../secure_storage/amplify_secure_storage_dart
+  aws_common:
+    path: ../../../aws_common
+  aws_signature_v4:
+    path: ../../../aws_signature_v4
+  worker_bee:
+    path: ../../../worker_bee/worker_bee
+
+dev_dependencies:
+  amplify_lints:
+    path: ../../../amplify_lints
+  build_runner: ^2.1.4
+  build_web_compilers: ^3.2.1

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/app_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/app_component.dart
@@ -1,0 +1,331 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:cognito_example/amplifyconfiguration.dart';
+import 'package:cognito_example/common.dart';
+import 'package:example_common/example_common.dart';
+
+import 'attribute_component.dart';
+import 'change_password_component.dart';
+import 'confirm_email_component.dart';
+import 'confirm_new_password_form_component.dart';
+import 'confirm_phone_component.dart';
+import 'confirm_sign_in_component.dart';
+import 'forgot_password_form_component.dart';
+import 'login_form_component.dart';
+import 'user_component.dart';
+
+enum AuthState {
+  loading.unauth(),
+  error.unauth(),
+  authenticated.auth(),
+  login.unauth(),
+  forgotPassword.unauth(),
+  confirmEmail.unauth(),
+  confirmPhone.unauth(),
+  confirmNewPassword.unauth(),
+  confirmSignin.unauth(),
+  manageAttributes.auth(),
+  changePassword.auth();
+
+  const AuthState.unauth() : isAuthenticatedRoute = false;
+  const AuthState.auth() : isAuthenticatedRoute = true;
+
+  final bool isAuthenticatedRoute;
+}
+
+/// global state for the application
+class AppState {
+  AppState({
+    this.authState = AuthState.loading,
+  });
+
+  final AuthState authState;
+
+  AppState copyWith({AuthState? authState}) {
+    return AppState(
+      authState: authState ?? this.authState,
+    );
+  }
+}
+
+/// main app component
+class AppComponent extends StatefulComponent {
+  AppState appState = AppState();
+
+  String? _error;
+
+  Future<void> _configureAmplify() async {
+    if (Amplify.isConfigured) return;
+    try {
+      await Amplify.addPlugin(AmplifyAuthCognitoDart());
+      await Amplify.configure(amplifyconfig);
+
+      Amplify.Hub.listen(HubChannel.Auth, (AuthHubEvent event) {
+        if (event.type == AuthHubEventType.signedIn) {
+          Amplify.asyncConfig.then((_) {
+            if (!appState.authState.isAuthenticatedRoute) {
+              setState(
+                (() {
+                  appState = appState.copyWith(
+                    authState: AuthState.authenticated,
+                  );
+                }),
+              );
+            }
+          });
+        }
+      });
+
+      AuthState startingAuthState;
+
+      try {
+        final session = await Amplify.Auth.fetchAuthSession(
+          options: const CognitoSessionOptions(
+            getAWSCredentials: true,
+          ),
+        ) as CognitoAuthSession;
+        startingAuthState =
+            session.isSignedIn ? AuthState.authenticated : AuthState.login;
+      } on Exception {
+        startingAuthState = AuthState.login;
+      }
+
+      setState(() {
+        appState = appState.copyWith(
+          authState: startingAuthState,
+        );
+      });
+    } on AmplifyException catch (e) {
+      setState(() {
+        _error = e.message;
+        appState = appState.copyWith(
+          authState: AuthState.error,
+        );
+      });
+    }
+  }
+
+  @override
+  void onInit() {
+    _configureAmplify();
+    super.onInit();
+  }
+
+  void _processSignInResult(SignInResult res) {
+    if (!res.isSignedIn) {
+      switch (res.nextStep!.signInStep) {
+        case 'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE':
+          setState(() {
+            appState = appState.copyWith(
+              authState: AuthState.confirmSignin,
+            );
+          });
+          return;
+        case 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD':
+          setState(() {
+            appState = appState.copyWith(
+              authState: AuthState.confirmNewPassword,
+            );
+          });
+          return;
+      }
+    }
+    setState(
+      (() {
+        appState = appState.copyWith(
+          authState: AuthState.authenticated,
+        );
+      }),
+    );
+  }
+
+  Future<void> _fetchUnAuthCredentials() async {
+    final session = await fetchAuthSession();
+    safePrint('sessionToken : ${session.credentials?.sessionToken}');
+  }
+
+  @override
+  Component render() {
+    return CenterComponent(
+      child: BuilderComponent(
+        builder: () {
+          switch (appState.authState) {
+            case AuthState.loading:
+              return TextComponent('loading ...');
+            case AuthState.error:
+              return TextComponent('Error configuring Amplify: $_error');
+            case AuthState.authenticated:
+              return UserComponent(
+                navigateTo: (AuthState screen) {
+                  setState(
+                    (() {
+                      appState = appState.copyWith(
+                        authState: screen,
+                      );
+                    }),
+                  );
+                },
+              );
+            case AuthState.login:
+              return ColumnComponent(
+                children: [
+                  LoginFormComponent(
+                    onSuccess: _processSignInResult,
+                  ),
+                  ButtonComponent(
+                    innerHtml: 'Forgot Password?',
+                    onClick: () {
+                      setState(
+                        (() {
+                          appState = appState.copyWith(
+                            authState: AuthState.forgotPassword,
+                          );
+                        }),
+                      );
+                    },
+                  ),
+                  ButtonComponent(
+                    innerHtml: 'Login with Amazon',
+                    onClick: () => hostedSignIn(provider: AuthProvider.amazon),
+                  ),
+                  ButtonComponent(
+                    innerHtml: 'Fetch Guess Token',
+                    onClick: _fetchUnAuthCredentials,
+                  ),
+                ],
+              );
+            case AuthState.forgotPassword:
+              return ColumnComponent(
+                children: [
+                  ForgotPasswordFormComponent(
+                    onSuccess: () {
+                      setState(
+                        (() {
+                          appState = appState.copyWith(
+                            authState: AuthState.confirmNewPassword,
+                          );
+                        }),
+                      );
+                    },
+                  ),
+                  ButtonComponent(
+                    innerHtml: 'Back to Login',
+                    onClick: () {
+                      setState(
+                        (() {
+                          appState = appState.copyWith(
+                            authState: AuthState.login,
+                          );
+                        }),
+                      );
+                    },
+                  ),
+                ],
+              );
+            case AuthState.confirmNewPassword:
+              return ColumnComponent(
+                children: [
+                  ConfirmNewPasswordFormComponent(
+                    onSuccess: () {
+                      setState(
+                        (() {
+                          appState = appState.copyWith(
+                            authState: AuthState.login,
+                          );
+                        }),
+                      );
+                    },
+                  ),
+                  ButtonComponent(
+                    innerHtml: 'Back to Login',
+                    onClick: () {
+                      setState(
+                        (() {
+                          appState = appState.copyWith(
+                            authState: AuthState.login,
+                          );
+                        }),
+                      );
+                    },
+                  ),
+                ],
+              );
+            case AuthState.confirmSignin:
+              return ConfirmSignInComponent(onSuccess: _processSignInResult);
+            case AuthState.manageAttributes:
+              return UserAttributeComponent(
+                onBack: () {
+                  setState(
+                    (() {
+                      appState = appState.copyWith(
+                        authState: AuthState.authenticated,
+                      );
+                    }),
+                  );
+                },
+                onConfirm: (appAuthState) {
+                  setState(
+                    (() {
+                      appState = appState.copyWith(
+                        authState: appAuthState,
+                      );
+                    }),
+                  );
+                },
+              );
+            case AuthState.confirmPhone:
+              return ConfirmPhoneComponent(
+                onNavigate: (appAuthState) {
+                  setState(
+                    (() {
+                      appState = appState.copyWith(
+                        authState: appAuthState,
+                      );
+                    }),
+                  );
+                },
+              );
+            case AuthState.confirmEmail:
+              return ConfirmEmailComponent(
+                onNavigate: (appAuthState) {
+                  setState(
+                    (() {
+                      appState = appState.copyWith(
+                        authState: appAuthState,
+                      );
+                    }),
+                  );
+                },
+              );
+            case AuthState.changePassword:
+              return ChangePasswordComponent(
+                onSuccess: () {
+                  setState(() {
+                    appState = appState.copyWith(
+                      authState: AuthState.authenticated,
+                    );
+                  });
+                },
+              );
+          }
+        },
+      ),
+    );
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/attribute_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/attribute_component.dart
@@ -1,0 +1,135 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart'
+    hide AuthState;
+import 'package:amplify_core/amplify_core.dart';
+import 'package:cognito_example/common.dart';
+import 'package:example_common/example_common.dart';
+import 'app_component.dart';
+
+class UserAttributeComponent extends StatefulComponent {
+  UserAttributeComponent({required this.onBack, required this.onConfirm});
+
+  final void Function(
+    AuthState authState,
+  ) onConfirm;
+
+  final void Function() onBack;
+  String? _errorText;
+
+  final Map<CognitoUserAttributeKey, String> _modifiedAttributes = {};
+  List<Component> _attributeFields = [];
+
+  @override
+  void onInit() {
+    _fetchAttributes();
+    super.onInit();
+  }
+
+  Future<void> _fetchAttributes() async {
+    final attributes = await fetchUserAttributes();
+    final attributeFields = <Component>[];
+
+    for (final attr in attributes) {
+      attributeFields.add(
+        TextFormFieldComponent(
+          initialValue: attr.value,
+          id: attr.userAttributeKey.toString(),
+          labelText: attr.userAttributeKey.toString(),
+          onChanged: (value) {
+            _modifiedAttributes[
+                attr.userAttributeKey as CognitoUserAttributeKey] = value ?? '';
+          },
+        ),
+      );
+    }
+
+    setState(() {
+      _attributeFields = attributeFields;
+    });
+  }
+
+  Future<void> _save() async {
+    if (_modifiedAttributes.length == 1) {
+      try {
+        final res = await updateUserAttribute(
+          key: _modifiedAttributes.entries.first.key,
+          value: _modifiedAttributes.entries.first.value,
+          options: const CognitoUpdateUserAttributeOptions(
+            clientMetadata: {
+              'method': 'updateUserAttribute',
+            },
+          ),
+        );
+        if (!res.isUpdated) {
+          if (res.nextStep.codeDeliveryDetails?.deliveryMedium == 'EMAIL') {
+            onConfirm(AuthState.confirmEmail);
+          } else {
+            onConfirm(AuthState.confirmPhone);
+          }
+        } else {
+          await _fetchAttributes();
+        }
+      } on Exception catch (e) {
+        setState(() {
+          _errorText = e.toString();
+        });
+      }
+    } else if (_modifiedAttributes.length > 1) {
+      try {
+        final res = await updateUserAttributes(
+          attributes: List.from(_modifiedAttributes.entries),
+          options: const CognitoUpdateUserAttributesOptions(
+            clientMetadata: {
+              'method': 'updateUserAttributes',
+            },
+          ),
+        );
+        final firstUnconfirmedAttr =
+            res.entries.firstWhere((el) => !el.value.isUpdated).value;
+        if (firstUnconfirmedAttr.nextStep.codeDeliveryDetails?.deliveryMedium ==
+            'EMAIL') {
+          onConfirm(AuthState.confirmEmail);
+        } else {
+          onConfirm(AuthState.confirmPhone);
+        }
+      } on Exception catch (e) {
+        setState(() {
+          _errorText = e.toString();
+        });
+      }
+    } else {
+      safePrint('No attributes have been modified.');
+    }
+  }
+
+  @override
+  Component render() {
+    return ColumnComponent(
+      children: [
+        if (_errorText != null) TextComponent(_errorText!),
+        ButtonComponent(innerHtml: 'Back', onClick: onBack),
+        FormComponent(
+          children: [
+            ColumnComponent(
+              children: _attributeFields,
+            ),
+          ],
+        ),
+        ButtonComponent(innerHtml: 'Submit', onClick: _save)
+      ],
+    );
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/change_password_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/change_password_component.dart
@@ -1,0 +1,94 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:cognito_example/common.dart';
+import 'package:example_common/example_common.dart';
+
+class ChangePasswordComponent extends StatefulComponent {
+  ChangePasswordComponent({required this.onSuccess});
+
+  final void Function() onSuccess;
+
+  String oldPassword = '';
+  String newPassword = '';
+
+  String? errorText;
+  bool isLoading = false;
+
+  Future<void> _changePassword() async {
+    setState(() {
+      errorText = null;
+      isLoading = true;
+    });
+    if (oldPassword.isEmpty || newPassword.isEmpty) {
+      setState(() {
+        errorText = 'Old Password and New Password are required.';
+        isLoading = false;
+      });
+      return;
+    }
+
+    try {
+      await changePassword(
+        oldPassword: oldPassword,
+        newPassword: newPassword,
+      );
+      onSuccess();
+    } on AmplifyException catch (e) {
+      setState(() {
+        errorText = 'Error: ${e.message}';
+        isLoading = false;
+      });
+    } on Exception catch (e) {
+      setState(() {
+        errorText = 'An unknown error occurred: $e';
+        isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Component render() {
+    return ColumnComponent(
+      children: [
+        if (errorText != null) TextComponent(errorText!),
+        FormComponent(
+          children: [
+            TextFormFieldComponent(
+              labelText: 'Old Password',
+              type: 'password',
+              onChanged: (value) {
+                oldPassword = value ?? '';
+              },
+            ),
+            TextFormFieldComponent(
+              labelText: 'New Password',
+              initialValue: newPassword,
+              type: 'password',
+              onChanged: (value) {
+                newPassword = value ?? '';
+              },
+            ),
+            ButtonComponent(
+              innerHtml: 'Submit',
+              loading: isLoading,
+              onClick: _changePassword,
+            ),
+          ],
+        )
+      ],
+    );
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/confirm_attribute_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/confirm_attribute_component.dart
@@ -1,0 +1,90 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart'
+    hide AuthState;
+import 'package:cognito_example/common.dart';
+import 'package:example_common/example_common.dart';
+
+import 'app_component.dart';
+
+abstract class ConfirmAttributeComponent extends StatefulComponent {
+  ConfirmAttributeComponent({required this.onNavigate});
+
+  final void Function(AuthState authState) onNavigate;
+  String? errorText;
+
+  String _confirmationCode = '';
+  CognitoUserAttributeKey get key;
+
+  void _back() {
+    onNavigate(AuthState.manageAttributes);
+  }
+
+  void _resendCode() {
+    resendUserAttributeConfirmationCode(
+      key: key,
+      options: const CognitoResendUserAttributeConfirmationCodeOptions(
+        clientMetadata: {
+          'method': 'resendUserAttributeConfirmationCode',
+        },
+      ),
+    );
+  }
+
+  Future<void> _confirm() async {
+    try {
+      await confirmUserAttribute(
+        key: key,
+        confirmationCode: _confirmationCode,
+      );
+      onNavigate(AuthState.manageAttributes);
+    } on AuthException catch (e) {
+      setState(() {
+        errorText = e.message;
+      });
+    } on Exception catch (e) {
+      setState(() {
+        errorText = e.toString();
+      });
+    }
+  }
+
+  @override
+  Component render() {
+    return ColumnComponent(
+      children: [
+        if (errorText != null) TextComponent(errorText!),
+        ButtonComponent(innerHtml: 'Back', onClick: _back),
+        FormComponent(
+          children: [
+            ColumnComponent(
+              children: [
+                TextFormFieldComponent(
+                  initialValue: _confirmationCode,
+                  labelText: 'Code',
+                  onChanged: (value) {
+                    _confirmationCode = value ?? '';
+                  },
+                )
+              ],
+            ),
+          ],
+        ),
+        ButtonComponent(innerHtml: 'Confirm', onClick: _confirm),
+        ButtonComponent(innerHtml: 'Resend code', onClick: _resendCode)
+      ],
+    );
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/confirm_email_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/confirm_email_component.dart
@@ -1,0 +1,23 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'confirm_attribute_component.dart';
+
+class ConfirmEmailComponent extends ConfirmAttributeComponent {
+  ConfirmEmailComponent({required super.onNavigate});
+
+  @override
+  CognitoUserAttributeKey key = CognitoUserAttributeKey.email;
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/confirm_new_password_form_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/confirm_new_password_form_component.dart
@@ -1,0 +1,104 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:cognito_example/common.dart';
+import 'package:example_common/example_common.dart';
+
+class ConfirmNewPasswordFormComponent extends StatefulComponent {
+  ConfirmNewPasswordFormComponent({required this.onSuccess});
+
+  final void Function() onSuccess;
+
+  String username = '';
+  String newPassword = '';
+  String confirmationCode = '';
+
+  String? errorText;
+  bool isLoading = false;
+
+  Future<void> _confirmPassword() async {
+    setState(() {
+      errorText = null;
+      isLoading = true;
+    });
+    if (username.isEmpty || newPassword.isEmpty || confirmationCode.isEmpty) {
+      setState(() {
+        errorText =
+            'Username, New Password, and Confirmation Code are required.';
+        isLoading = false;
+      });
+      return;
+    }
+
+    try {
+      await confirmResetPassword(
+        username: username,
+        newPassword: newPassword,
+        confirmationCode: confirmationCode,
+      );
+      onSuccess();
+    } on AmplifyException catch (e) {
+      setState(() {
+        errorText = 'Error: ${e.message}';
+        isLoading = false;
+      });
+    } on Exception catch (e) {
+      setState(() {
+        errorText = 'An unknown error occurred: $e';
+        isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Component render() {
+    return ColumnComponent(
+      children: [
+        if (errorText != null) TextComponent(errorText!),
+        FormComponent(
+          children: [
+            TextFormFieldComponent(
+              labelText: 'Username',
+              initialValue: username,
+              onChanged: (value) {
+                username = value ?? '';
+              },
+            ),
+            TextFormFieldComponent(
+              labelText: 'New Password',
+              initialValue: newPassword,
+              type: 'password',
+              onChanged: (value) {
+                newPassword = value ?? '';
+              },
+            ),
+            TextFormFieldComponent(
+              labelText: 'Confirmation Code',
+              initialValue: confirmationCode,
+              onChanged: (value) {
+                confirmationCode = value ?? '';
+              },
+            ),
+            ButtonComponent(
+              innerHtml: 'Submit',
+              loading: isLoading,
+              onClick: _confirmPassword,
+            ),
+          ],
+        )
+      ],
+    );
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/confirm_phone_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/confirm_phone_component.dart
@@ -1,0 +1,23 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'confirm_attribute_component.dart';
+
+class ConfirmPhoneComponent extends ConfirmAttributeComponent {
+  ConfirmPhoneComponent({required super.onNavigate});
+
+  @override
+  CognitoUserAttributeKey key = CognitoUserAttributeKey.phoneNumber;
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/confirm_sign_in_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/confirm_sign_in_component.dart
@@ -1,0 +1,85 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:cognito_example/common.dart';
+import 'package:example_common/example_common.dart';
+
+class ConfirmSignInComponent extends StatefulComponent {
+  ConfirmSignInComponent({
+    required this.onSuccess,
+  });
+
+  final void Function(SignInResult) onSuccess;
+
+  String confirmationCode = '';
+
+  String? errorText;
+  bool isLoading = false;
+
+  Future<void> _confirmSignIn() async {
+    setState(() {
+      errorText = null;
+      isLoading = true;
+    });
+    if (confirmationCode.isEmpty) {
+      setState(() {
+        errorText =
+            'Username, New Password, and Confirmation Code are required.';
+        isLoading = false;
+      });
+      return;
+    }
+
+    try {
+      final res = await confirmSignIn(confirmationCode);
+      onSuccess(res);
+    } on AmplifyException catch (e) {
+      setState(() {
+        errorText = 'Error: ${e.message}';
+        isLoading = false;
+      });
+    } on Exception catch (e) {
+      setState(() {
+        errorText = 'An unknown error occurred: $e';
+        isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Component render() {
+    return ColumnComponent(
+      children: [
+        if (errorText != null) TextComponent(errorText!),
+        FormComponent(
+          children: [
+            TextFormFieldComponent(
+              labelText: 'Confirmation Code',
+              initialValue: confirmationCode,
+              onChanged: (value) {
+                confirmationCode = value ?? '';
+              },
+            ),
+            ButtonComponent(
+              innerHtml: 'Submit',
+              loading: isLoading,
+              onClick: _confirmSignIn,
+            ),
+          ],
+        )
+      ],
+    );
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/forgot_password_form_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/forgot_password_form_component.dart
@@ -1,0 +1,82 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:cognito_example/common.dart';
+import 'package:example_common/example_common.dart';
+
+class ForgotPasswordFormComponent extends StatefulComponent {
+  ForgotPasswordFormComponent({required this.onSuccess});
+
+  final void Function() onSuccess;
+
+  String username = '';
+
+  String? errorText;
+  bool isLoading = false;
+
+  Future<void> _forgotPassword() async {
+    setState(() {
+      errorText = null;
+      isLoading = true;
+    });
+    if (username.isEmpty) {
+      setState(() {
+        errorText = 'Username is required.';
+        isLoading = false;
+      });
+      return;
+    }
+    try {
+      await forgotPassword(username: username);
+      onSuccess();
+    } on AmplifyException catch (e) {
+      setState(() {
+        errorText = 'Error: ${e.message}';
+        isLoading = false;
+      });
+    } on Exception catch (e) {
+      setState(() {
+        errorText = 'An unknown error occurred: $e';
+        isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Component render() {
+    return ColumnComponent(
+      children: [
+        if (errorText != null) TextComponent(errorText!),
+        FormComponent(
+          id: 'forgotPasswordForm',
+          children: [
+            TextFormFieldComponent(
+              initialValue: username,
+              labelText: 'Username',
+              onChanged: (value) {
+                username = value ?? '';
+              },
+            ),
+            ButtonComponent(
+              innerHtml: 'Submit',
+              loading: isLoading,
+              onClick: _forgotPassword,
+            ),
+          ],
+        )
+      ],
+    );
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/login_form_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/login_form_component.dart
@@ -1,0 +1,96 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:cognito_example/common.dart';
+import 'package:example_common/example_common.dart';
+
+class LoginFormComponent extends StatefulComponent {
+  LoginFormComponent({required this.onSuccess});
+
+  final void Function(SignInResult) onSuccess;
+
+  String username = '';
+  String password = '';
+
+  String? errorText;
+
+  bool isLoading = false;
+
+  Future<void> _login() async {
+    setState(() {
+      errorText = null;
+      isLoading = true;
+    });
+    if (username.isEmpty || password.isEmpty) {
+      setState(() {
+        errorText = 'Username and password are required.';
+        isLoading = false;
+      });
+      return;
+    }
+
+    try {
+      final res = await signIn(
+        username: username,
+        password: password,
+      );
+      onSuccess(res);
+    } on AmplifyException catch (e) {
+      setState(() {
+        errorText = e.message;
+        isLoading = false;
+      });
+    } on Exception catch (e) {
+      setState(() {
+        errorText = 'An unknown error occurred: $e';
+        isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Component render() {
+    return ColumnComponent(
+      children: [
+        if (errorText != null) TextComponent(errorText!),
+        FormComponent(
+          id: 'loginForm',
+          children: [
+            TextFormFieldComponent(
+              labelText: 'Username',
+              initialValue: username,
+              onChanged: (value) {
+                username = value ?? '';
+              },
+            ),
+            TextFormFieldComponent(
+              type: 'password',
+              labelText: 'Password',
+              initialValue: password,
+              onChanged: (value) {
+                password = value ?? '';
+              },
+            ),
+            ButtonComponent(
+              innerHtml: 'Submit',
+              onClick: _login,
+              loading: isLoading,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/user_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/user_component.dart
@@ -1,0 +1,133 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:html';
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart'
+    hide AuthState;
+import 'package:cognito_example/common.dart';
+import 'package:example_common/example_common.dart';
+
+import 'app_component.dart';
+
+class UserComponent extends StatefulComponent {
+  UserComponent({
+    required this.navigateTo,
+  });
+
+  final void Function(AuthState) navigateTo;
+
+  List<List<String>> rows = [];
+  bool _showSession = false;
+
+  Future<void> _fetchAuthSession() async {
+    final session = await fetchAuthSession();
+    final devices = await fetchDevices();
+    setState(() {
+      _showSession = true;
+      rows = [
+        ['userSub', session.userSub ?? 'null'],
+        ['accessToken', session.userPoolTokens?.accessToken.raw ?? 'null'],
+        ['idToken', session.userPoolTokens?.idToken.raw ?? 'null'],
+        ['refreshToken', session.userPoolTokens?.refreshToken ?? 'null'],
+        ['credential session', session.credentials?.sessionToken ?? 'null'],
+        ...devices.map((device) => device.asCognitoDevice).map(
+              (device) => [
+                'Device: ${device.id}',
+                device.attributes.toString(),
+              ],
+            )
+      ];
+    });
+  }
+
+  void _hideSession() {
+    setState(() => _showSession = false);
+  }
+
+  @override
+  Component render() {
+    return ColumnComponent(
+      alignItems: AlignItems.center,
+      children: [
+        TextComponent('You are logged in!'),
+        ButtonComponent(
+          innerHtml: 'Remember Device',
+          onClick: rememberDevice,
+        ),
+        ButtonComponent(
+          innerHtml: 'Forget Device',
+          onClick: forgetDevice,
+        ),
+        ButtonComponent(
+          innerHtml: 'Manage Attributes',
+          onClick: () => navigateTo(AuthState.manageAttributes),
+        ),
+        if (!_showSession)
+          ButtonComponent(
+            innerHtml: 'Fetch Session',
+            onClick: _fetchAuthSession,
+          ),
+        if (_showSession) ...[
+          ButtonComponent(
+            innerHtml: 'Hide Session',
+            onClick: _hideSession,
+          ),
+          TableComponent(
+            tableDefinition: TableDefinition(
+              headers: ['Key', 'Value'],
+              rows: rows,
+            ),
+          ),
+        ],
+        ButtonComponent(
+          innerHtml: 'Change Password',
+          onClick: () => navigateTo(AuthState.changePassword),
+        ),
+        ButtonComponent(
+          innerHtml: 'Sign Out',
+          onClick: () async {
+            try {
+              await signOut(globalSignOut: false);
+            } finally {
+              navigateTo(AuthState.login);
+            }
+          },
+        ),
+        ButtonComponent(
+          innerHtml: 'Sign Out (Global)',
+          onClick: () async {
+            try {
+              await signOut(globalSignOut: true);
+            } finally {
+              navigateTo(AuthState.login);
+            }
+          },
+        ),
+        ButtonComponent(
+          innerHtml: 'Delete User',
+          onClick: () async {
+            if (window.confirm('Are you sure you want to delete the user?')) {
+              try {
+                await deleteUser();
+              } finally {
+                navigateTo(AuthState.login);
+              }
+            }
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/web/index.html
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="scaffolded-by" content="https://github.com/dart-lang/sdk">
+  <title>Amplify Auth Dart Example</title>
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="main.dart.js"></script>
+</head>
+
+<body></body>
+
+</html>

--- a/packages/auth/amplify_auth_cognito_dart/example/web/main.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/main.dart
@@ -1,0 +1,23 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:example_common/example_common.dart';
+
+import 'components/app_component.dart';
+
+Future<void> main() async {
+  print(zIsWeb);
+  renderApp(AppComponent());
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/web/styles.css
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/styles.css
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import url(https://fonts.googleapis.com/css?family=Roboto);
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  font-family: "Roboto", sans-serif;
+}
+
+table {
+  table-layout: fixed;
+  margin: 30px;
+}
+
+td {
+  padding: 10px;
+  border: 1px solid black;
+  border-collapse: collapse;
+}
+
+#wrappedTableRow {
+  word-wrap: anywhere;
+  font-size: x-small;
+}

--- a/packages/example_common/.gitignore
+++ b/packages/example_common/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/example_common/CHANGELOG.md
+++ b/packages/example_common/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/packages/example_common/README.md
+++ b/packages/example_common/README.md
@@ -1,0 +1,3 @@
+# example_common
+
+Common components and utils for example apps.

--- a/packages/example_common/analysis_options.yaml
+++ b/packages/example_common/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:amplify_lints/library_core.yaml

--- a/packages/example_common/example/pubspec.yaml
+++ b/packages/example_common/example/pubspec.yaml
@@ -1,0 +1,17 @@
+name: example_common_example
+description: Example of common_example
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  example_common:
+    path: ../
+
+dev_dependencies:
+  amplify_lints:
+    path: ../../amplify_lints
+  build_runner: ^2.1.4
+  build_web_compilers: ^3.2.1

--- a/packages/example_common/example/web/index.html
+++ b/packages/example_common/example/web/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="scaffolded-by" content="https://github.com/dart-lang/sdk" />
+  <link rel="stylesheet" href="styles.css">
+  <title>Amplify Secure Storage Example</title>
+  <script defer src="main.dart.js"></script>
+</head>
+
+<body>
+  <!-- Placeholder for root element -->
+</body>
+
+</html>

--- a/packages/example_common/example/web/main.dart
+++ b/packages/example_common/example/web/main.dart
@@ -1,0 +1,29 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import 'package:example_common/example_common.dart';
+
+void main() {
+  renderApp(
+    ColumnComponent(
+      children: [
+        TextComponent('Example text component'),
+        TextFormFieldComponent(
+          labelText: 'Example Form Field',
+          onChanged: (_) {},
+        ),
+        ButtonComponent(innerHtml: 'Example Button', onClick: () {})
+      ],
+    ),
+  );
+}

--- a/packages/example_common/example/web/styles.css
+++ b/packages/example_common/example/web/styles.css
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import url(https://fonts.googleapis.com/css?family=Roboto);
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  font-family: "Roboto", sans-serif;
+}

--- a/packages/example_common/lib/example_common.dart
+++ b/packages/example_common/lib/example_common.dart
@@ -1,0 +1,32 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Common components and utilities for example apps in amplify dart.
+library example_common;
+
+export 'src/components/builder_component.dart';
+export 'src/components/button_component.dart';
+export 'src/components/center_component.dart';
+export 'src/components/component.dart';
+export 'src/components/container_component.dart';
+export 'src/components/flex_component.dart';
+export 'src/components/form_component.dart';
+export 'src/components/table_component.dart';
+export 'src/components/text_component.dart';
+export 'src/components/text_form_field_component.dart';
+
+export 'src/enums.dart';
+
+export 'src/utils/component_edge_insets.dart';
+export 'src/utils/render_app.dart';

--- a/packages/example_common/lib/src/components/builder_component.dart
+++ b/packages/example_common/lib/src/components/builder_component.dart
@@ -1,0 +1,32 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'component.dart';
+
+/// {@template example_common.builder_component}
+/// A component that exposes a [builder] method, which should
+/// return a [Component]
+/// {@endtemplate}
+class BuilderComponent extends Component {
+  /// {@macro example_common.builder_component}
+  BuilderComponent({required this.builder});
+
+  /// A builder method which will be used to render a child
+  final Component Function() builder;
+
+  @override
+  Component render() {
+    return builder();
+  }
+}

--- a/packages/example_common/lib/src/components/button_component.dart
+++ b/packages/example_common/lib/src/components/button_component.dart
@@ -1,0 +1,73 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:html';
+
+import '../utils/component_edge_insets.dart';
+import 'component.dart';
+
+/// {@template example_common.button_component}
+/// A component that renders an html button element.
+/// {@endtemplate}
+class ButtonComponent extends Component {
+  /// {@macro example_common.button_component}
+  ButtonComponent({
+    this.id,
+    this.margin = const ComponentEdgeInsets.all(8),
+    this.padding = const ComponentEdgeInsets.symmetric(
+      vertical: 4,
+      horizontal: 8,
+    ),
+    required this.innerHtml,
+    required this.onClick,
+    this.loading = false,
+  });
+
+  /// The ID for the button.
+  final String? id;
+
+  /// The margin of the component
+  final ComponentEdgeInsets margin;
+
+  /// The margin of the component
+  final ComponentEdgeInsets padding;
+
+  /// The innerHtml for the button.
+  final String innerHtml;
+
+  /// The click handler for the button
+  final Function() onClick;
+
+  /// wether or not the button is in a loading state.
+  final bool loading;
+
+  late final _buttonElement = ButtonElement()
+    ..innerHtml = loading ? 'Loading ...' : innerHtml;
+
+  @override
+  Component render() {
+    _buttonElement.style.margin = margin.toCssString();
+    _buttonElement.style.padding = padding.toCssString();
+    return Component.fromElement(_buttonElement);
+  }
+
+  @override
+  void componentDidMount() {
+    _buttonElement.onClick.listen((event) {
+      event.preventDefault();
+      onClick();
+    });
+    super.componentDidMount();
+  }
+}

--- a/packages/example_common/lib/src/components/center_component.dart
+++ b/packages/example_common/lib/src/components/center_component.dart
@@ -1,0 +1,38 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:html';
+
+import 'component.dart';
+
+/// {@template example_common.center_component}
+/// A component that centers the provided child
+/// {@endtemplate}
+class CenterComponent extends Component {
+  /// {@macro example_common.center_component}
+  CenterComponent({required this.child});
+
+  /// The child component to be centered.
+  final Component child;
+
+  @override
+  Component render() {
+    final container = Element.div();
+    container.style.display = 'flex';
+    container.style.alignItems = 'center';
+    container.style.justifyContent = 'center';
+    container.appendComponent(child);
+    return Component.fromElement(container);
+  }
+}

--- a/packages/example_common/lib/src/components/component.dart
+++ b/packages/example_common/lib/src/components/component.dart
@@ -1,0 +1,119 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+import 'dart:html';
+
+import 'package:meta/meta.dart';
+
+/// {@template example_common.component}
+/// A base component class that other components should extend
+///
+/// A Component is a wrapper around an [Element] that exposes some
+/// lifecycle events
+/// {@endtemplate}
+abstract class Component {
+  /// {@macro example_common.component}
+  Component();
+
+  // The current component instance
+  late Component _component = render();
+
+  // The element for this component
+  Element get _element => _component._element;
+
+  // Wether or not the component is mounted (current rendered in the DOM)
+  bool _isMounted = false;
+
+  /// The style of the component's element
+  CssStyleDeclaration get style => _element.style;
+
+  /// Calls [render], schedules the [componentDidMount] callback, and returns the [element]
+  ///
+  /// This should only be called when the Element is about to be inserted into the DOM.
+  /// For example, when calling `element.append(component.renderElement())`.
+  ///
+  /// This generally shouldn't be used directly, but is useful for creating primitives
+  Element renderElement() {
+    if (!_isMounted) scheduleMicrotask(componentDidMount);
+    return _element;
+  }
+
+  /// The render method for this component
+  Component render();
+
+  /// A callback to be executed when the component mounts (first rendered in the DOM)
+  @mustCallSuper
+  void componentDidMount() {
+    _isMounted = true;
+  }
+
+  /// Creates a component from an html [Element].
+  static Component fromElement(Element element) {
+    return _ElementComponent(element);
+  }
+}
+
+/// {@template example_common.stateful_component}
+/// A component that manages state
+/// {@endtemplate}
+abstract class StatefulComponent extends Component {
+  /// {@macro example_common.stateful_component}
+  StatefulComponent() {
+    onInit();
+  }
+  // re-render the component
+  void _rerenderComponent() {
+    final currentElement = _element;
+    _component = render();
+    currentElement.replaceWith(_element);
+  }
+
+  /// Execute a function, and then re-render the component
+  void setState(Function() fn) {
+    fn();
+    _rerenderComponent();
+  }
+
+  /// A lifecycle event that will be called after the component has been
+  /// created, but not necessarily added to the DOM.
+  ///
+  /// See [componentDidMount] for a lifecycle event that fires after
+  /// the component has been added to the DOM.
+  void onInit() {}
+}
+
+/// A Component created from an html Element
+///
+/// Useful for creating primitive components, but generally
+/// shouldn't be used directly
+class _ElementComponent extends Component {
+  @override
+  final Element _element;
+
+  _ElementComponent(Element element) : _element = element;
+
+  @override
+  Component render() {
+    return this;
+  }
+}
+
+/// Extension on [Node] to add component utils
+extension NodeX on Node {
+  /// calls [Component.renderElement], and appends the result to the node.
+  Node appendComponent(Component component) {
+    return append(component.renderElement());
+  }
+}

--- a/packages/example_common/lib/src/components/container_component.dart
+++ b/packages/example_common/lib/src/components/container_component.dart
@@ -1,0 +1,58 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:html';
+
+import '../utils/component_edge_insets.dart';
+import 'component.dart';
+
+/// {@template example_common.container_component}
+/// A component that renders a container with an optional child
+/// {@endtemplate}
+class ContainerComponent extends Component {
+  /// {@macro example_common.container_component}
+  ContainerComponent({
+    this.child,
+    this.height,
+    this.width,
+    this.margin,
+    this.padding,
+  });
+
+  /// The child component to render inside the container
+  final Component? child;
+
+  /// The margin of the component
+  final ComponentEdgeInsets? margin;
+
+  /// The padding of the component
+  final ComponentEdgeInsets? padding;
+
+  /// The height of the component in px
+  final double? height;
+
+  /// The width of the component in px
+  final double? width;
+
+  @override
+  Component render() {
+    final div = Element.div();
+    if (margin != null) div.style.margin = margin!.toCssString();
+    if (padding != null) div.style.padding = padding!.toCssString();
+    if (height != null) div.style.height = '${height}px';
+    if (width != null) div.style.width = '${width}px';
+    if (child != null) div.appendComponent(child!);
+    return Component.fromElement(div);
+  }
+}

--- a/packages/example_common/lib/src/components/flex_component.dart
+++ b/packages/example_common/lib/src/components/flex_component.dart
@@ -1,0 +1,81 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:html';
+
+import '../enums.dart';
+import 'component.dart';
+
+/// {@template example_common.flex_component}
+/// a component that displays a set of [children] in either a row or column
+/// {@endtemplate}
+class FlexComponent extends Component {
+  /// {@macro example_common.flex_component}
+  FlexComponent({
+    required this.direction,
+    this.alignItems = AlignItems.start,
+    required this.children,
+  });
+
+  /// The axis that the items should be displayed on.
+  final Axis direction;
+
+  /// The alignment of the child items.
+  final AlignItems alignItems;
+
+  /// The child components to be displayed.
+  final List<Component> children;
+
+  @override
+  Component render() {
+    final div = Element.div();
+    div.style.display = 'flex';
+    div.style.flexDirection = direction.flexDirection;
+    div.style.alignItems = alignItems.name;
+    for (var child in children) {
+      div.appendComponent(child);
+    }
+    return Component.fromElement(div);
+  }
+}
+
+/// {@template example_common.column_component}
+/// a component that displays a set of [children] in a column
+/// {@endtemplate}
+class ColumnComponent extends FlexComponent {
+  /// {@macro example_common.column_component}
+  ColumnComponent({
+    AlignItems alignItems = AlignItems.start,
+    required List<Component> children,
+  }) : super(
+          direction: Axis.vertical,
+          alignItems: alignItems,
+          children: children,
+        );
+}
+
+/// {@template example_common.row_component}
+/// a component that displays a set of [children] in a row
+/// {@endtemplate}
+class RowComponent extends FlexComponent {
+  /// {@macro example_common.row_component}
+  RowComponent({
+    AlignItems alignItems = AlignItems.start,
+    required List<Component> children,
+  }) : super(
+          direction: Axis.horizontal,
+          alignItems: alignItems,
+          children: children,
+        );
+}

--- a/packages/example_common/lib/src/components/form_component.dart
+++ b/packages/example_common/lib/src/components/form_component.dart
@@ -1,0 +1,41 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:html';
+
+import 'component.dart';
+
+/// {@template example_common.form_component}
+/// a component that displays a form
+/// {@endtemplate}
+class FormComponent extends Component {
+  /// {@macro example_common.form_component}
+  FormComponent({this.id, required this.children});
+
+  /// The ID of the form element
+  final String? id;
+
+  /// The form elements
+  final List<Component> children;
+
+  @override
+  Component render() {
+    final formElement = FormElement();
+    if (id != null) formElement.id = id!;
+    for (var child in children) {
+      formElement.appendComponent(child);
+    }
+    return Component.fromElement(formElement);
+  }
+}

--- a/packages/example_common/lib/src/components/table_component.dart
+++ b/packages/example_common/lib/src/components/table_component.dart
@@ -1,0 +1,68 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:html';
+
+import 'component.dart';
+
+/// {@template example_common.table_component}
+/// A component that displays a set of [rows] in a table
+/// {@endtemplate}
+class TableComponent extends Component {
+  /// Header and Rows for to-be table
+  final TableDefinition tableDefinition;
+
+  /// {@macro example_common.column_component}
+  TableComponent({
+    required this.tableDefinition,
+  });
+
+  @override
+  Component render() {
+    final table = TableElement();
+    table.createTHead();
+    var tbody = table.createTBody();
+
+    TableRowElement headerRow = table.tHead!.insertRow(-1);
+
+    for (var h = 0; h < tableDefinition.headers.length; h++) {
+      headerRow.insertCell(h).text = tableDefinition.headers[h];
+    }
+
+    for (var row in tableDefinition.rows) {
+      TableRowElement newRow = tbody.insertRow(-1);
+      newRow.id = 'wrappedTableRow';
+      newRow.style.border = '1px solid black'; // add at the end
+      for (var r = 0; r < row.length; r++) {
+        newRow.insertCell(r).text = row[r];
+      }
+    }
+    return Component.fromElement(table);
+  }
+}
+
+/// The input type for the [TableComponent] constructor
+class TableDefinition {
+  /// The header row for the [TableComponent]
+  List<String> headers;
+
+  /// The data rows for the [TableComponent]
+  List<List<String>> rows;
+
+  /// {@macro example_common.form_component}
+  TableDefinition({
+    required this.headers,
+    required this.rows,
+  });
+}

--- a/packages/example_common/lib/src/components/text_component.dart
+++ b/packages/example_common/lib/src/components/text_component.dart
@@ -1,0 +1,33 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:html';
+
+import 'component.dart';
+
+/// {@template example_common.text_component}
+/// a component that displays text
+/// {@endtemplate}
+class TextComponent extends Component {
+  /// {@macro example_common.text_component}
+  TextComponent(this.text);
+
+  /// The content to be displayed in the text element.
+  final String text;
+
+  @override
+  Component render() {
+    return Component.fromElement(Element.p()..innerHtml = text);
+  }
+}

--- a/packages/example_common/lib/src/components/text_form_field_component.dart
+++ b/packages/example_common/lib/src/components/text_form_field_component.dart
@@ -1,0 +1,94 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:html';
+
+import '../utils/component_edge_insets.dart';
+import 'component.dart';
+import 'container_component.dart';
+import 'flex_component.dart';
+
+/// {@template example_common.text_form_field_component}
+/// a component that displays a form field - an input and a label.
+/// {@endtemplate}
+class TextFormFieldComponent extends Component {
+  /// {@macro example_common.text_form_field_component}
+  TextFormFieldComponent({
+    this.id = '',
+    this.padding,
+    this.margin = const ComponentEdgeInsets.all(8),
+    required this.labelText,
+    this.initialValue,
+    required this.onChanged,
+    this.required = false,
+    this.type = 'text',
+  });
+
+  /// The id of the input element
+  final String id;
+
+  /// The padding of the component
+  final ComponentEdgeInsets? padding;
+
+  /// The padding of the component
+  final ComponentEdgeInsets margin;
+
+  /// The text of the label
+  final String labelText;
+
+  /// The initial value of the field
+  final String? initialValue;
+
+  /// Whether or not the field is required
+  final bool required;
+
+  /// The input type.
+  final String type;
+
+  /// A callback that will run when the value has changed.
+  final Function(String? value) onChanged;
+
+  late final _labelElement = LabelElement()..innerHtml = labelText;
+  late final _inputElement = InputElement()
+    ..type = type
+    ..required = required
+    ..id = id
+    ..style.width = '100%'
+    ..style.boxSizing = 'border-box'
+    ..value = initialValue;
+
+  @override
+  Component render() {
+    return ContainerComponent(
+      margin: margin,
+      padding: padding,
+      child: ColumnComponent(
+        children: [
+          Component.fromElement(_labelElement),
+          ContainerComponent(height: 6),
+          Component.fromElement(_inputElement),
+        ],
+      ),
+    );
+  }
+
+  @override
+  void componentDidMount() {
+    _inputElement.onKeyUp.listen((Event event) {
+      event.preventDefault();
+      onChanged((_inputElement).value);
+    });
+    super.componentDidMount();
+  }
+}

--- a/packages/example_common/lib/src/enums.dart
+++ b/packages/example_common/lib/src/enums.dart
@@ -1,0 +1,62 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Represents an axis in a two dimensional plane.
+enum Axis {
+  /// The horizontal axis
+  horizontal,
+
+  /// The vertical axis.
+  vertical,
+}
+
+/// Extension on [Axis]
+extension AxisX on Axis {
+  /// represents the CSS flex-direction property
+  String get flexDirection {
+    switch (this) {
+      case Axis.horizontal:
+        return 'row';
+      case Axis.vertical:
+        return 'column';
+    }
+  }
+}
+
+/// Represents the CSS align-items property
+///
+/// The CSS align-items property sets the align-self value on all
+/// direct children as a group. In Flexbox, it controls the alignment
+/// of items on the Cross Axis. In Grid Layout, it controls the
+/// alignment of items on the Block Axis within their grid area.
+///
+/// See: https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
+enum AlignItems {
+  /// The flex items' margin boxes are centered within the line on the cross-axis.
+  /// If the cross-size of an item is larger than the flex container, it will
+  /// overflow equally in both directions.
+  center,
+
+  /// The items are packed flush to each other toward the start edge of the
+  /// alignment container in the appropriate axis.
+  start,
+
+  /// The items are packed flush to each other toward the end edge of the
+  /// alignment container in the appropriate axis.
+  end,
+
+  /// Flex items are stretched such that the cross-size of the item's margin
+  /// box is the same as the line while respecting width and height constraints.
+  stretch,
+}

--- a/packages/example_common/lib/src/utils/component_edge_insets.dart
+++ b/packages/example_common/lib/src/utils/component_edge_insets.dart
@@ -1,0 +1,62 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// {@template example_common.component_edge_insets}
+/// A class representing the spacing around the sides of a component,
+/// usually in the form of padding or margin
+/// {@endtemplate}
+class ComponentEdgeInsets {
+  /// {@macro example_common.component_edge_insets}
+  const ComponentEdgeInsets({
+    this.left = 0,
+    this.right = 0,
+    this.top = 0,
+    this.bottom = 0,
+  });
+
+  /// Left edge inset in px
+  final double left;
+
+  /// Right edge inset in px
+  final double right;
+
+  /// Top edge inset in px
+  final double top;
+
+  /// Bottom edge inset in px
+  final double bottom;
+
+  /// Create [ComponentEdgeInsets] that is symmetric
+  const ComponentEdgeInsets.symmetric(
+      {double horizontal = 0, double vertical = 0})
+      : left = horizontal,
+        right = horizontal,
+        top = vertical,
+        bottom = vertical;
+
+  /// Create [ComponentEdgeInsets] that has equal value on each side
+  const ComponentEdgeInsets.all(double value)
+      : left = value,
+        right = value,
+        top = value,
+        bottom = value;
+
+  /// [ComponentEdgeInsets] with no value
+  static const zero = ComponentEdgeInsets.all(0);
+
+  /// Creates a CSS string
+  String toCssString() {
+    return '${top}px ${right}px ${bottom}px ${left}px';
+  }
+}

--- a/packages/example_common/lib/src/utils/render_app.dart
+++ b/packages/example_common/lib/src/utils/render_app.dart
@@ -1,0 +1,42 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:html';
+
+import 'package:example_common/example_common.dart';
+
+const _rootComponentId = 'root-component';
+
+/// Renders a [Component] as the root element
+///
+/// The DOM must have a body element
+void renderApp(Component component) {
+  var rootElement = document.getElementById(_rootComponentId);
+
+  if (rootElement == null) {
+    rootElement = Element.div()..id = _rootComponentId;
+    final body = document.body;
+    if (body == null) {
+      throw Exception('The DOM must have a body element.');
+    }
+    body.append(rootElement);
+  }
+
+  final app = rootElement.firstChild;
+  if (app == null) {
+    rootElement.appendComponent(component);
+  } else {
+    app.replaceWith(component.renderElement());
+  }
+}

--- a/packages/example_common/mono_pkg.yaml
+++ b/packages/example_common/mono_pkg.yaml
@@ -12,26 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: amplify_secure_storage_dart_example
-description: Example for amplify_secure_storage_dart
-version: 1.0.0
-publish_to: none
+sdk:
+  - stable
+  - dev
 
-environment:
-  sdk: ">=2.17.0 <3.0.0"
-
-dependencies:
-  amplify_secure_storage_dart:
-    path: ../
-  example_common:
-    path: ../../../example_common
-
-dependency_overrides:
-  worker_bee:
-    path: ../../../worker_bee/worker_bee
-
-dev_dependencies:
-  amplify_lints:
-    path: ../../../amplify_lints
-  build_runner: ^2.1.4
-  build_web_compilers: ^3.2.1
+stages:
+  - analyze_and_format:
+      - group:
+          - format
+          - analyze: --fatal-infos .
+  - unit_test:
+      - test: -p chrome

--- a/packages/example_common/pubspec.yaml
+++ b/packages/example_common/pubspec.yaml
@@ -1,0 +1,15 @@
+name: example_common
+description: Common components and utils for example apps.
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  meta: ^1.7.0
+
+dev_dependencies:
+  amplify_lints:
+    path: ../amplify_lints
+  test: ^1.16.0

--- a/packages/example_common/test/example_common_test.dart
+++ b/packages/example_common/test/example_common_test.dart
@@ -1,0 +1,29 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('browser')
+
+import 'dart:html';
+
+import 'package:example_common/example_common.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Can create a component and insert it into the DOM', () {
+    final component = CenterComponent(child: TextComponent('Hello World!'));
+    document.body?.append(component.renderElement());
+    final text = document.body?.innerText;
+    expect(text, 'Hello World!');
+  });
+}

--- a/packages/secure_storage/amplify_secure_storage_dart/example/mono_pkg.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/example/mono_pkg.yaml
@@ -12,26 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: amplify_secure_storage_dart_example
-description: Example for amplify_secure_storage_dart
-version: 1.0.0
-publish_to: none
+sdk:
+  - stable
+  - dev
 
-environment:
-  sdk: ">=2.17.0 <3.0.0"
-
-dependencies:
-  amplify_secure_storage_dart:
-    path: ../
-  example_common:
-    path: ../../../example_common
-
-dependency_overrides:
-  worker_bee:
-    path: ../../../worker_bee/worker_bee
-
-dev_dependencies:
-  amplify_lints:
-    path: ../../../amplify_lints
-  build_runner: ^2.1.4
-  build_web_compilers: ^3.2.1
+stages:
+  - analyze_and_format:
+      - group:
+          - format
+          - analyze: --fatal-infos .

--- a/packages/secure_storage/amplify_secure_storage_dart/example/web/index.html
+++ b/packages/secure_storage/amplify_secure_storage_dart/example/web/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="scaffolded-by" content="https://github.com/dart-lang/sdk" />
+  <link rel="stylesheet" href="styles.css">
+  <title>Amplify Secure Storage Example</title>
+  <script defer src="main.dart.js"></script>
+</head>
+
+<body>
+  <!-- Placeholder for root element -->
+</body>
+
+</html>

--- a/packages/secure_storage/amplify_secure_storage_dart/example/web/main.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/example/web/main.dart
@@ -1,0 +1,116 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
+import 'package:example_common/example_common.dart';
+
+final storage = AmplifySecureStorageDart(
+  config: AmplifySecureStorageConfig(
+    scope: 'default',
+  ),
+);
+Future<void> main() async {
+  renderApp(AppComponent());
+}
+
+class AppComponent extends StatefulComponent {
+  String _key = '';
+  String _value = '';
+
+  String? _errorText;
+  String? _successText;
+
+  void _clearMessages() {
+    setState(() {
+      _errorText = null;
+      _successText = null;
+    });
+  }
+
+  Future<void> _read() async {
+    _clearMessages();
+    if (_key.isEmpty) {
+      setState(() => _errorText = 'Key is required.');
+    } else {
+      final value = await storage.read(key: _key);
+      setState(() => _successText = 'value is: $value');
+    }
+  }
+
+  Future<void> _write() async {
+    _clearMessages();
+    if (_key.isEmpty || _value.isEmpty) {
+      setState(() => _errorText = 'Key and Value are required.');
+    } else {
+      await storage.write(key: _key, value: _value);
+      setState(() => _successText = 'Wrote value to storage!');
+    }
+  }
+
+  Future<void> _delete() async {
+    _clearMessages();
+    if (_key.isEmpty) {
+      setState(() => _errorText = 'Key is required.');
+    } else {
+      await storage.delete(key: _key);
+      setState(() => _successText = 'deleted key: $_key from storage!');
+    }
+  }
+
+  @override
+  Component render() {
+    return CenterComponent(
+      child: ColumnComponent(
+        children: [
+          if (_successText != null) TextComponent('Success: $_successText'),
+          if (_errorText != null) TextComponent('Error: $_errorText'),
+          FormComponent(
+            children: [
+              TextFormFieldComponent(
+                labelText: 'key',
+                initialValue: _key,
+                onChanged: (value) {
+                  _key = value ?? '';
+                },
+              ),
+              TextFormFieldComponent(
+                labelText: 'value',
+                initialValue: _value,
+                onChanged: (value) {
+                  _value = value ?? '';
+                },
+              ),
+              RowComponent(
+                children: [
+                  ButtonComponent(
+                    innerHtml: 'Write',
+                    onClick: _write,
+                  ),
+                  ButtonComponent(
+                    innerHtml: 'Read',
+                    onClick: _read,
+                  ),
+                  ButtonComponent(
+                    innerHtml: 'delete',
+                    onClick: _delete,
+                  ),
+                ],
+              )
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/packages/secure_storage/amplify_secure_storage_dart/example/web/styles.css
+++ b/packages/secure_storage/amplify_secure_storage_dart/example/web/styles.css
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import url(https://fonts.googleapis.com/css?family=Roboto);
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  font-family: "Roboto", sans-serif;
+}


### PR DESCRIPTION
Adds Dart-only examples to repo for debugging/testing purposes.

---

**Stack**:
- #1714
- #1713
- #1712
- #1711
- #1707
- #1706
- #1702


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*