### PR TITLE
fix(auth): Preserve Hosted UI options

### DIFF
--- a/packages/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/amplify_authenticator/lib/amplify_authenticator.dart
@@ -415,7 +415,7 @@ class Authenticator extends StatefulWidget {
   /// {@macro amplify_authenticator.exception_banner_location}
   final ExceptionBannerLocation exceptionBannerLocation;
 
-  /// {@macro amplify_auth_plugin_interface.cognito_sign_in_with_web_ui_options}
+  /// {@macro amplify_auth_cognito.model.cognito_sign_in_with_web_ui_options.private_session}
   final bool preferPrivateSession;
 
   /// This widget will be displayed after a user has signed in.

--- a/packages/auth/amplify_auth_cognito/example/lib/main.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/main.dart
@@ -98,6 +98,7 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return Authenticator(
+      preferPrivateSession: true,
       child: MaterialApp.router(
         title: 'Flutter Demo',
         builder: Authenticator.builder(),

--- a/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_flutter.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_flutter.dart
@@ -95,15 +95,18 @@ class HostedUiPlatformImpl extends io.HostedUiPlatformImpl {
   }
 
   @override
-  Future<void> signOut() async {
+  Future<void> signOut({
+    required CognitoSignInWithWebUIOptions options,
+  }) async {
     if (!_isMobile) {
-      return super.signOut();
+      return super.signOut(options: options);
     }
     final signOutUri = getSignOutUri();
     await _nativeAuthBridge.signOutWithUrl(
       signOutUri.toString(),
       signOutRedirectUri.scheme,
-      null,
+      options.isPreferPrivateSession,
+      options.browserPackageName,
     );
   }
 }

--- a/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_flutter.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_flutter.dart
@@ -96,7 +96,7 @@ class HostedUiPlatformImpl extends io.HostedUiPlatformImpl {
 
   @override
   Future<void> signOut({
-    required CognitoSignInWithWebUIOptions options,
+    required CognitoSignOutWithWebUIOptions options,
   }) async {
     if (!_isMobile) {
       return super.signOut(options: options);

--- a/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_stub.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_stub.dart
@@ -28,7 +28,9 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
   }
 
   @override
-  Future<void> signOut() {
+  Future<void> signOut({
+    required CognitoSignInWithWebUIOptions options,
+  }) {
     throw UnimplementedError();
   }
 

--- a/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_stub.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_stub.dart
@@ -29,7 +29,7 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
 
   @override
   Future<void> signOut({
-    required CognitoSignInWithWebUIOptions options,
+    required CognitoSignOutWithWebUIOptions options,
   }) {
     throw UnimplementedError();
   }

--- a/packages/auth/amplify_auth_cognito/lib/src/native_auth_plugin.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/native_auth_plugin.dart
@@ -267,13 +267,16 @@ class NativeAuthBridge {
   }
 
   Future<void> signOutWithUrl(String arg_url, String arg_callbackUrlScheme,
-      String? arg_browserPackageName) async {
+      bool arg_preferPrivateSession, String? arg_browserPackageName) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.NativeAuthBridge.signOutWithUrl', codec,
         binaryMessenger: _binaryMessenger);
-    final Map<Object?, Object?>? replyMap = await channel.send(
-            <Object?>[arg_url, arg_callbackUrlScheme, arg_browserPackageName])
-        as Map<Object?, Object?>?;
+    final Map<Object?, Object?>? replyMap = await channel.send(<Object?>[
+      arg_url,
+      arg_callbackUrlScheme,
+      arg_preferPrivateSession,
+      arg_browserPackageName
+    ]) as Map<Object?, Object?>?;
     if (replyMap == null) {
       throw PlatformException(
         code: 'channel-error',

--- a/packages/auth/amplify_auth_cognito/pigeons/native_auth_plugin.dart
+++ b/packages/auth/amplify_auth_cognito/pigeons/native_auth_plugin.dart
@@ -70,6 +70,7 @@ abstract class NativeAuthBridge {
   void signOutWithUrl(
     String url,
     String callbackUrlScheme, // iOS-only
+    bool preferPrivateSession, // iOS-only
     String? browserPackageName, // Android-only
   );
 }

--- a/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
+++ b/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
@@ -247,6 +247,7 @@ open class AuthCognito :
     override fun signOutWithUrl(
         url: String,
         callbackUrlScheme: String,
+        preferPrivateSession: Boolean,
         browserPackageName: String?,
         unsafeResult: NativeAuthPluginBindings.Result<Void>
     ) {

--- a/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/NativeAuthPluginBindings.java
+++ b/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/NativeAuthPluginBindings.java
@@ -370,7 +370,7 @@ public class NativeAuthPluginBindings {
   public interface NativeAuthBridge {
     void addPlugin(Result<Void> result);
     void signInWithUrl(@NonNull String url, @NonNull String callbackUrlScheme, @NonNull Boolean preferPrivateSession, @Nullable String browserPackageName, Result<Map<String, String>> result);
-    void signOutWithUrl(@NonNull String url, @NonNull String callbackUrlScheme, @Nullable String browserPackageName, Result<Void> result);
+    void signOutWithUrl(@NonNull String url, @NonNull String callbackUrlScheme, @NonNull Boolean preferPrivateSession, @Nullable String browserPackageName, Result<Void> result);
 
     /** The codec used by NativeAuthBridge. */
     static MessageCodec<Object> getCodec() {
@@ -467,7 +467,11 @@ public class NativeAuthPluginBindings {
               if (callbackUrlSchemeArg == null) {
                 throw new NullPointerException("callbackUrlSchemeArg unexpectedly null.");
               }
-              String browserPackageNameArg = (String)args.get(2);
+              Boolean preferPrivateSessionArg = (Boolean)args.get(2);
+              if (preferPrivateSessionArg == null) {
+                throw new NullPointerException("preferPrivateSessionArg unexpectedly null.");
+              }
+              String browserPackageNameArg = (String)args.get(3);
               Result<Void> resultCallback = new Result<Void>() {
                 public void success(Void result) {
                   wrapped.put("result", null);
@@ -479,7 +483,7 @@ public class NativeAuthPluginBindings {
                 }
               };
 
-              api.signOutWithUrl(urlArg, callbackUrlSchemeArg, browserPackageNameArg, resultCallback);
+              api.signOutWithUrl(urlArg, callbackUrlSchemeArg, preferPrivateSessionArg, browserPackageNameArg, resultCallback);
             }
             catch (Error | RuntimeException exception) {
               wrapped.put("error", wrapError(exception));

--- a/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
@@ -42,6 +42,7 @@ export 'src/model/signin/cognito_sign_in_options.dart';
 export 'src/model/signin/cognito_sign_in_result.dart';
 export 'src/model/signin/cognito_sign_in_step.dart';
 export 'src/model/signin/cognito_sign_in_with_web_ui_options.dart';
+export 'src/model/signout/cognito_sign_out_with_web_ui_options.dart';
 export 'src/model/signup/cognito_confirm_sign_up_options.dart';
 export 'src/model/signup/cognito_resend_sign_up_code_options.dart';
 export 'src/model/signup/cognito_resend_sign_up_code_result.dart';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
@@ -17,6 +17,7 @@ library amplify_auth_cognito.credentials.cognito_keys;
 
 import 'dart:collection';
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:meta/meta.dart';
 
@@ -78,6 +79,9 @@ enum HostedUiKey {
 
   /// The OIDC nonce value.
   nonce,
+
+  /// The [CognitoSignInWithWebUIOptions] passed to `signInWithWebUI`.
+  options,
 }
 
 /// {@template amplify_auth_cognito.cognito_identity_pool_keys}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
@@ -220,5 +220,7 @@ abstract class HostedUiPlatform {
   });
 
   /// Sign out the current user.
-  Future<void> signOut();
+  Future<void> signOut({
+    required CognitoSignInWithWebUIOptions options,
+  });
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
@@ -221,6 +221,6 @@ abstract class HostedUiPlatform {
 
   /// Sign out the current user.
   Future<void> signOut({
-    required CognitoSignInWithWebUIOptions options,
+    required CognitoSignOutWithWebUIOptions options,
   });
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_html.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_html.dart
@@ -89,7 +89,9 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
   }
 
   @override
-  Future<void> signOut() async {
+  Future<void> signOut({
+    required CognitoSignInWithWebUIOptions options,
+  }) async {
     final signOutUrl = getSignOutUri().toString();
     await launchUrl(signOutUrl);
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_html.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_html.dart
@@ -90,7 +90,7 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
 
   @override
   Future<void> signOut({
-    required CognitoSignInWithWebUIOptions options,
+    required CognitoSignOutWithWebUIOptions options,
   }) async {
     final signOutUrl = getSignOutUri().toString();
     await launchUrl(signOutUrl);

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_io.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_io.dart
@@ -224,7 +224,9 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
   }
 
   @override
-  Future<void> signOut() async {
+  Future<void> signOut({
+    required CognitoSignInWithWebUIOptions options,
+  }) async {
     final signOutUris = config.signOutRedirectUris.where(
       (uri) =>
           uri.scheme == 'http' &&

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_io.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_io.dart
@@ -225,7 +225,7 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
 
   @override
   Future<void> signOut({
-    required CognitoSignInWithWebUIOptions options,
+    required CognitoSignOutWithWebUIOptions options,
   }) async {
     final signOutUris = config.signOutRedirectUris.where(
       (uri) =>

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_stub.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_stub.dart
@@ -28,7 +28,9 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
   }
 
   @override
-  Future<void> signOut() {
+  Future<void> signOut({
+    required CognitoSignInWithWebUIOptions options,
+  }) {
     throw UnimplementedError();
   }
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_stub.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_stub.dart
@@ -29,7 +29,7 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
 
   @override
   Future<void> signOut({
-    required CognitoSignInWithWebUIOptions options,
+    required CognitoSignOutWithWebUIOptions options,
   }) {
     throw UnimplementedError();
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_with_web_ui_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_with_web_ui_options.dart
@@ -18,13 +18,13 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'cognito_sign_in_with_web_ui_options.g.dart';
 
-/// {@template amplify_auth_cognito.model.cognito_sign_in_options}
+/// {@template amplify_auth_cognito.model.cognito_sign_in_with_web_ui_options}
 /// Cognito options for `Amplify.Auth.signInWithWebUI`.
 /// {@endtemplate}
 @JsonSerializable(includeIfNull: false)
 class CognitoSignInWithWebUIOptions extends SignInWithWebUIOptions
     with AWSSerializable, AWSDebuggable {
-  /// {@macro amplify_auth_cognito.model.cognito_sign_in_options}
+  /// {@macro amplify_auth_cognito.model.cognito_sign_in_with_web_ui_options}
   const CognitoSignInWithWebUIOptions({
     this.isPreferPrivateSession = false,
     this.browserPackageName,
@@ -34,7 +34,7 @@ class CognitoSignInWithWebUIOptions extends SignInWithWebUIOptions
   factory CognitoSignInWithWebUIOptions.fromJson(Map<String, Object?> json) =>
       _$CognitoSignInWithWebUIOptionsFromJson(json);
 
-  /// {@template amplify_auth_plugin_interface.cognito_sign_in_with_web_ui_options}
+  /// {@template amplify_auth_cognito.model.cognito_sign_in_with_web_ui_options.private_session}
   /// iOS-only: Starts the webUI signin in a private browser session, if supported by the current browser.
   ///
   /// Note that this value internally sets `prefersEphemeralWebBrowserSession` in ASWebAuthenticationSession.
@@ -45,8 +45,10 @@ class CognitoSignInWithWebUIOptions extends SignInWithWebUIOptions
   /// {@endtemplate}
   final bool isPreferPrivateSession;
 
+  /// {@template amplify_auth_cognito.model.cognito_sign_in_with_web_ui_options.browser_package_name}
   /// Android-only: The browser package name (application ID) to use to launch
   /// the custom tab.
+  /// {@endtemplate}
   final String? browserPackageName;
 
   @override

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_with_web_ui_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_with_web_ui_options.dart
@@ -14,16 +14,25 @@
  */
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'cognito_sign_in_with_web_ui_options.g.dart';
 
 /// {@template amplify_auth_cognito.model.cognito_sign_in_options}
 /// Cognito options for `Amplify.Auth.signInWithWebUI`.
 /// {@endtemplate}
-class CognitoSignInWithWebUIOptions extends SignInWithWebUIOptions {
+@JsonSerializable(includeIfNull: false)
+class CognitoSignInWithWebUIOptions extends SignInWithWebUIOptions
+    with AWSSerializable, AWSDebuggable {
   /// {@macro amplify_auth_cognito.model.cognito_sign_in_options}
   const CognitoSignInWithWebUIOptions({
     this.isPreferPrivateSession = false,
     this.browserPackageName,
   });
+
+  /// {@macro amplify_auth_cognito.model.cognito_sign_in_options}
+  factory CognitoSignInWithWebUIOptions.fromJson(Map<String, Object?> json) =>
+      _$CognitoSignInWithWebUIOptionsFromJson(json);
 
   /// {@template amplify_auth_plugin_interface.cognito_sign_in_with_web_ui_options}
   /// iOS-only: Starts the webUI signin in a private browser session, if supported by the current browser.
@@ -41,9 +50,11 @@ class CognitoSignInWithWebUIOptions extends SignInWithWebUIOptions {
   final String? browserPackageName;
 
   @override
-  Map<String, Object?> serializeAsMap() => {
-        'isPreferPrivateSession': isPreferPrivateSession,
-        if (browserPackageName != null)
-          'browserPackageName': browserPackageName,
-      };
+  Map<String, Object?> serializeAsMap() => toJson();
+
+  @override
+  Map<String, Object?> toJson() => _$CognitoSignInWithWebUIOptionsToJson(this);
+
+  @override
+  String get runtimeTypeName => 'CognitoSignInWithWebUIOptions';
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_with_web_ui_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_with_web_ui_options.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cognito_sign_in_with_web_ui_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CognitoSignInWithWebUIOptions _$CognitoSignInWithWebUIOptionsFromJson(
+        Map<String, dynamic> json) =>
+    CognitoSignInWithWebUIOptions(
+      isPreferPrivateSession: json['isPreferPrivateSession'] as bool? ?? false,
+      browserPackageName: json['browserPackageName'] as String?,
+    );
+
+Map<String, dynamic> _$CognitoSignInWithWebUIOptionsToJson(
+    CognitoSignInWithWebUIOptions instance) {
+  final val = <String, dynamic>{
+    'isPreferPrivateSession': instance.isPreferPrivateSession,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('browserPackageName', instance.browserPackageName);
+  return val;
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_with_web_ui_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_with_web_ui_options.dart
@@ -1,0 +1,51 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'cognito_sign_out_with_web_ui_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_sign_out_with_web_ui_options}
+/// Cognito options for `Amplify.Auth.signOut` when using Hosted UI.
+/// {@endtemplate}
+@JsonSerializable(includeIfNull: false)
+class CognitoSignOutWithWebUIOptions extends SignOutOptions
+    with AWSSerializable, AWSDebuggable {
+  /// {@macro amplify_auth_cognito.model.cognito_sign_out_with_web_ui_options}
+  const CognitoSignOutWithWebUIOptions({
+    this.isPreferPrivateSession = false,
+    this.browserPackageName,
+    super.globalSignOut = false,
+  });
+
+  /// {@macro amplify_auth_cognito.model.cognito_sign_in_options}
+  factory CognitoSignOutWithWebUIOptions.fromJson(Map<String, Object?> json) =>
+      _$CognitoSignOutWithWebUIOptionsFromJson(json);
+
+  /// {@macro amplify_auth_cognito.model.cognito_sign_in_with_web_ui_options.private_session}
+  final bool isPreferPrivateSession;
+
+  /// {@macro amplify_auth_cognito.model.cognito_sign_in_with_web_ui_options.browser_package_name}
+  final String? browserPackageName;
+
+  @override
+  Map<String, Object?> serializeAsMap() => toJson();
+
+  @override
+  Map<String, Object?> toJson() => _$CognitoSignOutWithWebUIOptionsToJson(this);
+
+  @override
+  String get runtimeTypeName => 'CognitoSignOutWithWebUIOptions';
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_with_web_ui_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_with_web_ui_options.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cognito_sign_out_with_web_ui_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CognitoSignOutWithWebUIOptions _$CognitoSignOutWithWebUIOptionsFromJson(
+        Map<String, dynamic> json) =>
+    CognitoSignOutWithWebUIOptions(
+      isPreferPrivateSession: json['isPreferPrivateSession'] as bool? ?? false,
+      browserPackageName: json['browserPackageName'] as String?,
+      globalSignOut: json['globalSignOut'] as bool? ?? false,
+    );
+
+Map<String, dynamic> _$CognitoSignOutWithWebUIOptionsToJson(
+    CognitoSignOutWithWebUIOptions instance) {
+  final val = <String, dynamic>{
+    'globalSignOut': instance.globalSignOut,
+    'isPreferPrivateSession': instance.isPreferPrivateSession,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('browserPackageName', instance.browserPackageName);
+  return val;
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
@@ -138,8 +138,8 @@ class HostedUiStateMachine extends HostedUiStateMachineBase {
         key: _keys[HostedUiKey.options],
       );
       final options = optionsJson == null
-          ? const CognitoSignInWithWebUIOptions()
-          : CognitoSignInWithWebUIOptions.fromJson(
+          ? const CognitoSignOutWithWebUIOptions()
+          : CognitoSignOutWithWebUIOptions.fromJson(
               (jsonDecode(optionsJson) as Map<Object?, Object?>).cast(),
             );
       // Clear credentials before dispatching to platform since the platform

--- a/packages/auth/amplify_auth_cognito_dart/test/common/mock_hosted_ui.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/common/mock_hosted_ui.dart
@@ -23,7 +23,7 @@ typedef SignInFn = Future<void> Function(
 
 typedef SignOutFn = Future<void> Function(
   HostedUiPlatform platform,
-  CognitoSignInWithWebUIOptions options,
+  CognitoSignOutWithWebUIOptions options,
 );
 
 HostedUiPlatformFactory createHostedUiFactory({
@@ -60,7 +60,7 @@ class MockHostedUiPlatform extends HostedUiPlatform {
 
   @override
   Future<void> signOut({
-    required CognitoSignInWithWebUIOptions options,
+    required CognitoSignOutWithWebUIOptions options,
   }) =>
       _signOut(this, options);
 

--- a/packages/auth/amplify_auth_cognito_dart/test/common/mock_hosted_ui.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/common/mock_hosted_ui.dart
@@ -15,14 +15,20 @@
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 
-typedef SignInFn = Future<void> Function({
-  required CognitoSignInWithWebUIOptions options,
+typedef SignInFn = Future<void> Function(
+  HostedUiPlatform platform,
+  CognitoSignInWithWebUIOptions options,
   AuthProvider? provider,
-});
+);
+
+typedef SignOutFn = Future<void> Function(
+  HostedUiPlatform platform,
+  CognitoSignInWithWebUIOptions options,
+);
 
 HostedUiPlatformFactory createHostedUiFactory({
   required SignInFn signIn,
-  required Future<void> Function() signOut,
+  required SignOutFn signOut,
 }) {
   return (DependencyManager dependencyManager) {
     return MockHostedUiPlatform(
@@ -37,23 +43,26 @@ class MockHostedUiPlatform extends HostedUiPlatform {
   MockHostedUiPlatform(
     super.dependencyManager, {
     required SignInFn signIn,
-    required Future<void> Function() signOut,
+    required SignOutFn signOut,
   })  : _signIn = signIn,
         _signOut = signOut,
         super.protected();
 
   final SignInFn _signIn;
-  final Future<void> Function() _signOut;
+  final SignOutFn _signOut;
 
   @override
   Future<void> signIn({
     required CognitoSignInWithWebUIOptions options,
     AuthProvider? provider,
   }) =>
-      _signIn(options: options, provider: provider);
+      _signIn(this, options, provider);
 
   @override
-  Future<void> signOut() => _signOut();
+  Future<void> signOut({
+    required CognitoSignInWithWebUIOptions options,
+  }) =>
+      _signOut(this, options);
 
   @override
   Uri get signInRedirectUri => config.signInRedirectUris.first;

--- a/packages/auth/amplify_auth_cognito_dart/test/plugin/sign_out_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/plugin/sign_out_test.dart
@@ -84,11 +84,15 @@ void main() {
         ..addInstance(secureStorage)
         ..addBuilder(
           createHostedUiFactory(
-            signIn: ({
-              required CognitoSignInWithWebUIOptions options,
+            signIn: (
+              HostedUiPlatform platform,
+              CognitoSignInWithWebUIOptions options,
               AuthProvider? provider,
-            }) async {},
-            signOut: () async {},
+            ) async {},
+            signOut: (
+              HostedUiPlatform platform,
+              CognitoSignInWithWebUIOptions options,
+            ) async {},
           ),
           HostedUiPlatform.token,
         );
@@ -300,11 +304,16 @@ void main() {
           );
           stateMachine.addBuilder(
             createHostedUiFactory(
-              signIn: ({
-                required CognitoSignInWithWebUIOptions options,
+              signIn: (
+                HostedUiPlatform platform,
+                CognitoSignInWithWebUIOptions options,
                 AuthProvider? provider,
-              }) async {},
-              signOut: () async => throw _HostedUiException(),
+              ) async {},
+              signOut: (
+                HostedUiPlatform platform,
+                CognitoSignInWithWebUIOptions options,
+              ) async =>
+                  throw _HostedUiException(),
             ),
             HostedUiPlatform.token,
           );

--- a/packages/auth/amplify_auth_cognito_dart/test/plugin/sign_out_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/plugin/sign_out_test.dart
@@ -91,7 +91,7 @@ void main() {
             ) async {},
             signOut: (
               HostedUiPlatform platform,
-              CognitoSignInWithWebUIOptions options,
+              CognitoSignOutWithWebUIOptions options,
             ) async {},
           ),
           HostedUiPlatform.token,
@@ -311,7 +311,7 @@ void main() {
               ) async {},
               signOut: (
                 HostedUiPlatform platform,
-                CognitoSignInWithWebUIOptions options,
+                CognitoSignOutWithWebUIOptions options,
               ) async =>
                   throw _HostedUiException(),
             ),

--- a/packages/auth/amplify_auth_cognito_dart/test/state/hosted_ui_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/state/hosted_ui_state_machine_test.dart
@@ -45,7 +45,7 @@ class MockHostedUiPlatform extends HostedUiPlatform {
 
   @override
   Future<void> signOut({
-    required CognitoSignInWithWebUIOptions options,
+    required CognitoSignOutWithWebUIOptions options,
   }) async {}
 
   @override
@@ -68,7 +68,7 @@ class FailingHostedUiPlatform extends HostedUiPlatform {
 
   @override
   Future<void> signOut({
-    required CognitoSignInWithWebUIOptions options,
+    required CognitoSignOutWithWebUIOptions options,
   }) {
     throw Exception();
   }

--- a/packages/auth/amplify_auth_cognito_ios/ios/Classes/NativeAuthPlugin.h
+++ b/packages/auth/amplify_auth_cognito_ios/ios/Classes/NativeAuthPlugin.h
@@ -78,7 +78,7 @@ NSObject<FlutterMessageCodec> *NativeAuthBridgeGetCodec(void);
 @protocol NativeAuthBridge
 - (void)addPluginWithCompletion:(void(^)(FlutterError *_Nullable))completion;
 - (void)signInWithUrlUrl:(NSString *)url callbackUrlScheme:(NSString *)callbackUrlScheme preferPrivateSession:(NSNumber *)preferPrivateSession browserPackageName:(nullable NSString *)browserPackageName completion:(void(^)(NSDictionary<NSString *, NSString *> *_Nullable, FlutterError *_Nullable))completion;
-- (void)signOutWithUrlUrl:(NSString *)url callbackUrlScheme:(NSString *)callbackUrlScheme browserPackageName:(nullable NSString *)browserPackageName completion:(void(^)(FlutterError *_Nullable))completion;
+- (void)signOutWithUrlUrl:(NSString *)url callbackUrlScheme:(NSString *)callbackUrlScheme preferPrivateSession:(NSNumber *)preferPrivateSession browserPackageName:(nullable NSString *)browserPackageName completion:(void(^)(FlutterError *_Nullable))completion;
 @end
 
 extern void NativeAuthBridgeSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<NativeAuthBridge> *_Nullable api);

--- a/packages/auth/amplify_auth_cognito_ios/ios/Classes/NativeAuthPlugin.m
+++ b/packages/auth/amplify_auth_cognito_ios/ios/Classes/NativeAuthPlugin.m
@@ -333,13 +333,14 @@ void NativeAuthBridgeSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<
         binaryMessenger:binaryMessenger
         codec:NativeAuthBridgeGetCodec()        ];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(signOutWithUrlUrl:callbackUrlScheme:browserPackageName:completion:)], @"NativeAuthBridge api (%@) doesn't respond to @selector(signOutWithUrlUrl:callbackUrlScheme:browserPackageName:completion:)", api);
+      NSCAssert([api respondsToSelector:@selector(signOutWithUrlUrl:callbackUrlScheme:preferPrivateSession:browserPackageName:completion:)], @"NativeAuthBridge api (%@) doesn't respond to @selector(signOutWithUrlUrl:callbackUrlScheme:preferPrivateSession:browserPackageName:completion:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSString *arg_url = GetNullableObjectAtIndex(args, 0);
         NSString *arg_callbackUrlScheme = GetNullableObjectAtIndex(args, 1);
-        NSString *arg_browserPackageName = GetNullableObjectAtIndex(args, 2);
-        [api signOutWithUrlUrl:arg_url callbackUrlScheme:arg_callbackUrlScheme browserPackageName:arg_browserPackageName completion:^(FlutterError *_Nullable error) {
+        NSNumber *arg_preferPrivateSession = GetNullableObjectAtIndex(args, 2);
+        NSString *arg_browserPackageName = GetNullableObjectAtIndex(args, 3);
+        [api signOutWithUrlUrl:arg_url callbackUrlScheme:arg_callbackUrlScheme preferPrivateSession:arg_preferPrivateSession browserPackageName:arg_browserPackageName completion:^(FlutterError *_Nullable error) {
           callback(wrapResult(nil, error));
         }];
       }];

--- a/packages/auth/amplify_auth_cognito_ios/ios/Classes/SwiftAuthCognito.swift
+++ b/packages/auth/amplify_auth_cognito_ios/ios/Classes/SwiftAuthCognito.swift
@@ -60,13 +60,14 @@ public class SwiftAuthCognito: NSObject, FlutterPlugin, AuthCategoryPlugin, Nati
     public func signOut(
         withUrlUrl url: String,
         callbackUrlScheme: String,
+        preferPrivateSession: NSNumber,
         browserPackageName: String?
     ) async -> FlutterError? {
         do {
             _ = try await hostedUIFlow.launchUrl(
                 url,
                 callbackURLScheme: callbackUrlScheme,
-                preferPrivateSession: false
+                preferPrivateSession: preferPrivateSession.boolValue
             )
             return nil
         } catch {


### PR DESCRIPTION
Preserves the hosted UI options selected at sign in for use in sign out by saving the options in secure storage.

---

**Stack**:
- #1722
- #1721
- #1720
- #1719


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*