### PR TITLE
fix(auth): Erase plugin interface input types

### DIFF
--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -158,7 +158,7 @@ class AmplifyAuthCognito extends AmplifyAuthCognitoDart with AWSDebuggable {
 
   @override
   Future<CognitoSignUpResult> signUp({
-    required SignUpRequest<CognitoSignUpOptions> request,
+    required SignUpRequest request,
   }) async {
     Map<String, String>? validationData;
     if (!zIsWeb && (Platform.isAndroid || Platform.isIOS)) {
@@ -166,7 +166,8 @@ class AmplifyAuthCognito extends AmplifyAuthCognitoDart with AWSDebuggable {
           await stateMachine.expect<NativeAuthBridge>().getValidationData();
       validationData = nativeValidationData.cast();
     }
-    var options = request.options ?? CognitoSignUpOptions();
+    var options =
+        request.options as CognitoSignUpOptions? ?? CognitoSignUpOptions();
     options = options.copyWith(
       validationData: {
         ...?validationData,

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -298,9 +298,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<CognitoAuthSession> fetchAuthSession({
-    required AuthSessionRequest<CognitoSessionOptions> request,
+    required AuthSessionRequest request,
   }) async {
-    final options = request.options;
+    final options = request.options as CognitoSessionOptions?;
     _stateMachine.dispatch(FetchAuthSessionEvent.fetch(options));
 
     await for (final state
@@ -325,10 +325,10 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<CognitoSignInResult> signInWithWebUI({
-    SignInWithWebUIRequest<CognitoSignInWithWebUIOptions> request =
-        const SignInWithWebUIRequest(),
+    SignInWithWebUIRequest request = const SignInWithWebUIRequest(),
   }) async {
-    final options = request.options ?? const CognitoSignInWithWebUIOptions();
+    final options = request.options as CognitoSignInWithWebUIOptions? ??
+        const CognitoSignInWithWebUIOptions();
 
     // Create a new state machine which will close the previous one and cancel
     // any pending sign-ins.
@@ -369,9 +369,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<CognitoSignUpResult> signUp({
-    required SignUpRequest<CognitoSignUpOptions> request,
+    required SignUpRequest request,
   }) async {
-    final options = request.options;
+    final options = request.options as CognitoSignUpOptions?;
     _stateMachine.dispatch(
       SignUpEvent.initiate(
         parameters: SignUpParameters(
@@ -420,9 +420,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<CognitoSignUpResult> confirmSignUp({
-    required ConfirmSignUpRequest<CognitoConfirmSignUpOptions> request,
+    required ConfirmSignUpRequest request,
   }) async {
-    final options = request.options;
+    final options = request.options as CognitoConfirmSignUpOptions?;
     _stateMachine.dispatch(
       SignUpEvent.confirm(
         username: request.username,
@@ -466,9 +466,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<CognitoResendSignUpCodeResult> resendSignUpCode({
-    required ResendSignUpCodeRequest<CognitoResendSignUpCodeOptions> request,
+    required ResendSignUpCodeRequest request,
   }) async {
-    final options = request.options;
+    final options = request.options as CognitoResendSignUpCodeOptions?;
     final result = await _cognitoIdp.resendConfirmationCode(
       cognito.ResendConfirmationCodeRequest.build((b) {
         b
@@ -499,9 +499,10 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<CognitoSignInResult> signIn({
-    required SignInRequest<CognitoSignInOptions> request,
+    required SignInRequest request,
   }) async {
-    final options = request.options ?? const CognitoSignInOptions();
+    final options = request.options as CognitoSignInOptions? ??
+        const CognitoSignInOptions();
 
     // Create a new state machine for every call since it caches values
     // internally on each run.
@@ -570,9 +571,10 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<CognitoSignInResult> confirmSignIn({
-    required ConfirmSignInRequest<CognitoConfirmSignInOptions> request,
+    required ConfirmSignInRequest request,
   }) async {
-    final options = request.options ?? const CognitoConfirmSignInOptions();
+    final options = request.options as CognitoConfirmSignInOptions? ??
+        const CognitoConfirmSignInOptions();
     _stateMachine.dispatch(
       SignInEvent.respondToChallenge(
         answer: request.confirmationValue,
@@ -619,8 +621,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<List<AuthUserAttribute<CognitoUserAttributeKey>>> fetchUserAttributes({
-    FetchUserAttributesRequest<FetchUserAttributesOptions> request =
-        const FetchUserAttributesRequest(),
+    FetchUserAttributesRequest request = const FetchUserAttributesRequest(),
   }) async {
     final userPoolTokens = await getUserPoolTokens();
     final resp = await _cognitoIdp.getUser(
@@ -636,11 +637,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<UpdateUserAttributeResult> updateUserAttribute({
-    required UpdateUserAttributeRequest<CognitoUserAttributeKey,
-            CognitoUpdateUserAttributeOptions>
-        request,
+    required UpdateUserAttributeRequest request,
   }) async {
-    final options = request.options;
+    final options = request.options as CognitoUpdateUserAttributeOptions?;
     final results = await updateUserAttributes(
       request: UpdateUserAttributesRequest(
         attributes: [request.attribute],
@@ -655,12 +654,10 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
   @override
   Future<Map<CognitoUserAttributeKey, UpdateUserAttributeResult>>
       updateUserAttributes({
-    required UpdateUserAttributesRequest<CognitoUserAttributeKey,
-            CognitoUpdateUserAttributesOptions>
-        request,
+    required UpdateUserAttributesRequest request,
   }) async {
     final userPoolTokens = await getUserPoolTokens();
-    final options = request.options;
+    final options = request.options as CognitoUpdateUserAttributesOptions?;
     final response = await _cognitoIdp.updateUserAttributes(
       cognito.UpdateUserAttributesRequest.build(
         (b) => b
@@ -686,7 +683,8 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
       final nextStep = isUpdated
           ? CognitoUpdateUserAttributeStep.done
           : CognitoUpdateUserAttributeStep.confirmAttribute;
-      result[attribute.userAttributeKey] = UpdateUserAttributeResult(
+      result[attribute.userAttributeKey as CognitoUserAttributeKey] =
+          UpdateUserAttributeResult(
         isUpdated: isUpdated,
         nextStep: AuthNextUpdateAttributeStep(
           updateAttributeStep: nextStep.value,
@@ -699,9 +697,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<ConfirmUserAttributeResult> confirmUserAttribute({
-    required ConfirmUserAttributeRequest<CognitoUserAttributeKey,
-            ConfirmUserAttributeOptions>
-        request,
+    required ConfirmUserAttributeRequest request,
   }) async {
     final userPoolTokens = await getUserPoolTokens();
     await _cognitoIdp.verifyUserAttribute(
@@ -717,12 +713,11 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
   @override
   Future<ResendUserAttributeConfirmationCodeResult>
       resendUserAttributeConfirmationCode({
-    required ResendUserAttributeConfirmationCodeRequest<CognitoUserAttributeKey,
-            CognitoResendUserAttributeConfirmationCodeOptions>
-        request,
+    required ResendUserAttributeConfirmationCodeRequest request,
   }) async {
     final userPoolTokens = await getUserPoolTokens();
-    final options = request.options;
+    final options =
+        request.options as CognitoResendUserAttributeConfirmationCodeOptions?;
     final result = await _cognitoIdp.getUserAttributeVerificationCode(
       cognito.GetUserAttributeVerificationCodeRequest(
         accessToken: userPoolTokens.accessToken.raw,
@@ -742,11 +737,11 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<UpdatePasswordResult> updatePassword({
-    required UpdatePasswordRequest<CognitoUpdatePasswordOptions> request,
+    required UpdatePasswordRequest request,
   }) async {
     // TODO(dnys1): Where does clientMetadata go?
     // ignore: unused_local_variable
-    final options = request.options;
+    final options = request.options as CognitoUpdatePasswordOptions?;
 
     final tokens = await getUserPoolTokens();
     await _cognitoIdp.changePassword(
@@ -761,9 +756,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<CognitoResetPasswordResult> resetPassword({
-    required ResetPasswordRequest<CognitoResetPasswordOptions> request,
+    required ResetPasswordRequest request,
   }) async {
-    final options = request.options;
+    final options = request.options as CognitoResetPasswordOptions?;
     final result = await _cognitoIdp.forgotPassword(
       cognito.ForgotPasswordRequest.build((b) {
         b
@@ -802,10 +797,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<UpdatePasswordResult> confirmResetPassword({
-    required ConfirmResetPasswordRequest<CognitoConfirmResetPasswordOptions>
-        request,
+    required ConfirmResetPasswordRequest request,
   }) async {
-    final options = request.options;
+    final options = request.options as CognitoConfirmResetPasswordOptions?;
     await _cognitoIdp.confirmForgotPassword(
       cognito.ConfirmForgotPasswordRequest.build((b) {
         b
@@ -833,7 +827,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<AuthUser> getCurrentUser({
-    AuthUserRequest<AuthUserOptions> request = const AuthUserRequest(),
+    AuthUserRequest request = const AuthUserRequest(),
   }) async {
     final userPoolTokens = await getUserPoolTokens();
     final userId = userPoolTokens.idToken.userId;
@@ -863,7 +857,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
   }
 
   @override
-  Future<void> forgetDevice([CognitoDevice? device]) async {
+  Future<void> forgetDevice([AuthDevice? device]) async {
     final tokens = await getUserPoolTokens();
     final username = tokens.username;
     final deviceSecrets = await _deviceRepo.get(username);
@@ -924,7 +918,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   @override
   Future<SignOutResult> signOut({
-    SignOutRequest<SignOutOptions> request = const SignOutRequest(),
+    SignOutRequest request = const SignOutRequest(),
   }) async {
     final options = request.options ?? const SignOutOptions();
 


### PR DESCRIPTION
Since plugin types are erased via the category wrappers, do not use them in the input signature since generics cannot be reified this way. Perform casts within the plugin to revive the types.