### PR TITLE
feat(auth): Support user pool-only mode

### DIFF
--- a/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -173,9 +173,7 @@ class AmplifyAuthService implements AuthService {
   @override
   Future<bool> isValidSession() async {
     try {
-      var res = await Amplify.Auth.fetchAuthSession(
-              options: const CognitoSessionOptions(getAWSCredentials: true))
-          as CognitoAuthSession;
+      final res = await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
       return res.userPoolTokens != null;
     } on SignedOutException {
       return false;

--- a/packages/amplify_core/lib/src/types/exception/auth/invalid_account_type_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/auth/invalid_account_type_exception.dart
@@ -26,4 +26,13 @@ class InvalidAccountTypeException extends AuthException {
     super.recoverySuggestion,
     super.underlyingException,
   });
+
+  /// Thrown when no identity pool is available, but an identity pool operation
+  /// was explicitly requested.
+  const InvalidAccountTypeException.noIdentityPool({
+    String recoverySuggestion = 'Register an identity pool using the CLI',
+  }) : this(
+          'No identity pool registered for this account',
+          recoverySuggestion: recoverySuggestion,
+        );
 }


### PR DESCRIPTION
Removes the need to have an identity pool configured

---

**Stack**:
- #1721
- #1720
- #1719


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*