### PR TITLE
fix(authenticator): taps on widgets before entering text

### DIFF
--- a/packages/amplify_authenticator/example/integration_test/pages/confirm_sign_in_page.dart
+++ b/packages/amplify_authenticator/example/integration_test/pages/confirm_sign_in_page.dart
@@ -28,6 +28,8 @@ class ConfirmSignInPage extends AuthenticatorPage {
 
   Finder get newPasswordField =>
       find.byKey(keyNewPasswordConfirmSignInFormField);
+  Finder get confirmNewPasswordField =>
+      find.byKey(keyConfirmNewPasswordConfirmSignInFormField);
   Finder get verificationField => find.byKey(keyCodeConfirmSignInFormField);
   Finder get confirmSignInButton => find.byKey(keyConfirmSignInButton);
   Finder get backToSignIn => find.byKey(keyBackToSignInButton);
@@ -64,16 +66,18 @@ class ConfirmSignInPage extends AuthenticatorPage {
 
   /// When I enter a new password
   Future<void> enterNewPassword(String password) async {
+    await tester.tap(newPasswordField);
     await tester.enterText(
-      find.byKey(keyNewPasswordConfirmSignInFormField),
+      newPasswordField,
       password,
     );
   }
 
   /// When I confirm a new password
   Future<void> enterPasswordConfirmation(String password) async {
+    await tester.tap(confirmNewPasswordField);
     await tester.enterText(
-      find.byKey(keyConfirmNewPasswordConfirmSignInFormField),
+      confirmNewPasswordField,
       password,
     );
   }

--- a/packages/amplify_authenticator/example/integration_test/pages/sign_up_page.dart
+++ b/packages/amplify_authenticator/example/integration_test/pages/sign_up_page.dart
@@ -37,16 +37,19 @@ class SignUpPage extends AuthenticatorPage {
 
   /// When I type a new "username"
   Future<void> enterUsername(String username) async {
+    await tester.tap(usernameField);
     await tester.enterText(usernameField, username);
   }
 
   /// When I type my password
   Future<void> enterPassword(String password) async {
+    await tester.tap(passwordField);
     await tester.enterText(passwordField, password);
   }
 
   /// When I type my password confirmation
   Future<void> enterPasswordConfirmation(String password) async {
+    await tester.tap(confirmPasswordField);
     await tester.enterText(confirmPasswordField, password);
   }
 


### PR DESCRIPTION
*Description of changes:*
Fixes 3 integ test failures on desktop. These tests passed on mobile, but on macos integ tests there appeared to be some sort of race condition preventing text from being entered into fields.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
