### PR TITLE
fix(auth): Fix device serialization

### DIFF
--- a/packages/auth/amplify_auth_cognito_ios/example/ios/unit_tests/amplify_auth_cognito_ios_tests.swift
+++ b/packages/auth/amplify_auth_cognito_ios/example/ios/unit_tests/amplify_auth_cognito_ios_tests.swift
@@ -2055,4 +2055,16 @@ class amplify_auth_cognito_tests: XCTestCase {
         })
     }
     
+    func test_decode_and_encode_of_device() throws {
+        let deviceJson = [
+            "id": "123"
+        ]
+        let data = try JSONSerialization.data(withJSONObject: deviceJson)
+        let device = try DeviceHandler.decoder.decode(AWSAuthDevice.self, from: data)
+        XCTAssertEqual(device.id, "123")
+        let encodedDeviceData = try DeviceHandler.encoder.encode(device)
+        let encodedDevice = try JSONSerialization.jsonObject(with: encodedDeviceData) as? [String: String?]
+        XCTAssertEqual(encodedDevice?["id"], "123")
+    }
+    
 }

--- a/packages/auth/amplify_auth_cognito_ios/ios/Classes/Device/AWSAuthDevice+Codable.swift
+++ b/packages/auth/amplify_auth_cognito_ios/ios/Classes/Device/AWSAuthDevice+Codable.swift
@@ -21,7 +21,7 @@ import AmplifyPlugins
 extension AWSAuthDevice: Codable {
     /// Attribute key for retrieving a device's name.
     static let deviceNameKey = "device_name"
-    
+
     enum CodingKeys: String, CodingKey {
         case id
         case name
@@ -30,24 +30,24 @@ extension AWSAuthDevice: Codable {
         case lastAuthenticatedDate
         case lastModifiedDate
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let id = try container.decode(String.self, forKey: .id)
-        let name = try container.decode(String.self, forKey: .name)
-        let attributes = try container.decode([String: String]?.self, forKey: .attributes)
-        let createdDate = try container.decode(Date?.self, forKey: .createdDate)
-        let lastAuthenticatedDate = try container.decode(Date?.self, forKey: .lastAuthenticatedDate)
-        let lastModifiedDate = try container.decode(Date?.self, forKey: .lastModifiedDate)
+        let name = try container.decodeIfPresent(String?.self, forKey: .name) ?? nil
+        let attributes = try container.decodeIfPresent([String: String]?.self, forKey: .attributes) ?? nil
+        let createdDate = try container.decodeIfPresent(Date?.self, forKey: .createdDate) ?? nil
+        let lastAuthenticatedDate = try container.decodeIfPresent(Date?.self, forKey: .lastAuthenticatedDate) ?? nil
+        let lastModifiedDate = try container.decodeIfPresent(Date?.self, forKey: .lastModifiedDate) ?? nil
         self.init(
             id: id,
-            name: name,
+            name: name ?? "",
             attributes: attributes,
             createdDate: createdDate,
             lastAuthenticatedDate: lastAuthenticatedDate,
             lastModifiedDate: lastModifiedDate)
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)

--- a/packages/auth/amplify_auth_cognito_ios/ios/Classes/Device/DeviceHandler.swift
+++ b/packages/auth/amplify_auth_cognito_ios/ios/Classes/Device/DeviceHandler.swift
@@ -28,10 +28,10 @@ struct DeviceHandler {
         attributes: [.concurrent])
     
     /// Encoder used for proper [Date] handling.
-    private static let encoder = JSONEncoder(dateEncodingStrategy: .millisecondsSince1970)
+    internal static let encoder = JSONEncoder(dateEncodingStrategy: .millisecondsSince1970)
     
     /// Decoder used for proper [Date] handling.
-    private static let decoder = JSONDecoder(dateDecodingStrategy: .millisecondsSince1970)
+    internal static let decoder = JSONDecoder(dateDecodingStrategy: .millisecondsSince1970)
     
     /// Methods handled by [DeviceHandler].
     private static let methods: Set<String> = ["rememberDevice", "forgetDevice", "fetchDevices"]


### PR DESCRIPTION
Fixes #1696.

Fixes device serialization on iOS when just an ID is passed. I confirmed this issue does not exist on Android.