### PR TITLE
chore(api): add field to schema in provision script

### DIFF
--- a/packages/api/amplify_api/example/tool/schema.graphql
+++ b/packages/api/amplify_api/example/tool/schema.graphql
@@ -27,6 +27,7 @@ type Post @model {
   title: String!
   rating: Int!
   created: AWSDateTime
+  likeCount: Int
   blogID: ID! @index(name: "byBlog")
   blog: Blog @belongsTo(fields: ["blogID"])
   comments: [Comment] @hasMany(indexName: "byPost", fields: ["id"])


### PR DESCRIPTION
API integration tests were failing. This was because they use codegen models from amplify_test package, where another field was added to the schema. The provisioned backend didn't have that field, so appsync was giving some errors when trying to include in a selection set (which the model helpers will do from codegen models). To fix it, you can just add that field to the backend. This PR adds in provision script so it will be fixed in any newly provisioned backend.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
