### PR TITLE
fix(auth): Credential refresh on sign in

### DIFF
--- a/packages/amplify_core/lib/src/state_machine/state_machine.dart
+++ b/packages/amplify_core/lib/src/state_machine/state_machine.dart
@@ -22,7 +22,7 @@ import 'package:meta/meta.dart';
 @optionalTypeArgs
 abstract class Dispatcher<E extends StateMachineEvent> {
   /// Dispatches an event.
-  void dispatch(E event);
+  FutureOr<void> dispatch(E event);
 }
 
 /// Interface for emitting a state from a state machine.

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/auth_plugin_credentials_provider.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/auth_plugin_credentials_provider.dart
@@ -76,7 +76,7 @@ class AuthPluginCredentialsProviderImpl extends AuthPluginCredentialsProvider {
     // or refresh existing ones if needed, but do not initiate an
     // unauthenticated session since that should be handled via an explicit call
     // to `fetchAuthSession`.
-    _dispatcher.dispatch(
+    await _dispatcher.dispatch(
       const FetchAuthSessionEvent.fetch(
         CognitoSessionOptions(getAWSCredentials: false),
       ),

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
@@ -54,6 +54,9 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
 
   /// Gets the latest fetchAuthSession result.
   Future<FetchAuthSessionSuccess?> getLatestResult() async {
+    // Wait for any pending events to be processed and their initial states to
+    // fire.
+    await Future<void>.delayed(Duration.zero);
     final fetchState = await stream.startWith(currentState).firstWhere((state) {
       return state is FetchAuthSessionSuccess ||
           state is FetchAuthSessionFailure;


### PR DESCRIPTION
Fixes issue where multiple successive calls to fetchAuthSession were not being sequenced properly due to the state machine needing two event loops to process an event. This is by design but was not accurately captured in the sign in and fetch auth session state machines.

---

**Stack**:
- #1723
- #1722
- #1721
- #1720
- #1719


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*