### PR TITLE
Revert "fix(auth): Hosted UI task continuation (#2017)"

### DIFF
--- a/packages/auth/amplify_auth_cognito_ios/ios/Classes/SwiftAuthCognito.swift
+++ b/packages/auth/amplify_auth_cognito_ios/ios/Classes/SwiftAuthCognito.swift
@@ -40,27 +40,22 @@ public class SwiftAuthCognito: NSObject, FlutterPlugin, AuthCategoryPlugin, Nati
         let instance = SwiftAuthCognito(nativeAuthPlugin: nativeAuthPlugin)
         NativeAuthBridgeSetup(registrar.messenger(), instance)
     }
-    
+
     public func signIn(
         withUrlUrl url: String,
         callbackUrlScheme: String,
         preferPrivateSession: NSNumber,
-        browserPackageName: String?,
-        completion: @escaping ([String : String]?, FlutterError?) -> Void
-    ) {
-        hostedUIFlow.launchUrl(
-            url,
-            callbackURLScheme: callbackUrlScheme,
-            preferPrivateSession: preferPrivateSession.boolValue
-        ) { result in
-            switch result {
-            case let .success(queryParams):
-                completion(queryParams, nil)
-                return
-            case let .failure(error):
-                completion(nil, error.flutterError)
-                return
-            }
+        browserPackageName: String?
+    ) async -> ([String : String]?, FlutterError?) {
+        do {
+            let queryParameters = try await hostedUIFlow.launchUrl(
+                url,
+                callbackURLScheme: callbackUrlScheme,
+                preferPrivateSession: preferPrivateSession.boolValue
+            )
+            return (queryParameters, nil)
+        } catch {
+            return (nil, error.flutterError)
         }
     }
     
@@ -68,22 +63,17 @@ public class SwiftAuthCognito: NSObject, FlutterPlugin, AuthCategoryPlugin, Nati
         withUrlUrl url: String,
         callbackUrlScheme: String,
         preferPrivateSession: NSNumber,
-        browserPackageName: String?,
-        completion: @escaping (FlutterError?) -> Void
-    ) {
-        hostedUIFlow.launchUrl(
-            url,
-            callbackURLScheme: callbackUrlScheme,
-            preferPrivateSession: preferPrivateSession.boolValue
-        ) { result in
-            switch result {
-            case .success:
-                completion(nil)
-                return
-            case let .failure(error):
-                completion(error.flutterError)
-                return
-            }
+        browserPackageName: String?
+    ) async -> FlutterError? {
+        do {
+            _ = try await hostedUIFlow.launchUrl(
+                url,
+                callbackURLScheme: callbackUrlScheme,
+                preferPrivateSession: preferPrivateSession.boolValue
+            )
+            return nil
+        } catch {
+            return error.flutterError
         }
     }
     


### PR DESCRIPTION
This reverts commit c16e4dd424afcbb91e6b40bd545d8449b1e56d30.

Originally proposed as a fix to #2015 which turned out to be not needed. Async/await provides a much cleaner syntax and is good to gain exposure with.