### PR TITLE
fix(datastore): delete test fix

### DIFF
--- a/packages/amplify_datastore/example/integration_test/delete_test.dart
+++ b/packages/amplify_datastore/example/integration_test/delete_test.dart
@@ -35,9 +35,11 @@ void main() {
       const originalBlogName = 'non matching blog';
       Blog testBlog = Blog(name: originalBlogName);
       await Amplify.DataStore.save(testBlog);
-
-      await Amplify.DataStore.delete(testBlog,
-          where: Blog.NAME.contains("Predicate"));
+      expect(
+        Amplify.DataStore.delete(testBlog,
+            where: Blog.NAME.contains("Predicate")),
+        throwsA(isA<DataStoreException>()),
+      );
       var blogs = await Amplify.DataStore.query(Blog.classType);
       expect(blogs.length, 1);
       expect(blogs[0].name, originalBlogName);


### PR DESCRIPTION
*Description of changes:*
Fixes datastore delete test by expecting a DatastoreException on non-matching predicate failure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
