### PR TITLE
chore(auth): Emit Hosted UI user for Hosted UI tokens only

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
@@ -49,7 +49,8 @@ class HostedUiStateMachine extends HostedUiStateMachineBase {
     final result = await getOrCreate(CredentialStoreStateMachine.type)
         .getCredentialsResult();
     final userPoolTokens = result.data.userPoolTokens;
-    if (userPoolTokens != null) {
+    if (userPoolTokens != null &&
+        userPoolTokens.signInMethod == CognitoSignInMethod.hostedUi) {
       emit(HostedUiState.signedIn(userPoolTokens.authUser));
       return;
     }


### PR DESCRIPTION
Only trigger a Hosted UI signedIn event when the cached tokens are for a Hosted UI sign in.
