### PR TITLE
fix(storage): add missing expiresAt of S3StorageGetUrlResult

### DIFF
--- a/packages/amplify_core/lib/src/types/storage/get_properties_result.dart
+++ b/packages/amplify_core/lib/src/types/storage/get_properties_result.dart
@@ -24,6 +24,6 @@ class StorageGetPropertiesResult<Item extends StorageItem> {
   });
 
   /// The result object containing the properties retrieved from the
-  /// [StorageCopyOperation].
+  /// [StorageGetPropertiesOperation].
   final Item storageItem;
 }

--- a/packages/amplify_core/lib/src/types/storage/list_operation.dart
+++ b/packages/amplify_core/lib/src/types/storage/list_operation.dart
@@ -19,8 +19,8 @@ import 'base/storage_operation.dart';
 /// Presents a storage list operation.
 /// {@endtemplate}
 class StorageListOperation<Request extends StorageListRequest,
-        Response extends StorageListResult>
-    extends StorageOperation<Request, Response> {
+        Result extends StorageListResult>
+    extends StorageOperation<Request, Result> {
   /// {@macro amplify_core.storage.list_operation}
   StorageListOperation({
     required super.request,

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_get_properties_result.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_get_properties_result.dart
@@ -15,12 +15,12 @@
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 
-/// {@template storage.amplify_storage_s3.list_result}
+/// {@template storage.amplify_storage_s3.get_properties_result}
 /// The result returned by Storage S3 plugin `getProperties` API.
 /// {@endtemplate}
 class S3StorageGetPropertiesResult
     extends StorageGetPropertiesResult<S3StorageItem> {
-  /// {@macro storage.amplify_storage_s3.list_result}
+  /// {@macro storage.amplify_storage_s3.get_properties_result}
   const S3StorageGetPropertiesResult({
     required super.storageItem,
   });

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_get_url_result.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_storage_get_url_result.dart
@@ -17,4 +17,13 @@ import 'package:amplify_core/amplify_core.dart';
 /// {@template storage.amplify_storage_s3.get_url_result}
 /// The result returned by Storage S3 plugin `getUrl` API.
 /// {@endtemplate}
-typedef S3StorageGetUrlResult = StorageGetUrlResult;
+class S3StorageGetUrlResult extends StorageGetUrlResult {
+  /// {@macro storage.amplify_storage_s3.get_url_result}
+  const S3StorageGetUrlResult({
+    required super.url,
+    this.expiresAt,
+  });
+
+  /// The date and time that the url expires at.
+  final DateTime? expiresAt;
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
 import 'dart:math';
 
 import 'package:amplify_core/amplify_core.dart' hide PaginatedResult;
@@ -23,6 +24,10 @@ import 'package:aws_signature_v4/aws_signature_v4.dart';
 import 'package:meta/meta.dart';
 import 'package:smithy/smithy.dart' as smithy;
 import 'package:smithy_aws/smithy_aws.dart';
+
+/// Zone value symbol for testing.
+@visibleForTesting
+const testDateTimeNowOverride = #_testDateTimeNowOverride;
 
 /// {@template amplify_storage_s3.storage_s3_service}
 /// This is a wrapper implementation over Smithy S3Client as a glue layer
@@ -180,6 +185,9 @@ class StorageS3Service {
         expiresIn: options.expiresIn,
         serviceConfiguration: _defaultS3SignerConfiguration,
       ),
+      expiresAt:
+          (Zone.current[testDateTimeNowOverride] as DateTime? ?? DateTime.now())
+              .add(options.expiresIn),
     );
   }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Fixed typos in the codebase
2. Added missed `expiresAt` field to `S3StorageGetUrlResult`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
