### PR TITLE
chore(auth): enable integration tests in CI

### DIFF
--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scope: ["amplify_api_example", "amplify_storage_s3_example"] # , "amplify_auth_cognito_example"]
+        scope: ["amplify_api_example", "amplify_storage_s3_example", "amplify_auth_cognito_example"]
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
         with:
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scope: ["amplify_api_example", "amplify_storage_s3_example"] # "amplify_auth_cognito_example"]
+        scope: ["amplify_api_example", "amplify_storage_s3_example", "amplify_auth_cognito_example"]
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
         with:

--- a/packages/auth/amplify_auth_cognito/example/tool/pull_test_backend.sh
+++ b/packages/auth/amplify_auth_cognito/example/tool/pull_test_backend.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+APP_ID=$AUTH_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 


### PR DESCRIPTION
Enables integration tests in CI for auth category.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
