### PR TITLE
fix(datastore): correct plugin configuration

### DIFF
--- a/packages/amplify_core/lib/src/category/amplify_datastore_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_datastore_category.dart
@@ -35,9 +35,9 @@ class DataStoreCategory extends AmplifyCategory<DataStorePluginInterface> {
         await plugin.configureDataStore(
             modelProvider: plugin.modelProvider!,
             errorHandler: plugin.errorHandler);
-        plugins.add(plugin);
+        _plugins.add(plugin);
       } on AmplifyAlreadyConfiguredException {
-        plugins.add(plugin);
+        _plugins.add(plugin);
       } on Object catch (e) {
         try {
           throw AmplifyException.fromMap(


### PR DESCRIPTION
There is a bug on next where adding Datastore plugin throws an error which can be reproduced simply by trying to run example app. This is related to changes for multiple plugins per category where `plugins` is unmodifiable. This PR just changes to `_plugins` so it can be modified (added to).

Verified by running example app and integration tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
