### PR TITLE
fix(core): Emit precondition errors

### DIFF
--- a/packages/amplify_core/lib/amplify_core.dart
+++ b/packages/amplify_core/lib/amplify_core.dart
@@ -53,6 +53,7 @@ export 'src/plugin/amplify_storage_plugin_interface.dart';
 // State Machine
 export 'src/state_machine/dependency_manager.dart';
 export 'src/state_machine/event.dart';
+export 'src/state_machine/exception.dart';
 export 'src/state_machine/state.dart';
 export 'src/state_machine/state_machine.dart';
 export 'src/state_machine/token.dart';

--- a/packages/amplify_core/lib/src/state_machine/event.dart
+++ b/packages/amplify_core/lib/src/state_machine/event.dart
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:amplify_core/src/state_machine/state.dart';
-import 'package:aws_common/aws_common.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:meta/meta.dart';
 
 /// {@template amplify_core.event}
@@ -33,9 +32,11 @@ abstract class StateMachineEvent<EventType>
 
   /// Checks the precondition, given [currentState].
   ///
-  /// Returns a string with an error message if the check fails, otherwise
-  /// `null`.
-  String? checkPrecondition(covariant StateMachineState currentState) => null;
+  /// Returns a [PreconditionException] if the check fails, otherwise `null`.
+  PreconditionException? checkPrecondition(
+    covariant StateMachineState currentState,
+  ) =>
+      null;
 }
 
 /// Mixin functionality for error/failure events of a state machine.

--- a/packages/amplify_core/lib/src/state_machine/exception.dart
+++ b/packages/amplify_core/lib/src/state_machine/exception.dart
@@ -1,0 +1,29 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// (@template amplify_core.state_machine.precondition_exception)
+/// An exception raised within a state machine when an event could not be
+/// processed due to some precondition not being met.
+/// {@endtemplate}
+abstract class PreconditionException implements Exception {
+  /// (@macro amplify_core.state_machine.precondition_exception)
+  const PreconditionException();
+
+  /// The precondition which was not met.
+  String get precondition;
+
+  /// Whether the event should be resolved and emitted as a state machine state
+  /// (`true`) or whether the error should be reported but not emitted (`false`).
+  bool get shouldEmit;
+}

--- a/packages/amplify_core/test/state_machine/my_state_machine.dart
+++ b/packages/amplify_core/test/state_machine/my_state_machine.dart
@@ -23,6 +23,16 @@ final _builders = <StateMachineToken, StateMachineBuilder>{
 
 enum MyType { initial, doWork, tryWork, delegateWork, success, error }
 
+class MyPreconditionException implements PreconditionException {
+  const MyPreconditionException(this.precondition);
+
+  @override
+  final String precondition;
+
+  @override
+  bool get shouldEmit => false;
+}
+
 class MyEvent extends StateMachineEvent<MyType> {
   const MyEvent(this.type);
 
@@ -33,9 +43,9 @@ class MyEvent extends StateMachineEvent<MyType> {
   final MyType type;
 
   @override
-  String? checkPrecondition(MyState currentState) {
+  MyPreconditionException? checkPrecondition(MyState currentState) {
     if (currentState.type == type) {
-      return 'Cannot process event of same type';
+      return const MyPreconditionException('Cannot process event of same type');
     }
     return null;
   }
@@ -127,9 +137,9 @@ class WorkerEvent extends StateMachineEvent<WorkType> {
   final WorkType type;
 
   @override
-  String? checkPrecondition(WorkerState currentState) {
+  MyPreconditionException? checkPrecondition(WorkerState currentState) {
     if (currentState.type == type) {
-      return 'Cannot process event of same type';
+      return const MyPreconditionException('Cannot process event of same type');
     }
     return null;
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -55,7 +55,6 @@ import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
-import 'package:stream_transform/stream_transform.dart';
 
 /// {@template amplify_auth_cognito_dart.amplify_auth_cognito_dart}
 /// The AWS Cognito implementation of the Amplify Auth category.
@@ -159,6 +158,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface implements Closeable {
           _hubEventController.add(hubEvent);
         }
       },
+      cancelOnError: false,
       onDone: _hubEventController.close,
     );
     Amplify.Hub.addChannel(HubChannel.Auth, _hubEventController.stream);
@@ -181,7 +181,8 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface implements Closeable {
     await _init();
     _stateMachine.dispatch(AuthEvent.configure(config));
 
-    await for (final state in _stateMachine.stream.whereType<AuthState>()) {
+    await for (final state
+        in _stateMachine.expect(AuthStateMachine.type).stream) {
       switch (state.type) {
         case AuthStateType.notConfigured:
         case AuthStateType.configuring:
@@ -219,7 +220,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface implements Closeable {
     _stateMachine.dispatch(FetchAuthSessionEvent.fetch(options));
 
     await for (final state
-        in _stateMachine.stream.whereType<FetchAuthSessionState>()) {
+        in _stateMachine.expect(FetchAuthSessionStateMachine.type).stream) {
       switch (state.type) {
         case FetchAuthSessionStateType.idle:
         case FetchAuthSessionStateType.fetching:
@@ -251,7 +252,8 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface implements Closeable {
       ),
     );
 
-    await for (final state in _stateMachine.stream.whereType<HostedUiState>()) {
+    await for (final state
+        in _stateMachine.expect(HostedUiStateMachine.type).stream) {
       switch (state.type) {
         case HostedUiStateType.notConfigured:
         case HostedUiStateType.configuring:
@@ -297,7 +299,8 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface implements Closeable {
       ),
     );
 
-    await for (final state in _stateMachine.stream.whereType<SignUpState>()) {
+    await for (final state
+        in _stateMachine.expect(SignUpStateMachine.type).stream) {
       switch (state.type) {
         case SignUpStateType.notStarted:
         case SignUpStateType.initiating:
@@ -342,7 +345,8 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface implements Closeable {
       ),
     );
 
-    await for (final state in _stateMachine.stream.whereType<SignUpState>()) {
+    await for (final state
+        in _stateMachine.expect(SignUpStateMachine.type).stream) {
       switch (state.type) {
         case SignUpStateType.notStarted:
         case SignUpStateType.initiating:

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/exception/auth_precondition_exception.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/exception/auth_precondition_exception.dart
@@ -1,0 +1,33 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:meta/meta.dart';
+
+/// {@template amplify_auth_cognito.exception.auth_precondition_exception}
+/// Exception raised in the Auth state machine when a precondition for an event
+/// was not met.
+/// {@endtemplate}
+@internal
+class AuthPreconditionException extends AuthException
+    implements PreconditionException {
+  /// {@macro amplify_auth_cognito.exception.auth_precondition_exception}
+  const AuthPreconditionException(super.message, {this.shouldEmit = true});
+
+  @override
+  String get precondition => message;
+
+  @override
+  final bool shouldEmit;
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/auth_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/auth_event.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:amplify_auth_cognito_dart/src/state/state/auth_state.dart';
+import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 /// {@template amplify_auth_cognito.auth_event_type}
@@ -47,7 +47,7 @@ abstract class AuthEvent extends StateMachineEvent<AuthEventType> {
       AuthConfigureFailed;
 
   @override
-  String? checkPrecondition(AuthState currentState) => null;
+  PreconditionException? checkPrecondition(AuthState currentState) => null;
 
   @override
   String get runtimeTypeName => 'AuthEvent';
@@ -67,12 +67,18 @@ class AuthConfigure extends AuthEvent {
   AuthEventType get type => AuthEventType.configure;
 
   @override
-  String? checkPrecondition(AuthState currentState) {
+  PreconditionException? checkPrecondition(AuthState currentState) {
     if (currentState.type == AuthStateType.configuring) {
-      return 'Already configuring';
+      return const AuthPreconditionException(
+        'Already configuring',
+        shouldEmit: false,
+      );
     }
     if (currentState.type == AuthStateType.configured) {
-      return 'Runtime re-configuration is not supported';
+      return const AuthPreconditionException(
+        'Runtime re-configuration is not supported',
+        shouldEmit: false,
+      );
     }
     return null;
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/credential_store_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/credential_store_event.dart
@@ -14,6 +14,7 @@
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_auth_cognito_dart/src/model/cognito_device_secrets.dart';
+import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 /// {@template amplify_auth_cognito.credential_store_event_type}
@@ -81,7 +82,10 @@ abstract class CredentialStoreEvent
       CredentialStoreFailed;
 
   @override
-  String? checkPrecondition(CredentialStoreState currentState) => null;
+  PreconditionException? checkPrecondition(
+    CredentialStoreState currentState,
+  ) =>
+      null;
 
   @override
   String get runtimeTypeName => 'CredentialStoreEvent';
@@ -102,10 +106,15 @@ class CredentialStoreLoadCredentialStore extends CredentialStoreEvent {
   List<Object?> get props => [type];
 
   @override
-  String? checkPrecondition(CredentialStoreState currentState) {
+  PreconditionException? checkPrecondition(
+    CredentialStoreState currentState,
+  ) {
     if (currentState.type != CredentialStoreStateType.notConfigured &&
         currentState.type != CredentialStoreStateType.failure) {
-      return 'Credential store already configured';
+      return const AuthPreconditionException(
+        'Credential store already configured',
+        shouldEmit: false,
+      );
     }
     return null;
   }
@@ -127,10 +136,14 @@ class CredentialStoreMigrateLegacyCredentialStore extends CredentialStoreEvent {
   List<Object?> get props => [type];
 
   @override
-  String? checkPrecondition(CredentialStoreState currentState) {
+  PreconditionException? checkPrecondition(
+    CredentialStoreState currentState,
+  ) {
     if (currentState.type !=
         CredentialStoreStateType.loadingStoredCredentials) {
-      return 'Credential store cannot be migrated in current state';
+      return const AuthPreconditionException(
+        'Credential store cannot be migrated in current state',
+      );
     }
     return null;
   }
@@ -174,15 +187,21 @@ class CredentialStoreStoreCredentials extends CredentialStoreEvent {
       ];
 
   @override
-  String? checkPrecondition(CredentialStoreState currentState) {
+  PreconditionException? checkPrecondition(
+    CredentialStoreState currentState,
+  ) {
     if (currentState.type == CredentialStoreStateType.notConfigured) {
-      return 'Credential store is not configured';
+      return const AuthPreconditionException(
+        'Credential store is not configured',
+      );
     }
     if (currentState.type == CredentialStoreStateType.failure) {
-      return 'Credential store has error. Re-load before continuing.';
+      return const AuthPreconditionException(
+        'Credential store has error. Re-load before continuing.',
+      );
     }
     if (currentState.type != CredentialStoreStateType.success) {
-      return 'Credential store is busy';
+      return const AuthPreconditionException('Credential store is busy');
     }
     return null;
   }
@@ -207,15 +226,21 @@ class CredentialStoreClearCredentials extends CredentialStoreEvent {
   List<Object?> get props => [type, keys];
 
   @override
-  String? checkPrecondition(CredentialStoreState currentState) {
+  PreconditionException? checkPrecondition(
+    CredentialStoreState currentState,
+  ) {
     if (currentState.type == CredentialStoreStateType.notConfigured) {
-      return 'Credential store is not configured';
+      return const AuthPreconditionException(
+        'Credential store is not configured',
+      );
     }
     if (currentState.type == CredentialStoreStateType.failure) {
-      return 'Credential store has error. Re-load before continuing.';
+      return const AuthPreconditionException(
+        'Credential store has error. Re-load before continuing.',
+      );
     }
     if (currentState.type != CredentialStoreStateType.success) {
-      return 'Credential store is busy';
+      return const AuthPreconditionException('Credential store is busy');
     }
     return null;
   }
@@ -258,9 +283,13 @@ class CredentialStoreSucceeded extends CredentialStoreEvent {
       ];
 
   @override
-  String? checkPrecondition(CredentialStoreState currentState) {
+  PreconditionException? checkPrecondition(
+    CredentialStoreState currentState,
+  ) {
     if (currentState.type == CredentialStoreStateType.notConfigured) {
-      return 'Credential store is not configured';
+      return const AuthPreconditionException(
+        'Credential store is not configured',
+      );
     }
     return null;
   }
@@ -284,7 +313,9 @@ class CredentialStoreFailed extends CredentialStoreEvent with ErrorEvent {
   List<Object?> get props => [type, exception];
 
   @override
-  String? checkPrecondition(CredentialStoreState currentState) {
+  PreconditionException? checkPrecondition(
+    CredentialStoreState currentState,
+  ) {
     return null;
   }
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/fetch_auth_session_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/fetch_auth_session_event.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 /// Discrete event types of the fetch auth session state machine.
@@ -77,10 +78,15 @@ class FetchAuthSessionFetch extends FetchAuthSessionEvent {
   List<Object?> get props => [type, options];
 
   @override
-  String? checkPrecondition(FetchAuthSessionState currentState) {
+  PreconditionException? checkPrecondition(
+    FetchAuthSessionState currentState,
+  ) {
     if (currentState.type == FetchAuthSessionStateType.refreshing ||
         currentState.type == FetchAuthSessionStateType.fetching) {
-      return 'Credentials are already being fetched...';
+      return const AuthPreconditionException(
+        'Credentials are already being fetched',
+        shouldEmit: false,
+      );
     }
     return null;
   }
@@ -113,9 +119,14 @@ class FetchAuthSessionRefresh extends FetchAuthSessionEvent {
       ];
 
   @override
-  String? checkPrecondition(FetchAuthSessionState currentState) {
+  PreconditionException? checkPrecondition(
+    FetchAuthSessionState currentState,
+  ) {
     if (currentState.type == FetchAuthSessionStateType.refreshing) {
-      return 'Credentials are already being refreshed...';
+      return const AuthPreconditionException(
+        'Credentials are already being refreshed.',
+        shouldEmit: false,
+      );
     }
     return null;
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/hosted_ui_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/hosted_ui_event.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 /// Discrete event types of the hosted UI state machine.
@@ -169,9 +170,11 @@ class HostedUiCancelSignIn extends HostedUiEvent {
   HostedUiEventType get type => HostedUiEventType.cancelSignIn;
 
   @override
-  String? checkPrecondition(HostedUiState currentState) {
+  PreconditionException? checkPrecondition(HostedUiState currentState) {
     if (currentState.type != HostedUiStateType.signingIn) {
-      return 'There is no active sign-in session';
+      return const AuthPreconditionException(
+        'There is no active sign-in session',
+      );
     }
     return null;
   }
@@ -208,18 +211,23 @@ class HostedUiSignOut extends HostedUiEvent {
   HostedUiEventType get type => HostedUiEventType.signOut;
 
   @override
-  String? checkPrecondition(HostedUiState currentState) {
+  PreconditionException? checkPrecondition(HostedUiState currentState) {
     switch (currentState.type) {
       case HostedUiStateType.notConfigured:
-        return 'Hosted UI is not configured';
+        return const AuthPreconditionException('Hosted UI is not configured');
       case HostedUiStateType.configuring:
-        return 'Hosted UI is configuring';
+        return const AuthPreconditionException('Hosted UI is configuring');
       case HostedUiStateType.signingIn:
-        return 'Hosted UI is signing in';
+        return const AuthPreconditionException('Hosted UI is signing in');
       case HostedUiStateType.signedOut:
-        return 'Hosted UI is already signed out';
+        return const AuthPreconditionException(
+          'Hosted UI is already signed out',
+          shouldEmit: false,
+        );
       case HostedUiStateType.signingOut:
-        return 'Hosted UI is already signing out';
+        return const AuthPreconditionException(
+          'Hosted UI is already signing out',
+        );
       case HostedUiStateType.signedIn:
       case HostedUiStateType.failure:
         return null;
@@ -262,9 +270,12 @@ class HostedUiFailed extends HostedUiEvent with ErrorEvent {
   HostedUiEventType get type => HostedUiEventType.failed;
 
   @override
-  String? checkPrecondition(HostedUiState currentState) {
+  PreconditionException? checkPrecondition(HostedUiState currentState) {
     if (currentState.type == HostedUiStateType.failure) {
-      return 'The state machine is already in a failure state.';
+      return const AuthPreconditionException(
+        'The state machine is already in a failure state.',
+        shouldEmit: false,
+      );
     }
     return null;
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state.dart
@@ -19,6 +19,8 @@ library amplify_auth_cognito.state;
 
 import 'package:meta/meta.dart';
 
+export '../exception/auth_precondition_exception.dart';
+
 export 'event/auth_event.dart';
 export 'event/credential_store_event.dart';
 export 'event/fetch_auth_session_event.dart';


### PR DESCRIPTION
Currently, events which do not meet preconditions are just printed and then silently ignored. However, there are good reasons that some of these precondition failures should be translated to real exceptions. For example, when the user calls `confirmSignIn` when there's no active sign-in. Before, the call would never finish because the state machine was not reporting the precondition failure as an exception. 

This PR allows state machines to surface precondition failures as exceptions so that they can be handled appropriately by users of the state machine. The previous behavior is still available as needed and this is controlled via the `shouldEmit` flag.