### PR TITLE
fix: DDC compile issue

### DIFF
--- a/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute.dart
@@ -23,7 +23,8 @@ part 'auth_user_attribute.g.dart';
 @zAmplifyGenericSerializable
 class AuthUserAttribute<Key extends UserAttributeKey>
     with
-        AWSEquatable<AuthUserAttribute<UserAttributeKey>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<AuthUserAttribute<Key>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   /// {@macro amplify_core.auth.auth_user_attribute}

--- a/packages/amplify_core/lib/src/types/auth/attribute/confirm_user_attribute_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/confirm_user_attribute_request.dart
@@ -23,7 +23,8 @@ part 'confirm_user_attribute_request.g.dart';
 @zAmplifyGenericSerializable
 class ConfirmUserAttributeRequest<Key extends UserAttributeKey>
     with
-        AWSEquatable<ConfirmUserAttributeRequest<UserAttributeKey>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<ConfirmUserAttributeRequest<Key>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   /// {@macro amplify_core.confirm_user_attribute_request}

--- a/packages/amplify_core/lib/src/types/auth/attribute/fetch_user_attributes_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/fetch_user_attributes_request.dart
@@ -23,7 +23,8 @@ part 'fetch_user_attributes_request.g.dart';
 @zAmplifyGenericSerializable
 class FetchUserAttributesRequest<Options extends FetchUserAttributesOptions>
     with
-        AWSEquatable<FetchUserAttributesRequest<FetchUserAttributesOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<FetchUserAttributesRequest<Options>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   /// {@macro amplify_core.fetch_user_attribute_request}

--- a/packages/amplify_core/lib/src/types/auth/attribute/resend_user_attribute_confirmation_code_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/resend_user_attribute_confirmation_code_request.dart
@@ -25,9 +25,8 @@ part 'resend_user_attribute_confirmation_code_request.g.dart';
 class ResendUserAttributeConfirmationCodeRequest<Key extends UserAttributeKey,
         Options extends ResendUserAttributeConfirmationCodeOptions>
     with
-        AWSEquatable<
-            ResendUserAttributeConfirmationCodeRequest<UserAttributeKey,
-                ResendUserAttributeConfirmationCodeOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<ResendUserAttributeConfirmationCodeRequest<Key, Options>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   /// {@macro amplify_core.resend_user_attribute_confirmation_code_request}

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_request.dart
@@ -30,6 +30,7 @@ part 'update_user_attribute_request.g.dart';
 class UpdateUserAttributeRequest<Key extends UserAttributeKey,
         Options extends UpdateUserAttributeOptions>
     with
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
         AWSEquatable<UpdateUserAttributeRequest<Key, Options>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attributes_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attributes_request.dart
@@ -24,9 +24,8 @@ part 'update_user_attributes_request.g.dart';
 class UpdateUserAttributesRequest<Key extends UserAttributeKey,
         Options extends UpdateUserAttributesOptions>
     with
-        AWSEquatable<
-            UpdateUserAttributesRequest<UserAttributeKey,
-                UpdateUserAttributesOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<UpdateUserAttributesRequest<Key, Options>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   /// {@macro amplify_core.update_user_attributes_request}

--- a/packages/amplify_core/lib/src/types/auth/password/confirm_reset_password_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/confirm_reset_password_request.dart
@@ -23,7 +23,8 @@ part 'confirm_reset_password_request.g.dart';
 @zAmplifyGenericSerializable
 class ConfirmResetPasswordRequest<Options extends ConfirmResetPasswordOptions>
     with
-        AWSEquatable<ConfirmResetPasswordRequest<ConfirmResetPasswordOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<ConfirmResetPasswordRequest<Options>>,
         AWSSerializable<Map<String, Object?>> {
   /// {@macro amplify_core.confirm_reset_password_request}
   const ConfirmResetPasswordRequest({

--- a/packages/amplify_core/lib/src/types/auth/password/reset_password_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/reset_password_request.dart
@@ -23,7 +23,8 @@ part 'reset_password_request.g.dart';
 @zAmplifyGenericSerializable
 class ResetPasswordRequest<Options extends ResetPasswordOptions>
     with
-        AWSEquatable<ResetPasswordRequest<ResetPasswordOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<ResetPasswordRequest<Options>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   /// {@macro amplify_core.reset_password_request}

--- a/packages/amplify_core/lib/src/types/auth/password/update_password_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/update_password_request.dart
@@ -23,7 +23,8 @@ part 'update_password_request.g.dart';
 @zAmplifyGenericSerializable
 class UpdatePasswordRequest<Options extends UpdatePasswordOptions>
     with
-        AWSEquatable<UpdatePasswordRequest<UpdatePasswordOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<UpdatePasswordRequest<Options>>,
         AWSSerializable<Map<String, Object?>> {
   /// {@macro amplify_core.update_password_request}
   const UpdatePasswordRequest({

--- a/packages/amplify_core/lib/src/types/auth/session/auth_session_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/session/auth_session_request.dart
@@ -20,7 +20,8 @@ part 'auth_session_request.g.dart';
 @zAmplifyGenericSerializable
 class AuthSessionRequest<Options extends AuthSessionOptions>
     with
-        AWSEquatable<AuthSessionRequest<AuthSessionOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<AuthSessionRequest<Options>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   const AuthSessionRequest({this.options});

--- a/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.dart
@@ -19,7 +19,10 @@ part 'auth_next_sign_in_step.g.dart';
 
 @zAmplifyGenericSerializable
 class AuthNextSignInStep<Key extends UserAttributeKey> extends AuthNextStep
-    with AWSEquatable<AuthNextSignInStep<UserAttributeKey>>, AWSDebuggable {
+    with
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<AuthNextSignInStep<Key>>,
+        AWSDebuggable {
   const AuthNextSignInStep({
     super.additionalInfo,
     super.codeDeliveryDetails,

--- a/packages/amplify_core/lib/src/types/auth/sign_in/confirm_sign_in_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/confirm_sign_in_request.dart
@@ -20,7 +20,8 @@ part 'confirm_sign_in_request.g.dart';
 @zAmplifyGenericSerializable
 class ConfirmSignInRequest<Options extends ConfirmSignInOptions>
     with
-        AWSEquatable<ConfirmSignInRequest<ConfirmSignInOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<ConfirmSignInRequest<Options>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   const ConfirmSignInRequest({required this.confirmationValue, this.options});

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_request.dart
@@ -20,7 +20,8 @@ part 'sign_in_request.g.dart';
 @zAmplifyGenericSerializable
 class SignInRequest<Options extends SignInOptions>
     with
-        AWSEquatable<SignInRequest<SignInOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<SignInRequest<Options>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   const SignInRequest({this.username, this.password, this.options});

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_result.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_result.dart
@@ -27,6 +27,7 @@ part 'sign_in_result.g.dart';
 )
 class SignInResult<Key extends UserAttributeKey>
     with
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
         AWSEquatable<SignInResult<Key>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_with_web_ui_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_with_web_ui_request.dart
@@ -21,7 +21,8 @@ part 'sign_in_with_web_ui_request.g.dart';
 @zAmplifyGenericSerializable
 class SignInWithWebUIRequest<Options extends SignInWithWebUIOptions>
     with
-        AWSEquatable<SignInWithWebUIRequest<SignInWithWebUIOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<SignInWithWebUIRequest<Options>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   const SignInWithWebUIRequest({this.provider, this.options});

--- a/packages/amplify_core/lib/src/types/auth/sign_up/confirm_sign_up_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/confirm_sign_up_request.dart
@@ -20,7 +20,8 @@ part 'confirm_sign_up_request.g.dart';
 @zAmplifyGenericSerializable
 class ConfirmSignUpRequest<Options extends ConfirmSignUpOptions>
     with
-        AWSEquatable<ConfirmSignUpRequest<ConfirmSignUpOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<ConfirmSignUpRequest<Options>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   const ConfirmSignUpRequest({

--- a/packages/amplify_core/lib/src/types/auth/sign_up/resend_sign_up_code_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/resend_sign_up_code_request.dart
@@ -23,7 +23,8 @@ part 'resend_sign_up_code_request.g.dart';
 @zAmplifyGenericSerializable
 class ResendSignUpCodeRequest<Options extends ResendSignUpCodeOptions>
     with
-        AWSEquatable<ResendSignUpCodeRequest<ResendSignUpCodeOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<ResendSignUpCodeRequest<Options>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   /// {@macro amplify_core.auth.resend_sign_up_code_request}

--- a/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_request.dart
@@ -20,7 +20,8 @@ part 'sign_up_request.g.dart';
 @zAmplifyGenericSerializable
 class SignUpRequest<Options extends SignUpOptions>
     with
-        AWSEquatable<SignUpRequest<SignUpOptions>>,
+        // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
+        AWSEquatable<SignUpRequest<Options>>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   const SignUpRequest({

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -539,7 +539,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
   }
 
   @override
-  Future<List<AuthUserAttribute>> fetchUserAttributes({
+  Future<List<AuthUserAttribute<CognitoUserAttributeKey>>> fetchUserAttributes({
     FetchUserAttributesRequest? request,
   }) async {
     final userPoolTokens = await getUserPoolTokens();

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
@@ -81,7 +81,7 @@ extension AuthUserAttributeBridge on AuthUserAttribute {
 /// Bridging helpers for [AttributeType].
 extension AttributeTypeBridge on AttributeType {
   /// This attribute as an [AuthUserAttribute].
-  AuthUserAttribute get asAuthUserAttribute {
+  AuthUserAttribute<CognitoUserAttributeKey> get asAuthUserAttribute {
     final key = CognitoUserAttributeKey.parse(name);
     return AuthUserAttribute(
       userAttributeKey: key,


### PR DESCRIPTION
**ISSUE**: https://github.com/dart-lang/sdk/issues/49484

Workaround for DDC compiler issue. Compares classes with generic arguments on their subclass and not on the base class (which would be preferable in cases where the exact subtype is erased).