### PR TITLE
feat(storage): implement remove and removeMany APIs

### DIFF
--- a/packages/amplify_core/lib/src/types/storage/remove_result.dart
+++ b/packages/amplify_core/lib/src/types/storage/remove_result.dart
@@ -20,9 +20,9 @@ import 'package:amplify_core/amplify_core.dart';
 class StorageRemoveResult<Item extends StorageItem> {
   /// {@macro amplify_core.storage.remove_result}
   const StorageRemoveResult({
-    required this.storageItem,
+    required this.removedItem,
   });
 
   /// The removed object of the [StorageRemoveOperation].
-  final Item storageItem;
+  final Item removedItem;
 }

--- a/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
+++ b/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
@@ -52,6 +52,7 @@ Future<void> main() async {
 1. list
 2. getProperties
 3. getUrl
+4. remove
 0. exit
 ''');
     final operationNum = int.tryParse(operation);
@@ -65,6 +66,9 @@ Future<void> main() async {
         break;
       case 3:
         await getUrlOperation();
+        break;
+      case 4:
+        await removeOperation();
         break;
       case null:
         break;
@@ -168,10 +172,34 @@ Future<void> getUrlOperation() async {
     stdout
       ..writeln('Generated url for key: $key, the url expires in 10 minutes:')
       ..writeln(result.url.toString());
-  } on S3StorageException catch (error) {
+  } on Exception catch (error) {
     stderr
       ..writeln('Something went wrong...')
-      ..writeln(error.message);
+      ..writeln(error);
+  }
+}
+
+Future<void> removeOperation() async {
+  final key = prompt('Enter the object key to remove: ');
+  final storageAccessLevel = promptStorageAccessLevel();
+
+  final s3Plugin = Amplify.Storage.getPlugin(AmplifyStorageS3Dart.pluginKey);
+  final removeOperation = s3Plugin.remove(
+    key: key,
+    options: S3StorageRemoveOptions(
+      storageAccessLevel: storageAccessLevel,
+    ),
+  );
+
+  try {
+    final result = await removeOperation.result;
+    stdout
+      ..writeln('Remove completed.')
+      ..writeln('Removed object: ${result.removedItem.key}');
+  } on Exception catch (error) {
+    stderr
+      ..writeln('Something went wrong...')
+      ..writeln(error);
   }
 }
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -33,10 +33,10 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     StorageUploadDataOptions,
     StorageCopyOperation,
     StorageMoveOperation,
-    StorageRemoveOperation,
-    StorageRemoveOptions,
-    StorageRemoveManyOperation,
-    StorageRemoveManyOptions,
+    S3StorageRemoveOperation,
+    S3StorageRemoveOptions,
+    S3StorageRemoveManyOperation,
+    S3StorageRemoveManyOptions,
     S3StorageItem> with AWSDebuggable, AWSLoggerMixin {
   /// {@macro amplify_storage_s3_dart.amplify_storage_s3_plugin_dart}
   AmplifyStorageS3Dart({
@@ -61,10 +61,10 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
       StorageUploadDataOptions,
       StorageCopyOperation,
       StorageMoveOperation,
-      StorageRemoveOperation,
-      StorageRemoveOptions,
-      StorageRemoveManyOperation,
-      StorageRemoveManyOptions,
+      S3StorageRemoveOperation,
+      S3StorageRemoveOptions,
+      S3StorageRemoveManyOperation,
+      S3StorageRemoveManyOptions,
       S3StorageItem,
       AmplifyStorageS3Dart> pluginKey = _AmplifyStorageS3DartPluginKey();
 
@@ -203,17 +203,45 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
   }
 
   @override
-  StorageRemoveOperation remove({
+  S3StorageRemoveOperation remove({
     required StorageRemoveRequest request,
   }) {
-    throw UnimplementedError();
+    final s3Options = request.options as S3StorageRemoveOptions?;
+
+    return S3StorageRemoveOperation(
+      request: StorageRemoveRequest(
+        key: request.key,
+        options: s3Options,
+      ),
+      result: _storageS3Service.remove(
+        key: request.key,
+        options: s3Options ??
+            S3StorageRemoveOptions(
+              storageAccessLevel: _s3pluginConfig.defaultAccessLevel,
+            ),
+      ),
+    );
   }
 
   @override
-  StorageRemoveManyOperation removeMany({
+  S3StorageRemoveManyOperation removeMany({
     required StorageRemoveManyRequest request,
   }) {
-    throw UnimplementedError();
+    final s3Options = request.options as S3StorageRemoveManyOptions?;
+
+    return S3StorageRemoveManyOperation(
+      request: StorageRemoveManyRequest(
+        keys: request.keys,
+        options: s3Options,
+      ),
+      result: _storageS3Service.removeMany(
+        keys: request.keys,
+        options: s3Options ??
+            S3StorageRemoveManyOptions(
+              storageAccessLevel: _s3pluginConfig.defaultAccessLevel,
+            ),
+      ),
+    );
   }
 
   // TODO(HuiSF): add interface for remaining APIs
@@ -235,10 +263,10 @@ class _AmplifyStorageS3DartPluginKey extends StoragePluginKey<
     StorageUploadDataOptions,
     StorageCopyOperation,
     StorageMoveOperation,
-    StorageRemoveOperation,
-    StorageRemoveOptions,
-    StorageRemoveManyOperation,
-    StorageRemoveManyOptions,
+    S3StorageRemoveOperation,
+    S3StorageRemoveOptions,
+    S3StorageRemoveManyOperation,
+    S3StorageRemoveManyOptions,
     S3StorageItem,
     AmplifyStorageS3Dart> {
   const _AmplifyStorageS3DartPluginKey();

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_get_properties_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_get_properties_options.dart
@@ -19,13 +19,11 @@ import 'package:amplify_core/amplify_core.dart';
 /// {@endtemplate}
 class S3StorageGetPropertiesOptions extends StorageGetPropertiesOptions {
   /// {@macro storage.amplify_storage_s3.get_properties_options}
-  factory S3StorageGetPropertiesOptions({
+  const S3StorageGetPropertiesOptions({
     StorageAccessLevel storageAccessLevel = StorageAccessLevel.guest,
-  }) {
-    return S3StorageGetPropertiesOptions._(
-      storageAccessLevel: storageAccessLevel,
-    );
-  }
+  }) : this._(
+          storageAccessLevel: storageAccessLevel,
+        );
 
   const S3StorageGetPropertiesOptions._({
     super.storageAccessLevel = StorageAccessLevel.guest,
@@ -36,12 +34,12 @@ class S3StorageGetPropertiesOptions extends StorageGetPropertiesOptions {
   ///
   /// Use when call `getProperties` on an object that belongs to other user
   /// (identified by `targetIdentityId`) rather than the currently signed user.
-  factory S3StorageGetPropertiesOptions.forIdentity(String targetIdentityId) {
-    return S3StorageGetPropertiesOptions._(
-      storageAccessLevel: StorageAccessLevel.protected,
-      targetIdentityId: targetIdentityId,
-    );
-  }
+  const S3StorageGetPropertiesOptions.forIdentity(
+    String targetIdentityId,
+  ) : this._(
+          storageAccessLevel: StorageAccessLevel.protected,
+          targetIdentityId: targetIdentityId,
+        );
 
   /// The identity id of another user who uploaded the object that to get
   /// properties for.

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_get_url_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_get_url_options.dart
@@ -20,17 +20,15 @@ import 'package:amplify_core/amplify_core.dart';
 /// {@endtemplate}
 class S3StorageGetUrlOptions extends StorageGetUrlOptions {
   /// {@macro storage.amplify_storage_s3.get_url_options}
-  factory S3StorageGetUrlOptions({
+  const S3StorageGetUrlOptions({
     StorageAccessLevel storageAccessLevel = StorageAccessLevel.guest,
     Duration expiresIn = const Duration(days: 1),
     bool checkObjectExistence = false,
-  }) {
-    return S3StorageGetUrlOptions._(
-      storageAccessLevel: storageAccessLevel,
-      expiresIn: expiresIn,
-      checkObjectExistence: checkObjectExistence,
-    );
-  }
+  }) : this._(
+          storageAccessLevel: storageAccessLevel,
+          expiresIn: expiresIn,
+          checkObjectExistence: checkObjectExistence,
+        );
 
   const S3StorageGetUrlOptions._({
     super.storageAccessLevel = StorageAccessLevel.guest,
@@ -43,18 +41,16 @@ class S3StorageGetUrlOptions extends StorageGetUrlOptions {
   ///
   /// Use when call `getUrl` on an object that belongs to other user (identified
   /// by `targetIdentityId`) rather than the currently signed user.
-  factory S3StorageGetUrlOptions.forIdentity(
+  const S3StorageGetUrlOptions.forIdentity(
     String targetIdentityId, {
     Duration expiresIn = const Duration(days: 1),
     bool checkObjectExistence = false,
-  }) {
-    return S3StorageGetUrlOptions._(
-      storageAccessLevel: StorageAccessLevel.protected,
-      expiresIn: expiresIn,
-      checkObjectExistence: checkObjectExistence,
-      targetIdentityId: targetIdentityId,
-    );
-  }
+  }) : this._(
+          storageAccessLevel: StorageAccessLevel.protected,
+          expiresIn: expiresIn,
+          checkObjectExistence: checkObjectExistence,
+          targetIdentityId: targetIdentityId,
+        );
 
   /// Specifies the period of time that the generated url expires in.
   final Duration expiresIn;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_list_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_list_options.dart
@@ -19,15 +19,13 @@ import 'package:amplify_core/amplify_core.dart';
 /// {@endtemplate}
 class S3StorageListOptions extends StorageListOptions {
   /// {@macro storage.amplify_storage_s3.list_options}
-  factory S3StorageListOptions({
+  const S3StorageListOptions({
     StorageAccessLevel storageAccessLevel = StorageAccessLevel.guest,
     int pageSize = 1000,
-  }) {
-    return S3StorageListOptions._(
-      storageAccessLevel: storageAccessLevel,
-      pageSize: pageSize,
-    );
-  }
+  }) : this._(
+          storageAccessLevel: storageAccessLevel,
+          pageSize: pageSize,
+        );
 
   const S3StorageListOptions._({
     super.storageAccessLevel = StorageAccessLevel.guest,
@@ -39,16 +37,14 @@ class S3StorageListOptions extends StorageListOptions {
   ///
   /// Use when list objects that belongs to other user (identified by
   /// `targetIdentityId`) rather than the currently signed user.
-  factory S3StorageListOptions.forIdentity(
+  const S3StorageListOptions.forIdentity(
     String targetIdentityId, {
     int pageSize = 1000,
-  }) {
-    return S3StorageListOptions._(
-      storageAccessLevel: StorageAccessLevel.protected,
-      pageSize: pageSize,
-      targetIdentityId: targetIdentityId,
-    );
-  }
+  }) : this._(
+          storageAccessLevel: StorageAccessLevel.protected,
+          pageSize: pageSize,
+          targetIdentityId: targetIdentityId,
+        );
 
   /// The identity id of another user who uploaded the objects that to be
   /// listed.

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_models.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_models.dart
@@ -25,3 +25,11 @@ export 's3_storage_item.dart';
 export 's3_storage_list_operation.dart';
 export 's3_storage_list_options.dart';
 export 's3_storage_list_result.dart';
+
+export 's3_storage_remove_many_operation.dart';
+export 's3_storage_remove_many_options.dart';
+export 's3_storage_remove_many_result.dart';
+
+export 's3_storage_remove_operation.dart';
+export 's3_storage_remove_options.dart';
+export 's3_storage_remove_result.dart';

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_remove_many_operation.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_remove_many_operation.dart
@@ -13,16 +13,17 @@
 // limitations under the License.
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 
-/// {@template amplify_core.storage.remove_many_result}
-/// Presents the result of a [StorageRemoveManyOperation].
+/// {@template storage.amplify_storage_s3.remove_many_operation}
+/// An operation created by calling Storage S3 plugin `removeMany` API.
 /// {@endtemplate}
-class StorageRemoveManyResult<Item extends StorageItem> {
-  /// {@macro amplify_core.storage.remove_many_result}
-  const StorageRemoveManyResult({
-    required this.removedItems,
+class S3StorageRemoveManyOperation extends StorageRemoveManyOperation<
+    StorageRemoveManyRequest<S3StorageRemoveManyOptions>,
+    S3StorageRemoveManyResult> {
+  /// {@macro storage.amplify_storage_s3.remove_many_operation}
+  S3StorageRemoveManyOperation({
+    required super.request,
+    required super.result,
   });
-
-  /// The removed objects of the [StorageRemoveManyOperation].
-  final List<Item> removedItems;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_remove_many_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_remove_many_options.dart
@@ -14,15 +14,13 @@
 
 import 'package:amplify_core/amplify_core.dart';
 
-/// {@template amplify_core.storage.remove_many_result}
-/// Presents the result of a [StorageRemoveManyOperation].
+/// {@template storage.amplify_storage_s3.remove_many_options}
+/// The configurable parameters invoking Storage S3 plugin `removeMany`
+/// API.
 /// {@endtemplate}
-class StorageRemoveManyResult<Item extends StorageItem> {
-  /// {@macro amplify_core.storage.remove_many_result}
-  const StorageRemoveManyResult({
-    required this.removedItems,
+class S3StorageRemoveManyOptions extends StorageRemoveManyOptions {
+  /// {@macro storage.amplify_storage_s3.remove_many_options}
+  const S3StorageRemoveManyOptions({
+    super.storageAccessLevel = StorageAccessLevel.guest,
   });
-
-  /// The removed objects of the [StorageRemoveManyOperation].
-  final List<Item> removedItems;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_remove_many_result.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_remove_many_result.dart
@@ -13,16 +13,22 @@
 // limitations under the License.
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 
-/// {@template amplify_core.storage.remove_many_result}
-/// Presents the result of a [StorageRemoveManyOperation].
+/// {@template storage.amplify_storage_s3.remove_many_result}
+/// The result returned by Storage S3 plugin `removeMany` API.
 /// {@endtemplate}
-class StorageRemoveManyResult<Item extends StorageItem> {
-  /// {@macro amplify_core.storage.remove_many_result}
-  const StorageRemoveManyResult({
-    required this.removedItems,
+class S3StorageRemoveManyResult extends StorageRemoveManyResult<S3StorageItem> {
+  /// {@macro storage.amplify_storage_s3.remove_many_result}
+  const S3StorageRemoveManyResult({
+    required super.removedItems,
+    this.removeErrors = const [],
   });
 
-  /// The removed objects of the [StorageRemoveManyOperation].
-  final List<Item> removedItems;
+  /// A list of [Error] that represents objects that failed to remove.
+  ///
+  /// Please review the details of an [Error] to learn about the reason of
+  /// a failure.
+  final List<s3.Error> removeErrors;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_remove_operation.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_remove_operation.dart
@@ -13,16 +13,16 @@
 // limitations under the License.
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_dart/src/model/s3_storage_models.dart';
 
-/// {@template amplify_core.storage.remove_many_result}
-/// Presents the result of a [StorageRemoveManyOperation].
+/// {@template storage.amplify_storage_s3.remove_operation}
+/// An operation created by calling Storage S3 plugin `remove` API.
 /// {@endtemplate}
-class StorageRemoveManyResult<Item extends StorageItem> {
-  /// {@macro amplify_core.storage.remove_many_result}
-  const StorageRemoveManyResult({
-    required this.removedItems,
+class S3StorageRemoveOperation extends StorageRemoveOperation<
+    StorageRemoveRequest<S3StorageRemoveOptions>, S3StorageRemoveResult> {
+  /// {@macro storage.amplify_storage_s3.remove_operation}
+  S3StorageRemoveOperation({
+    required super.request,
+    required super.result,
   });
-
-  /// The removed objects of the [StorageRemoveManyOperation].
-  final List<Item> removedItems;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_remove_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_remove_options.dart
@@ -14,15 +14,13 @@
 
 import 'package:amplify_core/amplify_core.dart';
 
-/// {@template amplify_core.storage.remove_many_result}
-/// Presents the result of a [StorageRemoveManyOperation].
+/// {@template storage.amplify_storage_s3.remove_options}
+/// The configurable parameters invoking Storage S3 plugin `remove`
+/// API.
 /// {@endtemplate}
-class StorageRemoveManyResult<Item extends StorageItem> {
-  /// {@macro amplify_core.storage.remove_many_result}
-  const StorageRemoveManyResult({
-    required this.removedItems,
+class S3StorageRemoveOptions extends StorageRemoveOptions {
+  /// {@macro storage.amplify_storage_s3.remove_options}
+  const S3StorageRemoveOptions({
+    super.storageAccessLevel = StorageAccessLevel.guest,
   });
-
-  /// The removed objects of the [StorageRemoveManyOperation].
-  final List<Item> removedItems;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_remove_result.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_remove_result.dart
@@ -14,15 +14,7 @@
 
 import 'package:amplify_core/amplify_core.dart';
 
-/// {@template amplify_core.storage.remove_many_result}
-/// Presents the result of a [StorageRemoveManyOperation].
+/// {@template storage.amplify_storage_s3.remove_result}
+/// The result returned by Storage S3 plugin `remove` API.
 /// {@endtemplate}
-class StorageRemoveManyResult<Item extends StorageItem> {
-  /// {@macro amplify_core.storage.remove_many_result}
-  const StorageRemoveManyResult({
-    required this.removedItems,
-  });
-
-  /// The removed objects of the [StorageRemoveManyOperation].
-  final List<Item> removedItems;
-}
+typedef S3StorageRemoveResult = StorageRemoveResult;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:math';
+
 import 'package:amplify_core/amplify_core.dart' hide PaginatedResult;
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
-import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
+import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 import 'package:amplify_storage_s3_dart/src/sdk/src/s3/common/endpoint_resolver.dart'
     as endpoint_resolver;
 import 'package:aws_signature_v4/aws_signature_v4.dart';
 import 'package:meta/meta.dart';
-import 'package:smithy/smithy.dart';
+import 'package:smithy/smithy.dart' as smithy;
 import 'package:smithy_aws/smithy_aws.dart';
 
 /// {@template amplify_storage_s3.storage_s3_service}
@@ -39,7 +41,7 @@ class StorageS3Service {
         _defaultRegion = defaultRegion,
         // dependencyManagerOverride should be available only in unit tests
         _defaultS3Client = dependencyManagerOverride == null
-            ? S3Client(
+            ? s3.S3Client(
                 region: defaultRegion,
                 credentialsProvider: credentialsProvider,
                 s3ClientConfig: _defaultS3ClientConfig,
@@ -60,19 +62,19 @@ class StorageS3Service {
 
   final String _defaultBucket;
   final String _defaultRegion;
-  final S3Client _defaultS3Client;
+  final s3.S3Client _defaultS3Client;
   final S3StoragePrefixResolver _prefixResolver;
   final AWSLogger _logger;
   final AWSCredentialScope _signerScope;
   final AWSSigV4Signer _awsSigV4Signer;
 
   /// Takes in input from [AmplifyStorageS3Dart.list] to compose a
-  /// [ListObjectsV2Request] and to S3 service, then returns a
-  /// [S3StorageListResult] based on [PaginatedResult] returned by
-  /// [S3Client.listObjectsV2] API.
+  /// [s3.ListObjectsV2Request] and to S3 service, then returns a
+  /// [S3StorageListResult] based on [smithy.PaginatedResult] returned by
+  /// [s3.S3Client.listObjectsV2] API.
   ///
   /// {@template storage.s3_service.throw_exception_unknown_smithy_exception}
-  /// May throw [S3StorageException] based on [UnknownSmithyHttpException] if
+  /// May throw [S3StorageException] based on [smithy.UnknownSmithyHttpException] if
   /// any.
   /// {@endtemplate}
   Future<S3StorageListResult> list({
@@ -86,7 +88,7 @@ class StorageS3Service {
 
     final listTargetPrefix = '$resolvedPrefix${path ?? ''}';
 
-    final request = ListObjectsV2Request.build((builder) {
+    final request = s3.ListObjectsV2Request.build((builder) {
       builder
         ..bucket = _defaultBucket
         ..prefix = listTargetPrefix
@@ -98,15 +100,16 @@ class StorageS3Service {
         await _defaultS3Client.listObjectsV2(request),
         prefixToDrop: resolvedPrefix,
       );
-    } on UnknownSmithyHttpException catch (error) {
+    } on smithy.UnknownSmithyHttpException catch (error) {
+      // S3Client.headObject may return 403 error
       throw S3StorageException.fromUnknownSmithyHttpException(error);
     }
   }
 
   /// Takes in input from [AmplifyStorageS3Dart.getProperties] to compose a
-  /// [HeadObjectRequest] and send to S3 service, then returns a
-  /// [S3StorageGetPropertiesResult] based on [HeadObjectOutput] returned by
-  /// [S3Client.headObject] API.
+  /// [s3.HeadObjectRequest] and send to S3 service, then returns a
+  /// [S3StorageGetPropertiesResult] based on [s3.HeadObjectOutput] returned by
+  /// [s3.S3Client.headObject] API.
   ///
   /// {@macro storage.s3_service.throw_exception_unknown_smithy_exception}
   Future<S3StorageGetPropertiesResult> getProperties({
@@ -120,7 +123,7 @@ class StorageS3Service {
 
     final keyToGetProperties = '$resolvedPrefix$key';
 
-    final request = HeadObjectRequest.build((builder) {
+    final request = s3.HeadObjectRequest.build((builder) {
       builder
         ..bucket = _defaultBucket
         ..key = keyToGetProperties;
@@ -131,7 +134,8 @@ class StorageS3Service {
         await _defaultS3Client.headObject(request),
         key: key,
       );
-    } on UnknownSmithyHttpException catch (error) {
+    } on smithy.UnknownSmithyHttpException catch (error) {
+      // S3Client.headObject may return 403 or 404 error
       throw S3StorageException.fromUnknownSmithyHttpException(error);
     }
   }
@@ -182,6 +186,107 @@ class StorageS3Service {
         expiresIn: options.expiresIn,
         serviceConfiguration: _defaultS3SignerConfiguration,
       ),
+    );
+  }
+
+  /// Takes in input from [AmplifyStorageS3Dart.remove] to compose a
+  /// [s3.DeleteObjectRequest] and send to S3 service, then returns a
+  /// [S3StorageRemoveResult] based on the `key` to be removed.
+  ///
+  /// {@macro storage.s3_service.throw_exception_unknown_smithy_exception}
+  Future<S3StorageRemoveResult> remove({
+    required String key,
+    required S3StorageRemoveOptions options,
+  }) async {
+    final resolvedPrefix = await _getResolvedPrefix(
+      storageAccessLevel: options.storageAccessLevel,
+    );
+
+    final keyToRemove = '$resolvedPrefix$key';
+
+    final request = s3.DeleteObjectRequest.build((builder) {
+      builder
+        ..bucket = _defaultBucket
+        ..key = keyToRemove;
+    });
+
+    try {
+      // The current capability of the `remove` API doesn't require parsing
+      // the [DeleteObjectOutput] returned by [S3Client.deleteObject].
+      await _defaultS3Client.deleteObject(request);
+      return S3StorageRemoveResult(
+        removedItem: S3StorageItem(key: key),
+      );
+    } on smithy.UnknownSmithyHttpException catch (error) {
+      // S3Client.deleteObject may return 403, for deleting a non-existing
+      // object, the API call returns a successful response
+      throw S3StorageException.fromUnknownSmithyHttpException(error);
+    }
+  }
+
+  /// Takes in input from [AmplifyStorageS3Dart.removeMany] to compose a
+  /// [s3.DeleteObjectsRequest] and send to S3 service, then returns a
+  /// [S3StorageRemoveManyResult] based on the [s3.DeleteObjectsOutput] returned
+  /// by [s3.S3Client.deleteObjects] API.
+  ///
+  /// {@macro storage.s3_service.throw_exception_unknown_smithy_exception}
+  Future<S3StorageRemoveManyResult> removeMany({
+    required List<String> keys,
+    required S3StorageRemoveManyOptions options,
+  }) async {
+    // Each request can contain up to 1000 objects to remove
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
+    const defaultBatchSize = 1000;
+    final resolvedPrefix = await _getResolvedPrefix(
+      storageAccessLevel: options.storageAccessLevel,
+    );
+
+    final objectIdentifiersToRemove = keys
+        .map((key) => s3.ObjectIdentifier(key: '$resolvedPrefix$key'))
+        .toList();
+
+    final removedItems = <S3StorageItem>[];
+    final removedErrors = <s3.Error>[];
+
+    while (objectIdentifiersToRemove.isNotEmpty) {
+      final numOfBatchedItems =
+          min(defaultBatchSize, objectIdentifiersToRemove.length);
+      final bachedObjectIdentifiers = objectIdentifiersToRemove.sublist(
+        0,
+        numOfBatchedItems,
+      );
+      final request = s3.DeleteObjectsRequest.build((builder) {
+        builder
+          ..bucket = _defaultBucket
+          // force to use sha256 instead of md5
+          ..checksumAlgorithm = s3.ChecksumAlgorithm.sha256
+          ..delete = s3.Delete.build((builder) {
+            builder.objects.addAll(bachedObjectIdentifiers);
+          }).toBuilder();
+      });
+      try {
+        final output = await _defaultS3Client.deleteObjects(request);
+        removedItems.addAll(
+          output.deleted?.toList().map(
+                    (removedObject) => S3StorageItem.fromS3Object(
+                      s3.S3Object(key: removedObject.key),
+                      prefixToDrop: resolvedPrefix,
+                    ),
+                  ) ??
+              [],
+        );
+        removedErrors.addAll(output.errors?.toList() ?? []);
+      } on smithy.UnknownSmithyHttpException catch (error) {
+        // S3Client.deleteObjects may return 403
+        throw S3StorageException.fromUnknownSmithyHttpException(error);
+      } finally {
+        objectIdentifiersToRemove.removeRange(0, numOfBatchedItems);
+      }
+    }
+
+    return S3StorageRemoveManyResult(
+      removedItems: removedItems,
+      removeErrors: removedErrors,
     );
   }
 

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -148,7 +148,7 @@ void main() {
       });
 
       test(
-          'should forward default StorageS3Options with default StorageAccessLevel to StorageS3Service.list() API',
+          'should forward options with default StorageAccessLevel to to StorageS3Service.list() API',
           () {
         const testRequest =
             StorageListRequest<S3StorageListOptions>(path: testPath);
@@ -171,10 +171,13 @@ void main() {
           ),
         ).captured.last;
 
-        expect(capturedOptions is S3StorageListOptions, isTrue);
         expect(
-          (capturedOptions as S3StorageListOptions).storageAccessLevel,
-          testDefaultStorageAccessLevel,
+          capturedOptions,
+          isA<S3StorageListOptions>().having(
+            (o) => o.storageAccessLevel,
+            'storageAccessLevel',
+            testDefaultStorageAccessLevel,
+          ),
         );
       });
     });
@@ -225,10 +228,13 @@ void main() {
           ),
         ).captured.last;
 
-        expect(capturedOptions is S3StorageGetPropertiesOptions, isTrue);
         expect(
-          (capturedOptions as S3StorageGetPropertiesOptions).storageAccessLevel,
-          testDefaultStorageAccessLevel,
+          capturedOptions,
+          isA<S3StorageGetPropertiesOptions>().having(
+            (o) => o.storageAccessLevel,
+            'storageAccessLevel',
+            testDefaultStorageAccessLevel,
+          ),
         );
       });
     });
@@ -270,14 +276,115 @@ void main() {
           ),
         ).captured.last;
 
-        expect(capturedOptions is S3StorageGetUrlOptions, isTrue);
         expect(
-          (capturedOptions as S3StorageGetUrlOptions).storageAccessLevel,
-          testDefaultStorageAccessLevel,
+          capturedOptions,
+          isA<S3StorageGetUrlOptions>().having(
+            (o) => o.storageAccessLevel,
+            'storageAccessLevel',
+            testDefaultStorageAccessLevel,
+          ),
         );
 
         final result = await getUrlOperation.result;
         expect(result.url, testResult.url);
+      });
+    });
+
+    group('remove() API', () {
+      const testKey = 'object-to-remove';
+      final testResult = S3StorageRemoveResult(
+        removedItem: S3StorageItem(
+          key: testKey,
+        ),
+      );
+
+      setUpAll(() {
+        registerFallbackValue(const S3StorageRemoveOptions());
+      });
+
+      test(
+          'should forward options with default StorageAccessLevel StorageS3Service.remove() API',
+          () async {
+        const testRequest = StorageRemoveRequest(key: testKey);
+
+        when(
+          () => storageS3Service.remove(
+            key: testKey,
+            options: any(named: 'options'),
+          ),
+        ).thenAnswer((_) async => testResult);
+
+        final removeOperation = storageS3Plugin.remove(request: testRequest);
+
+        final capturedOptions = verify(
+          () => storageS3Service.remove(
+            key: testKey,
+            options: captureAny<S3StorageRemoveOptions>(named: 'options'),
+          ),
+        ).captured.last;
+
+        expect(
+          capturedOptions,
+          isA<S3StorageRemoveOptions>().having(
+            (o) => o.storageAccessLevel,
+            'storageAccessLevel',
+            testDefaultStorageAccessLevel,
+          ),
+        );
+
+        final result = await removeOperation.result;
+        expect(result, testResult);
+      });
+    });
+
+    group('removeMany() API', () {
+      final testKeys = List.generate(
+        20,
+        (index) => 'object-to-remove-${index + 1}',
+      );
+      final resultRemoveItems =
+          testKeys.map((key) => S3StorageItem(key: key)).toList();
+      final testResult = S3StorageRemoveManyResult(
+        removedItems: resultRemoveItems,
+      );
+
+      setUpAll(() {
+        registerFallbackValue(const S3StorageRemoveManyOptions());
+      });
+
+      test(
+          'should forward options with default StorageAccessLevel StorageS3Service.removeMany() API',
+          () async {
+        final testRequest = StorageRemoveManyRequest(keys: testKeys);
+
+        when(
+          () => storageS3Service.removeMany(
+            keys: testKeys,
+            options: any(named: 'options'),
+          ),
+        ).thenAnswer((_) async => testResult);
+
+        final removeManyOperation =
+            storageS3Plugin.removeMany(request: testRequest);
+
+        final capturedOptions = verify(
+          () => storageS3Service.removeMany(
+            keys: testKeys,
+            options: captureAny(named: 'options'),
+          ),
+        ).captured.last;
+
+        expect(
+          capturedOptions,
+          isA<S3StorageRemoveManyOptions>().having(
+            (o) => o.storageAccessLevel,
+            'storageAccessLevel',
+            testDefaultStorageAccessLevel,
+          ),
+        );
+
+        final result = await removeManyOperation.result;
+        expect(result.removedItems, resultRemoveItems);
       });
     });
   });

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -144,7 +144,7 @@ void main() {
       );
 
       setUpAll(() {
-        registerFallbackValue(S3StorageListOptions());
+        registerFallbackValue(const S3StorageListOptions());
       });
 
       test(
@@ -195,7 +195,7 @@ void main() {
       );
 
       setUpAll(() {
-        registerFallbackValue(S3StorageGetPropertiesOptions());
+        registerFallbackValue(const S3StorageGetPropertiesOptions());
       });
 
       test(
@@ -244,7 +244,7 @@ void main() {
       );
 
       setUpAll(() {
-        registerFallbackValue(S3StorageGetUrlOptions());
+        registerFallbackValue(const S3StorageGetUrlOptions());
       });
 
       test(

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service.dart/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service.dart/storage_s3_service_test.dart
@@ -23,6 +23,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:smithy/smithy.dart';
 import 'package:test/test.dart';
 
+import '../utils/custom_matchers.dart';
 import '../utils/mocks.dart';
 import '../utils/test_token_provider.dart';
 
@@ -202,12 +203,13 @@ void main() {
           ),
         ).thenThrow(testUnknownException);
 
-        try {
-          await storageS3Service.list(path: 'a path', options: testOptions);
-          fail('Expected exception wasn\'t thrown.');
-        } on Object catch (error) {
-          expect(error is S3StorageException, isTrue);
-        }
+        expect(
+          storageS3Service.list(
+            path: 'a path',
+            options: testOptions,
+          ),
+          throwsA(isA<S3StorageException>()),
+        );
       });
     });
 
@@ -298,14 +300,13 @@ void main() {
           ),
         ).thenThrow(testUnknownException);
 
-        try {
-          await storageS3Service.getProperties(
+        expect(
+          storageS3Service.getProperties(
             key: 'a key',
             options: testOptions,
-          );
-        } on Object catch (error) {
-          expect(error is S3StorageException, isTrue);
-        }
+          ),
+          throwsA(isA<S3StorageException>()),
+        );
       });
     });
 
@@ -422,6 +423,7 @@ void main() {
             key: testKey,
             options: testOptions,
           );
+          fail('Expected exception wasn\'t thrown.');
         } on Object catch (error) {
           expect(error is S3StorageException, isTrue);
         }
@@ -464,6 +466,7 @@ void main() {
             key: testKey,
             options: testOptions,
           );
+          fail('Expected exception wasn\'t thrown.');
         } on Object catch (error) {
           expect(error is S3StorageException, isTrue);
         }
@@ -479,6 +482,230 @@ void main() {
           '${await testPrefixResolver.resolvePrefix(
             storageAccessLevel: testOptions.storageAccessLevel,
           )}$testKey',
+        );
+      });
+    });
+
+    group('remove() API', () {
+      late S3StorageRemoveResult removeResult;
+      const testKey = 'object-to-remove';
+
+      setUpAll(() {
+        registerFallbackValue(
+          DeleteObjectRequest(
+            bucket: 'fake bucket',
+            key: 'dummy key',
+          ),
+        );
+      });
+
+      test('should invoke S3Client.deleteObject with expected parameters',
+          () async {
+        const testOptions = S3StorageRemoveOptions(
+          storageAccessLevel: StorageAccessLevel.private,
+        );
+        final testDeleteObjectOutput = DeleteObjectOutput();
+
+        when(
+          () => s3Client.deleteObject(any()),
+        ).thenAnswer((_) async => testDeleteObjectOutput);
+
+        removeResult = await storageS3Service.remove(
+          key: testKey,
+          options: testOptions,
+        );
+
+        final capturedRequest = verify(
+          () => s3Client.deleteObject(
+            captureAny<DeleteObjectRequest>(),
+          ),
+        ).captured.last;
+        expect(capturedRequest is DeleteObjectRequest, isTrue);
+
+        final request = capturedRequest as DeleteObjectRequest;
+        expect(request.bucket, testBucket);
+        expect(
+          request.key,
+          '${await testPrefixResolver.resolvePrefix(
+            storageAccessLevel: testOptions.storageAccessLevel,
+          )}$testKey',
+        );
+      });
+
+      test('should return correct S3StorageRemoveResult', () {
+        expect(removeResult.removedItem.key, testKey);
+      });
+
+      test(
+          'should throw S3StorageException when UnknownSmithHttpException is returned from service',
+          () async {
+        const testOptions = S3StorageRemoveOptions();
+        const testUnknownException = UnknownSmithyHttpException(
+          statusCode: 403,
+          body: 'Access denied.',
+        );
+
+        when(
+          () => s3Client.deleteObject(any()),
+        ).thenThrow(testUnknownException);
+
+        expect(
+          storageS3Service.remove(
+            key: 'a key',
+            options: testOptions,
+          ),
+          throwsA(isA<S3StorageException>()),
+        );
+      });
+    });
+
+    group('removeMany() API', () {
+      late S3StorageRemoveManyResult removeManyResult;
+      const testNumOfRemovedItems = 955;
+      const testNumOfRemoveErrors = 50;
+      final testKeys = List.generate(
+        1005,
+        (index) => 'object-to-remove-${index + 1}',
+      ).toList();
+
+      setUpAll(() {
+        registerFallbackValue(
+          DeleteObjectsRequest(
+            bucket: 'fake bucket',
+            delete: Delete(objects: BuiltList(<ObjectIdentifier>[])),
+          ),
+        );
+      });
+
+      test('should invoke S3Client.deleteObjects with expected parameters',
+          () async {
+        const testOptions = S3StorageRemoveManyOptions(
+          storageAccessLevel: StorageAccessLevel.protected,
+        );
+        final testPrefix =
+            '${testOptions.storageAccessLevel.defaultPrefix}$testDelimiter';
+        final testDeleteObjectsOutput1 = DeleteObjectsOutput(
+          deleted: BuiltList(
+            testKeys
+                .take(1000 - testNumOfRemoveErrors)
+                .map((key) => DeletedObject(key: '$testPrefix$key')),
+          ),
+          errors: BuiltList(
+            testKeys
+                .skip(1000 - testNumOfRemoveErrors)
+                .take(testNumOfRemoveErrors)
+                .map(
+                  (key) => Error(
+                    key: '$testPrefix$key',
+                    message: 'some error',
+                  ),
+                ),
+          ),
+        );
+        final testDeleteObjectsOutput2 = DeleteObjectsOutput(
+          deleted: BuiltList(
+            testKeys
+                .skip(1000)
+                .take(5)
+                .map((key) => DeletedObject(key: '$testPrefix$key')),
+          ),
+        );
+
+        // response to the first 1000 delete objects request
+        when(
+          () => s3Client.deleteObjects(
+            any(that: DeleteObjectsLength(equals(1000))),
+          ),
+        ).thenAnswer((_) async => testDeleteObjectsOutput1);
+
+        // response to the remaining delete objects request
+        when(
+          () => s3Client.deleteObjects(
+            any(that: DeleteObjectsLength(equals(5))),
+          ),
+        ).thenAnswer((_) async => testDeleteObjectsOutput2);
+
+        removeManyResult = await storageS3Service.removeMany(
+          keys: testKeys,
+          options: testOptions,
+        );
+
+        final capturedRequests = verify(
+          () => s3Client.deleteObjects(captureAny<DeleteObjectsRequest>()),
+        ).captured;
+
+        // 1005 objects to remove therefore should send 2 requests for
+        // 2 batches
+        expect(capturedRequests, hasLength(2));
+
+        final capturedRequest1 = capturedRequests.first;
+        final capturedRequest2 = capturedRequests.last;
+
+        expect(capturedRequest1 is DeleteObjectsRequest, isTrue);
+        expect(capturedRequest2 is DeleteObjectsRequest, isTrue);
+
+        final request1 = capturedRequest1 as DeleteObjectsRequest;
+        final request2 = capturedRequest2 as DeleteObjectsRequest;
+
+        final expectedKeysForRequest1 = await Future.wait(
+          testKeys.take(1000).map(
+                (key) async => '${await testPrefixResolver.resolvePrefix(
+                  storageAccessLevel: testOptions.storageAccessLevel,
+                )}$key',
+              ),
+        );
+        final expectedKeysForRequest2 = await Future.wait(
+          testKeys.skip(1000).map(
+                (key) async => '${await testPrefixResolver.resolvePrefix(
+                  storageAccessLevel: testOptions.storageAccessLevel,
+                )}$key',
+              ),
+        );
+
+        expect(
+          request1.delete.objects.map((object) => object.key),
+          containsAllInOrder(expectedKeysForRequest1),
+        );
+
+        expect(
+          request2.delete.objects.map((object) => object.key),
+          containsAllInOrder(expectedKeysForRequest2),
+        );
+      });
+
+      test('should return correct S3StorageRemoveManyResult', () {
+        final removedItems = removeManyResult.removedItems;
+        final removeErrors = removeManyResult.removeErrors;
+
+        expect(removedItems, hasLength(testNumOfRemovedItems));
+        expect(removeErrors, hasLength(testNumOfRemoveErrors));
+
+        removedItems.asMap().forEach((index, item) {
+          final lookupIndex =
+              index < 950 ? index : index + testNumOfRemoveErrors;
+          expect(item.key, testKeys[lookupIndex]);
+        });
+      });
+
+      test(
+          'should throw S3StorageException when UnknownSmithHttpException is returned from service',
+          () async {
+        const testOptions = S3StorageRemoveManyOptions();
+        const testUnknownException = UnknownSmithyHttpException(
+          statusCode: 403,
+          body: 'Access denied.',
+        );
+
+        when(
+          () => s3Client.deleteObjects(any()),
+        ).thenThrow(testUnknownException);
+
+        expect(
+          storageS3Service.removeMany(
+            keys: testKeys,
+            options: testOptions,
+          ),
+          throwsA(isA<S3StorageException>()),
         );
       });
     });

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service.dart/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service.dart/storage_s3_service_test.dart
@@ -74,7 +74,7 @@ void main() {
       test(
           'should throw a StorageS3Exception if supplied prefix resolver throws an exception',
           () async {
-        final testOptions =
+        const testOptions =
             S3StorageListOptions.forIdentity('throw exception for me');
 
         try {
@@ -114,7 +114,7 @@ void main() {
         );
         const testPath = 'album';
         const testTargetIdentityId = 'someone-else-id';
-        final testOptions = S3StorageListOptions.forIdentity(
+        const testOptions = S3StorageListOptions.forIdentity(
           testTargetIdentityId,
           pageSize: testPageSize,
         );
@@ -190,7 +190,7 @@ void main() {
       test(
           'should throw S3StorageException when UnknownSmithHttpException is returned from service',
           () async {
-        final testOptions = S3StorageListOptions();
+        const testOptions = S3StorageListOptions();
         const testUnknownException = UnknownSmithyHttpException(
           statusCode: 403,
           body: 'some exception',
@@ -234,7 +234,7 @@ void main() {
       test('should invoke S3Client.headObject with expected parameters',
           () async {
         const testTargetIdentityId = 'someone-else-id';
-        final testOptions = S3StorageGetPropertiesOptions.forIdentity(
+        const testOptions = S3StorageGetPropertiesOptions.forIdentity(
           testTargetIdentityId,
         );
         final testHeadObjectOutput = HeadObjectOutput(
@@ -286,7 +286,7 @@ void main() {
       test(
           'should throw S3StorageException when UnknownSmithHttpException is returned from service',
           () async {
-        final testOptions = S3StorageGetPropertiesOptions();
+        const testOptions = S3StorageGetPropertiesOptions();
         const testUnknownException = UnknownSmithyHttpException(
           statusCode: 404,
           body: 'Nod found.',
@@ -339,7 +339,7 @@ void main() {
       test('should invoke AWSSigV4Signer.presign with correct parameters',
           () async {
         const testTargetIdentityId = 'someone-else-id';
-        final testOptions = S3StorageGetUrlOptions.forIdentity(
+        const testOptions = S3StorageGetUrlOptions.forIdentity(
           testTargetIdentityId,
           expiresIn: testExpiresIn,
         );
@@ -402,7 +402,7 @@ void main() {
       test(
           'should invoke s3Client.headObject when checkObjectExistence option is set to true',
           () async {
-        final testOptions = S3StorageGetUrlOptions(
+        const testOptions = S3StorageGetUrlOptions(
           storageAccessLevel: StorageAccessLevel.private,
           checkObjectExistence: true,
         );
@@ -444,7 +444,7 @@ void main() {
           'should invoke s3Client.headObject when checkObjectExistence option is set to true and specified targetIdentityId',
           () async {
         const testTargetIdentityId = 'some-else-id';
-        final testOptions = S3StorageGetUrlOptions.forIdentity(
+        const testOptions = S3StorageGetUrlOptions.forIdentity(
           testTargetIdentityId,
           checkObjectExistence: true,
         );

--- a/packages/storage/amplify_storage_s3_dart/test/utils/custom_matchers.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/utils/custom_matchers.dart
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
+import 'package:test/test.dart';
 
-/// {@template amplify_core.storage.remove_many_result}
-/// Presents the result of a [StorageRemoveManyOperation].
-/// {@endtemplate}
-class StorageRemoveManyResult<Item extends StorageItem> {
-  /// {@macro amplify_core.storage.remove_many_result}
-  const StorageRemoveManyResult({
-    required this.removedItems,
-  });
+class DeleteObjectsLength extends CustomMatcher {
+  DeleteObjectsLength(Matcher matcher)
+      : super(
+          'DeleteObjectsRequest that is',
+          'delete objects length',
+          matcher,
+        );
 
-  /// The removed objects of the [StorageRemoveManyOperation].
-  final List<Item> removedItems;
+  @override
+  Object? featureValueOf(dynamic actual) =>
+      (actual as DeleteObjectsRequest).delete.objects.length;
 }

--- a/packages/storage/amplify_storage_s3_dart/test/utils/mocks.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/utils/mocks.dart
@@ -1,3 +1,17 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Implemented `remove` and `removeMany` APIs
2. Added relevant unit tests
3. Added `remove` API usage example in `example.dart` (remove any will be added later when `S3Client.deleteObjects` issue gets resolved)
4. Fixes and adjustments here and there

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
