### PR TITLE
feat: exposes secure-storage as plugin constructor parameter

### DIFF
--- a/packages/amplify/amplify_flutter/lib/amplify_flutter.dart
+++ b/packages/amplify/amplify_flutter/lib/amplify_flutter.dart
@@ -21,6 +21,9 @@ import 'src/amplify_impl.dart';
 
 export 'package:amplify_core/amplify_core.dart' hide Amplify;
 
+// ignore: depend_on_referenced_packages
+export 'package:amplify_secure_storage/amplify_secure_storage.dart';
+
 /// Top level singleton Amplify object.
 AmplifyClass get Amplify {
   return AmplifyClass.instance ??= AmplifyClassImpl();

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -25,6 +25,7 @@ dev_dependencies:
   amplify_auth_cognito: 0.5.0
   amplify_datastore: 0.5.0
   amplify_lints: ^2.0.0
+  amplify_secure_storage: 0.1.0
   amplify_storage_s3: 0.5.0
   amplify_test:
     path: ../../amplify_test

--- a/packages/amplify_authenticator/example/lib/main.dart
+++ b/packages/amplify_authenticator/example/lib/main.dart
@@ -34,6 +34,15 @@ class _MyAppState extends State<MyApp> {
   void _configureAmplify() async {
     try {
       await Amplify.addPlugin(AmplifyAuthCognito());
+      // Uncomment this block, and comment out the one above, in order to persist credentials
+      // await Amplify.addPlugin(AmplifyAuthCognito(credentialStorage: AmplifySecureStorage(
+      //       config: AmplifySecureStorageConfig(
+      //         scope: 'authtest',
+      //         webOptions: WebSecureStorageOptions(
+      //           persistenceOption: WebPersistenceOption.indexedDB,
+      //         ),
+      //       ),
+      //     )));
       await Amplify.configure(amplifyconfig);
       print('Successfully configured');
     } on Exception catch (e) {
@@ -95,20 +104,20 @@ class _MyAppState extends State<MyApp> {
       signUpForm: SignUpForm.custom(
         fields: [
           SignUpFormField.username(
-            validator: _validateUsername,
-          ),
+              // validator: _validateUsername,
+              ),
           SignUpFormField.email(required: true),
           SignUpFormField.password(),
           SignUpFormField.passwordConfirmation(),
-          SignUpFormField.address(),
-          SignUpFormField.custom(
-            title: 'Bio',
-            attributeKey: const CognitoUserAttributeKey.custom('bio'),
-          ),
-          SignUpFormField.custom(
-            title: 'Age',
-            attributeKey: const CognitoUserAttributeKey.custom('age'),
-          )
+          // SignUpFormField.address(),
+          // SignUpFormField.custom(
+          //   title: 'Bio',
+          //   attributeKey: const CognitoUserAttributeKey.custom('bio'),
+          // ),
+          // SignUpFormField.custom(
+          //   title: 'Age',
+          //   attributeKey: const CognitoUserAttributeKey.custom('age'),
+          // )
         ],
       ),
 

--- a/packages/amplify_authenticator/example/lib/main.dart
+++ b/packages/amplify_authenticator/example/lib/main.dart
@@ -104,20 +104,20 @@ class _MyAppState extends State<MyApp> {
       signUpForm: SignUpForm.custom(
         fields: [
           SignUpFormField.username(
-              // validator: _validateUsername,
+              validator: _validateUsername,
               ),
           SignUpFormField.email(required: true),
           SignUpFormField.password(),
           SignUpFormField.passwordConfirmation(),
-          // SignUpFormField.address(),
-          // SignUpFormField.custom(
-          //   title: 'Bio',
-          //   attributeKey: const CognitoUserAttributeKey.custom('bio'),
-          // ),
-          // SignUpFormField.custom(
-          //   title: 'Age',
-          //   attributeKey: const CognitoUserAttributeKey.custom('age'),
-          // )
+          SignUpFormField.address(),
+          SignUpFormField.custom(
+            title: 'Bio',
+            attributeKey: const CognitoUserAttributeKey.custom('bio'),
+          ),
+          SignUpFormField.custom(
+            title: 'Age',
+            attributeKey: const CognitoUserAttributeKey.custom('age'),
+          )
         ],
       ),
 

--- a/packages/amplify_authenticator/example/lib/main.dart
+++ b/packages/amplify_authenticator/example/lib/main.dart
@@ -34,15 +34,6 @@ class _MyAppState extends State<MyApp> {
   void _configureAmplify() async {
     try {
       await Amplify.addPlugin(AmplifyAuthCognito());
-      // Uncomment this block, and comment out the one above, in order to persist credentials
-      // await Amplify.addPlugin(AmplifyAuthCognito(credentialStorage: AmplifySecureStorage(
-      //       config: AmplifySecureStorageConfig(
-      //         scope: 'authtest',
-      //         webOptions: WebSecureStorageOptions(
-      //           persistenceOption: WebPersistenceOption.indexedDB,
-      //         ),
-      //       ),
-      //     )));
       await Amplify.configure(amplifyconfig);
       print('Successfully configured');
     } on Exception catch (e) {

--- a/packages/amplify_authenticator/example/lib/main.dart
+++ b/packages/amplify_authenticator/example/lib/main.dart
@@ -104,8 +104,8 @@ class _MyAppState extends State<MyApp> {
       signUpForm: SignUpForm.custom(
         fields: [
           SignUpFormField.username(
-              validator: _validateUsername,
-              ),
+            validator: _validateUsername,
+          ),
           SignUpFormField.email(required: true),
           SignUpFormField.password(),
           SignUpFormField.passwordConfirmation(),

--- a/packages/auth/amplify_auth_cognito/example/lib/main.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/main.dart
@@ -84,6 +84,15 @@ class _MyAppState extends State<MyApp> {
         await Amplify.addPlugin(AmplifyAPI());
       }
       await Amplify.addPlugin(AmplifyAuthCognito());
+      // Uncomment this block, and comment out the one above, in order to persist credentials
+      // await Amplify.addPlugin(AmplifyAuthCognito(credentialStorage: AmplifySecureStorage(
+      //       config: AmplifySecureStorageConfig(
+      //         scope: 'authtest',
+      //         webOptions: WebSecureStorageOptions(
+      //           persistenceOption: WebPersistenceOption.inMemory,
+      //         ),
+      //       ),
+      //     )));
       await Amplify.configure(amplifyconfig);
       safePrint('Successfully configured Amplify');
 

--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -32,9 +32,11 @@ import 'package:flutter/services.dart';
 /// {@endtemplate}
 class AmplifyAuthCognito extends AmplifyAuthCognitoDart {
   /// {@macro amplify_auth_cognito.amplify_auth_cognito}
-  AmplifyAuthCognito()
+  AmplifyAuthCognito({
+    SecureStorageInterface? credentialStorage,
+  })
       : super(
-          credentialStorage: AmplifySecureStorage(
+          credentialStorage: credentialStorage ?? AmplifySecureStorage(
             config: AmplifySecureStorageConfig(
               scope: 'auth',
             ),

--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -27,8 +27,16 @@ import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage/amplify_secure_storage.dart';
 import 'package:flutter/services.dart';
 
+
 /// {@template amplify_auth_cognito.amplify_auth_cognito}
 /// The AWS Cognito implementation of the Amplify Auth category.
+/// To change the default behavior of credential storage,
+/// provide a [credentialStorage] value. If no value is provided,
+/// [AmplifySecureStorage] will be used with a `scope` of "auth".
+///
+/// **Warning:** Changing the credential provider, or customizing 
+/// the config value for [AmplifySecureStorage], will likely result in 
+/// end users having to re-authenticate then next time the app is opened.
 /// {@endtemplate}
 class AmplifyAuthCognito extends AmplifyAuthCognitoDart {
   /// {@macro amplify_auth_cognito.amplify_auth_cognito}


### PR DESCRIPTION
*Description of changes:*
Exposes secure-storage as an auth plugin constructor parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
