### PR TITLE
fix(datastore): adapt amplify-ios CPK fix breaking change

### DIFF
--- a/packages/amplify/amplify_flutter_android/android/build.gradle
+++ b/packages/amplify/amplify_flutter_android/android/build.gradle
@@ -72,7 +72,7 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:core:v1.37.0-cpkey-preview.3'
+    implementation 'com.amplifyframework:core:1.37.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 
     testImplementation 'junit:junit:4.13.2'
@@ -81,6 +81,6 @@ dependencies {
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'com.google.code.gson:gson:2.8.6'
-    testImplementation 'com.amplifyframework:aws-auth-cognito:v1.37.0-cpkey-preview.3'
+    testImplementation 'com.amplifyframework:aws-auth-cognito:1.37.0'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9'
 }

--- a/packages/amplify/amplify_flutter_ios/ios/amplify_flutter_ios.podspec
+++ b/packages/amplify/amplify_flutter_ios/ios/amplify_flutter_ios.podspec
@@ -17,9 +17,9 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.27.1-cpk.1'
-  s.dependency 'AWSPluginsCore', '1.27.1-cpk.1'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.27.1-cpk.1'
+  s.dependency 'Amplify', '1.28.0'
+  s.dependency 'AWSPluginsCore', '1.28.0'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.28.0'
   s.dependency 'amplify_core'
   s.dependency 'SwiftLint'
   s.dependency 'SwiftFormat/CLI'

--- a/packages/amplify_core/android/build.gradle
+++ b/packages/amplify_core/android/build.gradle
@@ -69,7 +69,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.amplifyframework:core:v1.37.0-cpkey-preview.3'
+    implementation 'com.amplifyframework:core:1.37.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -69,8 +69,8 @@ android {
 }
 
 dependencies {
-    implementation "com.amplifyframework:aws-datastore:v1.37.0-cpkey-preview.3"
-    implementation "com.amplifyframework:aws-api-appsync:v1.37.0-cpkey-preview.3"
+    implementation "com.amplifyframework:aws-datastore:1.37.0"
+    implementation "com.amplifyframework:aws-api-appsync:1.37.0"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/packages/amplify_datastore/example/ios/unit_tests/QueryPredicateBuilderUnitTests.swift
+++ b/packages/amplify_datastore/example/ios/unit_tests/QueryPredicateBuilderUnitTests.swift
@@ -152,7 +152,7 @@ class QueryPredicateBuilderUnitTests: XCTestCase {
     func test_when_query_associated_model_identifier_used() throws {
         XCTAssertEqual(
             hasManyParent.eq(
-                FlutterSerializedModel.Identifier.make(
+                FlutterSerializedModel.IdentifierProtocol.make(
                     fields: [
                         (name: "id", value: "parent-id"),
                         (name: "name", value: "parent-name")

--- a/packages/amplify_datastore/ios/Classes/types/model/FlutterSerializedModel.swift
+++ b/packages/amplify_datastore/ios/Classes/types/model/FlutterSerializedModel.swift
@@ -19,7 +19,7 @@ import Amplify
 
 public struct FlutterSerializedModel: Model, ModelIdentifiable, JSONValueHolder {
     public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-    public typealias Identifier = ModelIdentifier<FlutterSerializedModel, ModelIdentifierFormat.Custom>
+    public typealias IdentifierProtocol = ModelIdentifier<FlutterSerializedModel, ModelIdentifierFormat.Custom>
 
     public var values: [String: JSONValue]
     var _modelName: String

--- a/packages/amplify_datastore/ios/Classes/types/query/QueryPredicateBuilder.swift
+++ b/packages/amplify_datastore/ios/Classes/types/query/QueryPredicateBuilder.swift
@@ -160,7 +160,7 @@ public enum QueryPredicateBuilder {
 
     static func convertIdentifierFieldOperatorToPredicate(operands: [[String: Any]], field: QueryField, isEqualOperator: Bool) throws -> QueryPredicate {
         let identifierFields = try convertToModelIdentifierFields(values: operands)
-        let operand = FlutterSerializedModel.Identifier.make(fields: identifierFields).stringValue
+        let operand = FlutterSerializedModel.IdentifierProtocol.make(fields: identifierFields).stringValue
 
         return isEqualOperator ? field.eq(operand) : field.ne(operand)
     }

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,8 +15,8 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.27.1-cpk.1'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.27.1-cpk.1'
+  s.dependency 'Amplify', '1.28.0'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.28.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '13.0'
 

--- a/packages/analytics/amplify_analytics_pinpoint_android/android/build.gradle
+++ b/packages/analytics/amplify_analytics_pinpoint_android/android/build.gradle
@@ -72,8 +72,8 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:v1.37.0-cpkey-preview.3'
-    implementation 'com.amplifyframework:aws-auth-cognito:v1.37.0-cpkey-preview.3'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.37.0'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.37.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/packages/analytics/amplify_analytics_pinpoint_ios/ios/amplify_analytics_pinpoint_ios.podspec
+++ b/packages/analytics/amplify_analytics_pinpoint_ios/ios/amplify_analytics_pinpoint_ios.podspec
@@ -15,8 +15,8 @@ This code is the iOS part of the Amplify Flutter Pinpoint Analytics Plugin.  The
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.27.1-cpk.1'
-  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.27.1-cpk.1'
+  s.dependency 'Amplify', '1.28.0'
+  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.28.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/api/amplify_api_android/android/build.gradle
+++ b/packages/api/amplify_api_android/android/build.gradle
@@ -72,8 +72,8 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation "com.amplifyframework:aws-api:v1.37.0-cpkey-preview.3"
-    implementation "com.amplifyframework:aws-api-appsync:v1.37.0-cpkey-preview.3"
+    implementation "com.amplifyframework:aws-api:1.37.0"
+    implementation "com.amplifyframework:aws-api-appsync:1.37.0"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 
     testImplementation 'junit:junit:4.13.2'

--- a/packages/api/amplify_api_ios/ios/amplify_api_ios.podspec
+++ b/packages/api/amplify_api_ios/ios/amplify_api_ios.podspec
@@ -15,8 +15,8 @@ The API module for Amplify Flutter.
   s.source           = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.27.1-cpk.1'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.27.1-cpk.1'
+  s.dependency 'Amplify', '1.28.0'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.28.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/auth/amplify_auth_cognito_android/android/build.gradle
+++ b/packages/auth/amplify_auth_cognito_android/android/build.gradle
@@ -74,7 +74,7 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:aws-auth-cognito:v1.37.0-cpkey-preview.3'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.37.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
+++ b/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.27.1-cpk.1'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.27.1-cpk.1'
+  s.dependency 'Amplify', '1.28.0'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.28.0'
   s.dependency 'ObjectMapper'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'

--- a/packages/storage/amplify_storage_s3_android/android/build.gradle
+++ b/packages/storage/amplify_storage_s3_android/android/build.gradle
@@ -62,5 +62,5 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:aws-storage-s3:v1.37.0-cpkey-preview.3'
+    implementation 'com.amplifyframework:aws-storage-s3:1.37.0'
 }

--- a/packages/storage/amplify_storage_s3_ios/ios/amplify_storage_s3_ios.podspec
+++ b/packages/storage/amplify_storage_s3_ios/ios/amplify_storage_s3_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.27.1-cpk.1'
-  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.27.1-cpk.1'
+  s.dependency 'Amplify', '1.28.0'
+  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.28.0'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Adapt [this amplify-ios change](https://github.com/aws-amplify/amplify-ios/pull/2077) for custom primary key feature 
* [chore: bump amplify-ios to 1.28.0](https://github.com/aws-amplify/amplify-flutter/pull/2005/commits/ff1a16ec297ec15f8c9b7a2509c9163db0d36615)
* [chore: bump amplify-android to 1.37.0](https://github.com/aws-amplify/amplify-flutter/pull/2005/commits/8a5b424e3cc8426748cec33a2342bb9ad56b43ce)

Do not merge until amplify-ios fix is released.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
