### PR TITLE
fix(auth): Browser query on Android

### DIFF
--- a/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
+++ b/packages/auth/amplify_auth_cognito_android/android/src/main/kotlin/com/amazonaws/amplify/amplify_auth_cognito/AuthCognito.kt
@@ -17,6 +17,8 @@ package com.amazonaws.amplify.amplify_auth_cognito
 
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager.MATCH_ALL
+import android.content.pm.PackageManager.MATCH_DEFAULT_ONLY
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION
@@ -172,14 +174,17 @@ open class AuthCognito :
             addCategory(Intent.CATEGORY_BROWSABLE)
             data = Uri.fromParts("https", "", null)
         }
-        val defaultViewHandlerInfo = packageManager.resolveActivity(activityIntent, 0)
+        val defaultViewHandlerInfo = packageManager.resolveActivity(
+            activityIntent,
+            MATCH_DEFAULT_ONLY
+        )
         var defaultViewHandlerPackageName: String? = null
         if (defaultViewHandlerInfo != null) {
             defaultViewHandlerPackageName = defaultViewHandlerInfo.activityInfo.packageName
         }
 
         // Get all apps that can handle VIEW intents.
-        val resolvedActivityList = packageManager.queryIntentActivities(activityIntent, 0)
+        val resolvedActivityList = packageManager.queryIntentActivities(activityIntent, MATCH_ALL)
         val packagesSupportingCustomTabs = mutableListOf<String>()
         for (info in resolvedActivityList) {
             val serviceIntent = Intent()


### PR DESCRIPTION
Even though the Android [docs](https://developer.chrome.com/docs/android/custom-tabs/integration-guide/#how-can-i-check-whether-the-android-device-has-a-browser-that-supports-custom-tab) specify `0` for these flags, the correct behavior of querying the correct default package along with a full list of custom tabs packages only happens with this combination of flags. The docs for [resolveActivity](https://developer.android.com/reference/android/content/pm/PackageManager#resolveActivity(android.content.Intent,%20int)) and [queryIntentActivities](https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20int)) have more info as to what these flags do and why they're important.
