### PR TITLE
feat: custom signIn method without build in form;

### DIFF
--- a/packages/amplify_authenticator/lib/src/state/authenticator_state.dart
+++ b/packages/amplify_authenticator/lib/src/state/authenticator_state.dart
@@ -381,6 +381,21 @@ class AuthenticatorState extends ChangeNotifier {
     _setIsBusy(false);
   }
 
+  /// Sign in with [username], and [password] without a build in form
+  Future<void> customSignIn(String userName, String password) async {
+    if(userName.isEmpty || password.isEmpty) {
+      return;
+    }
+    _setIsBusy(true);
+    AuthSignInData signIn = AuthUsernamePasswordSignInData(
+      username: userName,
+      password: password,
+    );
+    _authBloc.add(AuthSignIn(signIn));
+    await nextBlocEvent();
+    _setIsBusy(false);
+  }
+
   /// Perform sicial sign in with the given provider
   Future<void> signInWithProvider(AuthProvider provider) async {
     _setIsBusy(true);


### PR DESCRIPTION

*Added a way to custom signIn with a username and password without the build in form fields*
*The business case scenario: having a server that generates the Cognito user and returns the username and password to the application which then will use it to login*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
