### PR TITLE
feat(api): GraphQL Custom Request Headers

### DIFF
--- a/packages/amplify_core/lib/src/types/api/graphql/graphql_request.dart
+++ b/packages/amplify_core/lib/src/types/api/graphql/graphql_request.dart
@@ -22,6 +22,9 @@ class GraphQLRequest<T> {
   /// Only required if your backend has multiple GraphQL endpoints in the amplifyconfiguration.dart file. This parameter is then needed to specify which one to use for this request.
   final String? apiName;
 
+  /// A map of Strings to dynamically use for custom headers in the http request.
+  final Map<String, String>? customHeaders;
+
   /// The body of the request, starting with the operation type and operation name.
   ///
   /// See https://graphql.org/learn/queries/#operation-name for examples and more information.
@@ -57,12 +60,14 @@ class GraphQLRequest<T> {
       {this.apiName,
       required this.document,
       this.variables = const <String, dynamic>{},
+      this.customHeaders,
       this.decodePath,
       this.modelType});
 
   Map<String, dynamic> serializeAsMap() => <String, dynamic>{
         'document': document,
         'variables': variables,
+        'customHeaders': customHeaders,
         'cancelToken': id,
         if (apiName != null) 'apiName': apiName,
       };

--- a/packages/amplify_core/lib/src/types/api/graphql/graphql_request.dart
+++ b/packages/amplify_core/lib/src/types/api/graphql/graphql_request.dart
@@ -23,7 +23,7 @@ class GraphQLRequest<T> {
   final String? apiName;
 
   /// A map of Strings to dynamically use for custom headers in the http request.
-  final Map<String, String>? customHeaders;
+  final Map<String, String>? headers;
 
   /// The body of the request, starting with the operation type and operation name.
   ///
@@ -60,14 +60,14 @@ class GraphQLRequest<T> {
       {this.apiName,
       required this.document,
       this.variables = const <String, dynamic>{},
-      this.customHeaders,
+      this.headers,
       this.decodePath,
       this.modelType});
 
   Map<String, dynamic> serializeAsMap() => <String, dynamic>{
         'document': document,
         'variables': variables,
-        'customHeaders': customHeaders,
+        'headers': headers,
         'cancelToken': id,
         if (apiName != null) 'apiName': apiName,
       };

--- a/packages/api/amplify_api/lib/src/graphql/send_graphql_request.dart
+++ b/packages/api/amplify_api/lib/src/graphql/send_graphql_request.dart
@@ -32,7 +32,7 @@ Future<GraphQLResponse<T>> sendGraphQLRequest<T>({
   try {
     final body = {'variables': request.variables, 'query': request.document};
     final graphQLResponse = await client.post(uri,
-        body: json.encode(body), headers: request.customHeaders);
+        body: json.encode(body), headers: request.headers);
 
     final responseBody = json.decode(graphQLResponse.body);
 

--- a/packages/api/amplify_api/lib/src/graphql/send_graphql_request.dart
+++ b/packages/api/amplify_api/lib/src/graphql/send_graphql_request.dart
@@ -31,7 +31,8 @@ Future<GraphQLResponse<T>> sendGraphQLRequest<T>({
 }) async {
   try {
     final body = {'variables': request.variables, 'query': request.document};
-    final graphQLResponse = await client.post(uri, body: json.encode(body));
+    final graphQLResponse = await client.post(uri,
+        body: json.encode(body), headers: request.customHeaders);
 
     final responseBody = json.decode(graphQLResponse.body);
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/1217

*Description of changes:*
Allows devs to pass custom headers for GraphQL http requests. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
