### PR TITLE
fix(auth): removes success precondition from CredentialStoreClearCredentials event

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/credential_store_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/credential_store_event.dart
@@ -212,9 +212,6 @@ class CredentialStoreClearCredentials extends CredentialStoreEvent {
         'Credential store has error. Re-load before continuing.',
       );
     }
-    if (currentState.type != CredentialStoreStateType.success) {
-      return const AuthPreconditionException('Credential store is busy');
-    }
     return null;
   }
 }


### PR DESCRIPTION
*Description of changes:*

Integration tests were failed on a 'Credential store is busy` exception. The event to clear credentails was being rejected instead of queued in the sign in state machine because the storeCredentials event was still processing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
