### PR TITLE
fix(datastore): missing query field model name cause ambigous column …

### DIFF
--- a/packages/amplify/amplify_flutter_android/android/build.gradle
+++ b/packages/amplify/amplify_flutter_android/android/build.gradle
@@ -72,7 +72,7 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:core:v1.37.0-cpkey-preview.2'
+    implementation 'com.amplifyframework:core:v1.37.0-cpkey-preview.3'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 
     testImplementation 'junit:junit:4.13.2'
@@ -81,6 +81,6 @@ dependencies {
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'com.google.code.gson:gson:2.8.6'
-    testImplementation 'com.amplifyframework:aws-auth-cognito:v1.37.0-cpkey-preview.2'
+    testImplementation 'com.amplifyframework:aws-auth-cognito:v1.37.0-cpkey-preview.3'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9'
 }

--- a/packages/amplify_core/android/build.gradle
+++ b/packages/amplify_core/android/build.gradle
@@ -69,7 +69,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.amplifyframework:core:v1.37.0-cpkey-preview.2'
+    implementation 'com.amplifyframework:core:v1.37.0-cpkey-preview.3'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -69,8 +69,8 @@ android {
 }
 
 dependencies {
-    implementation "com.amplifyframework:aws-datastore:v1.37.0-cpkey-preview.2"
-    implementation "com.amplifyframework:aws-api-appsync:v1.37.0-cpkey-preview.2"
+    implementation "com.amplifyframework:aws-datastore:v1.37.0-cpkey-preview.3"
+    implementation "com.amplifyframework:aws-api-appsync:v1.37.0-cpkey-preview.3"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
@@ -58,7 +58,13 @@ class QueryPredicateBuilder {
                     }
                 }
 
-                val queryField: QueryField = QueryField.field(field)
+                // Here we are using query root model name to create QueryField to let amplify-android
+                // generate correct SQL command.
+                // This is based on the current assumption: amplify-flutter doesn't support cross models nested
+                // predicate e.g. query comments by post.id
+                // This part should be reviewed when introducing nested predicate functionality
+                val queryField: QueryField = if (field.startsWith("@@")) QueryField.field(field) else QueryField
+                    .field(modelSchema?.name, field)
                 val queryFieldOperatorMap: Map<String, Any> =
                     queryPredicateOperationMap["fieldOperator"].safeCastToMap()!!
                 val operand: Any? = queryFieldOperatorMap["value"]
@@ -175,8 +181,18 @@ class QueryPredicateBuilder {
                 }
 
                 return when (queryByIdentifierOperation["operatorName"]) {
-                    "equal" -> convertQueryByIdentifierOperationToPredicate(operands.cast(), true)
-                    "not_equal" -> convertQueryByIdentifierOperationToPredicate(operands.cast(), false)
+                    // In the query model identifier use case, we can only query by the fields on the query root mode
+                    // Hence, passing modelName from the root model schema to create the native QueryField is safe
+                    "equal" -> convertQueryByIdentifierOperationToPredicate(
+                        modelSchema?.name,
+                        operands.cast(),
+                        true
+                    )
+                    "not_equal" -> convertQueryByIdentifierOperationToPredicate(
+                        modelSchema?.name,
+                        operands.cast(),
+                        false
+                    )
                     else -> throw IllegalArgumentException(
                         "Operator cannot be equal for a queryByIdentifierOperation"
                     )
@@ -192,12 +208,14 @@ class QueryPredicateBuilder {
         }
 
         @JvmStatic
-        fun convertQueryByIdentifierOperationToPredicate(operands: List<Map<String, Any>>, isEqualOperator: Boolean):
+        fun convertQueryByIdentifierOperationToPredicate(modelName: String?, operands: List<Map<String, Any>>,
+                                                         isEqualOperator:
+        Boolean):
                 QueryPredicate {
             var predicates = operands.map {
                 val operandEntry = it.entries.first()
                 when {
-                    isEqualOperator -> QueryField.field(operandEntry.key).eq(operandEntry.value)
+                    isEqualOperator -> QueryField.field(modelName, operandEntry.key).eq(operandEntry.value)
                     else -> QueryField.field(operandEntry.key).ne(operandEntry.value)
                 }
             }

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
@@ -215,7 +215,7 @@ class QueryPredicateBuilder {
                 val operandEntry = it.entries.first()
                 when {
                     isEqualOperator -> QueryField.field(modelName, operandEntry.key).eq(operandEntry.value)
-                    else -> QueryField.field(operandEntry.key).ne(operandEntry.value)
+                    else -> QueryField.field(modelName, operandEntry.key).ne(operandEntry.value)
                 }
             }
 

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilder.kt
@@ -63,8 +63,7 @@ class QueryPredicateBuilder {
                 // This is based on the current assumption: amplify-flutter doesn't support cross models nested
                 // predicate e.g. query comments by post.id
                 // This part should be reviewed when introducing nested predicate functionality
-                val queryField: QueryField = if (field.startsWith("@@")) QueryField.field(field) else QueryField
-                    .field(modelSchema?.name, field)
+                val queryField: QueryField = QueryField.field(modelSchema?.name, field)
                 val queryFieldOperatorMap: Map<String, Any> =
                     queryPredicateOperationMap["fieldOperator"].safeCastToMap()!!
                 val operand: Any? = queryFieldOperatorMap["value"]

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePluginTest.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePluginTest.kt
@@ -305,10 +305,10 @@ class AmplifyDataStorePluginTest {
     fun test_query_with_predicates_success_zero_result() {
         val queryOptions =
             Where.matches(
-                field("id").eq("123").or(
-                    field("rating").ge(4).and(
+                field("Post","id").eq("123").or(
+                    field("Post","rating").ge(4).and(
                         not(
-                            field("created").eq("2020-02-20T20:20:20-08:00")
+                            field("Post","created").eq("2020-02-20T20:20:20-08:00")
                         )
                     )
                 )

--- a/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilderTest.kt
+++ b/packages/amplify_datastore/android/src/test/kotlin/com/amazonaws/amplify/amplify_datastore/types/query/QueryPredicateBuilderTest.kt
@@ -32,12 +32,12 @@ class QueryPredicateBuilderTest {
     private val title: QueryField = QueryField.field("title")
     private val rating: QueryField = QueryField.field("rating")
     private val created: QueryField = QueryField.field("created")
-    private val blogID: QueryField = QueryField.field("blogID")
+    private val blogID: QueryField = QueryField.field("Post", "blogID")
     private val inventoryProductID = QueryField.field("productID")
     private val inventoryName = QueryField.field("name")
     private val inventoryWarehouseID = QueryField.field("warehouseID")
     private val inventoryRegion = QueryField.field("region")
-    private val cpkBlogForeignKeyField = QueryField.field("@@blogForeignKey")
+    private val cpkBlogForeignKeyField = QueryField.field("Post","@@blogForeignKey")
 
     @Test
     fun test_when_id_not_equals() {

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/belongs_to_explicit_parent_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/belongs_to_explicit_parent_test.dart
@@ -50,8 +50,10 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: BelongsToParent.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier: BelongsToParent.MODEL_IDENTIFIER,
       associatedModelType: BelongsToChildExplicit.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier: BelongsToChildExplicit.MODEL_IDENTIFIER,
       supportCascadeDelete: true,
       enableCloudSync: enableCloudSync,
     );

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/belongs_to_implicit_parent_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/belongs_to_implicit_parent_test.dart
@@ -49,8 +49,10 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: BelongsToParent.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier: BelongsToParent.MODEL_IDENTIFIER,
       associatedModelType: BelongsToChildImplicit.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier: BelongsToChildImplicit.MODEL_IDENTIFIER,
       supportCascadeDelete: true,
       enableCloudSync: enableCloudSync,
     );

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_has_many_bidirectional_explicit_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_has_many_bidirectional_explicit_test.dart
@@ -55,8 +55,12 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: CpkHasManyParentBidirectionalExplicit.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier:
+          CpkHasManyParentBidirectionalExplicit.MODEL_IDENTIFIER,
       associatedModelType: CpkHasManyChildBidirectionalExplicit.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier:
+          CpkHasManyChildBidirectionalExplicit.MODEL_IDENTIFIER,
       supportCascadeDelete: true,
       enableCloudSync: enableCloudSync,
     );

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_has_many_bidirectional_implicit_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_has_many_bidirectional_implicit_test.dart
@@ -47,15 +47,27 @@ void main() {
         hasManyParent: rootModels.first,
       ),
     );
+    var associatedModelQueryPredicates = associatedModels
+        .map(
+          (associatedModel) => CpkHasManyChildBidirectionalImplicit.NAME
+              .eq(associatedModel.name),
+        )
+        .toList();
 
     testRootAndAssociatedModelsRelationship(
       modelProvider: ModelProvider.instance,
       rootModelType: CpkHasManyParentBidirectionalImplicit.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier:
+          CpkHasManyParentBidirectionalImplicit.MODEL_IDENTIFIER,
       associatedModelType: CpkHasManyChildBidirectionalImplicit.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier:
+          CpkHasManyChildBidirectionalImplicit.MODEL_IDENTIFIER,
+      associatedModelQueryPredicates: associatedModelQueryPredicates,
       supportCascadeDelete: true,
       enableCloudSync: enableCloudSync,
+      verifyBelongsToPopulating: true,
     );
   });
 }

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_has_many_unidirectional_explicit_parent_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_has_many_unidirectional_explicit_parent_test.dart
@@ -57,8 +57,11 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: CpkHasManyUnidirectionalParent.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier: CpkHasManyUnidirectionalParent.MODEL_IDENTIFIER,
       associatedModelType: CpkHasManyUnidirectionalChildExplicit.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier:
+          CpkHasManyUnidirectionalChildExplicit.MODEL_IDENTIFIER,
       enableCloudSync: enableCloudSync,
     );
   });

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_has_many_unidirectional_implicit_parent_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_has_many_unidirectional_implicit_parent_test.dart
@@ -55,8 +55,11 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: CpkHasManyUnidirectionalParent.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier: CpkHasManyUnidirectionalParent.MODEL_IDENTIFIER,
       associatedModelType: CpkHasManyUnidirectionalChildImplicit.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier:
+          CpkHasManyUnidirectionalChildImplicit.MODEL_IDENTIFIER,
       enableCloudSync: enableCloudSync,
     );
   });

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_one_to_one_bidirectional_explicit_belongs_to_custom_id_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_one_to_one_bidirectional_explicit_belongs_to_custom_id_test.dart
@@ -60,8 +60,12 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: CpkOneToOneBidirectionalParentCD.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier:
+          CpkOneToOneBidirectionalParentCD.MODEL_IDENTIFIER,
       associatedModelType: CpkOneToOneBidirectionalChildExplicitCD.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier:
+          CpkOneToOneBidirectionalChildExplicitCD.MODEL_IDENTIFIER,
       supportCascadeDelete: true,
       enableCloudSync: enableCloudSync,
     );

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_one_to_one_bidirectional_explicit_belongs_to_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_one_to_one_bidirectional_explicit_belongs_to_test.dart
@@ -56,8 +56,12 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: CpkOneToOneBidirectionalParentID.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier:
+          CpkOneToOneBidirectionalParentID.MODEL_IDENTIFIER,
       associatedModelType: CpkOneToOneBidirectionalChildExplicitID.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier:
+          CpkOneToOneBidirectionalChildExplicitID.MODEL_IDENTIFIER,
       supportCascadeDelete: true,
       enableCloudSync: enableCloudSync,
     );

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_one_to_one_bidirectional_implicit_belongs_to_custom_id_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_one_to_one_bidirectional_implicit_belongs_to_custom_id_test.dart
@@ -52,15 +52,26 @@ void main() {
         belongsToParent: rootModels.first,
       )
     ];
+    var associatedModelQueryPredicates = [
+      CpkOneToOneBidirectionalChildImplicitCD.NAME.eq(
+        associatedModels.first.name,
+      ),
+    ];
 
     testRootAndAssociatedModelsRelationship(
       modelProvider: ModelProvider.instance,
       rootModelType: CpkOneToOneBidirectionalParentCD.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier:
+          CpkOneToOneBidirectionalParentCD.MODEL_IDENTIFIER,
       associatedModelType: CpkOneToOneBidirectionalChildImplicitCD.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier:
+          CpkOneToOneBidirectionalChildImplicitCD.MODEL_IDENTIFIER,
       supportCascadeDelete: true,
       enableCloudSync: enableCloudSync,
+      associatedModelQueryPredicates: associatedModelQueryPredicates,
+      verifyBelongsToPopulating: true,
     );
   });
 }

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_one_to_one_bidirectional_implicit_belongs_to_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_one_to_one_bidirectional_implicit_belongs_to_test.dart
@@ -53,8 +53,12 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: CpkOneToOneBidirectionalParentID.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier:
+          CpkOneToOneBidirectionalParentID.MODEL_IDENTIFIER,
       associatedModelType: CpkOneToOneBidirectionalChildImplicitID.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier:
+          CpkOneToOneBidirectionalChildImplicitID.MODEL_IDENTIFIER,
       supportCascadeDelete: true,
       enableCloudSync: enableCloudSync,
     );

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_one_to_one_unidirectional_explicit_child_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_one_to_one_unidirectional_explicit_child_test.dart
@@ -56,8 +56,11 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: CpkHasOneUnidirectionalParent.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier: CpkHasOneUnidirectionalParent.MODEL_IDENTIFIER,
       associatedModelType: CpkHasOneUnidirectionalChild.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier:
+          CpkHasOneUnidirectionalChild.MODEL_IDENTIFIER,
       enableCloudSync: enableCloudSync,
     );
   });

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_one_to_one_unidirectional_implicit_child_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/cpk_one_to_one_unidirectional_implicit_child_test.dart
@@ -55,8 +55,11 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: CpkHasOneUnidirectionalParent.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier: CpkHasOneUnidirectionalParent.MODEL_IDENTIFIER,
       associatedModelType: CpkHasOneUnidirectionalChild.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier:
+          CpkHasOneUnidirectionalChild.MODEL_IDENTIFIER,
       enableCloudSync: enableCloudSync,
     );
   });

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/has_many_bidirectional_explicit_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/has_many_bidirectional_explicit_test.dart
@@ -50,15 +50,27 @@ void main() {
         hasManyParent: rootModels.first,
       ),
     );
+    var associatedModelQueryPredicates = associatedModels
+        .map(
+          (associatedModel) =>
+              HasManyChildBiDirectionalExplicit.NAME.eq(associatedModel.name),
+        )
+        .toList();
 
     testRootAndAssociatedModelsRelationship(
       modelProvider: ModelProvider.instance,
       rootModelType: HasManyParentBiDirectionalExplicit.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier:
+          HasManyParentBiDirectionalExplicit.MODEL_IDENTIFIER,
       associatedModelType: HasManyChildBiDirectionalExplicit.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier:
+          HasManyChildBiDirectionalExplicit.MODEL_IDENTIFIER,
+      associatedModelQueryPredicates: associatedModelQueryPredicates,
       supportCascadeDelete: true,
       enableCloudSync: enableCloudSync,
+      verifyBelongsToPopulating: true,
     );
   });
 }

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/has_many_bidirectional_implicit_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/has_many_bidirectional_implicit_test.dart
@@ -49,15 +49,27 @@ void main() {
         hasManyParent: rootModels.first,
       ),
     );
+    var associatedModelQueryPredicates = associatedModels
+        .map(
+          (associatedModel) =>
+              HasManyChildBiDirectionalImplicit.NAME.eq(associatedModel.name),
+        )
+        .toList();
 
     testRootAndAssociatedModelsRelationship(
       modelProvider: ModelProvider.instance,
       rootModelType: HasManyParentBiDirectionalImplicit.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier:
+          HasManyParentBiDirectionalImplicit.MODEL_IDENTIFIER,
       associatedModelType: HasManyChildBiDirectionalImplicit.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier:
+          HasManyChildBiDirectionalImplicit.MODEL_IDENTIFIER,
+      associatedModelQueryPredicates: associatedModelQueryPredicates,
       supportCascadeDelete: true,
       enableCloudSync: enableCloudSync,
+      verifyBelongsToPopulating: true,
     );
   });
 }

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/has_many_explicit_parent_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/has_many_explicit_parent_test.dart
@@ -52,8 +52,10 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: HasManyParent.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier: HasManyParent.MODEL_IDENTIFIER,
       associatedModelType: HasManyChildExplicit.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier: HasManyChildExplicit.MODEL_IDENTIFIER,
       enableCloudSync: enableCloudSync,
     );
   });

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/has_many_implicit_parent_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/has_many_implicit_parent_test.dart
@@ -49,8 +49,10 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: HasManyParent.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier: HasManyParent.MODEL_IDENTIFIER,
       associatedModelType: HasManyChildImplicit.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier: HasManyChildImplicit.MODEL_IDENTIFIER,
       enableCloudSync: enableCloudSync,
     );
   });

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/has_one_explicit_child_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/has_one_explicit_child_test.dart
@@ -48,8 +48,10 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: HasOneParent.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier: HasOneParent.MODEL_IDENTIFIER,
       associatedModelType: HasOneChild.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier: HasOneChild.MODEL_IDENTIFIER,
       enableCloudSync: enableCloudSync,
     );
   });

--- a/packages/amplify_datastore/example/integration_test/separate_integration_tests/has_one_implicit_child_test.dart
+++ b/packages/amplify_datastore/example/integration_test/separate_integration_tests/has_one_implicit_child_test.dart
@@ -51,8 +51,10 @@ void main() {
       modelProvider: ModelProvider.instance,
       rootModelType: HasOneParent.classType,
       rootModels: rootModels,
+      rootModelQueryIdentifier: HasOneParent.MODEL_IDENTIFIER,
       associatedModelType: HasOneChild.classType,
       associatedModels: associatedModels,
+      associatedModelQueryIdentifier: HasOneChild.MODEL_IDENTIFIER,
       enableCloudSync: enableCloudSync,
     );
   });

--- a/packages/amplify_datastore/test/resources/query_api/request/model_name_with_all_query_parameters.json
+++ b/packages/amplify_datastore/test/resources/query_api/request/model_name_with_all_query_parameters.json
@@ -6,7 +6,6 @@
       "predicates": [
         {
           "queryPredicateOperation": {
-            "modelName": "Post",
             "field": "id",
             "fieldOperator": { "operatorName": "equal", "value": "123" }
           }
@@ -17,7 +16,6 @@
             "predicates": [
               {
                 "queryPredicateOperation": {
-                  "modelName": "Post",
                   "field": "rating",
                   "fieldOperator": {
                     "operatorName": "greater_or_equal",
@@ -31,7 +29,6 @@
                   "predicates": [
                     {
                       "queryPredicateOperation": {
-                        "modelName": "Post",
                         "field": "created",
                         "fieldOperator": {
                           "operatorName": "equal",

--- a/packages/amplify_datastore/test/resources/query_api/request/model_name_with_all_query_parameters.json
+++ b/packages/amplify_datastore/test/resources/query_api/request/model_name_with_all_query_parameters.json
@@ -6,6 +6,7 @@
       "predicates": [
         {
           "queryPredicateOperation": {
+            "modelName": "Post",
             "field": "id",
             "fieldOperator": { "operatorName": "equal", "value": "123" }
           }
@@ -16,6 +17,7 @@
             "predicates": [
               {
                 "queryPredicateOperation": {
+                  "modelName": "Post",
                   "field": "rating",
                   "fieldOperator": {
                     "operatorName": "greater_or_equal",
@@ -29,6 +31,7 @@
                   "predicates": [
                     {
                       "queryPredicateOperation": {
+                        "modelName": "Post",
                         "field": "created",
                         "fieldOperator": {
                           "operatorName": "equal",

--- a/packages/analytics/amplify_analytics_pinpoint_android/android/build.gradle
+++ b/packages/analytics/amplify_analytics_pinpoint_android/android/build.gradle
@@ -72,8 +72,8 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:v1.37.0-cpkey-preview.2'
-    implementation 'com.amplifyframework:aws-auth-cognito:v1.37.0-cpkey-preview.2'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:v1.37.0-cpkey-preview.3'
+    implementation 'com.amplifyframework:aws-auth-cognito:v1.37.0-cpkey-preview.3'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/packages/api/amplify_api_android/android/build.gradle
+++ b/packages/api/amplify_api_android/android/build.gradle
@@ -72,8 +72,8 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation "com.amplifyframework:aws-api:v1.37.0-cpkey-preview.2"
-    implementation "com.amplifyframework:aws-api-appsync:v1.37.0-cpkey-preview.2"
+    implementation "com.amplifyframework:aws-api:v1.37.0-cpkey-preview.3"
+    implementation "com.amplifyframework:aws-api-appsync:v1.37.0-cpkey-preview.3"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 
     testImplementation 'junit:junit:4.13.2'

--- a/packages/auth/amplify_auth_cognito_android/android/build.gradle
+++ b/packages/auth/amplify_auth_cognito_android/android/build.gradle
@@ -74,7 +74,7 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:aws-auth-cognito:v1.37.0-cpkey-preview.2'
+    implementation 'com.amplifyframework:aws-auth-cognito:v1.37.0-cpkey-preview.3'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/packages/storage/amplify_storage_s3_android/android/build.gradle
+++ b/packages/storage/amplify_storage_s3_android/android/build.gradle
@@ -62,5 +62,5 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:aws-storage-s3:v1.37.0-cpkey-preview.2'
+    implementation 'com.amplifyframework:aws-storage-s3:v1.37.0-cpkey-preview.3'
 }


### PR DESCRIPTION
…SQL error

*Issue #, if available:*

*Description of changes:*

* Update QueryPredicateBuilder to supply `modelName` for native `QueryField`
* Update integration tests to cover related use case to verify the fix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
