### PR TITLE
feat(authenticator): handle `AuthHubEventType.signedIn`

### DIFF
--- a/packages/amplify_authenticator/example/integration_test/pages/authenticator_page.dart
+++ b/packages/amplify_authenticator/example/integration_test/pages/authenticator_page.dart
@@ -95,6 +95,15 @@ abstract class AuthenticatorPage {
     expect(inheritedBloc.authBloc.currentState, isA<AuthenticatedState>());
   }
 
+  Future<void> expectState(AuthState state) async {
+    final inheritedBloc =
+        tester.widget<InheritedAuthBloc>(find.byKey(keyInheritedAuthBloc));
+    if (inheritedBloc.authBloc.currentState != state) {
+      await nextBlocEvent(tester);
+    }
+    expect(inheritedBloc.authBloc.currentState, state);
+  }
+
   /// Then I see User not found banner
   Future<void> expectUserNotFound() async => expectError('User does not exist');
 

--- a/packages/amplify_authenticator/example/integration_test/verify_user_test.dart
+++ b/packages/amplify_authenticator/example/integration_test/verify_user_test.dart
@@ -17,6 +17,7 @@
 // https://github.com/aws-amplify/amplify-ui/blob/main/packages/e2e/features/ui/components/authenticator/verify-user.feature
 
 import 'package:amplify_authenticator/amplify_authenticator.dart';
+import 'package:amplify_authenticator/src/state/auth_state.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter/material.dart';
@@ -78,6 +79,9 @@ void main() {
       // And I click the "Sign in" button
       await signInPage.submitSignIn();
 
+      // Wait for verify user state
+      await verifyUserPage.expectState(UnauthenticatedState.verifyUser);
+
       // Then I see "Account recovery requires verified contact information"
       verifyUserPage.expectTitleIsVisible();
     });
@@ -101,6 +105,9 @@ void main() {
 
       // And I click the "Sign in" button
       await signInPage.submitSignIn();
+
+      // Wait for verify user state
+      await verifyUserPage.expectState(UnauthenticatedState.verifyUser);
 
       // And I click the "Skip" button
       await verifyUserPage.tapSkipButton();
@@ -132,6 +139,9 @@ void main() {
       // And I click the "Sign in" button
       await signInPage.submitSignIn();
 
+      // Wait for verify user state
+      await verifyUserPage.expectState(UnauthenticatedState.verifyUser);
+
       // And I see "Account recovery requires verified contact information"
       verifyUserPage.expectTitleIsVisible();
 
@@ -143,6 +153,25 @@ void main() {
 
       // Then I see "Code"
       confirmVerifyUserPage.expectCodeFieldIsPresent();
+    });
+
+    testWidgets('Auth.signIn does not redirect to "Verify" page',
+        (tester) async {
+      SignInPage signInPage = SignInPage(tester: tester);
+      await loadAuthenticator(tester: tester, authenticator: authenticator);
+
+      final username = generateEmail();
+      final password = generatePassword();
+
+      await adminCreateUser(username, password, autoConfirm: true);
+
+      // When I sign in with username and password.
+      await Amplify.Auth.signIn(username: username, password: password);
+
+      await tester.pumpAndSettle();
+
+      // Then I see "Sign out"
+      await signInPage.expectAuthenticated();
     });
   });
 }

--- a/packages/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/amplify_authenticator/lib/amplify_authenticator.dart
@@ -483,7 +483,6 @@ class _AuthenticatorState extends State<Authenticator> {
     _subscribeToInfoMessages();
     _subscribeToSuccessEvents();
     _waitForConfiguration();
-    _setUpHubSubscription();
   }
 
   void _subscribeToExceptions() {
@@ -566,23 +565,6 @@ class _AuthenticatorState extends State<Authenticator> {
     _successSub = _stateMachineBloc.stream.listen((state) {
       if (state is AuthenticatedState) {
         scaffoldMessengerKey.currentState?.removeCurrentMaterialBanner();
-      }
-    });
-  }
-
-  Future<void> _setUpHubSubscription() async {
-    // the stream does not exist until configuration is complete
-    await Amplify.asyncConfig;
-    _hubSubscription =
-        Amplify.Hub.listen(HubChannel.Auth, (AuthHubEvent event) {
-      switch (event.type) {
-        case AuthHubEventType.signedOut:
-          _stateMachineBloc.add(
-            const AuthChangeScreen(AuthenticatorStep.signIn),
-          );
-          break;
-        default:
-          break;
       }
     });
   }

--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -318,10 +318,6 @@ class StateMachineBloc
         if (isSocialSignIn) {
           _emit(const AuthenticatedState());
         } else {
-          if (currentState is UnauthenticatedState) {
-            final state = (currentState as UnauthenticatedState);
-            _emit(state.withPendingVerification());
-          }
           await for (final state in _checkUserVerification()) {
             _emit(state);
           }
@@ -386,6 +382,10 @@ class StateMachineBloc
   }
 
   Stream<AuthState> _checkUserVerification() async* {
+    if (currentState is UnauthenticatedState) {
+      final state = (currentState as UnauthenticatedState);
+      _emit(state.withPendingVerification());
+    }
     try {
       var attributeVerificationStatus =
           await _authService.getAttributeVerificationStatus();

--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -145,9 +145,8 @@ class StateMachineBloc
         if (currentState is! UnauthenticatedState) {
           break;
         }
-        final state = currentState as UnauthenticatedState;
         // do not change state if there is a pending user verification.
-        if (state.pendingVerification) {
+        if (currentState is PendingVerificationCheckState) {
           break;
         }
         return const AuthenticatedState();
@@ -384,7 +383,7 @@ class StateMachineBloc
   Stream<AuthState> _checkUserVerification() async* {
     if (currentState is UnauthenticatedState) {
       final state = (currentState as UnauthenticatedState);
-      _emit(state.withPendingVerification());
+      _emit(PendingVerificationCheckState(step: state.step));
     }
     try {
       var attributeVerificationStatus =

--- a/packages/amplify_authenticator/lib/src/state/auth_state.dart
+++ b/packages/amplify_authenticator/lib/src/state/auth_state.dart
@@ -35,18 +35,7 @@ class AuthenticatedState extends AuthState {
 class UnauthenticatedState extends AuthState {
   final AuthenticatorStep _step;
 
-  /// A flag to indicate if the current state is pending user
-  /// verification.
-  ///
-  /// Indicates that either Sign In OR Confirm Sign In has completed,
-  /// but it is currently unknown if the user needs to be taken to
-  /// the `veryUser` step or to an authenticated state.
-  final bool pendingVerification;
-
-  const UnauthenticatedState({
-    required AuthenticatorStep step,
-    this.pendingVerification = false,
-  }) : _step = step;
+  const UnauthenticatedState({required AuthenticatorStep step}) : _step = step;
 
   AuthenticatorStep get step => _step;
 
@@ -65,16 +54,6 @@ class UnauthenticatedState extends AuthState {
 
   static const verifyUser =
       UnauthenticatedState(step: AuthenticatorStep.verifyUser);
-
-  /// Returns the current state, with `pendingVerification` set to true.
-  ///
-  /// Should be used with signIn or confirmSignIn only.
-  UnauthenticatedState withPendingVerification() {
-    return UnauthenticatedState(
-      step: step,
-      pendingVerification: true,
-    );
-  }
 
   @override
   bool operator ==(Object other) =>
@@ -105,4 +84,21 @@ class ConfirmSignInCustom extends UnauthenticatedState {
   const ConfirmSignInCustom({
     this.publicParameters = const <String, String>{},
   }) : super(step: AuthenticatorStep.confirmSignInCustomAuth);
+}
+
+/// A state that indicates that there is a check to
+/// determine the user's verification state in progress.
+///
+/// This indicates that either Sign In OR Confirm Sign In
+/// has completed, but it is currently unknown if the user needs
+/// to be taken to the `veryUser` step or to an authenticated state
+/// because the call to fetch user attributes is pending.
+class PendingVerificationCheckState extends UnauthenticatedState {
+  const PendingVerificationCheckState({
+    required super.step,
+  }) : assert(
+          step == AuthenticatorStep.signIn ||
+              step == AuthenticatorStep.confirmSignUp,
+          'Invalid AuthenticatorStep type: $step',
+        );
 }

--- a/packages/amplify_authenticator/lib/src/state/auth_state.dart
+++ b/packages/amplify_authenticator/lib/src/state/auth_state.dart
@@ -34,7 +34,19 @@ class AuthenticatedState extends AuthState {
 @immutable
 class UnauthenticatedState extends AuthState {
   final AuthenticatorStep _step;
-  const UnauthenticatedState({required AuthenticatorStep step}) : _step = step;
+
+  /// A flag to indicate if the current state is pending user
+  /// verification.
+  ///
+  /// Indicates that either Sign In OR Confirm Sign In has completed,
+  /// but it is currently unknown if the user needs to be taken to
+  /// the `veryUser` step or to an authenticated state.
+  final bool pendingVerification;
+
+  const UnauthenticatedState({
+    required AuthenticatorStep step,
+    this.pendingVerification = false,
+  }) : _step = step;
 
   AuthenticatorStep get step => _step;
 
@@ -50,8 +62,19 @@ class UnauthenticatedState extends AuthState {
       UnauthenticatedState(step: AuthenticatorStep.resetPassword);
   static const confirmResetPassword =
       UnauthenticatedState(step: AuthenticatorStep.confirmResetPassword);
+
   static const verifyUser =
       UnauthenticatedState(step: AuthenticatorStep.verifyUser);
+
+  /// Returns the current state, with `pendingVerification` set to true.
+  ///
+  /// Should be used with signIn or confirmSignIn only.
+  UnauthenticatedState withPendingVerification() {
+    return UnauthenticatedState(
+      step: step,
+      pendingVerification: true,
+    );
+  }
 
   @override
   bool operator ==(Object other) =>


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/2041

*Description of changes:*
- Add a new state for pending verification
- Emit new state when verification is started 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
