### PR TITLE
feat(auth): TOTP MFA

### DIFF
--- a/deps.yaml
+++ b/deps.yaml
@@ -6,4 +6,5 @@
 # Application of these values can be verified/updated with the `aft` 
 # tool.
 dependencies:
+  qr: 3.0.1
   uuid: 3.0.6

--- a/packages/amplify_core/lib/src/types/auth/auth_types.dart
+++ b/packages/amplify_core/lib/src/types/auth/auth_types.dart
@@ -78,6 +78,7 @@ export 'sign_in/sign_in_request.dart';
 export 'sign_in/sign_in_result.dart';
 export 'sign_in/sign_in_with_web_ui_options.dart';
 export 'sign_in/sign_in_with_web_ui_request.dart';
+export 'sign_in/totp_secret_code.dart';
 
 /// Sign Out
 export 'sign_out/sign_out_options.dart';

--- a/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.dart
@@ -23,6 +23,8 @@ class AuthNextSignInStep extends AuthNextStep
     required this.signInStep,
     this.challengeParameters,
     this.missingAttributes = const [],
+    this.allowedMfaTypes,
+    this.totpSecretCode,
   });
 
   final String signInStep;
@@ -35,11 +37,25 @@ class AuthNextSignInStep extends AuthNextStep
   /// `Amplify.Auth.confirmSignIn` call.
   final List<UserAttributeKey> missingAttributes;
 
+  /// The list of allowed MFA types.
+  ///
+  /// This is non-null when the sign-in step requires an MFA method
+  /// to be set up.
+  final List<MfaType>? allowedMfaTypes;
+
+  /// {@macro amplify_core.auth.totp_secret_code}
+  ///
+  /// This is non-null when the sign-in step requires association of a TOTP
+  /// authenticator.
+  final TotpSecretCode? totpSecretCode;
+
   @override
   List<Object?> get props => [
         signInStep,
         challengeParameters,
         missingAttributes,
+        allowedMfaTypes,
+        totpSecretCode,
       ];
 
   @override

--- a/packages/amplify_core/lib/src/types/auth/sign_in/totp_secret_code.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/totp_secret_code.dart
@@ -1,0 +1,43 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:qr/qr.dart';
+
+/// {@template amplify_core.auth.totp_secret_code}
+/// The TOTP secret code and QR code, used to set up an authenticator for
+/// TOTP MFA.
+/// {@endtemplate}
+class TotpSecretCode with AWSEquatable<TotpSecretCode>, AWSDebuggable {
+  /// {@macro amplify_core.auth.totp_secret_code}
+  const TotpSecretCode({
+    required this.code,
+    required this.qrCode,
+  });
+
+  /// The secret code.
+  final String code;
+
+  /// The secret [code] as a QR code.
+  final QrCode qrCode;
+
+  /// The secret [code] as a QR image, which can be displayed to users.
+  QrImage get qrImage => QrImage(qrCode);
+
+  @override
+  List<Object?> get props => [code];
+
+  @override
+  String get runtimeTypeName => 'TotpSecretCode';
+}

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   intl: ^0.17.0
   json_annotation: ^4.4.0
   meta: ^1.7.0
+  qr: 3.0.1
   uuid: ^3.0.1
 
 dev_dependencies:

--- a/packages/auth/amplify_auth_cognito_dart/example/lib/common.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/lib/common.dart
@@ -19,6 +19,8 @@ import 'package:amplify_core/amplify_core.dart';
 
 import 'amplifyconfiguration.dart';
 
+export 'qr_code.dart';
+
 AmplifyConfig loadConfig() {
   return AmplifyConfig.fromJson(
     jsonDecode(amplifyconfig) as Map<String, Object?>,
@@ -86,11 +88,7 @@ Future<void> changePassword({
 }
 
 Future<CognitoAuthSession> fetchAuthSession() async {
-  final res = await Amplify.Auth.fetchAuthSession(
-    options: const CognitoSessionOptions(
-      getAWSCredentials: true,
-    ),
-  );
+  final res = await Amplify.Auth.fetchAuthSession();
   return res as CognitoAuthSession;
 }
 

--- a/packages/auth/amplify_auth_cognito_dart/example/lib/qr_code.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/lib/qr_code.dart
@@ -1,0 +1,39 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:ansicolor/ansicolor.dart';
+import 'package:qr/qr.dart';
+
+final _black = (AnsiPen()..black(bg: true))(' ');
+final _white = (AnsiPen()..white(bg: true))(' ');
+
+extension QrRenderer on QrImage {
+  /// Renders the QR image as console text for ANSI color-enabled terminals.
+  String renderConsoleText() {
+    final output = StringBuffer();
+    final border = _white * (moduleCount * 2 + 2);
+
+    output.writeln(border);
+    for (var x = 0; x < moduleCount; x++) {
+      output.write(_white);
+      for (var y = 0; y < moduleCount * 2; y++) {
+        output.write(isDark(x, y ~/ 2) ? _black : _white);
+      }
+      output.writeln(_white);
+    }
+    output.write(border);
+
+    return output.toString();
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
@@ -13,8 +13,10 @@ dependencies:
     path: ../../../amplify_core
   amplify_secure_storage_dart:
     path: ../../../secure_storage/amplify_secure_storage_dart
+  ansicolor: ^2.0.1
   example_common:
     path: ../../../example_common
+  qr: 3.0.1
 
 dependency_overrides:
   amplify_core:

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -446,6 +446,8 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface implements Closeable {
               ),
               challengeParameters: state.challengeParameters,
               missingAttributes: state.requiredAttributes,
+              allowedMfaTypes: state.allowedMfaTypes,
+              totpSecretCode: state.totpSecretCode,
             ),
           );
         case SignInStateType.success:
@@ -512,6 +514,8 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface implements Closeable {
               ),
               challengeParameters: state.challengeParameters,
               missingAttributes: state.requiredAttributes,
+              allowedMfaTypes: state.allowedMfaTypes,
+              totpSecretCode: state.totpSecretCode,
             ),
           );
         case SignInStateType.success:

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/constants.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/constants.dart
@@ -65,6 +65,16 @@ abstract class CognitoConstants {
   /// The `CODE_DELIVERY_DELIVERY_MEDIUM` parameter.
   static const challengeParamDeliveryMedium = 'CODE_DELIVERY_DELIVERY_MEDIUM';
 
+  /// The `MFAS_CAN_SETUP` parameter.
+  ///
+  /// Lists the MFA types which are allowed to be set up.
+  static const challengeParamMfasCanSetup = 'MFAS_CAN_SETUP';
+
+  /// The `Session` parameter.
+  ///
+  /// Used in the `SOFTWARE_TOKEN_MFA` flow.
+  static const challengeParamSession = 'Session';
+
   /// The `SMS_MFA_CODE` parameter.
   static const challengeParamSmsMfaCode = 'SMS_MFA_CODE';
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_step.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_step.dart
@@ -16,8 +16,16 @@
 /// The current step in the Cognito sign in flow.
 /// {@endtemplate}
 enum CognitoSignInStep {
+  /// The sign-in is not complete and the user must register an MFA method
+  /// before proceeding.
+  mfaSetup('MFA_SETUP'),
+
   /// The sign-in is not complete and must be confirmed with an SMS code.
   confirmSignInWithSmsMfaCode('CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE'),
+
+  /// The sign-in is not complete and must be confirmed with a TOTP code from
+  /// a registered authenticator.
+  confirmSignInWithTotpMfaCode('CONFIRM_SIGN_IN_WITH_TOTP_MFA_CODE'),
 
   /// The sign-in is not complete and must be confirmed with the user's new
   /// password.

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
@@ -35,13 +35,15 @@ extension ChallengeNameTypeBridge on ChallengeNameType {
         return CognitoSignInStep.confirmSignInWithNewPassword;
       case ChallengeNameType.smsMfa:
         return CognitoSignInStep.confirmSignInWithSmsMfaCode;
+      case ChallengeNameType.mfaSetup:
+        return CognitoSignInStep.mfaSetup;
+      case ChallengeNameType.softwareTokenMfa:
+        return CognitoSignInStep.confirmSignInWithTotpMfaCode;
       case ChallengeNameType.adminNoSrpAuth:
       case ChallengeNameType.selectMfaType:
       case ChallengeNameType.passwordVerifier:
       case ChallengeNameType.devicePasswordVerifier:
       case ChallengeNameType.deviceSrpAuth:
-      case ChallengeNameType.mfaSetup:
-      case ChallengeNameType.softwareTokenMfa:
         break;
     }
     throw InvalidStateException('Unrecognized challenge type: $this');

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/operation/associate_software_token_operation.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/operation/associate_software_token_operation.dart
@@ -80,7 +80,8 @@ class AssociateSoftwareTokenOperation extends _i1.HttpOperation<
           _i5.WithSigV4(
               region: _region,
               service: _i7.AWSService.cognitoIdentityProvider,
-              credentialsProvider: _credentialsProvider),
+              credentialsProvider: _credentialsProvider,
+              isOptional: true),
           const _i5.WithSdkInvocationId(),
           const _i5.WithSdkRequest()
         ],

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/operation/list_devices_operation.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/operation/list_devices_operation.dart
@@ -76,7 +76,8 @@ class ListDevicesOperation extends _i1.HttpOperation<_i2.ListDevicesRequest,
           _i5.WithSigV4(
               region: _region,
               service: _i7.AWSService.cognitoIdentityProvider,
-              credentialsProvider: _credentialsProvider),
+              credentialsProvider: _credentialsProvider,
+              isOptional: true),
           const _i5.WithSdkInvocationId(),
           const _i5.WithSdkRequest()
         ],

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/operation/verify_software_token_operation.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/operation/verify_software_token_operation.dart
@@ -88,7 +88,8 @@ class VerifySoftwareTokenOperation extends _i1.HttpOperation<
           _i5.WithSigV4(
               region: _region,
               service: _i7.AWSService.cognitoIdentityProvider,
-              credentialsProvider: _credentialsProvider),
+              credentialsProvider: _credentialsProvider,
+              isOptional: true),
           const _i5.WithSdkInvocationId(),
           const _i5.WithSdkRequest()
         ],

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_in_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_in_state.dart
@@ -57,6 +57,8 @@ abstract class SignInState extends StateMachineState<SignInStateType> {
     ChallengeNameType challengeName,
     Map<String, String> challengeParameters,
     List<CognitoUserAttributeKey> requiredAttributes,
+    List<MfaType>? allowedMfaTypes,
+    TotpSecretCode? totpSecretCode,
   ) = SignInChallenge;
 
   /// {@macro amplify_auth_cognito_dart.sign_in_success}
@@ -109,6 +111,8 @@ class SignInChallenge extends SignInState {
     this.challengeName,
     this.challengeParameters,
     this.requiredAttributes,
+    this.allowedMfaTypes,
+    this.totpSecretCode,
   );
 
   /// The name of the challenge requiring user input.
@@ -120,6 +124,13 @@ class SignInChallenge extends SignInState {
   /// Required user attributes which have not been previously provided.
   final List<CognitoUserAttributeKey> requiredAttributes;
 
+  /// The list of allowed MFA types.
+  final List<MfaType>? allowedMfaTypes;
+
+  /// The TOTP secret code which can be rendered as a QR code and displayed
+  /// to users.
+  final TotpSecretCode? totpSecretCode;
+
   @override
   SignInStateType get type => SignInStateType.challenge;
 
@@ -129,6 +140,8 @@ class SignInChallenge extends SignInState {
         challengeName,
         challengeParameters,
         requiredAttributes,
+        allowedMfaTypes,
+        totpSecretCode,
       ];
 }
 

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   meta: ^1.7.0
   oauth2: ^2.0.0
   path: ^1.8.0
+  qr: 3.0.1
   smithy:
     hosted: https://pub.dillonnys.com
     version: ^0.5.0


### PR DESCRIPTION
Introduces TOTP MFA with registration and verification flows. There are no new APIs for this approach. Instead, confirmSignIn is leveraged with two new sign in step types: `mfaSetup` and `confirmSignInWithTotpMfaCode`.

---

**Stack**:
- #1794
- #1793
- #1792
- #1787
- #1776


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*