### PR TITLE
feat(auth): Force refresh

### DIFF
--- a/packages/amplify_core/lib/src/types/auth/session/auth_session_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/session/auth_session_options.dart
@@ -16,7 +16,15 @@
 import 'package:amplify_core/amplify_core.dart';
 
 abstract class AuthSessionOptions with AWSSerializable<Map<String, Object?>> {
-  const AuthSessionOptions();
+  const AuthSessionOptions({
+    this.forceRefresh = false,
+  });
+
+  /// Whether to force a refresh of the cached credentials.
+  ///
+  /// When `true`, any cached credentials will be ignored when deciding whether
+  /// to refresh them.
+  final bool forceRefresh;
 
   @Deprecated('Use toJson instead')
   Map<String, Object?> serializeAsMap() => toJson();

--- a/packages/auth/amplify_auth_cognito/example/integration_test/force_refresh_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/force_refresh_test.dart
@@ -1,0 +1,82 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
+import 'package:amplify_test/amplify_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'utils/mock_data.dart';
+import 'utils/setup_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<Map<String, Object?>> getCustomAttributes({
+    bool forceRefresh = false,
+  }) async {
+    final session = await Amplify.Auth.fetchAuthSession(
+      options: CognitoSessionOptions(forceRefresh: forceRefresh),
+    ) as CognitoAuthSession;
+    final idToken = session.userPoolTokens?.idToken;
+    expect(idToken, isNotNull, reason: 'User is logged in');
+
+    return idToken!.claims.customClaims;
+  }
+
+  test('Force refresh', () async {
+    await configureAuth();
+
+    final username = generateUsername();
+    final password = generatePassword();
+
+    await adminCreateUser(
+      username,
+      password,
+      autoConfirm: true,
+      verifyAttributes: true,
+    );
+    addTearDown(Amplify.Auth.deleteUser);
+
+    final res = await Amplify.Auth.signIn(
+      username: username,
+      password: password,
+    );
+    expect(res.nextStep?.signInStep, 'DONE');
+
+    expect(
+      await getCustomAttributes(),
+      isNot(contains('address')),
+      reason: 'No custom attrs exist yet',
+    );
+
+    await Amplify.Auth.updateUserAttribute(
+      userAttributeKey: CognitoUserAttributeKey.address,
+      value: '1 Main St',
+    );
+
+    expect(
+      await getCustomAttributes(),
+      isNot(contains('address')),
+      reason: 'Token is not yet updated',
+    );
+
+    expect(
+      await getCustomAttributes(forceRefresh: true),
+      contains('address'),
+      reason: 'Token is updated via force refresh',
+    );
+  });
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_session_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_session_options.dart
@@ -26,6 +26,7 @@ class CognitoSessionOptions extends AuthSessionOptions
   /// {@macro amplify_auth_cognito.model.cognito_session_options}
   const CognitoSessionOptions({
     this.getAWSCredentials = false,
+    super.forceRefresh = false,
   });
 
   /// {@macro amplify_auth_cognito.model.cognito_session_options}
@@ -42,7 +43,7 @@ class CognitoSessionOptions extends AuthSessionOptions
   final bool getAWSCredentials;
 
   @override
-  List<Object?> get props => [getAWSCredentials];
+  List<Object?> get props => [getAWSCredentials, forceRefresh];
 
   @override
   String get runtimeTypeName => 'CognitoSessionOptions';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_session_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_session_options.g.dart
@@ -10,10 +10,12 @@ CognitoSessionOptions _$CognitoSessionOptionsFromJson(
         Map<String, dynamic> json) =>
     CognitoSessionOptions(
       getAWSCredentials: json['getAWSCredentials'] as bool? ?? false,
+      forceRefresh: json['forceRefresh'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$CognitoSessionOptionsToJson(
         CognitoSessionOptions instance) =>
     <String, dynamic>{
+      'forceRefresh': instance.forceRefresh,
       'getAWSCredentials': instance.getAWSCredentials,
     };

--- a/packages/auth/amplify_auth_cognito_test/test/state/fetch_auth_session_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/fetch_auth_session_state_machine_test.dart
@@ -453,6 +453,223 @@ void main() {
             throwsA(isA<_FetchAuthSessionException>()),
           );
         });
+
+        test('force refresh user pool tokens', () async {
+          seedStorage(
+            secureStorage,
+            userPoolKeys: userPoolKeys,
+          );
+          // Create an unexpired access token which we want to refresh.
+          final originalToken = createJwt(
+            type: TokenType.access,
+            expiration: const Duration(minutes: 3),
+          );
+          secureStorage.write(
+            key: userPoolKeys[CognitoUserPoolKey.accessToken],
+            value: originalToken.raw,
+          );
+          stateMachine.dispatch(AuthEvent.configure(userPoolOnlyConfig));
+          await stateMachine.stream.whereType<AuthConfigured>().first;
+
+          stateMachine
+            ..addInstance<CognitoIdentityProviderClient>(
+              MockCognitoIdentityProviderClient(
+                initiateAuth: expectAsync1(
+                  (request) async => InitiateAuthResponse(
+                    authenticationResult: AuthenticationResultType(
+                      accessToken: createJwt(
+                        type: TokenType.access,
+                        expiration: const Duration(minutes: 5),
+                      ).raw,
+                    ),
+                  ),
+                ),
+              ),
+            )
+            ..dispatch(
+              const FetchAuthSessionEvent.fetch(
+                CognitoSessionOptions(
+                  getAWSCredentials: false,
+                  forceRefresh: true,
+                ),
+              ),
+            );
+
+          final sm =
+              stateMachine.getOrCreate(FetchAuthSessionStateMachine.type);
+          await expectLater(
+            sm.stream.startWith(sm.currentState),
+            emitsInOrder(<Matcher>[
+              isA<FetchAuthSessionIdle>(),
+              isA<FetchAuthSessionFetching>(),
+              isA<FetchAuthSessionRefreshing>(),
+              isA<FetchAuthSessionSuccess>(),
+            ]),
+          );
+
+          final state = sm.currentState as FetchAuthSessionSuccess;
+          expect(state.session.isSignedIn, isTrue);
+          expect(state.session.userSub, userSub);
+          expect(state.session.userPoolTokens, isNotNull);
+
+          final newToken = state.session.userPoolTokens!.accessToken;
+          expect(newToken, isNot(originalToken));
+          expect(
+            newToken.claims.expiration!.millisecondsSinceEpoch,
+            greaterThan(
+              originalToken.claims.expiration!.millisecondsSinceEpoch,
+            ),
+          );
+        });
+
+        test('force refresh AWS creds', () async {
+          seedStorage(
+            secureStorage,
+            identityPoolKeys: identityPoolKeys,
+          );
+          // Create unexpired AWS credentials which we want to refresh.
+          final originalExpiration =
+              DateTime.now().add(const Duration(minutes: 3));
+          final newExpiration = DateTime.now().add(const Duration(minutes: 5));
+          secureStorage.write(
+            key: identityPoolKeys[CognitoIdentityPoolKey.expiration],
+            value: originalExpiration.toIso8601String(),
+          );
+          stateMachine.dispatch(AuthEvent.configure(mockConfig));
+          await stateMachine.stream.whereType<AuthConfigured>().first;
+
+          const newIdentityId = 'newIdentityId';
+          const newAccessKeyId = 'newAccessKeyId';
+          const newSecretAccessKey = 'newSecretAccessKey';
+          stateMachine
+            ..addInstance<CognitoIdentityClient>(
+              MockCognitoIdentityClient(
+                getId: expectAsync0(
+                  () async => GetIdResponse(identityId: newIdentityId),
+                ),
+                getCredentialsForIdentity: expectAsync0(
+                  () async => GetCredentialsForIdentityResponse(
+                    credentials: Credentials(
+                      accessKeyId: newAccessKeyId,
+                      secretKey: newSecretAccessKey,
+                      expiration: newExpiration,
+                    ),
+                  ),
+                ),
+              ),
+            )
+            ..dispatch(
+              const FetchAuthSessionEvent.fetch(
+                CognitoSessionOptions(
+                  getAWSCredentials: true,
+                  forceRefresh: true,
+                ),
+              ),
+            );
+
+          final sm =
+              stateMachine.getOrCreate(FetchAuthSessionStateMachine.type);
+          await expectLater(
+            sm.stream.startWith(sm.currentState),
+            emitsInOrder(<Matcher>[
+              isA<FetchAuthSessionIdle>(),
+              isA<FetchAuthSessionFetching>(),
+              isA<FetchAuthSessionRefreshing>(),
+              isA<FetchAuthSessionSuccess>(),
+            ]),
+          );
+
+          final state = sm.currentState as FetchAuthSessionSuccess;
+          expect(state.session.identityId, newIdentityId);
+          expect(
+            state.session.credentials?.accessKeyId,
+            newAccessKeyId,
+          );
+          expect(
+            state.session.credentials?.secretAccessKey,
+            newSecretAccessKey,
+          );
+          expect(state.session.credentials?.expiration, newExpiration);
+        });
+
+        test('force refresh all creds', () async {
+          seedStorage(
+            secureStorage,
+            identityPoolKeys: identityPoolKeys,
+            userPoolKeys: userPoolKeys,
+          );
+          // Create an unexpired access token which we want to refresh.
+          final originalToken = createJwt(
+            type: TokenType.access,
+            expiration: const Duration(minutes: 3),
+          );
+          secureStorage.write(
+            key: userPoolKeys[CognitoUserPoolKey.accessToken],
+            value: originalToken.raw,
+          );
+          // Create unexpired AWS credentials which we don't want to refresh.
+          final originalExpiration =
+              DateTime.now().add(const Duration(minutes: 3));
+          secureStorage.write(
+            key: identityPoolKeys[CognitoIdentityPoolKey.expiration],
+            value: originalExpiration.toIso8601String(),
+          );
+          stateMachine.dispatch(AuthEvent.configure(mockConfig));
+          await stateMachine.stream.whereType<AuthConfigured>().first;
+
+          stateMachine
+            ..addInstance<CognitoIdentityProviderClient>(
+              MockCognitoIdentityProviderClient(
+                initiateAuth: expectAsync1(
+                  (request) async => InitiateAuthResponse(
+                    authenticationResult: AuthenticationResultType(
+                      accessToken: createJwt(
+                        type: TokenType.access,
+                        expiration: const Duration(minutes: 5),
+                      ).raw,
+                    ),
+                  ),
+                ),
+              ),
+            )
+            ..dispatch(
+              const FetchAuthSessionEvent.fetch(
+                CognitoSessionOptions(
+                  getAWSCredentials: false,
+                  forceRefresh: true,
+                ),
+              ),
+            );
+
+          final sm =
+              stateMachine.getOrCreate(FetchAuthSessionStateMachine.type);
+          await expectLater(
+            sm.stream.startWith(sm.currentState),
+            emitsInOrder(<Matcher>[
+              isA<FetchAuthSessionIdle>(),
+              isA<FetchAuthSessionFetching>(),
+              isA<FetchAuthSessionRefreshing>(),
+              isA<FetchAuthSessionSuccess>(),
+            ]),
+          );
+
+          final state = sm.currentState as FetchAuthSessionSuccess;
+          expect(state.session.isSignedIn, isTrue);
+          expect(state.session.userSub, userSub);
+          expect(state.session.userPoolTokens, isNotNull);
+
+          final newToken = state.session.userPoolTokens!.accessToken;
+          expect(newToken, isNot(originalToken));
+          expect(
+            newToken.claims.expiration!.millisecondsSinceEpoch,
+            greaterThan(
+              originalToken.claims.expiration!.millisecondsSinceEpoch,
+            ),
+          );
+
+          expect(state.session.credentials, isNotNull);
+          expect(state.session.credentials!.expiration, originalExpiration);
+        });
       });
 
       test('fails', () async {


### PR DESCRIPTION
Adds a `forceRefresh` parameter which allows overriding the default refresh logic to perform refreshes on an as-needed basis.
