### PR TITLE
fix(datastore): cpk errors on a custom type

### DIFF
--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -519,7 +519,7 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
                 )
             }
             if !customTypeSchemaDependenciesOrder.contains(schemaName) {
-                let schema: ModelSchema = try FlutterModelSchema.init(serializedData: serializedCustomTypeSchema)
+                let schema: ModelSchema = try FlutterModelSchema.init(serializedData: serializedCustomTypeSchema, isModelType: false)
                     .convertToNativeModelSchema(customTypeSchemasRegistry: customTypeSchemaRegistry)
                 customTypeSchemaRegistry.addModelSchema(modelName: schemaName, modelSchema: schema)
             }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/2108
*Description of changes:*

Exclude custom type from amplify-ios primary key parsing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
