### PR TITLE
feat(storage): multiple plugin registration & list API

### DIFF
--- a/packages/amplify_core/lib/src/category/amplify_storage_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_storage_category.dart
@@ -40,7 +40,7 @@ class StorageCategory<
     PluginStorageRemoveOptions extends StorageRemoveOptions,
     PluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
     PluginStorageRemoveManyOptions extends StorageRemoveManyOptions,
-    PluginStorageItemWithAccessLevel extends StorageItemWithAccessLevel,
+    PluginStorageItem extends StorageItem,
     Plugin extends StoragePluginInterface<
         PluginStorageListOperation,
         PluginStorageListOptions,
@@ -56,11 +56,11 @@ class StorageCategory<
         PluginStorageRemoveOptions,
         PluginStorageRemoveManyOperation,
         PluginStorageRemoveManyOptions,
-        PluginStorageItemWithAccessLevel>> extends AmplifyCategory<Plugin> {
+        PluginStorageItem>> extends AmplifyCategory<Plugin> {
   StorageCategory([Plugin? plugin]) : _pluginOverride = plugin;
 
   final Plugin? _pluginOverride;
-  Plugin get _plugin => _pluginOverride ?? _plugin;
+  Plugin get _plugin => _pluginOverride ?? defaultPlugin;
 
   @override
   @nonVirtual
@@ -81,7 +81,7 @@ class StorageCategory<
       GetPluginStorageRemoveOptions,
       GetPluginStorageRemoveManyOperation,
       GetPluginStorageRemoveManyOptions,
-      GetPluginStorageItemWithAccessLevel,
+      GetPluginStorageItem,
       P> getPlugin<
           GetPluginStorageListOperation extends StorageListOperation,
           GetPluginStorageListOptions extends StorageListOptions,
@@ -97,7 +97,7 @@ class StorageCategory<
           GetPluginStorageRemoveOptions extends StorageRemoveOptions,
           GetPluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
           GetPluginStorageRemoveManyOptions extends StorageRemoveManyOptions,
-          GetPluginStorageItemWithAccessLevel extends StorageItemWithAccessLevel,
+          GetPluginStorageItem extends StorageItem,
           P extends StoragePluginInterface<
               GetPluginStorageListOperation,
               GetPluginStorageListOptions,
@@ -113,7 +113,7 @@ class StorageCategory<
               GetPluginStorageRemoveOptions,
               GetPluginStorageRemoveManyOperation,
               GetPluginStorageRemoveManyOptions,
-              GetPluginStorageItemWithAccessLevel>>(
+              GetPluginStorageItem>>(
     StoragePluginKey<
             GetPluginStorageListOperation,
             GetPluginStorageListOptions,
@@ -129,7 +129,7 @@ class StorageCategory<
             GetPluginStorageRemoveOptions,
             GetPluginStorageRemoveManyOperation,
             GetPluginStorageRemoveManyOptions,
-            GetPluginStorageItemWithAccessLevel,
+            GetPluginStorageItem,
             P>
         pluginKey,
   ) =>
@@ -211,8 +211,8 @@ class StorageCategory<
   /// Makes a copy of the `source` to `destination` with [StorageCopyOptions].
   /// {@endtemplate}
   PluginStorageCopyOperation copy({
-    required PluginStorageItemWithAccessLevel source,
-    required PluginStorageItemWithAccessLevel destination,
+    required StorageItemWithAccessLevel<PluginStorageItem> source,
+    required StorageItemWithAccessLevel<PluginStorageItem> destination,
   }) {
     final request = StorageCopyRequest(
       source: source,
@@ -230,8 +230,8 @@ class StorageCategory<
   ///   2. delete the source object
   /// {@endtemplate}
   PluginStorageMoveOperation move({
-    required PluginStorageItemWithAccessLevel source,
-    required PluginStorageItemWithAccessLevel destination,
+    required StorageItemWithAccessLevel<PluginStorageItem> source,
+    required StorageItemWithAccessLevel<PluginStorageItem> destination,
   }) {
     final request = StorageMoveRequest(
       source: source,

--- a/packages/amplify_core/lib/src/category/amplify_storage_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_storage_category.dart
@@ -25,24 +25,136 @@ part of amplify_interface;
 /// The Amplify CLI helps you to create and configure the storage category
 /// and auth category.
 /// {@endtemplate}
-class StorageCategory extends AmplifyCategory<StoragePluginInterface> {
+class StorageCategory<
+    PluginStorageListOperation extends StorageListOperation,
+    PluginStorageListOptions extends StorageListOptions,
+    PluginStorageGetPropertiesOperation extends StorageGetPropertiesOperation,
+    PluginStorageGetPropertiesOptions extends StorageGetPropertiesOptions,
+    PluginStorageGetUrlOperation extends StorageGetUrlOperation,
+    PluginStorageGetUrlOptions extends StorageGetUrlOptions,
+    PluginStorageUploadDataOperation extends StorageUploadDataOperation,
+    PluginStorageUploadDataOptions extends StorageUploadDataOptions,
+    PluginStorageCopyOperation extends StorageCopyOperation,
+    PluginStorageMoveOperation extends StorageMoveOperation,
+    PluginStorageRemoveOperation extends StorageRemoveOperation,
+    PluginStorageRemoveOptions extends StorageRemoveOptions,
+    PluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
+    PluginStorageRemoveManyOptions extends StorageRemoveManyOptions,
+    PluginStorageItemWithAccessLevel extends StorageItemWithAccessLevel,
+    Plugin extends StoragePluginInterface<
+        PluginStorageListOperation,
+        PluginStorageListOptions,
+        PluginStorageGetPropertiesOperation,
+        PluginStorageGetPropertiesOptions,
+        PluginStorageGetUrlOperation,
+        PluginStorageGetUrlOptions,
+        PluginStorageUploadDataOperation,
+        PluginStorageUploadDataOptions,
+        PluginStorageCopyOperation,
+        PluginStorageMoveOperation,
+        PluginStorageRemoveOperation,
+        PluginStorageRemoveOptions,
+        PluginStorageRemoveManyOperation,
+        PluginStorageRemoveManyOptions,
+        PluginStorageItemWithAccessLevel>> extends AmplifyCategory<Plugin> {
+  StorageCategory([Plugin? plugin]) : _pluginOverride = plugin;
+
+  final Plugin? _pluginOverride;
+  Plugin get _plugin => _pluginOverride ?? _plugin;
+
   @override
   @nonVirtual
   Category get category => Category.storage;
+
+  StorageCategory<
+      GetPluginStorageListOperation,
+      GetPluginStorageListOptions,
+      GetPluginStorageGetPropertiesOperation,
+      GetPluginStorageGetPropertiesOptions,
+      GetPluginStorageGetUrlOperation,
+      GetPluginStorageGetUrlOptions,
+      GetPluginStorageUploadDataOperation,
+      GetPluginStorageUploadDataOptions,
+      GetPluginStorageCopyOperation,
+      GetPluginStorageMoveOperation,
+      GetPluginStorageRemoveOperation,
+      GetPluginStorageRemoveOptions,
+      GetPluginStorageRemoveManyOperation,
+      GetPluginStorageRemoveManyOptions,
+      GetPluginStorageItemWithAccessLevel,
+      P> getPlugin<
+          GetPluginStorageListOperation extends StorageListOperation,
+          GetPluginStorageListOptions extends StorageListOptions,
+          GetPluginStorageGetPropertiesOperation extends StorageGetPropertiesOperation,
+          GetPluginStorageGetPropertiesOptions extends StorageGetPropertiesOptions,
+          GetPluginStorageGetUrlOperation extends StorageGetUrlOperation,
+          GetPluginStorageGetUrlOptions extends StorageGetUrlOptions,
+          GetPluginStorageUploadDataOperation extends StorageUploadDataOperation,
+          GetPluginStorageUploadDataOptions extends StorageUploadDataOptions,
+          GetPluginStorageCopyOperation extends StorageCopyOperation,
+          GetPluginStorageMoveOperation extends StorageMoveOperation,
+          GetPluginStorageRemoveOperation extends StorageRemoveOperation,
+          GetPluginStorageRemoveOptions extends StorageRemoveOptions,
+          GetPluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
+          GetPluginStorageRemoveManyOptions extends StorageRemoveManyOptions,
+          GetPluginStorageItemWithAccessLevel extends StorageItemWithAccessLevel,
+          P extends StoragePluginInterface<
+              GetPluginStorageListOperation,
+              GetPluginStorageListOptions,
+              GetPluginStorageGetPropertiesOperation,
+              GetPluginStorageGetPropertiesOptions,
+              GetPluginStorageGetUrlOperation,
+              GetPluginStorageGetUrlOptions,
+              GetPluginStorageUploadDataOperation,
+              GetPluginStorageUploadDataOptions,
+              GetPluginStorageCopyOperation,
+              GetPluginStorageMoveOperation,
+              GetPluginStorageRemoveOperation,
+              GetPluginStorageRemoveOptions,
+              GetPluginStorageRemoveManyOperation,
+              GetPluginStorageRemoveManyOptions,
+              GetPluginStorageItemWithAccessLevel>>(
+    StoragePluginKey<
+            GetPluginStorageListOperation,
+            GetPluginStorageListOptions,
+            GetPluginStorageGetPropertiesOperation,
+            GetPluginStorageGetPropertiesOptions,
+            GetPluginStorageGetUrlOperation,
+            GetPluginStorageGetUrlOptions,
+            GetPluginStorageUploadDataOperation,
+            GetPluginStorageUploadDataOptions,
+            GetPluginStorageCopyOperation,
+            GetPluginStorageMoveOperation,
+            GetPluginStorageRemoveOperation,
+            GetPluginStorageRemoveOptions,
+            GetPluginStorageRemoveManyOperation,
+            GetPluginStorageRemoveManyOptions,
+            GetPluginStorageItemWithAccessLevel,
+            P>
+        pluginKey,
+  ) =>
+      StorageCategory(
+        plugins.singleWhere(
+          (p) => p is P,
+          orElse: () => throw AmplifyException(
+            'No plugin registered for $pluginKey',
+          ),
+        ) as P,
+      );
 
   /// {@template amplify_core.amplify_storage_category.list}
   /// Lists objects under specified `path` with [StorageListOptions]. Returned
   /// result is paginated.
   /// {@endtemplate}
-  StorageListOperation list({
+  PluginStorageListOperation list({
     String? path,
-    StorageListOptions? options,
+    PluginStorageListOptions? options,
   }) {
     final request = StorageListRequest(
       path: path,
       options: options,
     );
-    return defaultPlugin.list(request: request);
+    return _plugin.list(request: request);
   }
 
   /// {@template amplify_core.amplify_storage_category.get_properties}
@@ -50,30 +162,30 @@ class StorageCategory extends AmplifyCategory<StoragePluginInterface> {
   /// [StorageGetPropertiesOptions]. The result may include the metadata
   /// (if any) specified when the object was uploaded.
   /// {@endtemplate}
-  StorageGetPropertiesOperation getProperties({
+  PluginStorageGetPropertiesOperation getProperties({
     required String key,
-    StorageGetPropertiesOptions? options,
+    PluginStorageGetPropertiesOptions? options,
   }) {
     final request = StorageGetPropertiesRequest(
       key: key,
       options: options,
     );
-    return defaultPlugin.getProperties(request: request);
+    return _plugin.getProperties(request: request);
   }
 
   /// {@template amplify_core.amplify_storage_category.get_url}
   /// Generates a downloadable url for the object specified by `key` with
   /// [StorageGetUrlOptions]. The url is presigned by the aws_signature_v4.
   /// {@endtemplate}
-  StorageGetUrlOperation getUrl({
+  PluginStorageGetUrlOperation getUrl({
     required String key,
-    StorageGetUrlOptions? options,
+    PluginStorageGetUrlOptions? options,
   }) {
     final request = StorageGetUrlRequest(
       key: key,
       options: options,
     );
-    return defaultPlugin.getUrl(request: request);
+    return _plugin.getUrl(request: request);
   }
 
   /// {@template amplify_core.amplify_storage_category.upload_data}
@@ -82,31 +194,31 @@ class StorageCategory extends AmplifyCategory<StoragePluginInterface> {
   /// The string to be uploaded can be a plain string (uploaded as text/plain)
   /// or a data url.
   /// {@endtemplate}
-  StorageUploadDataOperation uploadData({
+  PluginStorageUploadDataOperation uploadData({
     required String data,
     required String key,
-    StorageUploadDataOptions? options,
+    PluginStorageUploadDataOptions? options,
   }) {
     final request = StorageUploadDataRequest(
       data: data,
       key: key,
       options: options,
     );
-    return defaultPlugin.uploadData(request: request);
+    return _plugin.uploadData(request: request);
   }
 
   /// {@template amplify_core.amplify_storage_category.copy}
   /// Makes a copy of the `source` to `destination` with [StorageCopyOptions].
   /// {@endtemplate}
-  StorageCopyOperation copy({
-    required StorageItemWithAccessLevel source,
-    required StorageItemWithAccessLevel destination,
+  PluginStorageCopyOperation copy({
+    required PluginStorageItemWithAccessLevel source,
+    required PluginStorageItemWithAccessLevel destination,
   }) {
     final request = StorageCopyRequest(
       source: source,
       destination: destination,
     );
-    return defaultPlugin.copy(request: request);
+    return _plugin.copy(request: request);
   }
 
   /// {@template amplify_core.amplify_storage_category.move}
@@ -117,44 +229,44 @@ class StorageCategory extends AmplifyCategory<StoragePluginInterface> {
   ///   1. copy the source object to destination objection
   ///   2. delete the source object
   /// {@endtemplate}
-  StorageMoveOperation move({
-    required StorageItemWithAccessLevel source,
-    required StorageItemWithAccessLevel destination,
+  PluginStorageMoveOperation move({
+    required PluginStorageItemWithAccessLevel source,
+    required PluginStorageItemWithAccessLevel destination,
   }) {
     final request = StorageMoveRequest(
       source: source,
       destination: destination,
     );
-    return defaultPlugin.move(request: request);
+    return _plugin.move(request: request);
   }
 
   /// {@template amplify_core.amplify_storage_category.remove}
   /// Removes an object specified by `key` with [StorageRemoveOptions].
   /// {@endtemplate}
-  StorageRemoveOperation remove({
+  PluginStorageRemoveOperation remove({
     required String key,
-    StorageRemoveOptions? options,
+    PluginStorageRemoveOptions? options,
   }) {
     final request = StorageRemoveRequest(
       key: key,
       options: options,
     );
-    return defaultPlugin.remove(request: request);
+    return _plugin.remove(request: request);
   }
 
   /// {@template amplify_core.amplify_storage_category.remove_many}
   /// Removes multiple objects specified by a list of `keys` with
   /// [StorageRemoveManyOptions].
   /// {@endtemplate}
-  StorageRemoveManyOperation removeMany({
+  PluginStorageRemoveManyOperation removeMany({
     required List<String> keys,
-    StorageRemoveManyOptions? options,
+    PluginStorageRemoveManyOptions? options,
   }) {
     final request = StorageRemoveManyRequest(
       keys: keys,
       options: options,
     );
-    return defaultPlugin.removeMany(request: request);
+    return _plugin.removeMany(request: request);
   }
 
   // TODO(HuiSF): add interface for remaining APIs

--- a/packages/amplify_core/lib/src/plugin/amplify_plugin_key.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_plugin_key.dart
@@ -121,7 +121,7 @@ abstract class StoragePluginKey<
     PluginStorageRemoveOptions extends StorageRemoveOptions,
     PluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
     PluginStorageRemoveManyOptions extends StorageRemoveManyOptions,
-    PluginStorageItemWithAccessLevel extends StorageItemWithAccessLevel,
+    PluginStorageItem extends StorageItem,
     P extends StoragePluginInterface<
         PluginStorageListOperation,
         PluginStorageListOptions,
@@ -137,6 +137,6 @@ abstract class StoragePluginKey<
         PluginStorageRemoveOptions,
         PluginStorageRemoveManyOperation,
         PluginStorageRemoveManyOptions,
-        PluginStorageItemWithAccessLevel>> extends AmplifyPluginKey<P> {
+        PluginStorageItem>> extends AmplifyPluginKey<P> {
   const StoragePluginKey();
 }

--- a/packages/amplify_core/lib/src/plugin/amplify_plugin_key.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_plugin_key.dart
@@ -104,3 +104,39 @@ abstract class AuthPluginKey<
   /// {@macro amplify_core.plugin.auth_plugin_key}
   const AuthPluginKey();
 }
+
+// TODO(HuiSF): Define generic parameters for all API types
+abstract class StoragePluginKey<
+    PluginStorageListOperation extends StorageListOperation,
+    PluginStorageListOptions extends StorageListOptions,
+    PluginStorageGetPropertiesOperation extends StorageGetPropertiesOperation,
+    PluginStorageGetPropertiesOptions extends StorageGetPropertiesOptions,
+    PluginStorageGetUrlOperation extends StorageGetUrlOperation,
+    PluginStorageGetUrlOptions extends StorageGetUrlOptions,
+    PluginStorageUploadDataOperation extends StorageUploadDataOperation,
+    PluginStorageUploadDataOptions extends StorageUploadDataOptions,
+    PluginStorageCopyOperation extends StorageCopyOperation,
+    PluginStorageMoveOperation extends StorageMoveOperation,
+    PluginStorageRemoveOperation extends StorageRemoveOperation,
+    PluginStorageRemoveOptions extends StorageRemoveOptions,
+    PluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
+    PluginStorageRemoveManyOptions extends StorageRemoveManyOptions,
+    PluginStorageItemWithAccessLevel extends StorageItemWithAccessLevel,
+    P extends StoragePluginInterface<
+        PluginStorageListOperation,
+        PluginStorageListOptions,
+        PluginStorageGetPropertiesOperation,
+        PluginStorageGetPropertiesOptions,
+        PluginStorageGetUrlOperation,
+        PluginStorageGetUrlOptions,
+        PluginStorageUploadDataOperation,
+        PluginStorageUploadDataOptions,
+        PluginStorageCopyOperation,
+        PluginStorageMoveOperation,
+        PluginStorageRemoveOperation,
+        PluginStorageRemoveOptions,
+        PluginStorageRemoveManyOperation,
+        PluginStorageRemoveManyOptions,
+        PluginStorageItemWithAccessLevel>> extends AmplifyPluginKey<P> {
+  const StoragePluginKey();
+}

--- a/packages/amplify_core/lib/src/plugin/amplify_storage_plugin_interface.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_storage_plugin_interface.dart
@@ -22,22 +22,21 @@ import 'package:meta/meta.dart';
 ///
 /// {@macro amplify_core.amplify_storage_category}
 abstract class StoragePluginInterface<
-        PluginStorageListOperation extends StorageListOperation,
-        PluginStorageListOptions extends StorageListOptions,
-        PluginStorageGetPropertiesOperation extends StorageGetPropertiesOperation,
-        PluginStorageGetPropertiesOptions extends StorageGetPropertiesOptions,
-        PluginStorageGetUrlOperation extends StorageGetUrlOperation,
-        PluginStorageGetUrlOptions extends StorageGetUrlOptions,
-        PluginStorageUploadDataOperation extends StorageUploadDataOperation,
-        PluginStorageUploadDataOptions extends StorageUploadDataOptions,
-        PluginStorageCopyOperation extends StorageCopyOperation,
-        PluginStorageMoveOperation extends StorageMoveOperation,
-        PluginStorageRemoveOperation extends StorageRemoveOperation,
-        PluginStorageRemoveOptions extends StorageRemoveOptions,
-        PluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
-        PluginStorageRemoveManyOptions extends StorageRemoveManyOptions,
-        PluginStorageItemWithAccessLevel extends StorageItemWithAccessLevel>
-    extends AmplifyPluginInterface {
+    PluginStorageListOperation extends StorageListOperation,
+    PluginStorageListOptions extends StorageListOptions,
+    PluginStorageGetPropertiesOperation extends StorageGetPropertiesOperation,
+    PluginStorageGetPropertiesOptions extends StorageGetPropertiesOptions,
+    PluginStorageGetUrlOperation extends StorageGetUrlOperation,
+    PluginStorageGetUrlOptions extends StorageGetUrlOptions,
+    PluginStorageUploadDataOperation extends StorageUploadDataOperation,
+    PluginStorageUploadDataOptions extends StorageUploadDataOptions,
+    PluginStorageCopyOperation extends StorageCopyOperation,
+    PluginStorageMoveOperation extends StorageMoveOperation,
+    PluginStorageRemoveOperation extends StorageRemoveOperation,
+    PluginStorageRemoveOptions extends StorageRemoveOptions,
+    PluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
+    PluginStorageRemoveManyOptions extends StorageRemoveManyOptions,
+    PluginStorageItem extends StorageItem> extends AmplifyPluginInterface {
   @override
   @nonVirtual
   Category get category => Category.storage;
@@ -72,14 +71,14 @@ abstract class StoragePluginInterface<
 
   /// {@macro amplify_core.amplify_storage_category.copy}
   PluginStorageCopyOperation copy({
-    required StorageCopyRequest<PluginStorageItemWithAccessLevel> request,
+    required StorageCopyRequest<PluginStorageItem> request,
   }) {
     throw UnimplementedError('uploadFile() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.move}
   PluginStorageMoveOperation move({
-    required StorageMoveRequest<PluginStorageItemWithAccessLevel> request,
+    required StorageMoveRequest<PluginStorageItem> request,
   }) {
     throw UnimplementedError('uploadFile() has not been implemented.');
   }

--- a/packages/amplify_core/lib/src/plugin/amplify_storage_plugin_interface.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_storage_plugin_interface.dart
@@ -21,63 +21,79 @@ import 'package:meta/meta.dart';
 /// Defines Amplify Storage plugin interface.
 ///
 /// {@macro amplify_core.amplify_storage_category}
-abstract class StoragePluginInterface extends AmplifyPluginInterface {
+abstract class StoragePluginInterface<
+        PluginStorageListOperation extends StorageListOperation,
+        PluginStorageListOptions extends StorageListOptions,
+        PluginStorageGetPropertiesOperation extends StorageGetPropertiesOperation,
+        PluginStorageGetPropertiesOptions extends StorageGetPropertiesOptions,
+        PluginStorageGetUrlOperation extends StorageGetUrlOperation,
+        PluginStorageGetUrlOptions extends StorageGetUrlOptions,
+        PluginStorageUploadDataOperation extends StorageUploadDataOperation,
+        PluginStorageUploadDataOptions extends StorageUploadDataOptions,
+        PluginStorageCopyOperation extends StorageCopyOperation,
+        PluginStorageMoveOperation extends StorageMoveOperation,
+        PluginStorageRemoveOperation extends StorageRemoveOperation,
+        PluginStorageRemoveOptions extends StorageRemoveOptions,
+        PluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
+        PluginStorageRemoveManyOptions extends StorageRemoveManyOptions,
+        PluginStorageItemWithAccessLevel extends StorageItemWithAccessLevel>
+    extends AmplifyPluginInterface {
   @override
   @nonVirtual
   Category get category => Category.storage;
 
   /// {@macro amplify_core.amplify_storage_category.list}
-  StorageListOperation list({
-    required StorageListRequest request,
+  PluginStorageListOperation list({
+    required StorageListRequest<PluginStorageListOptions> request,
   }) {
     throw UnimplementedError('list() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.get_properties}
-  StorageGetPropertiesOperation getProperties({
-    required StorageGetPropertiesRequest request,
+  PluginStorageGetPropertiesOperation getProperties({
+    required StorageGetPropertiesRequest<StorageGetPropertiesOptions> request,
   }) {
     throw UnimplementedError('stat() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.get_url}
-  StorageGetUrlOperation getUrl({
-    required StorageGetUrlRequest request,
+  PluginStorageGetUrlOperation getUrl({
+    required StorageGetUrlRequest<PluginStorageGetUrlOptions> request,
   }) {
     throw UnimplementedError('getUrl() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.upload_data}
-  StorageUploadDataOperation uploadData({
-    required StorageUploadDataRequest request,
+  PluginStorageUploadDataOperation uploadData({
+    required StorageUploadDataRequest<PluginStorageUploadDataOptions> request,
   }) {
     throw UnimplementedError('uploadData() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.copy}
-  StorageCopyOperation copy({
-    required StorageCopyRequest request,
+  PluginStorageCopyOperation copy({
+    required StorageCopyRequest<PluginStorageItemWithAccessLevel> request,
   }) {
     throw UnimplementedError('uploadFile() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.move}
-  StorageMoveOperation move({
-    required StorageMoveRequest request,
+  PluginStorageMoveOperation move({
+    required StorageMoveRequest<PluginStorageItemWithAccessLevel> request,
   }) {
     throw UnimplementedError('uploadFile() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.remove}
-  StorageRemoveOperation remove({
-    required StorageRemoveRequest request,
+  PluginStorageRemoveOperation remove({
+    required StorageRemoveRequest<PluginStorageRemoveOptions> request,
   }) {
     throw UnimplementedError('remove() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.remove_many}
-  StorageRemoveManyOperation removeMany({
-    required StorageRemoveManyRequest request,
+  PluginStorageRemoveManyOperation removeMany({
+    required StorageRemoveManyRequest<PluginStorageRemoveManyOptions> request,
   }) {
     throw UnimplementedError('removeMany() has not been implemented.');
   }

--- a/packages/amplify_core/lib/src/types/storage/copy_request.dart
+++ b/packages/amplify_core/lib/src/types/storage/copy_request.dart
@@ -17,7 +17,7 @@ import 'package:amplify_core/amplify_core.dart';
 /// {@template amplify_core.storage.copy_request}
 /// Presents a storage copy request.
 /// {@endtemplate}
-class StorageCopyRequest<Item extends StorageItemWithAccessLevel> {
+class StorageCopyRequest<Item extends StorageItem> {
   /// {@macro amplify_core.storage.copy_request}
   const StorageCopyRequest({
     required this.source,
@@ -25,8 +25,8 @@ class StorageCopyRequest<Item extends StorageItemWithAccessLevel> {
   });
 
   /// Copy source.
-  final Item source;
+  final StorageItemWithAccessLevel<Item> source;
 
   /// Copy destination.
-  final Item destination;
+  final StorageItemWithAccessLevel<Item> destination;
 }

--- a/packages/amplify_core/lib/src/types/storage/list_request.dart
+++ b/packages/amplify_core/lib/src/types/storage/list_request.dart
@@ -19,7 +19,7 @@ import 'package:amplify_core/amplify_core.dart';
 /// {@endtemplate}
 class StorageListRequest<Options extends StorageListOptions> {
   /// {@macro amplify_core.storage.list_request}
-  StorageListRequest({
+  const StorageListRequest({
     this.path,
     this.options,
   });

--- a/packages/amplify_core/lib/src/types/storage/list_result.dart
+++ b/packages/amplify_core/lib/src/types/storage/list_result.dart
@@ -32,7 +32,7 @@ class StorageListResult<Items extends List<StorageItem>> {
   final bool hasNext;
 
   /// Function to list the next page.
-  Future<StorageListResult<Items>> get next => _next();
+  Future<StorageListResult<Items>> next() => _next();
 
   final Future<StorageListResult<Items>> Function() _next;
 }

--- a/packages/amplify_core/lib/src/types/storage/move_request.dart
+++ b/packages/amplify_core/lib/src/types/storage/move_request.dart
@@ -17,7 +17,7 @@ import 'package:amplify_core/amplify_core.dart';
 /// {@template amplify_core.storage.move_request}
 /// Presents a storage copy request.
 /// {@endtemplate}
-class StorageMoveRequest<Item extends StorageItemWithAccessLevel> {
+class StorageMoveRequest<Item extends StorageItem> {
   /// {@macro amplify_core.storage.move_request}
   const StorageMoveRequest({
     required this.source,
@@ -25,8 +25,8 @@ class StorageMoveRequest<Item extends StorageItemWithAccessLevel> {
   });
 
   /// Move source object.
-  final Item source;
+  final StorageItemWithAccessLevel<Item> source;
 
   /// Move destination object.
-  final Item destination;
+  final StorageItemWithAccessLevel<Item> destination;
 }

--- a/packages/amplify_core/lib/src/types/storage/storage_item.dart
+++ b/packages/amplify_core/lib/src/types/storage/storage_item.dart
@@ -38,12 +38,13 @@ typedef StorageItems<Item extends StorageItem> = List<Item>;
 /// {@template amplify_core.storage.storage_item_access_level}
 /// Presents a storage object with its access level information.
 /// {@endtemplate}
-class StorageItemWithAccessLevel extends StorageItem {
+class StorageItemWithAccessLevel<Item extends StorageItem> {
   /// {@macro amplify_core.storage.storage_item_access_level}
   const StorageItemWithAccessLevel({
-    required super.key,
+    required this.storageItem,
     required this.storageAccessLevel,
   });
 
+  final Item storageItem;
   final StorageAccessLevel storageAccessLevel;
 }

--- a/packages/storage/amplify_storage_s3/lib/src/amplify_storage_s3_impl.dart
+++ b/packages/storage/amplify_storage_s3/lib/src/amplify_storage_s3_impl.dart
@@ -38,7 +38,7 @@ class AmplifyStorageS3 extends AmplifyStorageS3Dart {
       StorageRemoveOptions,
       StorageRemoveManyOperation,
       StorageRemoveManyOptions,
-      StorageItemWithAccessLevel,
+      StorageItem,
       AmplifyStorageS3Dart> pluginKey = _AmplifyStorageS3PluginKey();
 }
 
@@ -58,7 +58,7 @@ class _AmplifyStorageS3PluginKey extends StoragePluginKey<
     StorageRemoveOptions,
     StorageRemoveManyOperation,
     StorageRemoveManyOptions,
-    StorageItemWithAccessLevel,
+    StorageItem,
     AmplifyStorageS3Dart> {
   const _AmplifyStorageS3PluginKey();
 

--- a/packages/storage/amplify_storage_s3/lib/src/amplify_storage_s3_impl.dart
+++ b/packages/storage/amplify_storage_s3/lib/src/amplify_storage_s3_impl.dart
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 
 class AmplifyStorageS3 extends AmplifyStorageS3Dart {
@@ -18,4 +19,49 @@ class AmplifyStorageS3 extends AmplifyStorageS3Dart {
     super.delimiter,
     super.prefixResolver,
   });
+
+  // TODO(HuiSF): replace with S3 specific types to the generic parameters
+  /// A plugin key which can be used with `Amplify.Storage.getPlugin` to retrieve
+  /// a S3-specific Storage category interface.
+  static const StoragePluginKey<
+      StorageListOperation,
+      StorageListOptions,
+      StorageGetPropertiesOperation,
+      StorageGetPropertiesOptions,
+      StorageGetUrlOperation,
+      StorageGetUrlOptions,
+      StorageUploadDataOperation,
+      StorageUploadDataOptions,
+      StorageCopyOperation,
+      StorageMoveOperation,
+      StorageRemoveOperation,
+      StorageRemoveOptions,
+      StorageRemoveManyOperation,
+      StorageRemoveManyOptions,
+      StorageItemWithAccessLevel,
+      AmplifyStorageS3Dart> pluginKey = _AmplifyStorageS3PluginKey();
+}
+
+// TODO(HuiSF): replace with S3 specific types to the generic parameters
+class _AmplifyStorageS3PluginKey extends StoragePluginKey<
+    StorageListOperation,
+    StorageListOptions,
+    StorageGetPropertiesOperation,
+    StorageGetPropertiesOptions,
+    StorageGetUrlOperation,
+    StorageGetUrlOptions,
+    StorageUploadDataOperation,
+    StorageUploadDataOptions,
+    StorageCopyOperation,
+    StorageMoveOperation,
+    StorageRemoveOperation,
+    StorageRemoveOptions,
+    StorageRemoveManyOperation,
+    StorageRemoveManyOptions,
+    StorageItemWithAccessLevel,
+    AmplifyStorageS3Dart> {
+  const _AmplifyStorageS3PluginKey();
+
+  @override
+  String get runtimeTypeName => 'AmplifyStorageS3PluginKey';
 }

--- a/packages/storage/amplify_storage_s3_dart/example/.gitignore
+++ b/packages/storage/amplify_storage_s3_dart/example/.gitignore
@@ -1,0 +1,30 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build output.
+build/
+
+
+amplify/
+
+#amplify-do-not-edit-begin
+amplify/\#current-cloud-backend
+amplify/.config/local-*
+amplify/logs
+amplify/mock-data
+amplify/backend/amplify-meta.json
+amplify/backend/.temp
+build/
+dist/
+node_modules/
+aws-exports.js
+awsconfiguration.json
+amplifyconfiguration.json
+amplifyconfiguration.dart
+amplify-build-config.json
+amplify-gradle-config.json
+amplifytools.xcconfig
+.secret-*
+**.sample
+#amplify-do-not-edit-end

--- a/packages/storage/amplify_storage_s3_dart/example/README.md
+++ b/packages/storage/amplify_storage_s3_dart/example/README.md
@@ -1,0 +1,3 @@
+# Amplify Storage S3 Dart Example
+
+Example app and testbed for [`amplify_storage_s3_dart`](../).

--- a/packages/storage/amplify_storage_s3_dart/example/analysis_options.yaml
+++ b/packages/storage/amplify_storage_s3_dart/example/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:amplify_lints/app.yaml
+
+analyzer:
+  exclude:
+    - lib/**/*.g.dart

--- a/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
+++ b/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
@@ -1,0 +1,140 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+
+import 'package:storage_s3_example/common.dart';
+
+Future<void> main() async {
+  AWSLogger().logLevel = LogLevel.debug;
+
+  try {
+    await configureAmplify();
+    stdout.writeln('Amplify plugins have been configured.');
+  } on Exception catch (e) {
+    stdout.writeln('Could not configure: $e');
+    exit(1);
+  }
+
+  stdout.writeln('Sign in your account');
+  final username = prompt('Enter username: ');
+  final password = prompt('Enter password: ');
+
+  stdout.writeln('Signing in...');
+
+  try {
+    await Amplify.Auth.signIn(username: username, password: password);
+  } on Object catch (e, st) {
+    exitError(e, st);
+  }
+
+  stdout.writeln('Signed in!');
+  while (true) {
+    final operation = prompt('''Choose an operation:
+1. list
+2. getUrl
+0. exit
+''');
+    final operationNum = int.parse(operation);
+
+    switch (operationNum) {
+      case 1:
+        await listOperation();
+        break;
+      case 0:
+      default:
+        stdout.writeln('Good bye!');
+        exit(0);
+    }
+  }
+}
+
+Future<void> listOperation() async {
+  final path = prompt('Enter a path to list objects for: ');
+  final accessLevel =
+      int.parse(prompt('''Enter storage access level for the objects:
+1. guest
+2. protected
+3. private
+'''));
+  var storageAccessLevel = StorageAccessLevel.guest;
+  if (accessLevel == 2) {
+    storageAccessLevel = StorageAccessLevel.protected;
+  } else if (accessLevel == 3) {
+    storageAccessLevel = StorageAccessLevel.private;
+  }
+
+  // get plugin with plugin key to gain S3 specific interface
+  final s3Plugin = Amplify.Storage.getPlugin(AmplifyStorageS3Dart.pluginKey);
+  final operation = s3Plugin.list(
+    path: path,
+    options: S3StorageListOptions(
+      storageAccessLevel: storageAccessLevel,
+      pageSize: 5,
+    ),
+  );
+
+  // or to call Amplify.Storage.list
+  // final operation = Amplify.Storage.list(
+  //   path: path,
+  //   options: StorageS3ListOptions(
+  //     storageAccessLevel: storageAccessLevel,
+  //     pageSize: 5,
+  //   ),
+  // );
+
+  var result = await operation.result;
+
+  stdout.writeln('list operation result: ');
+
+  while (true) {
+    stdout.writeln('Listed ${result.items.length} objects.');
+    result.items.asMap().forEach((index, item) {
+      stdout.writeln('$index. key: ${item.key} | size: ${item.size}');
+    });
+
+    if (!result.hasNext) {
+      break;
+    }
+
+    final listNextPage =
+        prompt(('There are more objects to list, list next page? (Y/n): '))
+            .toLowerCase();
+
+    if (listNextPage != 'y') {
+      break;
+    }
+
+    result = await result.next();
+  }
+}
+
+String prompt(String prompt) {
+  String? value;
+  while (value == null || value.isEmpty) {
+    stdout.write(prompt);
+    value = stdin.readLineSync(encoding: utf8);
+  }
+  return value;
+}
+
+Never exitError(Object error, [StackTrace? stackTrace]) {
+  stderr.writeln(error);
+  stderr.writeln(stackTrace);
+  exit(1);
+}

--- a/packages/storage/amplify_storage_s3_dart/example/lib/common.dart
+++ b/packages/storage/amplify_storage_s3_dart/example/lib/common.dart
@@ -11,17 +11,26 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import 'dart:convert';
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 
-/// A S3 prefix resolver that doesn't add extra prefix.
-class PassThroughPrefixResolver implements S3StoragePrefixResolver {
-  @override
-  Future<String> resolvePrefix({
-    required StorageAccessLevel storageAccessLevel,
-    String? identityId,
-  }) async {
-    return '';
-  }
+import 'amplifyconfiguration.dart';
+
+Future<void> configureAmplify() async {
+  final secureStorage = AmplifySecureStorageDart(
+    config: AmplifySecureStorageConfig(
+      scope: 'auth',
+      macOSOptions: MacOSSecureStorageOptions(useDataProtection: false),
+    ),
+  );
+
+  final auth = AmplifyAuthCognitoDart(credentialStorage: secureStorage);
+  final storage = AmplifyStorageS3Dart();
+
+  await Amplify.addPlugins([auth, storage]);
+  await Amplify.configure(amplifyconfig);
 }

--- a/packages/storage/amplify_storage_s3_dart/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/example/pubspec.yaml
@@ -1,0 +1,25 @@
+name: storage_s3_example
+description: Amplify Storage S3 for Dart example.
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: '>=2.17.6 <3.0.0'
+
+dependencies:
+  amplify_auth_cognito_dart:
+    path: ../../../auth/amplify_auth_cognito_dart
+  amplify_core:
+    path: ../../../amplify_core
+  amplify_secure_storage_dart:
+    path: ../../../secure_storage/amplify_secure_storage_dart
+  amplify_storage_s3_dart:
+    path: ../
+  example_common:
+    path: ../../../example_common
+
+dev_dependencies:
+  amplify_lints:
+    path: ../../../amplify_lints
+  build_runner: ^2.1.4
+  build_web_compilers: ^3.2.1

--- a/packages/storage/amplify_storage_s3_dart/example/pubspec_overrides.yaml
+++ b/packages/storage/amplify_storage_s3_dart/example/pubspec_overrides.yaml
@@ -1,0 +1,24 @@
+# Generated with `aft`. Do not modify by hand or check into source control.
+dependency_overrides: 
+  amplify_auth_cognito_dart:
+    path: ../../../auth/amplify_auth_cognito_dart
+  amplify_core:
+    path: ../../../amplify_core
+  amplify_lints:
+    path: ../../../amplify_lints
+  amplify_secure_storage_dart:
+    path: ../../../secure_storage/amplify_secure_storage_dart
+  amplify_storage_s3_dart:
+    path: ..
+  aws_common:
+    path: ../../../aws_common
+  aws_signature_v4:
+    path: ../../../aws_signature_v4
+  example_common:
+    path: ../../../example_common
+  smithy:
+    path: ../../../smithy/smithy
+  smithy_aws:
+    path: ../../../smithy/smithy_aws
+  worker_bee:
+    path: ../../../worker_bee/worker_bee

--- a/packages/storage/amplify_storage_s3_dart/example/web/index.html
+++ b/packages/storage/amplify_storage_s3_dart/example/web/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="scaffolded-by" content="https://github.com/dart-lang/sdk">
+    <title>storage_s3_example</title>
+    <link rel="stylesheet" href="styles.css">
+    <script defer src="main.dart.js"></script>
+</head>
+
+<body>
+
+  <div id="output"></div>
+
+</body>
+</html>

--- a/packages/storage/amplify_storage_s3_dart/example/web/main.dart
+++ b/packages/storage/amplify_storage_s3_dart/example/web/main.dart
@@ -1,0 +1,6 @@
+import 'dart:html';
+
+// TODO(HuiSF): Add example Web App
+void main() {
+  querySelector('#output')?.text = 'Your Dart app is running.';
+}

--- a/packages/storage/amplify_storage_s3_dart/example/web/styles.css
+++ b/packages/storage/amplify_storage_s3_dart/example/web/styles.css
@@ -1,0 +1,14 @@
+@import url(https://fonts.googleapis.com/css?family=Roboto);
+
+html, body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  font-family: 'Roboto', sans-serif;
+}
+
+#output {
+  padding: 20px;
+  text-align: center;
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -20,13 +20,50 @@ import 'package:meta/meta.dart';
 /// {@template amplify_storage_s3_dart.amplify_storage_s3_plugin_dart}
 /// The Dart S3 plugin the Amplify Storage Category.
 /// {@endtemplate}
-class AmplifyStorageS3Dart extends StoragePluginInterface {
+class AmplifyStorageS3Dart extends StoragePluginInterface<
+    // TODO(HuiSF): replace with Storage S3 types
+    StorageListOperation,
+    StorageListOptions,
+    StorageGetPropertiesOperation,
+    StorageGetPropertiesOptions,
+    StorageGetUrlOperation,
+    StorageGetUrlOptions,
+    StorageUploadDataOperation,
+    StorageUploadDataOptions,
+    StorageCopyOperation,
+    StorageMoveOperation,
+    StorageRemoveOperation,
+    StorageRemoveOptions,
+    StorageRemoveManyOperation,
+    StorageRemoveManyOptions,
+    StorageItemWithAccessLevel> {
   /// {@macro amplify_storage_s3_dart.amplify_storage_s3_plugin_dart}
   AmplifyStorageS3Dart({
     String? delimiter,
     StorageS3PrefixResolver? prefixResolver,
   })  : _delimiter = delimiter,
         _prefixResolver = prefixResolver;
+
+  // TODO(HuiSF): replace with S3 specific types to the generic parameters
+  /// A plugin key which can be used with `Amplify.Storage.getPlugin` to retrieve
+  /// a S3-specific Storage category interface.
+  static const StoragePluginKey<
+      StorageListOperation,
+      StorageListOptions,
+      StorageGetPropertiesOperation,
+      StorageGetPropertiesOptions,
+      StorageGetUrlOperation,
+      StorageGetUrlOptions,
+      StorageUploadDataOperation,
+      StorageUploadDataOptions,
+      StorageCopyOperation,
+      StorageMoveOperation,
+      StorageRemoveOperation,
+      StorageRemoveOptions,
+      StorageRemoveManyOperation,
+      StorageRemoveManyOptions,
+      StorageItemWithAccessLevel,
+      AmplifyStorageS3Dart> pluginKey = _AmplifyStorageS3DartPluginKey();
 
   final String? _delimiter;
 
@@ -121,4 +158,28 @@ class AmplifyStorageS3Dart extends StoragePluginInterface {
 
   // TODO(HuiSF): add interface for remaining APIs
   //  uploadFile, downloadFile, downloadData
+}
+
+// TODO(HuiSF): replace with S3 specific types to the generic parameters
+class _AmplifyStorageS3DartPluginKey extends StoragePluginKey<
+    StorageListOperation,
+    StorageListOptions,
+    StorageGetPropertiesOperation,
+    StorageGetPropertiesOptions,
+    StorageGetUrlOperation,
+    StorageGetUrlOptions,
+    StorageUploadDataOperation,
+    StorageUploadDataOptions,
+    StorageCopyOperation,
+    StorageMoveOperation,
+    StorageRemoveOperation,
+    StorageRemoveOptions,
+    StorageRemoveManyOperation,
+    StorageRemoveManyOptions,
+    StorageItemWithAccessLevel,
+    AmplifyStorageS3Dart> {
+  const _AmplifyStorageS3DartPluginKey();
+
+  @override
+  String get runtimeTypeName => 'AmplifyStorageS3DartPluginKey';
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
@@ -1,0 +1,68 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:smithy/smithy.dart';
+
+const _fileIssueMessage =
+    'This exception is not expected. Please try again. If the exception persists, please file an issue at https://github.com/aws-amplify/amplify-flutter/issues';
+
+/// {@template amplify_storage_s3_dart.s3_storage_exception}
+/// Represents exceptions that may be thrown calling Storage S3 plugin APIs.
+/// {@endtemplate}
+class S3StorageException extends StorageException {
+  /// {@macro amplify_storage_s3_dart.s3_storage_exception}
+  const S3StorageException(
+    super.message, {
+    required String super.recoverySuggestion,
+    super.underlyingException,
+  });
+
+  /// Creates a [S3StorageException] from [UnknownSmithyHttpException] that
+  /// represents an exception returned from S3 service.
+  factory S3StorageException.fromUnknownSmithyHttpException(
+    UnknownSmithyHttpException exception,
+  ) {
+    switch (exception.statusCode) {
+      case 403:
+        return S3StorageException(
+          'S3 access denied when making the API call.',
+          recoverySuggestion:
+              'Please ensure that correct `StorageAccessLevel` and `targetIdentityId` are included in the options.',
+          underlyingException: exception,
+        );
+      default:
+        return S3StorageException.unknownServiceException(exception);
+    }
+  }
+
+  /// Creates a [S3StorageException] that represents an error that shouldn't
+  /// happen normally.
+  factory S3StorageException.unknownException() {
+    return const S3StorageException(
+      'Unknown exception occurred.',
+      recoverySuggestion: _fileIssueMessage,
+    );
+  }
+
+  /// Creates a [S3StorageException] that represents an unexpected error
+  /// returned from S3 service.
+  factory S3StorageException.unknownServiceException([Object? exception]) {
+    return S3StorageException(
+      'Unknown service exception occurred.',
+      recoverySuggestion: _fileIssueMessage,
+      underlyingException: exception,
+    );
+  }
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_item.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_item.dart
@@ -1,0 +1,64 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
+import 'package:meta/meta.dart';
+
+/// {@template storage.amplify_storage_s3.storage_s3_item}
+/// An object in a S3 bucket.
+/// {@endtemplate}
+class S3StorageItem extends StorageItem {
+  /// {@macro storage.amplify_storage_s3.storage_s3_item}
+  S3StorageItem({
+    required super.key,
+    super.size,
+    super.lastModified,
+    super.eTag,
+    this.metadata = const <String, String>{},
+    this.versionId,
+  });
+
+  /// Creates a [S3StorageItem] from [S3Object] provided by smithy.
+  ///
+  /// This named constructor should be used internally only.
+  @internal
+  factory S3StorageItem.fromS3Object(
+    S3Object object, {
+    required String prefixToDrop,
+  }) {
+    final key = object.key;
+
+    // In S3 plugin, key is required property presenting an object
+    if (key == null) {
+      throw S3StorageException.unknownException();
+    }
+
+    final keyDroppedPrefix = key.replaceRange(0, prefixToDrop.length, '');
+
+    return S3StorageItem(
+      key: keyDroppedPrefix,
+      size: object.size?.toInt(),
+      lastModified: object.lastModified,
+      eTag: object.eTag,
+    );
+  }
+
+  /// Metadata specified when the object was uploaded.
+  final Map<String, String> metadata;
+
+  /// Object `versionId`, may be available when S3 bucket versioning is enabled.
+  final String? versionId;
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_list_operation.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_list_operation.dart
@@ -13,17 +13,16 @@
 // limitations under the License.
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 
-/// {@template amplify_storage_s3_dart.prefix_resolver}
-/// Defines the interface of a S3 prefix resolver.
+/// {@template storage.amplify_storage_s3.list_operation}
+/// An operation created by calling Storage S3 plugin `list` API.
 /// {@endtemplate}
-abstract class StorageS3PrefixResolver {
-  /// {@macro amplify_storage_s3_dart.prefix_resolver}
-  const StorageS3PrefixResolver();
-
-  /// Resolve prefix with given [StorageAccessLevel] and optional `identityId`.
-  Future<String> resolvePrefix({
-    required StorageAccessLevel storageAccessLevel,
-    String? identityId,
+class S3StorageListOperation extends StorageListOperation<
+    StorageListRequest<S3StorageListOptions>, S3StorageListResult> {
+  /// {@macro storage.amplify_storage_s3.list_operation}
+  S3StorageListOperation({
+    required super.request,
+    required super.result,
   });
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_list_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_list_options.dart
@@ -1,0 +1,56 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+
+/// {@template storage.amplify_storage_s3.list_options}
+/// The configurable parameters for Storage S3 plugin `list` requests.
+/// {@endtemplate}
+class S3StorageListOptions extends StorageListOptions {
+  /// {@macro storage.amplify_storage_s3.list_options}
+  factory S3StorageListOptions({
+    StorageAccessLevel storageAccessLevel = StorageAccessLevel.guest,
+    int pageSize = 1000,
+  }) {
+    return S3StorageListOptions._(
+      storageAccessLevel: storageAccessLevel,
+      pageSize: pageSize,
+    );
+  }
+
+  const S3StorageListOptions._({
+    super.storageAccessLevel = StorageAccessLevel.guest,
+    super.pageSize = 1000,
+    this.targetIdentityId,
+  });
+
+  /// {@macro storage.amplify_storage_s3.list_options}
+  ///
+  /// Use when list objects that belongs to other user (identified by
+  /// `targetIdentityId`) rather than the currently signed user.
+  factory S3StorageListOptions.forIdentity(
+    String targetIdentityId, {
+    int pageSize = 1000,
+  }) {
+    return S3StorageListOptions._(
+      storageAccessLevel: StorageAccessLevel.protected,
+      pageSize: pageSize,
+      targetIdentityId: targetIdentityId,
+    );
+  }
+
+  /// The other user's identity id to list objects with. Should be set by
+  /// `StorageS3ListOptions.withTargetIdentityId()` constructor.
+  final String? targetIdentityId;
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_list_result.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_list_result.dart
@@ -1,0 +1,78 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart' hide PaginatedResult;
+import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
+import 'package:meta/meta.dart';
+import 'package:smithy/smithy.dart';
+
+/// {@template storage.amplify_storage_s3.list_result}
+/// The result returned by Storage S3 plugin `list` API.
+/// {@endtemplate}
+class S3StorageListResult extends StorageListResult<List<S3StorageItem>> {
+  /// {@macro storage.amplify_storage_s3.list_result}
+  S3StorageListResult(
+    super.items, {
+    required super.hasNext,
+    required Future<S3StorageListResult> Function() super.next,
+    this.pluginMetadata = const <String, Object?>{},
+  }) : _next = next;
+
+  /// Creates a [S3StorageListResult] from a [PaginatedResult] provided by
+  /// smithy. This named constructor should be used internally only.
+  @internal
+  factory S3StorageListResult.fromPaginatedResult(
+    PaginatedResult<ListObjectsV2Output, int> paginatedResult, {
+    required String prefixToDrop,
+  }) {
+    final output = paginatedResult.items;
+    final requestedPageSize = output.maxKeys;
+    final metadata = <String, Object?>{
+      'commonPrefixes': output.commonPrefixes?.toList(),
+      'delimiter': output.delimiter,
+      'bucketName': output.name,
+    };
+    final items = output.contents
+            ?.map(
+              (S3Object item) => S3StorageItem.fromS3Object(
+                item,
+                prefixToDrop: prefixToDrop,
+              ),
+            )
+            .toList() ??
+        const <S3StorageItem>[];
+
+    return S3StorageListResult(
+      items,
+      hasNext: paginatedResult.hasNext,
+      next: () async {
+        final nextPageResult = await paginatedResult.next(requestedPageSize);
+        return S3StorageListResult.fromPaginatedResult(
+          nextPageResult,
+          prefixToDrop: prefixToDrop,
+        );
+      },
+      pluginMetadata: metadata,
+    );
+  }
+
+  @override
+  Future<S3StorageListResult> next() => _next();
+
+  final Future<S3StorageListResult> Function() _next;
+
+  /// Metadata that is specific to the plugin
+  final Map<String, Object?> pluginMetadata;
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_models.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_models.dart
@@ -12,14 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Amplify Storage S3 for Dart
-library amplify_storage_s3_dart;
+export 's3_storage_item.dart';
 
-export 'src/amplify_storage_s3_dart_impl.dart';
-
-export 'src/exception/s3_storage_exception.dart';
-
-export 'src/model/s3_storage_models.dart';
-
-export 'src/prefix_resolver/pass_through_prefix_resolver.dart';
-export 'src/prefix_resolver/s3_storage_prefix_resolver.dart';
+export 's3_storage_list_operation.dart';
+export 's3_storage_list_options.dart';
+export 's3_storage_list_result.dart';

--- a/packages/storage/amplify_storage_s3_dart/lib/src/prefix_resolver/s3_storage_prefix_resolver.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/prefix_resolver/s3_storage_prefix_resolver.dart
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Amplify Storage S3 for Dart
-library amplify_storage_s3_dart;
+import 'package:amplify_core/amplify_core.dart';
 
-export 'src/amplify_storage_s3_dart_impl.dart';
+/// {@template amplify_storage_s3_dart.prefix_resolver}
+/// Defines the interface of a S3 prefix resolver.
+/// {@endtemplate}
+abstract class S3StoragePrefixResolver {
+  /// {@macro amplify_storage_s3_dart.prefix_resolver}
+  const S3StoragePrefixResolver();
 
-export 'src/exception/s3_storage_exception.dart';
-
-export 'src/model/s3_storage_models.dart';
-
-export 'src/prefix_resolver/pass_through_prefix_resolver.dart';
-export 'src/prefix_resolver/s3_storage_prefix_resolver.dart';
+  /// Resolve prefix with given [StorageAccessLevel] and optional `identityId`.
+  Future<String> resolvePrefix({
+    required StorageAccessLevel storageAccessLevel,
+    String? identityId,
+  });
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/prefix_resolver/storage_access_level_aware_prefix_resolver.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/prefix_resolver/storage_access_level_aware_prefix_resolver.dart
@@ -24,7 +24,7 @@ import 'package:meta/meta.dart';
 /// * [StorageAccessLevel.protected] resolves `'protected/<userIdentityId>'`
 /// * [StorageAccessLevel.private] resolves `'private/<userIdentityId>'`
 /// {@endtemplate}
-class StorageAccessLevelAwarePrefixResolver implements StorageS3PrefixResolver {
+class StorageAccessLevelAwarePrefixResolver implements S3StoragePrefixResolver {
   /// {@macro amplify_storage_s3_dart.storage_access_level_aware_prefix_resolver}
   StorageAccessLevelAwarePrefixResolver({
     required TokenIdentityAmplifyAuthProvider identityProvider,

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -1,0 +1,105 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart' hide PaginatedResult;
+import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
+import 'package:meta/meta.dart';
+import 'package:smithy/smithy.dart';
+import 'package:smithy_aws/smithy_aws.dart';
+
+/// {@template amplify_storage_s3.storage_s3_service}
+/// This is a wrapper implementation over Smithy S3Client as a glue layer
+/// between the S3 plugin and S3Client.
+/// {@endtemplate}
+class StorageS3Service {
+  /// {@macro amplify_storage_s3.storage_s3_service}
+  StorageS3Service({
+    required String defaultBucket,
+    required String defaultRegion,
+    required S3StoragePrefixResolver prefixResolver,
+    required AWSIamAmplifyAuthProvider credentialsProvider,
+    required AWSLogger logger,
+    @visibleForTesting DependencyManager? dependencyManagerOverride,
+  })  : _defaultBucket = defaultBucket,
+        // dependencyManagerOverride should be available only in unit tests
+        _defaultS3Client = dependencyManagerOverride == null
+            ? S3Client(
+                region: defaultRegion,
+                credentialsProvider: credentialsProvider,
+                s3ClientConfig: _defaultS3ClientConfig,
+              )
+            : dependencyManagerOverride.getOrCreate<S3Client>(),
+        _prefixResolver = prefixResolver,
+        _logger = logger;
+
+  static const _defaultS3ClientConfig = S3ClientConfig();
+
+  final String _defaultBucket;
+  final S3Client _defaultS3Client;
+  final S3StoragePrefixResolver _prefixResolver;
+  final AWSLogger _logger;
+
+  /// Takes in input from [AmplifyStorageS3Dart.list] to compose a
+  /// [ListObjectsV2Request] and to S3 service, then returns a
+  /// [S3StorageListResult] based on [PaginatedResult] returned by
+  /// [S3Client.listObjectsV2] API.
+  Future<S3StorageListResult> list({
+    String? path,
+    required S3StorageListOptions options,
+  }) async {
+    final resolvedPrefix = await _getResolvedPrefix(
+      storageAccessLevel: options.storageAccessLevel,
+      identityId: options.targetIdentityId,
+    );
+
+    final listTargetPrefix = '$resolvedPrefix${path ?? ''}';
+
+    final request = ListObjectsV2Request.build((builder) {
+      builder
+        ..bucket = _defaultBucket
+        ..prefix = listTargetPrefix
+        ..maxKeys = options.pageSize;
+    });
+
+    try {
+      return S3StorageListResult.fromPaginatedResult(
+        await _defaultS3Client.listObjectsV2(request),
+        prefixToDrop: resolvedPrefix,
+      );
+    } on UnknownSmithyHttpException catch (error) {
+      throw S3StorageException.fromUnknownSmithyHttpException(error);
+    }
+  }
+
+  Future<String> _getResolvedPrefix({
+    required StorageAccessLevel storageAccessLevel,
+    String? identityId,
+  }) async {
+    try {
+      return await _prefixResolver.resolvePrefix(
+        storageAccessLevel: storageAccessLevel,
+        identityId: identityId,
+      );
+    } on Exception catch (error, st) {
+      _logger.error('Error happened while resolving prefix', error, st);
+      throw S3StorageException(
+        'Error happened while resolving prefix.',
+        recoverySuggestion:
+            'If you are providing a custom prefix resolver, please review the underlying exception to determine the cause.',
+        underlyingException: error,
+      );
+    }
+  }
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/storage_s3_service.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/storage_s3_service.dart
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Amplify Storage S3 for Dart
-library amplify_storage_s3_dart;
+@internal
+library s3_storage_service;
 
-export 'src/amplify_storage_s3_dart_impl.dart';
+import 'package:meta/meta.dart';
 
-export 'src/exception/s3_storage_exception.dart';
-
-export 'src/model/s3_storage_models.dart';
-
-export 'src/prefix_resolver/pass_through_prefix_resolver.dart';
-export 'src/prefix_resolver/s3_storage_prefix_resolver.dart';
+export 'service/storage_s3_service_impl.dart';

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   amplify_core: ^1.0.0-next.0
   aws_common: ^0.2.2
+  aws_signature_v4: ^0.2.0
   built_collection: ^5.0.0
   built_value: ^8.4.0
   meta: ^1.7.0
@@ -23,4 +24,6 @@ dev_dependencies:
   build_runner: ^2.0.0
   build_verify: ^3.0.0
   built_value_generator: 8.4.1
+  fixnum: ^1.0.1
+  mocktail: ^0.3.0
   test: ^1.16.0

--- a/packages/storage/amplify_storage_s3_dart/test/exception/s3_storage_exception_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/exception/s3_storage_exception_test.dart
@@ -12,16 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:smithy/smithy.dart';
+import 'package:test/test.dart';
 
-/// A S3 prefix resolver that doesn't add extra prefix.
-class PassThroughPrefixResolver implements S3StoragePrefixResolver {
-  @override
-  Future<String> resolvePrefix({
-    required StorageAccessLevel storageAccessLevel,
-    String? identityId,
-  }) async {
-    return '';
-  }
+void main() {
+  group('StorageS3Exception', () {
+    test(
+        'should create StorageS3Exception.unknownServiceException on unrecognizable UnknownSmithyHttpException',
+        () {
+      const smithyException =
+          UnknownSmithyHttpException(statusCode: 500, body: 'some error');
+      final exception =
+          S3StorageException.fromUnknownSmithyHttpException(smithyException);
+
+      expect(exception.underlyingException, smithyException);
+      expect(
+        exception.message,
+        S3StorageException.unknownServiceException().message,
+      );
+    });
+  });
 }

--- a/packages/storage/amplify_storage_s3_dart/test/model/storage_s3_item_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/model/storage_s3_item_test.dart
@@ -1,0 +1,68 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('S3StorageItem.fromS3Object()', () {
+    const testETag = '1234';
+    const testPrefixToDrop = 'prefix';
+    const testKey = '$testPrefixToDrop/object-key';
+    final testLastModified = DateTime(2022, 9, 12);
+    final testSize = Int64(5000);
+    test('should create a StorageS3Item from Smithy S3Object object', () {
+      final testS3Object = S3Object.build((builder) {
+        builder
+          ..eTag = testETag
+          ..key = testKey
+          ..size = testSize
+          ..lastModified = testLastModified;
+      });
+
+      final storageS3Item = S3StorageItem.fromS3Object(
+        testS3Object,
+        prefixToDrop: testPrefixToDrop,
+      );
+
+      expect(storageS3Item.eTag, testETag);
+      expect(
+        storageS3Item.key,
+        testKey.replaceRange(0, testPrefixToDrop.length, ''),
+      );
+      expect(storageS3Item.lastModified, testLastModified);
+      expect(storageS3Item.size, testSize.toInt());
+    });
+
+    test(
+        'should throw StorageS3Exception.unknownException() when S3Object.key is null (should never happen)',
+        () {
+      final testS3Object = S3Object.build((builder) {
+        builder.eTag = testETag;
+      });
+
+      try {
+        S3StorageItem.fromS3Object(
+          testS3Object,
+          prefixToDrop: testPrefixToDrop,
+        );
+        fail('Expected exception wasn\'t thrown.');
+      } on S3StorageException catch (error) {
+        expect(error, S3StorageException.unknownException());
+      }
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3_dart/test/prefix_resolver/storage_access_level_aware_prefix_resolver_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/prefix_resolver/storage_access_level_aware_prefix_resolver_test.dart
@@ -20,12 +20,12 @@ import '../utils/test_token_provider.dart';
 
 void main() {
   group('StorageAccessLevelAwarePrefixResolver', () {
-    final testTokenProvider = TestTokenProvider();
+    final testTokenIdentityProvider = TestTokenIdentityProvider();
 
     test('should resolve correct prefix for `StorageAccessLevel.guest`',
         () async {
       final prefixResolver = StorageAccessLevelAwarePrefixResolver(
-        identityProvider: testTokenProvider,
+        identityProvider: testTokenIdentityProvider,
       );
 
       final result = await prefixResolver.resolvePrefix(
@@ -41,7 +41,7 @@ void main() {
       const delimiter = '(fancySlash)';
       final prefixResolver = StorageAccessLevelAwarePrefixResolver(
         delimiter: delimiter,
-        identityProvider: testTokenProvider,
+        identityProvider: testTokenIdentityProvider,
       );
 
       final result = await prefixResolver.resolvePrefix(
@@ -50,7 +50,7 @@ void main() {
 
       expect(
         result,
-        '${StorageAccessLevel.protected.defaultPrefix}$delimiter${await testTokenProvider.getIdentityId()}$delimiter',
+        '${StorageAccessLevel.protected.defaultPrefix}$delimiter${await testTokenIdentityProvider.getIdentityId()}$delimiter',
       );
     });
 
@@ -59,7 +59,7 @@ void main() {
         () async {
       const testIdentityId = 'custom-id-123';
       final prefixResolver = StorageAccessLevelAwarePrefixResolver(
-        identityProvider: testTokenProvider,
+        identityProvider: testTokenIdentityProvider,
       );
 
       final result = await prefixResolver.resolvePrefix(
@@ -76,7 +76,7 @@ void main() {
     test('should resolve correct prefix for `StorageAccessLevel.private`',
         () async {
       final prefixResolver = StorageAccessLevelAwarePrefixResolver(
-        identityProvider: testTokenProvider,
+        identityProvider: testTokenIdentityProvider,
       );
 
       final result = await prefixResolver.resolvePrefix(
@@ -85,7 +85,7 @@ void main() {
 
       expect(
         result,
-        '${StorageAccessLevel.private.defaultPrefix}/${await testTokenProvider.getIdentityId()}/',
+        '${StorageAccessLevel.private.defaultPrefix}/${await testTokenIdentityProvider.getIdentityId()}/',
       );
     });
 
@@ -94,7 +94,7 @@ void main() {
         () async {
       const testIdentityId = 'custom-id-123';
       final prefixResolver = StorageAccessLevelAwarePrefixResolver(
-        identityProvider: testTokenProvider,
+        identityProvider: testTokenIdentityProvider,
       );
 
       final result = await prefixResolver.resolvePrefix(

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service.dart/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service.dart/storage_s3_service_test.dart
@@ -1,0 +1,209 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart' hide PaginatedResult;
+import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:smithy/smithy.dart';
+import 'package:test/test.dart';
+
+import '../utils/mocks.dart';
+import '../utils/test_token_provider.dart';
+
+const testDelimiter = '#';
+
+class TestPrefixResolver implements S3StoragePrefixResolver {
+  @override
+  Future<String> resolvePrefix({
+    required StorageAccessLevel storageAccessLevel,
+    String? identityId,
+  }) async {
+    if (identityId == 'throw exception for me') {
+      throw Exception('elaborated exception');
+    }
+
+    return '${storageAccessLevel.defaultPrefix}$testDelimiter';
+  }
+}
+
+void main() {
+  group('StorageS3Service', () {
+    const testBucket = 'bucket1';
+    const testRegion = 'west-2';
+    final testPrefixResolver = TestPrefixResolver();
+    late DependencyManager dependencyManager;
+    late S3Client s3Client;
+    late StorageS3Service storageS3Service;
+    late AWSLogger logger;
+
+    setUpAll(() {
+      registerFallbackValue(ListObjectsV2Request(bucket: 'fake bucket'));
+    });
+
+    setUp(() {
+      s3Client = MockS3Client();
+      logger = MockAWSLogger();
+      dependencyManager = DependencyManager()..addInstance<S3Client>(s3Client);
+      storageS3Service = StorageS3Service(
+        defaultBucket: testBucket,
+        defaultRegion: testRegion,
+        prefixResolver: testPrefixResolver,
+        credentialsProvider: TestIamAuthProvider(),
+        logger: logger,
+        dependencyManagerOverride: dependencyManager,
+      );
+    });
+
+    group('_getResolvedPrefix()', () {
+      test(
+          'should throw a StorageS3Exception if supplied prefix resolver throws an exception',
+          () async {
+        final testOptions =
+            S3StorageListOptions.forIdentity('throw exception for me');
+
+        try {
+          await storageS3Service.list(path: 'a path', options: testOptions);
+          fail('Expected exception wasn\'t thrown.');
+        } on Object catch (error) {
+          expect(error is S3StorageException, isTrue);
+        }
+
+        verify(() => logger.error(any(), any(), any())).called(1);
+      });
+    });
+
+    group('list() API', () {
+      var calledPageSize = 0;
+      late S3StorageListResult listResult;
+      const testPageSize = 100;
+      const testBucketName = 'a-bucket';
+      const testStorageAccessLevel = StorageAccessLevel.protected;
+      const testHasNext = true;
+      final testPrefixToDrop =
+          '${testStorageAccessLevel.defaultPrefix}$testDelimiter';
+      final testCommonPrefix = CommonPrefix(prefix: testPrefixToDrop);
+
+      test('should invoke S3Client.listObjectsV2 with expected parameters',
+          () async {
+        final testS3Objects = [1, 2, 3, 4, 5].map(
+          (e) => S3Object(
+            key: '${testPrefixToDrop}object-$e',
+            size: Int64(100 * 4),
+            eTag: 'object-$e-eTag',
+          ),
+        );
+        const testPath = 'album';
+        const testTargetIdentityId = 'someone-else-id';
+        final testOptions = S3StorageListOptions.forIdentity(
+          testTargetIdentityId,
+          pageSize: testPageSize,
+        );
+        final testSecondPaginatedResult =
+            PaginatedResult<ListObjectsV2Output, int>(
+          ListObjectsV2Output(),
+          hasNext: testHasNext,
+          next: ([int? pageSize]) {
+            throw UnimplementedError();
+          },
+        );
+        final testPaginatedResult = PaginatedResult<ListObjectsV2Output, int>(
+          ListObjectsV2Output(
+            contents: BuiltList(testS3Objects),
+            commonPrefixes: BuiltList([testCommonPrefix]),
+            delimiter: testDelimiter,
+            name: testBucketName,
+            maxKeys: testPageSize,
+          ),
+          hasNext: testHasNext,
+          next: ([int? pageSize]) async {
+            if (pageSize != null) {
+              calledPageSize = pageSize;
+            }
+            return testSecondPaginatedResult;
+          },
+        );
+
+        when(
+          () => s3Client.listObjectsV2(
+            any(),
+          ),
+        ).thenAnswer(
+          (_) => Future.value(testPaginatedResult),
+        );
+
+        listResult = await storageS3Service.list(
+          path: testPath,
+          options: testOptions,
+        );
+
+        final capturedRequest = verify(
+          () => s3Client.listObjectsV2(
+            captureAny<ListObjectsV2Request>(),
+          ),
+        ).captured.last;
+        expect(capturedRequest is ListObjectsV2Request, isTrue);
+
+        final request = capturedRequest as ListObjectsV2Request;
+        expect(request.bucket, testBucket);
+        expect(
+          request.prefix,
+          '${await testPrefixResolver.resolvePrefix(
+            storageAccessLevel: testStorageAccessLevel,
+            identityId: testTargetIdentityId,
+          )}$testPath',
+        );
+        expect(request.maxKeys, testPageSize);
+      });
+
+      test('should return correct StorageS3ListResult', () async {
+        listResult.items.asMap().forEach((index, item) {
+          expect(item.key, isNot(contains(testPrefixToDrop)));
+          expect(item.key, 'object-${index + 1}');
+        });
+        expect(listResult.hasNext, testHasNext);
+
+        final result2 = await listResult.next();
+        expect(calledPageSize, testPageSize);
+        expect(result2.next(), throwsA(isA<UnimplementedError>()));
+      });
+
+      test(
+          'should throw StorageS3Exception when UnknownSmithHttpException is returned from service',
+          () async {
+        final testOptions = S3StorageListOptions();
+        const testUnknownException = UnknownSmithyHttpException(
+          statusCode: 403,
+          body: 'some exception',
+        );
+
+        when(
+          () => s3Client.listObjectsV2(
+            any(),
+          ),
+        ).thenThrow(testUnknownException);
+
+        try {
+          await storageS3Service.list(path: 'a path', options: testOptions);
+          fail('Expected exception wasn\'t thrown.');
+        } on Object catch (error) {
+          expect(error is S3StorageException, isTrue);
+        }
+      });
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3_dart/test/utils/mocks.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/utils/mocks.dart
@@ -1,0 +1,10 @@
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockStorageS3Service extends Mock implements StorageS3Service {}
+
+class MockS3Client extends Mock implements S3Client {}
+
+class MockAWSLogger extends Mock implements AWSLogger {}

--- a/packages/storage/amplify_storage_s3_dart/test/utils/test_token_provider.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/utils/test_token_provider.dart
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_signature_v4/aws_signature_v4.dart';
 
 const _testToken = 'abc123-fake-token';
 const _testIdentityId = 'identity-id-321';
+const _testAccessKeyId = 'access-key-id';
+const _testSecretAccessKey = 'secret-access-key';
 
-class TestTokenProvider extends TokenIdentityAmplifyAuthProvider {
+class TestTokenIdentityProvider extends TokenIdentityAmplifyAuthProvider {
   @override
   Future<String> getLatestAuthToken() async {
     return _testToken;
@@ -26,5 +29,20 @@ class TestTokenProvider extends TokenIdentityAmplifyAuthProvider {
   @override
   Future<String> getIdentityId() async {
     return _testIdentityId;
+  }
+}
+
+class TestIamAuthProvider extends AWSIamAmplifyAuthProvider {
+  @override
+  Future<AWSCredentials> retrieve() async {
+    return const AWSCredentials(_testAccessKeyId, _testSecretAccessKey);
+  }
+
+  @override
+  Future<AWSSignedRequest> authorizeRequest(
+    AWSBaseHttpRequest request, {
+    IamAuthProviderOptions? options,
+  }) async {
+    throw UnimplementedError();
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Updated Storage plugin/category interface to support multiple plugin registration
2. Implemented `list` API and unit tests
3. Added example for `amplify_storage_s3_dart` package (Web example is coming later)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
