### PR TITLE
chore(auth): Fix device tracking example

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/example/bin/example.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/bin/example.dart
@@ -91,21 +91,27 @@ Future<void> main() async {
     }
     stdout.writeln();
 
-    final devices = await fetchDevices();
     stdout
       ..writeln('Devices')
       ..writeln('-------');
-    if (devices.isEmpty) {
-      stdout.writeln('No devices');
-    } else {
-      for (final device in devices) {
-        stdout.writeln(
-          '${device.name ?? device.id}: '
-          '${device.asCognitoDevice.attributes}',
-        );
+    try {
+      final devices = await fetchDevices();
+      if (devices.isEmpty) {
+        stdout.writeln('No devices');
+      } else {
+        for (final device in devices) {
+          stdout.writeln(
+            '${device.name ?? device.id}: '
+            '${device.asCognitoDevice.attributes}',
+          );
+        }
       }
+      stdout.writeln();
+    } on InvalidUserPoolConfigurationException {
+      stdout.writeln('Device tracking is not enabled.');
+    } on Object {
+      rethrow;
     }
-    stdout.writeln();
   } on Object catch (e, st) {
     exitError(e, st);
   }


### PR DESCRIPTION
Fixes example which was throwing for user pools without device tracking enabled