### PR TITLE
chore(secure_storage): use in-memory when indexedDB fails to open

### DIFF
--- a/packages/secure_storage/amplify_secure_storage/example/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/example/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   amplify_secure_storage:
     path: ../
-  aws_common: ^0.1.0
   flutter:
     sdk: flutter
 

--- a/packages/secure_storage/amplify_secure_storage/example/pubspec_overrides.yaml
+++ b/packages/secure_storage/amplify_secure_storage/example/pubspec_overrides.yaml
@@ -4,6 +4,8 @@
 # It may cause issues with publishing until https://github.com/dart-lang/pub/pull/3419
 # is released in stable.
 dependency_overrides:
+  amplify_core:
+    path: ../../../amplify_core
   amplify_secure_storage_dart:
     path: ../../amplify_secure_storage_dart
   aws_common:

--- a/packages/secure_storage/amplify_secure_storage_dart/example/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/example/pubspec.yaml
@@ -26,10 +26,6 @@ dependencies:
   example_common:
     path: ../../../example_common
 
-dependency_overrides:
-  worker_bee:
-    path: ../../../worker_bee/worker_bee
-
 dev_dependencies:
   amplify_lints:
     path: ../../../amplify_lints

--- a/packages/secure_storage/amplify_secure_storage_dart/example/pubspec_overrides.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/example/pubspec_overrides.yaml
@@ -1,0 +1,12 @@
+# This file is checked in until it can be easily generated locally
+# and in CI pipelines, e.g. with melos.
+#
+# It may cause issues with publishing until https://github.com/dart-lang/pub/pull/3419
+# is released in stable.
+dependency_overrides:
+  amplify_core:
+    path: ../../../amplify_core
+  aws_common:
+    path: ../../../aws_common
+  worker_bee:
+    path: ../../../worker_bee/worker_bee 

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/interfaces/amplify_secure_storage_interface.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/interfaces/amplify_secure_storage_interface.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/src/interfaces/secure_storage_interface.dart';
 import 'package:amplify_secure_storage_dart/src/types/amplify_secure_storage_config.dart';
 
@@ -26,4 +27,6 @@ abstract class AmplifySecureStorageInterface extends SecureStorageInterface {
 
   /// Configuration options for Secure Storage.
   final AmplifySecureStorageConfig config;
+
+  AmplifyLogger get logger => AmplifyLogger().createChild('SecureStorage');
 }

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/mixins/amplify_secure_storage_mixin.web.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/mixins/amplify_secure_storage_mixin.web.dart
@@ -16,17 +16,12 @@ import 'dart:async';
 
 import 'package:amplify_secure_storage_dart/src/interfaces/amplify_secure_storage_interface.dart';
 import 'package:amplify_secure_storage_dart/src/interfaces/secure_storage_interface.dart';
-import 'package:amplify_secure_storage_dart/src/platforms/amplify_secure_storage_in_memory.dart';
 import 'package:amplify_secure_storage_dart/src/platforms/amplify_secure_storage_web.dart';
-import 'package:amplify_secure_storage_dart/src/types/web_secure_storage_options.dart';
 
 /// [AmplifySecureStorageDartMixin] that will be used on the web
 mixin AmplifySecureStorageDartMixin on AmplifySecureStorageInterface
     implements SecureStorageInterface {
-  late final _instance =
-      config.webOptions.persistenceOption == WebPersistenceOption.inMemory
-          ? const AmplifySecureStorageInMemory()
-          : AmplifySecureStorageWeb(config: config);
+  late final _instance = AmplifySecureStorageWeb(config: config);
 
   @override
   FutureOr<void> write({required String key, required String value}) {

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_web.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_web.dart
@@ -32,7 +32,7 @@ class AmplifySecureStorageWeb extends AmplifySecureStorageInterface {
     if (indexedDB == null) {
       logger.warn(
         'IndexedDB is not available. '
-        'Falling back on in-memory storage.',
+        'Falling back to in-memory storage.',
       );
       return const AmplifySecureStorageInMemory();
     }
@@ -42,11 +42,11 @@ class AmplifySecureStorageWeb extends AmplifySecureStorageInterface {
       final openRequest = indexedDB!.open('test', 1);
       await openRequest.future;
       return _IndexedDBStorage(config: config);
-    } on Object catch (_) {
+    } on Object {
       logger.warn(
         'Could not open IndexedDB database. '
         'It may not be supported by the current browser. '
-        'Falling back on in-memory storage.',
+        'Falling back to in-memory storage.',
       );
       return const AmplifySecureStorageInMemory();
     }

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_web.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_web.dart
@@ -14,15 +14,65 @@
 
 import 'dart:async';
 
+import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 import 'package:amplify_secure_storage_dart/src/exception/not_available_exception.dart';
 import 'package:amplify_secure_storage_dart/src/exception/secure_storage_exception.dart';
-import 'package:amplify_secure_storage_dart/src/interfaces/amplify_secure_storage_interface.dart';
-import 'package:amplify_secure_storage_dart/src/interfaces/secure_storage_interface.dart';
 import 'package:amplify_secure_storage_dart/src/js/indexed_db.dart';
+import 'package:amplify_secure_storage_dart/src/platforms/amplify_secure_storage_in_memory.dart';
 
 /// The web implementation of [SecureStorageInterface].
 class AmplifySecureStorageWeb extends AmplifySecureStorageInterface {
   AmplifySecureStorageWeb({required super.config});
+
+  /// The [SecureStorageInterface] instance to use.
+  late final Future<SecureStorageInterface> _instance = () async {
+    if (config.webOptions.persistenceOption == WebPersistenceOption.inMemory) {
+      return const AmplifySecureStorageInMemory();
+    }
+    if (indexedDB == null) {
+      logger.warn(
+        'IndexedDB is not available. '
+        'Falling back on in-memory storage.',
+      );
+      return const AmplifySecureStorageInMemory();
+    }
+    // indexedDB will be non-null in Firefox private browsing,
+    // but will fail to open.
+    try {
+      final openRequest = indexedDB!.open('test', 1);
+      await openRequest.future;
+      return _IndexedDBStorage(config: config);
+    } on Object catch (_) {
+      logger.warn(
+        'Could not open IndexedDB database. '
+        'It may not be supported by the current browser. '
+        'Falling back on in-memory storage.',
+      );
+      return const AmplifySecureStorageInMemory();
+    }
+  }();
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    final instance = await _instance;
+    return instance.write(key: key, value: value);
+  }
+
+  @override
+  Future<String?> read({required String key}) async {
+    final instance = await _instance;
+    return instance.read(key: key);
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    final instance = await _instance;
+    return instance.delete(key: key);
+  }
+}
+
+class _IndexedDBStorage extends AmplifySecureStorageInterface {
+  _IndexedDBStorage({required super.config});
 
   /// The name of the database
   ///
@@ -40,9 +90,9 @@ class AmplifySecureStorageWeb extends AmplifySecureStorageInterface {
 
   late final IDBDatabase _database;
 
-  /// Opens the database and returns it as a future.
+  /// Checks for IDB availability and attempts to open the database.
   ///
-  /// Will throw a [NotAvailableException] if IndexedDB is not supported.
+  /// Will throw a [NotAvailableException] if IndexedDB is not available.
   Future<void> _openDatabase() async {
     if (indexedDB == null) {
       throw const NotAvailableException(

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
@@ -21,6 +21,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
+  amplify_core: ^0.5.0
   aws_common: ^0.1.0
   built_collection: ^5.0.0
   built_value: ^8.0.0

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec_overrides.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec_overrides.yaml
@@ -4,6 +4,8 @@
 # It may cause issues with publishing until https://github.com/dart-lang/pub/pull/3419
 # is released in stable.
 dependency_overrides:
+  amplify_core:
+    path: ../../../amplify_core
   aws_common:
     path: ../../aws_common
   worker_bee:

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec_overrides.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec_overrides.yaml
@@ -5,7 +5,7 @@
 # is released in stable.
 dependency_overrides:
   amplify_core:
-    path: ../../../amplify_core
+    path: ../../amplify_core
   aws_common:
     path: ../../aws_common
   worker_bee:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Check that indexedDB can open without exceptions, add in-memory as fallback

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
