### PR TITLE
chore(authenticator): simplify use of generics

### DIFF
--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
@@ -18,7 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 mixin AuthenticatorDateField<FieldType,
-        T extends AuthenticatorFormField<FieldType, String, T>>
+        T extends AuthenticatorFormField<FieldType, String>>
     on AuthenticatorFormFieldState<FieldType, String, T> {
   static final DateFormat _formatter = DateFormat('yyyy-MM-dd');
 

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_phone_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_phone_field.dart
@@ -21,7 +21,7 @@ import 'package:amplify_authenticator/src/widgets/form_field.dart';
 import 'package:flutter/material.dart';
 
 mixin AuthenticatorPhoneFieldMixin<FieldType,
-        T extends AuthenticatorFormField<FieldType, String, T>>
+        T extends AuthenticatorFormField<FieldType, String>>
     on AuthenticatorFormFieldState<FieldType, String, T>
     implements SelectableConfig<CountryResolverKey, Country> {
   late final CountryResolver _countriesResolver = stringResolver.countries;

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_radio_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_radio_field.dart
@@ -20,7 +20,7 @@ import 'package:amplify_authenticator/src/widgets/form_field.dart';
 import 'package:flutter/material.dart';
 
 mixin AuthenticatorRadioField<FieldType, FieldValue,
-        T extends AuthenticatorFormField<FieldType, FieldValue, T>>
+        T extends AuthenticatorFormField<FieldType, FieldValue>>
     on AuthenticatorFormFieldState<FieldType, FieldValue, T>
     implements SelectableConfig<InputResolverKey, FieldValue> {
   @override

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
@@ -19,7 +19,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 mixin AuthenticatorTextField<FieldType,
-        T extends AuthenticatorFormField<FieldType, String, T>>
+        T extends AuthenticatorFormField<FieldType, String>>
     on AuthenticatorFormFieldState<FieldType, String, T> {
   @override
   Widget buildFormField(BuildContext context) {

--- a/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -25,7 +25,7 @@ import 'package:amplify_authenticator/src/widgets/form_field.dart';
 import 'package:flutter/material.dart';
 
 mixin AuthenticatorUsernameField<FieldType,
-        T extends AuthenticatorFormField<FieldType, UsernameInput, T>>
+        T extends AuthenticatorFormField<FieldType, UsernameInput>>
     on AuthenticatorFormFieldState<FieldType, UsernameInput, T> {
   @override
   UsernameInput? get initialValue {

--- a/packages/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -56,9 +56,8 @@ part 'form_fields/verify_user_form_field.dart';
 /// - [ConfirmSignUpFormField]
 /// - [VerifyUserFormField]
 /// {@endtemplate}
-abstract class AuthenticatorFormField<FieldType, FieldValue,
-        T extends AuthenticatorFormField<FieldType, FieldValue, T>>
-    extends AuthenticatorComponent<T> {
+abstract class AuthenticatorFormField<FieldType, FieldValue>
+    extends AuthenticatorComponent {
   /// {@macro amplify_authenticator.authenticator_form_field}
   const AuthenticatorFormField._({
     Key? key,
@@ -126,7 +125,7 @@ abstract class AuthenticatorFormField<FieldType, FieldValue,
 }
 
 abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
-        T extends AuthenticatorFormField<FieldType, FieldValue, T>>
+        T extends AuthenticatorFormField<FieldType, FieldValue>>
     extends AuthenticatorComponentState<T> {
   @nonVirtual
   Widget get visibilityToggle =>

--- a/packages/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -57,7 +57,8 @@ part 'form_fields/verify_user_form_field.dart';
 /// - [VerifyUserFormField]
 /// {@endtemplate}
 abstract class AuthenticatorFormField<FieldType, FieldValue>
-    extends AuthenticatorComponent {
+    extends AuthenticatorComponent<
+        AuthenticatorFormField<FieldType, FieldValue>> {
   /// {@macro amplify_authenticator.authenticator_form_field}
   const AuthenticatorFormField._({
     Key? key,

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/confirm_sign_in_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/confirm_sign_in_form_field.dart
@@ -20,8 +20,7 @@ part of authenticator.form_field;
 /// A prebuilt form field widget for use on the Confirm Sign In step.
 /// {@endtemplate}
 abstract class ConfirmSignInFormField<FieldValue>
-    extends AuthenticatorFormField<ConfirmSignInField, FieldValue,
-        ConfirmSignInFormField<FieldValue>> {
+    extends AuthenticatorFormField<ConfirmSignInField, FieldValue> {
   /// {@macro amplify_authenticator.confirm_sign_in_form_field}
   ///
   /// Either [titleKey] or [title] is required.
@@ -440,7 +439,9 @@ class _ConfirmSignInPhoneField extends ConfirmSignInFormField<String> {
 }
 
 class _ConfirmSignInPhoneFieldState extends _ConfirmSignInTextFieldState
-    with AuthenticatorPhoneFieldMixin {
+    with
+        AuthenticatorPhoneFieldMixin<ConfirmSignInField,
+            ConfirmSignInFormField<String>> {
   @override
   String? get initialValue {
     var initialValue = state.getAttribute(CognitoUserAttributeKey.phoneNumber);
@@ -499,7 +500,9 @@ class _ConfirmSignInTextField extends ConfirmSignInFormField<String> {
 }
 
 class _ConfirmSignInTextFieldState extends _ConfirmSignInFormFieldState<String>
-    with AuthenticatorTextField {
+    with
+        AuthenticatorTextField<ConfirmSignInField,
+            ConfirmSignInFormField<String>> {
   @override
   String? get initialValue {
     switch (widget.field) {

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/confirm_sign_up_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/confirm_sign_up_form_field.dart
@@ -20,8 +20,7 @@ part of authenticator.form_field;
 /// A prebuilt form field widget for use on the Confirm Sign Up step.
 /// {@endtemplate}
 abstract class ConfirmSignUpFormField<FieldValue>
-    extends AuthenticatorFormField<ConfirmSignUpField, FieldValue,
-        ConfirmSignUpFormField<FieldValue>> {
+    extends AuthenticatorFormField<ConfirmSignUpField, FieldValue> {
   /// {@macro amplify_authenticator.confirm_sign_up_form_field}
   ///
   /// Either [titleKey] or [title] is required.

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/phone_number_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/phone_number_field.dart
@@ -15,8 +15,8 @@
 
 part of '../form_field.dart';
 
-class AuthenticatorPhoneField<FieldType> extends AuthenticatorFormField<
-    FieldType, String, AuthenticatorPhoneField<FieldType>> {
+class AuthenticatorPhoneField<FieldType>
+    extends AuthenticatorFormField<FieldType, String> {
   const AuthenticatorPhoneField({
     Key? key,
     required FieldType field,
@@ -60,7 +60,10 @@ class AuthenticatorPhoneField<FieldType> extends AuthenticatorFormField<
 class _AuthenticatorPhoneFieldState<FieldType>
     extends AuthenticatorFormFieldState<FieldType, String,
         AuthenticatorPhoneField<FieldType>>
-    with AuthenticatorPhoneFieldMixin, AuthenticatorTextField {
+    with
+        AuthenticatorPhoneFieldMixin<FieldType,
+            AuthenticatorPhoneField<FieldType>>,
+        AuthenticatorTextField<FieldType, AuthenticatorPhoneField<FieldType>> {
   @override
   String? get initialValue {
     var initialValue = widget.initialValue ?? super.initialValue;

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/reset_password_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/reset_password_form_field.dart
@@ -19,8 +19,8 @@ part of authenticator.form_field;
 /// {@template amplify_authenticator.confirm_sign_up_form_field}
 /// A prebuild form field widget for use on the Reset Password Step.
 /// {@endtemplate}
-class ResetPasswordFormField extends AuthenticatorFormField<ResetPasswordField,
-    String, ResetPasswordFormField> {
+class ResetPasswordFormField
+    extends AuthenticatorFormField<ResetPasswordField, String> {
   /// {@macro amplify_authenticator.sign_up_form_field}
   ///
   /// Either [titleKey] or [title] is required.
@@ -71,8 +71,8 @@ class ResetPasswordFormField extends AuthenticatorFormField<ResetPasswordField,
   bool get required => true;
 
   @override
-  AuthenticatorComponentState<ResetPasswordFormField> createState() =>
-      _ResetPasswordFormFieldState();
+  AuthenticatorFormFieldState<ResetPasswordField, String,
+      ResetPasswordFormField> createState() => _ResetPasswordFormFieldState();
 }
 
 class _ResetPasswordFormFieldState extends AuthenticatorFormFieldState<

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/sign_in_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/sign_in_form_field.dart
@@ -23,8 +23,8 @@ part of authenticator.form_field;
 ///
 /// See also: [SignInForm.custom]
 /// {@endtemplate}
-abstract class SignInFormField<FieldValue> extends AuthenticatorFormField<
-    SignInField, FieldValue, SignInFormField<FieldValue>> {
+abstract class SignInFormField<FieldValue>
+    extends AuthenticatorFormField<SignInField, FieldValue> {
   /// {@macro amplify_authenticator.sign_in_form_field}
   ///
   /// Either [titleKey] or [title] is required.

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/sign_up_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/sign_up_form_field.dart
@@ -19,8 +19,8 @@ part of authenticator.form_field;
 /// {@template amplify_authenticator.sign_up_form_field}
 /// A prebuilt form field widget for use on the Sign Up step.
 /// {@endtemplate}
-abstract class SignUpFormField<FieldValue> extends AuthenticatorFormField<
-    SignUpField, FieldValue, SignUpFormField<FieldValue>> {
+abstract class SignUpFormField<FieldValue>
+    extends AuthenticatorFormField<SignUpField, FieldValue> {
   /// {@macro amplify_authenticator.sign_up_form_field}
   ///
   /// Either [titleKey] or [title] is required.

--- a/packages/amplify_authenticator/lib/src/widgets/form_fields/verify_user_form_field.dart
+++ b/packages/amplify_authenticator/lib/src/widgets/form_fields/verify_user_form_field.dart
@@ -19,8 +19,8 @@ part of authenticator.form_field;
 /// {@template amplify_authenticator.verify_user_form_field}
 /// A prebuilt [Radio] widget for use on the Verify User step.
 /// {@endtemplate}
-abstract class VerifyUserFormField<FieldValue> extends AuthenticatorFormField<
-    VerifyAttributeField, FieldValue, VerifyUserFormField<FieldValue>> {
+abstract class VerifyUserFormField<FieldValue>
+    extends AuthenticatorFormField<VerifyAttributeField, FieldValue> {
   /// {@macro amplify_authenticator.verify_user_form_field}
   const VerifyUserFormField._({
     Key? key,


### PR DESCRIPTION
Due to ongoing issues with DDC which rear their head in certain unavoidable cases (like using zapp.run which compiles apps as a single DDC module)