### PR TITLE
[DRAFT] chore: refactor api docs for MacOSSecureStorageOptions

### DIFF
--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/macos_secure_storage_options.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/macos_secure_storage_options.dart
@@ -24,6 +24,23 @@ abstract class MacOSSecureStorageOptions
     implements
         Built<MacOSSecureStorageOptions, MacOSSecureStorageOptionsBuilder> {
   /// {@macro amplify_secure_storage_dart.macos_secure_storage_options}
+  ///
+  /// {@template amplify_secure_storage_dart.macos_secure_storage_options.useDataProtection}
+  /// [useDataProtection] sets the [`kSecUseDataProtectionKeychain`](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps?language=objc)
+  /// attribute for all Keychain operations. Set this to true to
+  /// enforce that Keychain items behave like iOS Keychain items.
+  /// {@endtemplate}
+  ///
+  /// {@template amplify_secure_storage_dart.macos_secure_storage_options.accessGroup}
+  /// [accessGroup] sets the [kSecAttrAccessGroup](https://developer.apple.com/documentation/security/ksecattraccessgroup?language=objc)
+  /// attribute for all Keychain operations.
+  /// {@endtemplate}
+  ///
+  /// **Note:** [useDataProtection] must be set to true when specifying an [accessGroup].
+  ///
+  /// **Note:** When [useDataProtection] is set to true, the app must be added to one
+  /// or more Keychain Access Groups in Xcode. See the project setup docs for more info.
+  // TODO: include link to docs on Mac Setup when available.
   factory MacOSSecureStorageOptions({
     bool useDataProtection = true,
     String? accessGroup,
@@ -41,29 +58,10 @@ abstract class MacOSSecureStorageOptions
 
   const MacOSSecureStorageOptions._();
 
-  /// Sets the `kSecUseDataProtectionKeychain` attribute to true for
-  /// all Keychain operations.
-  ///
-  /// Reference: [kSecUseDataProtectionKeychain](https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain?language=objc)
-  ///
-  /// Set this to true to enforce that Keychain items behave
-  /// like iOS Keychain items.
-  ///
-  /// **Note:** This must be set to true when specifying an [accessGroup].
-  ///
-  /// **Note:** Setting this to true requires that the app is added to one
-  /// or more Keychain Access Groups. See the section titled
-  /// "Add Apps to One or More Keychain Access Groups" at the
-  /// link below for more info.
-  ///
-  /// Reference: [Sharing Access to Keychain Items Among a Collection of Apps](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps?language=objc)
+  /// {@macro amplify_secure_storage_dart.macos_secure_storage_options.useDataProtection}
   bool get useDataProtection;
 
-  /// Sets the `kSecAttrAccessGroup` attribute for all Keychain operations.
-  ///
-  /// **Note:** [useDataProtection] must be set to true if a value is provided.
-  ///
-  /// Reference: [kSecAttrAccessGroup](https://developer.apple.com/documentation/security/ksecattraccessgroup?language=objc)
+  /// {@macro amplify_secure_storage_dart.macos_secure_storage_options.accessGroup}
   String? get accessGroup;
 
   /// The [MacOSSecureStorageOptions] serializer.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Move API docs for MacOSSecureStorageOptions so that they are visible in the constructor

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
