### PR TITLE
chore: Unpin dependencies

### DIFF
--- a/packages/amplify/amplify_flutter/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.0+3
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.0+2
 
 - Minor bug fixes and improvements

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter
 description: The top level Flutter package for the AWS Amplify libraries.
-version: 1.0.0-next.0+2
+version: 1.0.0-next.0+3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -20,9 +20,9 @@ platforms:
 
 dependencies:
   amplify_core: ">=1.0.0-next.0+1 <1.0.0-next.1"
-  amplify_datastore_plugin_interface: 1.0.0-next.0
-  amplify_flutter_android: 1.0.0-next.0
-  amplify_flutter_ios: 1.0.0-next.0
+  amplify_datastore_plugin_interface: ">=1.0.0-next.0 <1.0.0-next.1"
+  amplify_flutter_android: ">=1.0.0-next.0 <1.0.0-next.1"
+  amplify_flutter_ios: ">=1.0.0-next.0 <1.0.0-next.1"
   amplify_secure_storage: ">=0.1.1 <0.2.0"
   aws_common: ">=0.2.3 <0.3.0"
   collection: ^1.15.0

--- a/packages/amplify/amplify_flutter_ios/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.0+1
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.0 (2022-08-02)
 
 Initial developer preview release for all platforms.

--- a/packages/amplify/amplify_flutter_ios/pubspec.yaml
+++ b/packages/amplify/amplify_flutter_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter_ios
 description: The method channel implementation for amplify_flutter on iOS
-version: 1.0.0-next.0
+version: 1.0.0-next.0+1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_core: 1.0.0-next.0
+  amplify_core: ">=1.0.0-next.0 <1.0.0-next.1"
   flutter:
     sdk: flutter
 

--- a/packages/amplify_datastore/CHANGELOG.md
+++ b/packages/amplify_datastore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.0+2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.0+1
 
 - Minor bug fixes and improvements

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore
 description: The Amplify Flutter DataStore category plugin, providing a queryable, on-device data store.
-version: 1.0.0-next.0+1
+version: 1.0.0-next.0+2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_datastore
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_datastore_plugin_interface: 1.0.0-next.0
+  amplify_datastore_plugin_interface: ">=1.0.0-next.0 <1.0.0-next.1"
   amplify_core: ">=1.0.0-next.0+1 <1.0.0-next.1"
   plugin_platform_interface: ^2.0.0
   meta: ^1.7.0

--- a/packages/amplify_datastore_plugin_interface/CHANGELOG.md
+++ b/packages/amplify_datastore_plugin_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.0+1
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.0 (2022-08-02)
 
 Initial developer preview release for all platforms.

--- a/packages/amplify_datastore_plugin_interface/pubspec.yaml
+++ b/packages/amplify_datastore_plugin_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore_plugin_interface
 description: The platform interface for the DataStore module of Amplify Flutter.
-version: 1.0.0-next.0
+version: 1.0.0-next.0+1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_datastore_plugin_interface
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_core: 1.0.0-next.0
+  amplify_core: ">=1.0.0-next.0 <1.0.0-next.1"
   collection: ^1.15.0
   flutter:
     sdk: flutter

--- a/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.0+2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.0+1
 
 - Minor bug fixes and improvements

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint
 description: The Amplify Flutter Analytics category plugin using the AWS Pinpoint provider.
-version: 1.0.0-next.0+1
+version: 1.0.0-next.0+2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/analytics/amplify_analytics_pinpoint
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,8 +10,8 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_analytics_pinpoint_android: 1.0.0-next.0
-  amplify_analytics_pinpoint_ios: 1.0.0-next.0
+  amplify_analytics_pinpoint_android: ">=1.0.0-next.0 <1.0.0-next.1"
+  amplify_analytics_pinpoint_ios: ">=1.0.0-next.0 <1.0.0-next.1"
   amplify_core: ">=1.0.0-next.0+1 <1.0.0-next.1"
   aws_common: ^0.2.0
   flutter:

--- a/packages/api/amplify_api/CHANGELOG.md
+++ b/packages/api/amplify_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.0+3
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.0+2
 
 - Minor bug fixes and improvements

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api
 description: The Amplify Flutter API category plugin, supporting GraphQL and REST operations.
-version: 1.0.0-next.0+2
+version: 1.0.0-next.0+3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,8 +10,8 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_api_android: 1.0.0-next.0
-  amplify_api_ios: 1.0.0-next.0
+  amplify_api_android: ">=1.0.0-next.0 <1.0.0-next.1"
+  amplify_api_ios: ">=1.0.0-next.0 <1.0.0-next.1"
   amplify_core: ">=1.0.0-next.0+1 <1.0.0-next.1"
   amplify_flutter: ">=1.0.0-next.0+2 <1.0.0-next.1"
   aws_common: ">=0.2.3 <0.3.0"

--- a/packages/api/amplify_api_ios/CHANGELOG.md
+++ b/packages/api/amplify_api_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.0+1
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.0 (2022-08-02)
 
 Initial developer preview release for all platforms.

--- a/packages/api/amplify_api_ios/pubspec.yaml
+++ b/packages/api/amplify_api_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_ios
 description: The method channel implementation for amplify_api on iOS
-version: 1.0.0-next.0
+version: 1.0.0-next.0+1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_core: 1.0.0-next.0
+  amplify_core: ">=1.0.0-next.0 <1.0.0-next.1"
   flutter:
     sdk: flutter
 

--- a/packages/auth/amplify_auth_cognito_ios/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.0+3
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.0+2
 
 ### Features

--- a/packages/auth/amplify_auth_cognito_ios/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_ios
 description: The method channel implementation for amplify_auth_cognito on iOS
-version: 1.0.0-next.0+2
+version: 1.0.0-next.0+3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_core: 1.0.0-next.0
+  amplify_core: ">=1.0.0-next.0 <1.0.0-next.1"
   flutter:
     sdk: flutter
 

--- a/packages/storage/amplify_storage_s3/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.0+2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.0+1
 
 - Minor bug fixes and improvements

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3
 description: The Amplify Flutter Storage category plugin using the AWS S3 provider.
-version: 1.0.0-next.0+1
+version: 1.0.0-next.0+2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/storage/amplify_storage_s3
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,8 +10,8 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_storage_s3_android: 1.0.0-next.0
-  amplify_storage_s3_ios: 1.0.0-next.0
+  amplify_storage_s3_android: ">=1.0.0-next.0 <1.0.0-next.1"
+  amplify_storage_s3_ios: ">=1.0.0-next.0 <1.0.0-next.1"
   amplify_core: ">=1.0.0-next.0+1 <1.0.0-next.1"
   aws_common: ^0.2.0
   flutter:


### PR DESCRIPTION
Dependency pinning is no longer needed - packages are allowed to individually vary and be published as needed and new aft commands make sure it all works.

Fixes #2152.
