### PR TITLE
chore(aft): Revert flutter_tools workaround

### DIFF
--- a/packages/aft/lib/src/commands/pub_command.dart
+++ b/packages/aft/lib/src/commands/pub_command.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:aft/aft.dart';
 import 'package:async/async.dart';
@@ -143,9 +144,6 @@ Future<void> pubAction({
         ..stderr(error.error.toString())
         ..stderr(error.stackTrace.toString());
     }
-    // TODO(dnys1): Should this be behind a flag?
-    /// Can add back when https://github.com/flutter/flutter/issues/107647 is
-    /// resolved.
-    // exitCode = 1;
+    exitCode = 1;
   }
 }

--- a/packages/aft/pubspec.yaml
+++ b/packages/aft/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_tools:
     git:
       url: https://github.com/flutter/flutter.git
-      ref: master
+      ref: f3d182f4b4e3c5e5cde322f5a14e49e9a50cc083
       path: packages/flutter_tools
   git: ^2.0.0
   graphs: ^2.1.0
@@ -27,7 +27,7 @@ dependencies:
   pub:
     git:
       url: https://github.com/dart-lang/pub.git
-      ref: master
+      ref: bc32a30ea5c86653e2a1899613c0a19d91b9a21c
   pub_semver: ^2.1.1
   pubspec_parse: ^1.2.0
   smithy: ^0.1.0


### PR DESCRIPTION
Reverts the change needed to due the `flutter_tools` bug. The `exitCode` should be set if `pub get` fails for any reason now, since it would be to an issue outside the underlying tooling.
