### PR TITLE
feat(auth): Switch auth flow at runtime

### DIFF
--- a/packages/amplify_core/lib/src/config/auth/cognito/authentication_flow_type.dart
+++ b/packages/amplify_core/lib/src/config/auth/cognito/authentication_flow_type.dart
@@ -17,8 +17,12 @@ import 'package:json_annotation/json_annotation.dart';
 
 enum AuthenticationFlowType {
   @JsonValue('USER_SRP_AUTH')
-  userSrpAuth,
+  userSrpAuth('USER_SRP_AUTH'),
 
   @JsonValue('CUSTOM_AUTH')
-  customAuth,
+  customAuth('CUSTOM_AUTH');
+
+  const AuthenticationFlowType(this.value);
+
+  final String value;
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -411,19 +411,21 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface implements Closeable {
   Future<SignInResult> signIn({
     required SignInRequest request,
   }) async {
-    final options = request.options as CognitoSignInOptions?;
+    final options = request.options as CognitoSignInOptions? ??
+        const CognitoSignInOptions();
 
     // Create a new state machine for every call since it caches values
     // internally on each run.
     final stream = _stateMachine.create(SignInStateMachine.type).stream;
     _stateMachine.dispatch(
       SignInEvent.initiate(
+        authFlow: options.authFlow?.sdkValue,
         parameters: SignInParameters(
           (p) => p
             ..username = request.username
             ..password = request.password,
         ),
-        clientMetadata: options?.clientMetadata,
+        clientMetadata: options.clientMetadata,
       ),
     );
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_options.dart
@@ -20,7 +20,10 @@ import 'package:amplify_core/amplify_core.dart';
 /// {@endtemplate}
 class CognitoSignInOptions extends SignInOptions {
   /// {@macro amplify_auth_cognito.model.cognito_sign_in_options}
-  const CognitoSignInOptions({this.clientMetadata});
+  const CognitoSignInOptions({this.authFlow, this.clientMetadata});
+
+  /// Runtime override of the Authentication flow to use for sign in.
+  final AuthenticationFlowType? authFlow;
 
   /// A map of custom key-value pairs that you can provide as input for certain
   /// custom workflows that this action triggers.
@@ -28,6 +31,7 @@ class CognitoSignInOptions extends SignInOptions {
 
   @override
   Map<String, Object?> serializeAsMap() => {
+        if (authFlow != null) 'authFlow': authFlow?.value,
         if (clientMetadata != null) 'clientMetadata': clientMetadata,
       };
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
@@ -20,6 +20,7 @@ import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart'
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/sdk_exception.dart';
+import 'package:amplify_core/amplify_core.dart' show AuthenticationFlowType;
 import 'package:aws_signature_v4/aws_signature_v4.dart';
 import 'package:smithy/smithy.dart';
 
@@ -77,6 +78,19 @@ extension AttributeTypeBridge on AttributeType {
       userAttributeKey: key,
       value: value ?? '',
     );
+  }
+}
+
+/// Bridging helpers for [AuthenticationFlowType].
+extension AuthenticationFlowTypeBridge on AuthenticationFlowType {
+  /// The Cognito SDK value of `this`.
+  AuthFlowType get sdkValue {
+    switch (this) {
+      case AuthenticationFlowType.userSrpAuth:
+        return AuthFlowType.userSrpAuth;
+      case AuthenticationFlowType.customAuth:
+        return AuthFlowType.customAuth;
+    }
   }
 }
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/sign_in_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/sign_in_event.dart
@@ -15,6 +15,7 @@
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_auth_cognito_dart/src/model/cognito_user.dart';
 import 'package:amplify_auth_cognito_dart/src/model/sign_in_parameters.dart';
+import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 /// {@template amplify_auth_cognito.sign_in_event_type}
@@ -46,6 +47,7 @@ abstract class SignInEvent extends StateMachineEvent<SignInEventType> {
 
   /// {@macro amplify_auth_cognito.sign_in_initiate}
   const factory SignInEvent.initiate({
+    AuthFlowType? authFlow,
     required SignInParameters parameters,
     Map<String, String>? clientMetadata,
   }) = SignInInitiate;
@@ -79,10 +81,14 @@ abstract class SignInEvent extends StateMachineEvent<SignInEventType> {
 class SignInInitiate extends SignInEvent {
   /// {@macro amplify_auth_cognito.sign_in_initiate}
   const SignInInitiate({
+    this.authFlow,
     required this.parameters,
     Map<String, String>? clientMetadata,
   })  : clientMetadata = clientMetadata ?? const {},
         super._();
+
+  /// Runtime override of the Authentication flow.
+  final AuthFlowType? authFlow;
 
   /// The flow-specific parameters.
   final SignInParameters parameters;
@@ -94,7 +100,7 @@ class SignInInitiate extends SignInEvent {
   SignInEventType get type => SignInEventType.initiate;
 
   @override
-  List<Object?> get props => [type, clientMetadata, parameters];
+  List<Object?> get props => [type, authFlow, clientMetadata, parameters];
 
   @override
   String? checkPrecondition(SignInState currentState) {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ignore_for_file: close_sinks
-
 import 'dart:async';
 import 'dart:convert';
 
@@ -55,7 +53,10 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState> {
   SignInState get initialState => const SignInState.notStarted();
 
   /// Flow used to sign in.
-  late final AuthFlowType authFlowType = () {
+  late final AuthFlowType authFlowType;
+
+  /// The default flow used to sign in.
+  late final AuthFlowType defaultAuthFlowType = () {
     // Get the flow from the plugin config
     final pluginFlowType =
         expect<CognitoPluginConfig>().auth?.default$?.authenticationFlowType ??
@@ -175,6 +176,7 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState> {
       _password = password;
     }
 
+    authFlowType = event.authFlow ?? defaultAuthFlowType;
     if (authFlowType != AuthFlowType.customAuth) {
       return initiateSrp(event);
     }

--- a/packages/auth/amplify_auth_cognito_dart/test/state/sign_in_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/state/sign_in_state_machine_test.dart
@@ -1,0 +1,115 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_auth_cognito_dart/src/model/sign_in_parameters.dart';
+import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
+import 'package:amplify_auth_cognito_dart/src/state/machines/sign_in_state_machine.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
+import 'package:mockito/mockito.dart';
+import 'package:smithy/smithy.dart';
+import 'package:stream_transform/stream_transform.dart';
+import 'package:test/test.dart';
+
+import '../common/mock_config.dart';
+import '../common/mock_secure_storage.dart';
+
+class MockCognitoIdentityProviderClient extends Fake
+    implements CognitoIdentityProviderClient {
+  MockCognitoIdentityProviderClient({
+    required Future<InitiateAuthResponse> Function() initiateAuth,
+  }) : _initiateAuth = initiateAuth;
+
+  final Future<InitiateAuthResponse> Function() _initiateAuth;
+
+  @override
+  Future<InitiateAuthResponse> initiateAuth(
+    InitiateAuthRequest input, {
+    HttpClient? client,
+  }) =>
+      _initiateAuth();
+}
+
+void main() {
+  group('SignInStateMachine', () {
+    late CognitoAuthStateMachine stateMachine;
+
+    setUp(() {
+      stateMachine = CognitoAuthStateMachine()
+        ..addInstance<SecureStorageInterface>(MockSecureStorage());
+    });
+
+    test('can change flow at runtime', () async {
+      const config = AmplifyConfig(
+        auth: AuthConfig(
+          plugins: {
+            CognitoPluginConfig.pluginKey: CognitoPluginConfig(
+              auth: AWSConfigMap(
+                {
+                  'Default': CognitoAuthConfig(
+                    authenticationFlowType: AuthenticationFlowType.userSrpAuth,
+                  ),
+                },
+              ),
+              cognitoUserPool: AWSConfigMap(
+                {
+                  'Default': CognitoUserPoolConfig(
+                    poolId: testUserPoolId,
+                    appClientId: testAppClientId,
+                    region: testRegion,
+                  ),
+                },
+              ),
+            ),
+          },
+        ),
+      );
+      stateMachine.dispatch(
+        const AuthEvent.configure(config),
+      );
+      await expectLater(
+        stateMachine.stream.whereType<AuthState>().firstWhere(
+              (event) => event is AuthConfigured || event is AuthFailure,
+            ),
+        completion(isA<AuthConfigured>()),
+      );
+
+      final mockClient = MockCognitoIdentityProviderClient(
+        initiateAuth: () async => InitiateAuthResponse(
+          challengeName: ChallengeNameType.customChallenge,
+        ),
+      );
+      stateMachine
+        ..addInstance<CognitoIdentityProviderClient>(mockClient)
+        ..dispatch(
+          SignInEvent.initiate(
+            authFlow: AuthFlowType.customAuth,
+            parameters: SignInParameters(
+              (p) => p
+                ..username = 'username'
+                ..password = 'password',
+            ),
+          ),
+        );
+
+      final signInStateMachine = stateMachine.expect(SignInStateMachine.type);
+      await signInStateMachine.stream.whereType<SignInChallenge>().first;
+      expect(
+        signInStateMachine.authFlowType,
+        AuthFlowType.customAuth,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Adds Dart implementation of the runtime auth flow switch to allow customizing a flow other than the default.

---

**Stack**:
- #1720
- #1719


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*