### PR TITLE
chore: enable integration tests in gh actions

### DIFF
--- a/.github/composite_actions/fetch_backends/action.yaml
+++ b/.github/composite_actions/fetch_backends/action.yaml
@@ -1,0 +1,47 @@
+name: "Fetch backends"
+description: "Downloads Amplify configurations after getting temporary AWS credentials"
+inputs:
+  aws-region:
+    required: true
+  role-to-assume:
+    required: true
+  # scope for melos, e.g. "amplify_api_example"
+  scope:
+    required: true
+  # Amplify app IDs for specific categories
+  api-app-id:
+    required: true
+  auth-app-id:
+    required: true
+  datastore-app-id:
+    required: true
+  storage-app-id:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # 1.6.1
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+        role-duration-seconds: 900
+
+    - name: Create AWS profile
+      run: ./build-support/create_integration_test_profile.sh
+      shell: bash
+
+    - name: Pull Amplify Configurations
+      run: |
+        API_APP_ID=${{ inputs.api-app-id }} \
+        AUTH_APP_ID=${{ inputs.auth-app-id }} \
+        DATASTORE_APP_ID=${{ inputs.datastore-app-id }} \
+        STORAGE_APP_ID=${{ inputs.storage-app-id }} \
+          melos exec --scope=${{ inputs.scope }} ./tool/pull_test_backend.sh
+      shell: bash
+
+    - name: Delete AWS profile
+      run: rm -rf ~/.aws
+      shell: bash
+

--- a/.github/composite_actions/install_dependencies/action.yaml
+++ b/.github/composite_actions/install_dependencies/action.yaml
@@ -13,7 +13,7 @@ runs:
     - uses: subosito/flutter-action@d8687e6979e8ef66d2b2970e2c92c1d8e801d7bf # 2.4.0
       with:
         channel: 'stable'
-        architecture: x64 # needed for https://github.com/flutter/flutter/issues/74511
+        architecture: x64 # needed to prevent "Bad CPU type" error
 
     - name: Run Melos bootstrap
       run: |

--- a/.github/composite_actions/install_dependencies/action.yaml
+++ b/.github/composite_actions/install_dependencies/action.yaml
@@ -1,0 +1,22 @@
+name: "Install Non-Platform Dependencies"
+description: "Installs non-platform dependencies: Amplify CLI, Flutter and runs melos bootstrap"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Amplify CLI
+      # retry once
+      run: |
+        yarn global add @aws-amplify/cli --network-timeout 100000 || yarn global add @aws-amplify/cli --network-timeout 100000
+      shell: bash
+
+    - uses: subosito/flutter-action@d8687e6979e8ef66d2b2970e2c92c1d8e801d7bf # 2.4.0
+      with:
+        channel: 'stable'
+        architecture: x64 # needed for https://github.com/flutter/flutter/issues/74511
+
+    - name: Run Melos bootstrap
+      run: |
+        flutter pub global activate melos 2.4.0
+        melos bootstrap
+      shell: bash

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scope: ["amplify_api_example", "amplify_storage_s3_example", "amplify_auth_cognito_example"]
+        scope: ["amplify_api_example"] #, "amplify_storage_s3_example", "amplify_auth_cognito_example"]
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
         with:

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -53,9 +53,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@e790971012b979513b4e2fe70d4079bc0ca8a1ae # 2.24.0
         timeout-minutes: 25
         with:
-          api-level: 31
-          # retry once
-          script: melos exec --scope=${{ matrix.scope }} "flutter test --no-pub integration_test/main_test.dart -d emulator-5554" || melos exec --scope=${{ matrix.scope }} "flutter test --no-pub integration_test/main_test.dart -d emulator-5554"
+          api-level: 29
+          script: melos exec -c 1 --scope ${{ matrix.scope }} -- "deviceId=emulator-5554 retries=1 \$MELOS_ROOT_PATH/build-support/integ_test_android.sh"
 
   ios:
     runs-on: macos-latest
@@ -76,7 +75,7 @@ jobs:
 
       - name: Boot iOS Simulator
         run: |
-          xcrun simctl boot "iPhone 12"
+          xcrun simctl boot "iPhone 13"
 
       - name: Fetch Amplify backend configurations
         uses: ./.github/composite_actions/fetch_backends
@@ -94,15 +93,5 @@ jobs:
           melos exec --scope=${{ matrix.scope }} flutter build ios --simulator
 
       - name: Run integration tests
-        # retry once
-        id: iosTestFirstAttempt
-        continue-on-error: true
-        timeout-minutes: 10
         run: |
-          melos exec --scope=${{ matrix.scope }} "flutter test --no-pub integration_test/main_test.dart -d iPhone"
-
-      - name: run integration tests (2nd attempt)
-        if: steps.iosTestFirstAttempt.outcome == 'failure'
-        timeout-minutes: 30
-        run: |
-          melos exec --scope=${{ matrix.scope }} "flutter test --no-pub integration_test/main_test.dart -d iPhone"
+          melos exec -c 1 --scope ${{ matrix.scope }} -- "retries=1 \$MELOS_ROOT_PATH/build-support/integ_test_ios.sh"

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   android:
     runs-on: macos-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
       contents: read
@@ -53,11 +54,13 @@ jobs:
         uses: reactivecircus/android-emulator-runner@e790971012b979513b4e2fe70d4079bc0ca8a1ae # 2.24.0
         timeout-minutes: 25
         with:
+          # API levels 30+ too slow https://github.com/ReactiveCircus/android-emulator-runner/issues/222
           api-level: 29
           script: melos exec -c 1 --scope ${{ matrix.scope }} -- "deviceId=emulator-5554 retries=1 \$MELOS_ROOT_PATH/build-support/integ_test_android.sh"
 
   ios:
     runs-on: macos-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -50,10 +50,10 @@ jobs:
           melos exec --scope=${{ matrix.scope }} --file-exists="integration_test/main_test.dart" --fail-fast flutter build apk --verbose
 
       - name: Run Android integration tests
-        uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc # 2.23.0
+        uses: reactivecircus/android-emulator-runner@e790971012b979513b4e2fe70d4079bc0ca8a1ae # 2.24.0
         timeout-minutes: 25
         with:
-          api-level: 29
+          api-level: 31
           # retry once
           script: melos exec --scope=${{ matrix.scope }} "flutter test --no-pub integration_test/main_test.dart -d emulator-5554" || melos exec --scope=${{ matrix.scope }} "flutter test --no-pub integration_test/main_test.dart -d emulator-5554"
 

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -1,0 +1,108 @@
+name: Amplify Integration Tests
+on:
+  push:
+    branches: [main, next, stable, feat/*]
+  schedule:
+    # 6am pacific time daily, only runs on default branch
+    - cron:  '0 13 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android:
+    runs-on: macos-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        scope: ["amplify_api_example", "amplify_storage_s3_example", "amplify_auth_cognito_example"]
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+
+      # Flutter requires Java 11 to build android apps with Gradle.
+      - uses: actions/setup-java@860f60056505705214d223b91ed7a30f173f6142 # 3.3.0
+        with:
+          distribution: 'corretto' # Amazon Corretto Build of OpenJDK
+          java-version: '11'
+      
+      - name: Install dependencies
+        uses: ./.github/composite_actions/install_dependencies
+
+      - name: Fetch Amplify backend configurations
+        uses: ./.github/composite_actions/fetch_backends
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          scope: ${{ matrix.scope }}
+          api-app-id: ${{ secrets.API_APP_ID }}
+          auth-app-id: ${{ secrets.AUTH_APP_ID }}
+          datastore-app-id: ${{ secrets.DATASTORE_APP_ID }}
+          storage-app-id: ${{ secrets.STORAGE_APP_ID }}
+
+      - name: Build example app with integration tests
+        run: |
+          melos exec --scope=${{ matrix.scope }} --file-exists="integration_test/main_test.dart" --fail-fast flutter build apk --verbose
+
+      - name: Run Android integration tests
+        uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc # 2.23.0
+        timeout-minutes: 25
+        with:
+          api-level: 29
+          # retry once
+          script: melos exec --scope=${{ matrix.scope }} "flutter test --no-pub integration_test/main_test.dart -d emulator-5554" || melos exec --scope=${{ matrix.scope }} "flutter test --no-pub integration_test/main_test.dart -d emulator-5554"
+
+  ios:
+    runs-on: macos-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        scope: ["amplify_api_example"] #, "amplify_storage_s3_example", "amplify_auth_cognito_example"]
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
+        with:
+          persist-credentials: false
+      
+      - name: Install dependencies
+        uses: ./.github/composite_actions/install_dependencies
+
+      - name: Boot iOS Simulator
+        run: |
+          xcrun simctl boot "iPhone 12"
+
+      - name: Fetch Amplify backend configurations
+        uses: ./.github/composite_actions/fetch_backends
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          scope: ${{ matrix.scope }}
+          api-app-id: ${{ secrets.API_APP_ID }}
+          auth-app-id: ${{ secrets.AUTH_APP_ID }}
+          datastore-app-id: ${{ secrets.DATASTORE_APP_ID }}
+          storage-app-id: ${{ secrets.STORAGE_APP_ID }}
+
+      - name: Build example app with integration tests
+        run: |
+          melos exec --scope=${{ matrix.scope }} flutter build ios --simulator
+
+      - name: Run integration tests
+        # retry once
+        id: iosTestFirstAttempt
+        continue-on-error: true
+        timeout-minutes: 10
+        run: |
+          melos exec --scope=${{ matrix.scope }} "flutter test --no-pub integration_test/main_test.dart -d iPhone"
+
+      - name: run integration tests (2nd attempt)
+        if: steps.iosTestFirstAttempt.outcome == 'failure'
+        timeout-minutes: 30
+        run: |
+          melos exec --scope=${{ matrix.scope }} "flutter test --no-pub integration_test/main_test.dart -d iPhone"

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Podfile.lock
 **/test-results/
 .test_coverage.dart
 .last_build_id
+temp/
 .fvm/
 
 # IDEs

--- a/build-support/create_integration_test_profile.sh
+++ b/build-support/create_integration_test_profile.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+aws configure set aws_session_token $AWS_SESSION_TOKEN
+aws configure set default.region $AWS_DEFAULT_REGION

--- a/build-support/pull_backend_by_app_id.sh
+++ b/build-support/pull_backend_by_app_id.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+IFS='|'
+
+FLUTTERCONFIG="{\
+\"ResDir\":\"./lib/\",\
+\"SourceDir\":\"lib\",\
+}"
+
+AMPLIFY="{\
+\"appId\":\"$APP_ID\",\
+\"envName\":\"test\",\
+\"defaultEditor\":\"code\"\
+}"
+
+FRONTEND="{\
+\"frontend\":\"flutter\",\
+\"config\":$FLUTTERCONFIG\
+}"
+
+AWSCLOUDFORMATIONCONFIG="{\
+\"configLevel\":\"project\",\
+\"useProfile\":true,\
+\"profileName\":\"default\",\
+\"region\":\"us-west-2\"\
+}"
+PROVIDERS="{\
+\"awscloudformation\":$AWSCLOUDFORMATIONCONFIG\
+}"
+
+echo n | amplify pull \
+--amplify $AMPLIFY \
+--frontend $FRONTEND \
+--providers $PROVIDERS

--- a/packages/api/amplify_api/example/tool/pull_test_backend.sh
+++ b/packages/api/amplify_api/example/tool/pull_test_backend.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+APP_ID=$API_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 


### PR DESCRIPTION
This PR has the central config files/scripts to enable integration tests in github actions. It only actually runs them for API with the plan to enable the other categories once API passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
