### PR TITLE
chore(core,api): remove unneeded imports

### DIFF
--- a/packages/amplify_core/lib/src/category/amplify_categories.dart
+++ b/packages/amplify_core/lib/src/category/amplify_categories.dart
@@ -18,7 +18,6 @@ library amplify_interface;
 import 'dart:async';
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:async/async.dart';
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 

--- a/packages/amplify_core/lib/src/plugin/amplify_api_plugin_interface.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_api_plugin_interface.dart
@@ -14,7 +14,6 @@
  */
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:async/async.dart';
 import 'package:meta/meta.dart';
 
 abstract class APIPluginInterface extends AmplifyPluginInterface {

--- a/packages/amplify_core/lib/src/types/api/rest/rest_operation.dart
+++ b/packages/amplify_core/lib/src/types/api/rest/rest_operation.dart
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-import 'package:async/async.dart';
 import 'package:aws_common/aws_common.dart';
 
 /// Allows callers to synchronously get unstreamed response with the decoded body.


### PR DESCRIPTION
Removes some unneeded imports which are causing lint errors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
