### PR TITLE
chore(amplify): remove redundant AWSCognitoAuthPlugin dependency

### DIFF
--- a/packages/amplify/amplify_flutter_ios/ios/Classes/SwiftAmplify.swift
+++ b/packages/amplify/amplify_flutter_ios/ios/Classes/SwiftAmplify.swift
@@ -16,7 +16,6 @@
 import Flutter
 import UIKit
 import Amplify
-import AmplifyPlugins
 import AWSPluginsCore
 
 public class SwiftAmplify: NSObject, FlutterPlugin {

--- a/packages/amplify/amplify_flutter_ios/ios/amplify_flutter_ios.podspec
+++ b/packages/amplify/amplify_flutter_ios/ios/amplify_flutter_ios.podspec
@@ -17,7 +17,6 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   s.dependency 'Amplify', '1.23.0'
   s.dependency 'AWSPluginsCore', '1.23.0'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.23.0'
   s.platform = :ios, '11.0'
   s.swift_version = '5.0'
 

--- a/packages/auth/amplify_auth_cognito_ios/ios/Classes/SwiftAuthCognito.swift
+++ b/packages/auth/amplify_auth_cognito_ios/ios/Classes/SwiftAuthCognito.swift
@@ -16,7 +16,6 @@
 import Flutter
 import UIKit
 import Amplify
-import AmplifyPlugins
 import AWSPluginsCore
 import amplify_flutter_ios
 

--- a/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
+++ b/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
@@ -17,7 +17,6 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'Amplify', '1.23.0'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.23.0'
   s.dependency 'amplify_flutter_ios'
   
   # These are needed to support async/await and ASWebAuthenticationSession

--- a/packages/storage/amplify_storage_s3_ios/ios/Classes/AmplifyStorageOperations.swift
+++ b/packages/storage/amplify_storage_s3_ios/ios/Classes/AmplifyStorageOperations.swift
@@ -17,7 +17,6 @@ import Flutter
 import UIKit
 import Amplify
 import AmplifyPlugins
-import AWSMobileClient
 import amplify_flutter_ios
 
 public class AmplifyStorageOperations {

--- a/packages/storage/amplify_storage_s3_ios/ios/Classes/SwiftStorageS3.swift
+++ b/packages/storage/amplify_storage_s3_ios/ios/Classes/SwiftStorageS3.swift
@@ -17,7 +17,6 @@ import Flutter
 import UIKit
 import Amplify
 import AmplifyPlugins
-import AWSMobileClient
 import amplify_flutter_ios
 
 public class SwiftStorageS3: NSObject, FlutterPlugin {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove redundant pod dependency `AWSCognitoAuthPlugin` from `amplify` and `auth` packages. This amplify-ios plugin package should not be used going forward.

Remove unused reference of `AWSMobileClient` from s3 iOS implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
