### PR TITLE
feat(aft): `publish` command

### DIFF
--- a/packages/aft/bin/aft.dart
+++ b/packages/aft/bin/aft.dart
@@ -25,6 +25,14 @@ Future<void> main(List<String> args) async {
     )
     ..addCommand(GenerateSdkCommand())
     ..addCommand(ListPackagesCommand())
-    ..addCommand(DepsCommand());
-  await runner.run(args);
+    ..addCommand(DepsCommand())
+    ..addCommand(PublishCommand());
+  try {
+    await runner.run(args);
+  } finally {
+    // Free up resources before exiting. This prevents hangs from `pkg:http`.
+    for (final command in runner.commands.values.whereType<AmplifyCommand>()) {
+      command.close();
+    }
+  }
 }

--- a/packages/aft/lib/aft.dart
+++ b/packages/aft/lib/aft.dart
@@ -18,4 +18,5 @@ export 'src/commands/amplify_command.dart';
 export 'src/commands/deps_command.dart';
 export 'src/commands/generate_sdk_command.dart';
 export 'src/commands/list_packages_command.dart';
+export 'src/commands/publish_command.dart';
 export 'src/models.dart';

--- a/packages/aft/lib/src/commands/publish_command.dart
+++ b/packages/aft/lib/src/commands/publish_command.dart
@@ -1,0 +1,200 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:aft/aft.dart';
+import 'package:aft/src/util.dart';
+import 'package:graphs/graphs.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+
+/// Command to publish all Dart/Flutter packages in the repo.
+class PublishCommand extends AmplifyCommand {
+  PublishCommand() {
+    argParser
+      ..addFlag(
+        'force',
+        abbr: 'f',
+        help: 'Ignores errors in pre-publishing commands and publishes '
+            'without prompt',
+        negatable: false,
+      )
+      ..addFlag(
+        'dry-run',
+        help: 'Passes `--dry-run` flag to `dart` or `flutter` publish command',
+        negatable: false,
+      );
+  }
+
+  late final bool force = argResults!['force'] as bool;
+  late final bool dryRun = argResults!['dry-run'] as bool;
+
+  @override
+  String get description =>
+      'Publishes all packages in the Amplify Flutter repo which '
+      'need publishing.';
+
+  @override
+  String get name => 'publish';
+
+  /// Checks if [package] can be published based on whether the local version
+  /// is newer than the one published to `pub.dev`.
+  Future<PackageInfo?> _checkPublishable(PackageInfo package) async {
+    final publishTo = package.pubspecInfo.pubspec.publishTo;
+    if (publishTo == 'none') {
+      return null;
+    }
+
+    Never fail(String error) {
+      logger
+        ..stderr('Could not retrieve package info for ${package.name}: ')
+        ..stderr(error)
+        ..stderr('Retry with `--force` to ignore this error');
+      exit(1);
+    }
+
+    // Get the currently published version of the package.
+    final uri = Uri.parse(publishTo ?? 'https://pub.dev')
+        .replace(path: '/api/packages/${package.name}');
+    logger.trace('GET $uri');
+    final resp = await httpClient.get(
+      uri,
+      headers: {'Accept': 'application/vnd.pub.v2+json'},
+    );
+
+    // Package is unpublished
+    if (resp.statusCode == 404) {
+      return package;
+    }
+    if (resp.statusCode != 200) {
+      if (force) {
+        return package;
+      } else {
+        fail(resp.body);
+      }
+    }
+
+    final respJson = jsonDecode(resp.body) as Map<String, Object?>;
+    final latestVersionStr =
+        (respJson['latest'] as Map?)?['version'] as String?;
+    if (latestVersionStr == null) {
+      if (force) {
+        return package;
+      } else {
+        fail('Could not determine latest version');
+      }
+    }
+
+    final latestVersion = Version.parse(latestVersionStr);
+    return latestVersion < package.pubspecInfo.pubspec.version!
+        ? package
+        : null;
+  }
+
+  Future<void> _publish(PackageInfo package) async {
+    final publishCmd = await Process.start(
+      package.flavor.entrypoint,
+      [
+        'pub',
+        'publish',
+        if (dryRun) '--dry-run',
+      ],
+      workingDirectory: package.path,
+    );
+    if (verbose) {
+      publishCmd
+        ..captureStdout()
+        ..captureStderr();
+    }
+    if (force) {
+      publishCmd.stdin.writeln('y');
+    }
+
+    if (await publishCmd.exitCode != 0) {
+      exitError('Failed to publish package ${package.name}');
+    }
+  }
+
+  @override
+  Future<void> run() async {
+    // Gather packages which can be published.
+    final publishablePackages = (await Future.wait([
+      for (final package in await allPackages) _checkPublishable(package),
+    ]))
+        .whereType<PackageInfo>()
+        .toList();
+
+    try {
+      sortPackagesTopologically<PackageInfo>(
+        publishablePackages,
+        (pkg) => pkg.pubspecInfo.pubspec,
+      );
+    } on CycleException<dynamic> {
+      if (!force) {
+        exitError('Cannot sort packages with inter-dependencies.');
+      }
+    }
+
+    stdout
+      ..writeln('Preparing to publish: ')
+      ..writeln(
+        publishablePackages
+            .map((pkg) => '${pkg.pubspecInfo.pubspec.version} ${pkg.name}')
+            .join('\n'),
+      );
+
+    if (!force) {
+      final shouldProceed = prompt('Proceed with publish (y/N)? ') == 'y';
+      if (!shouldProceed) {
+        return;
+      }
+    }
+
+    for (final package in publishablePackages) {
+      await _publish(package);
+    }
+
+    stdout.writeln(
+      dryRun
+          ? 'All packages passed pre-publish checks'
+          : 'All packages were successfully published',
+    );
+  }
+}
+
+/// Sorts packages in topological order so they may be published in the order
+/// they're sorted.
+///
+/// Packages with inter-dependencies cannot be topologically sorted and will
+/// throw a [CycleException].
+void sortPackagesTopologically<T>(
+  List<T> packages,
+  Pubspec Function(T) getPubspec,
+) {
+  final pubspecs = packages.map(getPubspec);
+  final packageNames = pubspecs.map((el) => el.name).toList();
+  final graph = <String, Iterable<String>>{
+    for (var package in pubspecs)
+      package.name: package.dependencies.keys.where(packageNames.contains),
+  };
+  final ordered = topologicalSort(graph.keys, (key) => graph[key]!);
+  packages.sort((a, b) {
+    // `ordered` is in reverse ordering to our desired publish precedence.
+    return ordered
+        .indexOf(getPubspec(b).name)
+        .compareTo(ordered.indexOf(getPubspec(a).name));
+  });
+}

--- a/packages/aft/lib/src/models.dart
+++ b/packages/aft/lib/src/models.dart
@@ -26,11 +26,13 @@ part 'models.g.dart';
 
 /// The flavor of a package, e.g. Dart/Flutter.
 enum PackageFlavor {
-  flutter('Flutter'),
-  dart('Dart');
+  flutter('Flutter', 'flutter'),
+  dart('Dart', 'dart');
 
-  const PackageFlavor(this.displayName);
+  const PackageFlavor(this.displayName, this.entrypoint);
+
   final String displayName;
+  final String entrypoint;
 }
 
 /// {@template amplify_tools.package_info}

--- a/packages/aft/lib/src/util.dart
+++ b/packages/aft/lib/src/util.dart
@@ -1,0 +1,42 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+import 'dart:io';
+
+typedef ProcessSink = void Function(String);
+
+/// Helpers on [Process].
+extension ProcessUtil on Process {
+  static void _printToStdout(String message) => stdout.writeln(message);
+  static void _printToStderr(String message) => stderr.writeln(message);
+
+  /// Captures `stdout` to the provided sink, the global [stdout] by default.
+  void captureStdout([ProcessSink sink = _printToStdout]) {
+    this
+        .stdout
+        .transform(const Utf8Decoder())
+        .transform(const LineSplitter())
+        .listen(sink);
+  }
+
+  /// Captures `stderr` to the provided sink, the global [stderr] by default.
+  void captureStderr([ProcessSink sink = _printToStderr]) {
+    this
+        .stderr
+        .transform(const Utf8Decoder())
+        .transform(const LineSplitter())
+        .listen(sink);
+  }
+}

--- a/packages/aft/pubspec.yaml
+++ b/packages/aft/pubspec.yaml
@@ -14,7 +14,10 @@ dependencies:
   cli_util: ^0.3.5
   collection: ^1.16.0
   git: ^2.0.0
+  graphs: ^2.1.0
+  http: ^0.13.0
   json_annotation: ^4.4.0
+  meta: ^1.8.0
   path: any
   pub_semver: ^2.1.1
   pubspec_parse: ^1.2.0

--- a/packages/aft/test/publish_command_test.dart
+++ b/packages/aft/test/publish_command_test.dart
@@ -1,0 +1,82 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:aft/aft.dart';
+import 'package:graphs/graphs.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+final throwsCyclicError = throwsA(isA<CycleException<dynamic>>());
+
+void main() {
+  group('publish', () {
+    group('sort packages', () {
+      test('', () {
+        //     b
+        //   /   \
+        // a       d
+        //   \   /
+        //     c
+        //
+        // e  -->  *f (external package)
+        final packages = [
+          _dummyPackage('a', deps: ['b', 'c']),
+          _dummyPackage('b', deps: ['d']),
+          _dummyPackage('c', deps: ['d']),
+          _dummyPackage('d', deps: []),
+          _dummyPackage('e', deps: ['f']),
+        ]..shuffle();
+        final packageNames = packages.map((el) => el.name).toList();
+        sortPackagesTopologically<Pubspec>(packages, (pkg) => pkg);
+
+        final published = <String>{};
+        for (final package in packages) {
+          final dependencies = package.dependencies;
+          for (final dependency in dependencies.keys) {
+            final isExternal = !packageNames.contains(dependency);
+            final isPublished = published.contains(dependency);
+            expect(isExternal || isPublished, isTrue);
+          }
+          published.add(package.name);
+        }
+      });
+
+      test('w/ cyclic dependencies', () {
+        final packages = [
+          _dummyPackage('a', deps: ['b']),
+          _dummyPackage('b', deps: ['a']),
+        ];
+        expect(
+          () => sortPackagesTopologically<Pubspec>(packages, (pkg) => pkg),
+          throwsCyclicError,
+        );
+      });
+    });
+  });
+}
+
+Pubspec _dummyPackage(String name, {List<String> deps = const []}) {
+  return Pubspec(
+    name,
+    devDependencies: {},
+    dependencies: {
+      for (final dep in deps) dep: HostedDependency(),
+    },
+    dependencyOverrides: {},
+    version: Version(1, 0, 0),
+    publishTo: null,
+  );
+}

--- a/packages/api/amplify_api_ios/example/pubspec.yaml
+++ b/packages/api/amplify_api_ios/example/pubspec.yaml
@@ -1,6 +1,7 @@
 name: amplify_api_ios_example
 description: Test bed for amplify_api_ios
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/api/amplify_api_ios
+publish_to: none
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
Adds a `publish` command to `aft` which operates similarly to `melos publish` but will be extended to add build_runner + other pre-publish integrations.