### PR TITLE
fix(authenticator): do not return new state on sign in hub event

### DIFF
--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -142,9 +142,8 @@ class StateMachineBloc
     logger.debug('Handling hub event: ${event.type}');
     switch (event.type) {
       case AuthHubEventType.signedIn:
-        if (_currentState is! AuthenticatedState) {
-          return const AuthenticatedState();
-        }
+        // TODO(Jordan-Nelson): Display app after sign in hub event.
+        // Need requirements for how this impacts verify user.
         break;
       case AuthHubEventType.signedOut:
       case AuthHubEventType.sessionExpired:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- do not return new state on sign in hub event

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
