### PR TITLE
fix(auth): Add initial route parameters for mobile platforms

### DIFF
--- a/packages/auth/amplify_auth_cognito/lib/src/native_auth_plugin.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/native_auth_plugin.dart
@@ -164,8 +164,29 @@ class _NativeAuthPluginCodec extends StandardMessageCodec {
 abstract class NativeAuthPlugin {
   static const MessageCodec<Object?> codec = _NativeAuthPluginCodec();
 
+  void exchange(Map<String?, String?> params);
   Future<NativeAuthSession> fetchAuthSession(bool getAwsCredentials);
   static void setup(NativeAuthPlugin? api, {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.NativeAuthPlugin.exchange', codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.NativeAuthPlugin.exchange was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final Map<String?, String?>? arg_params =
+              (args[0] as Map<Object?, Object?>?)?.cast<String?, String?>();
+          assert(arg_params != null,
+              'Argument for dev.flutter.pigeon.NativeAuthPlugin.exchange was null, expected non-null Map<String?, String?>.');
+          api.exchange(arg_params!);
+          return;
+        });
+      }
+    }
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
           'dev.flutter.pigeon.NativeAuthPlugin.fetchAuthSession', codec,

--- a/packages/auth/amplify_auth_cognito/pigeons/native_auth_plugin.dart
+++ b/packages/auth/amplify_auth_cognito/pigeons/native_auth_plugin.dart
@@ -39,6 +39,11 @@ import 'package:pigeon/pigeon.dart';
 
 @FlutterApi()
 abstract class NativeAuthPlugin {
+  /// Exchanges the route parameters used to launch the app, i.e. if the app
+  /// was closed and a redirect happened to the custom URI scheme (iOS) or an
+  /// intent was launched with the redirect parameters (Android).
+  void exchange(Map<String, String> params);
+
   @async
   NativeAuthSession fetchAuthSession(bool getAwsCredentials);
 }

--- a/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
+++ b/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
@@ -78,6 +78,13 @@ open class AuthCognito :
      */
     private var nativePlugin: NativeAuthPluginBindings.NativeAuthPlugin? = null
 
+    /**
+     * The initial route parameters used to launch the main activity, which can happen when using
+     * non-Chrome browsers or when a Hosted UI redirect occurs while the app is closed. They are
+     * sent to the platform during configuration.
+     */
+    private var initialParameters: Map<String, String>? = null
+
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         nativePlugin = NativeAuthPluginBindings.NativeAuthPlugin(binding.binaryMessenger)
         NativeAuthPluginBindings.NativeAuthBridge.setup(
@@ -98,6 +105,9 @@ open class AuthCognito :
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         mainActivity = binding.activity
         activityBinding = binding
+        // Treat the launching intent the same as an intent created while the application was
+        // running to capture a sign in callback which launched the app.
+        onNewIntent(binding.activity.intent)
         binding.addOnNewIntentListener(this)
         binding.addActivityResultListener(this)
     }
@@ -135,11 +145,7 @@ open class AuthCognito :
     /**
      * Handles the result of a sign in redirect.
      */
-    private fun handleSignInResult(uri: Uri): Boolean {
-        val queryParameters = mutableMapOf<String, String>()
-        for (name in uri.queryParameterNames) {
-            queryParameters[name] = uri.getQueryParameter(name) ?: ""
-        }
+    private fun handleSignInResult(queryParameters: MutableMap<String, String>): Boolean {
         signInResult?.success(queryParameters)
         signInResult = null
         return true
@@ -272,16 +278,19 @@ open class AuthCognito :
                 Log.e(TAG, "No data associated with intent")
                 return false
             }
+            val queryParameters = uri.queryParameters
             return if (signInResult != null && signOutResult != null) {
                 Log.e(TAG, "Inconsistent state. Pending sign in and sign out.")
                 false
             } else if (signInResult != null) {
-                handleSignInResult(uri)
+                handleSignInResult(queryParameters)
             } else if (signOutResult != null) {
                 handleSignOutResult()
             } else {
-                Log.e(TAG, "Could not handle intent as there is no active session.")
-                false
+                if (queryParameters.isNotEmpty()) {
+                    initialParameters = queryParameters
+                }
+                true
             }
         }
         return false
@@ -321,3 +330,15 @@ open class AuthCognito :
     }
 
 }
+
+/**
+ * The query parameters of the URI.
+ */
+val Uri.queryParameters: MutableMap<String, String>
+    get() {
+        val queryParameters = mutableMapOf<String, String>()
+        for (name in queryParameterNames) {
+            queryParameters[name] = getQueryParameter(name) ?: ""
+        }
+        return queryParameters
+    }

--- a/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/NativeAuthPluginBindings.java
+++ b/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/NativeAuthPluginBindings.java
@@ -351,6 +351,13 @@ public class NativeAuthPluginBindings {
       return NativeAuthPluginCodec.INSTANCE;
     }
 
+    public void exchange(@NonNull Map<String, String> paramsArg, Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NativeAuthPlugin.exchange", getCodec());
+      channel.send(new ArrayList<Object>(Arrays.asList(paramsArg)), channelReply -> {
+        callback.reply(null);
+      });
+    }
     public void fetchAuthSession(@NonNull Boolean getAwsCredentialsArg, Reply<NativeAuthSession> callback) {
       BasicMessageChannel<Object> channel =
           new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NativeAuthPlugin.fetchAuthSession", getCodec());

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
@@ -204,6 +204,17 @@ abstract class HostedUiPlatform {
     required String state,
     required String codeVerifier,
   }) async {
+    final parameters = dependencyManager.get<OAuthParameters>();
+    if (parameters != null) {
+      authCodeGrant = restoreGrant(
+        config,
+        state: state,
+        codeVerifier: codeVerifier,
+        httpClient: httpClient,
+      );
+      return dispatcher.dispatch(HostedUiEvent.exchange(parameters));
+    }
+
     _authCodeGrant = null;
     _secureStorage
       ..delete(key: _keys[HostedUiKey.state])

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_html.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_html.dart
@@ -15,7 +15,6 @@
 import 'dart:html';
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
-import 'package:amplify_auth_cognito_dart/src/crypto/oauth.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:path/path.dart' show url;
 
@@ -53,30 +52,6 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
   /// Launches the given URL.
   Future<void> launchUrl(String url) async {
     window.open(url, '_self');
-  }
-
-  @override
-  Future<void> onFoundState({
-    required String state,
-    required String codeVerifier,
-  }) async {
-    authCodeGrant = restoreGrant(
-      config,
-      state: state,
-      codeVerifier: codeVerifier,
-      httpClient: httpClient,
-    );
-
-    final parameters = dependencyManager.get<OAuthParameters>();
-    if (parameters != null) {
-      dispatcher.dispatch(HostedUiEvent.exchange(parameters));
-      return;
-    }
-
-    return super.onFoundState(
-      state: state,
-      codeVerifier: codeVerifier,
-    );
   }
 
   @override

--- a/packages/auth/amplify_auth_cognito_ios/ios/Classes/NativeAuthPlugin.h
+++ b/packages/auth/amplify_auth_cognito_ios/ios/Classes/NativeAuthPlugin.h
@@ -70,6 +70,7 @@ NSObject<FlutterMessageCodec> *NativeAuthPluginGetCodec(void);
 
 @interface NativeAuthPlugin : NSObject
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger;
+- (void)exchangeParams:(NSDictionary<NSString *, NSString *> *)params completion:(void(^)(NSError *_Nullable))completion;
 - (void)fetchAuthSessionGetAwsCredentials:(NSNumber *)getAwsCredentials completion:(void(^)(NativeAuthSession *_Nullable, NSError *_Nullable))completion;
 @end
 /// The codec used by NativeAuthBridge.

--- a/packages/auth/amplify_auth_cognito_ios/ios/Classes/NativeAuthPlugin.m
+++ b/packages/auth/amplify_auth_cognito_ios/ios/Classes/NativeAuthPlugin.m
@@ -240,6 +240,16 @@ NSObject<FlutterMessageCodec> *NativeAuthPluginGetCodec() {
   }
   return self;
 }
+- (void)exchangeParams:(NSDictionary<NSString *, NSString *> *)arg_params completion:(void(^)(NSError *_Nullable))completion {
+  FlutterBasicMessageChannel *channel =
+    [FlutterBasicMessageChannel
+      messageChannelWithName:@"dev.flutter.pigeon.NativeAuthPlugin.exchange"
+      binaryMessenger:self.binaryMessenger
+      codec:NativeAuthPluginGetCodec()];
+  [channel sendMessage:@[arg_params ?: [NSNull null]] reply:^(id reply) {
+    completion(nil);
+  }];
+}
 - (void)fetchAuthSessionGetAwsCredentials:(NSNumber *)arg_getAwsCredentials completion:(void(^)(NativeAuthSession *_Nullable, NSError *_Nullable))completion {
   FlutterBasicMessageChannel *channel =
     [FlutterBasicMessageChannel


### PR DESCRIPTION
Some Android custom tabs will relaunch the app on completion, requiring a different mechanism for capturing the intent data. The same was already true for Web, so that mechanism is re-leveraged in mobile (Android).