### PR TITLE
chore: Add build.yaml

### DIFF
--- a/packages/amplify/amplify_flutter/build.yaml
+++ b/packages/amplify/amplify_flutter/build.yaml
@@ -1,0 +1,5 @@
+targets:
+  $default:
+    sources:
+      exclude:
+        - example/**

--- a/packages/api/amplify_api/build.yaml
+++ b/packages/api/amplify_api/build.yaml
@@ -1,0 +1,5 @@
+targets:
+  $default:
+    sources:
+      exclude:
+        - example/**


### PR DESCRIPTION
Fixes errors running `build_runner` when a package's example has nested symlink'd directories. This should be the default for all Flutter packages using `build_runner`.