### PR TITLE
chore(aft): add self-update command

### DIFF
--- a/packages/aft/README.md
+++ b/packages/aft/README.md
@@ -14,3 +14,4 @@ A CLI tool for managing the Amplify Flutter repository.
   - `get`: Runs `dart pub get`/`flutter pub get` for all packages
   - `upgrade`: Runs `dart pub upgrade`/`flutter pub upgrade` for all packages
   - `publish`: Runs `dart pub publish`/`flutter pub publish` for all packages which need publishing
+- `self-update`: Updates aft by running `dart pub global activate -spath <root>/packages/aft`

--- a/packages/aft/bin/aft.dart
+++ b/packages/aft/bin/aft.dart
@@ -15,6 +15,7 @@
 import 'dart:io';
 
 import 'package:aft/aft.dart';
+import 'package:aft/src/commands/self_update_command.dart';
 import 'package:args/command_runner.dart';
 
 Future<void> main(List<String> args) async {
@@ -36,7 +37,8 @@ Future<void> main(List<String> args) async {
     ..addCommand(LinkCommand())
     ..addCommand(CleanCommand())
     ..addCommand(PubCommand())
-    ..addCommand(BootstrapCommand());
+    ..addCommand(BootstrapCommand())
+    ..addCommand(SelfUpdateCommand());
   try {
     await runner.run(args);
   } on UsageException catch (e) {

--- a/packages/aft/lib/src/commands/self_update_command.dart
+++ b/packages/aft/lib/src/commands/self_update_command.dart
@@ -1,0 +1,41 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:aft/aft.dart';
+
+/// A command to update the aft package.
+class SelfUpdateCommand extends AmplifyCommand {
+  @override
+  String get description =>
+      'Updates aft with the current contents of packages/aft';
+
+  @override
+  String get name => 'self-update';
+
+  @override
+  Future<void> run() async {
+    final root = await rootDir;
+    final aftDir = '${root.path}/packages/aft';
+    final pubRunner = createPubRunner();
+    await pubRunner.run(
+      [
+        'pub',
+        'global',
+        'activate',
+        '-spath',
+        aftDir,
+      ],
+    );
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add a `self-update` command to update aft. Inspired by [yarn self-update](https://classic.yarnpkg.com/lang/en/docs/cli/self-update/) or `flutter upgrade`

This just runs `dart pub global activate -spath <root>/packages/aft`.

Motivation: I always forget what the command it to activate a package from a path and have to look it up each time I switch to a branch with new aft changes. This makes it a little easier.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
