### PR TITLE
fix(auth): add toString override of AuthProvider

### DIFF
--- a/packages/amplify_core/lib/src/types/auth/sign_in/auth_provider.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/auth_provider.dart
@@ -44,4 +44,7 @@ class AuthProvider {
     }
     return name;
   }
+
+  @override
+  String toString() => 'AuthProvider.$name';
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/1827

*Description of changes:*
- Add `toString()` override to AuthProvider so that it works in localization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
