### PR TITLE
chore(aft): Make `pub upgrade` the default

### DIFF
--- a/packages/aft/lib/src/commands/bootstrap_command.dart
+++ b/packages/aft/lib/src/commands/bootstrap_command.dart
@@ -25,7 +25,8 @@ class BootstrapCommand extends AmplifyCommand {
         'upgrade',
         abbr: 'u',
         help: 'Runs `pub upgrade` instead of `pub get`',
-        negatable: false,
+        negatable: true,
+        defaultsTo: true,
       )
       ..addFlag(
         'build',


### PR DESCRIPTION
vs. pub get. This provides a better experience in most cases esp since this is how tests are configured to run - so this will prevent build errors due simply to an outdated dependency.
