### PR TITLE
fix(storage): throw pluginNotAddedException when storage plugin not c…

### DIFF
--- a/packages/amplify_core/lib/src/category/amplify_storage_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_storage_category.dart
@@ -27,22 +27,30 @@ class StorageCategory extends AmplifyCategory<StoragePluginInterface> {
       UploadFileOptions? options}) {
     final UploadFileRequest request =
         UploadFileRequest(local: local, key: key, options: options);
-    return plugins[0].uploadFile(request: request, onProgress: onProgress);
+    return plugins.length == 1
+        ? plugins[0].uploadFile(request: request, onProgress: onProgress)
+        : throw _pluginNotAddedException('Storage');
   }
 
   Future<GetUrlResult> getUrl({required String key, GetUrlOptions? options}) {
     final GetUrlRequest request = GetUrlRequest(key: key, options: options);
-    return plugins[0].getUrl(request: request);
+    return plugins.length == 1
+        ? plugins[0].getUrl(request: request)
+        : throw _pluginNotAddedException('Storage');
   }
 
   Future<RemoveResult> remove({required String key, RemoveOptions? options}) {
     final RemoveRequest request = RemoveRequest(key: key, options: options);
-    return plugins[0].remove(request: request);
+    return plugins.length == 1
+        ? plugins[0].remove(request: request)
+        : throw _pluginNotAddedException('Storage');
   }
 
   Future<ListResult> list({String? path, ListOptions? options}) {
     final ListRequest request = ListRequest(path: path, options: options);
-    return plugins[0].list(request: request);
+    return plugins.length == 1
+        ? plugins[0].list(request: request)
+        : throw _pluginNotAddedException('Storage');
   }
 
   Future<DownloadFileResult> downloadFile(
@@ -52,6 +60,8 @@ class StorageCategory extends AmplifyCategory<StoragePluginInterface> {
       DownloadFileOptions? options}) {
     final DownloadFileRequest request =
         DownloadFileRequest(key: key, local: local, options: options);
-    return plugins[0].downloadFile(request: request, onProgress: onProgress);
+    return plugins.length == 1
+        ? plugins[0].downloadFile(request: request, onProgress: onProgress)
+        : throw _pluginNotAddedException('Storage');
   }
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
@@ -56,7 +56,7 @@ void main() async {
     }
 
     setUpAll(() async {
-      Amplify.addPlugins([AmplifyAuthCognito(), AmplifyStorageS3()]);
+      await Amplify.addPlugins([AmplifyAuthCognito(), AmplifyStorageS3()]);
       await Amplify.configure(amplifyconfig);
 
       await deleteAllGuestFiles();


### PR DESCRIPTION
Issue #1875

This PR improves error handling for storage category when plugin has not been added. Other categories have this check in core to ensure there is a plugin configured before calling a method on the plugin. Storage didn't have it, which gives an inconsistent error message in that scenario. This PR adds the same logic to storage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
