### PR TITLE
fix: DDC build issue

### DIFF
--- a/packages/amplify_core/lib/src/types/auth/attribute/auth_next_update_attribute_step.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/auth_next_update_attribute_step.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/auth_code_delivery_details.dart';
+import 'package:amplify_core/src/types/auth/auth_next_step.dart';
+import 'package:amplify_core/src/util/serializable.dart';
 
 part 'auth_next_update_attribute_step.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/attribute/user_attribute_key.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'auth_user_attribute.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/attribute/cognito_user_attribute_key.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/cognito_user_attribute_key.dart
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/attribute/user_attribute_key.dart';
+import 'package:aws_common/aws_common.dart';
 import 'package:meta/meta.dart';
 
 /// User attributes available for configuring via `Amplify.Auth.signUp`,

--- a/packages/amplify_core/lib/src/types/auth/attribute/confirm_user_attribute_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/confirm_user_attribute_request.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/auth_types.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'confirm_user_attribute_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/attribute/fetch_user_attributes_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/fetch_user_attributes_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 /// {@template amplify_core.fetch_user_attributes_options}
 /// The shared fetch user attributes options among all Auth plugins.

--- a/packages/amplify_core/lib/src/types/auth/attribute/fetch_user_attributes_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/fetch_user_attributes_request.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/attribute/fetch_user_attributes_options.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'fetch_user_attributes_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/attribute/resend_user_attribute_confirmation_code_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/resend_user_attribute_confirmation_code_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 /// {@template amplify_core.resend_user_attribute_confirmation_code_options}
 /// The shared resend user attribute confirmation code options among all Auth

--- a/packages/amplify_core/lib/src/types/auth/attribute/resend_user_attribute_confirmation_code_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/resend_user_attribute_confirmation_code_request.dart
@@ -13,7 +13,10 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/attribute/resend_user_attribute_confirmation_code_options.dart';
+import 'package:amplify_core/src/types/auth/attribute/user_attribute_key.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'resend_user_attribute_confirmation_code_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/attribute/resend_user_attribute_confirmation_code_result.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/resend_user_attribute_confirmation_code_result.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/auth_code_delivery_details.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'resend_user_attribute_confirmation_code_result.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 /// {@template amplify_core.update_user_attribute_options}
 /// The shared update user attribute options among all Auth plugins.

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_request.dart
@@ -13,7 +13,10 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/attribute/auth_user_attribute.dart';
+import 'package:amplify_core/src/types/auth/attribute/update_user_attribute_options.dart';
+import 'package:amplify_core/src/types/auth/attribute/user_attribute_key.dart';
+import 'package:aws_common/aws_common.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'update_user_attribute_request.g.dart';

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_result.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_result.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/attribute/auth_next_update_attribute_step.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'update_user_attribute_result.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attributes_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attributes_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 /// {@template amplify_core.update_user_attributes_options}
 /// The shared update user attributes options among all Auth plugins.

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attributes_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attributes_request.dart
@@ -13,7 +13,11 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/attribute/auth_user_attribute.dart';
+import 'package:amplify_core/src/types/auth/attribute/update_user_attributes_options.dart';
+import 'package:amplify_core/src/types/auth/attribute/user_attribute_key.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'update_user_attributes_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/attribute/user_attribute_key.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/user_attribute_key.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 import 'package:meta/meta.dart';
 
 /// {@template amplify_core.user_attribute_key}

--- a/packages/amplify_core/lib/src/types/auth/auth_code_delivery_details.dart
+++ b/packages/amplify_core/lib/src/types/auth/auth_code_delivery_details.dart
@@ -13,7 +13,8 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'auth_code_delivery_details.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/auth_next_step.dart
+++ b/packages/amplify_core/lib/src/types/auth/auth_next_step.dart
@@ -13,7 +13,8 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/auth_code_delivery_details.dart';
+import 'package:aws_common/aws_common.dart';
 
 abstract class AuthNextStep with AWSSerializable<Map<String, Object?>> {
   const AuthNextStep({this.codeDeliveryDetails, this.additionalInfo});

--- a/packages/amplify_core/lib/src/types/auth/hub/auth_hub_event.dart
+++ b/packages/amplify_core/lib/src/types/auth/hub/auth_hub_event.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/hub/hub_event.dart';
+import 'package:amplify_core/src/types/auth/session/auth_user.dart';
+import 'package:aws_common/aws_common.dart';
 
 /// {@template amplify_common.hub.auth_hub_event_type}
 /// Hub Event types for the Auth category.

--- a/packages/amplify_core/lib/src/types/auth/password/confirm_reset_password_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/confirm_reset_password_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 /// {@template amplify_core.confirm_reset_password_options}
 /// The shared confirm reset password options among all Auth plugins.

--- a/packages/amplify_core/lib/src/types/auth/password/confirm_reset_password_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/confirm_reset_password_request.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/password/confirm_reset_password_options.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'confirm_reset_password_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/password/reset_password_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/reset_password_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 /// {@template amplify_core.reset_password_options}
 /// The shared reset password options among all Auth plugins.

--- a/packages/amplify_core/lib/src/types/auth/password/reset_password_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/reset_password_request.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/password/reset_password_options.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'reset_password_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/password/reset_password_result.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/reset_password_result.dart
@@ -13,7 +13,8 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/password/reset_password_step.dart';
+import 'package:aws_common/aws_common.dart';
 
 /// {@template amplify_core.reset_password_result}
 /// The result of a password reset request.

--- a/packages/amplify_core/lib/src/types/auth/password/reset_password_step.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/reset_password_step.dart
@@ -13,7 +13,10 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/auth_code_delivery_details.dart';
+import 'package:amplify_core/src/types/auth/auth_next_step.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'reset_password_step.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/password/update_password_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/update_password_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 /// {@template amplify_core.update_password_options}
 /// The shared update password options among all Auth plugins.

--- a/packages/amplify_core/lib/src/types/auth/password/update_password_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/update_password_request.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/password/update_password_options.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'update_password_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/password/update_password_result.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/update_password_result.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 /// {@template amplify_core.update_password_result}
 /// The result of an update password request.

--- a/packages/amplify_core/lib/src/types/auth/session/auth_session.dart
+++ b/packages/amplify_core/lib/src/types/auth/session/auth_session.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 abstract class AuthSession with AWSSerializable<Map<String, Object?>> {
   const AuthSession({

--- a/packages/amplify_core/lib/src/types/auth/session/auth_session_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/session/auth_session_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 abstract class AuthSessionOptions with AWSSerializable<Map<String, Object?>> {
   const AuthSessionOptions();

--- a/packages/amplify_core/lib/src/types/auth/session/auth_session_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/session/auth_session_request.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/session/auth_session_options.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'auth_session_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/session/auth_user.dart
+++ b/packages/amplify_core/lib/src/types/auth/session/auth_user.dart
@@ -13,7 +13,8 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'auth_user.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/session/auth_user_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/session/auth_user_options.dart
@@ -12,7 +12,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-import 'package:amplify_core/amplify_core.dart';
+
+import 'package:aws_common/aws_common.dart';
 
 abstract class AuthUserOptions with AWSSerializable<Map<String, Object?>> {
   const AuthUserOptions();

--- a/packages/amplify_core/lib/src/types/auth/session/auth_user_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/session/auth_user_request.dart
@@ -12,6 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 import 'auth_user_options.dart';
 
 class AuthUserRequest {

--- a/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.dart
@@ -13,7 +13,11 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/attribute/user_attribute_key.dart';
+import 'package:amplify_core/src/types/auth/auth_code_delivery_details.dart';
+import 'package:amplify_core/src/types/auth/auth_next_step.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'auth_next_sign_in_step.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/sign_in/confirm_sign_in_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/confirm_sign_in_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 abstract class ConfirmSignInOptions with AWSSerializable<Map<String, Object?>> {
   const ConfirmSignInOptions();

--- a/packages/amplify_core/lib/src/types/auth/sign_in/confirm_sign_in_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/confirm_sign_in_request.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/sign_in/confirm_sign_in_options.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'confirm_sign_in_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_options.dart
@@ -12,7 +12,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-import 'package:amplify_core/amplify_core.dart';
+
+import 'package:aws_common/aws_common.dart';
 
 abstract class SignInOptions with AWSSerializable<Map<String, Object?>> {
   const SignInOptions();

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_request.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/sign_in/sign_in_options.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'sign_in_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_result.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_result.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/attribute/user_attribute_key.dart';
+import 'package:amplify_core/src/types/auth/sign_in/auth_next_sign_in_step.dart';
+import 'package:aws_common/aws_common.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'sign_in_result.g.dart';

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_with_web_ui_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_with_web_ui_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 abstract class SignInWithWebUIOptions
     with AWSSerializable<Map<String, Object?>> {

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_with_web_ui_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_with_web_ui_request.dart
@@ -13,7 +13,10 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/sign_in/auth_provider.dart';
+import 'package:amplify_core/src/types/auth/sign_in/sign_in_with_web_ui_options.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'sign_in_with_web_ui_request.g.dart';

--- a/packages/amplify_core/lib/src/types/auth/sign_out/sign_out_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_out/sign_out_options.dart
@@ -13,7 +13,8 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'sign_out_options.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/sign_out/sign_out_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_out/sign_out_request.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/sign_out/sign_out_options.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'sign_out_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/sign_out/sign_out_result.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_out/sign_out_result.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 class SignOutResult with AWSEquatable<SignOutResult>, AWSDebuggable {
   const SignOutResult();

--- a/packages/amplify_core/lib/src/types/auth/sign_up/auth_next_sign_up_step.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/auth_next_sign_up_step.dart
@@ -13,7 +13,10 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/auth_code_delivery_details.dart';
+import 'package:amplify_core/src/types/auth/auth_next_step.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'auth_next_sign_up_step.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/sign_up/confirm_sign_up_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/confirm_sign_up_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 /// {@template amplify_core.types.auth.cognito_confirm_sign_up_options}
 /// Options passed to `Amplify.Auth.confirmSignUp`.

--- a/packages/amplify_core/lib/src/types/auth/sign_up/confirm_sign_up_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/confirm_sign_up_request.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/sign_up/confirm_sign_up_options.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'confirm_sign_up_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/sign_up/resend_sign_up_code_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/resend_sign_up_code_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 /// {@template amplify_core.auth.resend_sign_up_code_options}
 /// The shared resend sign up code options among all Auth plugins.

--- a/packages/amplify_core/lib/src/types/auth/sign_up/resend_sign_up_code_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/resend_sign_up_code_request.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/sign_up/resend_sign_up_code_options.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'resend_sign_up_code_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/sign_up/resend_sign_up_code_result.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/resend_sign_up_code_result.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/auth_code_delivery_details.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'resend_sign_up_code_result.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_options.dart
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
 
 abstract class SignUpOptions with AWSSerializable<Map<String, Object?>> {
   final Map<String, String> userAttributes;

--- a/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_request.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/sign_up/sign_up_options.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'sign_up_request.g.dart';
 

--- a/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_result.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_result.dart
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/auth/sign_up/auth_next_sign_up_step.dart';
+import 'package:amplify_core/src/util/serializable.dart';
+import 'package:aws_common/aws_common.dart';
 
 part 'sign_up_result.g.dart';
 


### PR DESCRIPTION
**ISSUE**: https://github.com/dart-lang/sdk/issues/49484

This fixes a pretty weird issue in DDC, similar to this one: https://github.com/dart-lang/sdk/issues/47645. I say similar because, despite my best efforts, I haven't been able to reproduce it outside our repo. The issue has to do with the ordering of statements in compiled DDC modules - for example, a constructor calling another constructor which hasn't been defined yet. In all my reproductions, the ordering was correct, so I'm not sure what is special with our set up.

As noted by a Dart team member [here](https://github.com/dart-lang/sdk/issues/47645#issuecomment-967718351), DDC modules are created with all interdependent types in a package. So, one way to reduce DDC compile errors due to module ordering is to reduce the number of interdependencies i.e. cyclic imports.

This "fix", then, is simply to remove bulk imports in the Auth types which were causing the issue, reducing the average size of the compiled DDC modules. Luckily, this fixes the issue for now.