### PR TITLE
feat(auth): Allow multiple Hosted UI sign-in attempts

### DIFF
--- a/packages/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/amplify_authenticator/lib/amplify_authenticator.dart
@@ -598,7 +598,7 @@ class _AuthenticatorState extends State<Authenticator> {
     _exceptionSub.cancel();
     _infoSub.cancel();
     _successSub.cancel();
-    _stateMachineBloc.dispose();
+    _stateMachineBloc.close();
     _hubSubscription?.cancel();
     super.dispose();
   }

--- a/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -72,6 +72,8 @@ abstract class AuthService {
   Future<AmplifyConfig> waitForConfiguration();
 
   Future<void> rememberDevice();
+
+  Stream<AuthHubEvent> get hubEvents;
 }
 
 class AmplifyAuthService implements AuthService {
@@ -264,6 +266,10 @@ class AmplifyAuthService implements AuthService {
   Future<AmplifyConfig> waitForConfiguration() {
     return Amplify.asyncConfig;
   }
+
+  @override
+  Stream<AuthHubEvent> get hubEvents =>
+      Amplify.Hub.availableStreams[HubChannel.Auth]!.cast();
 }
 
 class GetAttributeVerificationStatusResult {

--- a/packages/amplify_authenticator/lib/src/state/authenticator_state.dart
+++ b/packages/amplify_authenticator/lib/src/state/authenticator_state.dart
@@ -382,11 +382,8 @@ class AuthenticatorState extends ChangeNotifier {
 
   /// Perform sicial sign in with the given provider
   Future<void> signInWithProvider(AuthProvider provider) async {
-    _setIsBusy(true);
     final signInData = AuthSocialSignInData(provider: provider);
     _authBloc.add(AuthSignIn(signInData));
-    await nextBlocEvent();
-    _setIsBusy(false);
   }
 
   /// Sign out the currecnt user

--- a/packages/amplify_authenticator/pubspec.yaml
+++ b/packages/amplify_authenticator/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   amplify_auth_cognito: ">=0.3.0 <0.6.0"
   amplify_core: ">=0.3.0 <0.6.0"
   amplify_flutter: ">=0.3.0 <0.6.0"
+  async: ^2.8.0
   aws_common: ^0.1.0
   collection: ^1.15.0
   flutter:
@@ -21,6 +22,7 @@ dependencies:
   intl: ^0.17.0
   meta: ^1.7.0
   smithy: ^0.1.0
+  stream_transform: ^2.0.0
 
 dev_dependencies:
   amplify_lints:

--- a/packages/amplify_authenticator/test/ui/tab_view_test.dart
+++ b/packages/amplify_authenticator/test/ui/tab_view_test.dart
@@ -248,7 +248,12 @@ void main() {
 
 class MockAuthViewModel extends Mock implements AuthenticatorState {}
 
-class MockBloc implements StateMachineBloc {
+class MockBloc
+    with AWSDebuggable, AmplifyLoggerMixin
+    implements StateMachineBloc {
+  @override
+  String get runtimeTypeName => 'MockBloc';
+
   @override
   void add(AuthEvent event) {}
 
@@ -256,7 +261,7 @@ class MockBloc implements StateMachineBloc {
   AuthState get currentState => UnauthenticatedState.signIn;
 
   @override
-  Future<void> dispose() async {}
+  Future<void> close() async {}
 
   @override
   Stream<AuthenticatorException> get exceptions => const Stream.empty();

--- a/packages/amplify_core/lib/src/config/auth/auth_config.dart
+++ b/packages/amplify_core/lib/src/config/auth/auth_config.dart
@@ -31,6 +31,34 @@ class AuthConfig extends AmplifyPluginConfigMap {
   factory AuthConfig.fromJson(Map<String, Object?> json) =>
       _$AuthConfigFromJson(json);
 
+  /// Creates an [AuthConfig] with the given Cognito configurations.
+  factory AuthConfig.cognito({
+    CognitoUserPoolConfig? userPoolConfig,
+    CognitoIdentityPoolConfig? identityPoolConfig,
+    CognitoOAuthConfig? hostedUiConfig,
+  }) =>
+      AuthConfig(
+        plugins: {
+          CognitoPluginConfig.pluginKey: CognitoPluginConfig(
+            auth: hostedUiConfig == null
+                ? null
+                : AWSConfigMap.withDefault(
+                    CognitoAuthConfig(oAuth: hostedUiConfig)),
+            cognitoUserPool: userPoolConfig == null
+                ? null
+                : AWSConfigMap.withDefault(userPoolConfig),
+            credentialsProvider: identityPoolConfig == null
+                ? null
+                : CredentialsProviders(
+                    AWSConfigMap({
+                      CognitoIdentityCredentialsProvider.configKey:
+                          AWSConfigMap.withDefault(identityPoolConfig),
+                    }),
+                  ),
+          ),
+        },
+      );
+
   /// The AWS Cognito plugin configuration, if available.
   @override
   CognitoPluginConfig? get awsPlugin =>

--- a/packages/amplify_core/lib/src/config/auth/cognito/credentials_provider.dart
+++ b/packages/amplify_core/lib/src/config/auth/cognito/credentials_provider.dart
@@ -17,6 +17,8 @@ import 'package:amplify_core/amplify_core.dart';
 
 part 'credentials_provider.g.dart';
 
+typedef CognitoIdentityPoolConfig = CognitoIdentityCredentialsProvider;
+
 class CredentialsProviders extends AWSConfigMap {
   const CredentialsProviders(
     Map<String, AWSSerializable> providers,
@@ -31,7 +33,7 @@ class CredentialsProviders extends AWSConfigMap {
           '${value.runtimeType} is not a Map',
         );
       }
-      if (key == 'CognitoIdentity') {
+      if (key == CognitoIdentityCredentialsProvider.configKey) {
         final configs = AWSConfigMap.fromJson(
           value,
           (json) =>
@@ -56,6 +58,8 @@ class CredentialsProviders extends AWSConfigMap {
 @zAwsSerializable
 class CognitoIdentityCredentialsProvider
     with AWSEquatable<CognitoIdentityCredentialsProvider>, AWSSerializable {
+  static const configKey = 'CognitoIdentity';
+
   final String poolId;
   final String region;
 

--- a/packages/amplify_core/lib/src/config/config_map.dart
+++ b/packages/amplify_core/lib/src/config/config_map.dart
@@ -71,10 +71,6 @@ class AWSConfigMap<T extends AWSSerializable> extends ConfigMap<T> {
   /// {@macro amplify_core.aws_config_map}
   const AWSConfigMap(this.configs);
 
-  /// All configurations.
-  @JsonKey(name: 'configs')
-  final Map<String, T> configs;
-
   factory AWSConfigMap.fromJson(
     Map<String, Object?> json,
     T Function(Object? json) fromJsonT,
@@ -84,8 +80,19 @@ class AWSConfigMap<T extends AWSSerializable> extends ConfigMap<T> {
         fromJsonT,
       );
 
+  /// Creates an [AWSConfigMap] with a single, default, [value].
+  factory AWSConfigMap.withDefault(T value) => AWSConfigMap({
+        _defaultKey: value,
+      });
+
+  static const _defaultKey = 'Default';
+
+  /// All configurations.
+  @JsonKey(name: 'configs')
+  final Map<String, T> configs;
+
   @override
-  T? get default$ => this['Default'];
+  T? get default$ => this[_defaultKey];
 
   @override
   AWSConfigMap<T> copy() => AWSConfigMap(Map.of(configs));

--- a/packages/amplify_core/lib/src/state_machine/state_machine.dart
+++ b/packages/amplify_core/lib/src/state_machine/state_machine.dart
@@ -213,7 +213,7 @@ abstract class StateMachine<Event extends StateMachineEvent,
   bool _checkPrecondition(Event event) {
     final precondError = event.checkPrecondition(currentState);
     if (precondError != null) {
-      logger.info(
+      logger.debug(
         'Precondition not met for event ($event):\n'
         '${precondError.precondition}',
       );

--- a/packages/amplify_core/test/hub/hub_test.dart
+++ b/packages/amplify_core/test/hub/hub_test.dart
@@ -33,169 +33,186 @@ void main() {
       await additionalController.close();
     });
 
-    test('single channel, single subscription', () {
-      Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
+    group('listen', () {
+      test('single channel, single subscription', () {
+        Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
 
-      final Completer<AuthHubEvent> subscriber = Completer();
-      Amplify.Hub.listen(HubChannel.Auth, subscriber.complete);
+        final Completer<AuthHubEvent> subscriber = Completer();
+        Amplify.Hub.listen(HubChannel.Auth, subscriber.complete);
 
-      expect(
-        subscriber.future,
-        completes,
-        reason: 'The subscriber should receive the event',
-      );
+        expect(
+          subscriber.future,
+          completes,
+          reason: 'The subscriber should receive the event',
+        );
 
-      controller.add(AuthHubEvent.sessionExpired());
-    });
-
-    test('can listen before channel registered', () {
-      final Completer<AuthHubEvent> subscriber = Completer();
-      expect(
-        () => Amplify.Hub.listen(HubChannel.Auth, subscriber.complete),
-        returnsNormally,
-        reason: 'Listen before add should not throw',
-      );
-
-      Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
-
-      expect(
-        subscriber.future,
-        completes,
-        reason: 'The subscriber should receive the event even though it '
-            'subscribed before the stream was added',
-      );
-
-      controller.add(AuthHubEvent.sessionExpired());
-    });
-
-    test('single channel, multiple subscriptions', () {
-      Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
-
-      final Completer<AuthHubEvent> subscriber1 = Completer();
-      Amplify.Hub.listen(HubChannel.Auth, subscriber1.complete);
-
-      final Completer<AuthHubEvent> subscriber2 = Completer();
-      Amplify.Hub.listen(HubChannel.Auth, subscriber2.complete);
-
-      expect(
-        subscriber1.future,
-        completes,
-        reason: 'Both subscribers should receive the event',
-      );
-      expect(
-        subscriber2.future,
-        completes,
-        reason: 'Both subscribers should receive the event',
-      );
-
-      controller.add(AuthHubEvent.sessionExpired());
-    });
-
-    test('multiple channel, single subscription', () {
-      Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
-      Amplify.Hub.addChannel(HubChannel.Auth, additionalController.stream);
-
-      var events = 0;
-      final Completer<void> subscriber = Completer();
-      Amplify.Hub.listen(HubChannel.Auth, (AuthHubEvent event) {
-        if (++events == 2) {
-          subscriber.complete();
-        }
+        controller.add(AuthHubEvent.sessionExpired());
       });
 
-      expect(
-        subscriber.future,
-        completes,
-        reason: 'The subscriber should receive the events of both streams',
-      );
+      test('can listen before channel registered', () {
+        final Completer<AuthHubEvent> subscriber = Completer();
+        expect(
+          () => Amplify.Hub.listen(HubChannel.Auth, subscriber.complete),
+          returnsNormally,
+          reason: 'Listen before add should not throw',
+        );
 
-      controller.add(AuthHubEvent.sessionExpired());
-      additionalController.add(AuthHubEvent.sessionExpired());
-    });
+        Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
 
-    test('multiple channel, multiple subscriptions', () {
-      Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
-      Amplify.Hub.addChannel(HubChannel.Auth, additionalController.stream);
+        expect(
+          subscriber.future,
+          completes,
+          reason: 'The subscriber should receive the event even though it '
+              'subscribed before the stream was added',
+        );
 
-      var subscriber1Events = 0;
-      final Completer<void> subscriber1 = Completer();
-      Amplify.Hub.listen(HubChannel.Auth, (AuthHubEvent event) {
-        if (++subscriber1Events == 2) {
-          subscriber1.complete();
-        }
+        controller.add(AuthHubEvent.sessionExpired());
       });
 
-      var subscriber2Events = 0;
-      final Completer<void> subscriber2 = Completer();
-      Amplify.Hub.listen(HubChannel.Auth, (AuthHubEvent event) {
-        if (++subscriber2Events == 2) {
-          subscriber2.complete();
-        }
+      test('single channel, multiple subscriptions', () {
+        Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
+
+        final Completer<AuthHubEvent> subscriber1 = Completer();
+        Amplify.Hub.listen(HubChannel.Auth, subscriber1.complete);
+
+        final Completer<AuthHubEvent> subscriber2 = Completer();
+        Amplify.Hub.listen(HubChannel.Auth, subscriber2.complete);
+
+        expect(
+          subscriber1.future,
+          completes,
+          reason: 'Both subscribers should receive the event',
+        );
+        expect(
+          subscriber2.future,
+          completes,
+          reason: 'Both subscribers should receive the event',
+        );
+
+        controller.add(AuthHubEvent.sessionExpired());
       });
 
-      controller.add(AuthHubEvent.sessionExpired());
-      additionalController.add(AuthHubEvent.sessionExpired());
+      test('multiple channel, single subscription', () {
+        Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
+        Amplify.Hub.addChannel(HubChannel.Auth, additionalController.stream);
 
-      expect(
-        subscriber1.future,
-        completes,
-        reason: 'Both subscribers should receive the events of both streams',
-      );
-      expect(
-        subscriber1.future,
-        completes,
-        reason: 'Both subscribers should receive the events of both streams',
-      );
+        var events = 0;
+        final Completer<void> subscriber = Completer();
+        Amplify.Hub.listen(HubChannel.Auth, (AuthHubEvent event) {
+          if (++events == 2) {
+            subscriber.complete();
+          }
+        });
+
+        expect(
+          subscriber.future,
+          completes,
+          reason: 'The subscriber should receive the events of both streams',
+        );
+
+        controller.add(AuthHubEvent.sessionExpired());
+        additionalController.add(AuthHubEvent.sessionExpired());
+      });
+
+      test('multiple channel, multiple subscriptions', () {
+        Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
+        Amplify.Hub.addChannel(HubChannel.Auth, additionalController.stream);
+
+        var subscriber1Events = 0;
+        final Completer<void> subscriber1 = Completer();
+        Amplify.Hub.listen(HubChannel.Auth, (AuthHubEvent event) {
+          if (++subscriber1Events == 2) {
+            subscriber1.complete();
+          }
+        });
+
+        var subscriber2Events = 0;
+        final Completer<void> subscriber2 = Completer();
+        Amplify.Hub.listen(HubChannel.Auth, (AuthHubEvent event) {
+          if (++subscriber2Events == 2) {
+            subscriber2.complete();
+          }
+        });
+
+        controller.add(AuthHubEvent.sessionExpired());
+        additionalController.add(AuthHubEvent.sessionExpired());
+
+        expect(
+          subscriber1.future,
+          completes,
+          reason: 'Both subscribers should receive the events of both streams',
+        );
+        expect(
+          subscriber1.future,
+          completes,
+          reason: 'Both subscribers should receive the events of both streams',
+        );
+      });
+
+      test('single subscriber error', () {
+        Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
+
+        final Completer<void> finished = Completer();
+        Amplify.Hub.listen(
+          HubChannel.Auth,
+          (_) {},
+          onError: finished.complete,
+        );
+
+        controller.addError(Exception());
+
+        expect(
+          finished.future,
+          completes,
+          reason: 'Subscriptions should be able to capture errors',
+        );
+      });
+
+      test('multiple subscriber error', () {
+        Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
+
+        final Completer<void> finished1 = Completer();
+        Amplify.Hub.listen(
+          HubChannel.Auth,
+          (_) {},
+          onError: finished1.complete,
+        );
+
+        final Completer<void> finished2 = Completer();
+        Amplify.Hub.listen(
+          HubChannel.Auth,
+          (_) {},
+          onError: finished2.complete,
+        );
+
+        controller.addError(Exception());
+
+        expect(
+          finished1.future,
+          completes,
+          reason: 'Errors should be forwarded to all subscribers',
+        );
+        expect(
+          finished2.future,
+          completes,
+          reason: 'Errors should be forwarded to all subscribers',
+        );
+      });
     });
 
-    test('single subscriber error', () {
-      Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
+    group('availableStreams', () {
+      test('can listen to channel before plugin registration', () {
+        final stream = Amplify.Hub.availableStreams[HubChannel.Auth];
+        expect(stream, isNotNull);
 
-      final Completer<void> finished = Completer();
-      Amplify.Hub.listen(
-        HubChannel.Auth,
-        (_) {},
-        onError: finished.complete,
-      );
+        final Completer<void> gotEvent = Completer();
+        stream!.listen((_) => gotEvent.complete());
 
-      controller.addError(Exception());
+        Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
+        controller.add(AuthHubEvent.sessionExpired());
 
-      expect(
-        finished.future,
-        completes,
-        reason: 'Subscriptions should be able to capture errors',
-      );
-    });
-
-    test('multiple subscriber error', () {
-      Amplify.Hub.addChannel(HubChannel.Auth, controller.stream);
-
-      final Completer<void> finished1 = Completer();
-      Amplify.Hub.listen(
-        HubChannel.Auth,
-        (_) {},
-        onError: finished1.complete,
-      );
-
-      final Completer<void> finished2 = Completer();
-      Amplify.Hub.listen(
-        HubChannel.Auth,
-        (_) {},
-        onError: finished2.complete,
-      );
-
-      controller.addError(Exception());
-
-      expect(
-        finished1.future,
-        completes,
-        reason: 'Errors should be forwarded to all subscribers',
-      );
-      expect(
-        finished2.future,
-        completes,
-        reason: 'Errors should be forwarded to all subscribers',
-      );
+        expect(gotEvent.future, completes);
+      });
     });
   });
 }

--- a/packages/auth/amplify_auth_cognito/example/lib/main.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/main.dart
@@ -91,15 +91,20 @@ class _MyAppState extends State<MyApp> {
         await Amplify.addPlugin(AmplifyAPI());
       }
       await Amplify.addPlugin(AmplifyAuthCognito());
-      // Uncomment this block, and comment out the one above, in order to persist credentials
-      // await Amplify.addPlugin(AmplifyAuthCognito(credentialStorage: AmplifySecureStorage(
+      // Uncomment this block, and comment out the one above to change how
+      // credentials are persisted.
+      // await Amplify.addPlugin(
+      //   AmplifyAuthCognito(
+      //     credentialStorage: AmplifySecureStorage(
       //       config: AmplifySecureStorageConfig(
       //         scope: 'authtest',
       //         webOptions: WebSecureStorageOptions(
       //           persistenceOption: WebPersistenceOption.inMemory,
       //         ),
       //       ),
-      //     )));
+      //     ),
+      //   ),
+      // );
       await Amplify.configure(amplifyconfig);
       safePrint('Successfully configured Amplify');
 

--- a/packages/auth/amplify_auth_cognito/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/auth/amplify_auth_cognito/example/macos/Runner/DebugProfile.entitlements
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>

--- a/packages/auth/amplify_auth_cognito/example/macos/Runner/Release.entitlements
+++ b/packages/auth/amplify_auth_cognito/example/macos/Runner/Release.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
+
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_auth_cognito_dart/src/credentials/cognito_keys.dart';
 import 'package:amplify_auth_cognito_dart/src/crypto/oauth.dart';
@@ -33,7 +35,7 @@ typedef HostedUiPlatformFactory = HostedUiPlatform Function(
 /// {@template amplify_auth_cognito.hosted_ui_platform}
 /// Platform-specific behavior for the Hosted UI flow.
 /// {@endtemplate}
-abstract class HostedUiPlatform {
+abstract class HostedUiPlatform implements Closeable {
   /// {@macro amplify_auth_cognito.hosted_ui_platform}
   factory HostedUiPlatform(DependencyManager dependencyManager) =
       HostedUiPlatformImpl;
@@ -285,8 +287,14 @@ abstract class HostedUiPlatform {
     AuthProvider? provider,
   });
 
+  /// Cancels the active sign in.
+  Future<void> cancelSignIn() async {}
+
   /// Sign out the current user.
   Future<void> signOut({
     required CognitoSignOutWithWebUIOptions options,
   });
+
+  @override
+  FutureOr<void> close() {}
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/hosted_ui_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/hosted_ui_event.dart
@@ -175,6 +175,7 @@ class HostedUiCancelSignIn extends HostedUiEvent {
     if (currentState.type != HostedUiStateType.signingIn) {
       return const AuthPreconditionException(
         'There is no active sign-in session',
+        shouldEmit: false,
       );
     }
     return null;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
@@ -83,8 +83,7 @@ class HostedUiStateMachine extends HostedUiStateMachineBase {
     }
   }
 
-  @override
-  Future<void> onSignIn(HostedUiSignIn event) async {
+  Future<void> _handleSignIn(HostedUiSignIn event) async {
     try {
       _secureStorage.write(
         key: _keys[HostedUiKey.options],
@@ -100,7 +99,13 @@ class HostedUiStateMachine extends HostedUiStateMachineBase {
   }
 
   @override
+  Future<void> onSignIn(HostedUiSignIn event) async {
+    unawaited(_handleSignIn(event));
+  }
+
+  @override
   Future<void> onCancelSignIn(HostedUiCancelSignIn event) async {
+    await _platform.cancelSignIn();
     await dispatch(CredentialStoreEvent.clearCredentials(_keys));
     dispatch(
       const HostedUiEvent.failed(
@@ -159,4 +164,10 @@ class HostedUiStateMachine extends HostedUiStateMachineBase {
 
   @override
   Future<void> onFailed(HostedUiFailed event) async {}
+
+  @override
+  Future<void> close() async {
+    await _platform.close();
+    return super.close();
+  }
 }

--- a/packages/auth/amplify_auth_cognito_dart/test/common/mock_config.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/common/mock_config.dart
@@ -33,49 +33,27 @@ const hostedUiConfig = CognitoOAuthConfig(
   webDomain: webDomain,
 );
 
-const userPoolOnlyConfig = AmplifyConfig(
-  auth: AuthConfig(
-    plugins: {
-      CognitoPluginConfig.pluginKey: CognitoPluginConfig(
-        cognitoUserPool: AWSConfigMap(
-          {
-            'Default': CognitoUserPoolConfig(
-              poolId: testUserPoolId,
-              appClientId: testAppClientId,
-              region: testRegion,
-            ),
-          },
-        ),
-      ),
-    },
+final userPoolOnlyConfig = AmplifyConfig(
+  auth: AuthConfig.cognito(
+    userPoolConfig: const CognitoUserPoolConfig(
+      poolId: testUserPoolId,
+      appClientId: testAppClientId,
+      region: testRegion,
+    ),
   ),
 );
-const mockConfig = AmplifyConfig(
-  auth: AuthConfig(
-    plugins: {
-      CognitoPluginConfig.pluginKey: CognitoPluginConfig(
-        auth: AWSConfigMap({
-          'Default': CognitoAuthConfig(
-            oAuth: hostedUiConfig,
-          ),
-        }),
-        cognitoUserPool: AWSConfigMap({
-          'Default': CognitoUserPoolConfig(
-            poolId: testUserPoolId,
-            appClientId: testAppClientId,
-            region: testRegion,
-          ),
-        }),
-        credentialsProvider: CredentialsProviders({
-          'CognitoIdentity': AWSConfigMap({
-            'Default': CognitoIdentityCredentialsProvider(
-              poolId: testIdentityPoolId,
-              region: testRegion,
-            ),
-          }),
-        }),
-      ),
-    },
+final mockConfig = AmplifyConfig(
+  auth: AuthConfig.cognito(
+    userPoolConfig: const CognitoUserPoolConfig(
+      poolId: testUserPoolId,
+      appClientId: testAppClientId,
+      region: testRegion,
+    ),
+    identityPoolConfig: const CognitoIdentityPoolConfig(
+      poolId: testIdentityPoolId,
+      region: testRegion,
+    ),
+    hostedUiConfig: hostedUiConfig,
   ),
 );
 

--- a/packages/auth/amplify_auth_cognito_dart/test/common/mock_hosted_ui.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/common/mock_hosted_ui.dart
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/hosted_ui_platform_stub.dart'
+    if (dart.library.html) 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/hosted_ui_platform_html.dart'
+    if (dart.library.io) 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/hosted_ui_platform_io.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 typedef SignInFn = Future<void> Function(
@@ -39,14 +42,13 @@ HostedUiPlatformFactory createHostedUiFactory({
   };
 }
 
-class MockHostedUiPlatform extends HostedUiPlatform {
+class MockHostedUiPlatform extends HostedUiPlatformImpl {
   MockHostedUiPlatform(
     super.dependencyManager, {
     required SignInFn signIn,
     required SignOutFn signOut,
   })  : _signIn = signIn,
-        _signOut = signOut,
-        super.protected();
+        _signOut = signOut;
 
   final SignInFn _signIn;
   final SignOutFn _signOut;

--- a/packages/auth/amplify_auth_cognito_dart/test/credentials/auth_plugin_credentials_provider_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/credentials/auth_plugin_credentials_provider_test.dart
@@ -70,7 +70,7 @@ void main() {
     setUp(() async {
       stateMachine = CognitoAuthStateMachine()
         ..addBuilder<SecureStorageInterface>(MockSecureStorage.new)
-        ..dispatch(const AuthEvent.configure(mockConfig));
+        ..dispatch(AuthEvent.configure(mockConfig));
       provider = AuthPluginCredentialsProviderImpl(stateMachine);
 
       await stateMachine.stream.firstWhere((state) => state is AuthConfigured);

--- a/packages/auth/amplify_auth_cognito_dart/test/flows/hostedui/hosted_ui_platform_io_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/flows/hostedui/hosted_ui_platform_io_test.dart
@@ -1,0 +1,121 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('windows || mac-os || linux')
+
+import 'dart:io';
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/hosted_ui_platform_io.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
+import 'package:test/test.dart';
+
+import '../../common/mock_hosted_ui.dart';
+import '../../common/mock_secure_storage.dart';
+
+void main() {
+  group('HostedUIPlatform', () {
+    late DependencyManager dependencyManager;
+
+    setUp(() {
+      dependencyManager = DependencyManager();
+      final secureStorage = MockSecureStorage();
+      dependencyManager.addInstance<SecureStorageInterface>(secureStorage);
+    });
+
+    tearDown(() {
+      dependencyManager.close();
+    });
+
+    group('localConnect', () {
+      final uris = [
+        Uri.parse('http://localhost:10000'),
+        Uri.parse('http://localhost:10001'),
+        Uri.parse('http://localhost:10002'),
+      ];
+
+      test('selects from multiple URIs when a port is blocked', () async {
+        final platform = createHostedUiFactory(
+          signIn: expectAsync3((platform, options, provider) async {
+            final boundServer =
+                await (platform as HostedUiPlatformImpl).localConnect(uris);
+            addTearDown(() => boundServer.server.close(force: true));
+            expect(boundServer.uri, equals(uris[1]));
+          }),
+          signOut: (platform, options) => throw UnimplementedError(),
+        );
+
+        final server = await HttpServer.bind(
+          InternetAddress.loopbackIPv4,
+          uris[0].port,
+        );
+        addTearDown(() => server.close(force: true));
+        await platform(dependencyManager).signIn(
+          options: const CognitoSignInWithWebUIOptions(),
+        );
+      });
+
+      test('multiple calls do not fail', () async {
+        final platform = createHostedUiFactory(
+          signIn: expectAsync3(
+            count: 2,
+            (platform, options, provider) async {
+              final boundServer =
+                  await (platform as HostedUiPlatformImpl).localConnect(uris);
+              addTearDown(() => boundServer.server.close(force: true));
+            },
+          ),
+          signOut: (platform, options) => throw UnimplementedError(),
+        );
+
+        await expectLater(
+          platform(dependencyManager).signIn(
+            options: const CognitoSignInWithWebUIOptions(),
+          ),
+          completes,
+        );
+        await expectLater(
+          platform(dependencyManager).signIn(
+            options: const CognitoSignInWithWebUIOptions(),
+          ),
+          completes,
+        );
+      });
+
+      test('fails when all ports are blocked', () async {
+        final platform = createHostedUiFactory(
+          signIn: expectAsync3((platform, options, provider) async {
+            expect(
+              (platform as HostedUiPlatformImpl).localConnect(uris),
+              throwsA(isA<UrlLauncherException>()),
+            );
+          }),
+          signOut: (platform, options) => throw UnimplementedError(),
+        );
+
+        for (final uri in uris) {
+          final server = await HttpServer.bind(
+            InternetAddress.loopbackIPv4,
+            uri.port,
+          );
+          addTearDown(() => server.close(force: true));
+        }
+        await platform(dependencyManager).signIn(
+          options: const CognitoSignInWithWebUIOptions(),
+        );
+      });
+    });
+  });
+}

--- a/packages/auth/amplify_auth_cognito_dart/test/state/auth_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/state/auth_state_machine_test.dart
@@ -38,7 +38,7 @@ void main() {
     test('configure succeeds', () async {
       final authStateMachine = stateMachine.getOrCreate(AuthStateMachine.type);
 
-      stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+      stateMachine.dispatch(AuthEvent.configure(mockConfig));
       await expectLater(
         authStateMachine.stream.startWith(authStateMachine.currentState),
         emitsInOrder(<Matcher>[
@@ -80,7 +80,7 @@ void main() {
         ]),
       );
 
-      stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+      stateMachine.dispatch(AuthEvent.configure(mockConfig));
       await expectLater(
         authStateMachine.stream.startWith(authStateMachine.currentState),
         emitsInOrder(<Matcher>[
@@ -96,7 +96,7 @@ void main() {
     test('multiple configures are ignored', () async {
       final authStateMachine = stateMachine.getOrCreate(AuthStateMachine.type);
 
-      stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+      stateMachine.dispatch(AuthEvent.configure(mockConfig));
       await expectLater(
         authStateMachine.stream.startWith(authStateMachine.currentState),
         emitsInOrder(<Matcher>[
@@ -106,7 +106,7 @@ void main() {
         ]),
       );
 
-      stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+      stateMachine.dispatch(AuthEvent.configure(mockConfig));
       expect(
         authStateMachine.stream,
         emitsDone,

--- a/packages/auth/amplify_auth_cognito_dart/test/state/fetch_auth_session_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/state/fetch_auth_session_state_machine_test.dart
@@ -152,7 +152,7 @@ void main() {
           secureStorage,
           userPoolKeys: userPoolKeys,
         );
-        stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+        stateMachine.dispatch(AuthEvent.configure(mockConfig));
         await stateMachine.stream.whereType<AuthConfigured>().first;
 
         stateMachine
@@ -251,7 +251,7 @@ void main() {
             key: identityPoolKeys[CognitoIdentityPoolKey.expiration],
             value: DateTime.now().toIso8601String(),
           );
-          stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+          stateMachine.dispatch(AuthEvent.configure(mockConfig));
           await stateMachine.stream.whereType<AuthConfigured>().first;
 
           const newIdentityId = 'newIdentityId';
@@ -314,7 +314,7 @@ void main() {
             key: identityPoolKeys[CognitoIdentityPoolKey.expiration],
             value: DateTime.now().toIso8601String(),
           );
-          stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+          stateMachine.dispatch(AuthEvent.configure(mockConfig));
           await stateMachine.stream.whereType<AuthConfigured>().first;
 
           stateMachine
@@ -363,7 +363,7 @@ void main() {
               expiration: Duration.zero,
             ).raw,
           );
-          stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+          stateMachine.dispatch(AuthEvent.configure(mockConfig));
           await stateMachine.stream.whereType<AuthConfigured>().first;
 
           stateMachine
@@ -417,7 +417,7 @@ void main() {
               expiration: Duration.zero,
             ).raw,
           );
-          stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+          stateMachine.dispatch(AuthEvent.configure(mockConfig));
           await stateMachine.stream.whereType<AuthConfigured>().first;
 
           stateMachine
@@ -460,7 +460,7 @@ void main() {
           secureStorage,
           userPoolKeys: userPoolKeys,
         );
-        stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+        stateMachine.dispatch(AuthEvent.configure(mockConfig));
         await stateMachine.stream.whereType<AuthConfigured>().first;
 
         stateMachine

--- a/packages/auth/amplify_auth_cognito_dart/test/state/hosted_ui_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/state/hosted_ui_state_machine_test.dart
@@ -132,7 +132,7 @@ void main() {
 
     group('onFoundState', () {
       test('nothing in storage', () {
-        stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+        stateMachine.dispatch(AuthEvent.configure(mockConfig));
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         expect(
@@ -151,7 +151,7 @@ void main() {
             value: codeVerifier,
           );
 
-        stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+        stateMachine.dispatch(AuthEvent.configure(mockConfig));
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -170,7 +170,7 @@ void main() {
     group('onConfigure', () {
       test('logged in', () async {
         seedStorage(secureStorage, hostedUiKeys: keys);
-        stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+        stateMachine.dispatch(AuthEvent.configure(mockConfig));
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -185,7 +185,7 @@ void main() {
 
     group('onSignIn', () {
       test('no provider', () async {
-        stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+        stateMachine.dispatch(AuthEvent.configure(mockConfig));
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -201,7 +201,7 @@ void main() {
       });
 
       test('w/ provider', () async {
-        stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+        stateMachine.dispatch(AuthEvent.configure(mockConfig));
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -226,7 +226,7 @@ void main() {
             FailingHostedUiPlatform.new,
             HostedUiPlatform.token,
           )
-          ..dispatch(const AuthEvent.configure(mockConfig));
+          ..dispatch(AuthEvent.configure(mockConfig));
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -254,7 +254,7 @@ void main() {
 
     group('onExchange', () {
       test('no provider', () async {
-        stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+        stateMachine.dispatch(AuthEvent.configure(mockConfig));
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -296,7 +296,7 @@ void main() {
       });
 
       test('fails with remote error', () async {
-        stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+        stateMachine.dispatch(AuthEvent.configure(mockConfig));
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -331,7 +331,7 @@ void main() {
       });
 
       test('fails with bad code', () async {
-        stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+        stateMachine.dispatch(AuthEvent.configure(mockConfig));
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -367,7 +367,7 @@ void main() {
     group('onSignOut', () {
       test('succeeds', () async {
         seedStorage(secureStorage, hostedUiKeys: keys);
-        stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+        stateMachine.dispatch(AuthEvent.configure(mockConfig));
         await expectLater(
           stateMachine.stream.whereType<HostedUiState>(),
           emitsInOrder(<Matcher>[
@@ -388,7 +388,7 @@ void main() {
 
       test('multiple events are ignored', () async {
         seedStorage(secureStorage, hostedUiKeys: keys);
-        stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+        stateMachine.dispatch(AuthEvent.configure(mockConfig));
         await expectLater(
           stateMachine.stream.whereType<HostedUiState>(),
           emitsInOrder(<Matcher>[
@@ -416,7 +416,7 @@ void main() {
             FailingHostedUiPlatform.new,
             HostedUiPlatform.token,
           )
-          ..dispatch(const AuthEvent.configure(mockConfig));
+          ..dispatch(AuthEvent.configure(mockConfig));
         await expectLater(
           stateMachine.stream.whereType<HostedUiState>(),
           emitsInOrder(<Matcher>[
@@ -454,7 +454,7 @@ void main() {
             ),
             HostedUiPlatform.token,
           )
-          ..dispatch(const AuthEvent.configure(mockConfig));
+          ..dispatch(AuthEvent.configure(mockConfig));
 
         await expectLater(
           stateMachine.stream.whereType<HostedUiState>(),

--- a/packages/auth/amplify_auth_cognito_dart/test/state/sign_up_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/state/sign_up_state_machine_test.dart
@@ -89,7 +89,7 @@ void main() {
           userConfirmed: true,
         ),
       );
-      stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+      stateMachine.dispatch(AuthEvent.configure(mockConfig));
       await stateMachine.stream.whereType<AuthConfigured>().first;
 
       stateMachine
@@ -113,7 +113,7 @@ void main() {
         ),
         confirmSignUp: (input) async => ConfirmSignUpResponse(),
       );
-      stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+      stateMachine.dispatch(AuthEvent.configure(mockConfig));
       await stateMachine.stream.whereType<AuthConfigured>().first;
 
       stateMachine
@@ -147,7 +147,7 @@ void main() {
       var client = MockCognitoIdentityProviderClient(
         signUp: (input) async => throw _SignUpException(),
       );
-      stateMachine.dispatch(const AuthEvent.configure(mockConfig));
+      stateMachine.dispatch(AuthEvent.configure(mockConfig));
       await stateMachine.stream.whereType<AuthConfigured>().first;
 
       stateMachine


### PR DESCRIPTION
Allows multiple calls to `signInWithWebUI` so that, for example, desktop UIs do not have to be aware of the state of the launched browser. Users can launch a Hosted UI browser only to close it and re-initiate a new sign-in.