### PR TITLE
fix(auth): Hosted UI server contention

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
@@ -93,10 +93,12 @@ abstract class HostedUiPlatform implements Closeable {
 
   /// The default redirect URI for sign in.
   @protected
+  @visibleForTesting
   Uri get signInRedirectUri;
 
   /// The default redirect URI for sign out.
   @protected
+  @visibleForTesting
   Uri get signOutRedirectUri;
 
   /// Gets the authrorization URL for presenting to the user.

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_io.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_io.dart
@@ -336,7 +336,7 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
   /// Closes the open server, if any.
   @override
   Future<void> close() async {
-    await _localServer?.server.close(force: true);
+    await _localServer?.server.close();
     _localServer = null;
   }
 }

--- a/packages/auth/amplify_auth_cognito_test/test/common/mock_config.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/common/mock_config.dart
@@ -23,7 +23,7 @@ const testAppClientId = 'appClientId';
 const testIdentityPoolId = 'identityPoolId';
 const testRegion = 'region';
 const scopes = ['profile'];
-const redirectUri = 'http://localhost:9999';
+const redirectUri = 'http://localhost:9999/';
 const webDomain = 'example.com';
 const hostedUiConfig = CognitoOAuthConfig(
   appClientId: testAppClientId,

--- a/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_io_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_io_test.dart
@@ -14,16 +14,40 @@
 
 @TestOn('windows || mac-os || linux')
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/hosted_ui_platform_io.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
+import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 
+import '../../common/mock_config.dart';
+import '../../common/mock_dispatcher.dart';
 import '../../common/mock_hosted_ui.dart';
 import '../../common/mock_secure_storage.dart';
+
+class MockHostedUiPlatform extends HostedUiPlatformImpl {
+  MockHostedUiPlatform(super.dependencyManager);
+
+  LocalServer? _localServer;
+
+  @override
+  Future<void> launchUrl(String url) async {}
+
+  @override
+  Future<LocalServer> localConnect(Iterable<Uri> uris) async {
+    return _localServer = await super.localConnect(uris);
+  }
+
+  @override
+  Future<void> close() async {
+    _localServer = null;
+    await super.close();
+  }
+}
 
 void main() {
   group('HostedUIPlatform', () {
@@ -114,6 +138,55 @@ void main() {
         }
         await platform(dependencyManager).signIn(
           options: const CognitoSignInWithWebUIOptions(),
+        );
+      });
+    });
+
+    group('signIn', () {
+      test('completes', () async {
+        final client = http.Client();
+        final dispatcher = DispatchListener(
+          onDispatch: expectAsync1((event) {
+            expect(event, isA<HostedUiExchange>());
+          }),
+        );
+        dependencyManager
+          ..addInstance(client)
+          ..addInstance(mockConfig)
+          ..addInstance(hostedUiConfig)
+          ..addInstance<Dispatcher>(dispatcher);
+        final hostedUiPlatform = MockHostedUiPlatform(dependencyManager);
+
+        final redirect = Uri.parse(redirectUri);
+        expect(hostedUiPlatform.signInRedirectUri, redirect);
+        expect(hostedUiPlatform.signOutRedirectUri, redirect);
+
+        unawaited(
+          hostedUiPlatform.signIn(
+            options: const CognitoSignInWithWebUIOptions(),
+          ),
+        );
+
+        await expectLater(client.get(redirect), completes);
+        expect(
+          hostedUiPlatform._localServer,
+          isNotNull,
+          reason: "Server won't close until a valid redirect is performed",
+        );
+
+        await expectLater(
+          client.get(
+            redirect.replace(
+              queryParameters: {'state': 'state', 'code': 'code'},
+            ),
+          ),
+          completes,
+        );
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          hostedUiPlatform._localServer,
+          isNull,
+          reason: 'A valid redirect includes state + code/error',
         );
       });
     });


### PR DESCRIPTION
Fixes https://github.com/aws-amplify/amplify-flutter/issues/2011

Fixes an issue where, on certain platforms, the open server connection is not closed before trying to force close the server.
