### PR TITLE
chore(auth): Better Lambda error handling

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
@@ -16,7 +16,6 @@ import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_auth_cognito_dart/src/credentials/cognito_keys.dart';
 import 'package:amplify_auth_cognito_dart/src/crypto/oauth.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/hosted_ui_config.dart';
-import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 import 'package:http/http.dart' as http;
@@ -47,15 +46,6 @@ abstract class HostedUiPlatform {
 
   /// The dependency token for [HostedUiPlatform].
   static const token = Token<HostedUiPlatform>([Token<DependencyManager>()]);
-
-  /// Used to match errors returned from Hosted UI exchanges for errors
-  /// originating in user-defined Lambda triggers.
-  ///
-  /// This is the only way to check for these currently since Cognito does not
-  /// send back any special code to distinguish these from other, more general
-  /// errors.
-  static final RegExp _lambdaErrorRegex =
-      RegExp(r'^\w+ failed with error (.*)\. $');
 
   /// The Hosted UI configuration.
   @protected
@@ -230,9 +220,8 @@ abstract class HostedUiPlatform {
       final errorDesc = parameters.errorDescription ?? error.description;
 
       // Handle Lambda exceptions
-      final lambdaMessage = _lambdaErrorRegex.firstMatch(errorDesc)?.group(1);
-      if (lambdaMessage != null) {
-        throw UnexpectedLambdaException(message: lambdaMessage);
+      if (LambdaException.isLambdaException(errorDesc)) {
+        throw LambdaException(errorDesc);
       }
 
       final errorUri = parameters.errorUri;

--- a/packages/auth/amplify_auth_cognito_dart/test/sdk/sdk_exception_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/sdk/sdk_exception_test.dart
@@ -1,0 +1,40 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LambdaException', () {
+    const error = 'something bad happened';
+    const message = 'PreConfirmation failed with error $error.';
+
+    test('matches string', () {
+      expect(LambdaException.isLambdaException(message), isTrue);
+
+      final exception = LambdaException(message);
+      expect(exception.message, error);
+      expect(exception.lambdaName, 'PreConfirmation');
+    });
+
+    test('matches exception', () {
+      final wrapped = UserNotConfirmedException(message: message);
+      expect(LambdaException.isLambdaException(wrapped.toString()), isTrue);
+
+      final exception = LambdaException(wrapped.toString());
+      expect(exception.message, error);
+      expect(exception.lambdaName, 'PreConfirmation');
+    });
+  });
+}


### PR DESCRIPTION
Adds better error handling around Lambda errors thrown from non-hosted UI methods. Un-deprecates the `LambdaException` class since it actually provides a lot of utility and makes it easy for users to catch when they're only concerned with whether an error originated in a lambda.