### PR TITLE
chore(worker_bee): Soften log level of internal messages

### DIFF
--- a/packages/worker_bee/worker_bee/lib/src/common.dart
+++ b/packages/worker_bee/worker_bee/lib/src/common.dart
@@ -200,7 +200,7 @@ abstract class WorkerBeeCommon<Request extends Object, Response>
   /// Internal method for completing with an error.
   @protected
   void completeError(Object error, [StackTrace? stackTrace]) {
-    logger.error('Error in worker', error, stackTrace);
+    logger.debug('Error in worker', error, stackTrace);
     if (!isCompleted) {
       _resultCompleter.complete(Result.error(error, stackTrace));
     }

--- a/packages/worker_bee/worker_bee/lib/src/js/impl.dart
+++ b/packages/worker_bee/worker_bee/lib/src/js/impl.dart
@@ -294,7 +294,7 @@ mixin WorkerBeeImpl<Request extends Object, Response>
 
             return;
           } on Object catch (e, st) {
-            logger.error('Error initializing worker', e, st);
+            logger.debug('Error initializing worker', e, st);
             continue;
           }
         }


### PR DESCRIPTION
Reduce log level of internal messages to `debug` to avoid printing expected events as errors. For example, workers closing was reporting as error but this happens when hot restarting in Flutter. Since the result also completes with an error, there's no need to report it if the result value is not needed.

Likewise, the one in `impl.dart` is expected in certain cases and will print when falling back to a different JS file. In the case no files are usable it will throw an Error which is surfaced through the appropriate mechanisms.
