### PR TITLE
feat(auth,api): cognito user pools auth provider & auth mode for API HTTP requests

### DIFF
--- a/packages/api/amplify_api/lib/src/decorators/authorize_http_request.dart
+++ b/packages/api/amplify_api/lib/src/decorators/authorize_http_request.dart
@@ -64,8 +64,14 @@ Future<http.BaseRequest> authorizeHttpRequest(http.BaseRequest request,
       return authorizedRequest.httpRequest;
     case APIAuthorizationType.function:
     case APIAuthorizationType.oidc:
-    case APIAuthorizationType.userPools:
       throw UnimplementedError('${authType.name} not implemented.');
+    case APIAuthorizationType.userPools:
+      final authProvider = _validateAuthProvider(
+          authProviderRepo.getAuthProvider(authType.authProviderToken),
+          authType) as TokenAmplifyAuthProvider;
+      final authorizedRequest =
+          await authProvider.authorizeRequest(_httpToAWSRequest(request));
+      return authorizedRequest.httpRequest;
     case APIAuthorizationType.none:
       return request;
   }

--- a/packages/api/amplify_api/lib/src/decorators/authorize_http_request.dart
+++ b/packages/api/amplify_api/lib/src/decorators/authorize_http_request.dart
@@ -67,8 +67,9 @@ Future<http.BaseRequest> authorizeHttpRequest(http.BaseRequest request,
       throw UnimplementedError('${authType.name} not implemented.');
     case APIAuthorizationType.userPools:
       final authProvider = _validateAuthProvider(
-          authProviderRepo.getAuthProvider(authType.authProviderToken),
-          authType) as TokenAmplifyAuthProvider;
+        authProviderRepo.getAuthProvider(authType.authProviderToken),
+        authType,
+      );
       final authorizedRequest =
           await authProvider.authorizeRequest(_httpToAWSRequest(request));
       return authorizedRequest.httpRequest;

--- a/packages/api/amplify_api/test/authorize_http_request_test.dart
+++ b/packages/api/amplify_api/test/authorize_http_request_test.dart
@@ -34,8 +34,10 @@ void main() {
 
   setUpAll(() {
     authProviderRepo
-      ..registerAuthProvider(APIAuthorizationType.apiKey.authProviderToken,
-          AppSyncApiKeyAuthProvider())
+      ..registerAuthProvider(
+        APIAuthorizationType.apiKey.authProviderToken,
+        AppSyncApiKeyAuthProvider(),
+      )
       ..registerAuthProvider(
         APIAuthorizationType.iam.authProviderToken,
         TestIamAuthProvider(),
@@ -151,7 +153,9 @@ void main() {
         authProviderRepo: authProviderRepo,
       );
       expect(
-          authorizedRequest.headers[AWSHeaders.authorization], testAccessToken);
+        authorizedRequest.headers[AWSHeaders.authorization],
+        testAccessToken,
+      );
     });
 
     test('authorizes with OIDC auth mode', () {}, skip: true);

--- a/packages/api/amplify_api/test/util.dart
+++ b/packages/api/amplify_api/test/util.dart
@@ -17,6 +17,8 @@ import 'package:aws_signature_v4/aws_signature_v4.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 
+const testAccessToken = 'test-access-token-123';
+
 class TestIamAuthProvider extends AWSIamAmplifyAuthProvider {
   @override
   Future<AWSCredentials> retrieve() async {
@@ -40,6 +42,13 @@ class TestIamAuthProvider extends AWSIamAmplifyAuthProvider {
       request,
       credentialScope: scope,
     );
+  }
+}
+
+class TestTokenAuthProvider extends TokenAmplifyAuthProvider {
+  @override
+  Future<String> getLatestAuthToken() async {
+    return testAccessToken;
   }
 }
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -51,6 +51,7 @@ import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart
 import 'package:amplify_auth_cognito_dart/src/sdk/sdk_bridge.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_auth_cognito_dart/src/util/cognito_iam_auth_provider.dart';
+import 'package:amplify_auth_cognito_dart/src/util/cognito_user_pools_auth_provider.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 import 'package:built_collection/built_collection.dart';
@@ -180,10 +181,15 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
 
     // Register auth providers to provide auth functionality to other plugins
     // without requiring other plugins to call `Amplify.Auth...` directly.
-    authProviderRepo.registerAuthProvider(
-      APIAuthorizationType.iam.authProviderToken,
-      CognitoIamAuthProvider(),
-    );
+    authProviderRepo
+      ..registerAuthProvider(
+        APIAuthorizationType.iam.authProviderToken,
+        CognitoIamAuthProvider(),
+      )
+      ..registerAuthProvider(
+        APIAuthorizationType.userPools.authProviderToken,
+        CognitoUserPoolsAuthProvider(),
+      );
 
     if (_stateMachine.getOrCreate(AuthStateMachine.type).currentState.type !=
         AuthStateType.notConfigured) {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/util/cognito_user_pools_auth_provider.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/util/cognito_user_pools_auth_provider.dart
@@ -1,0 +1,38 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:meta/meta.dart';
+
+/// [AmplifyAuthProvider] implementation that adds access token to request headers.
+@internal
+class CognitoUserPoolsAuthProvider extends TokenAmplifyAuthProvider {
+  /// Get access token from `Amplify.Auth.fetchAuthSession()`.
+  @override
+  Future<String> getLatestAuthToken() async {
+    final authSession = await Amplify.Auth.fetchAuthSession(
+      options: const CognitoSessionOptions(getAWSCredentials: true),
+    ) as CognitoAuthSession;
+    final token = authSession.userPoolTokens?.accessToken.raw;
+    if (token == null) {
+      throw const AuthException(
+        'Unable to fetch access token while authorizing with Cognito User Pools.',
+      );
+    }
+    return token;
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/util/cognito_user_pools_auth_provider.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/util/cognito_user_pools_auth_provider.dart
@@ -24,9 +24,8 @@ class CognitoUserPoolsAuthProvider extends TokenAmplifyAuthProvider {
   /// Get access token from `Amplify.Auth.fetchAuthSession()`.
   @override
   Future<String> getLatestAuthToken() async {
-    final authSession = await Amplify.Auth.fetchAuthSession(
-      options: const CognitoSessionOptions(getAWSCredentials: true),
-    ) as CognitoAuthSession;
+    final authSession =
+        await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
     final token = authSession.userPoolTokens?.accessToken.raw;
     if (token == null) {
       throw const AuthException(


### PR DESCRIPTION
This PR enables cognito user pools auth mode in HTTP requests for API category, thus enabling REST and query/mutate in GraphQL. It does so by defining an auth provider in the auth plugin that provides the access token as a header to HTTP requests. In API plugin, that auth provider is used to authorize HTTP requests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
