### PR TITLE
fix(auth): CognitoDeviceSecrets attempts to build without secrets

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/cognito_user.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/cognito_user.dart
@@ -36,24 +36,6 @@ abstract class CognitoUser implements Built<CognitoUser, CognitoUserBuilder> {
   @BuiltValueHook(finalizeBuilder: true)
   static void _finalize(CognitoUserBuilder b) {
     b.username ??= b.userId!;
-
-    // Assert that all device info is included if any is included.
-    if (b.deviceSecrets.deviceKey != null ||
-        b.deviceSecrets.deviceGroupKey != null ||
-        b.deviceSecrets.devicePassword != null) {
-      ArgumentError.checkNotNull(
-        b.deviceSecrets.deviceGroupKey,
-        'deviceGroupKey',
-      );
-      ArgumentError.checkNotNull(
-        b.deviceSecrets.deviceKey,
-        'deviceKey',
-      );
-      ArgumentError.checkNotNull(
-        b.deviceSecrets.devicePassword,
-        'devicePassword',
-      );
-    }
   }
 
   /// AWS Identity ID
@@ -66,6 +48,7 @@ abstract class CognitoUser implements Built<CognitoUser, CognitoUserBuilder> {
   CognitoUserPoolTokens? get userPoolTokens;
 
   /// Confirmed device secrets
+  @BuiltValueField(autoCreateNestedBuilder: false)
   CognitoDeviceSecrets? get deviceSecrets;
 
   /// Cognito user ID

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/cognito_user.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/cognito_user.g.dart
@@ -109,8 +109,7 @@ class CognitoUserBuilder implements Builder<CognitoUser, CognitoUserBuilder> {
       _$this._userPoolTokens = userPoolTokens;
 
   CognitoDeviceSecretsBuilder? _deviceSecrets;
-  CognitoDeviceSecretsBuilder get deviceSecrets =>
-      _$this._deviceSecrets ??= new CognitoDeviceSecretsBuilder();
+  CognitoDeviceSecretsBuilder? get deviceSecrets => _$this._deviceSecrets;
   set deviceSecrets(CognitoDeviceSecretsBuilder? deviceSecrets) =>
       _$this._deviceSecrets = deviceSecrets;
 


### PR DESCRIPTION
Fixes #2029

Fixes a regression caused by #2010 for non-device flows where the state machine expects device secrets even though none are present.