### PR TITLE
fix(auth): Use same redirect for all interactions

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/crypto/oauth.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/crypto/oauth.dart
@@ -20,12 +20,8 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:amplify_auth_cognito_dart/src/crypto/crypto.dart';
-import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/hosted_ui_config.dart';
 import 'package:amplify_auth_cognito_dart/src/jwt/jwt.dart';
-import 'package:amplify_core/amplify_core.dart';
-import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
-import 'package:oauth2/oauth2.dart' as oauth2;
 
 /// Generates a random state parameter for the auth code flow.
 String generateState() {
@@ -50,50 +46,6 @@ String createCodeVerifier() {
     );
   }
   return String.fromCharCodes(codeVerifier);
-}
-
-/// Creates an authorization code grant.
-oauth2.AuthorizationCodeGrant createGrant(
-  CognitoOAuthConfig config, {
-  AuthProvider? provider,
-  String? codeVerifier,
-  http.Client? httpClient,
-}) {
-  return oauth2.AuthorizationCodeGrant(
-    config.appClientId,
-    HostedUiConfig(config).signInUri(provider),
-    HostedUiConfig(config).tokenUri,
-    secret: config.appClientSecret,
-    httpClient: httpClient,
-    codeVerifier: codeVerifier,
-
-    // The spec recommends against this, but it's what Cognito expects. Basic
-    // authorization will fail with `invalid_grant`.
-    basicAuth: false,
-  );
-}
-
-/// Creates an authorization code grant and advances the internal state to
-/// `pendingResponse` so that parameter exchange will work.
-oauth2.AuthorizationCodeGrant restoreGrant(
-  CognitoOAuthConfig config, {
-  required String state,
-  required String codeVerifier,
-  http.Client? httpClient,
-}) {
-  final grant = createGrant(
-    config,
-    codeVerifier: codeVerifier,
-    httpClient: httpClient,
-  );
-
-  return grant
-    // Advances the internal state.
-    ..getAuthorizationUrl(
-      HostedUiConfig(config).signInRedirectUri,
-      scopes: config.scopes,
-      state: state,
-    );
 }
 
 /// Creates a `Basic` authorization header for identifiying clients.

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
@@ -161,6 +161,56 @@ abstract class HostedUiPlatform {
     );
   }
 
+  /// Creates an authorization code grant.
+  @protected
+  @visibleForTesting
+  @nonVirtual
+  oauth2.AuthorizationCodeGrant createGrant(
+    CognitoOAuthConfig config, {
+    AuthProvider? provider,
+    String? codeVerifier,
+    http.Client? httpClient,
+  }) {
+    return oauth2.AuthorizationCodeGrant(
+      config.appClientId,
+      HostedUiConfig(config).signInUri(provider),
+      HostedUiConfig(config).tokenUri,
+      secret: config.appClientSecret,
+      httpClient: httpClient,
+      codeVerifier: codeVerifier,
+
+      // The spec recommends against this, but it's what Cognito expects. Basic
+      // authorization will fail with `invalid_grant`.
+      basicAuth: false,
+    );
+  }
+
+  /// Creates an authorization code grant and advances the internal state to
+  /// `pendingResponse` so that parameter exchange will work.
+  @protected
+  @visibleForTesting
+  @nonVirtual
+  oauth2.AuthorizationCodeGrant restoreGrant(
+    CognitoOAuthConfig config, {
+    required String state,
+    required String codeVerifier,
+    http.Client? httpClient,
+  }) {
+    final grant = createGrant(
+      config,
+      codeVerifier: codeVerifier,
+      httpClient: httpClient,
+    );
+
+    return grant
+      // Advances the internal state.
+      ..getAuthorizationUrl(
+        signInRedirectUri,
+        scopes: config.scopes,
+        state: state,
+      );
+  }
+
   /// Performs the second part of the authorization code flow, exhanging the
   /// parameters retrieved via the WebView with the OAuth server for an access
   /// and refresh token.


### PR DESCRIPTION
The redirect used in the exchange call for an asynchronous Hosted UI login was not matching the one used to get the authorization code which was causing the login to fail with an obtuse `unauthorized_client` error. The methods used to create/restore the grant have been moved inside HostedUiPlatform so that the internal `signInRedirectUri` getter can be used.

If runtime override of the redirect URI is ever supported, some slight changes will be required to this setup. But right now, it's not something we need to worry about.

commit-id:e0e46724

---

**Stack**:
- #1751 ⬅
- #1750
- #1749


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*