### PR TITLE
fix(authenticator): duplicate phone showing for SMS MFA

### DIFF
--- a/packages/amplify_authenticator/lib/src/widgets/form.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form.dart
@@ -340,7 +340,7 @@ class _SignUpFormState extends AuthenticatorFormState<SignUpForm> {
         .toList();
 
     final hasSmsMfa = authConfig?.mfaTypes?.contains(MfaType.sms) ?? false;
-    if (hasSmsMfa) {
+    if (hasSmsMfa && selectedUsernameType != UsernameType.phoneNumber) {
       final mfaConfiguration =
           authConfig?.mfaConfiguration ?? MfaConfiguration.off;
       final hasSmsField = runtimeFields.any(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix an issue in the authenticator where duplicate phone fields are displayed when SMS is set as the MFA method and phone is used as the login identifier.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
