### PR TITLE
chore(lints): Ignore `implementation_imports` for libraries

### DIFF
--- a/packages/amplify/amplify_flutter/lib/src/amplify_impl.dart
+++ b/packages/amplify/amplify_flutter/lib/src/amplify_impl.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ignore_for_file: invalid_use_of_internal_member, implementation_imports
+// ignore_for_file: invalid_use_of_internal_member
 
 import 'dart:async';
 import 'dart:io';

--- a/packages/amplify_authenticator/lib/src/utils/validators.dart
+++ b/packages/amplify_authenticator/lib/src/utils/validators.dart
@@ -181,5 +181,3 @@ FormFieldValidator<String> validateCode({
     return null;
   };
 }
-
-// ignore_for_file: implementation_imports

--- a/packages/amplify_lints/CHANGELOG.md
+++ b/packages/amplify_lints/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Migrated specs as follows:
     - `flutter_lib.yaml`, `dart.yaml` -> `library.yaml`
     - `flutter_app.yaml` -> `app.yaml`
+- Ignores `implementation_imports` lint for `library.yaml` and `library_core.yaml`
 
 Introduced the following new lints to `library.yaml`:
   - `avoid_classes_with_only_static_members`

--- a/packages/amplify_lints/lib/library.yaml
+++ b/packages/amplify_lints/lib/library.yaml
@@ -7,6 +7,7 @@ analyzer:
     strict-raw-types: true
   errors:
     depend_on_referenced_packages: error               # To prevent issues publishing.
+    implementation_imports: ignore                     # This is okay for libraries (as opposed to apps), especially when referencing our own packages.
 
 linter:
   rules:

--- a/packages/amplify_lints/lib/library_core.yaml
+++ b/packages/amplify_lints/lib/library_core.yaml
@@ -6,6 +6,7 @@ analyzer:
     strict-inference: true
   errors:
     depend_on_referenced_packages: error               # To prevent issues publishing.
+    implementation_imports: ignore                     # This is okay for libraries (as opposed to apps), especially when referencing our own packages.
 
 linter:
   rules:

--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ignore_for_file: implementation_imports
-
 import 'dart:async';
 import 'dart:io';
 

--- a/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_flutter.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_flutter.dart
@@ -16,7 +16,6 @@ import 'dart:async';
 import 'dart:io';
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_auth_cognito/src/native_auth_plugin.dart';
-// ignore: implementation_imports
 import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/hosted_ui_platform_io.dart'
     as io;
 import 'package:amplify_core/amplify_core.dart';

--- a/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_html.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_html.dart
@@ -14,7 +14,6 @@
 
 import 'dart:html';
 
-// ignore: implementation_imports
 import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/hosted_ui_platform_html.dart'
     as dart;
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';


### PR DESCRIPTION
This is generally okay for libraries (especially when referencing our own). However, when building apps, this is usually a poor practice.