### PR TITLE
chore(core): Export `safePrint` from amplify_core

### DIFF
--- a/packages/amplify_core/lib/amplify_core.dart
+++ b/packages/amplify_core/lib/amplify_core.dart
@@ -15,6 +15,9 @@
 
 library amplify_core;
 
+/// Common types
+export 'package:aws_common/aws_common.dart';
+
 /// Categories
 export 'src/category/amplify_categories.dart';
 


### PR DESCRIPTION
And, by extension `amplify_flutter` which already exports `amplify_core`. This aligns the exports with `next`.

Fixes #2092.
