### PR TITLE
fix(auth): Fix typo

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -676,7 +676,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
   Future<CognitoResetPasswordResult> resetPassword({
     required ResetPasswordRequest request,
   }) async {
-    final options = request.options as CognitoResendSignUpCodeOptions?;
+    final options = request.options as CognitoResetPasswordOptions?;
     final result = await _cognitoIdp.forgotPassword(
       cognito.ForgotPasswordRequest.build((b) {
         b


### PR DESCRIPTION
Fixes a typo in the options type for `resetPassword`
