### PR TITLE
chore(core): Distinguish user agent

### DIFF
--- a/packages/amplify_core/lib/src/http/amplify_http_client.dart
+++ b/packages/amplify_core/lib/src/http/amplify_http_client.dart
@@ -30,7 +30,10 @@ class AmplifyHttpClient extends http.BaseClient {
   final http.Client _baseClient;
 
   late final String _userAgent = [
-    'amplify-flutter/${Amplify.version}',
+    if (zIsFlutter)
+      'amplify-flutter/${Amplify.version}'
+    else
+      'amplify-dart/${Amplify.version}',
     osIdentifier,
   ].join(' ');
 


### PR DESCRIPTION
Distinguishes Amplify Flutter users from those using Amplify outside of Flutter, e.g. in a Dart web or server application, in the user agent for reporting purposes.
