### PR TITLE
chore(repo): Update bug report to include deployment option

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yaml
@@ -120,19 +120,44 @@ body:
       placeholder: "iOS 15.1, Android 11"
     validations:
       required: true
+  - type: dropdown
+    id: deployment-method
+    attributes:
+      label: Deployment Method
+      description: "How do you currently deploy your backend?"
+      multiple: false
+      options:
+        - Amplify CLI
+        - Amplify CLI + Custom Pipeline
+        - Custom Pipeline
+    validations:
+      required: true
   - type: input
     id: cli-version
     attributes:
       label: CLI Version
       description: "Which version of the Amplify CLI are you running? (`amplify -v`)"
       placeholder: "7.6.21"
-    validations:
-      required: true
   - type: textarea
     id: additional-context
     attributes:
       label: Additional Context
-      description: Please add any other context about the problem here.
+      description: > 
+        Please add any other context about the problem here. If you are currently using a custom deployment
+        pipeline, it is helpful to understand how your cloud resources might differ from those provisioned by
+        the Amplify CLI, for example.
       placeholder: "No additional context provided"
     validations:
       required: false
+  - type: textarea
+    id: amplify-config
+    attributes:
+      label: Amplify Config
+      description: Please provide a sanitized version of your Amplify config.
+      placeholder: |
+        {
+          "UserAgent": "aws-amplify-cli/2.0",
+          "Version": "1.0"
+        }
+    validations:
+      required: true


### PR DESCRIPTION
Adds the following info to the bug report template:
- Whether the CLI or another mechanism was used to deploy their backend
- Their sanitized amplifyconfig

These both seem to provide a lot of insight and they can be missed in the conversation, especially the first one. We cannot assume that people filing issues are using pristine Amplify-generated backends.