### PR TITLE
fix(core): Podspec deployment target

### DIFF
--- a/packages/amplify_core/ios/amplify_core.podspec
+++ b/packages/amplify_core/ios/amplify_core.podspec
@@ -19,7 +19,7 @@ A base package shared across Amplify Flutter library.
   s.dependency 'Flutter'
   s.dependency 'SwiftLint', '0.48.0'
   s.dependency 'SwiftFormat/CLI'
-  s.platform = :ios, '9.0'
+  s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
Fixes https://github.com/aws-amplify/amplify-flutter/issues/2098.

Fixes an issue surfaced in Flutter 3.3.0 which configures XCode projects based off this value. Previously, if the value was <9, the logic would apply. Now if the value is <11, the logic applies. We don't want this logic to apply.

The previous value was incorrect anyway so it's a good change to make regardless.
