### PR TITLE
feat(auth): Validation data

### DIFF
--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -69,6 +69,22 @@ class AmplifyAuthCognito extends AmplifyAuthCognitoDart {
       );
     }
   }
+
+  @override
+  Future<SignUpResult> signUp({required SignUpRequest request}) async {
+    Map<String, String>? validationData;
+    if (!zIsWeb && (Platform.isAndroid || Platform.isIOS)) {
+      final nativeValidationData =
+          await stateMachine.expect<NativeAuthBridge>().getValidationData();
+      validationData = nativeValidationData.cast();
+    }
+    request = SignUpRequest(
+      username: request.username,
+      password: request.password,
+      options: CognitoSignUpOptions(validationData: validationData),
+    );
+    return super.signUp(request: request);
+  }
 }
 
 class _NativeAmplifyAuthCognito implements NativeAuthPlugin {

--- a/packages/auth/amplify_auth_cognito/lib/src/native_auth_plugin.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/native_auth_plugin.dart
@@ -294,4 +294,34 @@ class NativeAuthBridge {
       return;
     }
   }
+
+  Future<Map<String?, String?>> getValidationData() async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.NativeAuthBridge.getValidationData', codec,
+        binaryMessenger: _binaryMessenger);
+    final Map<Object?, Object?>? replyMap =
+        await channel.send(null) as Map<Object?, Object?>?;
+    if (replyMap == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyMap['error'] != null) {
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
+      throw PlatformException(
+        code: (error['code'] as String?)!,
+        message: error['message'] as String?,
+        details: error['details'],
+      );
+    } else if (replyMap['result'] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyMap['result'] as Map<Object?, Object?>?)!
+          .cast<String?, String?>();
+    }
+  }
 }

--- a/packages/auth/amplify_auth_cognito/pigeons/native_auth_plugin.dart
+++ b/packages/auth/amplify_auth_cognito/pigeons/native_auth_plugin.dart
@@ -49,7 +49,6 @@ abstract class NativeAuthBridge {
   ///
   /// On iOS/Android, this calls `Amplify.addPlugin` with the [NativeAuthPlugin]
   /// implementation.
-  @async
   void addPlugin();
 
   /// Sign in by presenting [url] and waiting for a response to a URL with
@@ -73,6 +72,9 @@ abstract class NativeAuthBridge {
     bool preferPrivateSession, // iOS-only
     String? browserPackageName, // Android-only
   );
+
+  /// Retrieves the validation data for the current iOS/Android device.
+  Map<String, String> getValidationData();
 }
 
 class NativeAuthSession {

--- a/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
+++ b/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
@@ -123,13 +123,13 @@ open class AuthCognito :
         mainActivity = null
     }
 
-    override fun addPlugin(result: NativeAuthPluginBindings.Result<Void>) {
-        try {
-            Amplify.addPlugin(NativeAuthPlugin { nativePlugin })
-            result.success(null)
-        } catch (e: Exception) {
-            result.error(e)
-        }
+    override fun addPlugin() {
+        Amplify.addPlugin(NativeAuthPlugin { nativePlugin })
+    }
+
+    override fun getValidationData(): MutableMap<String, String> {
+        // Currently, the Android libraries do not provide any data by default.
+        return mutableMapOf()
     }
 
     /**

--- a/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/NativeAuthPluginBindings.java
+++ b/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/NativeAuthPluginBindings.java
@@ -368,9 +368,10 @@ public class NativeAuthPluginBindings {
 
   /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
   public interface NativeAuthBridge {
-    void addPlugin(Result<Void> result);
+    void addPlugin();
     void signInWithUrl(@NonNull String url, @NonNull String callbackUrlScheme, @NonNull Boolean preferPrivateSession, @Nullable String browserPackageName, Result<Map<String, String>> result);
     void signOutWithUrl(@NonNull String url, @NonNull String callbackUrlScheme, @NonNull Boolean preferPrivateSession, @Nullable String browserPackageName, Result<Void> result);
+    @NonNull Map<String, String> getValidationData();
 
     /** The codec used by NativeAuthBridge. */
     static MessageCodec<Object> getCodec() {
@@ -386,23 +387,13 @@ public class NativeAuthPluginBindings {
           channel.setMessageHandler((message, reply) -> {
             Map<String, Object> wrapped = new HashMap<>();
             try {
-              Result<Void> resultCallback = new Result<Void>() {
-                public void success(Void result) {
-                  wrapped.put("result", null);
-                  reply.reply(wrapped);
-                }
-                public void error(Throwable error) {
-                  wrapped.put("error", wrapError(error));
-                  reply.reply(wrapped);
-                }
-              };
-
-              api.addPlugin(resultCallback);
+              api.addPlugin();
+              wrapped.put("result", null);
             }
             catch (Error | RuntimeException exception) {
               wrapped.put("error", wrapError(exception));
-              reply.reply(wrapped);
             }
+            reply.reply(wrapped);
           });
         } else {
           channel.setMessageHandler(null);
@@ -489,6 +480,25 @@ public class NativeAuthPluginBindings {
               wrapped.put("error", wrapError(exception));
               reply.reply(wrapped);
             }
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NativeAuthBridge.getValidationData", getCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            Map<String, Object> wrapped = new HashMap<>();
+            try {
+              Map<String, String> output = api.getValidationData();
+              wrapped.put("result", output);
+            }
+            catch (Error | RuntimeException exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
           });
         } else {
           channel.setMessageHandler(null);

--- a/packages/auth/amplify_auth_cognito_android/android/src/test/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AmplifyHostedUiPluginTest.kt
+++ b/packages/auth/amplify_auth_cognito_android/android/src/test/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AmplifyHostedUiPluginTest.kt
@@ -46,7 +46,7 @@ internal class AmplifyHostedUiPluginTest {
         val handler = argumentCaptor<BinaryMessenger.BinaryMessageHandler>()
         verify(
             binaryMessenger,
-            times(3)
+            times(4)
         ).setMessageHandler(anyString(), handler.capture())
 
         val codec = NativeAuthPluginBindings.NativeAuthBridge.getCodec()
@@ -84,7 +84,7 @@ internal class AmplifyHostedUiPluginTest {
         val handler = argumentCaptor<BinaryMessenger.BinaryMessageHandler>()
         verify(
             binaryMessenger,
-            times(3)
+            times(4)
         ).setMessageHandler(anyString(), handler.capture())
 
         val codec = NativeAuthPluginBindings.NativeAuthBridge.getCodec()

--- a/packages/auth/amplify_auth_cognito_ios/ios/Classes/NativeAuthPlugin.h
+++ b/packages/auth/amplify_auth_cognito_ios/ios/Classes/NativeAuthPlugin.h
@@ -76,9 +76,11 @@ NSObject<FlutterMessageCodec> *NativeAuthPluginGetCodec(void);
 NSObject<FlutterMessageCodec> *NativeAuthBridgeGetCodec(void);
 
 @protocol NativeAuthBridge
-- (void)addPluginWithCompletion:(void(^)(FlutterError *_Nullable))completion;
+- (void)addPluginWithError:(FlutterError *_Nullable *_Nonnull)error;
 - (void)signInWithUrlUrl:(NSString *)url callbackUrlScheme:(NSString *)callbackUrlScheme preferPrivateSession:(NSNumber *)preferPrivateSession browserPackageName:(nullable NSString *)browserPackageName completion:(void(^)(NSDictionary<NSString *, NSString *> *_Nullable, FlutterError *_Nullable))completion;
 - (void)signOutWithUrlUrl:(NSString *)url callbackUrlScheme:(NSString *)callbackUrlScheme preferPrivateSession:(NSNumber *)preferPrivateSession browserPackageName:(nullable NSString *)browserPackageName completion:(void(^)(FlutterError *_Nullable))completion;
+/// @return `nil` only when `error != nil`.
+- (nullable NSDictionary<NSString *, NSString *> *)getValidationDataWithError:(FlutterError *_Nullable *_Nonnull)error;
 @end
 
 extern void NativeAuthBridgeSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<NativeAuthBridge> *_Nullable api);

--- a/packages/auth/amplify_auth_cognito_ios/ios/Classes/NativeAuthPlugin.m
+++ b/packages/auth/amplify_auth_cognito_ios/ios/Classes/NativeAuthPlugin.m
@@ -292,11 +292,11 @@ void NativeAuthBridgeSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<
         binaryMessenger:binaryMessenger
         codec:NativeAuthBridgeGetCodec()        ];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(addPluginWithCompletion:)], @"NativeAuthBridge api (%@) doesn't respond to @selector(addPluginWithCompletion:)", api);
+      NSCAssert([api respondsToSelector:@selector(addPluginWithError:)], @"NativeAuthBridge api (%@) doesn't respond to @selector(addPluginWithError:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
-        [api addPluginWithCompletion:^(FlutterError *_Nullable error) {
-          callback(wrapResult(nil, error));
-        }];
+        FlutterError *error;
+        [api addPluginWithError:&error];
+        callback(wrapResult(nil, error));
       }];
     }
     else {
@@ -343,6 +343,24 @@ void NativeAuthBridgeSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<
         [api signOutWithUrlUrl:arg_url callbackUrlScheme:arg_callbackUrlScheme preferPrivateSession:arg_preferPrivateSession browserPackageName:arg_browserPackageName completion:^(FlutterError *_Nullable error) {
           callback(wrapResult(nil, error));
         }];
+      }];
+    }
+    else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:@"dev.flutter.pigeon.NativeAuthBridge.getValidationData"
+        binaryMessenger:binaryMessenger
+        codec:NativeAuthBridgeGetCodec()        ];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(getValidationDataWithError:)], @"NativeAuthBridge api (%@) doesn't respond to @selector(getValidationDataWithError:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        FlutterError *error;
+        NSDictionary<NSString *, NSString *> *output = [api getValidationDataWithError:&error];
+        callback(wrapResult(output, error));
       }];
     }
     else {


### PR DESCRIPTION
Adds iOS validation data to sign up as the current iOS SDK does: <a href="https://github.com/aws-amplify/amplify-ios/blob/979e39fc1437f7aeeebab1cb91a99e0fd007aa82/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignUp/InitiateSignUp.swift#L122">https://github.com/aws-amplify/amplify-ios/blob/979e39fc1437f7aeeebab1cb91a99e0fd007aa82/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignUp/InitiateSignUp.swift#L122</a>

Currently, Android does not add any automatically

---

**Stack**:
- #1726
- #1725
- #1724
- #1723
- #1722
- #1721
- #1720
- #1719


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*