### PR TITLE
chore(state_machine): Handle all error types

### DIFF
--- a/packages/amplify_core/lib/src/state_machine/state_machine.dart
+++ b/packages/amplify_core/lib/src/state_machine/state_machine.dart
@@ -167,7 +167,7 @@ abstract class StateMachine<Event extends StateMachineEvent,
         // Resolve in the next event loop since `emit` is synchronous and may
         // fire before listeners are registered.
         await Future.delayed(Duration.zero, () => resolve(event));
-      } on Exception catch (error, st) {
+      } on Object catch (error, st) {
         final resolution = resolveError(error, st);
 
         // Add the error to the state stream if it cannot be resolved to a new
@@ -206,8 +206,7 @@ abstract class StateMachine<Event extends StateMachineEvent,
     final precondError = event.checkPrecondition(currentState);
     if (precondError != null) {
       // TODO(dnys1): Log
-      // ignore:avoid_print
-      print('Precondition not met for event: $event ($precondError)');
+      safePrint('Precondition not met for event: $event ($precondError)');
       return false;
     }
 


### PR DESCRIPTION
All error types should be handled by the state machine. If `resolveError` cannot handle it, add it to the state stream.

---

**Stack**:
- #1793
- #1792
- #1787
- #1776


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*