### PR TITLE
fix(auth): add sub and identities as standard attributes

### DIFF
--- a/packages/amplify_core/lib/src/types/auth/attribute/cognito_user_attribute_key.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/cognito_user_attribute_key.dart
@@ -102,6 +102,12 @@ class CognitoUserAttributeKey extends UserAttributeKey {
   /// Read-only: `false`
   static const givenName = CognitoUserAttributeKey._('given_name');
 
+  /// Federated identities of the user.
+  ///
+  /// Read-only: `true`
+  static const identities =
+      CognitoUserAttributeKey._('identities', readOnly: true);
+
   /// The user's locale, represented as a BCP47 language tag, e.g. `en-US`.
   ///
   /// Read-only: `false`
@@ -155,6 +161,11 @@ class CognitoUserAttributeKey extends UserAttributeKey {
   /// Read-only: `false`
   static const profile = CognitoUserAttributeKey._('profile');
 
+  /// The user ID.
+  ///
+  /// Read-only: `true`
+  static const sub = CognitoUserAttributeKey._('sub', readOnly: true);
+
   /// The time the user's information was last updated.
   ///
   /// Read-only: `false`
@@ -179,6 +190,7 @@ class CognitoUserAttributeKey extends UserAttributeKey {
     familyName,
     gender,
     givenName,
+    identities,
     locale,
     middleName,
     name,
@@ -188,6 +200,7 @@ class CognitoUserAttributeKey extends UserAttributeKey {
     picture,
     preferredUsername,
     profile,
+    sub,
     updatedAt,
     website,
     zoneinfo


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add sub and identities attributes

This is a subset of the changes that went into next in https://github.com/aws-amplify/amplify-flutter/pull/1768 and https://github.com/aws-amplify/amplify-flutter/pull/1804. I did not include the rest of the changes since the changes to the `parse` constructor is breaking.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
