### PR TITLE
fix(auth): Return username used for sign-in

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
@@ -51,10 +51,8 @@ void main() {
     });
 
     testWidgets('should return the current user', (WidgetTester tester) async {
-      var authUser = await Amplify.Auth.getCurrentUser();
-      // usernames need to be compared case insensitive due to
-      // https://github.com/aws-amplify/amplify-flutter/issues/723
-      expect(authUser.username.toLowerCase(), username.toLowerCase());
+      final authUser = await Amplify.Auth.getCurrentUser();
+      expect(authUser.username, username);
       expect(isValidUserSub(authUser.userId), isTrue);
     });
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
@@ -36,6 +36,12 @@ enum CognitoUserPoolKey {
 
   /// The user ID.
   userSub,
+
+  /// The username with which the user logged in.
+  ///
+  /// This is stored so that calls to `getCurrentUser` return the expected
+  /// username instead of the one assigned by Cognito.
+  username,
 }
 
 /// Discrete keys stored for Cognito User Pool device tracking operations in

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_user_pool_tokens.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_user_pool_tokens.dart
@@ -39,12 +39,14 @@ abstract class CognitoUserPoolTokens
     required JsonWebToken accessToken,
     required String refreshToken,
     required JsonWebToken idToken,
+    String? username,
   }) {
     return _$CognitoUserPoolTokens._(
       signInMethod: signInMethod,
       accessToken: accessToken,
       refreshToken: refreshToken,
       idToken: idToken,
+      username: username ?? CognitoIdToken(idToken).username,
     );
   }
 
@@ -61,7 +63,9 @@ abstract class CognitoUserPoolTokens
 
   @BuiltValueHook(finalizeBuilder: true)
   static void _finalize(CognitoUserPoolTokensBuilder b) {
-    b.signInMethod ??= CognitoSignInMethod.default$;
+    b
+      ..signInMethod ??= CognitoSignInMethod.default$
+      ..username ??= CognitoIdToken(b.idToken!).username;
   }
 
   /// The method by which the user signed in and retrieved these tokens.
@@ -90,7 +94,7 @@ abstract class CognitoUserPoolTokens
   String get userId => idToken.userId;
 
   /// The Cognito user's username.
-  String get username => CognitoIdToken(idToken).username;
+  String get username;
 
   /// Validates the tokens against the client state.
   void validate({

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_user_pool_tokens.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_user_pool_tokens.g.dart
@@ -35,6 +35,8 @@ class _$CognitoUserPoolTokens extends CognitoUserPoolTokens {
   final String refreshToken;
   @override
   final JsonWebToken idToken;
+  @override
+  final String username;
 
   factory _$CognitoUserPoolTokens(
           [void Function(CognitoUserPoolTokensBuilder)? updates]) =>
@@ -44,7 +46,8 @@ class _$CognitoUserPoolTokens extends CognitoUserPoolTokens {
       {required this.signInMethod,
       required this.accessToken,
       required this.refreshToken,
-      required this.idToken})
+      required this.idToken,
+      required this.username})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
         signInMethod, r'CognitoUserPoolTokens', 'signInMethod');
@@ -54,6 +57,8 @@ class _$CognitoUserPoolTokens extends CognitoUserPoolTokens {
         refreshToken, r'CognitoUserPoolTokens', 'refreshToken');
     BuiltValueNullFieldError.checkNotNull(
         idToken, r'CognitoUserPoolTokens', 'idToken');
+    BuiltValueNullFieldError.checkNotNull(
+        username, r'CognitoUserPoolTokens', 'username');
   }
 
   @override
@@ -72,15 +77,18 @@ class _$CognitoUserPoolTokens extends CognitoUserPoolTokens {
         signInMethod == other.signInMethod &&
         accessToken == other.accessToken &&
         refreshToken == other.refreshToken &&
-        idToken == other.idToken;
+        idToken == other.idToken &&
+        username == other.username;
   }
 
   @override
   int get hashCode {
     return $jf($jc(
-        $jc($jc($jc(0, signInMethod.hashCode), accessToken.hashCode),
-            refreshToken.hashCode),
-        idToken.hashCode));
+        $jc(
+            $jc($jc($jc(0, signInMethod.hashCode), accessToken.hashCode),
+                refreshToken.hashCode),
+            idToken.hashCode),
+        username.hashCode));
   }
 }
 
@@ -106,6 +114,10 @@ class CognitoUserPoolTokensBuilder
   JsonWebToken? get idToken => _$this._idToken;
   set idToken(JsonWebToken? idToken) => _$this._idToken = idToken;
 
+  String? _username;
+  String? get username => _$this._username;
+  set username(String? username) => _$this._username = username;
+
   CognitoUserPoolTokensBuilder();
 
   CognitoUserPoolTokensBuilder get _$this {
@@ -115,6 +127,7 @@ class CognitoUserPoolTokensBuilder
       _accessToken = $v.accessToken;
       _refreshToken = $v.refreshToken;
       _idToken = $v.idToken;
+      _username = $v.username;
       _$v = null;
     }
     return this;
@@ -145,7 +158,9 @@ class CognitoUserPoolTokensBuilder
             refreshToken: BuiltValueNullFieldError.checkNotNull(
                 refreshToken, r'CognitoUserPoolTokens', 'refreshToken'),
             idToken: BuiltValueNullFieldError.checkNotNull(
-                idToken, r'CognitoUserPoolTokens', 'idToken'));
+                idToken, r'CognitoUserPoolTokens', 'idToken'),
+            username: BuiltValueNullFieldError.checkNotNull(
+                username, r'CognitoUserPoolTokens', 'username'));
     replace(_$result);
     return _$result;
   }
@@ -169,6 +184,7 @@ CognitoUserPoolTokens _$CognitoUserPoolTokensFromJson(
       refreshToken: json['refreshToken'] as String,
       idToken:
           const JsonWebTokenSerializer().fromJson(json['idToken'] as String),
+      username: json['username'] as String?,
     );
 
 Map<String, dynamic> _$CognitoUserPoolTokensToJson(
@@ -188,5 +204,6 @@ Map<String, dynamic> _$CognitoUserPoolTokensToJson(
   val['refreshToken'] = instance.refreshToken;
   writeNotNull(
       'idToken', const JsonWebTokenSerializer().toJson(instance.idToken));
+  val['username'] = instance.username;
   return val;
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart
@@ -95,12 +95,16 @@ class CredentialStoreStateMachine extends CredentialStoreStateMachineBase {
       final idToken = await _secureStorage.read(
         key: keys[CognitoUserPoolKey.idToken],
       );
+      final username = await _secureStorage.read(
+        key: keys[CognitoUserPoolKey.username],
+      );
       if (accessToken != null && refreshToken != null && idToken != null) {
         userPoolTokens = CognitoUserPoolTokens(
           signInMethod: CognitoSignInMethod.default$,
           accessToken: JsonWebToken.parse(accessToken),
           refreshToken: refreshToken,
           idToken: JsonWebToken.parse(idToken),
+          username: username,
         );
       }
     }
@@ -187,6 +191,7 @@ class CredentialStoreStateMachine extends CredentialStoreStateMachineBase {
           keys[CognitoUserPoolKey.accessToken]: userPoolTokens.accessToken.raw,
           keys[CognitoUserPoolKey.refreshToken]: userPoolTokens.refreshToken,
           keys[CognitoUserPoolKey.idToken]: userPoolTokens.idToken.raw,
+          keys[CognitoUserPoolKey.username]: userPoolTokens.username,
         });
       }
     }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
@@ -398,6 +398,7 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
         idToken: idToken != null
             ? JsonWebToken.parse(idToken)
             : userPoolTokens.idToken,
+        username: userPoolTokens.username,
       );
 
       await dispatch(

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -572,7 +572,9 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState> {
     user.userPoolTokens
       ..accessToken = accessTokenJwt
       ..refreshToken = refreshToken
-      ..idToken = idTokenJwt;
+      ..idToken = idTokenJwt
+      // Use the username which was used to sign in.
+      ..username = parameters.username;
 
     await dispatch(
       CredentialStoreEvent.storeCredentials(

--- a/packages/auth/amplify_auth_cognito_test/test/common/mock_config.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/common/mock_config.dart
@@ -74,7 +74,7 @@ const idToken = JsonWebToken(
   claims: JsonWebClaims(
     subject: userSub,
     customClaims: {
-      'cognito:username': username,
+      'cognito:username': userSub,
     },
   ),
   signature: [],
@@ -100,6 +100,7 @@ final userPoolTokens = CognitoUserPoolTokens(
   accessToken: accessToken,
   idToken: idToken,
   refreshToken: refreshToken,
+  username: username,
 );
 final awsCredentials = AWSCredentials(
   accessKeyId,

--- a/packages/auth/amplify_auth_cognito_test/test/common/mock_secure_storage.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/common/mock_secure_storage.dart
@@ -57,6 +57,10 @@ void seedStorage(
       ..write(
         key: userPoolKeys[CognitoUserPoolKey.userSub],
         value: userSub,
+      )
+      ..write(
+        key: userPoolKeys[CognitoUserPoolKey.username],
+        value: username,
       );
   }
   if (deviceKeys != null) {

--- a/packages/auth/amplify_auth_cognito_test/test/state/credential_store_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/credential_store_state_machine_test.dart
@@ -99,6 +99,7 @@ void main() {
       expect(result.data.userPoolTokens?.accessToken, accessToken);
       expect(result.data.userPoolTokens?.refreshToken, refreshToken);
       expect(result.data.userPoolTokens?.idToken, idToken);
+      expect(result.data.userPoolTokens?.username, username);
 
       await stateMachine.close();
     });
@@ -133,6 +134,7 @@ void main() {
               accessToken: accessToken,
               refreshToken: refreshToken,
               idToken: idToken,
+              username: username,
             ),
           ),
         );
@@ -158,6 +160,7 @@ void main() {
         expect(result.data.userPoolTokens?.accessToken, accessToken);
         expect(result.data.userPoolTokens?.refreshToken, refreshToken);
         expect(result.data.userPoolTokens?.idToken, idToken);
+        expect(result.data.userPoolTokens?.username, username);
 
         await stateMachine.close();
       });
@@ -211,6 +214,7 @@ void main() {
         expect(result.data.userPoolTokens?.accessToken, accessToken);
         expect(result.data.userPoolTokens?.refreshToken, refreshToken);
         expect(result.data.userPoolTokens?.idToken, idToken);
+        expect(result.data.userPoolTokens?.username, username);
 
         await stateMachine.close();
       });
@@ -430,6 +434,7 @@ void main() {
         expect(result.data.userPoolTokens?.accessToken, accessToken);
         expect(result.data.userPoolTokens?.refreshToken, refreshToken);
         expect(result.data.userPoolTokens?.idToken, idToken);
+        expect(result.data.userPoolTokens?.username, username);
 
         // verify credential store version has been updated.
         expect(await sm.getVersion(), CredentialStoreVersion.v1);
@@ -476,9 +481,6 @@ void main() {
         expect(result.data.awsCredentials?.expiration, expiration);
         expect(result.data.identityId, identityId);
         expect(result.data.userPoolTokens, isNull);
-        expect(result.data.userPoolTokens?.accessToken, isNull);
-        expect(result.data.userPoolTokens?.refreshToken, isNull);
-        expect(result.data.userPoolTokens?.idToken, isNull);
 
         // verify credential store version has been updated.
         expect(await sm.getVersion(), CredentialStoreVersion.v1);
@@ -525,9 +527,6 @@ void main() {
         expect(result.data.awsCredentials?.expiration, isNull);
         expect(result.data.identityId, isNull);
         expect(result.data.userPoolTokens, isNull);
-        expect(result.data.userPoolTokens?.accessToken, isNull);
-        expect(result.data.userPoolTokens?.refreshToken, isNull);
-        expect(result.data.userPoolTokens?.idToken, isNull);
 
         await stateMachine.close();
       });

--- a/packages/auth/amplify_auth_cognito_test/test/state/sign_in_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/sign_in_state_machine_test.dart
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_auth_cognito_dart/src/jwt/src/cognito.dart';
 import 'package:amplify_auth_cognito_dart/src/model/sign_in_parameters.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
+import 'package:amplify_auth_cognito_dart/src/state/machines/credential_store_state_machine.dart';
 import 'package:amplify_auth_cognito_dart/src/state/machines/sign_in_state_machine.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
@@ -152,6 +154,22 @@ void main() {
           isA<SignInInitiating>(),
           isA<SignInSuccess>(),
         ]),
+      );
+
+      final credentialStoreMachine =
+          stateMachine.expect(CredentialStoreStateMachine.type);
+      expect(CognitoIdToken(idToken).username, isNot(username));
+      expect(
+        credentialStoreMachine.stream,
+        emitsThrough(
+          isA<CredentialStoreSuccess>().having(
+            (e) => e.data.userPoolTokens?.username,
+            'username',
+            username,
+          ),
+        ),
+        reason: 'Username should match what was used to sign in, not what '
+            'Cognito returns as part of the JWT tokens',
       );
     });
   });


### PR DESCRIPTION
Fixes an issue where the username which Cognito assigned to the JWT tokens was being returned from `getCurrentUser` as the username. However, this is not always accurate since Cognito will use the user ID as the username in cases where there is a sign-in alias. For these cases, it makes more sense to return the username used locally to sign-in for `getCurrentUser`.

Fixes #2161.
