### PR TITLE
chore: Use `Object?` for `underlyingException`

### DIFF
--- a/packages/amplify/amplify_flutter/lib/src/hybrid_impl.dart
+++ b/packages/amplify/amplify_flutter/lib/src/hybrid_impl.dart
@@ -90,7 +90,7 @@ class AmplifyHybridImpl extends AmplifyClassImpl {
       throw AmplifyException(
         'Amplify plugin ${plugin.runtimeType} was not added successfully.',
         recoverySuggestion: AmplifyExceptionMessages.missingRecoverySuggestion,
-        underlyingException: e.toString(),
+        underlyingException: e,
       );
     }
   }

--- a/packages/amplify_authenticator/lib/src/models/authenticator_exception.dart
+++ b/packages/amplify_authenticator/lib/src/models/authenticator_exception.dart
@@ -22,7 +22,7 @@ import 'package:smithy/smithy.dart';
 /// An exception originating within the Authenticator as part of the sign up/
 /// sign in flow.
 /// {@endtemplate}
-class AuthenticatorException implements Exception {
+class AuthenticatorException extends AmplifyException {
   /// {@macro amplify_authenticator.authenticator_exception}
   factory AuthenticatorException(
     Object exception, {
@@ -51,23 +51,15 @@ class AuthenticatorException implements Exception {
 
   /// {@macro amplify_authenticator.authenticator_exception}
   const AuthenticatorException._(
-    this.message, {
+    super.message, {
     this.showBanner = true,
     Object? underlyingException,
-  }) : underlyingException = underlyingException ?? message;
+  }) : super(underlyingException: underlyingException ?? message);
 
   static const _unknownMessage = 'An unknown error occurred';
 
-  /// A message passed from the server, or generated locally, which can be
-  /// presented to users.
-  final String message;
-
   /// Whether to show a banner for this exception.
   final bool showBanner;
-
-  /// The underlying exception which may not be sanitized for presentation to
-  /// users.
-  final Object underlyingException;
 
   const AuthenticatorException.customAuth()
       : this._(

--- a/packages/amplify_core/lib/src/amplify_class.dart
+++ b/packages/amplify_core/lib/src/amplify_class.dart
@@ -99,7 +99,7 @@ abstract class AmplifyClass {
         'The provided configuration is not a valid json. Check underlyingException.',
         recoverySuggestion:
             'Inspect your amplifyconfiguration.dart and ensure that the string is proper json',
-        underlyingException: e.toString(),
+        underlyingException: e,
       );
     }
 

--- a/packages/amplify_core/lib/src/types/analytics/exceptions/analytics_exception.dart
+++ b/packages/amplify_core/lib/src/types/analytics/exceptions/analytics_exception.dart
@@ -18,14 +18,10 @@ import 'package:amplify_core/amplify_core.dart';
 /// Base Class for Analytics Exceptions
 class AnalyticsException extends AmplifyException {
   const AnalyticsException(
-    String message, {
-    String? recoverySuggestion,
-    String? underlyingException,
-  }) : super(
-          message,
-          recoverySuggestion: recoverySuggestion,
-          underlyingException: underlyingException,
-        );
+    super.message, {
+    super.recoverySuggestion,
+    super.underlyingException,
+  });
 
   /// Constructor for down casting an AmplifyException to this exception
   AnalyticsException._private(AmplifyException exception)

--- a/packages/amplify_core/lib/src/types/api/exceptions/api_exception.dart
+++ b/packages/amplify_core/lib/src/types/api/exceptions/api_exception.dart
@@ -27,15 +27,11 @@ class ApiException extends AmplifyException {
 
   /// {@macro api_exception}
   const ApiException(
-    String message, {
-    String? recoverySuggestion,
-    String? underlyingException,
+    super.message, {
+    super.recoverySuggestion,
+    super.underlyingException,
     this.httpStatusCode,
-  }) : super(
-          message,
-          recoverySuggestion: recoverySuggestion,
-          underlyingException: underlyingException,
-        );
+  });
 
   /// Constructor for down casting an AmplifyException to this exception
   ApiException._private(

--- a/packages/amplify_core/lib/src/types/datastore/exception/datstore_exception.dart
+++ b/packages/amplify_core/lib/src/types/datastore/exception/datstore_exception.dart
@@ -18,11 +18,11 @@ import 'package:amplify_core/amplify_core.dart';
 /// Exception thrown from DataStore Category
 class DataStoreException extends AmplifyException {
   /// Named constructor
-  const DataStoreException(String message,
-      {String? recoverySuggestion, String? underlyingException})
-      : super(message,
-            recoverySuggestion: recoverySuggestion,
-            underlyingException: underlyingException);
+  const DataStoreException(
+    super.message, {
+    super.recoverySuggestion,
+    super.underlyingException,
+  });
 
   /// Constructor for down casting an AmplifyException to this exception
   DataStoreException._private(AmplifyException exception)

--- a/packages/amplify_core/lib/src/types/exception/amplify_already_configured_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/amplify_already_configured_exception.dart
@@ -22,14 +22,10 @@ import 'amplify_exception.dart';
 class AmplifyAlreadyConfiguredException extends AmplifyException {
   /// Named constructor
   const AmplifyAlreadyConfiguredException(
-    String message, {
-    String? recoverySuggestion,
-    String? underlyingException,
-  }) : super(
-          message,
-          recoverySuggestion: recoverySuggestion,
-          underlyingException: underlyingException,
-        );
+    super.message, {
+    super.recoverySuggestion,
+    super.underlyingException,
+  });
 
   /// Constructor for down casting an AmplifyException to this exception
   AmplifyAlreadyConfiguredException._private(AmplifyException exception)

--- a/packages/amplify_core/lib/src/types/exception/amplify_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/amplify_exception.dart
@@ -16,8 +16,10 @@
 import 'package:amplify_core/amplify_core.dart';
 import 'package:meta/meta.dart';
 
+/// {@template amplify_core.amplify_exception}
 /// Thrown from top level Amplify APIs from the amplify-flutter package.
 /// All other Amplify APIs throw subclasses of AmplifyException.
+/// {@endtemplate}
 @immutable
 class AmplifyException
     with AWSEquatable<AmplifyException>
@@ -29,15 +31,17 @@ class AmplifyException
   final String? recoverySuggestion;
 
   /// Underlying cause of this exception helpful for debugging.
-  // TODO(dnys1): Migrate to `Exception` type when DataStore codegen can be fixed.
-  final String? underlyingException;
+  final Object? underlyingException;
 
   @override
   List<Object?> get props => [message, recoverySuggestion, underlyingException];
 
-  /// Named constructor
-  const AmplifyException(this.message,
-      {this.recoverySuggestion, this.underlyingException});
+  /// {@macro amplify_core.amplify_exception}
+  const AmplifyException(
+    this.message, {
+    this.recoverySuggestion,
+    this.underlyingException,
+  });
 
   /// Instantiates and return a new `AmplifyException` from the
   /// serialized exception data

--- a/packages/amplify_core/lib/src/types/exception/auth/auth_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/auth/auth_exception.dart
@@ -21,14 +21,10 @@ import 'package:amplify_core/amplify_core.dart';
 class AuthException extends AmplifyException {
   /// {@macro amplify_core.auth.auth_exception}
   const AuthException(
-    String message, {
-    String? recoverySuggestion,
-    String? underlyingException,
-  }) : super(
-          message,
-          recoverySuggestion: recoverySuggestion,
-          underlyingException: underlyingException,
-        );
+    super.message, {
+    super.recoverySuggestion,
+    super.underlyingException,
+  });
 
   /// {@template amplify_core.auth.exception_downcasting}
   /// Internal named constructor for downcasting an [AuthException] to this

--- a/packages/amplify_core/lib/src/types/exception/codegen_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/codegen_exception.dart
@@ -18,11 +18,11 @@ import 'amplify_exception.dart';
 /// Exception thrown from codegen models
 class AmplifyCodeGenModelException extends AmplifyException {
   /// Named constructor
-  const AmplifyCodeGenModelException(String message,
-      {String? recoverySuggestion, String? underlyingException})
-      : super(message,
-            recoverySuggestion: recoverySuggestion,
-            underlyingException: underlyingException);
+  const AmplifyCodeGenModelException(
+    super.message, {
+    super.recoverySuggestion,
+    super.underlyingException,
+  });
 
   /// Constructor for down casting an AmplifyException to this exception
   AmplifyCodeGenModelException._private(AmplifyException exception)

--- a/packages/amplify_core/lib/src/types/storage/exceptions/storage_exception.dart
+++ b/packages/amplify_core/lib/src/types/storage/exceptions/storage_exception.dart
@@ -18,11 +18,11 @@ import 'package:amplify_core/amplify_core.dart';
 /// Exception thrown from Storage Category
 class StorageException extends AmplifyException {
   /// Named constructor
-  const StorageException(String message,
-      {String? recoverySuggestion, String? underlyingException})
-      : super(message,
-            recoverySuggestion: recoverySuggestion,
-            underlyingException: underlyingException);
+  const StorageException(
+    super.message, {
+    super.recoverySuggestion,
+    super.underlyingException,
+  });
 
   /// Constructor for down casting an AmplifyException to this exception
   StorageException._private(AmplifyException exception)

--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -79,7 +79,7 @@ class AmplifyAuthCognito extends AmplifyAuthCognitoDart with AWSDebuggable {
       }
       throw AmplifyException(
         e.message ?? 'An unknown error occurred',
-        underlyingException: e.toString(),
+        underlyingException: e,
       );
     }
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_io.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_io.dart
@@ -151,7 +151,7 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
     } on Exception catch (e) {
       throw UrlLauncherException(
         couldNotLaunch,
-        underlyingException: e.toString(),
+        underlyingException: e,
       );
     }
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_exception.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_exception.dart
@@ -91,7 +91,7 @@ Exception transformSdkException(Exception e) {
       e is cognito_idp.InvalidLambdaResponseException ||
       e is cognito_idp.UnexpectedLambdaException ||
       e is cognito_idp.UserLambdaValidationException) {
-    return LambdaException(message, underlyingException: e.toString());
+    return LambdaException(message, underlyingException: e);
   }
   if (e is cognito_identity.LimitExceededException ||
       e is cognito_idp.LimitExceededException) {
@@ -149,7 +149,7 @@ class InvalidParameterException extends core.AmplifyException
 /// {@endtemplate}
 class LambdaException extends core.AmplifyException with core.AWSDebuggable {
   /// {@macro amplify_auth_cognito_dart.sdk.lambda_exception}
-  factory LambdaException(String message, {String? underlyingException}) {
+  factory LambdaException(String message, {Object? underlyingException}) {
     final match = _errorRegex.firstMatch(message);
     final lambdaName = match?.group(1);
     final parsedMessage = match?.group(2);

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/exception/secure_storage_exception.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/exception/secure_storage_exception.dart
@@ -33,7 +33,7 @@ class SecureStorageException implements Exception {
   final String? recoverySuggestion;
 
   /// Underlying cause of this exception helpful for debugging (Optional)
-  final String? underlyingException;
+  final Object? underlyingException;
 
   static const String missingRecovery = 'An unknown exception occurred. \n'
       'Please take a look at https://github.com/aws-amplify/amplify-flutter/issues '

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/utils/dynamic_library_utils.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/utils/dynamic_library_utils.dart
@@ -28,13 +28,13 @@ DynamicLibrary openDynamicLibrary(String name, {String fileExtension = '.so'}) {
       recoverySuggestion:
           'For local development on Debian based linux distributions such as Ubuntu, '
           'this can be installed by running "sudo apt-get update && sudo apt-get install $name-dev"',
-      underlyingException: e.toString(),
+      underlyingException: e,
     );
   } on Object catch (e) {
     throw UnknownException(
       'An unknown exception occurred while trying to open $name.',
       recoverySuggestion: SecureStorageException.missingRecovery,
-      underlyingException: e.toString(),
+      underlyingException: e,
     );
   }
 }

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_cupertino.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_cupertino.dart
@@ -318,7 +318,6 @@ class _SecurityFrameworkError {
 
   /// Maps the error to a [SecureStorageException].
   SecureStorageException toSecureStorageException() {
-    final underlyingException = toString();
     switch (code) {
       case errSecItemNotFound:
         // A missing recovery is used because this should be caught
@@ -326,7 +325,7 @@ class _SecurityFrameworkError {
         return ItemNotFoundException(
           'Them item was not found in the keychain.',
           recoverySuggestion: SecureStorageException.missingRecovery,
-          underlyingException: underlyingException,
+          underlyingException: this,
         );
       case errSecDuplicateItem:
         // A missing recovery is used because this should be caught
@@ -334,7 +333,7 @@ class _SecurityFrameworkError {
         return DuplicateItemException(
           'The item is already present in the keychain.',
           recoverySuggestion: SecureStorageException.missingRecovery,
-          underlyingException: underlyingException,
+          underlyingException: this,
         );
       case errSecUserCanceled:
       case errSecAuthFailed:
@@ -343,7 +342,7 @@ class _SecurityFrameworkError {
           'Could not access the items in the keychain.',
           recoverySuggestion:
               'Ensure that the keychain is available and unlocked.',
-          underlyingException: underlyingException,
+          underlyingException: this,
         );
       case errSecMissingEntitlement:
         // TODO(Jordan-Nelson): point to amplify documentation when available.
@@ -353,13 +352,13 @@ class _SecurityFrameworkError {
         return AccessDeniedException(
           'Could not access the items in the keychain due to a missing entitlement.',
           recoverySuggestion: recoverySuggestion,
-          underlyingException: underlyingException,
+          underlyingException: this,
         );
       default:
         return UnknownException(
           'An unknown exception occurred.',
           recoverySuggestion: SecureStorageException.missingRecovery,
-          underlyingException: underlyingException,
+          underlyingException: this,
         );
     }
   }

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_windows.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_windows.dart
@@ -119,7 +119,7 @@ class AmplifySecureStorageWindows extends AmplifySecureStorageInterface {
   SecureStorageException _getExceptionFromErrorCode(int errorCode) {
     final underlying = WindowsException(
       HRESULT_FROM_WIN32(errorCode),
-    ).toString();
+    );
     return UnknownException(
       'An unknown exception occurred.',
       recoverySuggestion: SecureStorageException.missingRecovery,


### PR DESCRIPTION
This allows both strings and raw `Exception`/`Error` types to be passed which can support `is` checks in the future after all code is migrated.
