### PR TITLE
fix(authenticator): move username selection state to authenticator state

### DIFF
--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -14,10 +14,12 @@
  */
 
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
-import 'package:amplify_authenticator/amplify_authenticator.dart';
+import 'package:amplify_authenticator/src/l10n/auth_strings_resolver.dart';
 import 'package:amplify_authenticator/src/models/username_input.dart';
+import 'package:amplify_authenticator/src/state/authenticator_state.dart';
 import 'package:amplify_authenticator/src/utils/validators.dart';
 import 'package:amplify_authenticator/src/widgets/component.dart';
+import 'package:amplify_authenticator/src/widgets/form.dart';
 import 'package:amplify_authenticator/src/widgets/form_field.dart';
 import 'package:flutter/material.dart';
 

--- a/packages/amplify_authenticator/lib/src/state/authenticator_state.dart
+++ b/packages/amplify_authenticator/lib/src/state/authenticator_state.dart
@@ -21,6 +21,12 @@ import 'package:amplify_authenticator/src/state/auth_state.dart';
 import 'package:amplify_authenticator/src/utils/country_code.dart';
 import 'package:flutter/material.dart';
 
+/// {@macro amplify_authenticator.authenticator_state.username_selection}
+enum UsernameSelection {
+  email,
+  phoneNumber,
+}
+
 @visibleForTesting
 typedef BlocEventPredicate = bool Function(AuthState state);
 
@@ -97,6 +103,21 @@ class AuthenticatorState extends ChangeNotifier {
   }
 
   String _username = '';
+
+  /// {@template amplify_authenticator.authenticator_state.username_selection}
+  /// The username type to use during sign up and sign in.
+  ///
+  /// For auth configurations that allow sign up via username or email,
+  /// this will determine which option is currently selected.
+  /// {@endtemplate}
+  UsernameSelection get usernameSelection => _usernameSelection;
+
+  set usernameSelection(UsernameSelection value) {
+    _usernameSelection = value;
+    notifyListeners();
+  }
+
+  UsernameSelection _usernameSelection = UsernameSelection.email;
 
   /// The value for the password form field
   ///

--- a/packages/amplify_authenticator/lib/src/widgets/form.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form.dart
@@ -142,26 +142,6 @@ class AuthenticatorFormState<T extends AuthenticatorForm>
 
   final ValueNotifier<bool> obscureTextToggleValue = ValueNotifier(true);
 
-  @override
-  void initState() {
-    super.initState();
-    useEmail.addListener(_updateUseEmail);
-  }
-
-  @override
-  void dispose() {
-    useEmail.removeListener(_updateUseEmail);
-    super.dispose();
-  }
-
-  void _updateUseEmail() {
-    // Clear attributes on switch
-    state.authAttributes.clear();
-
-    // Refresh state
-    setState(() {});
-  }
-
   /// Controls optional visibility of the field.
   Widget get obscureTextToggle {
     return ValueListenableBuilder<bool>(

--- a/packages/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -140,10 +140,6 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
   UsernameType get selectedUsernameType =>
       AuthenticatorFormState.of(context).selectedUsernameType;
 
-  @nonVirtual
-  ValueNotifier<bool> get useEmail =>
-      AuthenticatorFormState.of(context).useEmail;
-
   /// Callback for when `onChanged` is triggered on the [FormField].
   ValueChanged<FieldValue> get onChanged => (_) {};
 
@@ -255,8 +251,6 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
         .add(EnumProperty<UsernameConfigType>('usernameType', usernameType));
     properties.add(EnumProperty<UsernameType>(
         'selectedUsernameType', selectedUsernameType));
-    properties
-        .add(DiagnosticsProperty<ValueNotifier<bool>>('useEmail', useEmail));
     properties.add(IntProperty('maxLength', maxLength));
     properties.add(DiagnosticsProperty<bool>('isOptional', isOptional));
     properties.add(StringProperty('labelText', labelText));


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/1765

*Description of changes:*
- Move username selection state to AuthenticatorState class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
