### PR TITLE
fix(auth): Remember device metadata

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -15,7 +15,7 @@
 import 'dart:async';
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
-import 'package:amplify_auth_cognito_dart/src/credentials/cognito_keys.dart';
+import 'package:amplify_auth_cognito_dart/src/credentials/device_metadata_repository.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/constants.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/helpers.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/initial_parameters_stub.dart'
@@ -116,6 +116,10 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
   /// The Cognito identity pool configuration.
   CognitoIdentityCredentialsProvider? get _identityPoolConfig =>
       _stateMachine.get();
+
+  /// The device metadata repository, used for handling device operations.
+  DeviceMetadataRepository get _deviceRepo =>
+      _stateMachine.getOrCreate(DeviceMetadataRepository.token);
 
   final StreamController<AuthHubEvent> _hubEventController =
       StreamController.broadcast();
@@ -760,21 +764,16 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
 
   @override
   Future<void> rememberDevice() async {
-    // Use credentials state machine since we need device info as well.
-    final result = await _stateMachine
-        .expect(CredentialStoreStateMachine.type)
-        .getCredentialsResult();
-    final deviceKey = result.data.deviceSecrets?.deviceKey;
+    final tokens = await getUserPoolTokens();
+    final username = CognitoIdToken(tokens.idToken).username;
+    final deviceSecrets = await _deviceRepo.get(username);
+    final deviceKey = deviceSecrets?.deviceKey;
     if (deviceKey == null) {
       throw const DeviceNotTrackedException();
     }
-    final accessToken = result.data.userPoolTokens?.accessToken;
-    if (accessToken == null) {
-      throw const SignedOutException('No user is currently signed in');
-    }
     await _cognitoIdp.updateDeviceStatus(
       cognito.UpdateDeviceStatusRequest(
-        accessToken: accessToken.raw,
+        accessToken: tokens.accessToken.raw,
         deviceKey: deviceKey,
         deviceRememberedStatus: cognito.DeviceRememberedStatusType.remembered,
       ),
@@ -783,28 +782,22 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
 
   @override
   Future<void> forgetDevice([AuthDevice? device]) async {
-    // Use credentials state machine since we need device info as well.
-    final result = await _stateMachine
-        .expect(CredentialStoreStateMachine.type)
-        .getCredentialsResult();
-    final deviceKey = device?.id ?? result.data.deviceSecrets?.deviceKey;
+    final tokens = await getUserPoolTokens();
+    final username = CognitoIdToken(tokens.idToken).username;
+    final deviceSecrets = await _deviceRepo.get(username);
+    final deviceKey = device?.id ?? deviceSecrets?.deviceKey;
     if (deviceKey == null) {
       throw const DeviceNotTrackedException();
     }
     try {
       await _cognitoIdp.forgetDevice(
         cognito.ForgetDeviceRequest(
-          accessToken: result.data.userPoolTokens?.accessToken.raw,
+          accessToken: tokens.accessToken.raw,
           deviceKey: deviceKey,
         ),
       );
     } finally {
-      _stateMachine.dispatch(
-        CredentialStoreEvent.clearCredentials(
-          keys: CognitoUserPoolKeys(_userPoolConfig).deviceKeys,
-          force: true,
-        ),
-      );
+      await _deviceRepo.remove(username);
     }
   }
 
@@ -928,6 +921,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
     await _stateMachine.dispatch(
       const CredentialStoreEvent.clearCredentials(),
     );
+    await _deviceRepo.remove(CognitoIdToken(tokens.idToken).username);
     _hubEventController
       ..add(AuthHubEvent.signedOut())
       ..add(AuthHubEvent.userDeleted());

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_auth_cognito_dart/src/credentials/cognito_keys.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/constants.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/helpers.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/initial_parameters_stub.dart'
@@ -790,12 +791,20 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
     if (deviceKey == null) {
       throw const DeviceNotTrackedException();
     }
-    await _cognitoIdp.forgetDevice(
-      cognito.ForgetDeviceRequest(
-        accessToken: result.data.userPoolTokens?.accessToken.raw,
-        deviceKey: deviceKey,
-      ),
-    );
+    try {
+      await _cognitoIdp.forgetDevice(
+        cognito.ForgetDeviceRequest(
+          accessToken: result.data.userPoolTokens?.accessToken.raw,
+          deviceKey: deviceKey,
+        ),
+      );
+    } finally {
+      _stateMachine.dispatch(
+        CredentialStoreEvent.clearCredentials(
+          CognitoUserPoolKeys(_userPoolConfig).deviceValues,
+        ),
+      );
+    }
   }
 
   @override

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -801,7 +801,8 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
     } finally {
       _stateMachine.dispatch(
         CredentialStoreEvent.clearCredentials(
-          CognitoUserPoolKeys(_userPoolConfig).deviceValues,
+          keys: CognitoUserPoolKeys(_userPoolConfig).deviceKeys,
+          force: true,
         ),
       );
     }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
@@ -117,7 +117,7 @@ class CognitoIdentityPoolKeys extends CognitoKeys<CognitoIdentityPoolKey> {
   final CognitoIdentityCredentialsProvider config;
 
   @override
-  List<CognitoIdentityPoolKey> get values => CognitoIdentityPoolKey.values;
+  List<CognitoIdentityPoolKey> get _values => CognitoIdentityPoolKey.values;
 
   @override
   String get prefix => config.poolId;
@@ -135,10 +135,10 @@ class CognitoUserPoolKeys extends CognitoKeys<CognitoUserPoolKey> {
   final CognitoUserPoolConfig config;
 
   @override
-  List<CognitoUserPoolKey> get values => CognitoUserPoolKey.values;
+  List<CognitoUserPoolKey> get _values => CognitoUserPoolKey.values;
 
   /// The [CognitoKey] values specific to device tracking.
-  List<CognitoUserPoolKey> get deviceValues => [
+  List<CognitoUserPoolKey> get deviceKeys => [
         CognitoUserPoolKey.deviceKey,
         CognitoUserPoolKey.deviceGroupKey,
         CognitoUserPoolKey.devicePassword,
@@ -160,7 +160,7 @@ class HostedUiKeys extends CognitoKeys<HostedUiKey> {
   final CognitoOAuthConfig config;
 
   @override
-  List<HostedUiKey> get values => HostedUiKey.values;
+  List<HostedUiKey> get _values => HostedUiKey.values;
 
   @override
   String get prefix => '${config.appClientId}.hostedUi';
@@ -169,13 +169,12 @@ class HostedUiKeys extends CognitoKeys<HostedUiKey> {
 /// {@template amplify_auth_cognito.cognito_keys}
 /// Iterable secure storage keys.
 /// {@endtemplate}
-abstract class CognitoKeys<Key extends CognitoKey>
-    extends IterableBase<String> {
+abstract class CognitoKeys<Key extends CognitoKey> extends IterableBase<Key> {
   /// {@macro amplify_auth_cognito.cognito_keys}
   const CognitoKeys();
 
   /// Enum values of the key type.
-  List<Key> get values;
+  List<Key> get _values;
 
   /// The prefix to use for keys.
   String get prefix;
@@ -184,10 +183,10 @@ abstract class CognitoKeys<Key extends CognitoKey>
   String operator [](Key key) => '$prefix.${key.name}';
 
   @override
-  Iterator<String> get iterator => _CognitoKeysIterator(this);
+  Iterator<Key> get iterator => _CognitoKeysIterator(this);
 }
 
-class _CognitoKeysIterator<Key extends CognitoKey> implements Iterator<String> {
+class _CognitoKeysIterator<Key extends CognitoKey> implements Iterator<Key> {
   _CognitoKeysIterator(this._keys);
 
   final CognitoKeys<Key> _keys;
@@ -196,14 +195,13 @@ class _CognitoKeysIterator<Key extends CognitoKey> implements Iterator<String> {
   int _currentIndex = -1;
 
   @override
-  String get current {
+  Key get current {
     if (_currentIndex < 0) {
       throw StateError('Must call moveNext first');
     }
-    final currentKey = _keys.values[_currentIndex];
-    return _keys[currentKey];
+    return _keys._values[_currentIndex];
   }
 
   @override
-  bool moveNext() => ++_currentIndex < _keys.values.length;
+  bool moveNext() => ++_currentIndex < _keys._values.length;
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
@@ -45,21 +45,22 @@ enum CognitoUserPoolKey with CognitoKey {
 
   /// The user ID.
   userSub,
+}
 
+/// Discrete keys stored for Cognito User Pool device tracking operations in
+/// secure storage.
+enum CognitoDeviceKey with CognitoKey {
   /// The device key.
-  deviceKey(shouldClear: false),
+  deviceKey,
 
   /// The device group key.
-  deviceGroupKey(shouldClear: false),
+  deviceGroupKey,
 
-  /// The device password
-  devicePassword(shouldClear: false);
-
-  /// {@macro amplify_auth_cognito_dart.cognito_user_pool_key}
-  const CognitoUserPoolKey({this.shouldClear = true});
+  /// The device password.
+  devicePassword;
 
   @override
-  final bool shouldClear;
+  bool get shouldClear => false;
 }
 
 /// Discrete keys stored for Cognito Identity Pool operations in secure storage.
@@ -137,15 +138,29 @@ class CognitoUserPoolKeys extends CognitoKeys<CognitoUserPoolKey> {
   @override
   List<CognitoUserPoolKey> get _values => CognitoUserPoolKey.values;
 
-  /// The [CognitoKey] values specific to device tracking.
-  List<CognitoUserPoolKey> get deviceKeys => [
-        CognitoUserPoolKey.deviceKey,
-        CognitoUserPoolKey.deviceGroupKey,
-        CognitoUserPoolKey.devicePassword,
-      ];
-
   @override
   String get prefix => config.appClientId;
+}
+
+/// {@template amplify_auth_cognito.cognito_user_pool_keys}
+/// Enumerates and iterates over the keys stored in secure storage by
+/// Cognito User Pool device tracking operations.
+/// {@endtemplate}
+class CognitoDeviceKeys extends CognitoKeys<CognitoDeviceKey> {
+  /// {@macro amplify_auth_cognito.cognito_user_pool_keys}
+  const CognitoDeviceKeys(this.config, this.username);
+
+  /// The Cognito user pool configuration, used to determine the key prefixes.
+  final CognitoUserPoolConfig config;
+
+  /// Device keys are tracked by username.
+  final String username;
+
+  @override
+  List<CognitoDeviceKey> get _values => CognitoDeviceKey.values;
+
+  @override
+  String get prefix => '${config.appClientId}.$username';
 }
 
 /// {@template amplify_auth_cognito.hosted_ui_keys}
@@ -169,7 +184,8 @@ class HostedUiKeys extends CognitoKeys<HostedUiKey> {
 /// {@template amplify_auth_cognito.cognito_keys}
 /// Iterable secure storage keys.
 /// {@endtemplate}
-abstract class CognitoKeys<Key extends CognitoKey> extends IterableBase<Key> {
+abstract class CognitoKeys<Key extends CognitoKey>
+    extends IterableBase<String> {
   /// {@macro amplify_auth_cognito.cognito_keys}
   const CognitoKeys();
 
@@ -183,10 +199,10 @@ abstract class CognitoKeys<Key extends CognitoKey> extends IterableBase<Key> {
   String operator [](Key key) => '$prefix.${key.name}';
 
   @override
-  Iterator<Key> get iterator => _CognitoKeysIterator(this);
+  Iterator<String> get iterator => _CognitoKeysIterator(this);
 }
 
-class _CognitoKeysIterator<Key extends CognitoKey> implements Iterator<Key> {
+class _CognitoKeysIterator<Key extends CognitoKey> implements Iterator<String> {
   _CognitoKeysIterator(this._keys);
 
   final CognitoKeys<Key> _keys;
@@ -195,11 +211,12 @@ class _CognitoKeysIterator<Key extends CognitoKey> implements Iterator<Key> {
   int _currentIndex = -1;
 
   @override
-  Key get current {
+  String get current {
     if (_currentIndex < 0) {
       throw StateError('Must call moveNext first');
     }
-    return _keys._values[_currentIndex];
+    final currentKey = _keys._values[_currentIndex];
+    return _keys[currentKey];
   }
 
   @override

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
@@ -21,19 +21,10 @@ import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:meta/meta.dart';
 
-/// Common key configuration for [CognitoKeys].
-mixin CognitoKey on Enum {
-  /// Whether the credential should be cleared by default.
-  ///
-  /// This is useful to disambiguate credentials which should be persisted
-  /// across sessions, e.g. device secrets.
-  bool get shouldClear => true;
-}
-
 /// {@template amplify_auth_cognito_dart.cognito_user_pool_key}
 /// Discrete keys stored for Cognito User Pool operations in secure storage.
 /// {@endtemplate}
-enum CognitoUserPoolKey with CognitoKey {
+enum CognitoUserPoolKey {
   /// The access token, serialized as a JWT.
   accessToken,
 
@@ -49,7 +40,7 @@ enum CognitoUserPoolKey with CognitoKey {
 
 /// Discrete keys stored for Cognito User Pool device tracking operations in
 /// secure storage.
-enum CognitoDeviceKey with CognitoKey {
+enum CognitoDeviceKey {
   /// The device key.
   deviceKey,
 
@@ -57,14 +48,11 @@ enum CognitoDeviceKey with CognitoKey {
   deviceGroupKey,
 
   /// The device password.
-  devicePassword;
-
-  @override
-  bool get shouldClear => false;
+  devicePassword
 }
 
 /// Discrete keys stored for Cognito Identity Pool operations in secure storage.
-enum CognitoIdentityPoolKey with CognitoKey {
+enum CognitoIdentityPoolKey {
   /// AWS Access Key ID
   accessKeyId,
 
@@ -82,7 +70,7 @@ enum CognitoIdentityPoolKey with CognitoKey {
 }
 
 /// Discrete keys stored for Hosted UI operations in secure storage.
-enum HostedUiKey with CognitoKey {
+enum HostedUiKey {
   /// The access token, serialized as a JWT.
   accessToken,
 
@@ -184,8 +172,7 @@ class HostedUiKeys extends CognitoKeys<HostedUiKey> {
 /// {@template amplify_auth_cognito.cognito_keys}
 /// Iterable secure storage keys.
 /// {@endtemplate}
-abstract class CognitoKeys<Key extends CognitoKey>
-    extends IterableBase<String> {
+abstract class CognitoKeys<Key extends Enum> extends IterableBase<String> {
   /// {@macro amplify_auth_cognito.cognito_keys}
   const CognitoKeys();
 
@@ -202,7 +189,7 @@ abstract class CognitoKeys<Key extends CognitoKey>
   Iterator<String> get iterator => _CognitoKeysIterator(this);
 }
 
-class _CognitoKeysIterator<Key extends CognitoKey> implements Iterator<String> {
+class _CognitoKeysIterator<Key extends Enum> implements Iterator<String> {
   _CognitoKeysIterator(this._keys);
 
   final CognitoKeys<Key> _keys;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/device_metadata_repository.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/device_metadata_repository.dart
@@ -1,0 +1,88 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_auth_cognito_dart/src/credentials/cognito_keys.dart';
+import 'package:amplify_auth_cognito_dart/src/model/cognito_device_secrets.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
+
+/// {@template amplify_auth_cognito_dart.credentials.device_metadata_repository}
+/// Repository for device secrets and metadata, used to isolate the loading
+/// {@endtemplate}
+class DeviceMetadataRepository {
+  /// {@macro amplify_auth_cognito_dart.credentials.device_metadata_repository}
+  const DeviceMetadataRepository(
+    this._userPoolConfig,
+    this._secureStorage,
+  );
+
+  /// The token of [DeviceMetadataRepository] for use with a
+  /// [DependencyManager].
+  static const token = Token<DeviceMetadataRepository>([
+    Token<CognitoUserPoolConfig>(),
+    Token<SecureStorageInterface>(),
+  ]);
+
+  final CognitoUserPoolConfig _userPoolConfig;
+  final SecureStorageInterface _secureStorage;
+
+  /// Retrieves the device secrets for [username].
+  Future<CognitoDeviceSecrets?> get(String username) async {
+    CognitoDeviceSecrets? deviceSecrets;
+    final deviceKeys = CognitoDeviceKeys(_userPoolConfig, username);
+    final deviceKey = await _secureStorage.read(
+      key: deviceKeys[CognitoDeviceKey.deviceKey],
+    );
+    final deviceGroupKey = await _secureStorage.read(
+      key: deviceKeys[CognitoDeviceKey.deviceGroupKey],
+    );
+    final devicePassword = await _secureStorage.read(
+      key: deviceKeys[CognitoDeviceKey.devicePassword],
+    );
+    if (deviceKey != null && deviceGroupKey != null && devicePassword != null) {
+      deviceSecrets = CognitoDeviceSecrets(
+        (b) => b
+          ..deviceKey = deviceKey
+          ..deviceGroupKey = deviceGroupKey
+          ..devicePassword = devicePassword,
+      );
+    }
+    return deviceSecrets;
+  }
+
+  /// Save the [deviceSecrets] for [username].
+  Future<void> put(String username, CognitoDeviceSecrets deviceSecrets) async {
+    final deviceKeys = CognitoDeviceKeys(_userPoolConfig, username);
+    await _secureStorage.write(
+      key: deviceKeys[CognitoDeviceKey.deviceKey],
+      value: deviceSecrets.deviceKey,
+    );
+    await _secureStorage.write(
+      key: deviceKeys[CognitoDeviceKey.deviceGroupKey],
+      value: deviceSecrets.deviceGroupKey,
+    );
+    await _secureStorage.write(
+      key: deviceKeys[CognitoDeviceKey.devicePassword],
+      value: deviceSecrets.devicePassword,
+    );
+  }
+
+  /// Clears the device secrets for [username].
+  Future<void> remove(String username) async {
+    final deviceKeys = CognitoDeviceKeys(_userPoolConfig, username);
+    for (final key in deviceKeys) {
+      await _secureStorage.delete(key: key);
+    }
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/device/confirm_device_worker.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/device/confirm_device_worker.g.dart
@@ -7,10 +7,13 @@ part of 'confirm_device_worker.dart';
 // **************************************************************************
 
 Serializers _$_serializers = (new Serializers().toBuilder()
-      ..add(ConfirmDeviceMessage.serializer))
+      ..add(ConfirmDeviceMessage.serializer)
+      ..add(ConfirmDeviceResponse.serializer))
     .build();
 Serializer<ConfirmDeviceMessage> _$confirmDeviceMessageSerializer =
     new _$ConfirmDeviceMessageSerializer();
+Serializer<ConfirmDeviceResponse> _$confirmDeviceResponseSerializer =
+    new _$ConfirmDeviceResponseSerializer();
 
 class _$ConfirmDeviceMessageSerializer
     implements StructuredSerializer<ConfirmDeviceMessage> {
@@ -58,6 +61,60 @@ class _$ConfirmDeviceMessageSerializer
           result.newDeviceMetadata.replace(serializers.deserialize(value,
                   specifiedType: const FullType(NewDeviceMetadataType))!
               as NewDeviceMetadataType);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ConfirmDeviceResponseSerializer
+    implements StructuredSerializer<ConfirmDeviceResponse> {
+  @override
+  final Iterable<Type> types = const [
+    ConfirmDeviceResponse,
+    _$ConfirmDeviceResponse
+  ];
+  @override
+  final String wireName = 'ConfirmDeviceResponse';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, ConfirmDeviceResponse object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'devicePassword',
+      serializers.serialize(object.devicePassword,
+          specifiedType: const FullType(String)),
+      'request',
+      serializers.serialize(object.request,
+          specifiedType: const FullType(ConfirmDeviceRequest)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ConfirmDeviceResponse deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new ConfirmDeviceResponseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'devicePassword':
+          result.devicePassword = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'request':
+          result.request.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(ConfirmDeviceRequest))!
+              as ConfirmDeviceRequest);
           break;
       }
     }
@@ -172,6 +229,121 @@ class ConfirmDeviceMessageBuilder
       } catch (e) {
         throw new BuiltValueNestedFieldError(
             r'ConfirmDeviceMessage', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ConfirmDeviceResponse extends ConfirmDeviceResponse {
+  @override
+  final String devicePassword;
+  @override
+  final ConfirmDeviceRequest request;
+
+  factory _$ConfirmDeviceResponse(
+          [void Function(ConfirmDeviceResponseBuilder)? updates]) =>
+      (new ConfirmDeviceResponseBuilder()..update(updates))._build();
+
+  _$ConfirmDeviceResponse._(
+      {required this.devicePassword, required this.request})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        devicePassword, r'ConfirmDeviceResponse', 'devicePassword');
+    BuiltValueNullFieldError.checkNotNull(
+        request, r'ConfirmDeviceResponse', 'request');
+  }
+
+  @override
+  ConfirmDeviceResponse rebuild(
+          void Function(ConfirmDeviceResponseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ConfirmDeviceResponseBuilder toBuilder() =>
+      new ConfirmDeviceResponseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ConfirmDeviceResponse &&
+        devicePassword == other.devicePassword &&
+        request == other.request;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc($jc(0, devicePassword.hashCode), request.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ConfirmDeviceResponse')
+          ..add('devicePassword', devicePassword)
+          ..add('request', request))
+        .toString();
+  }
+}
+
+class ConfirmDeviceResponseBuilder
+    implements Builder<ConfirmDeviceResponse, ConfirmDeviceResponseBuilder> {
+  _$ConfirmDeviceResponse? _$v;
+
+  String? _devicePassword;
+  String? get devicePassword => _$this._devicePassword;
+  set devicePassword(String? devicePassword) =>
+      _$this._devicePassword = devicePassword;
+
+  ConfirmDeviceRequestBuilder? _request;
+  ConfirmDeviceRequestBuilder get request =>
+      _$this._request ??= new ConfirmDeviceRequestBuilder();
+  set request(ConfirmDeviceRequestBuilder? request) =>
+      _$this._request = request;
+
+  ConfirmDeviceResponseBuilder();
+
+  ConfirmDeviceResponseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _devicePassword = $v.devicePassword;
+      _request = $v.request.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ConfirmDeviceResponse other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ConfirmDeviceResponse;
+  }
+
+  @override
+  void update(void Function(ConfirmDeviceResponseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ConfirmDeviceResponse build() => _build();
+
+  _$ConfirmDeviceResponse _build() {
+    _$ConfirmDeviceResponse _$result;
+    try {
+      _$result = _$v ??
+          new _$ConfirmDeviceResponse._(
+              devicePassword: BuiltValueNullFieldError.checkNotNull(
+                  devicePassword, r'ConfirmDeviceResponse', 'devicePassword'),
+              request: request.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'request';
+        request.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'ConfirmDeviceResponse', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_device_password_verifier_worker.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_device_password_verifier_worker.dart
@@ -91,8 +91,6 @@ abstract class SrpDevicePasswordVerifierWorker extends WorkerBeeBase<
     await for (final message in listen) {
       final username =
           message.challengeParameters[CognitoConstants.challengeParamUsername]!;
-      final userId = message
-          .challengeParameters[CognitoConstants.challengeParamUserIdForSrp]!;
       final deviceKey = message
           .challengeParameters[CognitoConstants.challengeParamDeviceKey]!;
       final secretBlock = message
@@ -105,15 +103,14 @@ abstract class SrpDevicePasswordVerifierWorker extends WorkerBeeBase<
       final formattedTimestamp = _dateFormat.format(timestamp);
 
       final encodedClaim = SrpHelper.createDeviceClaim(
-        deviceKey,
-        message.deviceSecrets,
-        userId,
-        message.parameters,
-        message.initResult,
-        encodedSalt,
-        encodedB,
-        secretBlock,
-        formattedTimestamp,
+        deviceKey: deviceKey,
+        deviceSecrets: message.deviceSecrets,
+        username: username,
+        initResult: message.initResult,
+        encodedSalt: encodedSalt,
+        encodedB: encodedB,
+        secretBlock: secretBlock,
+        formattedTimestamp: formattedTimestamp,
       );
       final response = RespondToAuthChallengeRequest.build((b) {
         b

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_helper.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_helper.dart
@@ -67,22 +67,26 @@ class SrpHelper {
   }
 
   /// Generates the claim for authenticating the user via the SRP protocol.
-  static String authenticateUser(
-    String userId,
-    SignInParameters parameters,
-    SrpInitResult initResult,
-    String poolName,
-    BigInt salt,
-    BigInt publicB,
-    String encodedSecretBlock,
-    String formattedTimestamp,
-  ) {
+  static String authenticateUser({
+    required String userId,
+    required SignInParameters parameters,
+    required SrpInitResult initResult,
+    required String poolName,
+    required BigInt salt,
+    required BigInt publicB,
+    required String encodedSecretBlock,
+    required String formattedTimestamp,
+  }) {
     final secretBlock = base64Decode(encodedSecretBlock);
     final passwordAuthKey = getAuthenticationKey(
-      initResult,
-      publicB,
-      salt,
-      privateKeyIdentifier(poolName, userId, parameters.password!),
+      initResult: initResult,
+      publicB: publicB,
+      salt: salt,
+      privateKeyIdentifier: privateKeyIdentifier(
+        poolName,
+        userId,
+        parameters.password!,
+      ),
     );
 
     final hmac = Hmac(sha256, passwordAuthKey);
@@ -101,7 +105,6 @@ class SrpHelper {
     required String deviceKey,
     required String deviceGroup,
     required String devicePassword,
-    required String username,
     required SrpInitResult initResult,
     required BigInt salt,
     required BigInt publicB,
@@ -110,10 +113,14 @@ class SrpHelper {
   }) {
     final secretBlock = base64Decode(encodedSecretBlock);
     final passwordAuthKey = getAuthenticationKey(
-      initResult,
-      publicB,
-      salt,
-      privateKeyIdentifier(deviceGroup, deviceKey, devicePassword),
+      initResult: initResult,
+      publicB: publicB,
+      salt: salt,
+      privateKeyIdentifier: privateKeyIdentifier(
+        deviceGroup,
+        deviceKey,
+        devicePassword,
+      ),
     );
 
     final hmac = Hmac(sha256, passwordAuthKey);
@@ -144,12 +151,12 @@ class SrpHelper {
   }
 
   /// Creates the password authentication key for the SRP flow.
-  static List<int> getAuthenticationKey(
-    SrpInitResult initResult,
-    BigInt publicB,
-    BigInt salt,
-    List<int> privateKeyIdentifier,
-  ) {
+  static List<int> getAuthenticationKey({
+    required SrpInitResult initResult,
+    required BigInt publicB,
+    required BigInt salt,
+    required List<int> privateKeyIdentifier,
+  }) {
     // u = H(A, B)
     final contentDigest = DigestSink();
     sha256.startChunkedConversion(contentDigest)
@@ -218,7 +225,6 @@ class SrpHelper {
       deviceKey: deviceKey,
       deviceGroup: deviceSecrets.deviceGroupKey,
       devicePassword: deviceSecrets.devicePassword,
-      username: username,
       initResult: initResult,
       salt: salt,
       publicB: publicB,
@@ -228,16 +234,16 @@ class SrpHelper {
   }
 
   /// Creates the password verifier claim, or signature, for the SRP flow.
-  static String createPasswordClaim(
-    String userId,
-    SignInParameters parameters,
-    SrpInitResult initResult,
-    String encodedSalt,
-    String encodedB,
-    String poolName,
-    String secretBlock,
-    String formattedTimestamp,
-  ) {
+  static String createPasswordClaim({
+    required String userId,
+    required SignInParameters parameters,
+    required SrpInitResult initResult,
+    required String encodedSalt,
+    required String encodedB,
+    required String poolName,
+    required String secretBlock,
+    required String formattedTimestamp,
+  }) {
     final salt = BigInt.parse(encodedSalt, radix: 16);
     final publicB = BigInt.parse(encodedB, radix: 16);
 
@@ -249,14 +255,14 @@ class SrpHelper {
     }
 
     return authenticateUser(
-      userId,
-      parameters,
-      initResult,
-      poolName,
-      salt,
-      publicB,
-      secretBlock,
-      formattedTimestamp,
+      userId: userId,
+      parameters: parameters,
+      initResult: initResult,
+      poolName: poolName,
+      salt: salt,
+      publicB: publicB,
+      encodedSecretBlock: secretBlock,
+      formattedTimestamp: formattedTimestamp,
     );
   }
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_password_verifier_worker.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_password_verifier_worker.dart
@@ -112,14 +112,14 @@ abstract class SrpPasswordVerifierWorker extends WorkerBeeBase<
       final formattedTimestamp = _dateFormat.format(timestamp);
 
       final encodedClaim = SrpHelper.createPasswordClaim(
-        userId,
-        message.parameters,
-        message.initResult,
-        encodedSalt,
-        encodedB,
-        poolName,
-        secretBlock,
-        formattedTimestamp,
+        userId: userId,
+        parameters: message.parameters,
+        initResult: message.initResult,
+        encodedSalt: encodedSalt,
+        encodedB: encodedB,
+        poolName: poolName,
+        secretBlock: secretBlock,
+        formattedTimestamp: formattedTimestamp,
       );
       final response = RespondToAuthChallengeRequest.build((b) {
         b

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/cognito_device_secrets.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/cognito_device_secrets.dart
@@ -36,6 +36,9 @@ abstract class CognitoDeviceSecrets
   /// The device key/ID.
   String get deviceKey;
 
+  /// The device password.
+  String get devicePassword;
+
   /// The [CognitoDeviceSecrets] serializer.
   static Serializer<CognitoDeviceSecrets> get serializer =>
       _$cognitoDeviceSecretsSerializer;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/cognito_device_secrets.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/cognito_device_secrets.g.dart
@@ -30,6 +30,9 @@ class _$CognitoDeviceSecretsSerializer
       'deviceKey',
       serializers.serialize(object.deviceKey,
           specifiedType: const FullType(String)),
+      'devicePassword',
+      serializers.serialize(object.devicePassword,
+          specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -55,6 +58,10 @@ class _$CognitoDeviceSecretsSerializer
           result.deviceKey = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
+        case 'devicePassword':
+          result.devicePassword = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
       }
     }
 
@@ -67,18 +74,24 @@ class _$CognitoDeviceSecrets extends CognitoDeviceSecrets {
   final String deviceGroupKey;
   @override
   final String deviceKey;
+  @override
+  final String devicePassword;
 
   factory _$CognitoDeviceSecrets(
           [void Function(CognitoDeviceSecretsBuilder)? updates]) =>
       (new CognitoDeviceSecretsBuilder()..update(updates))._build();
 
   _$CognitoDeviceSecrets._(
-      {required this.deviceGroupKey, required this.deviceKey})
+      {required this.deviceGroupKey,
+      required this.deviceKey,
+      required this.devicePassword})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
         deviceGroupKey, r'CognitoDeviceSecrets', 'deviceGroupKey');
     BuiltValueNullFieldError.checkNotNull(
         deviceKey, r'CognitoDeviceSecrets', 'deviceKey');
+    BuiltValueNullFieldError.checkNotNull(
+        devicePassword, r'CognitoDeviceSecrets', 'devicePassword');
   }
 
   @override
@@ -95,19 +108,22 @@ class _$CognitoDeviceSecrets extends CognitoDeviceSecrets {
     if (identical(other, this)) return true;
     return other is CognitoDeviceSecrets &&
         deviceGroupKey == other.deviceGroupKey &&
-        deviceKey == other.deviceKey;
+        deviceKey == other.deviceKey &&
+        devicePassword == other.devicePassword;
   }
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, deviceGroupKey.hashCode), deviceKey.hashCode));
+    return $jf($jc($jc($jc(0, deviceGroupKey.hashCode), deviceKey.hashCode),
+        devicePassword.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'CognitoDeviceSecrets')
           ..add('deviceGroupKey', deviceGroupKey)
-          ..add('deviceKey', deviceKey))
+          ..add('deviceKey', deviceKey)
+          ..add('devicePassword', devicePassword))
         .toString();
   }
 }
@@ -125,6 +141,11 @@ class CognitoDeviceSecretsBuilder
   String? get deviceKey => _$this._deviceKey;
   set deviceKey(String? deviceKey) => _$this._deviceKey = deviceKey;
 
+  String? _devicePassword;
+  String? get devicePassword => _$this._devicePassword;
+  set devicePassword(String? devicePassword) =>
+      _$this._devicePassword = devicePassword;
+
   CognitoDeviceSecretsBuilder();
 
   CognitoDeviceSecretsBuilder get _$this {
@@ -132,6 +153,7 @@ class CognitoDeviceSecretsBuilder
     if ($v != null) {
       _deviceGroupKey = $v.deviceGroupKey;
       _deviceKey = $v.deviceKey;
+      _devicePassword = $v.devicePassword;
       _$v = null;
     }
     return this;
@@ -157,7 +179,9 @@ class CognitoDeviceSecretsBuilder
             deviceGroupKey: BuiltValueNullFieldError.checkNotNull(
                 deviceGroupKey, r'CognitoDeviceSecrets', 'deviceGroupKey'),
             deviceKey: BuiltValueNullFieldError.checkNotNull(
-                deviceKey, r'CognitoDeviceSecrets', 'deviceKey'));
+                deviceKey, r'CognitoDeviceSecrets', 'deviceKey'),
+            devicePassword: BuiltValueNullFieldError.checkNotNull(
+                devicePassword, r'CognitoDeviceSecrets', 'devicePassword'));
     replace(_$result);
     return _$result;
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/cognito_user.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/cognito_user.dart
@@ -38,8 +38,9 @@ abstract class CognitoUser implements Built<CognitoUser, CognitoUserBuilder> {
     b.username ??= b.userId!;
 
     // Assert that all device info is included if any is included.
-    if (b.device != null) {
-      ArgumentError.checkNotNull(b.device, 'device');
+    if (b.deviceSecrets.deviceKey != null ||
+        b.deviceSecrets.deviceGroupKey != null ||
+        b.deviceSecrets.devicePassword != null) {
       ArgumentError.checkNotNull(
         b.deviceSecrets.deviceGroupKey,
         'deviceGroupKey',
@@ -47,6 +48,10 @@ abstract class CognitoUser implements Built<CognitoUser, CognitoUserBuilder> {
       ArgumentError.checkNotNull(
         b.deviceSecrets.deviceKey,
         'deviceKey',
+      );
+      ArgumentError.checkNotNull(
+        b.deviceSecrets.devicePassword,
+        'devicePassword',
       );
     }
   }
@@ -59,9 +64,6 @@ abstract class CognitoUser implements Built<CognitoUser, CognitoUserBuilder> {
 
   /// Cognito User Pool tokens
   CognitoUserPoolTokens? get userPoolTokens;
-
-  /// Confirmed device
-  CognitoDevice? get device;
 
   /// Confirmed device secrets
   CognitoDeviceSecrets? get deviceSecrets;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/cognito_user.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/cognito_user.g.dart
@@ -14,8 +14,6 @@ class _$CognitoUser extends CognitoUser {
   @override
   final CognitoUserPoolTokens? userPoolTokens;
   @override
-  final CognitoDevice? device;
-  @override
   final CognitoDeviceSecrets? deviceSecrets;
   @override
   final String userId;
@@ -31,7 +29,6 @@ class _$CognitoUser extends CognitoUser {
       {this.identityId,
       this.awsCredentials,
       this.userPoolTokens,
-      this.device,
       this.deviceSecrets,
       required this.userId,
       required this.username,
@@ -57,7 +54,6 @@ class _$CognitoUser extends CognitoUser {
         identityId == other.identityId &&
         awsCredentials == other.awsCredentials &&
         userPoolTokens == other.userPoolTokens &&
-        device == other.device &&
         deviceSecrets == other.deviceSecrets &&
         userId == other.userId &&
         username == other.username &&
@@ -71,11 +67,9 @@ class _$CognitoUser extends CognitoUser {
             $jc(
                 $jc(
                     $jc(
-                        $jc(
-                            $jc($jc(0, identityId.hashCode),
-                                awsCredentials.hashCode),
-                            userPoolTokens.hashCode),
-                        device.hashCode),
+                        $jc($jc(0, identityId.hashCode),
+                            awsCredentials.hashCode),
+                        userPoolTokens.hashCode),
                     deviceSecrets.hashCode),
                 userId.hashCode),
             username.hashCode),
@@ -88,7 +82,6 @@ class _$CognitoUser extends CognitoUser {
           ..add('identityId', identityId)
           ..add('awsCredentials', awsCredentials)
           ..add('userPoolTokens', userPoolTokens)
-          ..add('device', device)
           ..add('deviceSecrets', deviceSecrets)
           ..add('userId', userId)
           ..add('username', username)
@@ -114,10 +107,6 @@ class CognitoUserBuilder implements Builder<CognitoUser, CognitoUserBuilder> {
       _$this._userPoolTokens ??= new CognitoUserPoolTokensBuilder();
   set userPoolTokens(CognitoUserPoolTokensBuilder? userPoolTokens) =>
       _$this._userPoolTokens = userPoolTokens;
-
-  CognitoDevice? _device;
-  CognitoDevice? get device => _$this._device;
-  set device(CognitoDevice? device) => _$this._device = device;
 
   CognitoDeviceSecretsBuilder? _deviceSecrets;
   CognitoDeviceSecretsBuilder get deviceSecrets =>
@@ -147,7 +136,6 @@ class CognitoUserBuilder implements Builder<CognitoUser, CognitoUserBuilder> {
       _identityId = $v.identityId;
       _awsCredentials = $v.awsCredentials;
       _userPoolTokens = $v.userPoolTokens?.toBuilder();
-      _device = $v.device;
       _deviceSecrets = $v.deviceSecrets?.toBuilder();
       _userId = $v.userId;
       _username = $v.username;
@@ -180,7 +168,6 @@ class CognitoUserBuilder implements Builder<CognitoUser, CognitoUserBuilder> {
               identityId: identityId,
               awsCredentials: awsCredentials,
               userPoolTokens: _userPoolTokens?.build(),
-              device: device,
               deviceSecrets: _deviceSecrets?.build(),
               userId: BuiltValueNullFieldError.checkNotNull(
                   userId, r'CognitoUser', 'userId'),
@@ -192,7 +179,6 @@ class CognitoUserBuilder implements Builder<CognitoUser, CognitoUserBuilder> {
       try {
         _$failedField = 'userPoolTokens';
         _userPoolTokens?.build();
-
         _$failedField = 'deviceSecrets';
         _deviceSecrets?.build();
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_user_pool_tokens.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_user_pool_tokens.dart
@@ -86,6 +86,12 @@ abstract class CognitoUserPoolTokens
   /// The issued at time of [accessToken].
   DateTime? get issuedTime => accessToken.claims.issuedAt;
 
+  /// The Cognito user's ID.
+  String get userId => idToken.userId;
+
+  /// The Cognito user's username.
+  String get username => CognitoIdToken(idToken).username;
+
   /// Validates the tokens against the client state.
   void validate({
     String? nonce,

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/cognito_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/cognito_state_machine.dart
@@ -16,6 +16,7 @@ import 'dart:async';
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_auth_cognito_dart/src/credentials/auth_plugin_credentials_provider.dart';
+import 'package:amplify_auth_cognito_dart/src/credentials/device_metadata_repository.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/sdk_bridge.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
@@ -45,6 +46,7 @@ final defaultDependencies = <Token, DependencyBuilder>{
   const Token<http.Client>(): http.Client.new,
   AuthPluginCredentialsProvider.token: AuthPluginCredentialsProviderImpl.new,
   zSmithyHttpClientToken: _makeSmithyHttpClient,
+  DeviceMetadataRepository.token: DeviceMetadataRepository.new,
 };
 
 /// {@template amplify_auth_cognito.cognito_auth_state_machine}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/credential_store_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/credential_store_event.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:amplify_auth_cognito_dart/src/credentials/cognito_keys.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
 
@@ -61,10 +60,9 @@ abstract class CredentialStoreEvent extends StateMachineEvent<
   ) = CredentialStoreStoreCredentials;
 
   /// {@macro amplify_auth_cognito.clear_credentials}
-  const factory CredentialStoreEvent.clearCredentials({
-    Iterable<CognitoKey> keys,
-    bool force,
-  }) = CredentialStoreClearCredentials;
+  const factory CredentialStoreEvent.clearCredentials([
+    Iterable<String> keys,
+  ]) = CredentialStoreClearCredentials;
 
   /// {@macro amplify_auth_cognito.credential_store_succeeded}
   const factory CredentialStoreEvent.succeeded(CredentialStoreData data) =
@@ -187,18 +185,13 @@ class CredentialStoreStoreCredentials extends CredentialStoreEvent {
 /// {@endtemplate}
 class CredentialStoreClearCredentials extends CredentialStoreEvent {
   /// {@macro amplify_auth_cognito.clear_credentials}
-  const CredentialStoreClearCredentials({
+  const CredentialStoreClearCredentials([
     this.keys = const [],
-    this.force = false,
-  }) : super._();
+  ]) : super._();
 
   /// When set, only these keys will be cleared from the store. Otherwise,
   /// all keys are cleared.
-  final Iterable<CognitoKey> keys;
-
-  /// When `true`, all [keys] will be cleared, regardless if they specify
-  /// `shouldClear = false`.
-  final bool force;
+  final Iterable<String> keys;
 
   @override
   CredentialStoreEventType get type =>

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/credential_store_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/credential_store_event.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:amplify_auth_cognito_dart/src/credentials/cognito_keys.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
 
@@ -61,7 +62,7 @@ abstract class CredentialStoreEvent extends StateMachineEvent<
 
   /// {@macro amplify_auth_cognito.clear_credentials}
   const factory CredentialStoreEvent.clearCredentials([
-    Iterable<String> keys,
+    Iterable<CognitoKey> keys,
   ]) = CredentialStoreClearCredentials;
 
   /// {@macro amplify_auth_cognito.credential_store_succeeded}
@@ -189,7 +190,7 @@ class CredentialStoreClearCredentials extends CredentialStoreEvent {
 
   /// When set, only these keys will be cleared from the store. Otherwise,
   /// all keys are cleared.
-  final Iterable<String> keys;
+  final Iterable<CognitoKey> keys;
 
   @override
   CredentialStoreEventType get type =>

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/credential_store_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/credential_store_event.dart
@@ -61,9 +61,10 @@ abstract class CredentialStoreEvent extends StateMachineEvent<
   ) = CredentialStoreStoreCredentials;
 
   /// {@macro amplify_auth_cognito.clear_credentials}
-  const factory CredentialStoreEvent.clearCredentials([
+  const factory CredentialStoreEvent.clearCredentials({
     Iterable<CognitoKey> keys,
-  ]) = CredentialStoreClearCredentials;
+    bool force,
+  }) = CredentialStoreClearCredentials;
 
   /// {@macro amplify_auth_cognito.credential_store_succeeded}
   const factory CredentialStoreEvent.succeeded(CredentialStoreData data) =
@@ -186,11 +187,18 @@ class CredentialStoreStoreCredentials extends CredentialStoreEvent {
 /// {@endtemplate}
 class CredentialStoreClearCredentials extends CredentialStoreEvent {
   /// {@macro amplify_auth_cognito.clear_credentials}
-  const CredentialStoreClearCredentials([this.keys = const []]) : super._();
+  const CredentialStoreClearCredentials({
+    this.keys = const [],
+    this.force = false,
+  }) : super._();
 
   /// When set, only these keys will be cleared from the store. Otherwise,
   /// all keys are cleared.
   final Iterable<CognitoKey> keys;
+
+  /// When `true`, all [keys] will be cleared, regardless if they specify
+  /// `shouldClear = false`.
+  final bool force;
 
   @override
   CredentialStoreEventType get type =>

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart
@@ -299,7 +299,7 @@ class CredentialStoreStateMachine extends CredentialStoreStateMachineBase {
     final authConfig = expect<AuthConfiguration>();
 
     final clearKeys = event.keys;
-    final deletions = Set.of(clearKeys);
+    final deletions = <String>[];
     bool shouldDelete(String key) =>
         clearKeys.isEmpty || clearKeys.contains(key);
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart
@@ -333,12 +333,13 @@ class CredentialStoreStateMachine extends CredentialStoreStateMachineBase {
     final clearKeys = event.keys;
     final deletions = <String>[];
     bool shouldDelete(CognitoKey key) =>
-        (clearKeys.isEmpty && key.shouldClear) || clearKeys.contains(key);
+        (clearKeys.isEmpty || clearKeys.contains(key)) &&
+        (key.shouldClear || event.force);
 
     final userPoolConfig = authConfig.userPoolConfig;
     if (userPoolConfig != null) {
       final userPoolKeys = CognitoUserPoolKeys(userPoolConfig);
-      for (final key in userPoolKeys.values) {
+      for (final key in userPoolKeys) {
         if (shouldDelete(key)) {
           deletions.add(userPoolKeys[key]);
         }
@@ -348,7 +349,7 @@ class CredentialStoreStateMachine extends CredentialStoreStateMachineBase {
     final hostedUiConfig = authConfig.hostedUiConfig;
     if (hostedUiConfig != null) {
       final hostedUiKeys = HostedUiKeys(hostedUiConfig);
-      for (final key in hostedUiKeys.values) {
+      for (final key in hostedUiKeys) {
         if (shouldDelete(key)) {
           deletions.add(hostedUiKeys[key]);
         }
@@ -358,7 +359,7 @@ class CredentialStoreStateMachine extends CredentialStoreStateMachineBase {
     final identityPoolConfig = authConfig.identityPoolConfig;
     if (identityPoolConfig != null) {
       final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig);
-      for (final key in identityPoolKeys.values) {
+      for (final key in identityPoolKeys) {
         if (shouldDelete(key)) {
           deletions.add(identityPoolKeys[key]);
         }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
@@ -292,7 +292,7 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
       // access and we should prevent further attempts at refreshing.
       dispatch(
         CredentialStoreEvent.clearCredentials(
-          CognitoIdentityPoolKeys(identityPoolConfig).values,
+          keys: CognitoIdentityPoolKeys(identityPoolConfig),
         ),
       );
       rethrow;
@@ -350,20 +350,22 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
       late Iterable<CognitoKey> keys;
       switch (userPoolTokens.signInMethod) {
         case CognitoSignInMethod.default$:
-          keys = CognitoUserPoolKeys(_userPoolConfig).values;
+          keys = CognitoUserPoolKeys(_userPoolConfig);
           break;
         case CognitoSignInMethod.hostedUi:
-          keys = HostedUiKeys(expect()).values;
+          keys = HostedUiKeys(expect());
           break;
       }
       final identityPoolConfig = _identityPoolConfig;
       dispatch(
-        CredentialStoreEvent.clearCredentials([
-          ...keys,
-          if (identityPoolConfig != null)
-            // Clear associated AWS credentials
-            ...CognitoIdentityPoolKeys(identityPoolConfig).values,
-        ]),
+        CredentialStoreEvent.clearCredentials(
+          keys: [
+            ...keys,
+            if (identityPoolConfig != null)
+              // Clear associated AWS credentials
+              ...CognitoIdentityPoolKeys(identityPoolConfig),
+          ],
+        ),
       );
       rethrow;
     }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
@@ -17,9 +17,10 @@ import 'dart:async';
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_auth_cognito_dart/src/credentials/auth_plugin_credentials_provider.dart';
 import 'package:amplify_auth_cognito_dart/src/credentials/cognito_keys.dart';
+import 'package:amplify_auth_cognito_dart/src/credentials/device_metadata_repository.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/constants.dart';
 import 'package:amplify_auth_cognito_dart/src/jwt/jwt.dart';
-import 'package:amplify_auth_cognito_dart/src/model/cognito_device_secrets.dart';
+import 'package:amplify_auth_cognito_dart/src/model/auth_user_ext.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity.dart'
     hide NotAuthorizedException;
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart'
@@ -231,10 +232,7 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
         );
         return;
       }
-      userPoolTokens = await _refreshUserPoolTokens(
-        userPoolTokens: userPoolTokens,
-        deviceSecrets: result.data.deviceSecrets,
-      );
+      userPoolTokens = await _refreshUserPoolTokens(userPoolTokens);
     }
     if (event.refreshAwsCredentials) {
       final awsCredentialsResult = await _retrieveAwsCredentials(
@@ -292,17 +290,18 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
       // access and we should prevent further attempts at refreshing.
       dispatch(
         CredentialStoreEvent.clearCredentials(
-          keys: CognitoIdentityPoolKeys(identityPoolConfig),
+          CognitoIdentityPoolKeys(identityPoolConfig),
         ),
       );
       rethrow;
     }
   }
 
-  Future<CognitoUserPoolTokens> _refreshUserPoolTokens({
-    required CognitoUserPoolTokens userPoolTokens,
-    CognitoDeviceSecrets? deviceSecrets,
-  }) async {
+  Future<CognitoUserPoolTokens> _refreshUserPoolTokens(
+    CognitoUserPoolTokens userPoolTokens,
+  ) async {
+    final deviceSecrets = await getOrCreate(DeviceMetadataRepository.token)
+        .get(userPoolTokens.authUser.username);
     final refreshRequest = cognito_idp.InitiateAuthRequest.build((b) {
       b
         ..authFlow = cognito_idp.AuthFlowType.refreshTokenAuth
@@ -347,7 +346,7 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
 
       return newTokens;
     } on NotAuthorizedException {
-      late Iterable<CognitoKey> keys;
+      late Iterable<String> keys;
       switch (userPoolTokens.signInMethod) {
         case CognitoSignInMethod.default$:
           keys = CognitoUserPoolKeys(_userPoolConfig);
@@ -358,14 +357,12 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
       }
       final identityPoolConfig = _identityPoolConfig;
       dispatch(
-        CredentialStoreEvent.clearCredentials(
-          keys: [
-            ...keys,
-            if (identityPoolConfig != null)
-              // Clear associated AWS credentials
-              ...CognitoIdentityPoolKeys(identityPoolConfig),
-          ],
-        ),
+        CredentialStoreEvent.clearCredentials([
+          ...keys,
+          if (identityPoolConfig != null)
+            // Clear associated AWS credentials
+            ...CognitoIdentityPoolKeys(identityPoolConfig),
+        ]),
       );
       rethrow;
     }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
@@ -292,7 +292,7 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
       // access and we should prevent further attempts at refreshing.
       dispatch(
         CredentialStoreEvent.clearCredentials(
-          CognitoIdentityPoolKeys(identityPoolConfig),
+          CognitoIdentityPoolKeys(identityPoolConfig).values,
         ),
       );
       rethrow;
@@ -347,13 +347,13 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
 
       return newTokens;
     } on NotAuthorizedException {
-      late Iterable<String> keys;
+      late Iterable<CognitoKey> keys;
       switch (userPoolTokens.signInMethod) {
         case CognitoSignInMethod.default$:
-          keys = CognitoUserPoolKeys(_userPoolConfig);
+          keys = CognitoUserPoolKeys(_userPoolConfig).values;
           break;
         case CognitoSignInMethod.hostedUi:
-          keys = HostedUiKeys(expect());
+          keys = HostedUiKeys(expect()).values;
           break;
       }
       final identityPoolConfig = _identityPoolConfig;
@@ -362,7 +362,7 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
           ...keys,
           if (identityPoolConfig != null)
             // Clear associated AWS credentials
-            ...CognitoIdentityPoolKeys(identityPoolConfig),
+            ...CognitoIdentityPoolKeys(identityPoolConfig).values,
         ]),
       );
       rethrow;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
@@ -106,7 +106,9 @@ class HostedUiStateMachine extends HostedUiStateMachineBase {
   @override
   Future<void> onCancelSignIn(HostedUiCancelSignIn event) async {
     await _platform.cancelSignIn();
-    await dispatch(CredentialStoreEvent.clearCredentials(_keys.values));
+    await dispatch(
+      CredentialStoreEvent.clearCredentials(keys: _keys),
+    );
     dispatch(
       const HostedUiEvent.failed(
         UserCancelledException('The user cancelled the sign-in flow'),
@@ -140,7 +142,7 @@ class HostedUiStateMachine extends HostedUiStateMachineBase {
       // credentials should be cleared regardless of how the platform handles
       // the sign out.
       dispatch(
-        CredentialStoreEvent.clearCredentials(_keys.values),
+        CredentialStoreEvent.clearCredentials(keys: _keys),
       );
       await expect(CredentialStoreStateMachine.type).getCredentialsResult();
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
@@ -107,7 +107,7 @@ class HostedUiStateMachine extends HostedUiStateMachineBase {
   Future<void> onCancelSignIn(HostedUiCancelSignIn event) async {
     await _platform.cancelSignIn();
     await dispatch(
-      CredentialStoreEvent.clearCredentials(keys: _keys),
+      CredentialStoreEvent.clearCredentials(_keys),
     );
     dispatch(
       const HostedUiEvent.failed(
@@ -142,7 +142,7 @@ class HostedUiStateMachine extends HostedUiStateMachineBase {
       // credentials should be cleared regardless of how the platform handles
       // the sign out.
       dispatch(
-        CredentialStoreEvent.clearCredentials(keys: _keys),
+        CredentialStoreEvent.clearCredentials(_keys),
       );
       await expect(CredentialStoreStateMachine.type).getCredentialsResult();
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
@@ -106,7 +106,7 @@ class HostedUiStateMachine extends HostedUiStateMachineBase {
   @override
   Future<void> onCancelSignIn(HostedUiCancelSignIn event) async {
     await _platform.cancelSignIn();
-    await dispatch(CredentialStoreEvent.clearCredentials(_keys));
+    await dispatch(CredentialStoreEvent.clearCredentials(_keys.values));
     dispatch(
       const HostedUiEvent.failed(
         UserCancelledException('The user cancelled the sign-in flow'),
@@ -140,7 +140,7 @@ class HostedUiStateMachine extends HostedUiStateMachineBase {
       // credentials should be cleared regardless of how the platform handles
       // the sign out.
       dispatch(
-        CredentialStoreEvent.clearCredentials(_keys),
+        CredentialStoreEvent.clearCredentials(_keys.values),
       );
       await expect(CredentialStoreStateMachine.type).getCredentialsResult();
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -586,7 +586,7 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState> {
     if (hasIdentityPool) {
       dispatch(
         CredentialStoreEvent.clearCredentials(
-          CognitoIdentityPoolKeys(identityPoolConfig!).values,
+          keys: CognitoIdentityPoolKeys(identityPoolConfig!),
         ),
       );
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/credential_store_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/credential_store_state.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
-import 'package:amplify_auth_cognito_dart/src/model/cognito_device_secrets.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 /// Discrete state types of the credential store state machine.
@@ -198,7 +197,6 @@ class CredentialStoreData with AWSEquatable<CredentialStoreData> {
     this.identityId,
     this.awsCredentials,
     this.userPoolTokens,
-    this.deviceSecrets,
   });
 
   /// AWS Identity ID
@@ -210,14 +208,10 @@ class CredentialStoreData with AWSEquatable<CredentialStoreData> {
   /// Cognito User Pool tokens
   final CognitoUserPoolTokens? userPoolTokens;
 
-  /// Registered device secrets
-  final CognitoDeviceSecrets? deviceSecrets;
-
   @override
   List<Object?> get props => [
         identityId,
         awsCredentials,
         userPoolTokens,
-        deviceSecrets,
       ];
 }

--- a/packages/auth/amplify_auth_cognito_test/test/common/mock_config.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/common/mock_config.dart
@@ -87,11 +87,14 @@ const sessionToken = 'sessionToken';
 final expiration = DateTime.utc(2100, 1, 1);
 const identityId = 'identityId';
 const deviceKey = 'deviceKey';
+const deviceGroupKey = 'deviceGroupKey';
+const devicePassword = 'devicePassword';
 
 final authConfig = AuthConfiguration.fromConfig(mockConfig.auth!.awsPlugin!);
 final userPoolConfig = authConfig.userPoolConfig!;
 final identityPoolConfig = authConfig.identityPoolConfig!;
 final userPoolKeys = CognitoUserPoolKeys(userPoolConfig);
+final deviceKeys = CognitoDeviceKeys(userPoolConfig, userSub);
 final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig);
 final userPoolTokens = CognitoUserPoolTokens(
   accessToken: accessToken,

--- a/packages/auth/amplify_auth_cognito_test/test/common/mock_config.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/common/mock_config.dart
@@ -86,6 +86,7 @@ const secretAccessKey = 'secretAccessKey';
 const sessionToken = 'sessionToken';
 final expiration = DateTime.utc(2100, 1, 1);
 const identityId = 'identityId';
+const deviceKey = 'deviceKey';
 
 final authConfig = AuthConfiguration.fromConfig(mockConfig.auth!.awsPlugin!);
 final userPoolConfig = authConfig.userPoolConfig!;

--- a/packages/auth/amplify_auth_cognito_test/test/common/mock_secure_storage.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/common/mock_secure_storage.dart
@@ -35,7 +35,7 @@ class MockSecureStorage implements SecureStorageInterface {
 void seedStorage(
   SecureStorageInterface secureStorage, {
   CognitoUserPoolKeys? userPoolKeys,
-  List<CognitoUserPoolKey>? deviceKeys,
+  CognitoDeviceKeys? deviceKeys,
   CognitoIdentityPoolKeys? identityPoolKeys,
   HostedUiKeys? hostedUiKeys,
   CredentialStoreVersion? version,
@@ -58,14 +58,21 @@ void seedStorage(
         key: userPoolKeys[CognitoUserPoolKey.userSub],
         value: userSub,
       );
-    if (deviceKeys != null) {
-      for (final key in deviceKeys) {
-        secureStorage.write(
-          key: userPoolKeys[key],
-          value: deviceKey,
-        );
-      }
-    }
+  }
+  if (deviceKeys != null) {
+    secureStorage
+      ..write(
+        key: deviceKeys[CognitoDeviceKey.deviceKey],
+        value: deviceKey,
+      )
+      ..write(
+        key: deviceKeys[CognitoDeviceKey.deviceGroupKey],
+        value: deviceGroupKey,
+      )
+      ..write(
+        key: deviceKeys[CognitoDeviceKey.devicePassword],
+        value: devicePassword,
+      );
   }
   if (identityPoolKeys != null) {
     secureStorage

--- a/packages/auth/amplify_auth_cognito_test/test/common/mock_secure_storage.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/common/mock_secure_storage.dart
@@ -35,6 +35,7 @@ class MockSecureStorage implements SecureStorageInterface {
 void seedStorage(
   SecureStorageInterface secureStorage, {
   CognitoUserPoolKeys? userPoolKeys,
+  List<CognitoUserPoolKey>? deviceKeys,
   CognitoIdentityPoolKeys? identityPoolKeys,
   HostedUiKeys? hostedUiKeys,
   CredentialStoreVersion? version,
@@ -57,6 +58,14 @@ void seedStorage(
         key: userPoolKeys[CognitoUserPoolKey.userSub],
         value: userSub,
       );
+    if (deviceKeys != null) {
+      for (final key in deviceKeys) {
+        secureStorage.write(
+          key: userPoolKeys[key],
+          value: deviceKey,
+        );
+      }
+    }
   }
   if (identityPoolKeys != null) {
     secureStorage

--- a/packages/auth/amplify_auth_cognito_test/test/flows/device/confirm_device_worker_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/device/confirm_device_worker_test.dart
@@ -42,7 +42,7 @@ void main() {
 
       expect(
         worker.stream,
-        emits(isA<ConfirmDeviceRequest>()),
+        emits(isA<ConfirmDeviceResponse>()),
       );
     });
 

--- a/packages/auth/amplify_auth_cognito_test/test/flows/device/confirm_device_worker_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/device/confirm_device_worker_test.dart
@@ -15,7 +15,6 @@
 import 'dart:async';
 
 import 'package:amplify_auth_cognito_dart/src/flows/device/confirm_device_worker.dart';
-import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/confirm_device_request.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:test/test.dart';
 import 'package:worker_bee/worker_bee.dart';

--- a/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_test.dart
@@ -67,7 +67,7 @@ void main() {
 
       tearDown(() {
         for (final key in keys) {
-          secureStorage.delete(key: key);
+          secureStorage.delete(key: keys[key]);
         }
       });
 

--- a/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_test.dart
@@ -67,7 +67,7 @@ void main() {
 
       tearDown(() {
         for (final key in keys) {
-          secureStorage.delete(key: keys[key]);
+          secureStorage.delete(key: key);
         }
       });
 

--- a/packages/auth/amplify_auth_cognito_test/test/flows/srp/srp_helper_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/srp/srp_helper_test.dart
@@ -86,18 +86,18 @@ void main() {
     group('createPasswordClaim', () {
       test('authenticateUser', () {
         final claim = SrpHelper.createPasswordClaim(
-          username,
-          SignInParameters(
+          userId: username,
+          parameters: SignInParameters(
             (b) => b
               ..username = username
               ..password = password,
           ),
-          initResult,
-          salt,
-          publicB,
-          poolName,
-          secretBlock,
-          formattedTimestamp,
+          initResult: initResult,
+          encodedSalt: salt,
+          encodedB: publicB,
+          poolName: poolName,
+          secretBlock: secretBlock,
+          formattedTimestamp: formattedTimestamp,
         );
         const expectedClaim = 'QwHbbUqF6DSSepJh2QqTWDCb1XjmqaxnnW5kDn5dz7E=';
 
@@ -109,18 +109,18 @@ void main() {
 
         expect(
           () => SrpHelper.createPasswordClaim(
-            username,
-            SignInParameters(
+            userId: username,
+            parameters: SignInParameters(
               (b) => b
                 ..username = username
                 ..password = password,
             ),
-            initResult,
-            salt,
-            publicB,
-            poolName,
-            secretBlock,
-            formattedTimestamp,
+            initResult: initResult,
+            encodedSalt: salt,
+            encodedB: publicB,
+            poolName: poolName,
+            secretBlock: secretBlock,
+            formattedTimestamp: formattedTimestamp,
           ),
           throwsA(isA<SrpSignInCalculationException>()),
         );
@@ -131,18 +131,18 @@ void main() {
 
         expect(
           () => SrpHelper.createPasswordClaim(
-            username,
-            SignInParameters(
+            userId: username,
+            parameters: SignInParameters(
               (b) => b
                 ..username = username
                 ..password = password,
             ),
-            initResult,
-            salt,
-            publicB,
-            poolName,
-            secretBlock,
-            formattedTimestamp,
+            initResult: initResult,
+            encodedSalt: salt,
+            encodedB: publicB,
+            poolName: poolName,
+            secretBlock: secretBlock,
+            formattedTimestamp: formattedTimestamp,
           ),
           throwsA(isA<SrpSignInCalculationException>()),
         );
@@ -169,10 +169,14 @@ void main() {
       const salt = 'b704a27deb8cf5efec43a40eac5b60d2';
 
       final key = SrpHelper.getAuthenticationKey(
-        initResult,
-        BigInt.parse(publicB, radix: 16),
-        BigInt.parse(salt, radix: 16),
-        SrpHelper.privateKeyIdentifier(poolName, username, password),
+        initResult: initResult,
+        publicB: BigInt.parse(publicB, radix: 16),
+        salt: BigInt.parse(salt, radix: 16),
+        privateKeyIdentifier: SrpHelper.privateKeyIdentifier(
+          poolName,
+          username,
+          password,
+        ),
       );
       const expectedKey = 'LmbBsy/4chqMRYOhmtmCrA==';
 

--- a/packages/auth/amplify_auth_cognito_test/test/state/credential_store_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/credential_store_state_machine_test.dart
@@ -338,7 +338,7 @@ void main() {
 
         stateMachine.dispatch(
           CredentialStoreEvent.clearCredentials(
-            identityPoolKeys.values,
+            keys: identityPoolKeys,
           ),
         );
 

--- a/packages/auth/amplify_auth_cognito_test/test/state/credential_store_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/credential_store_state_machine_test.dart
@@ -338,7 +338,7 @@ void main() {
 
         stateMachine.dispatch(
           CredentialStoreEvent.clearCredentials(
-            identityPoolKeys,
+            identityPoolKeys.values,
           ),
         );
 


### PR DESCRIPTION
Fixes issue 1 of #2009 by not clearing the device credentials on log out, only when uninstalling the app or calling `forgetDevice`. Refactors the internal device metadata as well. Related to #1929.
