### PR TITLE
fix(sigv4): Correct user agent

### DIFF
--- a/packages/aws_signature_v4/lib/src/configuration/service_configuration.dart
+++ b/packages/aws_signature_v4/lib/src/configuration/service_configuration.dart
@@ -140,7 +140,7 @@ class BaseServiceConfiguration extends ServiceConfiguration {
     // Add user agent header
     final isSigningTest = Zone.current[zSigningTest] as bool? ?? false;
     if (!isSigningTest) {
-      const userAgent = 'aws-sdk-dart/$packageVersion';
+      const userAgent = 'aws-sigv4-dart/$packageVersion';
       headers.update(
         zIsWeb ? AWSHeaders.amzUserAgent : AWSHeaders.userAgent,
         (value) => '$value $userAgent',

--- a/packages/aws_signature_v4/test/headers_test.dart
+++ b/packages/aws_signature_v4/test/headers_test.dart
@@ -60,7 +60,26 @@ void main() {
       );
     });
 
-    test(testOn: 'vm', 'Host, Content-Length set by signer', () {
+    test(testOn: 'browser', 'X-Amz-User-Agent header is included', () {
+      expect(
+        sentHeaders,
+        containsPair(AWSHeaders.amzUserAgent, contains('aws-sigv4-dart')),
+      );
+      expect(
+        sentHeaders,
+        isNot(contains(AWSHeaders.userAgent)),
+      );
+      expect(
+        signedHeaders,
+        contains(AWSHeaders.amzUserAgent),
+      );
+      expect(
+        signedHeaders,
+        isNot(contains(AWSHeaders.userAgent)),
+      );
+    });
+
+    test(testOn: 'vm', 'Host, Content-Length, User-Agent set by signer', () {
       expect(
         signedHeaders,
         contains(AWSHeaders.host),
@@ -76,6 +95,26 @@ void main() {
       expect(
         sentHeaders,
         contains(AWSHeaders.contentLength),
+      );
+    });
+
+    test(testOn: 'vm', 'User-Agent header is included', () {
+      expect(
+        sentHeaders,
+        isNot(contains(AWSHeaders.amzUserAgent)),
+      );
+      expect(
+        sentHeaders,
+        containsPair(AWSHeaders.userAgent, contains('aws-sigv4-dart')),
+      );
+      expect(
+        signedHeaders,
+        isNot(contains(AWSHeaders.amzUserAgent)),
+      );
+      expect(
+        signedHeaders,
+        isNot(contains(AWSHeaders.userAgent)),
+        reason: 'User-Agent header is never signed',
       );
     });
   });


### PR DESCRIPTION
Fixes the user agent which was not pulled in correctly from `main`: <a href="https://github.com/aws-amplify/amplify-flutter/pull/1561">https://github.com/aws-amplify/amplify-flutter/pull/1561</a>

**Issue references**: 

 - https://github.com/aws-amplify/amplify-flutter/pull/1561