### PR TITLE
chore: fix android canary test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ orbs:
         executor:
           name: android/android-machine
           resource-class: large
-          tag: 2021.10.1
+          tag: 2022.07.1
         working_directory: ~/flutter-canaries/amplified_todo
         steps:
           - checkout:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Here is the error from the log
A problem occurred evaluating project ':app'.
> Failed to apply plugin 'com.android.internal.version-check'.
   > Minimum supported Gradle version is 7.3.3. Current version is 7.2. If using the gradle wrapper, try editing the distributionUrl in /home/circleci/flutter-canaries/amplified_todo/android/gradle/wrapper/gradle-wrapper.properties to gradle-7.3.3-all.zip

Upgrading to a newer android executor to use newer version of gradle to fix the problem 

Spec for this version: https://discuss.circleci.com/t/android-machine-executor-images-2022-july-update/44874

Tested in personal circleci project: https://app.circleci.com/pipelines/github/yeung-wah/amplify-flutter/598/workflows/3e939579-1de3-4ae7-bb36-e7f993c4e3b9
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
