### PR TITLE
feat(smithy)!: Remove built types from factory constructors

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -54,7 +54,6 @@ import 'package:amplify_auth_cognito_dart/src/sdk/sdk_bridge.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
@@ -766,7 +765,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
       cognito.GetUserAttributeVerificationCodeRequest(
         accessToken: userPoolTokens.accessToken.raw,
         attributeName: request.userAttributeKey.key,
-        clientMetadata: BuiltMap(options?.clientMetadata ?? const {}),
+        clientMetadata: options?.clientMetadata,
       ),
     );
     final codeDeliveryDetails =

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity/model/get_credentials_for_identity_input.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity/model/get_credentials_for_identity_input.dart
@@ -36,12 +36,12 @@ abstract class GetCredentialsForIdentityInput
   factory GetCredentialsForIdentityInput({
     String? customRoleArn,
     required String identityId,
-    _i3.BuiltMap<String, String>? logins,
+    Map<String, String>? logins,
   }) {
     return _$GetCredentialsForIdentityInput._(
       customRoleArn: customRoleArn,
       identityId: identityId,
-      logins: logins,
+      logins: logins == null ? null : _i3.BuiltMap(logins),
     );
   }
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity/model/get_id_input.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity/model/get_id_input.dart
@@ -32,12 +32,12 @@ abstract class GetIdInput
   factory GetIdInput({
     String? accountId,
     required String identityPoolId,
-    _i3.BuiltMap<String, String>? logins,
+    Map<String, String>? logins,
   }) {
     return _$GetIdInput._(
       accountId: accountId,
       identityPoolId: identityPoolId,
-      logins: logins,
+      logins: logins == null ? null : _i3.BuiltMap(logins),
     );
   }
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/confirm_forgot_password_request.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/confirm_forgot_password_request.dart
@@ -19,9 +19,9 @@ library amplify_auth_cognito_dart.cognito_identity_provider.model.confirm_forgot
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/analytics_metadata_type.dart'
     as _i3;
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/user_context_data_type.dart'
-    as _i5;
+    as _i4;
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i4;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i1;
@@ -40,17 +40,18 @@ abstract class ConfirmForgotPasswordRequest
   factory ConfirmForgotPasswordRequest({
     _i3.AnalyticsMetadataType? analyticsMetadata,
     required String clientId,
-    _i4.BuiltMap<String, String>? clientMetadata,
+    Map<String, String>? clientMetadata,
     required String confirmationCode,
     required String password,
     String? secretHash,
-    _i5.UserContextDataType? userContextData,
+    _i4.UserContextDataType? userContextData,
     required String username,
   }) {
     return _$ConfirmForgotPasswordRequest._(
       analyticsMetadata: analyticsMetadata,
       clientId: clientId,
-      clientMetadata: clientMetadata,
+      clientMetadata:
+          clientMetadata == null ? null : _i5.BuiltMap(clientMetadata),
       confirmationCode: confirmationCode,
       password: password,
       secretHash: secretHash,
@@ -99,7 +100,7 @@ abstract class ConfirmForgotPasswordRequest
   /// *   Validate the ClientMetadata value.
   ///
   /// *   Encrypt the ClientMetadata value. Don't use Amazon Cognito to provide sensitive information.
-  _i4.BuiltMap<String, String>? get clientMetadata;
+  _i5.BuiltMap<String, String>? get clientMetadata;
 
   /// The confirmation code from your user's request to reset their password. For more information, see [ForgotPassword](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ForgotPassword.html).
   String get confirmationCode;
@@ -111,7 +112,7 @@ abstract class ConfirmForgotPasswordRequest
   String? get secretHash;
 
   /// Contextual data about your user session, such as the device fingerprint, IP address, or location. Amazon Cognito advanced security evaluates the risk of an authentication event based on the context that your app generates and passes to Amazon Cognito when it makes API requests.
-  _i5.UserContextDataType? get userContextData;
+  _i4.UserContextDataType? get userContextData;
 
   /// The user name of the user for whom you want to enter a code to retrieve a forgotten password.
   String get username;
@@ -216,13 +217,13 @@ class ConfirmForgotPasswordRequestAwsJson11Serializer
             result.clientMetadata.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i4.BuiltMap,
+                _i5.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i4.BuiltMap<String, String>));
+            ) as _i5.BuiltMap<String, String>));
           }
           break;
         case 'ConfirmationCode':
@@ -249,8 +250,8 @@ class ConfirmForgotPasswordRequestAwsJson11Serializer
           if (value != null) {
             result.userContextData.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.UserContextDataType),
-            ) as _i5.UserContextDataType));
+              specifiedType: const FullType(_i4.UserContextDataType),
+            ) as _i4.UserContextDataType));
           }
           break;
         case 'Username':
@@ -308,7 +309,7 @@ class ConfirmForgotPasswordRequestAwsJson11Serializer
         ..add(serializers.serialize(
           payload.clientMetadata!,
           specifiedType: const FullType(
-            _i4.BuiltMap,
+            _i5.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -329,7 +330,7 @@ class ConfirmForgotPasswordRequestAwsJson11Serializer
         ..add('UserContextData')
         ..add(serializers.serialize(
           payload.userContextData!,
-          specifiedType: const FullType(_i5.UserContextDataType),
+          specifiedType: const FullType(_i4.UserContextDataType),
         ));
     }
     return result;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/confirm_forgot_password_request.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/confirm_forgot_password_request.g.dart
@@ -12,7 +12,7 @@ class _$ConfirmForgotPasswordRequest extends ConfirmForgotPasswordRequest {
   @override
   final String clientId;
   @override
-  final _i4.BuiltMap<String, String>? clientMetadata;
+  final _i5.BuiltMap<String, String>? clientMetadata;
   @override
   final String confirmationCode;
   @override
@@ -20,7 +20,7 @@ class _$ConfirmForgotPasswordRequest extends ConfirmForgotPasswordRequest {
   @override
   final String? secretHash;
   @override
-  final _i5.UserContextDataType? userContextData;
+  final _i4.UserContextDataType? userContextData;
   @override
   final String username;
 
@@ -106,10 +106,10 @@ class ConfirmForgotPasswordRequestBuilder
   String? get clientId => _$this._clientId;
   set clientId(String? clientId) => _$this._clientId = clientId;
 
-  _i4.MapBuilder<String, String>? _clientMetadata;
-  _i4.MapBuilder<String, String> get clientMetadata =>
-      _$this._clientMetadata ??= new _i4.MapBuilder<String, String>();
-  set clientMetadata(_i4.MapBuilder<String, String>? clientMetadata) =>
+  _i5.MapBuilder<String, String>? _clientMetadata;
+  _i5.MapBuilder<String, String> get clientMetadata =>
+      _$this._clientMetadata ??= new _i5.MapBuilder<String, String>();
+  set clientMetadata(_i5.MapBuilder<String, String>? clientMetadata) =>
       _$this._clientMetadata = clientMetadata;
 
   String? _confirmationCode;
@@ -125,10 +125,10 @@ class ConfirmForgotPasswordRequestBuilder
   String? get secretHash => _$this._secretHash;
   set secretHash(String? secretHash) => _$this._secretHash = secretHash;
 
-  _i5.UserContextDataTypeBuilder? _userContextData;
-  _i5.UserContextDataTypeBuilder get userContextData =>
-      _$this._userContextData ??= new _i5.UserContextDataTypeBuilder();
-  set userContextData(_i5.UserContextDataTypeBuilder? userContextData) =>
+  _i4.UserContextDataTypeBuilder? _userContextData;
+  _i4.UserContextDataTypeBuilder get userContextData =>
+      _$this._userContextData ??= new _i4.UserContextDataTypeBuilder();
+  set userContextData(_i4.UserContextDataTypeBuilder? userContextData) =>
       _$this._userContextData = userContextData;
 
   String? _username;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/confirm_sign_up_request.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/confirm_sign_up_request.dart
@@ -19,9 +19,9 @@ library amplify_auth_cognito_dart.cognito_identity_provider.model.confirm_sign_u
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/analytics_metadata_type.dart'
     as _i3;
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/user_context_data_type.dart'
-    as _i5;
+    as _i4;
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i4;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i1;
@@ -38,17 +38,18 @@ abstract class ConfirmSignUpRequest
   factory ConfirmSignUpRequest({
     _i3.AnalyticsMetadataType? analyticsMetadata,
     required String clientId,
-    _i4.BuiltMap<String, String>? clientMetadata,
+    Map<String, String>? clientMetadata,
     required String confirmationCode,
     bool? forceAliasCreation,
     String? secretHash,
-    _i5.UserContextDataType? userContextData,
+    _i4.UserContextDataType? userContextData,
     required String username,
   }) {
     return _$ConfirmSignUpRequest._(
       analyticsMetadata: analyticsMetadata,
       clientId: clientId,
-      clientMetadata: clientMetadata,
+      clientMetadata:
+          clientMetadata == null ? null : _i5.BuiltMap(clientMetadata),
       confirmationCode: confirmationCode,
       forceAliasCreation: forceAliasCreation,
       secretHash: secretHash,
@@ -97,7 +98,7 @@ abstract class ConfirmSignUpRequest
   /// *   Validate the ClientMetadata value.
   ///
   /// *   Encrypt the ClientMetadata value. Don't use Amazon Cognito to provide sensitive information.
-  _i4.BuiltMap<String, String>? get clientMetadata;
+  _i5.BuiltMap<String, String>? get clientMetadata;
 
   /// The confirmation code sent by a user's request to confirm registration.
   String get confirmationCode;
@@ -109,7 +110,7 @@ abstract class ConfirmSignUpRequest
   String? get secretHash;
 
   /// Contextual data about your user session, such as the device fingerprint, IP address, or location. Amazon Cognito advanced security evaluates the risk of an authentication event based on the context that your app generates and passes to Amazon Cognito when it makes API requests.
-  _i5.UserContextDataType? get userContextData;
+  _i4.UserContextDataType? get userContextData;
 
   /// The user name of the user whose registration you want to confirm.
   String get username;
@@ -214,13 +215,13 @@ class ConfirmSignUpRequestAwsJson11Serializer
             result.clientMetadata.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i4.BuiltMap,
+                _i5.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i4.BuiltMap<String, String>));
+            ) as _i5.BuiltMap<String, String>));
           }
           break;
         case 'ConfirmationCode':
@@ -249,8 +250,8 @@ class ConfirmSignUpRequestAwsJson11Serializer
           if (value != null) {
             result.userContextData.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.UserContextDataType),
-            ) as _i5.UserContextDataType));
+              specifiedType: const FullType(_i4.UserContextDataType),
+            ) as _i4.UserContextDataType));
           }
           break;
         case 'Username':
@@ -303,7 +304,7 @@ class ConfirmSignUpRequestAwsJson11Serializer
         ..add(serializers.serialize(
           payload.clientMetadata!,
           specifiedType: const FullType(
-            _i4.BuiltMap,
+            _i5.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -332,7 +333,7 @@ class ConfirmSignUpRequestAwsJson11Serializer
         ..add('UserContextData')
         ..add(serializers.serialize(
           payload.userContextData!,
-          specifiedType: const FullType(_i5.UserContextDataType),
+          specifiedType: const FullType(_i4.UserContextDataType),
         ));
     }
     return result;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/confirm_sign_up_request.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/confirm_sign_up_request.g.dart
@@ -12,7 +12,7 @@ class _$ConfirmSignUpRequest extends ConfirmSignUpRequest {
   @override
   final String clientId;
   @override
-  final _i4.BuiltMap<String, String>? clientMetadata;
+  final _i5.BuiltMap<String, String>? clientMetadata;
   @override
   final String confirmationCode;
   @override
@@ -20,7 +20,7 @@ class _$ConfirmSignUpRequest extends ConfirmSignUpRequest {
   @override
   final String? secretHash;
   @override
-  final _i5.UserContextDataType? userContextData;
+  final _i4.UserContextDataType? userContextData;
   @override
   final String username;
 
@@ -102,10 +102,10 @@ class ConfirmSignUpRequestBuilder
   String? get clientId => _$this._clientId;
   set clientId(String? clientId) => _$this._clientId = clientId;
 
-  _i4.MapBuilder<String, String>? _clientMetadata;
-  _i4.MapBuilder<String, String> get clientMetadata =>
-      _$this._clientMetadata ??= new _i4.MapBuilder<String, String>();
-  set clientMetadata(_i4.MapBuilder<String, String>? clientMetadata) =>
+  _i5.MapBuilder<String, String>? _clientMetadata;
+  _i5.MapBuilder<String, String> get clientMetadata =>
+      _$this._clientMetadata ??= new _i5.MapBuilder<String, String>();
+  set clientMetadata(_i5.MapBuilder<String, String>? clientMetadata) =>
       _$this._clientMetadata = clientMetadata;
 
   String? _confirmationCode;
@@ -122,10 +122,10 @@ class ConfirmSignUpRequestBuilder
   String? get secretHash => _$this._secretHash;
   set secretHash(String? secretHash) => _$this._secretHash = secretHash;
 
-  _i5.UserContextDataTypeBuilder? _userContextData;
-  _i5.UserContextDataTypeBuilder get userContextData =>
-      _$this._userContextData ??= new _i5.UserContextDataTypeBuilder();
-  set userContextData(_i5.UserContextDataTypeBuilder? userContextData) =>
+  _i4.UserContextDataTypeBuilder? _userContextData;
+  _i4.UserContextDataTypeBuilder get userContextData =>
+      _$this._userContextData ??= new _i4.UserContextDataTypeBuilder();
+  set userContextData(_i4.UserContextDataTypeBuilder? userContextData) =>
       _$this._userContextData = userContextData;
 
   String? _username;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/device_type.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/device_type.dart
@@ -17,9 +17,9 @@
 library amplify_auth_cognito_dart.cognito_identity_provider.model.device_type; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/attribute_type.dart'
-    as _i3;
+    as _i2;
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i2;
+import 'package:built_collection/built_collection.dart' as _i3;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i4;
@@ -32,14 +32,15 @@ abstract class DeviceType
     implements Built<DeviceType, DeviceTypeBuilder> {
   /// The device type.
   factory DeviceType({
-    _i2.BuiltList<_i3.AttributeType>? deviceAttributes,
+    List<_i2.AttributeType>? deviceAttributes,
     DateTime? deviceCreateDate,
     String? deviceKey,
     DateTime? deviceLastAuthenticatedDate,
     DateTime? deviceLastModifiedDate,
   }) {
     return _$DeviceType._(
-      deviceAttributes: deviceAttributes,
+      deviceAttributes:
+          deviceAttributes == null ? null : _i3.BuiltList(deviceAttributes),
       deviceCreateDate: deviceCreateDate,
       deviceKey: deviceKey,
       deviceLastAuthenticatedDate: deviceLastAuthenticatedDate,
@@ -61,7 +62,7 @@ abstract class DeviceType
   static void _init(DeviceTypeBuilder b) {}
 
   /// The device attributes.
-  _i2.BuiltList<_i3.AttributeType>? get deviceAttributes;
+  _i3.BuiltList<_i2.AttributeType>? get deviceAttributes;
 
   /// The creation date of the device.
   DateTime? get deviceCreateDate;
@@ -143,10 +144,10 @@ class DeviceTypeAwsJson11Serializer
             result.deviceAttributes.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltList,
-                [FullType(_i3.AttributeType)],
+                _i3.BuiltList,
+                [FullType(_i2.AttributeType)],
               ),
-            ) as _i2.BuiltList<_i3.AttributeType>));
+            ) as _i3.BuiltList<_i2.AttributeType>));
           }
           break;
         case 'DeviceCreateDate':
@@ -201,8 +202,8 @@ class DeviceTypeAwsJson11Serializer
         ..add(serializers.serialize(
           payload.deviceAttributes!,
           specifiedType: const FullType(
-            _i2.BuiltList,
-            [FullType(_i3.AttributeType)],
+            _i3.BuiltList,
+            [FullType(_i2.AttributeType)],
           ),
         ));
     }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/device_type.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/device_type.g.dart
@@ -8,7 +8,7 @@ part of amplify_auth_cognito_dart.cognito_identity_provider.model.device_type;
 
 class _$DeviceType extends DeviceType {
   @override
-  final _i2.BuiltList<_i3.AttributeType>? deviceAttributes;
+  final _i3.BuiltList<_i2.AttributeType>? deviceAttributes;
   @override
   final DateTime? deviceCreateDate;
   @override
@@ -63,10 +63,10 @@ class _$DeviceType extends DeviceType {
 class DeviceTypeBuilder implements Builder<DeviceType, DeviceTypeBuilder> {
   _$DeviceType? _$v;
 
-  _i2.ListBuilder<_i3.AttributeType>? _deviceAttributes;
-  _i2.ListBuilder<_i3.AttributeType> get deviceAttributes =>
-      _$this._deviceAttributes ??= new _i2.ListBuilder<_i3.AttributeType>();
-  set deviceAttributes(_i2.ListBuilder<_i3.AttributeType>? deviceAttributes) =>
+  _i3.ListBuilder<_i2.AttributeType>? _deviceAttributes;
+  _i3.ListBuilder<_i2.AttributeType> get deviceAttributes =>
+      _$this._deviceAttributes ??= new _i3.ListBuilder<_i2.AttributeType>();
+  set deviceAttributes(_i3.ListBuilder<_i2.AttributeType>? deviceAttributes) =>
       _$this._deviceAttributes = deviceAttributes;
 
   DateTime? _deviceCreateDate;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/forgot_password_request.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/forgot_password_request.dart
@@ -19,9 +19,9 @@ library amplify_auth_cognito_dart.cognito_identity_provider.model.forgot_passwor
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/analytics_metadata_type.dart'
     as _i3;
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/user_context_data_type.dart'
-    as _i5;
+    as _i4;
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i4;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i1;
@@ -38,15 +38,16 @@ abstract class ForgotPasswordRequest
   factory ForgotPasswordRequest({
     _i3.AnalyticsMetadataType? analyticsMetadata,
     required String clientId,
-    _i4.BuiltMap<String, String>? clientMetadata,
+    Map<String, String>? clientMetadata,
     String? secretHash,
-    _i5.UserContextDataType? userContextData,
+    _i4.UserContextDataType? userContextData,
     required String username,
   }) {
     return _$ForgotPasswordRequest._(
       analyticsMetadata: analyticsMetadata,
       clientId: clientId,
-      clientMetadata: clientMetadata,
+      clientMetadata:
+          clientMetadata == null ? null : _i5.BuiltMap(clientMetadata),
       secretHash: secretHash,
       userContextData: userContextData,
       username: username,
@@ -93,13 +94,13 @@ abstract class ForgotPasswordRequest
   /// *   Validate the ClientMetadata value.
   ///
   /// *   Encrypt the ClientMetadata value. Don't use Amazon Cognito to provide sensitive information.
-  _i4.BuiltMap<String, String>? get clientMetadata;
+  _i5.BuiltMap<String, String>? get clientMetadata;
 
   /// A keyed-hash message authentication code (HMAC) calculated using the secret key of a user pool client and username plus the client ID in the message.
   String? get secretHash;
 
   /// Contextual data about your user session, such as the device fingerprint, IP address, or location. Amazon Cognito advanced security evaluates the risk of an authentication event based on the context that your app generates and passes to Amazon Cognito when it makes API requests.
-  _i5.UserContextDataType? get userContextData;
+  _i4.UserContextDataType? get userContextData;
 
   /// The user name of the user for whom you want to enter a code to reset a forgotten password.
   String get username;
@@ -194,13 +195,13 @@ class ForgotPasswordRequestAwsJson11Serializer
             result.clientMetadata.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i4.BuiltMap,
+                _i5.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i4.BuiltMap<String, String>));
+            ) as _i5.BuiltMap<String, String>));
           }
           break;
         case 'SecretHash':
@@ -215,8 +216,8 @@ class ForgotPasswordRequestAwsJson11Serializer
           if (value != null) {
             result.userContextData.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.UserContextDataType),
-            ) as _i5.UserContextDataType));
+              specifiedType: const FullType(_i4.UserContextDataType),
+            ) as _i4.UserContextDataType));
           }
           break;
         case 'Username':
@@ -264,7 +265,7 @@ class ForgotPasswordRequestAwsJson11Serializer
         ..add(serializers.serialize(
           payload.clientMetadata!,
           specifiedType: const FullType(
-            _i4.BuiltMap,
+            _i5.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -285,7 +286,7 @@ class ForgotPasswordRequestAwsJson11Serializer
         ..add('UserContextData')
         ..add(serializers.serialize(
           payload.userContextData!,
-          specifiedType: const FullType(_i5.UserContextDataType),
+          specifiedType: const FullType(_i4.UserContextDataType),
         ));
     }
     return result;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/forgot_password_request.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/forgot_password_request.g.dart
@@ -12,11 +12,11 @@ class _$ForgotPasswordRequest extends ForgotPasswordRequest {
   @override
   final String clientId;
   @override
-  final _i4.BuiltMap<String, String>? clientMetadata;
+  final _i5.BuiltMap<String, String>? clientMetadata;
   @override
   final String? secretHash;
   @override
-  final _i5.UserContextDataType? userContextData;
+  final _i4.UserContextDataType? userContextData;
   @override
   final String username;
 
@@ -86,20 +86,20 @@ class ForgotPasswordRequestBuilder
   String? get clientId => _$this._clientId;
   set clientId(String? clientId) => _$this._clientId = clientId;
 
-  _i4.MapBuilder<String, String>? _clientMetadata;
-  _i4.MapBuilder<String, String> get clientMetadata =>
-      _$this._clientMetadata ??= new _i4.MapBuilder<String, String>();
-  set clientMetadata(_i4.MapBuilder<String, String>? clientMetadata) =>
+  _i5.MapBuilder<String, String>? _clientMetadata;
+  _i5.MapBuilder<String, String> get clientMetadata =>
+      _$this._clientMetadata ??= new _i5.MapBuilder<String, String>();
+  set clientMetadata(_i5.MapBuilder<String, String>? clientMetadata) =>
       _$this._clientMetadata = clientMetadata;
 
   String? _secretHash;
   String? get secretHash => _$this._secretHash;
   set secretHash(String? secretHash) => _$this._secretHash = secretHash;
 
-  _i5.UserContextDataTypeBuilder? _userContextData;
-  _i5.UserContextDataTypeBuilder get userContextData =>
-      _$this._userContextData ??= new _i5.UserContextDataTypeBuilder();
-  set userContextData(_i5.UserContextDataTypeBuilder? userContextData) =>
+  _i4.UserContextDataTypeBuilder? _userContextData;
+  _i4.UserContextDataTypeBuilder get userContextData =>
+      _$this._userContextData ??= new _i4.UserContextDataTypeBuilder();
+  set userContextData(_i4.UserContextDataTypeBuilder? userContextData) =>
       _$this._userContextData = userContextData;
 
   String? _username;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/get_user_attribute_verification_code_request.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/get_user_attribute_verification_code_request.dart
@@ -36,12 +36,13 @@ abstract class GetUserAttributeVerificationCodeRequest
   factory GetUserAttributeVerificationCodeRequest({
     required String accessToken,
     required String attributeName,
-    _i3.BuiltMap<String, String>? clientMetadata,
+    Map<String, String>? clientMetadata,
   }) {
     return _$GetUserAttributeVerificationCodeRequest._(
       accessToken: accessToken,
       attributeName: attributeName,
-      clientMetadata: clientMetadata,
+      clientMetadata:
+          clientMetadata == null ? null : _i3.BuiltMap(clientMetadata),
     );
   }
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/get_user_response.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/get_user_response.dart
@@ -17,11 +17,11 @@
 library amplify_auth_cognito_dart.cognito_identity_provider.model.get_user_response; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/attribute_type.dart'
-    as _i4;
-import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/mfa_option_type.dart'
     as _i3;
+import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/mfa_option_type.dart'
+    as _i2;
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i2;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i5;
@@ -34,17 +34,18 @@ abstract class GetUserResponse
     implements Built<GetUserResponse, GetUserResponseBuilder> {
   /// Represents the response from the server from the request to get information about the user.
   factory GetUserResponse({
-    _i2.BuiltList<_i3.MfaOptionType>? mfaOptions,
+    List<_i2.MfaOptionType>? mfaOptions,
     String? preferredMfaSetting,
-    required _i2.BuiltList<_i4.AttributeType> userAttributes,
-    _i2.BuiltList<String>? userMfaSettingList,
+    required List<_i3.AttributeType> userAttributes,
+    List<String>? userMfaSettingList,
     required String username,
   }) {
     return _$GetUserResponse._(
-      mfaOptions: mfaOptions,
+      mfaOptions: mfaOptions == null ? null : _i4.BuiltList(mfaOptions),
       preferredMfaSetting: preferredMfaSetting,
-      userAttributes: userAttributes,
-      userMfaSettingList: userMfaSettingList,
+      userAttributes: _i4.BuiltList(userAttributes),
+      userMfaSettingList:
+          userMfaSettingList == null ? null : _i4.BuiltList(userMfaSettingList),
       username: username,
     );
   }
@@ -70,7 +71,7 @@ abstract class GetUserResponse
   static void _init(GetUserResponseBuilder b) {}
 
   /// _This response parameter is no longer supported._ It provides information only about SMS MFA configurations. It doesn't provide information about time-based one-time password (TOTP) software token MFA configurations. To look up information about either type of MFA configuration, use UserMFASettingList instead.
-  _i2.BuiltList<_i3.MfaOptionType>? get mfaOptions;
+  _i4.BuiltList<_i2.MfaOptionType>? get mfaOptions;
 
   /// The user's preferred MFA setting.
   String? get preferredMfaSetting;
@@ -78,10 +79,10 @@ abstract class GetUserResponse
   /// An array of name-value pairs representing user attributes.
   ///
   /// For custom attributes, you must prepend the `custom:` prefix to the attribute name.
-  _i2.BuiltList<_i4.AttributeType> get userAttributes;
+  _i4.BuiltList<_i3.AttributeType> get userAttributes;
 
   /// The MFA options that are activated for the user. The possible values in this list are `SMS_MFA` and `SOFTWARE\_TOKEN\_MFA`.
-  _i2.BuiltList<String>? get userMfaSettingList;
+  _i4.BuiltList<String>? get userMfaSettingList;
 
   /// The user name of the user you want to retrieve from the get user request.
   String get username;
@@ -154,10 +155,10 @@ class GetUserResponseAwsJson11Serializer
             result.mfaOptions.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltList,
-                [FullType(_i3.MfaOptionType)],
+                _i4.BuiltList,
+                [FullType(_i2.MfaOptionType)],
               ),
-            ) as _i2.BuiltList<_i3.MfaOptionType>));
+            ) as _i4.BuiltList<_i2.MfaOptionType>));
           }
           break;
         case 'PreferredMfaSetting':
@@ -172,20 +173,20 @@ class GetUserResponseAwsJson11Serializer
           result.userAttributes.replace((serializers.deserialize(
             value,
             specifiedType: const FullType(
-              _i2.BuiltList,
-              [FullType(_i4.AttributeType)],
+              _i4.BuiltList,
+              [FullType(_i3.AttributeType)],
             ),
-          ) as _i2.BuiltList<_i4.AttributeType>));
+          ) as _i4.BuiltList<_i3.AttributeType>));
           break;
         case 'UserMFASettingList':
           if (value != null) {
             result.userMfaSettingList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltList,
+                _i4.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i2.BuiltList<String>));
+            ) as _i4.BuiltList<String>));
           }
           break;
         case 'Username':
@@ -212,8 +213,8 @@ class GetUserResponseAwsJson11Serializer
       serializers.serialize(
         payload.userAttributes,
         specifiedType: const FullType(
-          _i2.BuiltList,
-          [FullType(_i4.AttributeType)],
+          _i4.BuiltList,
+          [FullType(_i3.AttributeType)],
         ),
       ),
       'Username',
@@ -228,8 +229,8 @@ class GetUserResponseAwsJson11Serializer
         ..add(serializers.serialize(
           payload.mfaOptions!,
           specifiedType: const FullType(
-            _i2.BuiltList,
-            [FullType(_i3.MfaOptionType)],
+            _i4.BuiltList,
+            [FullType(_i2.MfaOptionType)],
           ),
         ));
     }
@@ -247,7 +248,7 @@ class GetUserResponseAwsJson11Serializer
         ..add(serializers.serialize(
           payload.userMfaSettingList!,
           specifiedType: const FullType(
-            _i2.BuiltList,
+            _i4.BuiltList,
             [FullType(String)],
           ),
         ));

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/get_user_response.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/get_user_response.g.dart
@@ -8,13 +8,13 @@ part of amplify_auth_cognito_dart.cognito_identity_provider.model.get_user_respo
 
 class _$GetUserResponse extends GetUserResponse {
   @override
-  final _i2.BuiltList<_i3.MfaOptionType>? mfaOptions;
+  final _i4.BuiltList<_i2.MfaOptionType>? mfaOptions;
   @override
   final String? preferredMfaSetting;
   @override
-  final _i2.BuiltList<_i4.AttributeType> userAttributes;
+  final _i4.BuiltList<_i3.AttributeType> userAttributes;
   @override
-  final _i2.BuiltList<String>? userMfaSettingList;
+  final _i4.BuiltList<String>? userMfaSettingList;
   @override
   final String username;
 
@@ -68,10 +68,10 @@ class GetUserResponseBuilder
     implements Builder<GetUserResponse, GetUserResponseBuilder> {
   _$GetUserResponse? _$v;
 
-  _i2.ListBuilder<_i3.MfaOptionType>? _mfaOptions;
-  _i2.ListBuilder<_i3.MfaOptionType> get mfaOptions =>
-      _$this._mfaOptions ??= new _i2.ListBuilder<_i3.MfaOptionType>();
-  set mfaOptions(_i2.ListBuilder<_i3.MfaOptionType>? mfaOptions) =>
+  _i4.ListBuilder<_i2.MfaOptionType>? _mfaOptions;
+  _i4.ListBuilder<_i2.MfaOptionType> get mfaOptions =>
+      _$this._mfaOptions ??= new _i4.ListBuilder<_i2.MfaOptionType>();
+  set mfaOptions(_i4.ListBuilder<_i2.MfaOptionType>? mfaOptions) =>
       _$this._mfaOptions = mfaOptions;
 
   String? _preferredMfaSetting;
@@ -79,16 +79,16 @@ class GetUserResponseBuilder
   set preferredMfaSetting(String? preferredMfaSetting) =>
       _$this._preferredMfaSetting = preferredMfaSetting;
 
-  _i2.ListBuilder<_i4.AttributeType>? _userAttributes;
-  _i2.ListBuilder<_i4.AttributeType> get userAttributes =>
-      _$this._userAttributes ??= new _i2.ListBuilder<_i4.AttributeType>();
-  set userAttributes(_i2.ListBuilder<_i4.AttributeType>? userAttributes) =>
+  _i4.ListBuilder<_i3.AttributeType>? _userAttributes;
+  _i4.ListBuilder<_i3.AttributeType> get userAttributes =>
+      _$this._userAttributes ??= new _i4.ListBuilder<_i3.AttributeType>();
+  set userAttributes(_i4.ListBuilder<_i3.AttributeType>? userAttributes) =>
       _$this._userAttributes = userAttributes;
 
-  _i2.ListBuilder<String>? _userMfaSettingList;
-  _i2.ListBuilder<String> get userMfaSettingList =>
-      _$this._userMfaSettingList ??= new _i2.ListBuilder<String>();
-  set userMfaSettingList(_i2.ListBuilder<String>? userMfaSettingList) =>
+  _i4.ListBuilder<String>? _userMfaSettingList;
+  _i4.ListBuilder<String> get userMfaSettingList =>
+      _$this._userMfaSettingList ??= new _i4.ListBuilder<String>();
+  set userMfaSettingList(_i4.ListBuilder<String>? userMfaSettingList) =>
       _$this._userMfaSettingList = userMfaSettingList;
 
   String? _username;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/initiate_auth_request.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/initiate_auth_request.dart
@@ -21,9 +21,9 @@ import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/auth_flow_type.dart'
     as _i4;
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/user_context_data_type.dart'
-    as _i6;
+    as _i5;
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i5;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i1;
@@ -40,17 +40,19 @@ abstract class InitiateAuthRequest
   factory InitiateAuthRequest({
     _i3.AnalyticsMetadataType? analyticsMetadata,
     required _i4.AuthFlowType authFlow,
-    _i5.BuiltMap<String, String>? authParameters,
+    Map<String, String>? authParameters,
     required String clientId,
-    _i5.BuiltMap<String, String>? clientMetadata,
-    _i6.UserContextDataType? userContextData,
+    Map<String, String>? clientMetadata,
+    _i5.UserContextDataType? userContextData,
   }) {
     return _$InitiateAuthRequest._(
       analyticsMetadata: analyticsMetadata,
       authFlow: authFlow,
-      authParameters: authParameters,
+      authParameters:
+          authParameters == null ? null : _i6.BuiltMap(authParameters),
       clientId: clientId,
-      clientMetadata: clientMetadata,
+      clientMetadata:
+          clientMetadata == null ? null : _i6.BuiltMap(clientMetadata),
       userContextData: userContextData,
     );
   }
@@ -109,7 +111,7 @@ abstract class InitiateAuthRequest
   /// *   For `REFRESH\_TOKEN\_AUTH/REFRESH_TOKEN`: `REFRESH_TOKEN` (required), `SECRET_HASH` (required if the app client is configured with a client secret), `DEVICE_KEY`.
   ///
   /// *   For `CUSTOM_AUTH`: `USERNAME` (required), `SECRET_HASH` (if app client is configured with client secret), `DEVICE_KEY`. To start the authentication flow with password verification, include `ChallengeName: SRP_A` and `SRP\_A: (The SRP\_A Value)`.
-  _i5.BuiltMap<String, String>? get authParameters;
+  _i6.BuiltMap<String, String>? get authParameters;
 
   /// The app client ID.
   String get clientId;
@@ -151,10 +153,10 @@ abstract class InitiateAuthRequest
   /// *   Validate the ClientMetadata value.
   ///
   /// *   Encrypt the ClientMetadata value. Don't use Amazon Cognito to provide sensitive information.
-  _i5.BuiltMap<String, String>? get clientMetadata;
+  _i6.BuiltMap<String, String>? get clientMetadata;
 
   /// Contextual data about your user session, such as the device fingerprint, IP address, or location. Amazon Cognito advanced security evaluates the risk of an authentication event based on the context that your app generates and passes to Amazon Cognito when it makes API requests.
-  _i6.UserContextDataType? get userContextData;
+  _i5.UserContextDataType? get userContextData;
   @override
   InitiateAuthRequest getPayload() => this;
   @override
@@ -245,13 +247,13 @@ class InitiateAuthRequestAwsJson11Serializer
             result.authParameters.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i5.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i5.BuiltMap<String, String>));
+            ) as _i6.BuiltMap<String, String>));
           }
           break;
         case 'ClientId':
@@ -265,21 +267,21 @@ class InitiateAuthRequestAwsJson11Serializer
             result.clientMetadata.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i5.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i5.BuiltMap<String, String>));
+            ) as _i6.BuiltMap<String, String>));
           }
           break;
         case 'UserContextData':
           if (value != null) {
             result.userContextData.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.UserContextDataType),
-            ) as _i6.UserContextDataType));
+              specifiedType: const FullType(_i5.UserContextDataType),
+            ) as _i5.UserContextDataType));
           }
           break;
       }
@@ -321,7 +323,7 @@ class InitiateAuthRequestAwsJson11Serializer
         ..add(serializers.serialize(
           payload.authParameters!,
           specifiedType: const FullType(
-            _i5.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -335,7 +337,7 @@ class InitiateAuthRequestAwsJson11Serializer
         ..add(serializers.serialize(
           payload.clientMetadata!,
           specifiedType: const FullType(
-            _i5.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -348,7 +350,7 @@ class InitiateAuthRequestAwsJson11Serializer
         ..add('UserContextData')
         ..add(serializers.serialize(
           payload.userContextData!,
-          specifiedType: const FullType(_i6.UserContextDataType),
+          specifiedType: const FullType(_i5.UserContextDataType),
         ));
     }
     return result;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/initiate_auth_request.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/initiate_auth_request.g.dart
@@ -12,13 +12,13 @@ class _$InitiateAuthRequest extends InitiateAuthRequest {
   @override
   final _i4.AuthFlowType authFlow;
   @override
-  final _i5.BuiltMap<String, String>? authParameters;
+  final _i6.BuiltMap<String, String>? authParameters;
   @override
   final String clientId;
   @override
-  final _i5.BuiltMap<String, String>? clientMetadata;
+  final _i6.BuiltMap<String, String>? clientMetadata;
   @override
-  final _i6.UserContextDataType? userContextData;
+  final _i5.UserContextDataType? userContextData;
 
   factory _$InitiateAuthRequest(
           [void Function(InitiateAuthRequestBuilder)? updates]) =>
@@ -86,26 +86,26 @@ class InitiateAuthRequestBuilder
   _i4.AuthFlowType? get authFlow => _$this._authFlow;
   set authFlow(_i4.AuthFlowType? authFlow) => _$this._authFlow = authFlow;
 
-  _i5.MapBuilder<String, String>? _authParameters;
-  _i5.MapBuilder<String, String> get authParameters =>
-      _$this._authParameters ??= new _i5.MapBuilder<String, String>();
-  set authParameters(_i5.MapBuilder<String, String>? authParameters) =>
+  _i6.MapBuilder<String, String>? _authParameters;
+  _i6.MapBuilder<String, String> get authParameters =>
+      _$this._authParameters ??= new _i6.MapBuilder<String, String>();
+  set authParameters(_i6.MapBuilder<String, String>? authParameters) =>
       _$this._authParameters = authParameters;
 
   String? _clientId;
   String? get clientId => _$this._clientId;
   set clientId(String? clientId) => _$this._clientId = clientId;
 
-  _i5.MapBuilder<String, String>? _clientMetadata;
-  _i5.MapBuilder<String, String> get clientMetadata =>
-      _$this._clientMetadata ??= new _i5.MapBuilder<String, String>();
-  set clientMetadata(_i5.MapBuilder<String, String>? clientMetadata) =>
+  _i6.MapBuilder<String, String>? _clientMetadata;
+  _i6.MapBuilder<String, String> get clientMetadata =>
+      _$this._clientMetadata ??= new _i6.MapBuilder<String, String>();
+  set clientMetadata(_i6.MapBuilder<String, String>? clientMetadata) =>
       _$this._clientMetadata = clientMetadata;
 
-  _i6.UserContextDataTypeBuilder? _userContextData;
-  _i6.UserContextDataTypeBuilder get userContextData =>
-      _$this._userContextData ??= new _i6.UserContextDataTypeBuilder();
-  set userContextData(_i6.UserContextDataTypeBuilder? userContextData) =>
+  _i5.UserContextDataTypeBuilder? _userContextData;
+  _i5.UserContextDataTypeBuilder get userContextData =>
+      _$this._userContextData ??= new _i5.UserContextDataTypeBuilder();
+  set userContextData(_i5.UserContextDataTypeBuilder? userContextData) =>
       _$this._userContextData = userContextData;
 
   InitiateAuthRequestBuilder() {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/initiate_auth_response.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/initiate_auth_response.dart
@@ -36,13 +36,15 @@ abstract class InitiateAuthResponse
   factory InitiateAuthResponse({
     _i2.AuthenticationResultType? authenticationResult,
     _i3.ChallengeNameType? challengeName,
-    _i4.BuiltMap<String, String>? challengeParameters,
+    Map<String, String>? challengeParameters,
     String? session,
   }) {
     return _$InitiateAuthResponse._(
       authenticationResult: authenticationResult,
       challengeName: challengeName,
-      challengeParameters: challengeParameters,
+      challengeParameters: challengeParameters == null
+          ? null
+          : _i4.BuiltMap(challengeParameters),
       session: session,
     );
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/list_devices_response.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/list_devices_response.dart
@@ -17,9 +17,9 @@
 library amplify_auth_cognito_dart.cognito_identity_provider.model.list_devices_response; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/device_type.dart'
-    as _i3;
+    as _i2;
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i2;
+import 'package:built_collection/built_collection.dart' as _i3;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i4;
@@ -32,11 +32,11 @@ abstract class ListDevicesResponse
     implements Built<ListDevicesResponse, ListDevicesResponseBuilder> {
   /// Represents the response to list devices.
   factory ListDevicesResponse({
-    _i2.BuiltList<_i3.DeviceType>? devices,
+    List<_i2.DeviceType>? devices,
     String? paginationToken,
   }) {
     return _$ListDevicesResponse._(
-      devices: devices,
+      devices: devices == null ? null : _i3.BuiltList(devices),
       paginationToken: paginationToken,
     );
   }
@@ -63,7 +63,7 @@ abstract class ListDevicesResponse
   static void _init(ListDevicesResponseBuilder b) {}
 
   /// The devices returned in the list devices response.
-  _i2.BuiltList<_i3.DeviceType>? get devices;
+  _i3.BuiltList<_i2.DeviceType>? get devices;
 
   /// The pagination token for the list device response.
   String? get paginationToken;
@@ -121,10 +121,10 @@ class ListDevicesResponseAwsJson11Serializer
             result.devices.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltList,
-                [FullType(_i3.DeviceType)],
+                _i3.BuiltList,
+                [FullType(_i2.DeviceType)],
               ),
-            ) as _i2.BuiltList<_i3.DeviceType>));
+            ) as _i3.BuiltList<_i2.DeviceType>));
           }
           break;
         case 'PaginationToken':
@@ -155,8 +155,8 @@ class ListDevicesResponseAwsJson11Serializer
         ..add(serializers.serialize(
           payload.devices!,
           specifiedType: const FullType(
-            _i2.BuiltList,
-            [FullType(_i3.DeviceType)],
+            _i3.BuiltList,
+            [FullType(_i2.DeviceType)],
           ),
         ));
     }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/list_devices_response.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/list_devices_response.g.dart
@@ -8,7 +8,7 @@ part of amplify_auth_cognito_dart.cognito_identity_provider.model.list_devices_r
 
 class _$ListDevicesResponse extends ListDevicesResponse {
   @override
-  final _i2.BuiltList<_i3.DeviceType>? devices;
+  final _i3.BuiltList<_i2.DeviceType>? devices;
   @override
   final String? paginationToken;
 
@@ -45,10 +45,10 @@ class ListDevicesResponseBuilder
     implements Builder<ListDevicesResponse, ListDevicesResponseBuilder> {
   _$ListDevicesResponse? _$v;
 
-  _i2.ListBuilder<_i3.DeviceType>? _devices;
-  _i2.ListBuilder<_i3.DeviceType> get devices =>
-      _$this._devices ??= new _i2.ListBuilder<_i3.DeviceType>();
-  set devices(_i2.ListBuilder<_i3.DeviceType>? devices) =>
+  _i3.ListBuilder<_i2.DeviceType>? _devices;
+  _i3.ListBuilder<_i2.DeviceType> get devices =>
+      _$this._devices ??= new _i3.ListBuilder<_i2.DeviceType>();
+  set devices(_i3.ListBuilder<_i2.DeviceType>? devices) =>
       _$this._devices = devices;
 
   String? _paginationToken;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/resend_confirmation_code_request.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/resend_confirmation_code_request.dart
@@ -19,9 +19,9 @@ library amplify_auth_cognito_dart.cognito_identity_provider.model.resend_confirm
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/analytics_metadata_type.dart'
     as _i3;
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/user_context_data_type.dart'
-    as _i5;
+    as _i4;
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i4;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i1;
@@ -40,15 +40,16 @@ abstract class ResendConfirmationCodeRequest
   factory ResendConfirmationCodeRequest({
     _i3.AnalyticsMetadataType? analyticsMetadata,
     required String clientId,
-    _i4.BuiltMap<String, String>? clientMetadata,
+    Map<String, String>? clientMetadata,
     String? secretHash,
-    _i5.UserContextDataType? userContextData,
+    _i4.UserContextDataType? userContextData,
     required String username,
   }) {
     return _$ResendConfirmationCodeRequest._(
       analyticsMetadata: analyticsMetadata,
       clientId: clientId,
-      clientMetadata: clientMetadata,
+      clientMetadata:
+          clientMetadata == null ? null : _i5.BuiltMap(clientMetadata),
       secretHash: secretHash,
       userContextData: userContextData,
       username: username,
@@ -95,13 +96,13 @@ abstract class ResendConfirmationCodeRequest
   /// *   Validate the ClientMetadata value.
   ///
   /// *   Encrypt the ClientMetadata value. Don't use Amazon Cognito to provide sensitive information.
-  _i4.BuiltMap<String, String>? get clientMetadata;
+  _i5.BuiltMap<String, String>? get clientMetadata;
 
   /// A keyed-hash message authentication code (HMAC) calculated using the secret key of a user pool client and username plus the client ID in the message.
   String? get secretHash;
 
   /// Contextual data about your user session, such as the device fingerprint, IP address, or location. Amazon Cognito advanced security evaluates the risk of an authentication event based on the context that your app generates and passes to Amazon Cognito when it makes API requests.
-  _i5.UserContextDataType? get userContextData;
+  _i4.UserContextDataType? get userContextData;
 
   /// The `username` attribute of the user to whom you want to resend a confirmation code.
   String get username;
@@ -196,13 +197,13 @@ class ResendConfirmationCodeRequestAwsJson11Serializer
             result.clientMetadata.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i4.BuiltMap,
+                _i5.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i4.BuiltMap<String, String>));
+            ) as _i5.BuiltMap<String, String>));
           }
           break;
         case 'SecretHash':
@@ -217,8 +218,8 @@ class ResendConfirmationCodeRequestAwsJson11Serializer
           if (value != null) {
             result.userContextData.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.UserContextDataType),
-            ) as _i5.UserContextDataType));
+              specifiedType: const FullType(_i4.UserContextDataType),
+            ) as _i4.UserContextDataType));
           }
           break;
         case 'Username':
@@ -266,7 +267,7 @@ class ResendConfirmationCodeRequestAwsJson11Serializer
         ..add(serializers.serialize(
           payload.clientMetadata!,
           specifiedType: const FullType(
-            _i4.BuiltMap,
+            _i5.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -287,7 +288,7 @@ class ResendConfirmationCodeRequestAwsJson11Serializer
         ..add('UserContextData')
         ..add(serializers.serialize(
           payload.userContextData!,
-          specifiedType: const FullType(_i5.UserContextDataType),
+          specifiedType: const FullType(_i4.UserContextDataType),
         ));
     }
     return result;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/resend_confirmation_code_request.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/resend_confirmation_code_request.g.dart
@@ -12,11 +12,11 @@ class _$ResendConfirmationCodeRequest extends ResendConfirmationCodeRequest {
   @override
   final String clientId;
   @override
-  final _i4.BuiltMap<String, String>? clientMetadata;
+  final _i5.BuiltMap<String, String>? clientMetadata;
   @override
   final String? secretHash;
   @override
-  final _i5.UserContextDataType? userContextData;
+  final _i4.UserContextDataType? userContextData;
   @override
   final String username;
 
@@ -88,20 +88,20 @@ class ResendConfirmationCodeRequestBuilder
   String? get clientId => _$this._clientId;
   set clientId(String? clientId) => _$this._clientId = clientId;
 
-  _i4.MapBuilder<String, String>? _clientMetadata;
-  _i4.MapBuilder<String, String> get clientMetadata =>
-      _$this._clientMetadata ??= new _i4.MapBuilder<String, String>();
-  set clientMetadata(_i4.MapBuilder<String, String>? clientMetadata) =>
+  _i5.MapBuilder<String, String>? _clientMetadata;
+  _i5.MapBuilder<String, String> get clientMetadata =>
+      _$this._clientMetadata ??= new _i5.MapBuilder<String, String>();
+  set clientMetadata(_i5.MapBuilder<String, String>? clientMetadata) =>
       _$this._clientMetadata = clientMetadata;
 
   String? _secretHash;
   String? get secretHash => _$this._secretHash;
   set secretHash(String? secretHash) => _$this._secretHash = secretHash;
 
-  _i5.UserContextDataTypeBuilder? _userContextData;
-  _i5.UserContextDataTypeBuilder get userContextData =>
-      _$this._userContextData ??= new _i5.UserContextDataTypeBuilder();
-  set userContextData(_i5.UserContextDataTypeBuilder? userContextData) =>
+  _i4.UserContextDataTypeBuilder? _userContextData;
+  _i4.UserContextDataTypeBuilder get userContextData =>
+      _$this._userContextData ??= new _i4.UserContextDataTypeBuilder();
+  set userContextData(_i4.UserContextDataTypeBuilder? userContextData) =>
       _$this._userContextData = userContextData;
 
   String? _username;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/respond_to_auth_challenge_request.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/respond_to_auth_challenge_request.dart
@@ -21,9 +21,9 @@ import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/challenge_name_type.dart'
     as _i4;
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/user_context_data_type.dart'
-    as _i6;
+    as _i5;
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i5;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i1;
@@ -42,18 +42,20 @@ abstract class RespondToAuthChallengeRequest
   factory RespondToAuthChallengeRequest({
     _i3.AnalyticsMetadataType? analyticsMetadata,
     required _i4.ChallengeNameType challengeName,
-    _i5.BuiltMap<String, String>? challengeResponses,
+    Map<String, String>? challengeResponses,
     required String clientId,
-    _i5.BuiltMap<String, String>? clientMetadata,
+    Map<String, String>? clientMetadata,
     String? session,
-    _i6.UserContextDataType? userContextData,
+    _i5.UserContextDataType? userContextData,
   }) {
     return _$RespondToAuthChallengeRequest._(
       analyticsMetadata: analyticsMetadata,
       challengeName: challengeName,
-      challengeResponses: challengeResponses,
+      challengeResponses:
+          challengeResponses == null ? null : _i6.BuiltMap(challengeResponses),
       clientId: clientId,
-      clientMetadata: clientMetadata,
+      clientMetadata:
+          clientMetadata == null ? null : _i6.BuiltMap(clientMetadata),
       session: session,
       userContextData: userContextData,
     );
@@ -109,7 +111,7 @@ abstract class RespondToAuthChallengeRequest
   /// *   `DEVICE\_PASSWORD\_VERIFIER` requires everything that `PASSWORD_VERIFIER` requires, plus `DEVICE_KEY`.
   ///
   /// *   `MFA_SETUP` requires `USERNAME`, plus you must use the session value returned by `VerifySoftwareToken` in the `Session` parameter.
-  _i5.BuiltMap<String, String>? get challengeResponses;
+  _i6.BuiltMap<String, String>? get challengeResponses;
 
   /// The app client ID.
   String get clientId;
@@ -127,13 +129,13 @@ abstract class RespondToAuthChallengeRequest
   /// *   Validate the ClientMetadata value.
   ///
   /// *   Encrypt the ClientMetadata value. Don't use Amazon Cognito to provide sensitive information.
-  _i5.BuiltMap<String, String>? get clientMetadata;
+  _i6.BuiltMap<String, String>? get clientMetadata;
 
   /// The session that should be passed both ways in challenge-response calls to the service. If `InitiateAuth` or `RespondToAuthChallenge` API call determines that the caller must pass another challenge, they return a session with other challenge parameters. This session should be passed as it is to the next `RespondToAuthChallenge` API call.
   String? get session;
 
   /// Contextual data about your user session, such as the device fingerprint, IP address, or location. Amazon Cognito advanced security evaluates the risk of an authentication event based on the context that your app generates and passes to Amazon Cognito when it makes API requests.
-  _i6.UserContextDataType? get userContextData;
+  _i5.UserContextDataType? get userContextData;
   @override
   RespondToAuthChallengeRequest getPayload() => this;
   @override
@@ -230,13 +232,13 @@ class RespondToAuthChallengeRequestAwsJson11Serializer
             result.challengeResponses.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i5.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i5.BuiltMap<String, String>));
+            ) as _i6.BuiltMap<String, String>));
           }
           break;
         case 'ClientId':
@@ -250,13 +252,13 @@ class RespondToAuthChallengeRequestAwsJson11Serializer
             result.clientMetadata.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i5.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i5.BuiltMap<String, String>));
+            ) as _i6.BuiltMap<String, String>));
           }
           break;
         case 'Session':
@@ -271,8 +273,8 @@ class RespondToAuthChallengeRequestAwsJson11Serializer
           if (value != null) {
             result.userContextData.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.UserContextDataType),
-            ) as _i6.UserContextDataType));
+              specifiedType: const FullType(_i5.UserContextDataType),
+            ) as _i5.UserContextDataType));
           }
           break;
       }
@@ -314,7 +316,7 @@ class RespondToAuthChallengeRequestAwsJson11Serializer
         ..add(serializers.serialize(
           payload.challengeResponses!,
           specifiedType: const FullType(
-            _i5.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -328,7 +330,7 @@ class RespondToAuthChallengeRequestAwsJson11Serializer
         ..add(serializers.serialize(
           payload.clientMetadata!,
           specifiedType: const FullType(
-            _i5.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -349,7 +351,7 @@ class RespondToAuthChallengeRequestAwsJson11Serializer
         ..add('UserContextData')
         ..add(serializers.serialize(
           payload.userContextData!,
-          specifiedType: const FullType(_i6.UserContextDataType),
+          specifiedType: const FullType(_i5.UserContextDataType),
         ));
     }
     return result;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/respond_to_auth_challenge_request.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/respond_to_auth_challenge_request.g.dart
@@ -12,15 +12,15 @@ class _$RespondToAuthChallengeRequest extends RespondToAuthChallengeRequest {
   @override
   final _i4.ChallengeNameType challengeName;
   @override
-  final _i5.BuiltMap<String, String>? challengeResponses;
+  final _i6.BuiltMap<String, String>? challengeResponses;
   @override
   final String clientId;
   @override
-  final _i5.BuiltMap<String, String>? clientMetadata;
+  final _i6.BuiltMap<String, String>? clientMetadata;
   @override
   final String? session;
   @override
-  final _i6.UserContextDataType? userContextData;
+  final _i5.UserContextDataType? userContextData;
 
   factory _$RespondToAuthChallengeRequest(
           [void Function(RespondToAuthChallengeRequestBuilder)? updates]) =>
@@ -97,30 +97,30 @@ class RespondToAuthChallengeRequestBuilder
   set challengeName(_i4.ChallengeNameType? challengeName) =>
       _$this._challengeName = challengeName;
 
-  _i5.MapBuilder<String, String>? _challengeResponses;
-  _i5.MapBuilder<String, String> get challengeResponses =>
-      _$this._challengeResponses ??= new _i5.MapBuilder<String, String>();
-  set challengeResponses(_i5.MapBuilder<String, String>? challengeResponses) =>
+  _i6.MapBuilder<String, String>? _challengeResponses;
+  _i6.MapBuilder<String, String> get challengeResponses =>
+      _$this._challengeResponses ??= new _i6.MapBuilder<String, String>();
+  set challengeResponses(_i6.MapBuilder<String, String>? challengeResponses) =>
       _$this._challengeResponses = challengeResponses;
 
   String? _clientId;
   String? get clientId => _$this._clientId;
   set clientId(String? clientId) => _$this._clientId = clientId;
 
-  _i5.MapBuilder<String, String>? _clientMetadata;
-  _i5.MapBuilder<String, String> get clientMetadata =>
-      _$this._clientMetadata ??= new _i5.MapBuilder<String, String>();
-  set clientMetadata(_i5.MapBuilder<String, String>? clientMetadata) =>
+  _i6.MapBuilder<String, String>? _clientMetadata;
+  _i6.MapBuilder<String, String> get clientMetadata =>
+      _$this._clientMetadata ??= new _i6.MapBuilder<String, String>();
+  set clientMetadata(_i6.MapBuilder<String, String>? clientMetadata) =>
       _$this._clientMetadata = clientMetadata;
 
   String? _session;
   String? get session => _$this._session;
   set session(String? session) => _$this._session = session;
 
-  _i6.UserContextDataTypeBuilder? _userContextData;
-  _i6.UserContextDataTypeBuilder get userContextData =>
-      _$this._userContextData ??= new _i6.UserContextDataTypeBuilder();
-  set userContextData(_i6.UserContextDataTypeBuilder? userContextData) =>
+  _i5.UserContextDataTypeBuilder? _userContextData;
+  _i5.UserContextDataTypeBuilder get userContextData =>
+      _$this._userContextData ??= new _i5.UserContextDataTypeBuilder();
+  set userContextData(_i5.UserContextDataTypeBuilder? userContextData) =>
       _$this._userContextData = userContextData;
 
   RespondToAuthChallengeRequestBuilder() {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/respond_to_auth_challenge_response.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/respond_to_auth_challenge_response.dart
@@ -39,13 +39,15 @@ abstract class RespondToAuthChallengeResponse
   factory RespondToAuthChallengeResponse({
     _i2.AuthenticationResultType? authenticationResult,
     _i3.ChallengeNameType? challengeName,
-    _i4.BuiltMap<String, String>? challengeParameters,
+    Map<String, String>? challengeParameters,
     String? session,
   }) {
     return _$RespondToAuthChallengeResponse._(
       authenticationResult: authenticationResult,
       challengeName: challengeName,
-      challengeParameters: challengeParameters,
+      challengeParameters: challengeParameters == null
+          ? null
+          : _i4.BuiltMap(challengeParameters),
       session: session,
     );
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/sign_up_request.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/sign_up_request.dart
@@ -19,11 +19,11 @@ library amplify_auth_cognito_dart.cognito_identity_provider.model.sign_up_reques
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/analytics_metadata_type.dart'
     as _i3;
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/attribute_type.dart'
-    as _i5;
+    as _i4;
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/user_context_data_type.dart'
-    as _i6;
+    as _i5;
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i4;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i1;
@@ -38,24 +38,27 @@ abstract class SignUpRequest
   factory SignUpRequest({
     _i3.AnalyticsMetadataType? analyticsMetadata,
     required String clientId,
-    _i4.BuiltMap<String, String>? clientMetadata,
+    Map<String, String>? clientMetadata,
     required String password,
     String? secretHash,
-    _i4.BuiltList<_i5.AttributeType>? userAttributes,
-    _i6.UserContextDataType? userContextData,
+    List<_i4.AttributeType>? userAttributes,
+    _i5.UserContextDataType? userContextData,
     required String username,
-    _i4.BuiltList<_i5.AttributeType>? validationData,
+    List<_i4.AttributeType>? validationData,
   }) {
     return _$SignUpRequest._(
       analyticsMetadata: analyticsMetadata,
       clientId: clientId,
-      clientMetadata: clientMetadata,
+      clientMetadata:
+          clientMetadata == null ? null : _i6.BuiltMap(clientMetadata),
       password: password,
       secretHash: secretHash,
-      userAttributes: userAttributes,
+      userAttributes:
+          userAttributes == null ? null : _i6.BuiltList(userAttributes),
       userContextData: userContextData,
       username: username,
-      validationData: validationData,
+      validationData:
+          validationData == null ? null : _i6.BuiltList(validationData),
     );
   }
 
@@ -98,7 +101,7 @@ abstract class SignUpRequest
   /// *   Validate the ClientMetadata value.
   ///
   /// *   Encrypt the ClientMetadata value. Don't use Amazon Cognito to provide sensitive information.
-  _i4.BuiltMap<String, String>? get clientMetadata;
+  _i6.BuiltMap<String, String>? get clientMetadata;
 
   /// The password of the user you want to register.
   String get password;
@@ -109,16 +112,16 @@ abstract class SignUpRequest
   /// An array of name-value pairs representing user attributes.
   ///
   /// For custom attributes, you must prepend the `custom:` prefix to the attribute name.
-  _i4.BuiltList<_i5.AttributeType>? get userAttributes;
+  _i6.BuiltList<_i4.AttributeType>? get userAttributes;
 
   /// Contextual data about your user session, such as the device fingerprint, IP address, or location. Amazon Cognito advanced security evaluates the risk of an authentication event based on the context that your app generates and passes to Amazon Cognito when it makes API requests.
-  _i6.UserContextDataType? get userContextData;
+  _i5.UserContextDataType? get userContextData;
 
   /// The user name of the user you want to register.
   String get username;
 
   /// The validation data in the request to register a user.
-  _i4.BuiltList<_i5.AttributeType>? get validationData;
+  _i6.BuiltList<_i4.AttributeType>? get validationData;
   @override
   SignUpRequest getPayload() => this;
   @override
@@ -224,13 +227,13 @@ class SignUpRequestAwsJson11Serializer
             result.clientMetadata.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i4.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i4.BuiltMap<String, String>));
+            ) as _i6.BuiltMap<String, String>));
           }
           break;
         case 'Password':
@@ -252,18 +255,18 @@ class SignUpRequestAwsJson11Serializer
             result.userAttributes.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i4.BuiltList,
-                [FullType(_i5.AttributeType)],
+                _i6.BuiltList,
+                [FullType(_i4.AttributeType)],
               ),
-            ) as _i4.BuiltList<_i5.AttributeType>));
+            ) as _i6.BuiltList<_i4.AttributeType>));
           }
           break;
         case 'UserContextData':
           if (value != null) {
             result.userContextData.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.UserContextDataType),
-            ) as _i6.UserContextDataType));
+              specifiedType: const FullType(_i5.UserContextDataType),
+            ) as _i5.UserContextDataType));
           }
           break;
         case 'Username':
@@ -277,10 +280,10 @@ class SignUpRequestAwsJson11Serializer
             result.validationData.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i4.BuiltList,
-                [FullType(_i5.AttributeType)],
+                _i6.BuiltList,
+                [FullType(_i4.AttributeType)],
               ),
-            ) as _i4.BuiltList<_i5.AttributeType>));
+            ) as _i6.BuiltList<_i4.AttributeType>));
           }
           break;
       }
@@ -327,7 +330,7 @@ class SignUpRequestAwsJson11Serializer
         ..add(serializers.serialize(
           payload.clientMetadata!,
           specifiedType: const FullType(
-            _i4.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -349,8 +352,8 @@ class SignUpRequestAwsJson11Serializer
         ..add(serializers.serialize(
           payload.userAttributes!,
           specifiedType: const FullType(
-            _i4.BuiltList,
-            [FullType(_i5.AttributeType)],
+            _i6.BuiltList,
+            [FullType(_i4.AttributeType)],
           ),
         ));
     }
@@ -359,7 +362,7 @@ class SignUpRequestAwsJson11Serializer
         ..add('UserContextData')
         ..add(serializers.serialize(
           payload.userContextData!,
-          specifiedType: const FullType(_i6.UserContextDataType),
+          specifiedType: const FullType(_i5.UserContextDataType),
         ));
     }
     if (payload.validationData != null) {
@@ -368,8 +371,8 @@ class SignUpRequestAwsJson11Serializer
         ..add(serializers.serialize(
           payload.validationData!,
           specifiedType: const FullType(
-            _i4.BuiltList,
-            [FullType(_i5.AttributeType)],
+            _i6.BuiltList,
+            [FullType(_i4.AttributeType)],
           ),
         ));
     }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/sign_up_request.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/sign_up_request.g.dart
@@ -12,19 +12,19 @@ class _$SignUpRequest extends SignUpRequest {
   @override
   final String clientId;
   @override
-  final _i4.BuiltMap<String, String>? clientMetadata;
+  final _i6.BuiltMap<String, String>? clientMetadata;
   @override
   final String password;
   @override
   final String? secretHash;
   @override
-  final _i4.BuiltList<_i5.AttributeType>? userAttributes;
+  final _i6.BuiltList<_i4.AttributeType>? userAttributes;
   @override
-  final _i6.UserContextDataType? userContextData;
+  final _i5.UserContextDataType? userContextData;
   @override
   final String username;
   @override
-  final _i4.BuiltList<_i5.AttributeType>? validationData;
+  final _i6.BuiltList<_i4.AttributeType>? validationData;
 
   factory _$SignUpRequest([void Function(SignUpRequestBuilder)? updates]) =>
       (new SignUpRequestBuilder()..update(updates))._build();
@@ -105,10 +105,10 @@ class SignUpRequestBuilder
   String? get clientId => _$this._clientId;
   set clientId(String? clientId) => _$this._clientId = clientId;
 
-  _i4.MapBuilder<String, String>? _clientMetadata;
-  _i4.MapBuilder<String, String> get clientMetadata =>
-      _$this._clientMetadata ??= new _i4.MapBuilder<String, String>();
-  set clientMetadata(_i4.MapBuilder<String, String>? clientMetadata) =>
+  _i6.MapBuilder<String, String>? _clientMetadata;
+  _i6.MapBuilder<String, String> get clientMetadata =>
+      _$this._clientMetadata ??= new _i6.MapBuilder<String, String>();
+  set clientMetadata(_i6.MapBuilder<String, String>? clientMetadata) =>
       _$this._clientMetadata = clientMetadata;
 
   String? _password;
@@ -119,26 +119,26 @@ class SignUpRequestBuilder
   String? get secretHash => _$this._secretHash;
   set secretHash(String? secretHash) => _$this._secretHash = secretHash;
 
-  _i4.ListBuilder<_i5.AttributeType>? _userAttributes;
-  _i4.ListBuilder<_i5.AttributeType> get userAttributes =>
-      _$this._userAttributes ??= new _i4.ListBuilder<_i5.AttributeType>();
-  set userAttributes(_i4.ListBuilder<_i5.AttributeType>? userAttributes) =>
+  _i6.ListBuilder<_i4.AttributeType>? _userAttributes;
+  _i6.ListBuilder<_i4.AttributeType> get userAttributes =>
+      _$this._userAttributes ??= new _i6.ListBuilder<_i4.AttributeType>();
+  set userAttributes(_i6.ListBuilder<_i4.AttributeType>? userAttributes) =>
       _$this._userAttributes = userAttributes;
 
-  _i6.UserContextDataTypeBuilder? _userContextData;
-  _i6.UserContextDataTypeBuilder get userContextData =>
-      _$this._userContextData ??= new _i6.UserContextDataTypeBuilder();
-  set userContextData(_i6.UserContextDataTypeBuilder? userContextData) =>
+  _i5.UserContextDataTypeBuilder? _userContextData;
+  _i5.UserContextDataTypeBuilder get userContextData =>
+      _$this._userContextData ??= new _i5.UserContextDataTypeBuilder();
+  set userContextData(_i5.UserContextDataTypeBuilder? userContextData) =>
       _$this._userContextData = userContextData;
 
   String? _username;
   String? get username => _$this._username;
   set username(String? username) => _$this._username = username;
 
-  _i4.ListBuilder<_i5.AttributeType>? _validationData;
-  _i4.ListBuilder<_i5.AttributeType> get validationData =>
-      _$this._validationData ??= new _i4.ListBuilder<_i5.AttributeType>();
-  set validationData(_i4.ListBuilder<_i5.AttributeType>? validationData) =>
+  _i6.ListBuilder<_i4.AttributeType>? _validationData;
+  _i6.ListBuilder<_i4.AttributeType> get validationData =>
+      _$this._validationData ??= new _i6.ListBuilder<_i4.AttributeType>();
+  set validationData(_i6.ListBuilder<_i4.AttributeType>? validationData) =>
       _$this._validationData = validationData;
 
   SignUpRequestBuilder() {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/update_user_attributes_request.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/update_user_attributes_request.dart
@@ -17,9 +17,9 @@
 library amplify_auth_cognito_dart.cognito_identity_provider.model.update_user_attributes_request; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/attribute_type.dart'
-    as _i4;
+    as _i3;
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i1;
@@ -36,13 +36,14 @@ abstract class UpdateUserAttributesRequest
   /// Represents the request to update user attributes.
   factory UpdateUserAttributesRequest({
     required String accessToken,
-    _i3.BuiltMap<String, String>? clientMetadata,
-    required _i3.BuiltList<_i4.AttributeType> userAttributes,
+    Map<String, String>? clientMetadata,
+    required List<_i3.AttributeType> userAttributes,
   }) {
     return _$UpdateUserAttributesRequest._(
       accessToken: accessToken,
-      clientMetadata: clientMetadata,
-      userAttributes: userAttributes,
+      clientMetadata:
+          clientMetadata == null ? null : _i4.BuiltMap(clientMetadata),
+      userAttributes: _i4.BuiltList(userAttributes),
     );
   }
 
@@ -83,14 +84,14 @@ abstract class UpdateUserAttributesRequest
   /// *   Validate the ClientMetadata value.
   ///
   /// *   Encrypt the ClientMetadata value. Don't use Amazon Cognito to provide sensitive information.
-  _i3.BuiltMap<String, String>? get clientMetadata;
+  _i4.BuiltMap<String, String>? get clientMetadata;
 
   /// An array of name-value pairs representing user attributes.
   ///
   /// For custom attributes, you must prepend the `custom:` prefix to the attribute name.
   ///
   /// If you have set an attribute to require verification before Amazon Cognito updates its value, this request doesn’t immediately update the value of that attribute. After your user receives and responds to a verification message to verify the new value, Amazon Cognito updates the attribute value. Your user can sign in and receive messages with the original attribute value until they verify the new value.
-  _i3.BuiltList<_i4.AttributeType> get userAttributes;
+  _i4.BuiltList<_i3.AttributeType> get userAttributes;
   @override
   UpdateUserAttributesRequest getPayload() => this;
   @override
@@ -159,23 +160,23 @@ class UpdateUserAttributesRequestAwsJson11Serializer
             result.clientMetadata.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i3.BuiltMap<String, String>));
+            ) as _i4.BuiltMap<String, String>));
           }
           break;
         case 'UserAttributes':
           result.userAttributes.replace((serializers.deserialize(
             value,
             specifiedType: const FullType(
-              _i3.BuiltList,
-              [FullType(_i4.AttributeType)],
+              _i4.BuiltList,
+              [FullType(_i3.AttributeType)],
             ),
-          ) as _i3.BuiltList<_i4.AttributeType>));
+          ) as _i4.BuiltList<_i3.AttributeType>));
           break;
       }
     }
@@ -200,8 +201,8 @@ class UpdateUserAttributesRequestAwsJson11Serializer
       serializers.serialize(
         payload.userAttributes,
         specifiedType: const FullType(
-          _i3.BuiltList,
-          [FullType(_i4.AttributeType)],
+          _i4.BuiltList,
+          [FullType(_i3.AttributeType)],
         ),
       ),
     ];
@@ -211,7 +212,7 @@ class UpdateUserAttributesRequestAwsJson11Serializer
         ..add(serializers.serialize(
           payload.clientMetadata!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(String),

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/update_user_attributes_request.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/update_user_attributes_request.g.dart
@@ -10,9 +10,9 @@ class _$UpdateUserAttributesRequest extends UpdateUserAttributesRequest {
   @override
   final String accessToken;
   @override
-  final _i3.BuiltMap<String, String>? clientMetadata;
+  final _i4.BuiltMap<String, String>? clientMetadata;
   @override
-  final _i3.BuiltList<_i4.AttributeType> userAttributes;
+  final _i4.BuiltList<_i3.AttributeType> userAttributes;
 
   factory _$UpdateUserAttributesRequest(
           [void Function(UpdateUserAttributesRequestBuilder)? updates]) =>
@@ -64,16 +64,16 @@ class UpdateUserAttributesRequestBuilder
   String? get accessToken => _$this._accessToken;
   set accessToken(String? accessToken) => _$this._accessToken = accessToken;
 
-  _i3.MapBuilder<String, String>? _clientMetadata;
-  _i3.MapBuilder<String, String> get clientMetadata =>
-      _$this._clientMetadata ??= new _i3.MapBuilder<String, String>();
-  set clientMetadata(_i3.MapBuilder<String, String>? clientMetadata) =>
+  _i4.MapBuilder<String, String>? _clientMetadata;
+  _i4.MapBuilder<String, String> get clientMetadata =>
+      _$this._clientMetadata ??= new _i4.MapBuilder<String, String>();
+  set clientMetadata(_i4.MapBuilder<String, String>? clientMetadata) =>
       _$this._clientMetadata = clientMetadata;
 
-  _i3.ListBuilder<_i4.AttributeType>? _userAttributes;
-  _i3.ListBuilder<_i4.AttributeType> get userAttributes =>
-      _$this._userAttributes ??= new _i3.ListBuilder<_i4.AttributeType>();
-  set userAttributes(_i3.ListBuilder<_i4.AttributeType>? userAttributes) =>
+  _i4.ListBuilder<_i3.AttributeType>? _userAttributes;
+  _i4.ListBuilder<_i3.AttributeType> get userAttributes =>
+      _$this._userAttributes ??= new _i4.ListBuilder<_i3.AttributeType>();
+  set userAttributes(_i4.ListBuilder<_i3.AttributeType>? userAttributes) =>
       _$this._userAttributes = userAttributes;
 
   UpdateUserAttributesRequestBuilder() {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/update_user_attributes_response.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/update_user_attributes_response.dart
@@ -17,9 +17,9 @@
 library amplify_auth_cognito_dart.cognito_identity_provider.model.update_user_attributes_response; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/code_delivery_details_type.dart'
-    as _i3;
+    as _i2;
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i2;
+import 'package:built_collection/built_collection.dart' as _i3;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i4;
@@ -35,9 +35,11 @@ abstract class UpdateUserAttributesResponse
             UpdateUserAttributesResponseBuilder> {
   /// Represents the response from the server for the request to update user attributes.
   factory UpdateUserAttributesResponse(
-      {_i2.BuiltList<_i3.CodeDeliveryDetailsType>? codeDeliveryDetailsList}) {
+      {List<_i2.CodeDeliveryDetailsType>? codeDeliveryDetailsList}) {
     return _$UpdateUserAttributesResponse._(
-        codeDeliveryDetailsList: codeDeliveryDetailsList);
+        codeDeliveryDetailsList: codeDeliveryDetailsList == null
+            ? null
+            : _i3.BuiltList(codeDeliveryDetailsList));
   }
 
   /// Represents the response from the server for the request to update user attributes.
@@ -62,7 +64,7 @@ abstract class UpdateUserAttributesResponse
   static void _init(UpdateUserAttributesResponseBuilder b) {}
 
   /// The code delivery details list from the server for the request to update user attributes.
-  _i2.BuiltList<_i3.CodeDeliveryDetailsType>? get codeDeliveryDetailsList;
+  _i3.BuiltList<_i2.CodeDeliveryDetailsType>? get codeDeliveryDetailsList;
   @override
   List<Object?> get props => [codeDeliveryDetailsList];
   @override
@@ -111,10 +113,10 @@ class UpdateUserAttributesResponseAwsJson11Serializer
             result.codeDeliveryDetailsList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltList,
-                [FullType(_i3.CodeDeliveryDetailsType)],
+                _i3.BuiltList,
+                [FullType(_i2.CodeDeliveryDetailsType)],
               ),
-            ) as _i2.BuiltList<_i3.CodeDeliveryDetailsType>));
+            ) as _i3.BuiltList<_i2.CodeDeliveryDetailsType>));
           }
           break;
       }
@@ -137,8 +139,8 @@ class UpdateUserAttributesResponseAwsJson11Serializer
         ..add(serializers.serialize(
           payload.codeDeliveryDetailsList!,
           specifiedType: const FullType(
-            _i2.BuiltList,
-            [FullType(_i3.CodeDeliveryDetailsType)],
+            _i3.BuiltList,
+            [FullType(_i2.CodeDeliveryDetailsType)],
           ),
         ));
     }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/update_user_attributes_response.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/model/update_user_attributes_response.g.dart
@@ -8,7 +8,7 @@ part of amplify_auth_cognito_dart.cognito_identity_provider.model.update_user_at
 
 class _$UpdateUserAttributesResponse extends UpdateUserAttributesResponse {
   @override
-  final _i2.BuiltList<_i3.CodeDeliveryDetailsType>? codeDeliveryDetailsList;
+  final _i3.BuiltList<_i2.CodeDeliveryDetailsType>? codeDeliveryDetailsList;
 
   factory _$UpdateUserAttributesResponse(
           [void Function(UpdateUserAttributesResponseBuilder)? updates]) =>
@@ -44,12 +44,12 @@ class UpdateUserAttributesResponseBuilder
             UpdateUserAttributesResponseBuilder> {
   _$UpdateUserAttributesResponse? _$v;
 
-  _i2.ListBuilder<_i3.CodeDeliveryDetailsType>? _codeDeliveryDetailsList;
-  _i2.ListBuilder<_i3.CodeDeliveryDetailsType> get codeDeliveryDetailsList =>
+  _i3.ListBuilder<_i2.CodeDeliveryDetailsType>? _codeDeliveryDetailsList;
+  _i3.ListBuilder<_i2.CodeDeliveryDetailsType> get codeDeliveryDetailsList =>
       _$this._codeDeliveryDetailsList ??=
-          new _i2.ListBuilder<_i3.CodeDeliveryDetailsType>();
+          new _i3.ListBuilder<_i2.CodeDeliveryDetailsType>();
   set codeDeliveryDetailsList(
-          _i2.ListBuilder<_i3.CodeDeliveryDetailsType>?
+          _i3.ListBuilder<_i2.CodeDeliveryDetailsType>?
               codeDeliveryDetailsList) =>
       _$this._codeDeliveryDetailsList = codeDeliveryDetailsList;
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
@@ -28,7 +28,6 @@ import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart
 import 'package:amplify_auth_cognito_dart/src/state/machines/generated/fetch_auth_session_state_machine_base.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:stream_transform/stream_transform.dart';
 
 /// {@template amplify_auth_cognito.fetch_auth_session_state_machine}
@@ -113,7 +112,7 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
       () => _cognitoIdentityClient.getId(
         GetIdInput(
           identityPoolId: config.poolId,
-          logins: BuiltMap(_logins(federatedIdentity)),
+          logins: _logins(federatedIdentity),
         ),
       ),
     );
@@ -133,7 +132,7 @@ class FetchAuthSessionStateMachine extends FetchAuthSessionStateMachineBase {
       () => _cognitoIdentityClient.getCredentialsForIdentity(
         GetCredentialsForIdentityInput(
           identityId: identityId,
-          logins: BuiltMap(_logins(federatedIdentity)),
+          logins: _logins(federatedIdentity),
         ),
       ),
     );

--- a/packages/auth/amplify_auth_cognito_test/test/plugin/fetch_user_attributes_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/plugin/fetch_user_attributes_test.dart
@@ -17,7 +17,6 @@ import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart'
 import 'package:amplify_auth_cognito_dart/src/crypto/crypto.dart';
 import 'package:amplify_auth_cognito_dart/src/jwt/jwt.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:mockito/mockito.dart';
 import 'package:smithy/smithy.dart';
 import 'package:test/test.dart';
@@ -138,10 +137,10 @@ void main() {
     stateMachine.addInstance<CognitoIdentityProviderClient>(
       MockCognitoIdpClient(
         getUser: () async => GetUserResponse(
-          userAttributes: BuiltList([
+          userAttributes: [
             for (final entry in claims.entries)
               AttributeType(name: entry.key, value: entry.value),
-          ]),
+          ],
           username: username,
         ),
       ),

--- a/packages/smithy/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/scoped_config.dart
@@ -5,12 +5,12 @@ library aws_json1_0_v1.json_rpc_10.model.scoped_config; // ignore_for_file: no_l
 import 'package:aws_common/aws_common.dart' as _i1;
 import 'package:aws_json1_0_v1/src/json_rpc_10/model/client_config.dart' as _i2;
 import 'package:aws_json1_0_v1/src/json_rpc_10/model/environment_config.dart'
-    as _i5;
-import 'package:aws_json1_0_v1/src/json_rpc_10/model/file_config_settings.dart'
     as _i4;
+import 'package:aws_json1_0_v1/src/json_rpc_10/model/file_config_settings.dart'
+    as _i3;
 import 'package:aws_json1_0_v1/src/json_rpc_10/model/operation_config.dart'
-    as _i6;
-import 'package:built_collection/built_collection.dart' as _i3;
+    as _i5;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i7;
@@ -24,15 +24,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -55,16 +56,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -142,13 +143,13 @@ class ScopedConfigAwsJson10Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -156,29 +157,29 @@ class ScopedConfigAwsJson10Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -209,10 +210,10 @@ class ScopedConfigAwsJson10Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -223,10 +224,10 @@ class ScopedConfigAwsJson10Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -236,7 +237,7 @@ class ScopedConfigAwsJson10Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -244,7 +245,7 @@ class ScopedConfigAwsJson10Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/error_with_members.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/error_with_members.dart
@@ -21,8 +21,8 @@ abstract class ErrorWithMembers
     String? code,
     _i3.KitchenSink? complexData,
     int? integerField,
-    _i4.BuiltList<String>? listField,
-    _i4.BuiltMap<String, String>? mapField,
+    List<String>? listField,
+    Map<String, String>? mapField,
     String? message,
     String? stringField,
   }) {
@@ -30,8 +30,8 @@ abstract class ErrorWithMembers
       code: code,
       complexData: complexData,
       integerField: integerField,
-      listField: listField,
-      mapField: mapField,
+      listField: listField == null ? null : _i4.BuiltList(listField),
+      mapField: mapField == null ? null : _i4.BuiltMap(mapField),
       message: message,
       stringField: stringField,
     );

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/json_enums_input_output.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/json_enums_input_output.dart
@@ -20,17 +20,17 @@ abstract class JsonEnumsInputOutput
     _i3.FooEnum? fooEnum1,
     _i3.FooEnum? fooEnum2,
     _i3.FooEnum? fooEnum3,
-    _i4.BuiltList<_i3.FooEnum>? fooEnumList,
-    _i4.BuiltMap<String, _i3.FooEnum>? fooEnumMap,
-    _i4.BuiltSet<_i3.FooEnum>? fooEnumSet,
+    List<_i3.FooEnum>? fooEnumList,
+    Map<String, _i3.FooEnum>? fooEnumMap,
+    Set<_i3.FooEnum>? fooEnumSet,
   }) {
     return _$JsonEnumsInputOutput._(
       fooEnum1: fooEnum1,
       fooEnum2: fooEnum2,
       fooEnum3: fooEnum3,
-      fooEnumList: fooEnumList,
-      fooEnumMap: fooEnumMap,
-      fooEnumSet: fooEnumSet,
+      fooEnumList: fooEnumList == null ? null : _i4.BuiltList(fooEnumList),
+      fooEnumMap: fooEnumMap == null ? null : _i4.BuiltMap(fooEnumMap),
+      fooEnumSet: fooEnumSet == null ? null : _i4.BuiltSet(fooEnumSet),
     );
   }
 

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/kitchen_sink.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/kitchen_sink.dart
@@ -8,14 +8,14 @@ import 'package:aws_common/aws_common.dart' as _i2;
 import 'package:aws_json1_1_v1/src/json_protocol/model/empty_struct.dart'
     as _i4;
 import 'package:aws_json1_1_v1/src/json_protocol/model/simple_struct.dart'
-    as _i7;
+    as _i5;
 import 'package:aws_json1_1_v1/src/json_protocol/model/struct_with_json_name.dart'
-    as _i9;
-import 'package:built_collection/built_collection.dart' as _i6;
+    as _i7;
+import 'package:built_collection/built_collection.dart' as _i9;
 import 'package:built_value/built_value.dart';
-import 'package:built_value/json_object.dart' as _i5;
+import 'package:built_value/json_object.dart' as _i8;
 import 'package:built_value/serializer.dart';
-import 'package:fixnum/fixnum.dart' as _i8;
+import 'package:fixnum/fixnum.dart' as _i6;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'kitchen_sink.g.dart';
@@ -32,22 +32,22 @@ abstract class KitchenSink
     DateTime? httpdateTimestamp,
     int? integer,
     DateTime? iso8601Timestamp,
-    _i5.JsonObject? jsonValue,
-    _i6.BuiltList<_i6.BuiltList<String>>? listOfLists,
-    _i6.BuiltList<_i6.BuiltMap<String, String>>? listOfMapsOfStrings,
-    _i6.BuiltList<String>? listOfStrings,
-    _i6.BuiltList<_i7.SimpleStruct>? listOfStructs,
-    _i8.Int64? long,
-    _i6.BuiltListMultimap<String, String>? mapOfListsOfStrings,
-    _i6.BuiltMap<String, _i6.BuiltMap<String, String>>? mapOfMaps,
-    _i6.BuiltMap<String, String>? mapOfStrings,
-    _i6.BuiltMap<String, _i7.SimpleStruct>? mapOfStructs,
-    _i6.BuiltList<KitchenSink>? recursiveList,
-    _i6.BuiltMap<String, KitchenSink>? recursiveMap,
+    Object? jsonValue,
+    List<List<String>>? listOfLists,
+    List<Map<String, String>>? listOfMapsOfStrings,
+    List<String>? listOfStrings,
+    List<_i5.SimpleStruct>? listOfStructs,
+    _i6.Int64? long,
+    Map<String, List<String>>? mapOfListsOfStrings,
+    Map<String, Map<String, String>>? mapOfMaps,
+    Map<String, String>? mapOfStrings,
+    Map<String, _i5.SimpleStruct>? mapOfStructs,
+    List<KitchenSink>? recursiveList,
+    Map<String, KitchenSink>? recursiveMap,
     KitchenSink? recursiveStruct,
-    _i7.SimpleStruct? simpleStruct,
+    _i5.SimpleStruct? simpleStruct,
     String? string,
-    _i9.StructWithJsonName? structWithJsonName,
+    _i7.StructWithJsonName? structWithJsonName,
     DateTime? timestamp,
     DateTime? unixTimestamp,
   }) {
@@ -60,18 +60,36 @@ abstract class KitchenSink
       httpdateTimestamp: httpdateTimestamp,
       integer: integer,
       iso8601Timestamp: iso8601Timestamp,
-      jsonValue: jsonValue,
-      listOfLists: listOfLists,
-      listOfMapsOfStrings: listOfMapsOfStrings,
-      listOfStrings: listOfStrings,
-      listOfStructs: listOfStructs,
+      jsonValue: jsonValue == null ? null : _i8.JsonObject(jsonValue),
+      listOfLists: listOfLists == null
+          ? null
+          : _i9.BuiltList(listOfLists.map((el) => _i9.BuiltList(el))),
+      listOfMapsOfStrings: listOfMapsOfStrings == null
+          ? null
+          : _i9.BuiltList(listOfMapsOfStrings.map((el) => _i9.BuiltMap(el))),
+      listOfStrings:
+          listOfStrings == null ? null : _i9.BuiltList(listOfStrings),
+      listOfStructs:
+          listOfStructs == null ? null : _i9.BuiltList(listOfStructs),
       long: long,
-      mapOfListsOfStrings: mapOfListsOfStrings,
-      mapOfMaps: mapOfMaps,
-      mapOfStrings: mapOfStrings,
-      mapOfStructs: mapOfStructs,
-      recursiveList: recursiveList,
-      recursiveMap: recursiveMap,
+      mapOfListsOfStrings: mapOfListsOfStrings == null
+          ? null
+          : _i9.BuiltListMultimap(mapOfListsOfStrings),
+      mapOfMaps: mapOfMaps == null
+          ? null
+          : _i9.BuiltMap(mapOfMaps.map((
+              key,
+              value,
+            ) =>
+              MapEntry(
+                key,
+                _i9.BuiltMap(value),
+              ))),
+      mapOfStrings: mapOfStrings == null ? null : _i9.BuiltMap(mapOfStrings),
+      mapOfStructs: mapOfStructs == null ? null : _i9.BuiltMap(mapOfStructs),
+      recursiveList:
+          recursiveList == null ? null : _i9.BuiltList(recursiveList),
+      recursiveMap: recursiveMap == null ? null : _i9.BuiltMap(recursiveMap),
       recursiveStruct: recursiveStruct,
       simpleStruct: simpleStruct,
       string: string,
@@ -114,22 +132,22 @@ abstract class KitchenSink
   DateTime? get httpdateTimestamp;
   int? get integer;
   DateTime? get iso8601Timestamp;
-  _i5.JsonObject? get jsonValue;
-  _i6.BuiltList<_i6.BuiltList<String>>? get listOfLists;
-  _i6.BuiltList<_i6.BuiltMap<String, String>>? get listOfMapsOfStrings;
-  _i6.BuiltList<String>? get listOfStrings;
-  _i6.BuiltList<_i7.SimpleStruct>? get listOfStructs;
-  _i8.Int64? get long;
-  _i6.BuiltListMultimap<String, String>? get mapOfListsOfStrings;
-  _i6.BuiltMap<String, _i6.BuiltMap<String, String>>? get mapOfMaps;
-  _i6.BuiltMap<String, String>? get mapOfStrings;
-  _i6.BuiltMap<String, _i7.SimpleStruct>? get mapOfStructs;
-  _i6.BuiltList<KitchenSink>? get recursiveList;
-  _i6.BuiltMap<String, KitchenSink>? get recursiveMap;
+  _i8.JsonObject? get jsonValue;
+  _i9.BuiltList<_i9.BuiltList<String>>? get listOfLists;
+  _i9.BuiltList<_i9.BuiltMap<String, String>>? get listOfMapsOfStrings;
+  _i9.BuiltList<String>? get listOfStrings;
+  _i9.BuiltList<_i5.SimpleStruct>? get listOfStructs;
+  _i6.Int64? get long;
+  _i9.BuiltListMultimap<String, String>? get mapOfListsOfStrings;
+  _i9.BuiltMap<String, _i9.BuiltMap<String, String>>? get mapOfMaps;
+  _i9.BuiltMap<String, String>? get mapOfStrings;
+  _i9.BuiltMap<String, _i5.SimpleStruct>? get mapOfStructs;
+  _i9.BuiltList<KitchenSink>? get recursiveList;
+  _i9.BuiltMap<String, KitchenSink>? get recursiveMap;
   KitchenSink? get recursiveStruct;
-  _i7.SimpleStruct? get simpleStruct;
+  _i5.SimpleStruct? get simpleStruct;
   String? get string;
-  _i9.StructWithJsonName? get structWithJsonName;
+  _i7.StructWithJsonName? get structWithJsonName;
   DateTime? get timestamp;
   DateTime? get unixTimestamp;
   @override
@@ -373,8 +391,8 @@ class KitchenSinkAwsJson11Serializer
           if (value != null) {
             result.jsonValue = (serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.JsonObject),
-            ) as _i5.JsonObject);
+              specifiedType: const FullType(_i8.JsonObject),
+            ) as _i8.JsonObject);
           }
           break;
         case 'ListOfLists':
@@ -382,15 +400,15 @@ class KitchenSinkAwsJson11Serializer
             result.listOfLists.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltList,
+                _i9.BuiltList,
                 [
                   FullType(
-                    _i6.BuiltList,
+                    _i9.BuiltList,
                     [FullType(String)],
                   )
                 ],
               ),
-            ) as _i6.BuiltList<_i6.BuiltList<String>>));
+            ) as _i9.BuiltList<_i9.BuiltList<String>>));
           }
           break;
         case 'ListOfMapsOfStrings':
@@ -398,10 +416,10 @@ class KitchenSinkAwsJson11Serializer
             result.listOfMapsOfStrings.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltList,
+                _i9.BuiltList,
                 [
                   FullType(
-                    _i6.BuiltMap,
+                    _i9.BuiltMap,
                     [
                       FullType(String),
                       FullType(String),
@@ -409,7 +427,7 @@ class KitchenSinkAwsJson11Serializer
                   )
                 ],
               ),
-            ) as _i6.BuiltList<_i6.BuiltMap<String, String>>));
+            ) as _i9.BuiltList<_i9.BuiltMap<String, String>>));
           }
           break;
         case 'ListOfStrings':
@@ -417,10 +435,10 @@ class KitchenSinkAwsJson11Serializer
             result.listOfStrings.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltList,
+                _i9.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i6.BuiltList<String>));
+            ) as _i9.BuiltList<String>));
           }
           break;
         case 'ListOfStructs':
@@ -428,18 +446,18 @@ class KitchenSinkAwsJson11Serializer
             result.listOfStructs.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltList,
-                [FullType(_i7.SimpleStruct)],
+                _i9.BuiltList,
+                [FullType(_i5.SimpleStruct)],
               ),
-            ) as _i6.BuiltList<_i7.SimpleStruct>));
+            ) as _i9.BuiltList<_i5.SimpleStruct>));
           }
           break;
         case 'Long':
           if (value != null) {
             result.long = (serializers.deserialize(
               value,
-              specifiedType: const FullType(_i8.Int64),
-            ) as _i8.Int64);
+              specifiedType: const FullType(_i6.Int64),
+            ) as _i6.Int64);
           }
           break;
         case 'MapOfListsOfStrings':
@@ -447,13 +465,13 @@ class KitchenSinkAwsJson11Serializer
             result.mapOfListsOfStrings.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltListMultimap,
+                _i9.BuiltListMultimap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i6.BuiltListMultimap<String, String>));
+            ) as _i9.BuiltListMultimap<String, String>));
           }
           break;
         case 'MapOfMaps':
@@ -461,11 +479,11 @@ class KitchenSinkAwsJson11Serializer
             result.mapOfMaps.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltMap,
+                _i9.BuiltMap,
                 [
                   FullType(String),
                   FullType(
-                    _i6.BuiltMap,
+                    _i9.BuiltMap,
                     [
                       FullType(String),
                       FullType(String),
@@ -473,7 +491,7 @@ class KitchenSinkAwsJson11Serializer
                   ),
                 ],
               ),
-            ) as _i6.BuiltMap<String, _i6.BuiltMap<String, String>>));
+            ) as _i9.BuiltMap<String, _i9.BuiltMap<String, String>>));
           }
           break;
         case 'MapOfStrings':
@@ -481,13 +499,13 @@ class KitchenSinkAwsJson11Serializer
             result.mapOfStrings.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltMap,
+                _i9.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i6.BuiltMap<String, String>));
+            ) as _i9.BuiltMap<String, String>));
           }
           break;
         case 'MapOfStructs':
@@ -495,13 +513,13 @@ class KitchenSinkAwsJson11Serializer
             result.mapOfStructs.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltMap,
+                _i9.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i7.SimpleStruct),
+                  FullType(_i5.SimpleStruct),
                 ],
               ),
-            ) as _i6.BuiltMap<String, _i7.SimpleStruct>));
+            ) as _i9.BuiltMap<String, _i5.SimpleStruct>));
           }
           break;
         case 'RecursiveList':
@@ -509,10 +527,10 @@ class KitchenSinkAwsJson11Serializer
             result.recursiveList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltList,
+                _i9.BuiltList,
                 [FullType(KitchenSink)],
               ),
-            ) as _i6.BuiltList<KitchenSink>));
+            ) as _i9.BuiltList<KitchenSink>));
           }
           break;
         case 'RecursiveMap':
@@ -520,13 +538,13 @@ class KitchenSinkAwsJson11Serializer
             result.recursiveMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltMap,
+                _i9.BuiltMap,
                 [
                   FullType(String),
                   FullType(KitchenSink),
                 ],
               ),
-            ) as _i6.BuiltMap<String, KitchenSink>));
+            ) as _i9.BuiltMap<String, KitchenSink>));
           }
           break;
         case 'RecursiveStruct':
@@ -541,8 +559,8 @@ class KitchenSinkAwsJson11Serializer
           if (value != null) {
             result.simpleStruct.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i7.SimpleStruct),
-            ) as _i7.SimpleStruct));
+              specifiedType: const FullType(_i5.SimpleStruct),
+            ) as _i5.SimpleStruct));
           }
           break;
         case 'String':
@@ -557,8 +575,8 @@ class KitchenSinkAwsJson11Serializer
           if (value != null) {
             result.structWithJsonName.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i9.StructWithJsonName),
-            ) as _i9.StructWithJsonName));
+              specifiedType: const FullType(_i7.StructWithJsonName),
+            ) as _i7.StructWithJsonName));
           }
           break;
         case 'Timestamp':
@@ -661,7 +679,7 @@ class KitchenSinkAwsJson11Serializer
         ..add('JsonValue')
         ..add(serializers.serialize(
           payload.jsonValue!,
-          specifiedType: const FullType(_i5.JsonObject),
+          specifiedType: const FullType(_i8.JsonObject),
         ));
     }
     if (payload.listOfLists != null) {
@@ -670,10 +688,10 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.listOfLists!,
           specifiedType: const FullType(
-            _i6.BuiltList,
+            _i9.BuiltList,
             [
               FullType(
-                _i6.BuiltList,
+                _i9.BuiltList,
                 [FullType(String)],
               )
             ],
@@ -686,10 +704,10 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.listOfMapsOfStrings!,
           specifiedType: const FullType(
-            _i6.BuiltList,
+            _i9.BuiltList,
             [
               FullType(
-                _i6.BuiltMap,
+                _i9.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
@@ -705,7 +723,7 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.listOfStrings!,
           specifiedType: const FullType(
-            _i6.BuiltList,
+            _i9.BuiltList,
             [FullType(String)],
           ),
         ));
@@ -716,8 +734,8 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.listOfStructs!,
           specifiedType: const FullType(
-            _i6.BuiltList,
-            [FullType(_i7.SimpleStruct)],
+            _i9.BuiltList,
+            [FullType(_i5.SimpleStruct)],
           ),
         ));
     }
@@ -726,7 +744,7 @@ class KitchenSinkAwsJson11Serializer
         ..add('Long')
         ..add(serializers.serialize(
           payload.long!,
-          specifiedType: const FullType(_i8.Int64),
+          specifiedType: const FullType(_i6.Int64),
         ));
     }
     if (payload.mapOfListsOfStrings != null) {
@@ -735,7 +753,7 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.mapOfListsOfStrings!,
           specifiedType: const FullType(
-            _i6.BuiltListMultimap,
+            _i9.BuiltListMultimap,
             [
               FullType(String),
               FullType(String),
@@ -749,11 +767,11 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.mapOfMaps!,
           specifiedType: const FullType(
-            _i6.BuiltMap,
+            _i9.BuiltMap,
             [
               FullType(String),
               FullType(
-                _i6.BuiltMap,
+                _i9.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
@@ -769,7 +787,7 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.mapOfStrings!,
           specifiedType: const FullType(
-            _i6.BuiltMap,
+            _i9.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -783,10 +801,10 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.mapOfStructs!,
           specifiedType: const FullType(
-            _i6.BuiltMap,
+            _i9.BuiltMap,
             [
               FullType(String),
-              FullType(_i7.SimpleStruct),
+              FullType(_i5.SimpleStruct),
             ],
           ),
         ));
@@ -797,7 +815,7 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.recursiveList!,
           specifiedType: const FullType(
-            _i6.BuiltList,
+            _i9.BuiltList,
             [FullType(KitchenSink)],
           ),
         ));
@@ -808,7 +826,7 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.recursiveMap!,
           specifiedType: const FullType(
-            _i6.BuiltMap,
+            _i9.BuiltMap,
             [
               FullType(String),
               FullType(KitchenSink),
@@ -829,7 +847,7 @@ class KitchenSinkAwsJson11Serializer
         ..add('SimpleStruct')
         ..add(serializers.serialize(
           payload.simpleStruct!,
-          specifiedType: const FullType(_i7.SimpleStruct),
+          specifiedType: const FullType(_i5.SimpleStruct),
         ));
     }
     if (payload.string != null) {
@@ -845,7 +863,7 @@ class KitchenSinkAwsJson11Serializer
         ..add('StructWithJsonName')
         ..add(serializers.serialize(
           payload.structWithJsonName!,
-          specifiedType: const FullType(_i9.StructWithJsonName),
+          specifiedType: const FullType(_i7.StructWithJsonName),
         ));
     }
     if (payload.timestamp != null) {

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/kitchen_sink.g.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/kitchen_sink.g.dart
@@ -24,37 +24,37 @@ class _$KitchenSink extends KitchenSink {
   @override
   final DateTime? iso8601Timestamp;
   @override
-  final _i5.JsonObject? jsonValue;
+  final _i8.JsonObject? jsonValue;
   @override
-  final _i6.BuiltList<_i6.BuiltList<String>>? listOfLists;
+  final _i9.BuiltList<_i9.BuiltList<String>>? listOfLists;
   @override
-  final _i6.BuiltList<_i6.BuiltMap<String, String>>? listOfMapsOfStrings;
+  final _i9.BuiltList<_i9.BuiltMap<String, String>>? listOfMapsOfStrings;
   @override
-  final _i6.BuiltList<String>? listOfStrings;
+  final _i9.BuiltList<String>? listOfStrings;
   @override
-  final _i6.BuiltList<_i7.SimpleStruct>? listOfStructs;
+  final _i9.BuiltList<_i5.SimpleStruct>? listOfStructs;
   @override
-  final _i8.Int64? long;
+  final _i6.Int64? long;
   @override
-  final _i6.BuiltListMultimap<String, String>? mapOfListsOfStrings;
+  final _i9.BuiltListMultimap<String, String>? mapOfListsOfStrings;
   @override
-  final _i6.BuiltMap<String, _i6.BuiltMap<String, String>>? mapOfMaps;
+  final _i9.BuiltMap<String, _i9.BuiltMap<String, String>>? mapOfMaps;
   @override
-  final _i6.BuiltMap<String, String>? mapOfStrings;
+  final _i9.BuiltMap<String, String>? mapOfStrings;
   @override
-  final _i6.BuiltMap<String, _i7.SimpleStruct>? mapOfStructs;
+  final _i9.BuiltMap<String, _i5.SimpleStruct>? mapOfStructs;
   @override
-  final _i6.BuiltList<KitchenSink>? recursiveList;
+  final _i9.BuiltList<KitchenSink>? recursiveList;
   @override
-  final _i6.BuiltMap<String, KitchenSink>? recursiveMap;
+  final _i9.BuiltMap<String, KitchenSink>? recursiveMap;
   @override
   final KitchenSink? recursiveStruct;
   @override
-  final _i7.SimpleStruct? simpleStruct;
+  final _i5.SimpleStruct? simpleStruct;
   @override
   final String? string;
   @override
-  final _i9.StructWithJsonName? structWithJsonName;
+  final _i7.StructWithJsonName? structWithJsonName;
   @override
   final DateTime? timestamp;
   @override
@@ -213,78 +213,78 @@ class KitchenSinkBuilder implements Builder<KitchenSink, KitchenSinkBuilder> {
   set iso8601Timestamp(DateTime? iso8601Timestamp) =>
       _$this._iso8601Timestamp = iso8601Timestamp;
 
-  _i5.JsonObject? _jsonValue;
-  _i5.JsonObject? get jsonValue => _$this._jsonValue;
-  set jsonValue(_i5.JsonObject? jsonValue) => _$this._jsonValue = jsonValue;
+  _i8.JsonObject? _jsonValue;
+  _i8.JsonObject? get jsonValue => _$this._jsonValue;
+  set jsonValue(_i8.JsonObject? jsonValue) => _$this._jsonValue = jsonValue;
 
-  _i6.ListBuilder<_i6.BuiltList<String>>? _listOfLists;
-  _i6.ListBuilder<_i6.BuiltList<String>> get listOfLists =>
-      _$this._listOfLists ??= new _i6.ListBuilder<_i6.BuiltList<String>>();
-  set listOfLists(_i6.ListBuilder<_i6.BuiltList<String>>? listOfLists) =>
+  _i9.ListBuilder<_i9.BuiltList<String>>? _listOfLists;
+  _i9.ListBuilder<_i9.BuiltList<String>> get listOfLists =>
+      _$this._listOfLists ??= new _i9.ListBuilder<_i9.BuiltList<String>>();
+  set listOfLists(_i9.ListBuilder<_i9.BuiltList<String>>? listOfLists) =>
       _$this._listOfLists = listOfLists;
 
-  _i6.ListBuilder<_i6.BuiltMap<String, String>>? _listOfMapsOfStrings;
-  _i6.ListBuilder<_i6.BuiltMap<String, String>> get listOfMapsOfStrings =>
+  _i9.ListBuilder<_i9.BuiltMap<String, String>>? _listOfMapsOfStrings;
+  _i9.ListBuilder<_i9.BuiltMap<String, String>> get listOfMapsOfStrings =>
       _$this._listOfMapsOfStrings ??=
-          new _i6.ListBuilder<_i6.BuiltMap<String, String>>();
+          new _i9.ListBuilder<_i9.BuiltMap<String, String>>();
   set listOfMapsOfStrings(
-          _i6.ListBuilder<_i6.BuiltMap<String, String>>? listOfMapsOfStrings) =>
+          _i9.ListBuilder<_i9.BuiltMap<String, String>>? listOfMapsOfStrings) =>
       _$this._listOfMapsOfStrings = listOfMapsOfStrings;
 
-  _i6.ListBuilder<String>? _listOfStrings;
-  _i6.ListBuilder<String> get listOfStrings =>
-      _$this._listOfStrings ??= new _i6.ListBuilder<String>();
-  set listOfStrings(_i6.ListBuilder<String>? listOfStrings) =>
+  _i9.ListBuilder<String>? _listOfStrings;
+  _i9.ListBuilder<String> get listOfStrings =>
+      _$this._listOfStrings ??= new _i9.ListBuilder<String>();
+  set listOfStrings(_i9.ListBuilder<String>? listOfStrings) =>
       _$this._listOfStrings = listOfStrings;
 
-  _i6.ListBuilder<_i7.SimpleStruct>? _listOfStructs;
-  _i6.ListBuilder<_i7.SimpleStruct> get listOfStructs =>
-      _$this._listOfStructs ??= new _i6.ListBuilder<_i7.SimpleStruct>();
-  set listOfStructs(_i6.ListBuilder<_i7.SimpleStruct>? listOfStructs) =>
+  _i9.ListBuilder<_i5.SimpleStruct>? _listOfStructs;
+  _i9.ListBuilder<_i5.SimpleStruct> get listOfStructs =>
+      _$this._listOfStructs ??= new _i9.ListBuilder<_i5.SimpleStruct>();
+  set listOfStructs(_i9.ListBuilder<_i5.SimpleStruct>? listOfStructs) =>
       _$this._listOfStructs = listOfStructs;
 
-  _i8.Int64? _long;
-  _i8.Int64? get long => _$this._long;
-  set long(_i8.Int64? long) => _$this._long = long;
+  _i6.Int64? _long;
+  _i6.Int64? get long => _$this._long;
+  set long(_i6.Int64? long) => _$this._long = long;
 
-  _i6.ListMultimapBuilder<String, String>? _mapOfListsOfStrings;
-  _i6.ListMultimapBuilder<String, String> get mapOfListsOfStrings =>
+  _i9.ListMultimapBuilder<String, String>? _mapOfListsOfStrings;
+  _i9.ListMultimapBuilder<String, String> get mapOfListsOfStrings =>
       _$this._mapOfListsOfStrings ??=
-          new _i6.ListMultimapBuilder<String, String>();
+          new _i9.ListMultimapBuilder<String, String>();
   set mapOfListsOfStrings(
-          _i6.ListMultimapBuilder<String, String>? mapOfListsOfStrings) =>
+          _i9.ListMultimapBuilder<String, String>? mapOfListsOfStrings) =>
       _$this._mapOfListsOfStrings = mapOfListsOfStrings;
 
-  _i6.MapBuilder<String, _i6.BuiltMap<String, String>>? _mapOfMaps;
-  _i6.MapBuilder<String, _i6.BuiltMap<String, String>> get mapOfMaps =>
+  _i9.MapBuilder<String, _i9.BuiltMap<String, String>>? _mapOfMaps;
+  _i9.MapBuilder<String, _i9.BuiltMap<String, String>> get mapOfMaps =>
       _$this._mapOfMaps ??=
-          new _i6.MapBuilder<String, _i6.BuiltMap<String, String>>();
+          new _i9.MapBuilder<String, _i9.BuiltMap<String, String>>();
   set mapOfMaps(
-          _i6.MapBuilder<String, _i6.BuiltMap<String, String>>? mapOfMaps) =>
+          _i9.MapBuilder<String, _i9.BuiltMap<String, String>>? mapOfMaps) =>
       _$this._mapOfMaps = mapOfMaps;
 
-  _i6.MapBuilder<String, String>? _mapOfStrings;
-  _i6.MapBuilder<String, String> get mapOfStrings =>
-      _$this._mapOfStrings ??= new _i6.MapBuilder<String, String>();
-  set mapOfStrings(_i6.MapBuilder<String, String>? mapOfStrings) =>
+  _i9.MapBuilder<String, String>? _mapOfStrings;
+  _i9.MapBuilder<String, String> get mapOfStrings =>
+      _$this._mapOfStrings ??= new _i9.MapBuilder<String, String>();
+  set mapOfStrings(_i9.MapBuilder<String, String>? mapOfStrings) =>
       _$this._mapOfStrings = mapOfStrings;
 
-  _i6.MapBuilder<String, _i7.SimpleStruct>? _mapOfStructs;
-  _i6.MapBuilder<String, _i7.SimpleStruct> get mapOfStructs =>
-      _$this._mapOfStructs ??= new _i6.MapBuilder<String, _i7.SimpleStruct>();
-  set mapOfStructs(_i6.MapBuilder<String, _i7.SimpleStruct>? mapOfStructs) =>
+  _i9.MapBuilder<String, _i5.SimpleStruct>? _mapOfStructs;
+  _i9.MapBuilder<String, _i5.SimpleStruct> get mapOfStructs =>
+      _$this._mapOfStructs ??= new _i9.MapBuilder<String, _i5.SimpleStruct>();
+  set mapOfStructs(_i9.MapBuilder<String, _i5.SimpleStruct>? mapOfStructs) =>
       _$this._mapOfStructs = mapOfStructs;
 
-  _i6.ListBuilder<KitchenSink>? _recursiveList;
-  _i6.ListBuilder<KitchenSink> get recursiveList =>
-      _$this._recursiveList ??= new _i6.ListBuilder<KitchenSink>();
-  set recursiveList(_i6.ListBuilder<KitchenSink>? recursiveList) =>
+  _i9.ListBuilder<KitchenSink>? _recursiveList;
+  _i9.ListBuilder<KitchenSink> get recursiveList =>
+      _$this._recursiveList ??= new _i9.ListBuilder<KitchenSink>();
+  set recursiveList(_i9.ListBuilder<KitchenSink>? recursiveList) =>
       _$this._recursiveList = recursiveList;
 
-  _i6.MapBuilder<String, KitchenSink>? _recursiveMap;
-  _i6.MapBuilder<String, KitchenSink> get recursiveMap =>
-      _$this._recursiveMap ??= new _i6.MapBuilder<String, KitchenSink>();
-  set recursiveMap(_i6.MapBuilder<String, KitchenSink>? recursiveMap) =>
+  _i9.MapBuilder<String, KitchenSink>? _recursiveMap;
+  _i9.MapBuilder<String, KitchenSink> get recursiveMap =>
+      _$this._recursiveMap ??= new _i9.MapBuilder<String, KitchenSink>();
+  set recursiveMap(_i9.MapBuilder<String, KitchenSink>? recursiveMap) =>
       _$this._recursiveMap = recursiveMap;
 
   KitchenSinkBuilder? _recursiveStruct;
@@ -293,20 +293,20 @@ class KitchenSinkBuilder implements Builder<KitchenSink, KitchenSinkBuilder> {
   set recursiveStruct(KitchenSinkBuilder? recursiveStruct) =>
       _$this._recursiveStruct = recursiveStruct;
 
-  _i7.SimpleStructBuilder? _simpleStruct;
-  _i7.SimpleStructBuilder get simpleStruct =>
-      _$this._simpleStruct ??= new _i7.SimpleStructBuilder();
-  set simpleStruct(_i7.SimpleStructBuilder? simpleStruct) =>
+  _i5.SimpleStructBuilder? _simpleStruct;
+  _i5.SimpleStructBuilder get simpleStruct =>
+      _$this._simpleStruct ??= new _i5.SimpleStructBuilder();
+  set simpleStruct(_i5.SimpleStructBuilder? simpleStruct) =>
       _$this._simpleStruct = simpleStruct;
 
   String? _string;
   String? get string => _$this._string;
   set string(String? string) => _$this._string = string;
 
-  _i9.StructWithJsonNameBuilder? _structWithJsonName;
-  _i9.StructWithJsonNameBuilder get structWithJsonName =>
-      _$this._structWithJsonName ??= new _i9.StructWithJsonNameBuilder();
-  set structWithJsonName(_i9.StructWithJsonNameBuilder? structWithJsonName) =>
+  _i7.StructWithJsonNameBuilder? _structWithJsonName;
+  _i7.StructWithJsonNameBuilder get structWithJsonName =>
+      _$this._structWithJsonName ??= new _i7.StructWithJsonNameBuilder();
+  set structWithJsonName(_i7.StructWithJsonNameBuilder? structWithJsonName) =>
       _$this._structWithJsonName = structWithJsonName;
 
   DateTime? _timestamp;

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/null_operation_input_output.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/null_operation_input_output.dart
@@ -17,13 +17,15 @@ abstract class NullOperationInputOutput
     implements
         Built<NullOperationInputOutput, NullOperationInputOutputBuilder> {
   factory NullOperationInputOutput({
-    _i3.BuiltList<String?>? sparseStringList,
-    _i3.BuiltMap<String, String?>? sparseStringMap,
+    List<String?>? sparseStringList,
+    Map<String, String?>? sparseStringMap,
     String? string,
   }) {
     return _$NullOperationInputOutput._(
-      sparseStringList: sparseStringList,
-      sparseStringMap: sparseStringMap,
+      sparseStringList:
+          sparseStringList == null ? null : _i3.BuiltList(sparseStringList),
+      sparseStringMap:
+          sparseStringMap == null ? null : _i3.BuiltMap(sparseStringMap),
       string: string,
     );
   }

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/put_and_get_inline_documents_input_output.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/put_and_get_inline_documents_input_output.dart
@@ -17,10 +17,10 @@ abstract class PutAndGetInlineDocumentsInputOutput
     implements
         Built<PutAndGetInlineDocumentsInputOutput,
             PutAndGetInlineDocumentsInputOutputBuilder> {
-  factory PutAndGetInlineDocumentsInputOutput(
-      {_i3.JsonObject? inlineDocument}) {
+  factory PutAndGetInlineDocumentsInputOutput({Object? inlineDocument}) {
     return _$PutAndGetInlineDocumentsInputOutput._(
-        inlineDocument: inlineDocument);
+        inlineDocument:
+            inlineDocument == null ? null : _i3.JsonObject(inlineDocument));
   }
 
   factory PutAndGetInlineDocumentsInputOutput.build(

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/scoped_config.dart
@@ -6,12 +6,12 @@ import 'package:aws_common/aws_common.dart' as _i1;
 import 'package:aws_json1_1_v1/src/json_protocol/model/client_config.dart'
     as _i2;
 import 'package:aws_json1_1_v1/src/json_protocol/model/environment_config.dart'
-    as _i5;
-import 'package:aws_json1_1_v1/src/json_protocol/model/file_config_settings.dart'
     as _i4;
+import 'package:aws_json1_1_v1/src/json_protocol/model/file_config_settings.dart'
+    as _i3;
 import 'package:aws_json1_1_v1/src/json_protocol/model/operation_config.dart'
-    as _i6;
-import 'package:built_collection/built_collection.dart' as _i3;
+    as _i5;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i7;
@@ -25,15 +25,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -56,16 +57,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -143,13 +144,13 @@ class ScopedConfigAwsJson11Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -157,29 +158,29 @@ class ScopedConfigAwsJson11Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -210,10 +211,10 @@ class ScopedConfigAwsJson11Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -224,10 +225,10 @@ class ScopedConfigAwsJson11Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -237,7 +238,7 @@ class ScopedConfigAwsJson11Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -245,7 +246,7 @@ class ScopedConfigAwsJson11Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/model/predict_input.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/model/predict_input.dart
@@ -16,12 +16,12 @@ abstract class PredictInput
   factory PredictInput({
     required String mlModelId,
     required String predictEndpoint,
-    required _i3.BuiltMap<String, String> record,
+    required Map<String, String> record,
   }) {
     return _$PredictInput._(
       mlModelId: mlModelId,
       predictEndpoint: predictEndpoint,
-      record: record,
+      record: _i3.BuiltMap(record),
     );
   }
 

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/model/prediction.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/model/prediction.dart
@@ -4,8 +4,8 @@ library aws_json1_1_v1.machine_learning.model.prediction; // ignore_for_file: no
 
 import 'package:aws_common/aws_common.dart' as _i1;
 import 'package:aws_json1_1_v1/src/machine_learning/model/details_attributes.dart'
-    as _i3;
-import 'package:built_collection/built_collection.dart' as _i2;
+    as _i2;
+import 'package:built_collection/built_collection.dart' as _i3;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i4;
@@ -16,15 +16,16 @@ abstract class Prediction
     with _i1.AWSEquatable<Prediction>
     implements Built<Prediction, PredictionBuilder> {
   factory Prediction({
-    _i2.BuiltMap<_i3.DetailsAttributes, String>? details,
+    Map<_i2.DetailsAttributes, String>? details,
     String? predictedLabel,
-    _i2.BuiltMap<String, double>? predictedScores,
+    Map<String, double>? predictedScores,
     double? predictedValue,
   }) {
     return _$Prediction._(
-      details: details,
+      details: details == null ? null : _i3.BuiltMap(details),
       predictedLabel: predictedLabel,
-      predictedScores: predictedScores,
+      predictedScores:
+          predictedScores == null ? null : _i3.BuiltMap(predictedScores),
       predictedValue: predictedValue,
     );
   }
@@ -40,9 +41,9 @@ abstract class Prediction
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(PredictionBuilder b) {}
-  _i2.BuiltMap<_i3.DetailsAttributes, String>? get details;
+  _i3.BuiltMap<_i2.DetailsAttributes, String>? get details;
   String? get predictedLabel;
-  _i2.BuiltMap<String, double>? get predictedScores;
+  _i3.BuiltMap<String, double>? get predictedScores;
   double? get predictedValue;
   @override
   List<Object?> get props => [
@@ -108,13 +109,13 @@ class PredictionAwsJson11Serializer
             result.details.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltMap,
+                _i3.BuiltMap,
                 [
-                  FullType(_i3.DetailsAttributes),
+                  FullType(_i2.DetailsAttributes),
                   FullType(String),
                 ],
               ),
-            ) as _i2.BuiltMap<_i3.DetailsAttributes, String>));
+            ) as _i3.BuiltMap<_i2.DetailsAttributes, String>));
           }
           break;
         case 'predictedLabel':
@@ -130,13 +131,13 @@ class PredictionAwsJson11Serializer
             result.predictedScores.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltMap,
+                _i3.BuiltMap,
                 [
                   FullType(String),
                   FullType(double),
                 ],
               ),
-            ) as _i2.BuiltMap<String, double>));
+            ) as _i3.BuiltMap<String, double>));
           }
           break;
         case 'predictedValue':
@@ -167,9 +168,9 @@ class PredictionAwsJson11Serializer
         ..add(serializers.serialize(
           payload.details!,
           specifiedType: const FullType(
-            _i2.BuiltMap,
+            _i3.BuiltMap,
             [
-              FullType(_i3.DetailsAttributes),
+              FullType(_i2.DetailsAttributes),
               FullType(String),
             ],
           ),
@@ -189,7 +190,7 @@ class PredictionAwsJson11Serializer
         ..add(serializers.serialize(
           payload.predictedScores!,
           specifiedType: const FullType(
-            _i2.BuiltMap,
+            _i3.BuiltMap,
             [
               FullType(String),
               FullType(double),

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/model/prediction.g.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/model/prediction.g.dart
@@ -8,11 +8,11 @@ part of aws_json1_1_v1.machine_learning.model.prediction;
 
 class _$Prediction extends Prediction {
   @override
-  final _i2.BuiltMap<_i3.DetailsAttributes, String>? details;
+  final _i3.BuiltMap<_i2.DetailsAttributes, String>? details;
   @override
   final String? predictedLabel;
   @override
-  final _i2.BuiltMap<String, double>? predictedScores;
+  final _i3.BuiltMap<String, double>? predictedScores;
   @override
   final double? predictedValue;
 
@@ -55,10 +55,10 @@ class _$Prediction extends Prediction {
 class PredictionBuilder implements Builder<Prediction, PredictionBuilder> {
   _$Prediction? _$v;
 
-  _i2.MapBuilder<_i3.DetailsAttributes, String>? _details;
-  _i2.MapBuilder<_i3.DetailsAttributes, String> get details =>
-      _$this._details ??= new _i2.MapBuilder<_i3.DetailsAttributes, String>();
-  set details(_i2.MapBuilder<_i3.DetailsAttributes, String>? details) =>
+  _i3.MapBuilder<_i2.DetailsAttributes, String>? _details;
+  _i3.MapBuilder<_i2.DetailsAttributes, String> get details =>
+      _$this._details ??= new _i3.MapBuilder<_i2.DetailsAttributes, String>();
+  set details(_i3.MapBuilder<_i2.DetailsAttributes, String>? details) =>
       _$this._details = details;
 
   String? _predictedLabel;
@@ -66,10 +66,10 @@ class PredictionBuilder implements Builder<Prediction, PredictionBuilder> {
   set predictedLabel(String? predictedLabel) =>
       _$this._predictedLabel = predictedLabel;
 
-  _i2.MapBuilder<String, double>? _predictedScores;
-  _i2.MapBuilder<String, double> get predictedScores =>
-      _$this._predictedScores ??= new _i2.MapBuilder<String, double>();
-  set predictedScores(_i2.MapBuilder<String, double>? predictedScores) =>
+  _i3.MapBuilder<String, double>? _predictedScores;
+  _i3.MapBuilder<String, double> get predictedScores =>
+      _$this._predictedScores ??= new _i3.MapBuilder<String, double>();
+  set predictedScores(_i3.MapBuilder<String, double>? predictedScores) =>
       _$this._predictedScores = predictedScores;
 
   double? _predictedValue;

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/model/scoped_config.dart
@@ -6,12 +6,12 @@ import 'package:aws_common/aws_common.dart' as _i1;
 import 'package:aws_json1_1_v1/src/machine_learning/model/client_config.dart'
     as _i2;
 import 'package:aws_json1_1_v1/src/machine_learning/model/environment_config.dart'
-    as _i5;
-import 'package:aws_json1_1_v1/src/machine_learning/model/file_config_settings.dart'
     as _i4;
+import 'package:aws_json1_1_v1/src/machine_learning/model/file_config_settings.dart'
+    as _i3;
 import 'package:aws_json1_1_v1/src/machine_learning/model/operation_config.dart'
-    as _i6;
-import 'package:built_collection/built_collection.dart' as _i3;
+    as _i5;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i7;
@@ -25,15 +25,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -56,16 +57,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -143,13 +144,13 @@ class ScopedConfigAwsJson11Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -157,29 +158,29 @@ class ScopedConfigAwsJson11Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -210,10 +211,10 @@ class ScopedConfigAwsJson11Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -224,10 +225,10 @@ class ScopedConfigAwsJson11Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -237,7 +238,7 @@ class ScopedConfigAwsJson11Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -245,7 +246,7 @@ class ScopedConfigAwsJson11Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/endpoint_configuration.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/endpoint_configuration.dart
@@ -3,10 +3,10 @@
 library rest_json1_v1.api_gateway.model.endpoint_configuration; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i2;
+import 'package:built_collection/built_collection.dart' as _i3;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:rest_json1_v1/src/api_gateway/model/endpoint_type.dart' as _i3;
+import 'package:rest_json1_v1/src/api_gateway/model/endpoint_type.dart' as _i2;
 import 'package:smithy/smithy.dart' as _i4;
 
 part 'endpoint_configuration.g.dart';
@@ -15,12 +15,13 @@ abstract class EndpointConfiguration
     with _i1.AWSEquatable<EndpointConfiguration>
     implements Built<EndpointConfiguration, EndpointConfigurationBuilder> {
   factory EndpointConfiguration({
-    _i2.BuiltList<_i3.EndpointType>? types,
-    _i2.BuiltList<String>? vpcEndpointIds,
+    List<_i2.EndpointType>? types,
+    List<String>? vpcEndpointIds,
   }) {
     return _$EndpointConfiguration._(
-      types: types,
-      vpcEndpointIds: vpcEndpointIds,
+      types: types == null ? null : _i3.BuiltList(types),
+      vpcEndpointIds:
+          vpcEndpointIds == null ? null : _i3.BuiltList(vpcEndpointIds),
     );
   }
 
@@ -36,8 +37,8 @@ abstract class EndpointConfiguration
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(EndpointConfigurationBuilder b) {}
-  _i2.BuiltList<_i3.EndpointType>? get types;
-  _i2.BuiltList<String>? get vpcEndpointIds;
+  _i3.BuiltList<_i2.EndpointType>? get types;
+  _i3.BuiltList<String>? get vpcEndpointIds;
   @override
   List<Object?> get props => [
         types,
@@ -93,10 +94,10 @@ class EndpointConfigurationRestJson1Serializer
             result.types.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltList,
-                [FullType(_i3.EndpointType)],
+                _i3.BuiltList,
+                [FullType(_i2.EndpointType)],
               ),
-            ) as _i2.BuiltList<_i3.EndpointType>));
+            ) as _i3.BuiltList<_i2.EndpointType>));
           }
           break;
         case 'vpcEndpointIds':
@@ -104,10 +105,10 @@ class EndpointConfigurationRestJson1Serializer
             result.vpcEndpointIds.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltList,
+                _i3.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i2.BuiltList<String>));
+            ) as _i3.BuiltList<String>));
           }
           break;
       }
@@ -130,8 +131,8 @@ class EndpointConfigurationRestJson1Serializer
         ..add(serializers.serialize(
           payload.types!,
           specifiedType: const FullType(
-            _i2.BuiltList,
-            [FullType(_i3.EndpointType)],
+            _i3.BuiltList,
+            [FullType(_i2.EndpointType)],
           ),
         ));
     }
@@ -141,7 +142,7 @@ class EndpointConfigurationRestJson1Serializer
         ..add(serializers.serialize(
           payload.vpcEndpointIds!,
           specifiedType: const FullType(
-            _i2.BuiltList,
+            _i3.BuiltList,
             [FullType(String)],
           ),
         ));

--- a/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/endpoint_configuration.g.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/endpoint_configuration.g.dart
@@ -8,9 +8,9 @@ part of rest_json1_v1.api_gateway.model.endpoint_configuration;
 
 class _$EndpointConfiguration extends EndpointConfiguration {
   @override
-  final _i2.BuiltList<_i3.EndpointType>? types;
+  final _i3.BuiltList<_i2.EndpointType>? types;
   @override
-  final _i2.BuiltList<String>? vpcEndpointIds;
+  final _i3.BuiltList<String>? vpcEndpointIds;
 
   factory _$EndpointConfiguration(
           [void Function(EndpointConfigurationBuilder)? updates]) =>
@@ -45,15 +45,15 @@ class EndpointConfigurationBuilder
     implements Builder<EndpointConfiguration, EndpointConfigurationBuilder> {
   _$EndpointConfiguration? _$v;
 
-  _i2.ListBuilder<_i3.EndpointType>? _types;
-  _i2.ListBuilder<_i3.EndpointType> get types =>
-      _$this._types ??= new _i2.ListBuilder<_i3.EndpointType>();
-  set types(_i2.ListBuilder<_i3.EndpointType>? types) => _$this._types = types;
+  _i3.ListBuilder<_i2.EndpointType>? _types;
+  _i3.ListBuilder<_i2.EndpointType> get types =>
+      _$this._types ??= new _i3.ListBuilder<_i2.EndpointType>();
+  set types(_i3.ListBuilder<_i2.EndpointType>? types) => _$this._types = types;
 
-  _i2.ListBuilder<String>? _vpcEndpointIds;
-  _i2.ListBuilder<String> get vpcEndpointIds =>
-      _$this._vpcEndpointIds ??= new _i2.ListBuilder<String>();
-  set vpcEndpointIds(_i2.ListBuilder<String>? vpcEndpointIds) =>
+  _i3.ListBuilder<String>? _vpcEndpointIds;
+  _i3.ListBuilder<String> get vpcEndpointIds =>
+      _$this._vpcEndpointIds ??= new _i3.ListBuilder<String>();
+  set vpcEndpointIds(_i3.ListBuilder<String>? vpcEndpointIds) =>
       _$this._vpcEndpointIds = vpcEndpointIds;
 
   EndpointConfigurationBuilder() {

--- a/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/rest_api.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/rest_api.dart
@@ -3,13 +3,13 @@
 library rest_json1_v1.api_gateway.model.rest_api; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v1/src/api_gateway/model/api_key_source_type.dart'
     as _i2;
 import 'package:rest_json1_v1/src/api_gateway/model/endpoint_configuration.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i5;
 
 part 'rest_api.g.dart';
@@ -19,22 +19,23 @@ abstract class RestApi
     implements Built<RestApi, RestApiBuilder> {
   factory RestApi({
     _i2.ApiKeySourceType? apiKeySource,
-    _i3.BuiltList<String>? binaryMediaTypes,
+    List<String>? binaryMediaTypes,
     DateTime? createdDate,
     String? description,
     bool? disableExecuteApiEndpoint,
-    _i4.EndpointConfiguration? endpointConfiguration,
+    _i3.EndpointConfiguration? endpointConfiguration,
     String? id,
     int? minimumCompressionSize,
     String? name,
     String? policy,
-    _i3.BuiltMap<String, String>? tags,
+    Map<String, String>? tags,
     String? version,
-    _i3.BuiltList<String>? warnings,
+    List<String>? warnings,
   }) {
     return _$RestApi._(
       apiKeySource: apiKeySource,
-      binaryMediaTypes: binaryMediaTypes,
+      binaryMediaTypes:
+          binaryMediaTypes == null ? null : _i4.BuiltList(binaryMediaTypes),
       createdDate: createdDate,
       description: description,
       disableExecuteApiEndpoint: disableExecuteApiEndpoint,
@@ -43,9 +44,9 @@ abstract class RestApi
       minimumCompressionSize: minimumCompressionSize,
       name: name,
       policy: policy,
-      tags: tags,
+      tags: tags == null ? null : _i4.BuiltMap(tags),
       version: version,
-      warnings: warnings,
+      warnings: warnings == null ? null : _i4.BuiltList(warnings),
     );
   }
 
@@ -60,18 +61,18 @@ abstract class RestApi
   @BuiltValueHook(initializeBuilder: true)
   static void _init(RestApiBuilder b) {}
   _i2.ApiKeySourceType? get apiKeySource;
-  _i3.BuiltList<String>? get binaryMediaTypes;
+  _i4.BuiltList<String>? get binaryMediaTypes;
   DateTime? get createdDate;
   String? get description;
   bool? get disableExecuteApiEndpoint;
-  _i4.EndpointConfiguration? get endpointConfiguration;
+  _i3.EndpointConfiguration? get endpointConfiguration;
   String? get id;
   int? get minimumCompressionSize;
   String? get name;
   String? get policy;
-  _i3.BuiltMap<String, String>? get tags;
+  _i4.BuiltMap<String, String>? get tags;
   String? get version;
-  _i3.BuiltList<String>? get warnings;
+  _i4.BuiltList<String>? get warnings;
   @override
   List<Object?> get props => [
         apiKeySource,
@@ -189,10 +190,10 @@ class RestApiRestJson1Serializer
             result.binaryMediaTypes.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i4.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltList<String>));
+            ) as _i4.BuiltList<String>));
           }
           break;
         case 'createdDate':
@@ -223,8 +224,8 @@ class RestApiRestJson1Serializer
           if (value != null) {
             result.endpointConfiguration.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i4.EndpointConfiguration),
-            ) as _i4.EndpointConfiguration));
+              specifiedType: const FullType(_i3.EndpointConfiguration),
+            ) as _i3.EndpointConfiguration));
           }
           break;
         case 'id':
@@ -264,13 +265,13 @@ class RestApiRestJson1Serializer
             result.tags.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i3.BuiltMap<String, String>));
+            ) as _i4.BuiltMap<String, String>));
           }
           break;
         case 'version':
@@ -286,10 +287,10 @@ class RestApiRestJson1Serializer
             result.warnings.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i4.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltList<String>));
+            ) as _i4.BuiltList<String>));
           }
           break;
       }
@@ -320,7 +321,7 @@ class RestApiRestJson1Serializer
         ..add(serializers.serialize(
           payload.binaryMediaTypes!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i4.BuiltList,
             [FullType(String)],
           ),
         ));
@@ -354,7 +355,7 @@ class RestApiRestJson1Serializer
         ..add('endpointConfiguration')
         ..add(serializers.serialize(
           payload.endpointConfiguration!,
-          specifiedType: const FullType(_i4.EndpointConfiguration),
+          specifiedType: const FullType(_i3.EndpointConfiguration),
         ));
     }
     if (payload.id != null) {
@@ -395,7 +396,7 @@ class RestApiRestJson1Serializer
         ..add(serializers.serialize(
           payload.tags!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -417,7 +418,7 @@ class RestApiRestJson1Serializer
         ..add(serializers.serialize(
           payload.warnings!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i4.BuiltList,
             [FullType(String)],
           ),
         ));

--- a/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/rest_api.g.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/rest_api.g.dart
@@ -10,7 +10,7 @@ class _$RestApi extends RestApi {
   @override
   final _i2.ApiKeySourceType? apiKeySource;
   @override
-  final _i3.BuiltList<String>? binaryMediaTypes;
+  final _i4.BuiltList<String>? binaryMediaTypes;
   @override
   final DateTime? createdDate;
   @override
@@ -18,7 +18,7 @@ class _$RestApi extends RestApi {
   @override
   final bool? disableExecuteApiEndpoint;
   @override
-  final _i4.EndpointConfiguration? endpointConfiguration;
+  final _i3.EndpointConfiguration? endpointConfiguration;
   @override
   final String? id;
   @override
@@ -28,11 +28,11 @@ class _$RestApi extends RestApi {
   @override
   final String? policy;
   @override
-  final _i3.BuiltMap<String, String>? tags;
+  final _i4.BuiltMap<String, String>? tags;
   @override
   final String? version;
   @override
-  final _i3.BuiltList<String>? warnings;
+  final _i4.BuiltList<String>? warnings;
 
   factory _$RestApi([void Function(RestApiBuilder)? updates]) =>
       (new RestApiBuilder()..update(updates))._build();
@@ -118,10 +118,10 @@ class RestApiBuilder implements Builder<RestApi, RestApiBuilder> {
   set apiKeySource(_i2.ApiKeySourceType? apiKeySource) =>
       _$this._apiKeySource = apiKeySource;
 
-  _i3.ListBuilder<String>? _binaryMediaTypes;
-  _i3.ListBuilder<String> get binaryMediaTypes =>
-      _$this._binaryMediaTypes ??= new _i3.ListBuilder<String>();
-  set binaryMediaTypes(_i3.ListBuilder<String>? binaryMediaTypes) =>
+  _i4.ListBuilder<String>? _binaryMediaTypes;
+  _i4.ListBuilder<String> get binaryMediaTypes =>
+      _$this._binaryMediaTypes ??= new _i4.ListBuilder<String>();
+  set binaryMediaTypes(_i4.ListBuilder<String>? binaryMediaTypes) =>
       _$this._binaryMediaTypes = binaryMediaTypes;
 
   DateTime? _createdDate;
@@ -137,11 +137,11 @@ class RestApiBuilder implements Builder<RestApi, RestApiBuilder> {
   set disableExecuteApiEndpoint(bool? disableExecuteApiEndpoint) =>
       _$this._disableExecuteApiEndpoint = disableExecuteApiEndpoint;
 
-  _i4.EndpointConfigurationBuilder? _endpointConfiguration;
-  _i4.EndpointConfigurationBuilder get endpointConfiguration =>
-      _$this._endpointConfiguration ??= new _i4.EndpointConfigurationBuilder();
+  _i3.EndpointConfigurationBuilder? _endpointConfiguration;
+  _i3.EndpointConfigurationBuilder get endpointConfiguration =>
+      _$this._endpointConfiguration ??= new _i3.EndpointConfigurationBuilder();
   set endpointConfiguration(
-          _i4.EndpointConfigurationBuilder? endpointConfiguration) =>
+          _i3.EndpointConfigurationBuilder? endpointConfiguration) =>
       _$this._endpointConfiguration = endpointConfiguration;
 
   String? _id;
@@ -161,19 +161,19 @@ class RestApiBuilder implements Builder<RestApi, RestApiBuilder> {
   String? get policy => _$this._policy;
   set policy(String? policy) => _$this._policy = policy;
 
-  _i3.MapBuilder<String, String>? _tags;
-  _i3.MapBuilder<String, String> get tags =>
-      _$this._tags ??= new _i3.MapBuilder<String, String>();
-  set tags(_i3.MapBuilder<String, String>? tags) => _$this._tags = tags;
+  _i4.MapBuilder<String, String>? _tags;
+  _i4.MapBuilder<String, String> get tags =>
+      _$this._tags ??= new _i4.MapBuilder<String, String>();
+  set tags(_i4.MapBuilder<String, String>? tags) => _$this._tags = tags;
 
   String? _version;
   String? get version => _$this._version;
   set version(String? version) => _$this._version = version;
 
-  _i3.ListBuilder<String>? _warnings;
-  _i3.ListBuilder<String> get warnings =>
-      _$this._warnings ??= new _i3.ListBuilder<String>();
-  set warnings(_i3.ListBuilder<String>? warnings) =>
+  _i4.ListBuilder<String>? _warnings;
+  _i4.ListBuilder<String> get warnings =>
+      _$this._warnings ??= new _i4.ListBuilder<String>();
+  set warnings(_i4.ListBuilder<String>? warnings) =>
       _$this._warnings = warnings;
 
   RestApiBuilder() {

--- a/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/rest_apis.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/rest_apis.dart
@@ -3,10 +3,10 @@
 library rest_json1_v1.api_gateway.model.rest_apis; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i2;
+import 'package:built_collection/built_collection.dart' as _i3;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:rest_json1_v1/src/api_gateway/model/rest_api.dart' as _i3;
+import 'package:rest_json1_v1/src/api_gateway/model/rest_api.dart' as _i2;
 import 'package:smithy/smithy.dart' as _i4;
 
 part 'rest_apis.g.dart';
@@ -15,11 +15,11 @@ abstract class RestApis
     with _i1.AWSEquatable<RestApis>
     implements Built<RestApis, RestApisBuilder> {
   factory RestApis({
-    _i2.BuiltList<_i3.RestApi>? items,
+    List<_i2.RestApi>? items,
     String? position,
   }) {
     return _$RestApis._(
-      items: items,
+      items: items == null ? null : _i3.BuiltList(items),
       position: position,
     );
   }
@@ -41,7 +41,7 @@ abstract class RestApis
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(RestApisBuilder b) {}
-  _i2.BuiltList<_i3.RestApi>? get items;
+  _i3.BuiltList<_i2.RestApi>? get items;
   String? get position;
   @override
   List<Object?> get props => [
@@ -97,10 +97,10 @@ class RestApisRestJson1Serializer
             result.items.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltList,
-                [FullType(_i3.RestApi)],
+                _i3.BuiltList,
+                [FullType(_i2.RestApi)],
               ),
-            ) as _i2.BuiltList<_i3.RestApi>));
+            ) as _i3.BuiltList<_i2.RestApi>));
           }
           break;
         case 'position':
@@ -131,8 +131,8 @@ class RestApisRestJson1Serializer
         ..add(serializers.serialize(
           payload.items!,
           specifiedType: const FullType(
-            _i2.BuiltList,
-            [FullType(_i3.RestApi)],
+            _i3.BuiltList,
+            [FullType(_i2.RestApi)],
           ),
         ));
     }

--- a/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/rest_apis.g.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/rest_apis.g.dart
@@ -8,7 +8,7 @@ part of rest_json1_v1.api_gateway.model.rest_apis;
 
 class _$RestApis extends RestApis {
   @override
-  final _i2.BuiltList<_i3.RestApi>? items;
+  final _i3.BuiltList<_i2.RestApi>? items;
   @override
   final String? position;
 
@@ -41,10 +41,10 @@ class _$RestApis extends RestApis {
 class RestApisBuilder implements Builder<RestApis, RestApisBuilder> {
   _$RestApis? _$v;
 
-  _i2.ListBuilder<_i3.RestApi>? _items;
-  _i2.ListBuilder<_i3.RestApi> get items =>
-      _$this._items ??= new _i2.ListBuilder<_i3.RestApi>();
-  set items(_i2.ListBuilder<_i3.RestApi>? items) => _$this._items = items;
+  _i3.ListBuilder<_i2.RestApi>? _items;
+  _i3.ListBuilder<_i2.RestApi> get items =>
+      _$this._items ??= new _i3.ListBuilder<_i2.RestApi>();
+  set items(_i3.ListBuilder<_i2.RestApi>? items) => _$this._items = items;
 
   String? _position;
   String? get position => _$this._position;

--- a/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/scoped_config.dart
@@ -3,16 +3,16 @@
 library rest_json1_v1.api_gateway.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v1/src/api_gateway/model/client_config.dart' as _i2;
 import 'package:rest_json1_v1/src/api_gateway/model/environment_config.dart'
-    as _i5;
-import 'package:rest_json1_v1/src/api_gateway/model/file_config_settings.dart'
     as _i4;
+import 'package:rest_json1_v1/src/api_gateway/model/file_config_settings.dart'
+    as _i3;
 import 'package:rest_json1_v1/src/api_gateway/model/operation_config.dart'
-    as _i6;
+    as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -24,15 +24,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -55,16 +56,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -142,13 +143,13 @@ class ScopedConfigRestJson1Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -156,29 +157,29 @@ class ScopedConfigRestJson1Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -209,10 +210,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -223,10 +224,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -236,7 +237,7 @@ class ScopedConfigRestJson1Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -244,7 +245,7 @@ class ScopedConfigRestJson1Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib/restJson1/lib/src/glacier/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/glacier/model/scoped_config.dart
@@ -3,14 +3,14 @@
 library rest_json1_v1.glacier.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v1/src/glacier/model/client_config.dart' as _i2;
-import 'package:rest_json1_v1/src/glacier/model/environment_config.dart' as _i5;
+import 'package:rest_json1_v1/src/glacier/model/environment_config.dart' as _i4;
 import 'package:rest_json1_v1/src/glacier/model/file_config_settings.dart'
-    as _i4;
-import 'package:rest_json1_v1/src/glacier/model/operation_config.dart' as _i6;
+    as _i3;
+import 'package:rest_json1_v1/src/glacier/model/operation_config.dart' as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -22,15 +22,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -53,16 +54,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -140,13 +141,13 @@ class ScopedConfigRestJson1Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -154,29 +155,29 @@ class ScopedConfigRestJson1Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -207,10 +208,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -221,10 +222,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -234,7 +235,7 @@ class ScopedConfigRestJson1Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -242,7 +243,7 @@ class ScopedConfigRestJson1Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib/restJson1/lib/src/glacier/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/glacier/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/all_query_string_types_input.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/all_query_string_types_input.dart
@@ -3,13 +3,13 @@
 library rest_json1_v1.rest_json_protocol.model.all_query_string_types_input; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:fixnum/fixnum.dart' as _i5;
+import 'package:fixnum/fixnum.dart' as _i4;
 import 'package:meta/meta.dart' as _i6;
 import 'package:rest_json1_v1/src/rest_json_protocol/model/foo_enum.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'all_query_string_types_input.g.dart';
@@ -24,45 +24,55 @@ abstract class AllQueryStringTypesInput
         _i1.HasPayload<AllQueryStringTypesInputPayload> {
   factory AllQueryStringTypesInput({
     bool? queryBoolean,
-    _i3.BuiltList<bool>? queryBooleanList,
+    List<bool>? queryBooleanList,
     int? queryByte,
     double? queryDouble,
-    _i3.BuiltList<double>? queryDoubleList,
-    _i4.FooEnum? queryEnum,
-    _i3.BuiltList<_i4.FooEnum>? queryEnumList,
+    List<double>? queryDoubleList,
+    _i3.FooEnum? queryEnum,
+    List<_i3.FooEnum>? queryEnumList,
     double? queryFloat,
     int? queryInteger,
-    _i3.BuiltList<int>? queryIntegerList,
-    _i3.BuiltSet<int>? queryIntegerSet,
-    _i5.Int64? queryLong,
-    _i3.BuiltListMultimap<String, String>? queryParamsMapOfStringList,
+    List<int>? queryIntegerList,
+    Set<int>? queryIntegerSet,
+    _i4.Int64? queryLong,
+    Map<String, List<String>>? queryParamsMapOfStringList,
     int? queryShort,
     String? queryString,
-    _i3.BuiltList<String>? queryStringList,
-    _i3.BuiltSet<String>? queryStringSet,
+    List<String>? queryStringList,
+    Set<String>? queryStringSet,
     DateTime? queryTimestamp,
-    _i3.BuiltList<DateTime>? queryTimestampList,
+    List<DateTime>? queryTimestampList,
   }) {
     return _$AllQueryStringTypesInput._(
       queryBoolean: queryBoolean,
-      queryBooleanList: queryBooleanList,
+      queryBooleanList:
+          queryBooleanList == null ? null : _i5.BuiltList(queryBooleanList),
       queryByte: queryByte,
       queryDouble: queryDouble,
-      queryDoubleList: queryDoubleList,
+      queryDoubleList:
+          queryDoubleList == null ? null : _i5.BuiltList(queryDoubleList),
       queryEnum: queryEnum,
-      queryEnumList: queryEnumList,
+      queryEnumList:
+          queryEnumList == null ? null : _i5.BuiltList(queryEnumList),
       queryFloat: queryFloat,
       queryInteger: queryInteger,
-      queryIntegerList: queryIntegerList,
-      queryIntegerSet: queryIntegerSet,
+      queryIntegerList:
+          queryIntegerList == null ? null : _i5.BuiltList(queryIntegerList),
+      queryIntegerSet:
+          queryIntegerSet == null ? null : _i5.BuiltSet(queryIntegerSet),
       queryLong: queryLong,
-      queryParamsMapOfStringList: queryParamsMapOfStringList,
+      queryParamsMapOfStringList: queryParamsMapOfStringList == null
+          ? null
+          : _i5.BuiltListMultimap(queryParamsMapOfStringList),
       queryShort: queryShort,
       queryString: queryString,
-      queryStringList: queryStringList,
-      queryStringSet: queryStringSet,
+      queryStringList:
+          queryStringList == null ? null : _i5.BuiltList(queryStringList),
+      queryStringSet:
+          queryStringSet == null ? null : _i5.BuiltSet(queryStringSet),
       queryTimestamp: queryTimestamp,
-      queryTimestampList: queryTimestampList,
+      queryTimestampList:
+          queryTimestampList == null ? null : _i5.BuiltList(queryTimestampList),
     );
   }
 
@@ -111,7 +121,7 @@ abstract class AllQueryStringTypesInput
               .map((el) => int.parse(el.trim())));
         }
         if (request.queryParameters['Long'] != null) {
-          b.queryLong = _i5.Int64.parseInt(request.queryParameters['Long']!);
+          b.queryLong = _i4.Int64.parseInt(request.queryParameters['Long']!);
         }
         if (request.queryParameters['Float'] != null) {
           b.queryFloat = double.parse(request.queryParameters['Float']!);
@@ -151,12 +161,12 @@ abstract class AllQueryStringTypesInput
         }
         if (request.queryParameters['Enum'] != null) {
           b.queryEnum =
-              _i4.FooEnum.values.byValue(request.queryParameters['Enum']!);
+              _i3.FooEnum.values.byValue(request.queryParameters['Enum']!);
         }
         if (request.queryParameters['EnumList'] != null) {
           b.queryEnumList.addAll(_i1
               .parseHeader(request.queryParameters['EnumList']!)
-              .map((el) => _i4.FooEnum.values.byValue(el.trim())));
+              .map((el) => _i3.FooEnum.values.byValue(el.trim())));
         }
       });
 
@@ -167,24 +177,24 @@ abstract class AllQueryStringTypesInput
   @BuiltValueHook(initializeBuilder: true)
   static void _init(AllQueryStringTypesInputBuilder b) {}
   bool? get queryBoolean;
-  _i3.BuiltList<bool>? get queryBooleanList;
+  _i5.BuiltList<bool>? get queryBooleanList;
   int? get queryByte;
   double? get queryDouble;
-  _i3.BuiltList<double>? get queryDoubleList;
-  _i4.FooEnum? get queryEnum;
-  _i3.BuiltList<_i4.FooEnum>? get queryEnumList;
+  _i5.BuiltList<double>? get queryDoubleList;
+  _i3.FooEnum? get queryEnum;
+  _i5.BuiltList<_i3.FooEnum>? get queryEnumList;
   double? get queryFloat;
   int? get queryInteger;
-  _i3.BuiltList<int>? get queryIntegerList;
-  _i3.BuiltSet<int>? get queryIntegerSet;
-  _i5.Int64? get queryLong;
-  _i3.BuiltListMultimap<String, String>? get queryParamsMapOfStringList;
+  _i5.BuiltList<int>? get queryIntegerList;
+  _i5.BuiltSet<int>? get queryIntegerSet;
+  _i4.Int64? get queryLong;
+  _i5.BuiltListMultimap<String, String>? get queryParamsMapOfStringList;
   int? get queryShort;
   String? get queryString;
-  _i3.BuiltList<String>? get queryStringList;
-  _i3.BuiltSet<String>? get queryStringSet;
+  _i5.BuiltList<String>? get queryStringList;
+  _i5.BuiltSet<String>? get queryStringSet;
   DateTime? get queryTimestamp;
-  _i3.BuiltList<DateTime>? get queryTimestampList;
+  _i5.BuiltList<DateTime>? get queryTimestampList;
   @override
   AllQueryStringTypesInputPayload getPayload() =>
       AllQueryStringTypesInputPayload();

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/all_query_string_types_input.g.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/all_query_string_types_input.g.dart
@@ -10,41 +10,41 @@ class _$AllQueryStringTypesInput extends AllQueryStringTypesInput {
   @override
   final bool? queryBoolean;
   @override
-  final _i3.BuiltList<bool>? queryBooleanList;
+  final _i5.BuiltList<bool>? queryBooleanList;
   @override
   final int? queryByte;
   @override
   final double? queryDouble;
   @override
-  final _i3.BuiltList<double>? queryDoubleList;
+  final _i5.BuiltList<double>? queryDoubleList;
   @override
-  final _i4.FooEnum? queryEnum;
+  final _i3.FooEnum? queryEnum;
   @override
-  final _i3.BuiltList<_i4.FooEnum>? queryEnumList;
+  final _i5.BuiltList<_i3.FooEnum>? queryEnumList;
   @override
   final double? queryFloat;
   @override
   final int? queryInteger;
   @override
-  final _i3.BuiltList<int>? queryIntegerList;
+  final _i5.BuiltList<int>? queryIntegerList;
   @override
-  final _i3.BuiltSet<int>? queryIntegerSet;
+  final _i5.BuiltSet<int>? queryIntegerSet;
   @override
-  final _i5.Int64? queryLong;
+  final _i4.Int64? queryLong;
   @override
-  final _i3.BuiltListMultimap<String, String>? queryParamsMapOfStringList;
+  final _i5.BuiltListMultimap<String, String>? queryParamsMapOfStringList;
   @override
   final int? queryShort;
   @override
   final String? queryString;
   @override
-  final _i3.BuiltList<String>? queryStringList;
+  final _i5.BuiltList<String>? queryStringList;
   @override
-  final _i3.BuiltSet<String>? queryStringSet;
+  final _i5.BuiltSet<String>? queryStringSet;
   @override
   final DateTime? queryTimestamp;
   @override
-  final _i3.BuiltList<DateTime>? queryTimestampList;
+  final _i5.BuiltList<DateTime>? queryTimestampList;
 
   factory _$AllQueryStringTypesInput(
           [void Function(AllQueryStringTypesInputBuilder)? updates]) =>
@@ -164,10 +164,10 @@ class AllQueryStringTypesInputBuilder
   bool? get queryBoolean => _$this._queryBoolean;
   set queryBoolean(bool? queryBoolean) => _$this._queryBoolean = queryBoolean;
 
-  _i3.ListBuilder<bool>? _queryBooleanList;
-  _i3.ListBuilder<bool> get queryBooleanList =>
-      _$this._queryBooleanList ??= new _i3.ListBuilder<bool>();
-  set queryBooleanList(_i3.ListBuilder<bool>? queryBooleanList) =>
+  _i5.ListBuilder<bool>? _queryBooleanList;
+  _i5.ListBuilder<bool> get queryBooleanList =>
+      _$this._queryBooleanList ??= new _i5.ListBuilder<bool>();
+  set queryBooleanList(_i5.ListBuilder<bool>? queryBooleanList) =>
       _$this._queryBooleanList = queryBooleanList;
 
   int? _queryByte;
@@ -178,20 +178,20 @@ class AllQueryStringTypesInputBuilder
   double? get queryDouble => _$this._queryDouble;
   set queryDouble(double? queryDouble) => _$this._queryDouble = queryDouble;
 
-  _i3.ListBuilder<double>? _queryDoubleList;
-  _i3.ListBuilder<double> get queryDoubleList =>
-      _$this._queryDoubleList ??= new _i3.ListBuilder<double>();
-  set queryDoubleList(_i3.ListBuilder<double>? queryDoubleList) =>
+  _i5.ListBuilder<double>? _queryDoubleList;
+  _i5.ListBuilder<double> get queryDoubleList =>
+      _$this._queryDoubleList ??= new _i5.ListBuilder<double>();
+  set queryDoubleList(_i5.ListBuilder<double>? queryDoubleList) =>
       _$this._queryDoubleList = queryDoubleList;
 
-  _i4.FooEnum? _queryEnum;
-  _i4.FooEnum? get queryEnum => _$this._queryEnum;
-  set queryEnum(_i4.FooEnum? queryEnum) => _$this._queryEnum = queryEnum;
+  _i3.FooEnum? _queryEnum;
+  _i3.FooEnum? get queryEnum => _$this._queryEnum;
+  set queryEnum(_i3.FooEnum? queryEnum) => _$this._queryEnum = queryEnum;
 
-  _i3.ListBuilder<_i4.FooEnum>? _queryEnumList;
-  _i3.ListBuilder<_i4.FooEnum> get queryEnumList =>
-      _$this._queryEnumList ??= new _i3.ListBuilder<_i4.FooEnum>();
-  set queryEnumList(_i3.ListBuilder<_i4.FooEnum>? queryEnumList) =>
+  _i5.ListBuilder<_i3.FooEnum>? _queryEnumList;
+  _i5.ListBuilder<_i3.FooEnum> get queryEnumList =>
+      _$this._queryEnumList ??= new _i5.ListBuilder<_i3.FooEnum>();
+  set queryEnumList(_i5.ListBuilder<_i3.FooEnum>? queryEnumList) =>
       _$this._queryEnumList = queryEnumList;
 
   double? _queryFloat;
@@ -202,28 +202,28 @@ class AllQueryStringTypesInputBuilder
   int? get queryInteger => _$this._queryInteger;
   set queryInteger(int? queryInteger) => _$this._queryInteger = queryInteger;
 
-  _i3.ListBuilder<int>? _queryIntegerList;
-  _i3.ListBuilder<int> get queryIntegerList =>
-      _$this._queryIntegerList ??= new _i3.ListBuilder<int>();
-  set queryIntegerList(_i3.ListBuilder<int>? queryIntegerList) =>
+  _i5.ListBuilder<int>? _queryIntegerList;
+  _i5.ListBuilder<int> get queryIntegerList =>
+      _$this._queryIntegerList ??= new _i5.ListBuilder<int>();
+  set queryIntegerList(_i5.ListBuilder<int>? queryIntegerList) =>
       _$this._queryIntegerList = queryIntegerList;
 
-  _i3.SetBuilder<int>? _queryIntegerSet;
-  _i3.SetBuilder<int> get queryIntegerSet =>
-      _$this._queryIntegerSet ??= new _i3.SetBuilder<int>();
-  set queryIntegerSet(_i3.SetBuilder<int>? queryIntegerSet) =>
+  _i5.SetBuilder<int>? _queryIntegerSet;
+  _i5.SetBuilder<int> get queryIntegerSet =>
+      _$this._queryIntegerSet ??= new _i5.SetBuilder<int>();
+  set queryIntegerSet(_i5.SetBuilder<int>? queryIntegerSet) =>
       _$this._queryIntegerSet = queryIntegerSet;
 
-  _i5.Int64? _queryLong;
-  _i5.Int64? get queryLong => _$this._queryLong;
-  set queryLong(_i5.Int64? queryLong) => _$this._queryLong = queryLong;
+  _i4.Int64? _queryLong;
+  _i4.Int64? get queryLong => _$this._queryLong;
+  set queryLong(_i4.Int64? queryLong) => _$this._queryLong = queryLong;
 
-  _i3.ListMultimapBuilder<String, String>? _queryParamsMapOfStringList;
-  _i3.ListMultimapBuilder<String, String> get queryParamsMapOfStringList =>
+  _i5.ListMultimapBuilder<String, String>? _queryParamsMapOfStringList;
+  _i5.ListMultimapBuilder<String, String> get queryParamsMapOfStringList =>
       _$this._queryParamsMapOfStringList ??=
-          new _i3.ListMultimapBuilder<String, String>();
+          new _i5.ListMultimapBuilder<String, String>();
   set queryParamsMapOfStringList(
-          _i3.ListMultimapBuilder<String, String>?
+          _i5.ListMultimapBuilder<String, String>?
               queryParamsMapOfStringList) =>
       _$this._queryParamsMapOfStringList = queryParamsMapOfStringList;
 
@@ -235,16 +235,16 @@ class AllQueryStringTypesInputBuilder
   String? get queryString => _$this._queryString;
   set queryString(String? queryString) => _$this._queryString = queryString;
 
-  _i3.ListBuilder<String>? _queryStringList;
-  _i3.ListBuilder<String> get queryStringList =>
-      _$this._queryStringList ??= new _i3.ListBuilder<String>();
-  set queryStringList(_i3.ListBuilder<String>? queryStringList) =>
+  _i5.ListBuilder<String>? _queryStringList;
+  _i5.ListBuilder<String> get queryStringList =>
+      _$this._queryStringList ??= new _i5.ListBuilder<String>();
+  set queryStringList(_i5.ListBuilder<String>? queryStringList) =>
       _$this._queryStringList = queryStringList;
 
-  _i3.SetBuilder<String>? _queryStringSet;
-  _i3.SetBuilder<String> get queryStringSet =>
-      _$this._queryStringSet ??= new _i3.SetBuilder<String>();
-  set queryStringSet(_i3.SetBuilder<String>? queryStringSet) =>
+  _i5.SetBuilder<String>? _queryStringSet;
+  _i5.SetBuilder<String> get queryStringSet =>
+      _$this._queryStringSet ??= new _i5.SetBuilder<String>();
+  set queryStringSet(_i5.SetBuilder<String>? queryStringSet) =>
       _$this._queryStringSet = queryStringSet;
 
   DateTime? _queryTimestamp;
@@ -252,10 +252,10 @@ class AllQueryStringTypesInputBuilder
   set queryTimestamp(DateTime? queryTimestamp) =>
       _$this._queryTimestamp = queryTimestamp;
 
-  _i3.ListBuilder<DateTime>? _queryTimestampList;
-  _i3.ListBuilder<DateTime> get queryTimestampList =>
-      _$this._queryTimestampList ??= new _i3.ListBuilder<DateTime>();
-  set queryTimestampList(_i3.ListBuilder<DateTime>? queryTimestampList) =>
+  _i5.ListBuilder<DateTime>? _queryTimestampList;
+  _i5.ListBuilder<DateTime> get queryTimestampList =>
+      _$this._queryTimestampList ??= new _i5.ListBuilder<DateTime>();
+  set queryTimestampList(_i5.ListBuilder<DateTime>? queryTimestampList) =>
       _$this._queryTimestampList = queryTimestampList;
 
   AllQueryStringTypesInputBuilder() {

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/document_type_as_payload_input_output.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/document_type_as_payload_input_output.dart
@@ -18,8 +18,10 @@ abstract class DocumentTypeAsPayloadInputOutput
         Built<DocumentTypeAsPayloadInputOutput,
             DocumentTypeAsPayloadInputOutputBuilder>,
         _i1.HasPayload<_i2.JsonObject> {
-  factory DocumentTypeAsPayloadInputOutput({_i2.JsonObject? documentValue}) {
-    return _$DocumentTypeAsPayloadInputOutput._(documentValue: documentValue);
+  factory DocumentTypeAsPayloadInputOutput({Object? documentValue}) {
+    return _$DocumentTypeAsPayloadInputOutput._(
+        documentValue:
+            documentValue == null ? null : _i2.JsonObject(documentValue));
   }
 
   factory DocumentTypeAsPayloadInputOutput.build(

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/document_type_input_output.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/document_type_input_output.dart
@@ -16,11 +16,12 @@ abstract class DocumentTypeInputOutput
         _i2.AWSEquatable<DocumentTypeInputOutput>
     implements Built<DocumentTypeInputOutput, DocumentTypeInputOutputBuilder> {
   factory DocumentTypeInputOutput({
-    _i3.JsonObject? documentValue,
+    Object? documentValue,
     String? stringValue,
   }) {
     return _$DocumentTypeInputOutput._(
-      documentValue: documentValue,
+      documentValue:
+          documentValue == null ? null : _i3.JsonObject(documentValue),
       stringValue: stringValue,
     );
   }

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/http_prefix_headers_in_response_output.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/http_prefix_headers_in_response_output.dart
@@ -20,8 +20,10 @@ abstract class HttpPrefixHeadersInResponseOutput
         _i2.EmptyPayload,
         _i2.HasPayload<HttpPrefixHeadersInResponseOutputPayload> {
   factory HttpPrefixHeadersInResponseOutput(
-      {_i3.BuiltMap<String, String>? prefixHeaders}) {
-    return _$HttpPrefixHeadersInResponseOutput._(prefixHeaders: prefixHeaders);
+      {Map<String, String>? prefixHeaders}) {
+    return _$HttpPrefixHeadersInResponseOutput._(
+        prefixHeaders:
+            prefixHeaders == null ? null : _i3.BuiltMap(prefixHeaders));
   }
 
   factory HttpPrefixHeadersInResponseOutput.build(

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/http_prefix_headers_input.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/http_prefix_headers_input.dart
@@ -21,11 +21,11 @@ abstract class HttpPrefixHeadersInput
         _i1.HasPayload<HttpPrefixHeadersInputPayload> {
   factory HttpPrefixHeadersInput({
     String? foo,
-    _i3.BuiltMap<String, String>? fooMap,
+    Map<String, String>? fooMap,
   }) {
     return _$HttpPrefixHeadersInput._(
       foo: foo,
-      fooMap: fooMap,
+      fooMap: fooMap == null ? null : _i3.BuiltMap(fooMap),
     );
   }
 

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/http_prefix_headers_output.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/http_prefix_headers_output.dart
@@ -19,11 +19,11 @@ abstract class HttpPrefixHeadersOutput
         _i2.HasPayload<HttpPrefixHeadersOutputPayload> {
   factory HttpPrefixHeadersOutput({
     String? foo,
-    _i3.BuiltMap<String, String>? fooMap,
+    Map<String, String>? fooMap,
   }) {
     return _$HttpPrefixHeadersOutput._(
       foo: foo,
-      fooMap: fooMap,
+      fooMap: fooMap == null ? null : _i3.BuiltMap(fooMap),
     );
   }
 

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/input_and_output_with_headers_io.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/input_and_output_with_headers_io.dart
@@ -3,13 +3,13 @@
 library rest_json1_v1.rest_json_protocol.model.input_and_output_with_headers_io; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:fixnum/fixnum.dart' as _i5;
+import 'package:fixnum/fixnum.dart' as _i4;
 import 'package:meta/meta.dart' as _i6;
 import 'package:rest_json1_v1/src/rest_json_protocol/model/foo_enum.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'input_and_output_with_headers_io.g.dart';
@@ -23,39 +23,46 @@ abstract class InputAndOutputWithHeadersIo
         _i1.EmptyPayload,
         _i1.HasPayload<InputAndOutputWithHeadersIoPayload> {
   factory InputAndOutputWithHeadersIo({
-    _i3.BuiltList<bool>? headerBooleanList,
+    List<bool>? headerBooleanList,
     int? headerByte,
     double? headerDouble,
-    _i4.FooEnum? headerEnum,
-    _i3.BuiltList<_i4.FooEnum>? headerEnumList,
+    _i3.FooEnum? headerEnum,
+    List<_i3.FooEnum>? headerEnumList,
     bool? headerFalseBool,
     double? headerFloat,
     int? headerInteger,
-    _i3.BuiltList<int>? headerIntegerList,
-    _i5.Int64? headerLong,
+    List<int>? headerIntegerList,
+    _i4.Int64? headerLong,
     int? headerShort,
     String? headerString,
-    _i3.BuiltList<String>? headerStringList,
-    _i3.BuiltSet<String>? headerStringSet,
-    _i3.BuiltList<DateTime>? headerTimestampList,
+    List<String>? headerStringList,
+    Set<String>? headerStringSet,
+    List<DateTime>? headerTimestampList,
     bool? headerTrueBool,
   }) {
     return _$InputAndOutputWithHeadersIo._(
-      headerBooleanList: headerBooleanList,
+      headerBooleanList:
+          headerBooleanList == null ? null : _i5.BuiltList(headerBooleanList),
       headerByte: headerByte,
       headerDouble: headerDouble,
       headerEnum: headerEnum,
-      headerEnumList: headerEnumList,
+      headerEnumList:
+          headerEnumList == null ? null : _i5.BuiltList(headerEnumList),
       headerFalseBool: headerFalseBool,
       headerFloat: headerFloat,
       headerInteger: headerInteger,
-      headerIntegerList: headerIntegerList,
+      headerIntegerList:
+          headerIntegerList == null ? null : _i5.BuiltList(headerIntegerList),
       headerLong: headerLong,
       headerShort: headerShort,
       headerString: headerString,
-      headerStringList: headerStringList,
-      headerStringSet: headerStringSet,
-      headerTimestampList: headerTimestampList,
+      headerStringList:
+          headerStringList == null ? null : _i5.BuiltList(headerStringList),
+      headerStringSet:
+          headerStringSet == null ? null : _i5.BuiltSet(headerStringSet),
+      headerTimestampList: headerTimestampList == null
+          ? null
+          : _i5.BuiltList(headerTimestampList),
       headerTrueBool: headerTrueBool,
     );
   }
@@ -85,7 +92,7 @@ abstract class InputAndOutputWithHeadersIo
           b.headerInteger = int.parse(request.headers['X-Integer']!);
         }
         if (request.headers['X-Long'] != null) {
-          b.headerLong = _i5.Int64.parseInt(request.headers['X-Long']!);
+          b.headerLong = _i4.Int64.parseInt(request.headers['X-Long']!);
         }
         if (request.headers['X-Float'] != null) {
           b.headerFloat = double.parse(request.headers['X-Float']!);
@@ -131,12 +138,12 @@ abstract class InputAndOutputWithHeadersIo
                   ).asDateTime));
         }
         if (request.headers['X-Enum'] != null) {
-          b.headerEnum = _i4.FooEnum.values.byValue(request.headers['X-Enum']!);
+          b.headerEnum = _i3.FooEnum.values.byValue(request.headers['X-Enum']!);
         }
         if (request.headers['X-EnumList'] != null) {
           b.headerEnumList.addAll(_i1
               .parseHeader(request.headers['X-EnumList']!)
-              .map((el) => _i4.FooEnum.values.byValue(el.trim())));
+              .map((el) => _i3.FooEnum.values.byValue(el.trim())));
         }
       });
 
@@ -159,7 +166,7 @@ abstract class InputAndOutputWithHeadersIo
           b.headerInteger = int.parse(response.headers['X-Integer']!);
         }
         if (response.headers['X-Long'] != null) {
-          b.headerLong = _i5.Int64.parseInt(response.headers['X-Long']!);
+          b.headerLong = _i4.Int64.parseInt(response.headers['X-Long']!);
         }
         if (response.headers['X-Float'] != null) {
           b.headerFloat = double.parse(response.headers['X-Float']!);
@@ -206,12 +213,12 @@ abstract class InputAndOutputWithHeadersIo
         }
         if (response.headers['X-Enum'] != null) {
           b.headerEnum =
-              _i4.FooEnum.values.byValue(response.headers['X-Enum']!);
+              _i3.FooEnum.values.byValue(response.headers['X-Enum']!);
         }
         if (response.headers['X-EnumList'] != null) {
           b.headerEnumList.addAll(_i1
               .parseHeader(response.headers['X-EnumList']!)
-              .map((el) => _i4.FooEnum.values.byValue(el.trim())));
+              .map((el) => _i3.FooEnum.values.byValue(el.trim())));
         }
       });
 
@@ -221,21 +228,21 @@ abstract class InputAndOutputWithHeadersIo
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(InputAndOutputWithHeadersIoBuilder b) {}
-  _i3.BuiltList<bool>? get headerBooleanList;
+  _i5.BuiltList<bool>? get headerBooleanList;
   int? get headerByte;
   double? get headerDouble;
-  _i4.FooEnum? get headerEnum;
-  _i3.BuiltList<_i4.FooEnum>? get headerEnumList;
+  _i3.FooEnum? get headerEnum;
+  _i5.BuiltList<_i3.FooEnum>? get headerEnumList;
   bool? get headerFalseBool;
   double? get headerFloat;
   int? get headerInteger;
-  _i3.BuiltList<int>? get headerIntegerList;
-  _i5.Int64? get headerLong;
+  _i5.BuiltList<int>? get headerIntegerList;
+  _i4.Int64? get headerLong;
   int? get headerShort;
   String? get headerString;
-  _i3.BuiltList<String>? get headerStringList;
-  _i3.BuiltSet<String>? get headerStringSet;
-  _i3.BuiltList<DateTime>? get headerTimestampList;
+  _i5.BuiltList<String>? get headerStringList;
+  _i5.BuiltSet<String>? get headerStringSet;
+  _i5.BuiltList<DateTime>? get headerTimestampList;
   bool? get headerTrueBool;
   @override
   InputAndOutputWithHeadersIoPayload getPayload() =>

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/input_and_output_with_headers_io.g.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/input_and_output_with_headers_io.g.dart
@@ -8,15 +8,15 @@ part of rest_json1_v1.rest_json_protocol.model.input_and_output_with_headers_io;
 
 class _$InputAndOutputWithHeadersIo extends InputAndOutputWithHeadersIo {
   @override
-  final _i3.BuiltList<bool>? headerBooleanList;
+  final _i5.BuiltList<bool>? headerBooleanList;
   @override
   final int? headerByte;
   @override
   final double? headerDouble;
   @override
-  final _i4.FooEnum? headerEnum;
+  final _i3.FooEnum? headerEnum;
   @override
-  final _i3.BuiltList<_i4.FooEnum>? headerEnumList;
+  final _i5.BuiltList<_i3.FooEnum>? headerEnumList;
   @override
   final bool? headerFalseBool;
   @override
@@ -24,19 +24,19 @@ class _$InputAndOutputWithHeadersIo extends InputAndOutputWithHeadersIo {
   @override
   final int? headerInteger;
   @override
-  final _i3.BuiltList<int>? headerIntegerList;
+  final _i5.BuiltList<int>? headerIntegerList;
   @override
-  final _i5.Int64? headerLong;
+  final _i4.Int64? headerLong;
   @override
   final int? headerShort;
   @override
   final String? headerString;
   @override
-  final _i3.BuiltList<String>? headerStringList;
+  final _i5.BuiltList<String>? headerStringList;
   @override
-  final _i3.BuiltSet<String>? headerStringSet;
+  final _i5.BuiltSet<String>? headerStringSet;
   @override
-  final _i3.BuiltList<DateTime>? headerTimestampList;
+  final _i5.BuiltList<DateTime>? headerTimestampList;
   @override
   final bool? headerTrueBool;
 
@@ -141,10 +141,10 @@ class InputAndOutputWithHeadersIoBuilder
             InputAndOutputWithHeadersIoBuilder> {
   _$InputAndOutputWithHeadersIo? _$v;
 
-  _i3.ListBuilder<bool>? _headerBooleanList;
-  _i3.ListBuilder<bool> get headerBooleanList =>
-      _$this._headerBooleanList ??= new _i3.ListBuilder<bool>();
-  set headerBooleanList(_i3.ListBuilder<bool>? headerBooleanList) =>
+  _i5.ListBuilder<bool>? _headerBooleanList;
+  _i5.ListBuilder<bool> get headerBooleanList =>
+      _$this._headerBooleanList ??= new _i5.ListBuilder<bool>();
+  set headerBooleanList(_i5.ListBuilder<bool>? headerBooleanList) =>
       _$this._headerBooleanList = headerBooleanList;
 
   int? _headerByte;
@@ -155,14 +155,14 @@ class InputAndOutputWithHeadersIoBuilder
   double? get headerDouble => _$this._headerDouble;
   set headerDouble(double? headerDouble) => _$this._headerDouble = headerDouble;
 
-  _i4.FooEnum? _headerEnum;
-  _i4.FooEnum? get headerEnum => _$this._headerEnum;
-  set headerEnum(_i4.FooEnum? headerEnum) => _$this._headerEnum = headerEnum;
+  _i3.FooEnum? _headerEnum;
+  _i3.FooEnum? get headerEnum => _$this._headerEnum;
+  set headerEnum(_i3.FooEnum? headerEnum) => _$this._headerEnum = headerEnum;
 
-  _i3.ListBuilder<_i4.FooEnum>? _headerEnumList;
-  _i3.ListBuilder<_i4.FooEnum> get headerEnumList =>
-      _$this._headerEnumList ??= new _i3.ListBuilder<_i4.FooEnum>();
-  set headerEnumList(_i3.ListBuilder<_i4.FooEnum>? headerEnumList) =>
+  _i5.ListBuilder<_i3.FooEnum>? _headerEnumList;
+  _i5.ListBuilder<_i3.FooEnum> get headerEnumList =>
+      _$this._headerEnumList ??= new _i5.ListBuilder<_i3.FooEnum>();
+  set headerEnumList(_i5.ListBuilder<_i3.FooEnum>? headerEnumList) =>
       _$this._headerEnumList = headerEnumList;
 
   bool? _headerFalseBool;
@@ -179,15 +179,15 @@ class InputAndOutputWithHeadersIoBuilder
   set headerInteger(int? headerInteger) =>
       _$this._headerInteger = headerInteger;
 
-  _i3.ListBuilder<int>? _headerIntegerList;
-  _i3.ListBuilder<int> get headerIntegerList =>
-      _$this._headerIntegerList ??= new _i3.ListBuilder<int>();
-  set headerIntegerList(_i3.ListBuilder<int>? headerIntegerList) =>
+  _i5.ListBuilder<int>? _headerIntegerList;
+  _i5.ListBuilder<int> get headerIntegerList =>
+      _$this._headerIntegerList ??= new _i5.ListBuilder<int>();
+  set headerIntegerList(_i5.ListBuilder<int>? headerIntegerList) =>
       _$this._headerIntegerList = headerIntegerList;
 
-  _i5.Int64? _headerLong;
-  _i5.Int64? get headerLong => _$this._headerLong;
-  set headerLong(_i5.Int64? headerLong) => _$this._headerLong = headerLong;
+  _i4.Int64? _headerLong;
+  _i4.Int64? get headerLong => _$this._headerLong;
+  set headerLong(_i4.Int64? headerLong) => _$this._headerLong = headerLong;
 
   int? _headerShort;
   int? get headerShort => _$this._headerShort;
@@ -197,22 +197,22 @@ class InputAndOutputWithHeadersIoBuilder
   String? get headerString => _$this._headerString;
   set headerString(String? headerString) => _$this._headerString = headerString;
 
-  _i3.ListBuilder<String>? _headerStringList;
-  _i3.ListBuilder<String> get headerStringList =>
-      _$this._headerStringList ??= new _i3.ListBuilder<String>();
-  set headerStringList(_i3.ListBuilder<String>? headerStringList) =>
+  _i5.ListBuilder<String>? _headerStringList;
+  _i5.ListBuilder<String> get headerStringList =>
+      _$this._headerStringList ??= new _i5.ListBuilder<String>();
+  set headerStringList(_i5.ListBuilder<String>? headerStringList) =>
       _$this._headerStringList = headerStringList;
 
-  _i3.SetBuilder<String>? _headerStringSet;
-  _i3.SetBuilder<String> get headerStringSet =>
-      _$this._headerStringSet ??= new _i3.SetBuilder<String>();
-  set headerStringSet(_i3.SetBuilder<String>? headerStringSet) =>
+  _i5.SetBuilder<String>? _headerStringSet;
+  _i5.SetBuilder<String> get headerStringSet =>
+      _$this._headerStringSet ??= new _i5.SetBuilder<String>();
+  set headerStringSet(_i5.SetBuilder<String>? headerStringSet) =>
       _$this._headerStringSet = headerStringSet;
 
-  _i3.ListBuilder<DateTime>? _headerTimestampList;
-  _i3.ListBuilder<DateTime> get headerTimestampList =>
-      _$this._headerTimestampList ??= new _i3.ListBuilder<DateTime>();
-  set headerTimestampList(_i3.ListBuilder<DateTime>? headerTimestampList) =>
+  _i5.ListBuilder<DateTime>? _headerTimestampList;
+  _i5.ListBuilder<DateTime> get headerTimestampList =>
+      _$this._headerTimestampList ??= new _i5.ListBuilder<DateTime>();
+  set headerTimestampList(_i5.ListBuilder<DateTime>? headerTimestampList) =>
       _$this._headerTimestampList = headerTimestampList;
 
   bool? _headerTrueBool;

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/json_enums_input_output.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/json_enums_input_output.dart
@@ -21,17 +21,17 @@ abstract class JsonEnumsInputOutput
     _i3.FooEnum? fooEnum1,
     _i3.FooEnum? fooEnum2,
     _i3.FooEnum? fooEnum3,
-    _i4.BuiltList<_i3.FooEnum>? fooEnumList,
-    _i4.BuiltMap<String, _i3.FooEnum>? fooEnumMap,
-    _i4.BuiltSet<_i3.FooEnum>? fooEnumSet,
+    List<_i3.FooEnum>? fooEnumList,
+    Map<String, _i3.FooEnum>? fooEnumMap,
+    Set<_i3.FooEnum>? fooEnumSet,
   }) {
     return _$JsonEnumsInputOutput._(
       fooEnum1: fooEnum1,
       fooEnum2: fooEnum2,
       fooEnum3: fooEnum3,
-      fooEnumList: fooEnumList,
-      fooEnumMap: fooEnumMap,
-      fooEnumSet: fooEnumSet,
+      fooEnumList: fooEnumList == null ? null : _i4.BuiltList(fooEnumList),
+      fooEnumMap: fooEnumMap == null ? null : _i4.BuiltMap(fooEnumMap),
+      fooEnumSet: fooEnumSet == null ? null : _i4.BuiltSet(fooEnumSet),
     );
   }
 

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/json_lists_input_output.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/json_lists_input_output.dart
@@ -3,13 +3,13 @@
 library rest_json1_v1.rest_json_protocol.model.json_lists_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v1/src/rest_json_protocol/model/foo_enum.dart'
-    as _i4;
+    as _i3;
 import 'package:rest_json1_v1/src/rest_json_protocol/model/structure_list_member.dart'
-    as _i5;
+    as _i4;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'json_lists_input_output.g.dart';
@@ -20,26 +20,31 @@ abstract class JsonListsInputOutput
         _i2.AWSEquatable<JsonListsInputOutput>
     implements Built<JsonListsInputOutput, JsonListsInputOutputBuilder> {
   factory JsonListsInputOutput({
-    _i3.BuiltList<bool>? booleanList,
-    _i3.BuiltList<_i4.FooEnum>? enumList,
-    _i3.BuiltList<int>? integerList,
-    _i3.BuiltList<_i3.BuiltList<String>>? nestedStringList,
-    _i3.BuiltList<String?>? sparseStringList,
-    _i3.BuiltList<String>? stringList,
-    _i3.BuiltSet<String>? stringSet,
-    _i3.BuiltList<_i5.StructureListMember>? structureList,
-    _i3.BuiltList<DateTime>? timestampList,
+    List<bool>? booleanList,
+    List<_i3.FooEnum>? enumList,
+    List<int>? integerList,
+    List<List<String>>? nestedStringList,
+    List<String?>? sparseStringList,
+    List<String>? stringList,
+    Set<String>? stringSet,
+    List<_i4.StructureListMember>? structureList,
+    List<DateTime>? timestampList,
   }) {
     return _$JsonListsInputOutput._(
-      booleanList: booleanList,
-      enumList: enumList,
-      integerList: integerList,
-      nestedStringList: nestedStringList,
-      sparseStringList: sparseStringList,
-      stringList: stringList,
-      stringSet: stringSet,
-      structureList: structureList,
-      timestampList: timestampList,
+      booleanList: booleanList == null ? null : _i5.BuiltList(booleanList),
+      enumList: enumList == null ? null : _i5.BuiltList(enumList),
+      integerList: integerList == null ? null : _i5.BuiltList(integerList),
+      nestedStringList: nestedStringList == null
+          ? null
+          : _i5.BuiltList(nestedStringList.map((el) => _i5.BuiltList(el))),
+      sparseStringList:
+          sparseStringList == null ? null : _i5.BuiltList(sparseStringList),
+      stringList: stringList == null ? null : _i5.BuiltList(stringList),
+      stringSet: stringSet == null ? null : _i5.BuiltSet(stringSet),
+      structureList:
+          structureList == null ? null : _i5.BuiltList(structureList),
+      timestampList:
+          timestampList == null ? null : _i5.BuiltList(timestampList),
     );
   }
 
@@ -69,17 +74,17 @@ abstract class JsonListsInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(JsonListsInputOutputBuilder b) {}
-  _i3.BuiltList<bool>? get booleanList;
-  _i3.BuiltList<_i4.FooEnum>? get enumList;
-  _i3.BuiltList<int>? get integerList;
+  _i5.BuiltList<bool>? get booleanList;
+  _i5.BuiltList<_i3.FooEnum>? get enumList;
+  _i5.BuiltList<int>? get integerList;
 
   /// A list of lists of strings.
-  _i3.BuiltList<_i3.BuiltList<String>>? get nestedStringList;
-  _i3.BuiltList<String?>? get sparseStringList;
-  _i3.BuiltList<String>? get stringList;
-  _i3.BuiltSet<String>? get stringSet;
-  _i3.BuiltList<_i5.StructureListMember>? get structureList;
-  _i3.BuiltList<DateTime>? get timestampList;
+  _i5.BuiltList<_i5.BuiltList<String>>? get nestedStringList;
+  _i5.BuiltList<String?>? get sparseStringList;
+  _i5.BuiltList<String>? get stringList;
+  _i5.BuiltSet<String>? get stringSet;
+  _i5.BuiltList<_i4.StructureListMember>? get structureList;
+  _i5.BuiltList<DateTime>? get timestampList;
   @override
   JsonListsInputOutput getPayload() => this;
   @override
@@ -172,10 +177,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.booleanList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(bool)],
               ),
-            ) as _i3.BuiltList<bool>));
+            ) as _i5.BuiltList<bool>));
           }
           break;
         case 'enumList':
@@ -183,10 +188,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.enumList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
-                [FullType(_i4.FooEnum)],
+                _i5.BuiltList,
+                [FullType(_i3.FooEnum)],
               ),
-            ) as _i3.BuiltList<_i4.FooEnum>));
+            ) as _i5.BuiltList<_i3.FooEnum>));
           }
           break;
         case 'integerList':
@@ -194,10 +199,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.integerList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(int)],
               ),
-            ) as _i3.BuiltList<int>));
+            ) as _i5.BuiltList<int>));
           }
           break;
         case 'nestedStringList':
@@ -205,15 +210,15 @@ class JsonListsInputOutputRestJson1Serializer
             result.nestedStringList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [
                   FullType(
-                    _i3.BuiltList,
+                    _i5.BuiltList,
                     [FullType(String)],
                   )
                 ],
               ),
-            ) as _i3.BuiltList<_i3.BuiltList<String>>));
+            ) as _i5.BuiltList<_i5.BuiltList<String>>));
           }
           break;
         case 'sparseStringList':
@@ -221,10 +226,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.sparseStringList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType.nullable(String)],
               ),
-            ) as _i3.BuiltList<String?>));
+            ) as _i5.BuiltList<String?>));
           }
           break;
         case 'stringList':
@@ -232,10 +237,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.stringList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltList<String>));
+            ) as _i5.BuiltList<String>));
           }
           break;
         case 'stringSet':
@@ -243,10 +248,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.stringSet.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltSet,
+                _i5.BuiltSet,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltSet<String>));
+            ) as _i5.BuiltSet<String>));
           }
           break;
         case 'myStructureList':
@@ -254,10 +259,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.structureList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
-                [FullType(_i5.StructureListMember)],
+                _i5.BuiltList,
+                [FullType(_i4.StructureListMember)],
               ),
-            ) as _i3.BuiltList<_i5.StructureListMember>));
+            ) as _i5.BuiltList<_i4.StructureListMember>));
           }
           break;
         case 'timestampList':
@@ -265,10 +270,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.timestampList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(DateTime)],
               ),
-            ) as _i3.BuiltList<DateTime>));
+            ) as _i5.BuiltList<DateTime>));
           }
           break;
       }
@@ -291,7 +296,7 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.booleanList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(bool)],
           ),
         ));
@@ -302,8 +307,8 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.enumList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
-            [FullType(_i4.FooEnum)],
+            _i5.BuiltList,
+            [FullType(_i3.FooEnum)],
           ),
         ));
     }
@@ -313,7 +318,7 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.integerList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(int)],
           ),
         ));
@@ -324,10 +329,10 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.nestedStringList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [
               FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(String)],
               )
             ],
@@ -340,7 +345,7 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.sparseStringList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType.nullable(String)],
           ),
         ));
@@ -351,7 +356,7 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.stringList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(String)],
           ),
         ));
@@ -362,7 +367,7 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.stringSet!,
           specifiedType: const FullType(
-            _i3.BuiltSet,
+            _i5.BuiltSet,
             [FullType(String)],
           ),
         ));
@@ -373,8 +378,8 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.structureList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
-            [FullType(_i5.StructureListMember)],
+            _i5.BuiltList,
+            [FullType(_i4.StructureListMember)],
           ),
         ));
     }
@@ -384,7 +389,7 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.timestampList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(DateTime)],
           ),
         ));

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/json_lists_input_output.g.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/json_lists_input_output.g.dart
@@ -8,23 +8,23 @@ part of rest_json1_v1.rest_json_protocol.model.json_lists_input_output;
 
 class _$JsonListsInputOutput extends JsonListsInputOutput {
   @override
-  final _i3.BuiltList<bool>? booleanList;
+  final _i5.BuiltList<bool>? booleanList;
   @override
-  final _i3.BuiltList<_i4.FooEnum>? enumList;
+  final _i5.BuiltList<_i3.FooEnum>? enumList;
   @override
-  final _i3.BuiltList<int>? integerList;
+  final _i5.BuiltList<int>? integerList;
   @override
-  final _i3.BuiltList<_i3.BuiltList<String>>? nestedStringList;
+  final _i5.BuiltList<_i5.BuiltList<String>>? nestedStringList;
   @override
-  final _i3.BuiltList<String?>? sparseStringList;
+  final _i5.BuiltList<String?>? sparseStringList;
   @override
-  final _i3.BuiltList<String>? stringList;
+  final _i5.BuiltList<String>? stringList;
   @override
-  final _i3.BuiltSet<String>? stringSet;
+  final _i5.BuiltSet<String>? stringSet;
   @override
-  final _i3.BuiltList<_i5.StructureListMember>? structureList;
+  final _i5.BuiltList<_i4.StructureListMember>? structureList;
   @override
-  final _i3.BuiltList<DateTime>? timestampList;
+  final _i5.BuiltList<DateTime>? timestampList;
 
   factory _$JsonListsInputOutput(
           [void Function(JsonListsInputOutputBuilder)? updates]) =>
@@ -91,59 +91,59 @@ class JsonListsInputOutputBuilder
     implements Builder<JsonListsInputOutput, JsonListsInputOutputBuilder> {
   _$JsonListsInputOutput? _$v;
 
-  _i3.ListBuilder<bool>? _booleanList;
-  _i3.ListBuilder<bool> get booleanList =>
-      _$this._booleanList ??= new _i3.ListBuilder<bool>();
-  set booleanList(_i3.ListBuilder<bool>? booleanList) =>
+  _i5.ListBuilder<bool>? _booleanList;
+  _i5.ListBuilder<bool> get booleanList =>
+      _$this._booleanList ??= new _i5.ListBuilder<bool>();
+  set booleanList(_i5.ListBuilder<bool>? booleanList) =>
       _$this._booleanList = booleanList;
 
-  _i3.ListBuilder<_i4.FooEnum>? _enumList;
-  _i3.ListBuilder<_i4.FooEnum> get enumList =>
-      _$this._enumList ??= new _i3.ListBuilder<_i4.FooEnum>();
-  set enumList(_i3.ListBuilder<_i4.FooEnum>? enumList) =>
+  _i5.ListBuilder<_i3.FooEnum>? _enumList;
+  _i5.ListBuilder<_i3.FooEnum> get enumList =>
+      _$this._enumList ??= new _i5.ListBuilder<_i3.FooEnum>();
+  set enumList(_i5.ListBuilder<_i3.FooEnum>? enumList) =>
       _$this._enumList = enumList;
 
-  _i3.ListBuilder<int>? _integerList;
-  _i3.ListBuilder<int> get integerList =>
-      _$this._integerList ??= new _i3.ListBuilder<int>();
-  set integerList(_i3.ListBuilder<int>? integerList) =>
+  _i5.ListBuilder<int>? _integerList;
+  _i5.ListBuilder<int> get integerList =>
+      _$this._integerList ??= new _i5.ListBuilder<int>();
+  set integerList(_i5.ListBuilder<int>? integerList) =>
       _$this._integerList = integerList;
 
-  _i3.ListBuilder<_i3.BuiltList<String>>? _nestedStringList;
-  _i3.ListBuilder<_i3.BuiltList<String>> get nestedStringList =>
-      _$this._nestedStringList ??= new _i3.ListBuilder<_i3.BuiltList<String>>();
+  _i5.ListBuilder<_i5.BuiltList<String>>? _nestedStringList;
+  _i5.ListBuilder<_i5.BuiltList<String>> get nestedStringList =>
+      _$this._nestedStringList ??= new _i5.ListBuilder<_i5.BuiltList<String>>();
   set nestedStringList(
-          _i3.ListBuilder<_i3.BuiltList<String>>? nestedStringList) =>
+          _i5.ListBuilder<_i5.BuiltList<String>>? nestedStringList) =>
       _$this._nestedStringList = nestedStringList;
 
-  _i3.ListBuilder<String?>? _sparseStringList;
-  _i3.ListBuilder<String?> get sparseStringList =>
-      _$this._sparseStringList ??= new _i3.ListBuilder<String?>();
-  set sparseStringList(_i3.ListBuilder<String?>? sparseStringList) =>
+  _i5.ListBuilder<String?>? _sparseStringList;
+  _i5.ListBuilder<String?> get sparseStringList =>
+      _$this._sparseStringList ??= new _i5.ListBuilder<String?>();
+  set sparseStringList(_i5.ListBuilder<String?>? sparseStringList) =>
       _$this._sparseStringList = sparseStringList;
 
-  _i3.ListBuilder<String>? _stringList;
-  _i3.ListBuilder<String> get stringList =>
-      _$this._stringList ??= new _i3.ListBuilder<String>();
-  set stringList(_i3.ListBuilder<String>? stringList) =>
+  _i5.ListBuilder<String>? _stringList;
+  _i5.ListBuilder<String> get stringList =>
+      _$this._stringList ??= new _i5.ListBuilder<String>();
+  set stringList(_i5.ListBuilder<String>? stringList) =>
       _$this._stringList = stringList;
 
-  _i3.SetBuilder<String>? _stringSet;
-  _i3.SetBuilder<String> get stringSet =>
-      _$this._stringSet ??= new _i3.SetBuilder<String>();
-  set stringSet(_i3.SetBuilder<String>? stringSet) =>
+  _i5.SetBuilder<String>? _stringSet;
+  _i5.SetBuilder<String> get stringSet =>
+      _$this._stringSet ??= new _i5.SetBuilder<String>();
+  set stringSet(_i5.SetBuilder<String>? stringSet) =>
       _$this._stringSet = stringSet;
 
-  _i3.ListBuilder<_i5.StructureListMember>? _structureList;
-  _i3.ListBuilder<_i5.StructureListMember> get structureList =>
-      _$this._structureList ??= new _i3.ListBuilder<_i5.StructureListMember>();
-  set structureList(_i3.ListBuilder<_i5.StructureListMember>? structureList) =>
+  _i5.ListBuilder<_i4.StructureListMember>? _structureList;
+  _i5.ListBuilder<_i4.StructureListMember> get structureList =>
+      _$this._structureList ??= new _i5.ListBuilder<_i4.StructureListMember>();
+  set structureList(_i5.ListBuilder<_i4.StructureListMember>? structureList) =>
       _$this._structureList = structureList;
 
-  _i3.ListBuilder<DateTime>? _timestampList;
-  _i3.ListBuilder<DateTime> get timestampList =>
-      _$this._timestampList ??= new _i3.ListBuilder<DateTime>();
-  set timestampList(_i3.ListBuilder<DateTime>? timestampList) =>
+  _i5.ListBuilder<DateTime>? _timestampList;
+  _i5.ListBuilder<DateTime> get timestampList =>
+      _$this._timestampList ??= new _i5.ListBuilder<DateTime>();
+  set timestampList(_i5.ListBuilder<DateTime>? timestampList) =>
       _$this._timestampList = timestampList;
 
   JsonListsInputOutputBuilder() {

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/json_maps_input_output.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/json_maps_input_output.dart
@@ -3,11 +3,11 @@
 library rest_json1_v1.rest_json_protocol.model.json_maps_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v1/src/rest_json_protocol/model/greeting_struct.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'json_maps_input_output.g.dart';
@@ -18,28 +18,38 @@ abstract class JsonMapsInputOutput
         _i2.AWSEquatable<JsonMapsInputOutput>
     implements Built<JsonMapsInputOutput, JsonMapsInputOutputBuilder> {
   factory JsonMapsInputOutput({
-    _i3.BuiltMap<String, bool>? denseBooleanMap,
-    _i3.BuiltMap<String, int>? denseNumberMap,
-    _i3.BuiltSetMultimap<String, String>? denseSetMap,
-    _i3.BuiltMap<String, String>? denseStringMap,
-    _i3.BuiltMap<String, _i4.GreetingStruct>? denseStructMap,
-    _i3.BuiltMap<String, bool?>? sparseBooleanMap,
-    _i3.BuiltMap<String, int?>? sparseNumberMap,
-    _i3.BuiltSetMultimap<String, String>? sparseSetMap,
-    _i3.BuiltMap<String, String?>? sparseStringMap,
-    _i3.BuiltMap<String, _i4.GreetingStruct?>? sparseStructMap,
+    Map<String, bool>? denseBooleanMap,
+    Map<String, int>? denseNumberMap,
+    Map<String, Set<String>>? denseSetMap,
+    Map<String, String>? denseStringMap,
+    Map<String, _i3.GreetingStruct>? denseStructMap,
+    Map<String, bool?>? sparseBooleanMap,
+    Map<String, int?>? sparseNumberMap,
+    Map<String, Set<String>>? sparseSetMap,
+    Map<String, String?>? sparseStringMap,
+    Map<String, _i3.GreetingStruct?>? sparseStructMap,
   }) {
     return _$JsonMapsInputOutput._(
-      denseBooleanMap: denseBooleanMap,
-      denseNumberMap: denseNumberMap,
-      denseSetMap: denseSetMap,
-      denseStringMap: denseStringMap,
-      denseStructMap: denseStructMap,
-      sparseBooleanMap: sparseBooleanMap,
-      sparseNumberMap: sparseNumberMap,
-      sparseSetMap: sparseSetMap,
-      sparseStringMap: sparseStringMap,
-      sparseStructMap: sparseStructMap,
+      denseBooleanMap:
+          denseBooleanMap == null ? null : _i4.BuiltMap(denseBooleanMap),
+      denseNumberMap:
+          denseNumberMap == null ? null : _i4.BuiltMap(denseNumberMap),
+      denseSetMap:
+          denseSetMap == null ? null : _i4.BuiltSetMultimap(denseSetMap),
+      denseStringMap:
+          denseStringMap == null ? null : _i4.BuiltMap(denseStringMap),
+      denseStructMap:
+          denseStructMap == null ? null : _i4.BuiltMap(denseStructMap),
+      sparseBooleanMap:
+          sparseBooleanMap == null ? null : _i4.BuiltMap(sparseBooleanMap),
+      sparseNumberMap:
+          sparseNumberMap == null ? null : _i4.BuiltMap(sparseNumberMap),
+      sparseSetMap:
+          sparseSetMap == null ? null : _i4.BuiltSetMultimap(sparseSetMap),
+      sparseStringMap:
+          sparseStringMap == null ? null : _i4.BuiltMap(sparseStringMap),
+      sparseStructMap:
+          sparseStructMap == null ? null : _i4.BuiltMap(sparseStructMap),
     );
   }
 
@@ -69,16 +79,16 @@ abstract class JsonMapsInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(JsonMapsInputOutputBuilder b) {}
-  _i3.BuiltMap<String, bool>? get denseBooleanMap;
-  _i3.BuiltMap<String, int>? get denseNumberMap;
-  _i3.BuiltSetMultimap<String, String>? get denseSetMap;
-  _i3.BuiltMap<String, String>? get denseStringMap;
-  _i3.BuiltMap<String, _i4.GreetingStruct>? get denseStructMap;
-  _i3.BuiltMap<String, bool?>? get sparseBooleanMap;
-  _i3.BuiltMap<String, int?>? get sparseNumberMap;
-  _i3.BuiltSetMultimap<String, String>? get sparseSetMap;
-  _i3.BuiltMap<String, String?>? get sparseStringMap;
-  _i3.BuiltMap<String, _i4.GreetingStruct?>? get sparseStructMap;
+  _i4.BuiltMap<String, bool>? get denseBooleanMap;
+  _i4.BuiltMap<String, int>? get denseNumberMap;
+  _i4.BuiltSetMultimap<String, String>? get denseSetMap;
+  _i4.BuiltMap<String, String>? get denseStringMap;
+  _i4.BuiltMap<String, _i3.GreetingStruct>? get denseStructMap;
+  _i4.BuiltMap<String, bool?>? get sparseBooleanMap;
+  _i4.BuiltMap<String, int?>? get sparseNumberMap;
+  _i4.BuiltSetMultimap<String, String>? get sparseSetMap;
+  _i4.BuiltMap<String, String?>? get sparseStringMap;
+  _i4.BuiltMap<String, _i3.GreetingStruct?>? get sparseStructMap;
   @override
   JsonMapsInputOutput getPayload() => this;
   @override
@@ -175,13 +185,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.denseBooleanMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(bool),
                 ],
               ),
-            ) as _i3.BuiltMap<String, bool>));
+            ) as _i4.BuiltMap<String, bool>));
           }
           break;
         case 'denseNumberMap':
@@ -189,13 +199,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.denseNumberMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(int),
                 ],
               ),
-            ) as _i3.BuiltMap<String, int>));
+            ) as _i4.BuiltMap<String, int>));
           }
           break;
         case 'denseSetMap':
@@ -203,13 +213,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.denseSetMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltSetMultimap,
+                _i4.BuiltSetMultimap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i3.BuiltSetMultimap<String, String>));
+            ) as _i4.BuiltSetMultimap<String, String>));
           }
           break;
         case 'denseStringMap':
@@ -217,13 +227,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.denseStringMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i3.BuiltMap<String, String>));
+            ) as _i4.BuiltMap<String, String>));
           }
           break;
         case 'denseStructMap':
@@ -231,13 +241,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.denseStructMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.GreetingStruct),
+                  FullType(_i3.GreetingStruct),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.GreetingStruct>));
+            ) as _i4.BuiltMap<String, _i3.GreetingStruct>));
           }
           break;
         case 'sparseBooleanMap':
@@ -245,13 +255,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.sparseBooleanMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType.nullable(bool),
                 ],
               ),
-            ) as _i3.BuiltMap<String, bool?>));
+            ) as _i4.BuiltMap<String, bool?>));
           }
           break;
         case 'sparseNumberMap':
@@ -259,13 +269,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.sparseNumberMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType.nullable(int),
                 ],
               ),
-            ) as _i3.BuiltMap<String, int?>));
+            ) as _i4.BuiltMap<String, int?>));
           }
           break;
         case 'sparseSetMap':
@@ -273,13 +283,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.sparseSetMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltSetMultimap,
+                _i4.BuiltSetMultimap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i3.BuiltSetMultimap<String, String>));
+            ) as _i4.BuiltSetMultimap<String, String>));
           }
           break;
         case 'sparseStringMap':
@@ -287,13 +297,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.sparseStringMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType.nullable(String),
                 ],
               ),
-            ) as _i3.BuiltMap<String, String?>));
+            ) as _i4.BuiltMap<String, String?>));
           }
           break;
         case 'sparseStructMap':
@@ -301,13 +311,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.sparseStructMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
-                  FullType.nullable(_i4.GreetingStruct),
+                  FullType.nullable(_i3.GreetingStruct),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.GreetingStruct?>));
+            ) as _i4.BuiltMap<String, _i3.GreetingStruct?>));
           }
           break;
       }
@@ -330,7 +340,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.denseBooleanMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(bool),
@@ -344,7 +354,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.denseNumberMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(int),
@@ -358,7 +368,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.denseSetMap!,
           specifiedType: const FullType(
-            _i3.BuiltSetMultimap,
+            _i4.BuiltSetMultimap,
             [
               FullType(String),
               FullType(String),
@@ -372,7 +382,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.denseStringMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -386,10 +396,10 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.denseStructMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.GreetingStruct),
+              FullType(_i3.GreetingStruct),
             ],
           ),
         ));
@@ -400,7 +410,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.sparseBooleanMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType.nullable(bool),
@@ -414,7 +424,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.sparseNumberMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType.nullable(int),
@@ -428,7 +438,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.sparseSetMap!,
           specifiedType: const FullType(
-            _i3.BuiltSetMultimap,
+            _i4.BuiltSetMultimap,
             [
               FullType(String),
               FullType(String),
@@ -442,7 +452,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.sparseStringMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType.nullable(String),
@@ -456,10 +466,10 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.sparseStructMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
-              FullType.nullable(_i4.GreetingStruct),
+              FullType.nullable(_i3.GreetingStruct),
             ],
           ),
         ));

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/json_maps_input_output.g.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/json_maps_input_output.g.dart
@@ -8,25 +8,25 @@ part of rest_json1_v1.rest_json_protocol.model.json_maps_input_output;
 
 class _$JsonMapsInputOutput extends JsonMapsInputOutput {
   @override
-  final _i3.BuiltMap<String, bool>? denseBooleanMap;
+  final _i4.BuiltMap<String, bool>? denseBooleanMap;
   @override
-  final _i3.BuiltMap<String, int>? denseNumberMap;
+  final _i4.BuiltMap<String, int>? denseNumberMap;
   @override
-  final _i3.BuiltSetMultimap<String, String>? denseSetMap;
+  final _i4.BuiltSetMultimap<String, String>? denseSetMap;
   @override
-  final _i3.BuiltMap<String, String>? denseStringMap;
+  final _i4.BuiltMap<String, String>? denseStringMap;
   @override
-  final _i3.BuiltMap<String, _i4.GreetingStruct>? denseStructMap;
+  final _i4.BuiltMap<String, _i3.GreetingStruct>? denseStructMap;
   @override
-  final _i3.BuiltMap<String, bool?>? sparseBooleanMap;
+  final _i4.BuiltMap<String, bool?>? sparseBooleanMap;
   @override
-  final _i3.BuiltMap<String, int?>? sparseNumberMap;
+  final _i4.BuiltMap<String, int?>? sparseNumberMap;
   @override
-  final _i3.BuiltSetMultimap<String, String>? sparseSetMap;
+  final _i4.BuiltSetMultimap<String, String>? sparseSetMap;
   @override
-  final _i3.BuiltMap<String, String?>? sparseStringMap;
+  final _i4.BuiltMap<String, String?>? sparseStringMap;
   @override
-  final _i3.BuiltMap<String, _i4.GreetingStruct?>? sparseStructMap;
+  final _i4.BuiltMap<String, _i3.GreetingStruct?>? sparseStructMap;
 
   factory _$JsonMapsInputOutput(
           [void Function(JsonMapsInputOutputBuilder)? updates]) =>
@@ -97,68 +97,68 @@ class JsonMapsInputOutputBuilder
     implements Builder<JsonMapsInputOutput, JsonMapsInputOutputBuilder> {
   _$JsonMapsInputOutput? _$v;
 
-  _i3.MapBuilder<String, bool>? _denseBooleanMap;
-  _i3.MapBuilder<String, bool> get denseBooleanMap =>
-      _$this._denseBooleanMap ??= new _i3.MapBuilder<String, bool>();
-  set denseBooleanMap(_i3.MapBuilder<String, bool>? denseBooleanMap) =>
+  _i4.MapBuilder<String, bool>? _denseBooleanMap;
+  _i4.MapBuilder<String, bool> get denseBooleanMap =>
+      _$this._denseBooleanMap ??= new _i4.MapBuilder<String, bool>();
+  set denseBooleanMap(_i4.MapBuilder<String, bool>? denseBooleanMap) =>
       _$this._denseBooleanMap = denseBooleanMap;
 
-  _i3.MapBuilder<String, int>? _denseNumberMap;
-  _i3.MapBuilder<String, int> get denseNumberMap =>
-      _$this._denseNumberMap ??= new _i3.MapBuilder<String, int>();
-  set denseNumberMap(_i3.MapBuilder<String, int>? denseNumberMap) =>
+  _i4.MapBuilder<String, int>? _denseNumberMap;
+  _i4.MapBuilder<String, int> get denseNumberMap =>
+      _$this._denseNumberMap ??= new _i4.MapBuilder<String, int>();
+  set denseNumberMap(_i4.MapBuilder<String, int>? denseNumberMap) =>
       _$this._denseNumberMap = denseNumberMap;
 
-  _i3.SetMultimapBuilder<String, String>? _denseSetMap;
-  _i3.SetMultimapBuilder<String, String> get denseSetMap =>
-      _$this._denseSetMap ??= new _i3.SetMultimapBuilder<String, String>();
-  set denseSetMap(_i3.SetMultimapBuilder<String, String>? denseSetMap) =>
+  _i4.SetMultimapBuilder<String, String>? _denseSetMap;
+  _i4.SetMultimapBuilder<String, String> get denseSetMap =>
+      _$this._denseSetMap ??= new _i4.SetMultimapBuilder<String, String>();
+  set denseSetMap(_i4.SetMultimapBuilder<String, String>? denseSetMap) =>
       _$this._denseSetMap = denseSetMap;
 
-  _i3.MapBuilder<String, String>? _denseStringMap;
-  _i3.MapBuilder<String, String> get denseStringMap =>
-      _$this._denseStringMap ??= new _i3.MapBuilder<String, String>();
-  set denseStringMap(_i3.MapBuilder<String, String>? denseStringMap) =>
+  _i4.MapBuilder<String, String>? _denseStringMap;
+  _i4.MapBuilder<String, String> get denseStringMap =>
+      _$this._denseStringMap ??= new _i4.MapBuilder<String, String>();
+  set denseStringMap(_i4.MapBuilder<String, String>? denseStringMap) =>
       _$this._denseStringMap = denseStringMap;
 
-  _i3.MapBuilder<String, _i4.GreetingStruct>? _denseStructMap;
-  _i3.MapBuilder<String, _i4.GreetingStruct> get denseStructMap =>
+  _i4.MapBuilder<String, _i3.GreetingStruct>? _denseStructMap;
+  _i4.MapBuilder<String, _i3.GreetingStruct> get denseStructMap =>
       _$this._denseStructMap ??=
-          new _i3.MapBuilder<String, _i4.GreetingStruct>();
+          new _i4.MapBuilder<String, _i3.GreetingStruct>();
   set denseStructMap(
-          _i3.MapBuilder<String, _i4.GreetingStruct>? denseStructMap) =>
+          _i4.MapBuilder<String, _i3.GreetingStruct>? denseStructMap) =>
       _$this._denseStructMap = denseStructMap;
 
-  _i3.MapBuilder<String, bool?>? _sparseBooleanMap;
-  _i3.MapBuilder<String, bool?> get sparseBooleanMap =>
-      _$this._sparseBooleanMap ??= new _i3.MapBuilder<String, bool?>();
-  set sparseBooleanMap(_i3.MapBuilder<String, bool?>? sparseBooleanMap) =>
+  _i4.MapBuilder<String, bool?>? _sparseBooleanMap;
+  _i4.MapBuilder<String, bool?> get sparseBooleanMap =>
+      _$this._sparseBooleanMap ??= new _i4.MapBuilder<String, bool?>();
+  set sparseBooleanMap(_i4.MapBuilder<String, bool?>? sparseBooleanMap) =>
       _$this._sparseBooleanMap = sparseBooleanMap;
 
-  _i3.MapBuilder<String, int?>? _sparseNumberMap;
-  _i3.MapBuilder<String, int?> get sparseNumberMap =>
-      _$this._sparseNumberMap ??= new _i3.MapBuilder<String, int?>();
-  set sparseNumberMap(_i3.MapBuilder<String, int?>? sparseNumberMap) =>
+  _i4.MapBuilder<String, int?>? _sparseNumberMap;
+  _i4.MapBuilder<String, int?> get sparseNumberMap =>
+      _$this._sparseNumberMap ??= new _i4.MapBuilder<String, int?>();
+  set sparseNumberMap(_i4.MapBuilder<String, int?>? sparseNumberMap) =>
       _$this._sparseNumberMap = sparseNumberMap;
 
-  _i3.SetMultimapBuilder<String, String>? _sparseSetMap;
-  _i3.SetMultimapBuilder<String, String> get sparseSetMap =>
-      _$this._sparseSetMap ??= new _i3.SetMultimapBuilder<String, String>();
-  set sparseSetMap(_i3.SetMultimapBuilder<String, String>? sparseSetMap) =>
+  _i4.SetMultimapBuilder<String, String>? _sparseSetMap;
+  _i4.SetMultimapBuilder<String, String> get sparseSetMap =>
+      _$this._sparseSetMap ??= new _i4.SetMultimapBuilder<String, String>();
+  set sparseSetMap(_i4.SetMultimapBuilder<String, String>? sparseSetMap) =>
       _$this._sparseSetMap = sparseSetMap;
 
-  _i3.MapBuilder<String, String?>? _sparseStringMap;
-  _i3.MapBuilder<String, String?> get sparseStringMap =>
-      _$this._sparseStringMap ??= new _i3.MapBuilder<String, String?>();
-  set sparseStringMap(_i3.MapBuilder<String, String?>? sparseStringMap) =>
+  _i4.MapBuilder<String, String?>? _sparseStringMap;
+  _i4.MapBuilder<String, String?> get sparseStringMap =>
+      _$this._sparseStringMap ??= new _i4.MapBuilder<String, String?>();
+  set sparseStringMap(_i4.MapBuilder<String, String?>? sparseStringMap) =>
       _$this._sparseStringMap = sparseStringMap;
 
-  _i3.MapBuilder<String, _i4.GreetingStruct?>? _sparseStructMap;
-  _i3.MapBuilder<String, _i4.GreetingStruct?> get sparseStructMap =>
+  _i4.MapBuilder<String, _i3.GreetingStruct?>? _sparseStructMap;
+  _i4.MapBuilder<String, _i3.GreetingStruct?> get sparseStructMap =>
       _$this._sparseStructMap ??=
-          new _i3.MapBuilder<String, _i4.GreetingStruct?>();
+          new _i4.MapBuilder<String, _i3.GreetingStruct?>();
   set sparseStructMap(
-          _i3.MapBuilder<String, _i4.GreetingStruct?>? sparseStructMap) =>
+          _i4.MapBuilder<String, _i3.GreetingStruct?>? sparseStructMap) =>
       _$this._sparseStructMap = sparseStructMap;
 
   JsonMapsInputOutputBuilder() {

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/malformed_list_input.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/malformed_list_input.dart
@@ -13,8 +13,9 @@ part 'malformed_list_input.g.dart';
 abstract class MalformedListInput
     with _i1.HttpInput<MalformedListInput>, _i2.AWSEquatable<MalformedListInput>
     implements Built<MalformedListInput, MalformedListInputBuilder> {
-  factory MalformedListInput({_i3.BuiltList<String>? bodyList}) {
-    return _$MalformedListInput._(bodyList: bodyList);
+  factory MalformedListInput({List<String>? bodyList}) {
+    return _$MalformedListInput._(
+        bodyList: bodyList == null ? null : _i3.BuiltList(bodyList));
   }
 
   factory MalformedListInput.build(

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/malformed_map_input.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/malformed_map_input.dart
@@ -13,8 +13,9 @@ part 'malformed_map_input.g.dart';
 abstract class MalformedMapInput
     with _i1.HttpInput<MalformedMapInput>, _i2.AWSEquatable<MalformedMapInput>
     implements Built<MalformedMapInput, MalformedMapInputBuilder> {
-  factory MalformedMapInput({_i3.BuiltMap<String, String>? bodyMap}) {
-    return _$MalformedMapInput._(bodyMap: bodyMap);
+  factory MalformedMapInput({Map<String, String>? bodyMap}) {
+    return _$MalformedMapInput._(
+        bodyMap: bodyMap == null ? null : _i3.BuiltMap(bodyMap));
   }
 
   factory MalformedMapInput.build(

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/malformed_string_input.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/malformed_string_input.dart
@@ -21,8 +21,9 @@ abstract class MalformedStringInput
         Built<MalformedStringInput, MalformedStringInputBuilder>,
         _i1.EmptyPayload,
         _i1.HasPayload<MalformedStringInputPayload> {
-  factory MalformedStringInput({_i3.JsonObject? blob}) {
-    return _$MalformedStringInput._(blob: blob);
+  factory MalformedStringInput({Object? blob}) {
+    return _$MalformedStringInput._(
+        blob: blob == null ? null : _i3.JsonObject(blob));
   }
 
   factory MalformedStringInput.build(

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/media_type_header_input.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/media_type_header_input.dart
@@ -21,8 +21,9 @@ abstract class MediaTypeHeaderInput
         Built<MediaTypeHeaderInput, MediaTypeHeaderInputBuilder>,
         _i1.EmptyPayload,
         _i1.HasPayload<MediaTypeHeaderInputPayload> {
-  factory MediaTypeHeaderInput({_i3.JsonObject? json}) {
-    return _$MediaTypeHeaderInput._(json: json);
+  factory MediaTypeHeaderInput({Object? json}) {
+    return _$MediaTypeHeaderInput._(
+        json: json == null ? null : _i3.JsonObject(json));
   }
 
   factory MediaTypeHeaderInput.build(

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/media_type_header_output.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/media_type_header_output.dart
@@ -19,8 +19,9 @@ abstract class MediaTypeHeaderOutput
         Built<MediaTypeHeaderOutput, MediaTypeHeaderOutputBuilder>,
         _i2.EmptyPayload,
         _i2.HasPayload<MediaTypeHeaderOutputPayload> {
-  factory MediaTypeHeaderOutput({_i3.JsonObject? json}) {
-    return _$MediaTypeHeaderOutput._(json: json);
+  factory MediaTypeHeaderOutput({Object? json}) {
+    return _$MediaTypeHeaderOutput._(
+        json: json == null ? null : _i3.JsonObject(json));
   }
 
   factory MediaTypeHeaderOutput.build(

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/null_and_empty_headers_io.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/null_and_empty_headers_io.dart
@@ -22,12 +22,12 @@ abstract class NullAndEmptyHeadersIo
   factory NullAndEmptyHeadersIo({
     String? a,
     String? b,
-    _i3.BuiltList<String>? c,
+    List<String>? c,
   }) {
     return _$NullAndEmptyHeadersIo._(
       a: a,
       b: b,
-      c: c,
+      c: c == null ? null : _i3.BuiltList(c),
     );
   }
 

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/query_params_as_string_list_map_input.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/query_params_as_string_list_map_input.dart
@@ -21,11 +21,11 @@ abstract class QueryParamsAsStringListMapInput
         _i1.EmptyPayload,
         _i1.HasPayload<QueryParamsAsStringListMapInputPayload> {
   factory QueryParamsAsStringListMapInput({
-    _i3.BuiltListMultimap<String, String>? foo,
+    Map<String, List<String>>? foo,
     String? qux,
   }) {
     return _$QueryParamsAsStringListMapInput._(
-      foo: foo,
+      foo: foo == null ? null : _i3.BuiltListMultimap(foo),
       qux: qux,
     );
   }

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/query_precedence_input.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/query_precedence_input.dart
@@ -20,11 +20,11 @@ abstract class QueryPrecedenceInput
         _i1.EmptyPayload,
         _i1.HasPayload<QueryPrecedenceInputPayload> {
   factory QueryPrecedenceInput({
-    _i3.BuiltMap<String, String>? baz,
+    Map<String, String>? baz,
     String? foo,
   }) {
     return _$QueryPrecedenceInput._(
-      baz: baz,
+      baz: baz == null ? null : _i3.BuiltMap(baz),
       foo: foo,
     );
   }

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/scoped_config.dart
@@ -3,17 +3,17 @@
 library rest_json1_v1.rest_json_protocol.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v1/src/rest_json_protocol/model/client_config.dart'
     as _i2;
 import 'package:rest_json1_v1/src/rest_json_protocol/model/environment_config.dart'
-    as _i5;
-import 'package:rest_json1_v1/src/rest_json_protocol/model/file_config_settings.dart'
     as _i4;
+import 'package:rest_json1_v1/src/rest_json_protocol/model/file_config_settings.dart'
+    as _i3;
 import 'package:rest_json1_v1/src/rest_json_protocol/model/operation_config.dart'
-    as _i6;
+    as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -25,15 +25,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -56,16 +57,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -143,13 +144,13 @@ class ScopedConfigRestJson1Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -157,29 +158,29 @@ class ScopedConfigRestJson1Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -210,10 +211,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -224,10 +225,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -237,7 +238,7 @@ class ScopedConfigRestJson1Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -245,7 +246,7 @@ class ScopedConfigRestJson1Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/all_query_string_types_input.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/all_query_string_types_input.dart
@@ -3,12 +3,12 @@
 library rest_xml_v1.rest_xml_protocol.model.all_query_string_types_input; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:fixnum/fixnum.dart' as _i5;
+import 'package:fixnum/fixnum.dart' as _i4;
 import 'package:meta/meta.dart' as _i6;
-import 'package:rest_xml_v1/src/rest_xml_protocol/model/foo_enum.dart' as _i4;
+import 'package:rest_xml_v1/src/rest_xml_protocol/model/foo_enum.dart' as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'all_query_string_types_input.g.dart';
@@ -23,45 +23,55 @@ abstract class AllQueryStringTypesInput
         _i1.HasPayload<AllQueryStringTypesInputPayload> {
   factory AllQueryStringTypesInput({
     bool? queryBoolean,
-    _i3.BuiltList<bool>? queryBooleanList,
+    List<bool>? queryBooleanList,
     int? queryByte,
     double? queryDouble,
-    _i3.BuiltList<double>? queryDoubleList,
-    _i4.FooEnum? queryEnum,
-    _i3.BuiltList<_i4.FooEnum>? queryEnumList,
+    List<double>? queryDoubleList,
+    _i3.FooEnum? queryEnum,
+    List<_i3.FooEnum>? queryEnumList,
     double? queryFloat,
     int? queryInteger,
-    _i3.BuiltList<int>? queryIntegerList,
-    _i3.BuiltSet<int>? queryIntegerSet,
-    _i5.Int64? queryLong,
-    _i3.BuiltMap<String, String>? queryParamsMapOfStrings,
+    List<int>? queryIntegerList,
+    Set<int>? queryIntegerSet,
+    _i4.Int64? queryLong,
+    Map<String, String>? queryParamsMapOfStrings,
     int? queryShort,
     String? queryString,
-    _i3.BuiltList<String>? queryStringList,
-    _i3.BuiltSet<String>? queryStringSet,
+    List<String>? queryStringList,
+    Set<String>? queryStringSet,
     DateTime? queryTimestamp,
-    _i3.BuiltList<DateTime>? queryTimestampList,
+    List<DateTime>? queryTimestampList,
   }) {
     return _$AllQueryStringTypesInput._(
       queryBoolean: queryBoolean,
-      queryBooleanList: queryBooleanList,
+      queryBooleanList:
+          queryBooleanList == null ? null : _i5.BuiltList(queryBooleanList),
       queryByte: queryByte,
       queryDouble: queryDouble,
-      queryDoubleList: queryDoubleList,
+      queryDoubleList:
+          queryDoubleList == null ? null : _i5.BuiltList(queryDoubleList),
       queryEnum: queryEnum,
-      queryEnumList: queryEnumList,
+      queryEnumList:
+          queryEnumList == null ? null : _i5.BuiltList(queryEnumList),
       queryFloat: queryFloat,
       queryInteger: queryInteger,
-      queryIntegerList: queryIntegerList,
-      queryIntegerSet: queryIntegerSet,
+      queryIntegerList:
+          queryIntegerList == null ? null : _i5.BuiltList(queryIntegerList),
+      queryIntegerSet:
+          queryIntegerSet == null ? null : _i5.BuiltSet(queryIntegerSet),
       queryLong: queryLong,
-      queryParamsMapOfStrings: queryParamsMapOfStrings,
+      queryParamsMapOfStrings: queryParamsMapOfStrings == null
+          ? null
+          : _i5.BuiltMap(queryParamsMapOfStrings),
       queryShort: queryShort,
       queryString: queryString,
-      queryStringList: queryStringList,
-      queryStringSet: queryStringSet,
+      queryStringList:
+          queryStringList == null ? null : _i5.BuiltList(queryStringList),
+      queryStringSet:
+          queryStringSet == null ? null : _i5.BuiltSet(queryStringSet),
       queryTimestamp: queryTimestamp,
-      queryTimestampList: queryTimestampList,
+      queryTimestampList:
+          queryTimestampList == null ? null : _i5.BuiltList(queryTimestampList),
     );
   }
 
@@ -110,7 +120,7 @@ abstract class AllQueryStringTypesInput
               .map((el) => int.parse(el.trim())));
         }
         if (request.queryParameters['Long'] != null) {
-          b.queryLong = _i5.Int64.parseInt(request.queryParameters['Long']!);
+          b.queryLong = _i4.Int64.parseInt(request.queryParameters['Long']!);
         }
         if (request.queryParameters['Float'] != null) {
           b.queryFloat = double.parse(request.queryParameters['Float']!);
@@ -150,12 +160,12 @@ abstract class AllQueryStringTypesInput
         }
         if (request.queryParameters['Enum'] != null) {
           b.queryEnum =
-              _i4.FooEnum.values.byValue(request.queryParameters['Enum']!);
+              _i3.FooEnum.values.byValue(request.queryParameters['Enum']!);
         }
         if (request.queryParameters['EnumList'] != null) {
           b.queryEnumList.addAll(_i1
               .parseHeader(request.queryParameters['EnumList']!)
-              .map((el) => _i4.FooEnum.values.byValue(el.trim())));
+              .map((el) => _i3.FooEnum.values.byValue(el.trim())));
         }
       });
 
@@ -166,24 +176,24 @@ abstract class AllQueryStringTypesInput
   @BuiltValueHook(initializeBuilder: true)
   static void _init(AllQueryStringTypesInputBuilder b) {}
   bool? get queryBoolean;
-  _i3.BuiltList<bool>? get queryBooleanList;
+  _i5.BuiltList<bool>? get queryBooleanList;
   int? get queryByte;
   double? get queryDouble;
-  _i3.BuiltList<double>? get queryDoubleList;
-  _i4.FooEnum? get queryEnum;
-  _i3.BuiltList<_i4.FooEnum>? get queryEnumList;
+  _i5.BuiltList<double>? get queryDoubleList;
+  _i3.FooEnum? get queryEnum;
+  _i5.BuiltList<_i3.FooEnum>? get queryEnumList;
   double? get queryFloat;
   int? get queryInteger;
-  _i3.BuiltList<int>? get queryIntegerList;
-  _i3.BuiltSet<int>? get queryIntegerSet;
-  _i5.Int64? get queryLong;
-  _i3.BuiltMap<String, String>? get queryParamsMapOfStrings;
+  _i5.BuiltList<int>? get queryIntegerList;
+  _i5.BuiltSet<int>? get queryIntegerSet;
+  _i4.Int64? get queryLong;
+  _i5.BuiltMap<String, String>? get queryParamsMapOfStrings;
   int? get queryShort;
   String? get queryString;
-  _i3.BuiltList<String>? get queryStringList;
-  _i3.BuiltSet<String>? get queryStringSet;
+  _i5.BuiltList<String>? get queryStringList;
+  _i5.BuiltSet<String>? get queryStringSet;
   DateTime? get queryTimestamp;
-  _i3.BuiltList<DateTime>? get queryTimestampList;
+  _i5.BuiltList<DateTime>? get queryTimestampList;
   @override
   AllQueryStringTypesInputPayload getPayload() =>
       AllQueryStringTypesInputPayload();

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/all_query_string_types_input.g.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/all_query_string_types_input.g.dart
@@ -10,41 +10,41 @@ class _$AllQueryStringTypesInput extends AllQueryStringTypesInput {
   @override
   final bool? queryBoolean;
   @override
-  final _i3.BuiltList<bool>? queryBooleanList;
+  final _i5.BuiltList<bool>? queryBooleanList;
   @override
   final int? queryByte;
   @override
   final double? queryDouble;
   @override
-  final _i3.BuiltList<double>? queryDoubleList;
+  final _i5.BuiltList<double>? queryDoubleList;
   @override
-  final _i4.FooEnum? queryEnum;
+  final _i3.FooEnum? queryEnum;
   @override
-  final _i3.BuiltList<_i4.FooEnum>? queryEnumList;
+  final _i5.BuiltList<_i3.FooEnum>? queryEnumList;
   @override
   final double? queryFloat;
   @override
   final int? queryInteger;
   @override
-  final _i3.BuiltList<int>? queryIntegerList;
+  final _i5.BuiltList<int>? queryIntegerList;
   @override
-  final _i3.BuiltSet<int>? queryIntegerSet;
+  final _i5.BuiltSet<int>? queryIntegerSet;
   @override
-  final _i5.Int64? queryLong;
+  final _i4.Int64? queryLong;
   @override
-  final _i3.BuiltMap<String, String>? queryParamsMapOfStrings;
+  final _i5.BuiltMap<String, String>? queryParamsMapOfStrings;
   @override
   final int? queryShort;
   @override
   final String? queryString;
   @override
-  final _i3.BuiltList<String>? queryStringList;
+  final _i5.BuiltList<String>? queryStringList;
   @override
-  final _i3.BuiltSet<String>? queryStringSet;
+  final _i5.BuiltSet<String>? queryStringSet;
   @override
   final DateTime? queryTimestamp;
   @override
-  final _i3.BuiltList<DateTime>? queryTimestampList;
+  final _i5.BuiltList<DateTime>? queryTimestampList;
 
   factory _$AllQueryStringTypesInput(
           [void Function(AllQueryStringTypesInputBuilder)? updates]) =>
@@ -164,10 +164,10 @@ class AllQueryStringTypesInputBuilder
   bool? get queryBoolean => _$this._queryBoolean;
   set queryBoolean(bool? queryBoolean) => _$this._queryBoolean = queryBoolean;
 
-  _i3.ListBuilder<bool>? _queryBooleanList;
-  _i3.ListBuilder<bool> get queryBooleanList =>
-      _$this._queryBooleanList ??= new _i3.ListBuilder<bool>();
-  set queryBooleanList(_i3.ListBuilder<bool>? queryBooleanList) =>
+  _i5.ListBuilder<bool>? _queryBooleanList;
+  _i5.ListBuilder<bool> get queryBooleanList =>
+      _$this._queryBooleanList ??= new _i5.ListBuilder<bool>();
+  set queryBooleanList(_i5.ListBuilder<bool>? queryBooleanList) =>
       _$this._queryBooleanList = queryBooleanList;
 
   int? _queryByte;
@@ -178,20 +178,20 @@ class AllQueryStringTypesInputBuilder
   double? get queryDouble => _$this._queryDouble;
   set queryDouble(double? queryDouble) => _$this._queryDouble = queryDouble;
 
-  _i3.ListBuilder<double>? _queryDoubleList;
-  _i3.ListBuilder<double> get queryDoubleList =>
-      _$this._queryDoubleList ??= new _i3.ListBuilder<double>();
-  set queryDoubleList(_i3.ListBuilder<double>? queryDoubleList) =>
+  _i5.ListBuilder<double>? _queryDoubleList;
+  _i5.ListBuilder<double> get queryDoubleList =>
+      _$this._queryDoubleList ??= new _i5.ListBuilder<double>();
+  set queryDoubleList(_i5.ListBuilder<double>? queryDoubleList) =>
       _$this._queryDoubleList = queryDoubleList;
 
-  _i4.FooEnum? _queryEnum;
-  _i4.FooEnum? get queryEnum => _$this._queryEnum;
-  set queryEnum(_i4.FooEnum? queryEnum) => _$this._queryEnum = queryEnum;
+  _i3.FooEnum? _queryEnum;
+  _i3.FooEnum? get queryEnum => _$this._queryEnum;
+  set queryEnum(_i3.FooEnum? queryEnum) => _$this._queryEnum = queryEnum;
 
-  _i3.ListBuilder<_i4.FooEnum>? _queryEnumList;
-  _i3.ListBuilder<_i4.FooEnum> get queryEnumList =>
-      _$this._queryEnumList ??= new _i3.ListBuilder<_i4.FooEnum>();
-  set queryEnumList(_i3.ListBuilder<_i4.FooEnum>? queryEnumList) =>
+  _i5.ListBuilder<_i3.FooEnum>? _queryEnumList;
+  _i5.ListBuilder<_i3.FooEnum> get queryEnumList =>
+      _$this._queryEnumList ??= new _i5.ListBuilder<_i3.FooEnum>();
+  set queryEnumList(_i5.ListBuilder<_i3.FooEnum>? queryEnumList) =>
       _$this._queryEnumList = queryEnumList;
 
   double? _queryFloat;
@@ -202,27 +202,27 @@ class AllQueryStringTypesInputBuilder
   int? get queryInteger => _$this._queryInteger;
   set queryInteger(int? queryInteger) => _$this._queryInteger = queryInteger;
 
-  _i3.ListBuilder<int>? _queryIntegerList;
-  _i3.ListBuilder<int> get queryIntegerList =>
-      _$this._queryIntegerList ??= new _i3.ListBuilder<int>();
-  set queryIntegerList(_i3.ListBuilder<int>? queryIntegerList) =>
+  _i5.ListBuilder<int>? _queryIntegerList;
+  _i5.ListBuilder<int> get queryIntegerList =>
+      _$this._queryIntegerList ??= new _i5.ListBuilder<int>();
+  set queryIntegerList(_i5.ListBuilder<int>? queryIntegerList) =>
       _$this._queryIntegerList = queryIntegerList;
 
-  _i3.SetBuilder<int>? _queryIntegerSet;
-  _i3.SetBuilder<int> get queryIntegerSet =>
-      _$this._queryIntegerSet ??= new _i3.SetBuilder<int>();
-  set queryIntegerSet(_i3.SetBuilder<int>? queryIntegerSet) =>
+  _i5.SetBuilder<int>? _queryIntegerSet;
+  _i5.SetBuilder<int> get queryIntegerSet =>
+      _$this._queryIntegerSet ??= new _i5.SetBuilder<int>();
+  set queryIntegerSet(_i5.SetBuilder<int>? queryIntegerSet) =>
       _$this._queryIntegerSet = queryIntegerSet;
 
-  _i5.Int64? _queryLong;
-  _i5.Int64? get queryLong => _$this._queryLong;
-  set queryLong(_i5.Int64? queryLong) => _$this._queryLong = queryLong;
+  _i4.Int64? _queryLong;
+  _i4.Int64? get queryLong => _$this._queryLong;
+  set queryLong(_i4.Int64? queryLong) => _$this._queryLong = queryLong;
 
-  _i3.MapBuilder<String, String>? _queryParamsMapOfStrings;
-  _i3.MapBuilder<String, String> get queryParamsMapOfStrings =>
-      _$this._queryParamsMapOfStrings ??= new _i3.MapBuilder<String, String>();
+  _i5.MapBuilder<String, String>? _queryParamsMapOfStrings;
+  _i5.MapBuilder<String, String> get queryParamsMapOfStrings =>
+      _$this._queryParamsMapOfStrings ??= new _i5.MapBuilder<String, String>();
   set queryParamsMapOfStrings(
-          _i3.MapBuilder<String, String>? queryParamsMapOfStrings) =>
+          _i5.MapBuilder<String, String>? queryParamsMapOfStrings) =>
       _$this._queryParamsMapOfStrings = queryParamsMapOfStrings;
 
   int? _queryShort;
@@ -233,16 +233,16 @@ class AllQueryStringTypesInputBuilder
   String? get queryString => _$this._queryString;
   set queryString(String? queryString) => _$this._queryString = queryString;
 
-  _i3.ListBuilder<String>? _queryStringList;
-  _i3.ListBuilder<String> get queryStringList =>
-      _$this._queryStringList ??= new _i3.ListBuilder<String>();
-  set queryStringList(_i3.ListBuilder<String>? queryStringList) =>
+  _i5.ListBuilder<String>? _queryStringList;
+  _i5.ListBuilder<String> get queryStringList =>
+      _$this._queryStringList ??= new _i5.ListBuilder<String>();
+  set queryStringList(_i5.ListBuilder<String>? queryStringList) =>
       _$this._queryStringList = queryStringList;
 
-  _i3.SetBuilder<String>? _queryStringSet;
-  _i3.SetBuilder<String> get queryStringSet =>
-      _$this._queryStringSet ??= new _i3.SetBuilder<String>();
-  set queryStringSet(_i3.SetBuilder<String>? queryStringSet) =>
+  _i5.SetBuilder<String>? _queryStringSet;
+  _i5.SetBuilder<String> get queryStringSet =>
+      _$this._queryStringSet ??= new _i5.SetBuilder<String>();
+  set queryStringSet(_i5.SetBuilder<String>? queryStringSet) =>
       _$this._queryStringSet = queryStringSet;
 
   DateTime? _queryTimestamp;
@@ -250,10 +250,10 @@ class AllQueryStringTypesInputBuilder
   set queryTimestamp(DateTime? queryTimestamp) =>
       _$this._queryTimestamp = queryTimestamp;
 
-  _i3.ListBuilder<DateTime>? _queryTimestampList;
-  _i3.ListBuilder<DateTime> get queryTimestampList =>
-      _$this._queryTimestampList ??= new _i3.ListBuilder<DateTime>();
-  set queryTimestampList(_i3.ListBuilder<DateTime>? queryTimestampList) =>
+  _i5.ListBuilder<DateTime>? _queryTimestampList;
+  _i5.ListBuilder<DateTime> get queryTimestampList =>
+      _$this._queryTimestampList ??= new _i5.ListBuilder<DateTime>();
+  set queryTimestampList(_i5.ListBuilder<DateTime>? queryTimestampList) =>
       _$this._queryTimestampList = queryTimestampList;
 
   AllQueryStringTypesInputBuilder() {

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_input_output.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_input_output.dart
@@ -3,10 +3,10 @@
 library rest_xml_v1.rest_xml_protocol.model.flattened_xml_map_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:rest_xml_v1/src/rest_xml_protocol/model/foo_enum.dart' as _i4;
+import 'package:rest_xml_v1/src/rest_xml_protocol/model/foo_enum.dart' as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'flattened_xml_map_input_output.g.dart';
@@ -17,9 +17,9 @@ abstract class FlattenedXmlMapInputOutput
         _i2.AWSEquatable<FlattenedXmlMapInputOutput>
     implements
         Built<FlattenedXmlMapInputOutput, FlattenedXmlMapInputOutputBuilder> {
-  factory FlattenedXmlMapInputOutput(
-      {_i3.BuiltMap<String, _i4.FooEnum>? myMap}) {
-    return _$FlattenedXmlMapInputOutput._(myMap: myMap);
+  factory FlattenedXmlMapInputOutput({Map<String, _i3.FooEnum>? myMap}) {
+    return _$FlattenedXmlMapInputOutput._(
+        myMap: myMap == null ? null : _i4.BuiltMap(myMap));
   }
 
   factory FlattenedXmlMapInputOutput.build(
@@ -48,7 +48,7 @@ abstract class FlattenedXmlMapInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(FlattenedXmlMapInputOutputBuilder b) {}
-  _i3.BuiltMap<String, _i4.FooEnum>? get myMap;
+  _i4.BuiltMap<String, _i3.FooEnum>? get myMap;
   @override
   FlattenedXmlMapInputOutput getPayload() => this;
   @override
@@ -102,10 +102,10 @@ class FlattenedXmlMapInputOutputRestXmlSerializer
                       serializers,
                       (value as Iterable<Object?>),
                       specifiedType: const FullType(
-                        _i3.BuiltMap,
+                        _i4.BuiltMap,
                         [
                           FullType(String),
-                          FullType(_i4.FooEnum),
+                          FullType(_i3.FooEnum),
                         ],
                       ),
                     )
@@ -135,10 +135,10 @@ class FlattenedXmlMapInputOutputRestXmlSerializer
         serializers,
         payload.myMap!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltMap,
+          _i4.BuiltMap,
           [
             FullType(String),
-            FullType(_i4.FooEnum),
+            FullType(_i3.FooEnum),
           ],
         ),
       ));

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_input_output.g.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_input_output.g.dart
@@ -8,7 +8,7 @@ part of rest_xml_v1.rest_xml_protocol.model.flattened_xml_map_input_output;
 
 class _$FlattenedXmlMapInputOutput extends FlattenedXmlMapInputOutput {
   @override
-  final _i3.BuiltMap<String, _i4.FooEnum>? myMap;
+  final _i4.BuiltMap<String, _i3.FooEnum>? myMap;
 
   factory _$FlattenedXmlMapInputOutput(
           [void Function(FlattenedXmlMapInputOutputBuilder)? updates]) =>
@@ -42,10 +42,10 @@ class FlattenedXmlMapInputOutputBuilder
         Builder<FlattenedXmlMapInputOutput, FlattenedXmlMapInputOutputBuilder> {
   _$FlattenedXmlMapInputOutput? _$v;
 
-  _i3.MapBuilder<String, _i4.FooEnum>? _myMap;
-  _i3.MapBuilder<String, _i4.FooEnum> get myMap =>
-      _$this._myMap ??= new _i3.MapBuilder<String, _i4.FooEnum>();
-  set myMap(_i3.MapBuilder<String, _i4.FooEnum>? myMap) =>
+  _i4.MapBuilder<String, _i3.FooEnum>? _myMap;
+  _i4.MapBuilder<String, _i3.FooEnum> get myMap =>
+      _$this._myMap ??= new _i4.MapBuilder<String, _i3.FooEnum>();
+  set myMap(_i4.MapBuilder<String, _i3.FooEnum>? myMap) =>
       _$this._myMap = myMap;
 
   FlattenedXmlMapInputOutputBuilder() {

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_with_xml_name_input_output.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_with_xml_name_input_output.dart
@@ -17,9 +17,9 @@ abstract class FlattenedXmlMapWithXmlNameInputOutput
     implements
         Built<FlattenedXmlMapWithXmlNameInputOutput,
             FlattenedXmlMapWithXmlNameInputOutputBuilder> {
-  factory FlattenedXmlMapWithXmlNameInputOutput(
-      {_i3.BuiltMap<String, String>? myMap}) {
-    return _$FlattenedXmlMapWithXmlNameInputOutput._(myMap: myMap);
+  factory FlattenedXmlMapWithXmlNameInputOutput({Map<String, String>? myMap}) {
+    return _$FlattenedXmlMapWithXmlNameInputOutput._(
+        myMap: myMap == null ? null : _i3.BuiltMap(myMap));
   }
 
   factory FlattenedXmlMapWithXmlNameInputOutput.build(

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_with_xml_namespace_output.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_with_xml_namespace_output.dart
@@ -16,9 +16,9 @@ abstract class FlattenedXmlMapWithXmlNamespaceOutput
     implements
         Built<FlattenedXmlMapWithXmlNamespaceOutput,
             FlattenedXmlMapWithXmlNamespaceOutputBuilder> {
-  factory FlattenedXmlMapWithXmlNamespaceOutput(
-      {_i2.BuiltMap<String, String>? myMap}) {
-    return _$FlattenedXmlMapWithXmlNamespaceOutput._(myMap: myMap);
+  factory FlattenedXmlMapWithXmlNamespaceOutput({Map<String, String>? myMap}) {
+    return _$FlattenedXmlMapWithXmlNamespaceOutput._(
+        myMap: myMap == null ? null : _i2.BuiltMap(myMap));
   }
 
   factory FlattenedXmlMapWithXmlNamespaceOutput.build(

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/http_prefix_headers_input_output.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/http_prefix_headers_input_output.dart
@@ -22,11 +22,11 @@ abstract class HttpPrefixHeadersInputOutput
         _i1.HasPayload<HttpPrefixHeadersInputOutputPayload> {
   factory HttpPrefixHeadersInputOutput({
     String? foo,
-    _i3.BuiltMap<String, String>? fooMap,
+    Map<String, String>? fooMap,
   }) {
     return _$HttpPrefixHeadersInputOutput._(
       foo: foo,
-      fooMap: fooMap,
+      fooMap: fooMap == null ? null : _i3.BuiltMap(fooMap),
     );
   }
 

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/input_and_output_with_headers_io.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/input_and_output_with_headers_io.dart
@@ -3,12 +3,12 @@
 library rest_xml_v1.rest_xml_protocol.model.input_and_output_with_headers_io; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:fixnum/fixnum.dart' as _i5;
+import 'package:fixnum/fixnum.dart' as _i4;
 import 'package:meta/meta.dart' as _i6;
-import 'package:rest_xml_v1/src/rest_xml_protocol/model/foo_enum.dart' as _i4;
+import 'package:rest_xml_v1/src/rest_xml_protocol/model/foo_enum.dart' as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'input_and_output_with_headers_io.g.dart';
@@ -22,39 +22,46 @@ abstract class InputAndOutputWithHeadersIo
         _i1.EmptyPayload,
         _i1.HasPayload<InputAndOutputWithHeadersIoPayload> {
   factory InputAndOutputWithHeadersIo({
-    _i3.BuiltList<bool>? headerBooleanList,
+    List<bool>? headerBooleanList,
     int? headerByte,
     double? headerDouble,
-    _i4.FooEnum? headerEnum,
-    _i3.BuiltList<_i4.FooEnum>? headerEnumList,
+    _i3.FooEnum? headerEnum,
+    List<_i3.FooEnum>? headerEnumList,
     bool? headerFalseBool,
     double? headerFloat,
     int? headerInteger,
-    _i3.BuiltList<int>? headerIntegerList,
-    _i5.Int64? headerLong,
+    List<int>? headerIntegerList,
+    _i4.Int64? headerLong,
     int? headerShort,
     String? headerString,
-    _i3.BuiltList<String>? headerStringList,
-    _i3.BuiltSet<String>? headerStringSet,
-    _i3.BuiltList<DateTime>? headerTimestampList,
+    List<String>? headerStringList,
+    Set<String>? headerStringSet,
+    List<DateTime>? headerTimestampList,
     bool? headerTrueBool,
   }) {
     return _$InputAndOutputWithHeadersIo._(
-      headerBooleanList: headerBooleanList,
+      headerBooleanList:
+          headerBooleanList == null ? null : _i5.BuiltList(headerBooleanList),
       headerByte: headerByte,
       headerDouble: headerDouble,
       headerEnum: headerEnum,
-      headerEnumList: headerEnumList,
+      headerEnumList:
+          headerEnumList == null ? null : _i5.BuiltList(headerEnumList),
       headerFalseBool: headerFalseBool,
       headerFloat: headerFloat,
       headerInteger: headerInteger,
-      headerIntegerList: headerIntegerList,
+      headerIntegerList:
+          headerIntegerList == null ? null : _i5.BuiltList(headerIntegerList),
       headerLong: headerLong,
       headerShort: headerShort,
       headerString: headerString,
-      headerStringList: headerStringList,
-      headerStringSet: headerStringSet,
-      headerTimestampList: headerTimestampList,
+      headerStringList:
+          headerStringList == null ? null : _i5.BuiltList(headerStringList),
+      headerStringSet:
+          headerStringSet == null ? null : _i5.BuiltSet(headerStringSet),
+      headerTimestampList: headerTimestampList == null
+          ? null
+          : _i5.BuiltList(headerTimestampList),
       headerTrueBool: headerTrueBool,
     );
   }
@@ -84,7 +91,7 @@ abstract class InputAndOutputWithHeadersIo
           b.headerInteger = int.parse(request.headers['X-Integer']!);
         }
         if (request.headers['X-Long'] != null) {
-          b.headerLong = _i5.Int64.parseInt(request.headers['X-Long']!);
+          b.headerLong = _i4.Int64.parseInt(request.headers['X-Long']!);
         }
         if (request.headers['X-Float'] != null) {
           b.headerFloat = double.parse(request.headers['X-Float']!);
@@ -130,12 +137,12 @@ abstract class InputAndOutputWithHeadersIo
                   ).asDateTime));
         }
         if (request.headers['X-Enum'] != null) {
-          b.headerEnum = _i4.FooEnum.values.byValue(request.headers['X-Enum']!);
+          b.headerEnum = _i3.FooEnum.values.byValue(request.headers['X-Enum']!);
         }
         if (request.headers['X-EnumList'] != null) {
           b.headerEnumList.addAll(_i1
               .parseHeader(request.headers['X-EnumList']!)
-              .map((el) => _i4.FooEnum.values.byValue(el.trim())));
+              .map((el) => _i3.FooEnum.values.byValue(el.trim())));
         }
       });
 
@@ -158,7 +165,7 @@ abstract class InputAndOutputWithHeadersIo
           b.headerInteger = int.parse(response.headers['X-Integer']!);
         }
         if (response.headers['X-Long'] != null) {
-          b.headerLong = _i5.Int64.parseInt(response.headers['X-Long']!);
+          b.headerLong = _i4.Int64.parseInt(response.headers['X-Long']!);
         }
         if (response.headers['X-Float'] != null) {
           b.headerFloat = double.parse(response.headers['X-Float']!);
@@ -205,12 +212,12 @@ abstract class InputAndOutputWithHeadersIo
         }
         if (response.headers['X-Enum'] != null) {
           b.headerEnum =
-              _i4.FooEnum.values.byValue(response.headers['X-Enum']!);
+              _i3.FooEnum.values.byValue(response.headers['X-Enum']!);
         }
         if (response.headers['X-EnumList'] != null) {
           b.headerEnumList.addAll(_i1
               .parseHeader(response.headers['X-EnumList']!)
-              .map((el) => _i4.FooEnum.values.byValue(el.trim())));
+              .map((el) => _i3.FooEnum.values.byValue(el.trim())));
         }
       });
 
@@ -220,21 +227,21 @@ abstract class InputAndOutputWithHeadersIo
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(InputAndOutputWithHeadersIoBuilder b) {}
-  _i3.BuiltList<bool>? get headerBooleanList;
+  _i5.BuiltList<bool>? get headerBooleanList;
   int? get headerByte;
   double? get headerDouble;
-  _i4.FooEnum? get headerEnum;
-  _i3.BuiltList<_i4.FooEnum>? get headerEnumList;
+  _i3.FooEnum? get headerEnum;
+  _i5.BuiltList<_i3.FooEnum>? get headerEnumList;
   bool? get headerFalseBool;
   double? get headerFloat;
   int? get headerInteger;
-  _i3.BuiltList<int>? get headerIntegerList;
-  _i5.Int64? get headerLong;
+  _i5.BuiltList<int>? get headerIntegerList;
+  _i4.Int64? get headerLong;
   int? get headerShort;
   String? get headerString;
-  _i3.BuiltList<String>? get headerStringList;
-  _i3.BuiltSet<String>? get headerStringSet;
-  _i3.BuiltList<DateTime>? get headerTimestampList;
+  _i5.BuiltList<String>? get headerStringList;
+  _i5.BuiltSet<String>? get headerStringSet;
+  _i5.BuiltList<DateTime>? get headerTimestampList;
   bool? get headerTrueBool;
   @override
   InputAndOutputWithHeadersIoPayload getPayload() =>

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/input_and_output_with_headers_io.g.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/input_and_output_with_headers_io.g.dart
@@ -8,15 +8,15 @@ part of rest_xml_v1.rest_xml_protocol.model.input_and_output_with_headers_io;
 
 class _$InputAndOutputWithHeadersIo extends InputAndOutputWithHeadersIo {
   @override
-  final _i3.BuiltList<bool>? headerBooleanList;
+  final _i5.BuiltList<bool>? headerBooleanList;
   @override
   final int? headerByte;
   @override
   final double? headerDouble;
   @override
-  final _i4.FooEnum? headerEnum;
+  final _i3.FooEnum? headerEnum;
   @override
-  final _i3.BuiltList<_i4.FooEnum>? headerEnumList;
+  final _i5.BuiltList<_i3.FooEnum>? headerEnumList;
   @override
   final bool? headerFalseBool;
   @override
@@ -24,19 +24,19 @@ class _$InputAndOutputWithHeadersIo extends InputAndOutputWithHeadersIo {
   @override
   final int? headerInteger;
   @override
-  final _i3.BuiltList<int>? headerIntegerList;
+  final _i5.BuiltList<int>? headerIntegerList;
   @override
-  final _i5.Int64? headerLong;
+  final _i4.Int64? headerLong;
   @override
   final int? headerShort;
   @override
   final String? headerString;
   @override
-  final _i3.BuiltList<String>? headerStringList;
+  final _i5.BuiltList<String>? headerStringList;
   @override
-  final _i3.BuiltSet<String>? headerStringSet;
+  final _i5.BuiltSet<String>? headerStringSet;
   @override
-  final _i3.BuiltList<DateTime>? headerTimestampList;
+  final _i5.BuiltList<DateTime>? headerTimestampList;
   @override
   final bool? headerTrueBool;
 
@@ -141,10 +141,10 @@ class InputAndOutputWithHeadersIoBuilder
             InputAndOutputWithHeadersIoBuilder> {
   _$InputAndOutputWithHeadersIo? _$v;
 
-  _i3.ListBuilder<bool>? _headerBooleanList;
-  _i3.ListBuilder<bool> get headerBooleanList =>
-      _$this._headerBooleanList ??= new _i3.ListBuilder<bool>();
-  set headerBooleanList(_i3.ListBuilder<bool>? headerBooleanList) =>
+  _i5.ListBuilder<bool>? _headerBooleanList;
+  _i5.ListBuilder<bool> get headerBooleanList =>
+      _$this._headerBooleanList ??= new _i5.ListBuilder<bool>();
+  set headerBooleanList(_i5.ListBuilder<bool>? headerBooleanList) =>
       _$this._headerBooleanList = headerBooleanList;
 
   int? _headerByte;
@@ -155,14 +155,14 @@ class InputAndOutputWithHeadersIoBuilder
   double? get headerDouble => _$this._headerDouble;
   set headerDouble(double? headerDouble) => _$this._headerDouble = headerDouble;
 
-  _i4.FooEnum? _headerEnum;
-  _i4.FooEnum? get headerEnum => _$this._headerEnum;
-  set headerEnum(_i4.FooEnum? headerEnum) => _$this._headerEnum = headerEnum;
+  _i3.FooEnum? _headerEnum;
+  _i3.FooEnum? get headerEnum => _$this._headerEnum;
+  set headerEnum(_i3.FooEnum? headerEnum) => _$this._headerEnum = headerEnum;
 
-  _i3.ListBuilder<_i4.FooEnum>? _headerEnumList;
-  _i3.ListBuilder<_i4.FooEnum> get headerEnumList =>
-      _$this._headerEnumList ??= new _i3.ListBuilder<_i4.FooEnum>();
-  set headerEnumList(_i3.ListBuilder<_i4.FooEnum>? headerEnumList) =>
+  _i5.ListBuilder<_i3.FooEnum>? _headerEnumList;
+  _i5.ListBuilder<_i3.FooEnum> get headerEnumList =>
+      _$this._headerEnumList ??= new _i5.ListBuilder<_i3.FooEnum>();
+  set headerEnumList(_i5.ListBuilder<_i3.FooEnum>? headerEnumList) =>
       _$this._headerEnumList = headerEnumList;
 
   bool? _headerFalseBool;
@@ -179,15 +179,15 @@ class InputAndOutputWithHeadersIoBuilder
   set headerInteger(int? headerInteger) =>
       _$this._headerInteger = headerInteger;
 
-  _i3.ListBuilder<int>? _headerIntegerList;
-  _i3.ListBuilder<int> get headerIntegerList =>
-      _$this._headerIntegerList ??= new _i3.ListBuilder<int>();
-  set headerIntegerList(_i3.ListBuilder<int>? headerIntegerList) =>
+  _i5.ListBuilder<int>? _headerIntegerList;
+  _i5.ListBuilder<int> get headerIntegerList =>
+      _$this._headerIntegerList ??= new _i5.ListBuilder<int>();
+  set headerIntegerList(_i5.ListBuilder<int>? headerIntegerList) =>
       _$this._headerIntegerList = headerIntegerList;
 
-  _i5.Int64? _headerLong;
-  _i5.Int64? get headerLong => _$this._headerLong;
-  set headerLong(_i5.Int64? headerLong) => _$this._headerLong = headerLong;
+  _i4.Int64? _headerLong;
+  _i4.Int64? get headerLong => _$this._headerLong;
+  set headerLong(_i4.Int64? headerLong) => _$this._headerLong = headerLong;
 
   int? _headerShort;
   int? get headerShort => _$this._headerShort;
@@ -197,22 +197,22 @@ class InputAndOutputWithHeadersIoBuilder
   String? get headerString => _$this._headerString;
   set headerString(String? headerString) => _$this._headerString = headerString;
 
-  _i3.ListBuilder<String>? _headerStringList;
-  _i3.ListBuilder<String> get headerStringList =>
-      _$this._headerStringList ??= new _i3.ListBuilder<String>();
-  set headerStringList(_i3.ListBuilder<String>? headerStringList) =>
+  _i5.ListBuilder<String>? _headerStringList;
+  _i5.ListBuilder<String> get headerStringList =>
+      _$this._headerStringList ??= new _i5.ListBuilder<String>();
+  set headerStringList(_i5.ListBuilder<String>? headerStringList) =>
       _$this._headerStringList = headerStringList;
 
-  _i3.SetBuilder<String>? _headerStringSet;
-  _i3.SetBuilder<String> get headerStringSet =>
-      _$this._headerStringSet ??= new _i3.SetBuilder<String>();
-  set headerStringSet(_i3.SetBuilder<String>? headerStringSet) =>
+  _i5.SetBuilder<String>? _headerStringSet;
+  _i5.SetBuilder<String> get headerStringSet =>
+      _$this._headerStringSet ??= new _i5.SetBuilder<String>();
+  set headerStringSet(_i5.SetBuilder<String>? headerStringSet) =>
       _$this._headerStringSet = headerStringSet;
 
-  _i3.ListBuilder<DateTime>? _headerTimestampList;
-  _i3.ListBuilder<DateTime> get headerTimestampList =>
-      _$this._headerTimestampList ??= new _i3.ListBuilder<DateTime>();
-  set headerTimestampList(_i3.ListBuilder<DateTime>? headerTimestampList) =>
+  _i5.ListBuilder<DateTime>? _headerTimestampList;
+  _i5.ListBuilder<DateTime> get headerTimestampList =>
+      _$this._headerTimestampList ??= new _i5.ListBuilder<DateTime>();
+  set headerTimestampList(_i5.ListBuilder<DateTime>? headerTimestampList) =>
       _$this._headerTimestampList = headerTimestampList;
 
   bool? _headerTrueBool;

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/nested_xml_maps_input_output.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/nested_xml_maps_input_output.dart
@@ -3,10 +3,10 @@
 library rest_xml_v1.rest_xml_protocol.model.nested_xml_maps_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:rest_xml_v1/src/rest_xml_protocol/model/foo_enum.dart' as _i4;
+import 'package:rest_xml_v1/src/rest_xml_protocol/model/foo_enum.dart' as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'nested_xml_maps_input_output.g.dart';
@@ -18,12 +18,30 @@ abstract class NestedXmlMapsInputOutput
     implements
         Built<NestedXmlMapsInputOutput, NestedXmlMapsInputOutputBuilder> {
   factory NestedXmlMapsInputOutput({
-    _i3.BuiltMap<String, _i3.BuiltMap<String, _i4.FooEnum>>? flatNestedMap,
-    _i3.BuiltMap<String, _i3.BuiltMap<String, _i4.FooEnum>>? nestedMap,
+    Map<String, Map<String, _i3.FooEnum>>? flatNestedMap,
+    Map<String, Map<String, _i3.FooEnum>>? nestedMap,
   }) {
     return _$NestedXmlMapsInputOutput._(
-      flatNestedMap: flatNestedMap,
-      nestedMap: nestedMap,
+      flatNestedMap: flatNestedMap == null
+          ? null
+          : _i4.BuiltMap(flatNestedMap.map((
+              key,
+              value,
+            ) =>
+              MapEntry(
+                key,
+                _i4.BuiltMap(value),
+              ))),
+      nestedMap: nestedMap == null
+          ? null
+          : _i4.BuiltMap(nestedMap.map((
+              key,
+              value,
+            ) =>
+              MapEntry(
+                key,
+                _i4.BuiltMap(value),
+              ))),
     );
   }
 
@@ -53,8 +71,8 @@ abstract class NestedXmlMapsInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(NestedXmlMapsInputOutputBuilder b) {}
-  _i3.BuiltMap<String, _i3.BuiltMap<String, _i4.FooEnum>>? get flatNestedMap;
-  _i3.BuiltMap<String, _i3.BuiltMap<String, _i4.FooEnum>>? get nestedMap;
+  _i4.BuiltMap<String, _i4.BuiltMap<String, _i3.FooEnum>>? get flatNestedMap;
+  _i4.BuiltMap<String, _i4.BuiltMap<String, _i3.FooEnum>>? get nestedMap;
   @override
   NestedXmlMapsInputOutput getPayload() => this;
   @override
@@ -115,14 +133,14 @@ class NestedXmlMapsInputOutputRestXmlSerializer
                       serializers,
                       (value as Iterable<Object?>),
                       specifiedType: const FullType(
-                        _i3.BuiltMap,
+                        _i4.BuiltMap,
                         [
                           FullType(String),
                           FullType(
-                            _i3.BuiltMap,
+                            _i4.BuiltMap,
                             [
                               FullType(String),
-                              FullType(_i4.FooEnum),
+                              FullType(_i3.FooEnum),
                             ],
                           ),
                         ],
@@ -139,14 +157,14 @@ class NestedXmlMapsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(
-                    _i3.BuiltMap,
+                    _i4.BuiltMap,
                     [
                       FullType(String),
-                      FullType(_i4.FooEnum),
+                      FullType(_i3.FooEnum),
                     ],
                   ),
                 ],
@@ -177,14 +195,14 @@ class NestedXmlMapsInputOutputRestXmlSerializer
         serializers,
         payload.flatNestedMap!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltMap,
+          _i4.BuiltMap,
           [
             FullType(String),
             FullType(
-              _i3.BuiltMap,
+              _i4.BuiltMap,
               [
                 FullType(String),
-                FullType(_i4.FooEnum),
+                FullType(_i3.FooEnum),
               ],
             ),
           ],
@@ -198,14 +216,14 @@ class NestedXmlMapsInputOutputRestXmlSerializer
           serializers,
           payload.nestedMap!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FooEnum),
+                  FullType(_i3.FooEnum),
                 ],
               ),
             ],

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/nested_xml_maps_input_output.g.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/nested_xml_maps_input_output.g.dart
@@ -8,9 +8,9 @@ part of rest_xml_v1.rest_xml_protocol.model.nested_xml_maps_input_output;
 
 class _$NestedXmlMapsInputOutput extends NestedXmlMapsInputOutput {
   @override
-  final _i3.BuiltMap<String, _i3.BuiltMap<String, _i4.FooEnum>>? flatNestedMap;
+  final _i4.BuiltMap<String, _i4.BuiltMap<String, _i3.FooEnum>>? flatNestedMap;
   @override
-  final _i3.BuiltMap<String, _i3.BuiltMap<String, _i4.FooEnum>>? nestedMap;
+  final _i4.BuiltMap<String, _i4.BuiltMap<String, _i3.FooEnum>>? nestedMap;
 
   factory _$NestedXmlMapsInputOutput(
           [void Function(NestedXmlMapsInputOutputBuilder)? updates]) =>
@@ -47,21 +47,21 @@ class NestedXmlMapsInputOutputBuilder
         Builder<NestedXmlMapsInputOutput, NestedXmlMapsInputOutputBuilder> {
   _$NestedXmlMapsInputOutput? _$v;
 
-  _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>>? _flatNestedMap;
-  _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>> get flatNestedMap =>
+  _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>>? _flatNestedMap;
+  _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>> get flatNestedMap =>
       _$this._flatNestedMap ??=
-          new _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>>();
+          new _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>>();
   set flatNestedMap(
-          _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>>?
+          _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>>?
               flatNestedMap) =>
       _$this._flatNestedMap = flatNestedMap;
 
-  _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>>? _nestedMap;
-  _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>> get nestedMap =>
+  _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>>? _nestedMap;
+  _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>> get nestedMap =>
       _$this._nestedMap ??=
-          new _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>>();
+          new _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>>();
   set nestedMap(
-          _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>>?
+          _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>>?
               nestedMap) =>
       _$this._nestedMap = nestedMap;
 

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/null_and_empty_headers_io.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/null_and_empty_headers_io.dart
@@ -22,12 +22,12 @@ abstract class NullAndEmptyHeadersIo
   factory NullAndEmptyHeadersIo({
     String? a,
     String? b,
-    _i3.BuiltList<String>? c,
+    List<String>? c,
   }) {
     return _$NullAndEmptyHeadersIo._(
       a: a,
       b: b,
-      c: c,
+      c: c == null ? null : _i3.BuiltList(c),
     );
   }
 

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/query_params_as_string_list_map_input.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/query_params_as_string_list_map_input.dart
@@ -21,11 +21,11 @@ abstract class QueryParamsAsStringListMapInput
         _i1.EmptyPayload,
         _i1.HasPayload<QueryParamsAsStringListMapInputPayload> {
   factory QueryParamsAsStringListMapInput({
-    _i3.BuiltListMultimap<String, String>? foo,
+    Map<String, List<String>>? foo,
     String? qux,
   }) {
     return _$QueryParamsAsStringListMapInput._(
-      foo: foo,
+      foo: foo == null ? null : _i3.BuiltListMultimap(foo),
       qux: qux,
     );
   }

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/query_precedence_input.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/query_precedence_input.dart
@@ -20,11 +20,11 @@ abstract class QueryPrecedenceInput
         _i1.EmptyPayload,
         _i1.HasPayload<QueryPrecedenceInputPayload> {
   factory QueryPrecedenceInput({
-    _i3.BuiltMap<String, String>? baz,
+    Map<String, String>? baz,
     String? foo,
   }) {
     return _$QueryPrecedenceInput._(
-      baz: baz,
+      baz: baz == null ? null : _i3.BuiltMap(baz),
       foo: foo,
     );
   }

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/scoped_config.dart
@@ -3,17 +3,17 @@
 library rest_xml_v1.rest_xml_protocol.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_xml_v1/src/rest_xml_protocol/model/client_config.dart'
     as _i2;
 import 'package:rest_xml_v1/src/rest_xml_protocol/model/environment_config.dart'
-    as _i5;
-import 'package:rest_xml_v1/src/rest_xml_protocol/model/file_config_settings.dart'
     as _i4;
+import 'package:rest_xml_v1/src/rest_xml_protocol/model/file_config_settings.dart'
+    as _i3;
 import 'package:rest_xml_v1/src/rest_xml_protocol/model/operation_config.dart'
-    as _i6;
+    as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -25,15 +25,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -56,16 +57,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -145,10 +146,10 @@ class ScopedConfigRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
             ));
@@ -161,10 +162,10 @@ class ScopedConfigRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
             ));
@@ -174,16 +175,16 @@ class ScopedConfigRestXmlSerializer
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -215,10 +216,10 @@ class ScopedConfigRestXmlSerializer
           serializers,
           payload.configFile!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -230,10 +231,10 @@ class ScopedConfigRestXmlSerializer
           serializers,
           payload.credentialsFile!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -243,7 +244,7 @@ class ScopedConfigRestXmlSerializer
         ..add(const _i7.XmlElementName('environment'))
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -251,7 +252,7 @@ class ScopedConfigRestXmlSerializer
         ..add(const _i7.XmlElementName('operation'))
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_enums_input_output.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_enums_input_output.dart
@@ -20,17 +20,17 @@ abstract class XmlEnumsInputOutput
     _i3.FooEnum? fooEnum1,
     _i3.FooEnum? fooEnum2,
     _i3.FooEnum? fooEnum3,
-    _i4.BuiltList<_i3.FooEnum>? fooEnumList,
-    _i4.BuiltMap<String, _i3.FooEnum>? fooEnumMap,
-    _i4.BuiltSet<_i3.FooEnum>? fooEnumSet,
+    List<_i3.FooEnum>? fooEnumList,
+    Map<String, _i3.FooEnum>? fooEnumMap,
+    Set<_i3.FooEnum>? fooEnumSet,
   }) {
     return _$XmlEnumsInputOutput._(
       fooEnum1: fooEnum1,
       fooEnum2: fooEnum2,
       fooEnum3: fooEnum3,
-      fooEnumList: fooEnumList,
-      fooEnumMap: fooEnumMap,
-      fooEnumSet: fooEnumSet,
+      fooEnumList: fooEnumList == null ? null : _i4.BuiltList(fooEnumList),
+      fooEnumMap: fooEnumMap == null ? null : _i4.BuiltMap(fooEnumMap),
+      fooEnumSet: fooEnumSet == null ? null : _i4.BuiltSet(fooEnumSet),
     );
   }
 

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_lists_input_output.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_lists_input_output.dart
@@ -3,12 +3,12 @@
 library rest_xml_v1.rest_xml_protocol.model.xml_lists_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:rest_xml_v1/src/rest_xml_protocol/model/foo_enum.dart' as _i4;
+import 'package:rest_xml_v1/src/rest_xml_protocol/model/foo_enum.dart' as _i3;
 import 'package:rest_xml_v1/src/rest_xml_protocol/model/structure_list_member.dart'
-    as _i5;
+    as _i4;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'xml_lists_input_output.g.dart';
@@ -19,36 +19,49 @@ abstract class XmlListsInputOutput
         _i2.AWSEquatable<XmlListsInputOutput>
     implements Built<XmlListsInputOutput, XmlListsInputOutputBuilder> {
   factory XmlListsInputOutput({
-    _i3.BuiltList<bool>? booleanList,
-    _i3.BuiltList<_i4.FooEnum>? enumList,
-    _i3.BuiltList<String>? flattenedList,
-    _i3.BuiltList<String>? flattenedList2,
-    _i3.BuiltList<String>? flattenedListWithMemberNamespace,
-    _i3.BuiltList<String>? flattenedListWithNamespace,
-    _i3.BuiltList<_i5.StructureListMember>? flattenedStructureList,
-    _i3.BuiltList<int>? integerList,
-    _i3.BuiltList<_i3.BuiltList<String>>? nestedStringList,
-    _i3.BuiltList<String>? renamedListMembers,
-    _i3.BuiltList<String>? stringList,
-    _i3.BuiltSet<String>? stringSet,
-    _i3.BuiltList<_i5.StructureListMember>? structureList,
-    _i3.BuiltList<DateTime>? timestampList,
+    List<bool>? booleanList,
+    List<_i3.FooEnum>? enumList,
+    List<String>? flattenedList,
+    List<String>? flattenedList2,
+    List<String>? flattenedListWithMemberNamespace,
+    List<String>? flattenedListWithNamespace,
+    List<_i4.StructureListMember>? flattenedStructureList,
+    List<int>? integerList,
+    List<List<String>>? nestedStringList,
+    List<String>? renamedListMembers,
+    List<String>? stringList,
+    Set<String>? stringSet,
+    List<_i4.StructureListMember>? structureList,
+    List<DateTime>? timestampList,
   }) {
     return _$XmlListsInputOutput._(
-      booleanList: booleanList,
-      enumList: enumList,
-      flattenedList: flattenedList,
-      flattenedList2: flattenedList2,
-      flattenedListWithMemberNamespace: flattenedListWithMemberNamespace,
-      flattenedListWithNamespace: flattenedListWithNamespace,
-      flattenedStructureList: flattenedStructureList,
-      integerList: integerList,
-      nestedStringList: nestedStringList,
-      renamedListMembers: renamedListMembers,
-      stringList: stringList,
-      stringSet: stringSet,
-      structureList: structureList,
-      timestampList: timestampList,
+      booleanList: booleanList == null ? null : _i5.BuiltList(booleanList),
+      enumList: enumList == null ? null : _i5.BuiltList(enumList),
+      flattenedList:
+          flattenedList == null ? null : _i5.BuiltList(flattenedList),
+      flattenedList2:
+          flattenedList2 == null ? null : _i5.BuiltList(flattenedList2),
+      flattenedListWithMemberNamespace: flattenedListWithMemberNamespace == null
+          ? null
+          : _i5.BuiltList(flattenedListWithMemberNamespace),
+      flattenedListWithNamespace: flattenedListWithNamespace == null
+          ? null
+          : _i5.BuiltList(flattenedListWithNamespace),
+      flattenedStructureList: flattenedStructureList == null
+          ? null
+          : _i5.BuiltList(flattenedStructureList),
+      integerList: integerList == null ? null : _i5.BuiltList(integerList),
+      nestedStringList: nestedStringList == null
+          ? null
+          : _i5.BuiltList(nestedStringList.map((el) => _i5.BuiltList(el))),
+      renamedListMembers:
+          renamedListMembers == null ? null : _i5.BuiltList(renamedListMembers),
+      stringList: stringList == null ? null : _i5.BuiltList(stringList),
+      stringSet: stringSet == null ? null : _i5.BuiltSet(stringSet),
+      structureList:
+          structureList == null ? null : _i5.BuiltList(structureList),
+      timestampList:
+          timestampList == null ? null : _i5.BuiltList(timestampList),
     );
   }
 
@@ -78,22 +91,22 @@ abstract class XmlListsInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(XmlListsInputOutputBuilder b) {}
-  _i3.BuiltList<bool>? get booleanList;
-  _i3.BuiltList<_i4.FooEnum>? get enumList;
-  _i3.BuiltList<String>? get flattenedList;
-  _i3.BuiltList<String>? get flattenedList2;
-  _i3.BuiltList<String>? get flattenedListWithMemberNamespace;
-  _i3.BuiltList<String>? get flattenedListWithNamespace;
-  _i3.BuiltList<_i5.StructureListMember>? get flattenedStructureList;
-  _i3.BuiltList<int>? get integerList;
+  _i5.BuiltList<bool>? get booleanList;
+  _i5.BuiltList<_i3.FooEnum>? get enumList;
+  _i5.BuiltList<String>? get flattenedList;
+  _i5.BuiltList<String>? get flattenedList2;
+  _i5.BuiltList<String>? get flattenedListWithMemberNamespace;
+  _i5.BuiltList<String>? get flattenedListWithNamespace;
+  _i5.BuiltList<_i4.StructureListMember>? get flattenedStructureList;
+  _i5.BuiltList<int>? get integerList;
 
   /// A list of lists of strings.
-  _i3.BuiltList<_i3.BuiltList<String>>? get nestedStringList;
-  _i3.BuiltList<String>? get renamedListMembers;
-  _i3.BuiltList<String>? get stringList;
-  _i3.BuiltSet<String>? get stringSet;
-  _i3.BuiltList<_i5.StructureListMember>? get structureList;
-  _i3.BuiltList<DateTime>? get timestampList;
+  _i5.BuiltList<_i5.BuiltList<String>>? get nestedStringList;
+  _i5.BuiltList<String>? get renamedListMembers;
+  _i5.BuiltList<String>? get stringList;
+  _i5.BuiltSet<String>? get stringSet;
+  _i5.BuiltList<_i4.StructureListMember>? get structureList;
+  _i5.BuiltList<DateTime>? get timestampList;
   @override
   XmlListsInputOutput getPayload() => this;
   @override
@@ -212,10 +225,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(bool)],
               ),
-            ) as _i3.BuiltList<bool>));
+            ) as _i5.BuiltList<bool>));
           }
           break;
         case 'enumList':
@@ -225,10 +238,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
-                [FullType(_i4.FooEnum)],
+                _i5.BuiltList,
+                [FullType(_i3.FooEnum)],
               ),
-            ) as _i3.BuiltList<_i4.FooEnum>));
+            ) as _i5.BuiltList<_i3.FooEnum>));
           }
           break;
         case 'flattenedList':
@@ -268,8 +281,8 @@ class XmlListsInputOutputRestXmlSerializer
           if (value != null) {
             result.flattenedStructureList.add((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.StructureListMember),
-            ) as _i5.StructureListMember));
+              specifiedType: const FullType(_i4.StructureListMember),
+            ) as _i4.StructureListMember));
           }
           break;
         case 'integerList':
@@ -279,10 +292,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(int)],
               ),
-            ) as _i3.BuiltList<int>));
+            ) as _i5.BuiltList<int>));
           }
           break;
         case 'nestedStringList':
@@ -292,15 +305,15 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [
                   FullType(
-                    _i3.BuiltList,
+                    _i5.BuiltList,
                     [FullType(String)],
                   )
                 ],
               ),
-            ) as _i3.BuiltList<_i3.BuiltList<String>>));
+            ) as _i5.BuiltList<_i5.BuiltList<String>>));
           }
           break;
         case 'renamed':
@@ -311,10 +324,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltList<String>));
+            ) as _i5.BuiltList<String>));
           }
           break;
         case 'stringList':
@@ -324,10 +337,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltList<String>));
+            ) as _i5.BuiltList<String>));
           }
           break;
         case 'stringSet':
@@ -337,10 +350,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltSet,
+                _i5.BuiltSet,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltSet<String>));
+            ) as _i5.BuiltSet<String>));
           }
           break;
         case 'myStructureList':
@@ -351,10 +364,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
-                [FullType(_i5.StructureListMember)],
+                _i5.BuiltList,
+                [FullType(_i4.StructureListMember)],
               ),
-            ) as _i3.BuiltList<_i5.StructureListMember>));
+            ) as _i5.BuiltList<_i4.StructureListMember>));
           }
           break;
         case 'timestampList':
@@ -364,10 +377,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(DateTime)],
               ),
-            ) as _i3.BuiltList<DateTime>));
+            ) as _i5.BuiltList<DateTime>));
           }
           break;
       }
@@ -391,7 +404,7 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.booleanList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(bool)],
           ),
         ));
@@ -403,8 +416,8 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.enumList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
-            [FullType(_i4.FooEnum)],
+            _i5.BuiltList,
+            [FullType(_i3.FooEnum)],
           ),
         ));
     }
@@ -415,7 +428,7 @@ class XmlListsInputOutputRestXmlSerializer
         serializers,
         payload.flattenedList!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltList,
+          _i5.BuiltList,
           [FullType(String)],
         ),
       ));
@@ -426,7 +439,7 @@ class XmlListsInputOutputRestXmlSerializer
         serializers,
         payload.flattenedList2!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltList,
+          _i5.BuiltList,
           [FullType(String)],
         ),
       ));
@@ -439,7 +452,7 @@ class XmlListsInputOutputRestXmlSerializer
         serializers,
         payload.flattenedListWithMemberNamespace!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltList,
+          _i5.BuiltList,
           [FullType(String)],
         ),
       ));
@@ -451,7 +464,7 @@ class XmlListsInputOutputRestXmlSerializer
         serializers,
         payload.flattenedListWithNamespace!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltList,
+          _i5.BuiltList,
           [FullType(String)],
         ),
       ));
@@ -463,8 +476,8 @@ class XmlListsInputOutputRestXmlSerializer
         serializers,
         payload.flattenedStructureList!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltList,
-          [FullType(_i5.StructureListMember)],
+          _i5.BuiltList,
+          [FullType(_i4.StructureListMember)],
         ),
       ));
     }
@@ -475,7 +488,7 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.integerList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(int)],
           ),
         ));
@@ -487,10 +500,10 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.nestedStringList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [
               FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(String)],
               )
             ],
@@ -504,7 +517,7 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.renamedListMembers!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(String)],
           ),
         ));
@@ -516,7 +529,7 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.stringList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(String)],
           ),
         ));
@@ -528,7 +541,7 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.stringSet!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltSet,
+            _i5.BuiltSet,
             [FullType(String)],
           ),
         ));
@@ -540,8 +553,8 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.structureList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
-            [FullType(_i5.StructureListMember)],
+            _i5.BuiltList,
+            [FullType(_i4.StructureListMember)],
           ),
         ));
     }
@@ -552,7 +565,7 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.timestampList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(DateTime)],
           ),
         ));

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_lists_input_output.g.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_lists_input_output.g.dart
@@ -8,33 +8,33 @@ part of rest_xml_v1.rest_xml_protocol.model.xml_lists_input_output;
 
 class _$XmlListsInputOutput extends XmlListsInputOutput {
   @override
-  final _i3.BuiltList<bool>? booleanList;
+  final _i5.BuiltList<bool>? booleanList;
   @override
-  final _i3.BuiltList<_i4.FooEnum>? enumList;
+  final _i5.BuiltList<_i3.FooEnum>? enumList;
   @override
-  final _i3.BuiltList<String>? flattenedList;
+  final _i5.BuiltList<String>? flattenedList;
   @override
-  final _i3.BuiltList<String>? flattenedList2;
+  final _i5.BuiltList<String>? flattenedList2;
   @override
-  final _i3.BuiltList<String>? flattenedListWithMemberNamespace;
+  final _i5.BuiltList<String>? flattenedListWithMemberNamespace;
   @override
-  final _i3.BuiltList<String>? flattenedListWithNamespace;
+  final _i5.BuiltList<String>? flattenedListWithNamespace;
   @override
-  final _i3.BuiltList<_i5.StructureListMember>? flattenedStructureList;
+  final _i5.BuiltList<_i4.StructureListMember>? flattenedStructureList;
   @override
-  final _i3.BuiltList<int>? integerList;
+  final _i5.BuiltList<int>? integerList;
   @override
-  final _i3.BuiltList<_i3.BuiltList<String>>? nestedStringList;
+  final _i5.BuiltList<_i5.BuiltList<String>>? nestedStringList;
   @override
-  final _i3.BuiltList<String>? renamedListMembers;
+  final _i5.BuiltList<String>? renamedListMembers;
   @override
-  final _i3.BuiltList<String>? stringList;
+  final _i5.BuiltList<String>? stringList;
   @override
-  final _i3.BuiltSet<String>? stringSet;
+  final _i5.BuiltSet<String>? stringSet;
   @override
-  final _i3.BuiltList<_i5.StructureListMember>? structureList;
+  final _i5.BuiltList<_i4.StructureListMember>? structureList;
   @override
-  final _i3.BuiltList<DateTime>? timestampList;
+  final _i5.BuiltList<DateTime>? timestampList;
 
   factory _$XmlListsInputOutput(
           [void Function(XmlListsInputOutputBuilder)? updates]) =>
@@ -127,95 +127,95 @@ class XmlListsInputOutputBuilder
     implements Builder<XmlListsInputOutput, XmlListsInputOutputBuilder> {
   _$XmlListsInputOutput? _$v;
 
-  _i3.ListBuilder<bool>? _booleanList;
-  _i3.ListBuilder<bool> get booleanList =>
-      _$this._booleanList ??= new _i3.ListBuilder<bool>();
-  set booleanList(_i3.ListBuilder<bool>? booleanList) =>
+  _i5.ListBuilder<bool>? _booleanList;
+  _i5.ListBuilder<bool> get booleanList =>
+      _$this._booleanList ??= new _i5.ListBuilder<bool>();
+  set booleanList(_i5.ListBuilder<bool>? booleanList) =>
       _$this._booleanList = booleanList;
 
-  _i3.ListBuilder<_i4.FooEnum>? _enumList;
-  _i3.ListBuilder<_i4.FooEnum> get enumList =>
-      _$this._enumList ??= new _i3.ListBuilder<_i4.FooEnum>();
-  set enumList(_i3.ListBuilder<_i4.FooEnum>? enumList) =>
+  _i5.ListBuilder<_i3.FooEnum>? _enumList;
+  _i5.ListBuilder<_i3.FooEnum> get enumList =>
+      _$this._enumList ??= new _i5.ListBuilder<_i3.FooEnum>();
+  set enumList(_i5.ListBuilder<_i3.FooEnum>? enumList) =>
       _$this._enumList = enumList;
 
-  _i3.ListBuilder<String>? _flattenedList;
-  _i3.ListBuilder<String> get flattenedList =>
-      _$this._flattenedList ??= new _i3.ListBuilder<String>();
-  set flattenedList(_i3.ListBuilder<String>? flattenedList) =>
+  _i5.ListBuilder<String>? _flattenedList;
+  _i5.ListBuilder<String> get flattenedList =>
+      _$this._flattenedList ??= new _i5.ListBuilder<String>();
+  set flattenedList(_i5.ListBuilder<String>? flattenedList) =>
       _$this._flattenedList = flattenedList;
 
-  _i3.ListBuilder<String>? _flattenedList2;
-  _i3.ListBuilder<String> get flattenedList2 =>
-      _$this._flattenedList2 ??= new _i3.ListBuilder<String>();
-  set flattenedList2(_i3.ListBuilder<String>? flattenedList2) =>
+  _i5.ListBuilder<String>? _flattenedList2;
+  _i5.ListBuilder<String> get flattenedList2 =>
+      _$this._flattenedList2 ??= new _i5.ListBuilder<String>();
+  set flattenedList2(_i5.ListBuilder<String>? flattenedList2) =>
       _$this._flattenedList2 = flattenedList2;
 
-  _i3.ListBuilder<String>? _flattenedListWithMemberNamespace;
-  _i3.ListBuilder<String> get flattenedListWithMemberNamespace =>
+  _i5.ListBuilder<String>? _flattenedListWithMemberNamespace;
+  _i5.ListBuilder<String> get flattenedListWithMemberNamespace =>
       _$this._flattenedListWithMemberNamespace ??=
-          new _i3.ListBuilder<String>();
+          new _i5.ListBuilder<String>();
   set flattenedListWithMemberNamespace(
-          _i3.ListBuilder<String>? flattenedListWithMemberNamespace) =>
+          _i5.ListBuilder<String>? flattenedListWithMemberNamespace) =>
       _$this._flattenedListWithMemberNamespace =
           flattenedListWithMemberNamespace;
 
-  _i3.ListBuilder<String>? _flattenedListWithNamespace;
-  _i3.ListBuilder<String> get flattenedListWithNamespace =>
-      _$this._flattenedListWithNamespace ??= new _i3.ListBuilder<String>();
+  _i5.ListBuilder<String>? _flattenedListWithNamespace;
+  _i5.ListBuilder<String> get flattenedListWithNamespace =>
+      _$this._flattenedListWithNamespace ??= new _i5.ListBuilder<String>();
   set flattenedListWithNamespace(
-          _i3.ListBuilder<String>? flattenedListWithNamespace) =>
+          _i5.ListBuilder<String>? flattenedListWithNamespace) =>
       _$this._flattenedListWithNamespace = flattenedListWithNamespace;
 
-  _i3.ListBuilder<_i5.StructureListMember>? _flattenedStructureList;
-  _i3.ListBuilder<_i5.StructureListMember> get flattenedStructureList =>
+  _i5.ListBuilder<_i4.StructureListMember>? _flattenedStructureList;
+  _i5.ListBuilder<_i4.StructureListMember> get flattenedStructureList =>
       _$this._flattenedStructureList ??=
-          new _i3.ListBuilder<_i5.StructureListMember>();
+          new _i5.ListBuilder<_i4.StructureListMember>();
   set flattenedStructureList(
-          _i3.ListBuilder<_i5.StructureListMember>? flattenedStructureList) =>
+          _i5.ListBuilder<_i4.StructureListMember>? flattenedStructureList) =>
       _$this._flattenedStructureList = flattenedStructureList;
 
-  _i3.ListBuilder<int>? _integerList;
-  _i3.ListBuilder<int> get integerList =>
-      _$this._integerList ??= new _i3.ListBuilder<int>();
-  set integerList(_i3.ListBuilder<int>? integerList) =>
+  _i5.ListBuilder<int>? _integerList;
+  _i5.ListBuilder<int> get integerList =>
+      _$this._integerList ??= new _i5.ListBuilder<int>();
+  set integerList(_i5.ListBuilder<int>? integerList) =>
       _$this._integerList = integerList;
 
-  _i3.ListBuilder<_i3.BuiltList<String>>? _nestedStringList;
-  _i3.ListBuilder<_i3.BuiltList<String>> get nestedStringList =>
-      _$this._nestedStringList ??= new _i3.ListBuilder<_i3.BuiltList<String>>();
+  _i5.ListBuilder<_i5.BuiltList<String>>? _nestedStringList;
+  _i5.ListBuilder<_i5.BuiltList<String>> get nestedStringList =>
+      _$this._nestedStringList ??= new _i5.ListBuilder<_i5.BuiltList<String>>();
   set nestedStringList(
-          _i3.ListBuilder<_i3.BuiltList<String>>? nestedStringList) =>
+          _i5.ListBuilder<_i5.BuiltList<String>>? nestedStringList) =>
       _$this._nestedStringList = nestedStringList;
 
-  _i3.ListBuilder<String>? _renamedListMembers;
-  _i3.ListBuilder<String> get renamedListMembers =>
-      _$this._renamedListMembers ??= new _i3.ListBuilder<String>();
-  set renamedListMembers(_i3.ListBuilder<String>? renamedListMembers) =>
+  _i5.ListBuilder<String>? _renamedListMembers;
+  _i5.ListBuilder<String> get renamedListMembers =>
+      _$this._renamedListMembers ??= new _i5.ListBuilder<String>();
+  set renamedListMembers(_i5.ListBuilder<String>? renamedListMembers) =>
       _$this._renamedListMembers = renamedListMembers;
 
-  _i3.ListBuilder<String>? _stringList;
-  _i3.ListBuilder<String> get stringList =>
-      _$this._stringList ??= new _i3.ListBuilder<String>();
-  set stringList(_i3.ListBuilder<String>? stringList) =>
+  _i5.ListBuilder<String>? _stringList;
+  _i5.ListBuilder<String> get stringList =>
+      _$this._stringList ??= new _i5.ListBuilder<String>();
+  set stringList(_i5.ListBuilder<String>? stringList) =>
       _$this._stringList = stringList;
 
-  _i3.SetBuilder<String>? _stringSet;
-  _i3.SetBuilder<String> get stringSet =>
-      _$this._stringSet ??= new _i3.SetBuilder<String>();
-  set stringSet(_i3.SetBuilder<String>? stringSet) =>
+  _i5.SetBuilder<String>? _stringSet;
+  _i5.SetBuilder<String> get stringSet =>
+      _$this._stringSet ??= new _i5.SetBuilder<String>();
+  set stringSet(_i5.SetBuilder<String>? stringSet) =>
       _$this._stringSet = stringSet;
 
-  _i3.ListBuilder<_i5.StructureListMember>? _structureList;
-  _i3.ListBuilder<_i5.StructureListMember> get structureList =>
-      _$this._structureList ??= new _i3.ListBuilder<_i5.StructureListMember>();
-  set structureList(_i3.ListBuilder<_i5.StructureListMember>? structureList) =>
+  _i5.ListBuilder<_i4.StructureListMember>? _structureList;
+  _i5.ListBuilder<_i4.StructureListMember> get structureList =>
+      _$this._structureList ??= new _i5.ListBuilder<_i4.StructureListMember>();
+  set structureList(_i5.ListBuilder<_i4.StructureListMember>? structureList) =>
       _$this._structureList = structureList;
 
-  _i3.ListBuilder<DateTime>? _timestampList;
-  _i3.ListBuilder<DateTime> get timestampList =>
-      _$this._timestampList ??= new _i3.ListBuilder<DateTime>();
-  set timestampList(_i3.ListBuilder<DateTime>? timestampList) =>
+  _i5.ListBuilder<DateTime>? _timestampList;
+  _i5.ListBuilder<DateTime> get timestampList =>
+      _$this._timestampList ??= new _i5.ListBuilder<DateTime>();
+  set timestampList(_i5.ListBuilder<DateTime>? timestampList) =>
       _$this._timestampList = timestampList;
 
   XmlListsInputOutputBuilder() {

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_maps_input_output.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_maps_input_output.dart
@@ -3,11 +3,11 @@
 library rest_xml_v1.rest_xml_protocol.model.xml_maps_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_xml_v1/src/rest_xml_protocol/model/greeting_struct.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'xml_maps_input_output.g.dart';
@@ -15,9 +15,9 @@ part 'xml_maps_input_output.g.dart';
 abstract class XmlMapsInputOutput
     with _i1.HttpInput<XmlMapsInputOutput>, _i2.AWSEquatable<XmlMapsInputOutput>
     implements Built<XmlMapsInputOutput, XmlMapsInputOutputBuilder> {
-  factory XmlMapsInputOutput(
-      {_i3.BuiltMap<String, _i4.GreetingStruct>? myMap}) {
-    return _$XmlMapsInputOutput._(myMap: myMap);
+  factory XmlMapsInputOutput({Map<String, _i3.GreetingStruct>? myMap}) {
+    return _$XmlMapsInputOutput._(
+        myMap: myMap == null ? null : _i4.BuiltMap(myMap));
   }
 
   factory XmlMapsInputOutput.build(
@@ -46,7 +46,7 @@ abstract class XmlMapsInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(XmlMapsInputOutputBuilder b) {}
-  _i3.BuiltMap<String, _i4.GreetingStruct>? get myMap;
+  _i4.BuiltMap<String, _i3.GreetingStruct>? get myMap;
   @override
   XmlMapsInputOutput getPayload() => this;
   @override
@@ -97,10 +97,10 @@ class XmlMapsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.GreetingStruct),
+                  FullType(_i3.GreetingStruct),
                 ],
               ),
             ));
@@ -127,10 +127,10 @@ class XmlMapsInputOutputRestXmlSerializer
           serializers,
           payload.myMap!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.GreetingStruct),
+              FullType(_i3.GreetingStruct),
             ],
           ),
         ));

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_maps_input_output.g.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_maps_input_output.g.dart
@@ -8,7 +8,7 @@ part of rest_xml_v1.rest_xml_protocol.model.xml_maps_input_output;
 
 class _$XmlMapsInputOutput extends XmlMapsInputOutput {
   @override
-  final _i3.BuiltMap<String, _i4.GreetingStruct>? myMap;
+  final _i4.BuiltMap<String, _i3.GreetingStruct>? myMap;
 
   factory _$XmlMapsInputOutput(
           [void Function(XmlMapsInputOutputBuilder)? updates]) =>
@@ -41,10 +41,10 @@ class XmlMapsInputOutputBuilder
     implements Builder<XmlMapsInputOutput, XmlMapsInputOutputBuilder> {
   _$XmlMapsInputOutput? _$v;
 
-  _i3.MapBuilder<String, _i4.GreetingStruct>? _myMap;
-  _i3.MapBuilder<String, _i4.GreetingStruct> get myMap =>
-      _$this._myMap ??= new _i3.MapBuilder<String, _i4.GreetingStruct>();
-  set myMap(_i3.MapBuilder<String, _i4.GreetingStruct>? myMap) =>
+  _i4.MapBuilder<String, _i3.GreetingStruct>? _myMap;
+  _i4.MapBuilder<String, _i3.GreetingStruct> get myMap =>
+      _$this._myMap ??= new _i4.MapBuilder<String, _i3.GreetingStruct>();
+  set myMap(_i4.MapBuilder<String, _i3.GreetingStruct>? myMap) =>
       _$this._myMap = myMap;
 
   XmlMapsInputOutputBuilder() {

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_maps_xml_name_input_output.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_maps_xml_name_input_output.dart
@@ -3,11 +3,11 @@
 library rest_xml_v1.rest_xml_protocol.model.xml_maps_xml_name_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_xml_v1/src/rest_xml_protocol/model/greeting_struct.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'xml_maps_xml_name_input_output.g.dart';
@@ -18,9 +18,9 @@ abstract class XmlMapsXmlNameInputOutput
         _i2.AWSEquatable<XmlMapsXmlNameInputOutput>
     implements
         Built<XmlMapsXmlNameInputOutput, XmlMapsXmlNameInputOutputBuilder> {
-  factory XmlMapsXmlNameInputOutput(
-      {_i3.BuiltMap<String, _i4.GreetingStruct>? myMap}) {
-    return _$XmlMapsXmlNameInputOutput._(myMap: myMap);
+  factory XmlMapsXmlNameInputOutput({Map<String, _i3.GreetingStruct>? myMap}) {
+    return _$XmlMapsXmlNameInputOutput._(
+        myMap: myMap == null ? null : _i4.BuiltMap(myMap));
   }
 
   factory XmlMapsXmlNameInputOutput.build(
@@ -49,7 +49,7 @@ abstract class XmlMapsXmlNameInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(XmlMapsXmlNameInputOutputBuilder b) {}
-  _i3.BuiltMap<String, _i4.GreetingStruct>? get myMap;
+  _i4.BuiltMap<String, _i3.GreetingStruct>? get myMap;
   @override
   XmlMapsXmlNameInputOutput getPayload() => this;
   @override
@@ -104,10 +104,10 @@ class XmlMapsXmlNameInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.GreetingStruct),
+                  FullType(_i3.GreetingStruct),
                 ],
               ),
             ));
@@ -139,10 +139,10 @@ class XmlMapsXmlNameInputOutputRestXmlSerializer
           serializers,
           payload.myMap!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.GreetingStruct),
+              FullType(_i3.GreetingStruct),
             ],
           ),
         ));

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_maps_xml_name_input_output.g.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_maps_xml_name_input_output.g.dart
@@ -8,7 +8,7 @@ part of rest_xml_v1.rest_xml_protocol.model.xml_maps_xml_name_input_output;
 
 class _$XmlMapsXmlNameInputOutput extends XmlMapsXmlNameInputOutput {
   @override
-  final _i3.BuiltMap<String, _i4.GreetingStruct>? myMap;
+  final _i4.BuiltMap<String, _i3.GreetingStruct>? myMap;
 
   factory _$XmlMapsXmlNameInputOutput(
           [void Function(XmlMapsXmlNameInputOutputBuilder)? updates]) =>
@@ -42,10 +42,10 @@ class XmlMapsXmlNameInputOutputBuilder
         Builder<XmlMapsXmlNameInputOutput, XmlMapsXmlNameInputOutputBuilder> {
   _$XmlMapsXmlNameInputOutput? _$v;
 
-  _i3.MapBuilder<String, _i4.GreetingStruct>? _myMap;
-  _i3.MapBuilder<String, _i4.GreetingStruct> get myMap =>
-      _$this._myMap ??= new _i3.MapBuilder<String, _i4.GreetingStruct>();
-  set myMap(_i3.MapBuilder<String, _i4.GreetingStruct>? myMap) =>
+  _i4.MapBuilder<String, _i3.GreetingStruct>? _myMap;
+  _i4.MapBuilder<String, _i3.GreetingStruct> get myMap =>
+      _$this._myMap ??= new _i4.MapBuilder<String, _i3.GreetingStruct>();
+  set myMap(_i4.MapBuilder<String, _i3.GreetingStruct>? myMap) =>
       _$this._myMap = myMap;
 
   XmlMapsXmlNameInputOutputBuilder() {

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_namespace_nested.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_namespace_nested.dart
@@ -15,11 +15,11 @@ abstract class XmlNamespaceNested
     implements Built<XmlNamespaceNested, XmlNamespaceNestedBuilder> {
   factory XmlNamespaceNested({
     String? foo,
-    _i2.BuiltList<String>? values,
+    List<String>? values,
   }) {
     return _$XmlNamespaceNested._(
       foo: foo,
-      values: values,
+      values: values == null ? null : _i2.BuiltList(values),
     );
   }
 

--- a/packages/smithy/goldens/lib/restXml/lib/src/s3/model/list_objects_v2_output.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/s3/model/list_objects_v2_output.dart
@@ -3,12 +3,12 @@
 library rest_xml_v1.s3.model.list_objects_v2_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i2;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:rest_xml_v1/src/s3/model/common_prefix.dart' as _i3;
-import 'package:rest_xml_v1/src/s3/model/encoding_type.dart' as _i5;
-import 'package:rest_xml_v1/src/s3/model/object.dart' as _i4;
+import 'package:rest_xml_v1/src/s3/model/common_prefix.dart' as _i2;
+import 'package:rest_xml_v1/src/s3/model/encoding_type.dart' as _i4;
+import 'package:rest_xml_v1/src/s3/model/object.dart' as _i3;
 import 'package:smithy/smithy.dart' as _i6;
 
 part 'list_objects_v2_output.g.dart';
@@ -17,11 +17,11 @@ abstract class ListObjectsV2Output
     with _i1.AWSEquatable<ListObjectsV2Output>
     implements Built<ListObjectsV2Output, ListObjectsV2OutputBuilder> {
   factory ListObjectsV2Output({
-    _i2.BuiltList<_i3.CommonPrefix>? commonPrefixes,
-    _i2.BuiltList<_i4.S3Object>? contents,
+    List<_i2.CommonPrefix>? commonPrefixes,
+    List<_i3.S3Object>? contents,
     String? continuationToken,
     String? delimiter,
-    _i5.EncodingType? encodingType,
+    _i4.EncodingType? encodingType,
     bool? isTruncated,
     int? keyCount,
     int? maxKeys,
@@ -31,8 +31,9 @@ abstract class ListObjectsV2Output
     String? startAfter,
   }) {
     return _$ListObjectsV2Output._(
-      commonPrefixes: commonPrefixes,
-      contents: contents,
+      commonPrefixes:
+          commonPrefixes == null ? null : _i5.BuiltList(commonPrefixes),
+      contents: contents == null ? null : _i5.BuiltList(contents),
       continuationToken: continuationToken,
       delimiter: delimiter,
       encodingType: encodingType,
@@ -65,11 +66,11 @@ abstract class ListObjectsV2Output
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(ListObjectsV2OutputBuilder b) {}
-  _i2.BuiltList<_i3.CommonPrefix>? get commonPrefixes;
-  _i2.BuiltList<_i4.S3Object>? get contents;
+  _i5.BuiltList<_i2.CommonPrefix>? get commonPrefixes;
+  _i5.BuiltList<_i3.S3Object>? get contents;
   String? get continuationToken;
   String? get delimiter;
-  _i5.EncodingType? get encodingType;
+  _i4.EncodingType? get encodingType;
   bool? get isTruncated;
   int? get keyCount;
   int? get maxKeys;
@@ -180,16 +181,16 @@ class ListObjectsV2OutputRestXmlSerializer
           if (value != null) {
             result.commonPrefixes.add((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i3.CommonPrefix),
-            ) as _i3.CommonPrefix));
+              specifiedType: const FullType(_i2.CommonPrefix),
+            ) as _i2.CommonPrefix));
           }
           break;
         case 'Contents':
           if (value != null) {
             result.contents.add((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i4.S3Object),
-            ) as _i4.S3Object));
+              specifiedType: const FullType(_i3.S3Object),
+            ) as _i3.S3Object));
           }
           break;
         case 'ContinuationToken':
@@ -212,8 +213,8 @@ class ListObjectsV2OutputRestXmlSerializer
           if (value != null) {
             result.encodingType = (serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EncodingType),
-            ) as _i5.EncodingType);
+              specifiedType: const FullType(_i4.EncodingType),
+            ) as _i4.EncodingType);
           }
           break;
         case 'IsTruncated':
@@ -298,8 +299,8 @@ class ListObjectsV2OutputRestXmlSerializer
         serializers,
         payload.commonPrefixes!,
         specifiedType: const FullType.nullable(
-          _i2.BuiltList,
-          [FullType(_i3.CommonPrefix)],
+          _i5.BuiltList,
+          [FullType(_i2.CommonPrefix)],
         ),
       ));
     }
@@ -309,8 +310,8 @@ class ListObjectsV2OutputRestXmlSerializer
         serializers,
         payload.contents!,
         specifiedType: const FullType.nullable(
-          _i2.BuiltList,
-          [FullType(_i4.S3Object)],
+          _i5.BuiltList,
+          [FullType(_i3.S3Object)],
         ),
       ));
     }
@@ -335,7 +336,7 @@ class ListObjectsV2OutputRestXmlSerializer
         ..add(const _i6.XmlElementName('EncodingType'))
         ..add(serializers.serialize(
           payload.encodingType!,
-          specifiedType: const FullType.nullable(_i5.EncodingType),
+          specifiedType: const FullType.nullable(_i4.EncodingType),
         ));
     }
     if (payload.isTruncated != null) {

--- a/packages/smithy/goldens/lib/restXml/lib/src/s3/model/list_objects_v2_output.g.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/s3/model/list_objects_v2_output.g.dart
@@ -8,15 +8,15 @@ part of rest_xml_v1.s3.model.list_objects_v2_output;
 
 class _$ListObjectsV2Output extends ListObjectsV2Output {
   @override
-  final _i2.BuiltList<_i3.CommonPrefix>? commonPrefixes;
+  final _i5.BuiltList<_i2.CommonPrefix>? commonPrefixes;
   @override
-  final _i2.BuiltList<_i4.S3Object>? contents;
+  final _i5.BuiltList<_i3.S3Object>? contents;
   @override
   final String? continuationToken;
   @override
   final String? delimiter;
   @override
-  final _i5.EncodingType? encodingType;
+  final _i4.EncodingType? encodingType;
   @override
   final bool? isTruncated;
   @override
@@ -109,16 +109,16 @@ class ListObjectsV2OutputBuilder
     implements Builder<ListObjectsV2Output, ListObjectsV2OutputBuilder> {
   _$ListObjectsV2Output? _$v;
 
-  _i2.ListBuilder<_i3.CommonPrefix>? _commonPrefixes;
-  _i2.ListBuilder<_i3.CommonPrefix> get commonPrefixes =>
-      _$this._commonPrefixes ??= new _i2.ListBuilder<_i3.CommonPrefix>();
-  set commonPrefixes(_i2.ListBuilder<_i3.CommonPrefix>? commonPrefixes) =>
+  _i5.ListBuilder<_i2.CommonPrefix>? _commonPrefixes;
+  _i5.ListBuilder<_i2.CommonPrefix> get commonPrefixes =>
+      _$this._commonPrefixes ??= new _i5.ListBuilder<_i2.CommonPrefix>();
+  set commonPrefixes(_i5.ListBuilder<_i2.CommonPrefix>? commonPrefixes) =>
       _$this._commonPrefixes = commonPrefixes;
 
-  _i2.ListBuilder<_i4.S3Object>? _contents;
-  _i2.ListBuilder<_i4.S3Object> get contents =>
-      _$this._contents ??= new _i2.ListBuilder<_i4.S3Object>();
-  set contents(_i2.ListBuilder<_i4.S3Object>? contents) =>
+  _i5.ListBuilder<_i3.S3Object>? _contents;
+  _i5.ListBuilder<_i3.S3Object> get contents =>
+      _$this._contents ??= new _i5.ListBuilder<_i3.S3Object>();
+  set contents(_i5.ListBuilder<_i3.S3Object>? contents) =>
       _$this._contents = contents;
 
   String? _continuationToken;
@@ -130,9 +130,9 @@ class ListObjectsV2OutputBuilder
   String? get delimiter => _$this._delimiter;
   set delimiter(String? delimiter) => _$this._delimiter = delimiter;
 
-  _i5.EncodingType? _encodingType;
-  _i5.EncodingType? get encodingType => _$this._encodingType;
-  set encodingType(_i5.EncodingType? encodingType) =>
+  _i4.EncodingType? _encodingType;
+  _i4.EncodingType? get encodingType => _$this._encodingType;
+  set encodingType(_i4.EncodingType? encodingType) =>
       _$this._encodingType = encodingType;
 
   bool? _isTruncated;

--- a/packages/smithy/goldens/lib/restXml/lib/src/s3/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/s3/model/scoped_config.dart
@@ -3,13 +3,13 @@
 library rest_xml_v1.s3.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_xml_v1/src/s3/model/client_config.dart' as _i2;
-import 'package:rest_xml_v1/src/s3/model/environment_config.dart' as _i5;
-import 'package:rest_xml_v1/src/s3/model/file_config_settings.dart' as _i4;
-import 'package:rest_xml_v1/src/s3/model/operation_config.dart' as _i6;
+import 'package:rest_xml_v1/src/s3/model/environment_config.dart' as _i4;
+import 'package:rest_xml_v1/src/s3/model/file_config_settings.dart' as _i3;
+import 'package:rest_xml_v1/src/s3/model/operation_config.dart' as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -21,15 +21,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -52,16 +53,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -141,10 +142,10 @@ class ScopedConfigRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
             ));
@@ -157,10 +158,10 @@ class ScopedConfigRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
             ));
@@ -170,16 +171,16 @@ class ScopedConfigRestXmlSerializer
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -216,10 +217,10 @@ class ScopedConfigRestXmlSerializer
           serializers,
           payload.configFile!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -231,10 +232,10 @@ class ScopedConfigRestXmlSerializer
           serializers,
           payload.credentialsFile!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -244,7 +245,7 @@ class ScopedConfigRestXmlSerializer
         ..add(const _i7.XmlElementName('environment'))
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -252,7 +253,7 @@ class ScopedConfigRestXmlSerializer
         ..add(const _i7.XmlElementName('operation'))
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib/restXml/lib/src/s3/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/s3/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/scoped_config.dart
@@ -3,17 +3,17 @@
 library rest_xml_with_namespace_v1.rest_xml_protocol_namespace.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_xml_with_namespace_v1/src/rest_xml_protocol_namespace/model/client_config.dart'
     as _i2;
 import 'package:rest_xml_with_namespace_v1/src/rest_xml_protocol_namespace/model/environment_config.dart'
-    as _i5;
-import 'package:rest_xml_with_namespace_v1/src/rest_xml_protocol_namespace/model/file_config_settings.dart'
     as _i4;
+import 'package:rest_xml_with_namespace_v1/src/rest_xml_protocol_namespace/model/file_config_settings.dart'
+    as _i3;
 import 'package:rest_xml_with_namespace_v1/src/rest_xml_protocol_namespace/model/operation_config.dart'
-    as _i6;
+    as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -25,15 +25,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -56,16 +57,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -145,10 +146,10 @@ class ScopedConfigRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
             ));
@@ -161,10 +162,10 @@ class ScopedConfigRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
             ));
@@ -174,16 +175,16 @@ class ScopedConfigRestXmlSerializer
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -220,10 +221,10 @@ class ScopedConfigRestXmlSerializer
           serializers,
           payload.configFile!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -235,10 +236,10 @@ class ScopedConfigRestXmlSerializer
           serializers,
           payload.credentialsFile!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -248,7 +249,7 @@ class ScopedConfigRestXmlSerializer
         ..add(const _i7.XmlElementName('environment'))
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -256,7 +257,7 @@ class ScopedConfigRestXmlSerializer
         ..add(const _i7.XmlElementName('operation'))
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib2/awsJson1_0/lib/src/json_rpc_10/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_0/lib/src/json_rpc_10/model/scoped_config.dart
@@ -5,12 +5,12 @@ library aws_json1_0_v2.json_rpc_10.model.scoped_config; // ignore_for_file: no_l
 import 'package:aws_common/aws_common.dart' as _i1;
 import 'package:aws_json1_0_v2/src/json_rpc_10/model/client_config.dart' as _i2;
 import 'package:aws_json1_0_v2/src/json_rpc_10/model/environment_config.dart'
-    as _i5;
-import 'package:aws_json1_0_v2/src/json_rpc_10/model/file_config_settings.dart'
     as _i4;
+import 'package:aws_json1_0_v2/src/json_rpc_10/model/file_config_settings.dart'
+    as _i3;
 import 'package:aws_json1_0_v2/src/json_rpc_10/model/operation_config.dart'
-    as _i6;
-import 'package:built_collection/built_collection.dart' as _i3;
+    as _i5;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i7;
@@ -24,15 +24,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -55,16 +56,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -142,13 +143,13 @@ class ScopedConfigAwsJson10Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -156,29 +157,29 @@ class ScopedConfigAwsJson10Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -209,10 +210,10 @@ class ScopedConfigAwsJson10Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -223,10 +224,10 @@ class ScopedConfigAwsJson10Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -236,7 +237,7 @@ class ScopedConfigAwsJson10Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -244,7 +245,7 @@ class ScopedConfigAwsJson10Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/awsJson1_0/lib/src/json_rpc_10/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_0/lib/src/json_rpc_10/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/error_with_members.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/error_with_members.dart
@@ -21,8 +21,8 @@ abstract class ErrorWithMembers
     String? code,
     _i3.KitchenSink? complexData,
     int? integerField,
-    _i4.BuiltList<String>? listField,
-    _i4.BuiltMap<String, String>? mapField,
+    List<String>? listField,
+    Map<String, String>? mapField,
     String? message,
     String? stringField,
   }) {
@@ -30,8 +30,8 @@ abstract class ErrorWithMembers
       code: code,
       complexData: complexData,
       integerField: integerField,
-      listField: listField,
-      mapField: mapField,
+      listField: listField == null ? null : _i4.BuiltList(listField),
+      mapField: mapField == null ? null : _i4.BuiltMap(mapField),
       message: message,
       stringField: stringField,
     );

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/json_enums_input_output.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/json_enums_input_output.dart
@@ -20,17 +20,17 @@ abstract class JsonEnumsInputOutput
     _i3.FooEnum? fooEnum1,
     _i3.FooEnum? fooEnum2,
     _i3.FooEnum? fooEnum3,
-    _i4.BuiltList<_i3.FooEnum>? fooEnumList,
-    _i4.BuiltMap<String, _i3.FooEnum>? fooEnumMap,
-    _i4.BuiltSet<_i3.FooEnum>? fooEnumSet,
+    List<_i3.FooEnum>? fooEnumList,
+    Map<String, _i3.FooEnum>? fooEnumMap,
+    Set<_i3.FooEnum>? fooEnumSet,
   }) {
     return _$JsonEnumsInputOutput._(
       fooEnum1: fooEnum1,
       fooEnum2: fooEnum2,
       fooEnum3: fooEnum3,
-      fooEnumList: fooEnumList,
-      fooEnumMap: fooEnumMap,
-      fooEnumSet: fooEnumSet,
+      fooEnumList: fooEnumList == null ? null : _i4.BuiltList(fooEnumList),
+      fooEnumMap: fooEnumMap == null ? null : _i4.BuiltMap(fooEnumMap),
+      fooEnumSet: fooEnumSet == null ? null : _i4.BuiltSet(fooEnumSet),
     );
   }
 

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/kitchen_sink.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/kitchen_sink.dart
@@ -8,14 +8,14 @@ import 'package:aws_common/aws_common.dart' as _i2;
 import 'package:aws_json1_1_v2/src/json_protocol/model/empty_struct.dart'
     as _i4;
 import 'package:aws_json1_1_v2/src/json_protocol/model/simple_struct.dart'
-    as _i7;
+    as _i5;
 import 'package:aws_json1_1_v2/src/json_protocol/model/struct_with_json_name.dart'
-    as _i9;
-import 'package:built_collection/built_collection.dart' as _i6;
+    as _i7;
+import 'package:built_collection/built_collection.dart' as _i9;
 import 'package:built_value/built_value.dart';
-import 'package:built_value/json_object.dart' as _i5;
+import 'package:built_value/json_object.dart' as _i8;
 import 'package:built_value/serializer.dart';
-import 'package:fixnum/fixnum.dart' as _i8;
+import 'package:fixnum/fixnum.dart' as _i6;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'kitchen_sink.g.dart';
@@ -32,22 +32,22 @@ abstract class KitchenSink
     DateTime? httpdateTimestamp,
     int? integer,
     DateTime? iso8601Timestamp,
-    _i5.JsonObject? jsonValue,
-    _i6.BuiltList<_i6.BuiltList<String>>? listOfLists,
-    _i6.BuiltList<_i6.BuiltMap<String, String>>? listOfMapsOfStrings,
-    _i6.BuiltList<String>? listOfStrings,
-    _i6.BuiltList<_i7.SimpleStruct>? listOfStructs,
-    _i8.Int64? long,
-    _i6.BuiltListMultimap<String, String>? mapOfListsOfStrings,
-    _i6.BuiltMap<String, _i6.BuiltMap<String, String>>? mapOfMaps,
-    _i6.BuiltMap<String, String>? mapOfStrings,
-    _i6.BuiltMap<String, _i7.SimpleStruct>? mapOfStructs,
-    _i6.BuiltList<KitchenSink>? recursiveList,
-    _i6.BuiltMap<String, KitchenSink>? recursiveMap,
+    Object? jsonValue,
+    List<List<String>>? listOfLists,
+    List<Map<String, String>>? listOfMapsOfStrings,
+    List<String>? listOfStrings,
+    List<_i5.SimpleStruct>? listOfStructs,
+    _i6.Int64? long,
+    Map<String, List<String>>? mapOfListsOfStrings,
+    Map<String, Map<String, String>>? mapOfMaps,
+    Map<String, String>? mapOfStrings,
+    Map<String, _i5.SimpleStruct>? mapOfStructs,
+    List<KitchenSink>? recursiveList,
+    Map<String, KitchenSink>? recursiveMap,
     KitchenSink? recursiveStruct,
-    _i7.SimpleStruct? simpleStruct,
+    _i5.SimpleStruct? simpleStruct,
     String? string,
-    _i9.StructWithJsonName? structWithJsonName,
+    _i7.StructWithJsonName? structWithJsonName,
     DateTime? timestamp,
     DateTime? unixTimestamp,
   }) {
@@ -60,18 +60,36 @@ abstract class KitchenSink
       httpdateTimestamp: httpdateTimestamp,
       integer: integer,
       iso8601Timestamp: iso8601Timestamp,
-      jsonValue: jsonValue,
-      listOfLists: listOfLists,
-      listOfMapsOfStrings: listOfMapsOfStrings,
-      listOfStrings: listOfStrings,
-      listOfStructs: listOfStructs,
+      jsonValue: jsonValue == null ? null : _i8.JsonObject(jsonValue),
+      listOfLists: listOfLists == null
+          ? null
+          : _i9.BuiltList(listOfLists.map((el) => _i9.BuiltList(el))),
+      listOfMapsOfStrings: listOfMapsOfStrings == null
+          ? null
+          : _i9.BuiltList(listOfMapsOfStrings.map((el) => _i9.BuiltMap(el))),
+      listOfStrings:
+          listOfStrings == null ? null : _i9.BuiltList(listOfStrings),
+      listOfStructs:
+          listOfStructs == null ? null : _i9.BuiltList(listOfStructs),
       long: long,
-      mapOfListsOfStrings: mapOfListsOfStrings,
-      mapOfMaps: mapOfMaps,
-      mapOfStrings: mapOfStrings,
-      mapOfStructs: mapOfStructs,
-      recursiveList: recursiveList,
-      recursiveMap: recursiveMap,
+      mapOfListsOfStrings: mapOfListsOfStrings == null
+          ? null
+          : _i9.BuiltListMultimap(mapOfListsOfStrings),
+      mapOfMaps: mapOfMaps == null
+          ? null
+          : _i9.BuiltMap(mapOfMaps.map((
+              key,
+              value,
+            ) =>
+              MapEntry(
+                key,
+                _i9.BuiltMap(value),
+              ))),
+      mapOfStrings: mapOfStrings == null ? null : _i9.BuiltMap(mapOfStrings),
+      mapOfStructs: mapOfStructs == null ? null : _i9.BuiltMap(mapOfStructs),
+      recursiveList:
+          recursiveList == null ? null : _i9.BuiltList(recursiveList),
+      recursiveMap: recursiveMap == null ? null : _i9.BuiltMap(recursiveMap),
       recursiveStruct: recursiveStruct,
       simpleStruct: simpleStruct,
       string: string,
@@ -114,22 +132,22 @@ abstract class KitchenSink
   DateTime? get httpdateTimestamp;
   int? get integer;
   DateTime? get iso8601Timestamp;
-  _i5.JsonObject? get jsonValue;
-  _i6.BuiltList<_i6.BuiltList<String>>? get listOfLists;
-  _i6.BuiltList<_i6.BuiltMap<String, String>>? get listOfMapsOfStrings;
-  _i6.BuiltList<String>? get listOfStrings;
-  _i6.BuiltList<_i7.SimpleStruct>? get listOfStructs;
-  _i8.Int64? get long;
-  _i6.BuiltListMultimap<String, String>? get mapOfListsOfStrings;
-  _i6.BuiltMap<String, _i6.BuiltMap<String, String>>? get mapOfMaps;
-  _i6.BuiltMap<String, String>? get mapOfStrings;
-  _i6.BuiltMap<String, _i7.SimpleStruct>? get mapOfStructs;
-  _i6.BuiltList<KitchenSink>? get recursiveList;
-  _i6.BuiltMap<String, KitchenSink>? get recursiveMap;
+  _i8.JsonObject? get jsonValue;
+  _i9.BuiltList<_i9.BuiltList<String>>? get listOfLists;
+  _i9.BuiltList<_i9.BuiltMap<String, String>>? get listOfMapsOfStrings;
+  _i9.BuiltList<String>? get listOfStrings;
+  _i9.BuiltList<_i5.SimpleStruct>? get listOfStructs;
+  _i6.Int64? get long;
+  _i9.BuiltListMultimap<String, String>? get mapOfListsOfStrings;
+  _i9.BuiltMap<String, _i9.BuiltMap<String, String>>? get mapOfMaps;
+  _i9.BuiltMap<String, String>? get mapOfStrings;
+  _i9.BuiltMap<String, _i5.SimpleStruct>? get mapOfStructs;
+  _i9.BuiltList<KitchenSink>? get recursiveList;
+  _i9.BuiltMap<String, KitchenSink>? get recursiveMap;
   KitchenSink? get recursiveStruct;
-  _i7.SimpleStruct? get simpleStruct;
+  _i5.SimpleStruct? get simpleStruct;
   String? get string;
-  _i9.StructWithJsonName? get structWithJsonName;
+  _i7.StructWithJsonName? get structWithJsonName;
   DateTime? get timestamp;
   DateTime? get unixTimestamp;
   @override
@@ -373,8 +391,8 @@ class KitchenSinkAwsJson11Serializer
           if (value != null) {
             result.jsonValue = (serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.JsonObject),
-            ) as _i5.JsonObject);
+              specifiedType: const FullType(_i8.JsonObject),
+            ) as _i8.JsonObject);
           }
           break;
         case 'ListOfLists':
@@ -382,15 +400,15 @@ class KitchenSinkAwsJson11Serializer
             result.listOfLists.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltList,
+                _i9.BuiltList,
                 [
                   FullType(
-                    _i6.BuiltList,
+                    _i9.BuiltList,
                     [FullType(String)],
                   )
                 ],
               ),
-            ) as _i6.BuiltList<_i6.BuiltList<String>>));
+            ) as _i9.BuiltList<_i9.BuiltList<String>>));
           }
           break;
         case 'ListOfMapsOfStrings':
@@ -398,10 +416,10 @@ class KitchenSinkAwsJson11Serializer
             result.listOfMapsOfStrings.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltList,
+                _i9.BuiltList,
                 [
                   FullType(
-                    _i6.BuiltMap,
+                    _i9.BuiltMap,
                     [
                       FullType(String),
                       FullType(String),
@@ -409,7 +427,7 @@ class KitchenSinkAwsJson11Serializer
                   )
                 ],
               ),
-            ) as _i6.BuiltList<_i6.BuiltMap<String, String>>));
+            ) as _i9.BuiltList<_i9.BuiltMap<String, String>>));
           }
           break;
         case 'ListOfStrings':
@@ -417,10 +435,10 @@ class KitchenSinkAwsJson11Serializer
             result.listOfStrings.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltList,
+                _i9.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i6.BuiltList<String>));
+            ) as _i9.BuiltList<String>));
           }
           break;
         case 'ListOfStructs':
@@ -428,18 +446,18 @@ class KitchenSinkAwsJson11Serializer
             result.listOfStructs.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltList,
-                [FullType(_i7.SimpleStruct)],
+                _i9.BuiltList,
+                [FullType(_i5.SimpleStruct)],
               ),
-            ) as _i6.BuiltList<_i7.SimpleStruct>));
+            ) as _i9.BuiltList<_i5.SimpleStruct>));
           }
           break;
         case 'Long':
           if (value != null) {
             result.long = (serializers.deserialize(
               value,
-              specifiedType: const FullType(_i8.Int64),
-            ) as _i8.Int64);
+              specifiedType: const FullType(_i6.Int64),
+            ) as _i6.Int64);
           }
           break;
         case 'MapOfListsOfStrings':
@@ -447,13 +465,13 @@ class KitchenSinkAwsJson11Serializer
             result.mapOfListsOfStrings.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltListMultimap,
+                _i9.BuiltListMultimap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i6.BuiltListMultimap<String, String>));
+            ) as _i9.BuiltListMultimap<String, String>));
           }
           break;
         case 'MapOfMaps':
@@ -461,11 +479,11 @@ class KitchenSinkAwsJson11Serializer
             result.mapOfMaps.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltMap,
+                _i9.BuiltMap,
                 [
                   FullType(String),
                   FullType(
-                    _i6.BuiltMap,
+                    _i9.BuiltMap,
                     [
                       FullType(String),
                       FullType(String),
@@ -473,7 +491,7 @@ class KitchenSinkAwsJson11Serializer
                   ),
                 ],
               ),
-            ) as _i6.BuiltMap<String, _i6.BuiltMap<String, String>>));
+            ) as _i9.BuiltMap<String, _i9.BuiltMap<String, String>>));
           }
           break;
         case 'MapOfStrings':
@@ -481,13 +499,13 @@ class KitchenSinkAwsJson11Serializer
             result.mapOfStrings.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltMap,
+                _i9.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i6.BuiltMap<String, String>));
+            ) as _i9.BuiltMap<String, String>));
           }
           break;
         case 'MapOfStructs':
@@ -495,13 +513,13 @@ class KitchenSinkAwsJson11Serializer
             result.mapOfStructs.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltMap,
+                _i9.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i7.SimpleStruct),
+                  FullType(_i5.SimpleStruct),
                 ],
               ),
-            ) as _i6.BuiltMap<String, _i7.SimpleStruct>));
+            ) as _i9.BuiltMap<String, _i5.SimpleStruct>));
           }
           break;
         case 'RecursiveList':
@@ -509,10 +527,10 @@ class KitchenSinkAwsJson11Serializer
             result.recursiveList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltList,
+                _i9.BuiltList,
                 [FullType(KitchenSink)],
               ),
-            ) as _i6.BuiltList<KitchenSink>));
+            ) as _i9.BuiltList<KitchenSink>));
           }
           break;
         case 'RecursiveMap':
@@ -520,13 +538,13 @@ class KitchenSinkAwsJson11Serializer
             result.recursiveMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i6.BuiltMap,
+                _i9.BuiltMap,
                 [
                   FullType(String),
                   FullType(KitchenSink),
                 ],
               ),
-            ) as _i6.BuiltMap<String, KitchenSink>));
+            ) as _i9.BuiltMap<String, KitchenSink>));
           }
           break;
         case 'RecursiveStruct':
@@ -541,8 +559,8 @@ class KitchenSinkAwsJson11Serializer
           if (value != null) {
             result.simpleStruct.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i7.SimpleStruct),
-            ) as _i7.SimpleStruct));
+              specifiedType: const FullType(_i5.SimpleStruct),
+            ) as _i5.SimpleStruct));
           }
           break;
         case 'String':
@@ -557,8 +575,8 @@ class KitchenSinkAwsJson11Serializer
           if (value != null) {
             result.structWithJsonName.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i9.StructWithJsonName),
-            ) as _i9.StructWithJsonName));
+              specifiedType: const FullType(_i7.StructWithJsonName),
+            ) as _i7.StructWithJsonName));
           }
           break;
         case 'Timestamp':
@@ -661,7 +679,7 @@ class KitchenSinkAwsJson11Serializer
         ..add('JsonValue')
         ..add(serializers.serialize(
           payload.jsonValue!,
-          specifiedType: const FullType(_i5.JsonObject),
+          specifiedType: const FullType(_i8.JsonObject),
         ));
     }
     if (payload.listOfLists != null) {
@@ -670,10 +688,10 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.listOfLists!,
           specifiedType: const FullType(
-            _i6.BuiltList,
+            _i9.BuiltList,
             [
               FullType(
-                _i6.BuiltList,
+                _i9.BuiltList,
                 [FullType(String)],
               )
             ],
@@ -686,10 +704,10 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.listOfMapsOfStrings!,
           specifiedType: const FullType(
-            _i6.BuiltList,
+            _i9.BuiltList,
             [
               FullType(
-                _i6.BuiltMap,
+                _i9.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
@@ -705,7 +723,7 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.listOfStrings!,
           specifiedType: const FullType(
-            _i6.BuiltList,
+            _i9.BuiltList,
             [FullType(String)],
           ),
         ));
@@ -716,8 +734,8 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.listOfStructs!,
           specifiedType: const FullType(
-            _i6.BuiltList,
-            [FullType(_i7.SimpleStruct)],
+            _i9.BuiltList,
+            [FullType(_i5.SimpleStruct)],
           ),
         ));
     }
@@ -726,7 +744,7 @@ class KitchenSinkAwsJson11Serializer
         ..add('Long')
         ..add(serializers.serialize(
           payload.long!,
-          specifiedType: const FullType(_i8.Int64),
+          specifiedType: const FullType(_i6.Int64),
         ));
     }
     if (payload.mapOfListsOfStrings != null) {
@@ -735,7 +753,7 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.mapOfListsOfStrings!,
           specifiedType: const FullType(
-            _i6.BuiltListMultimap,
+            _i9.BuiltListMultimap,
             [
               FullType(String),
               FullType(String),
@@ -749,11 +767,11 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.mapOfMaps!,
           specifiedType: const FullType(
-            _i6.BuiltMap,
+            _i9.BuiltMap,
             [
               FullType(String),
               FullType(
-                _i6.BuiltMap,
+                _i9.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
@@ -769,7 +787,7 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.mapOfStrings!,
           specifiedType: const FullType(
-            _i6.BuiltMap,
+            _i9.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -783,10 +801,10 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.mapOfStructs!,
           specifiedType: const FullType(
-            _i6.BuiltMap,
+            _i9.BuiltMap,
             [
               FullType(String),
-              FullType(_i7.SimpleStruct),
+              FullType(_i5.SimpleStruct),
             ],
           ),
         ));
@@ -797,7 +815,7 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.recursiveList!,
           specifiedType: const FullType(
-            _i6.BuiltList,
+            _i9.BuiltList,
             [FullType(KitchenSink)],
           ),
         ));
@@ -808,7 +826,7 @@ class KitchenSinkAwsJson11Serializer
         ..add(serializers.serialize(
           payload.recursiveMap!,
           specifiedType: const FullType(
-            _i6.BuiltMap,
+            _i9.BuiltMap,
             [
               FullType(String),
               FullType(KitchenSink),
@@ -829,7 +847,7 @@ class KitchenSinkAwsJson11Serializer
         ..add('SimpleStruct')
         ..add(serializers.serialize(
           payload.simpleStruct!,
-          specifiedType: const FullType(_i7.SimpleStruct),
+          specifiedType: const FullType(_i5.SimpleStruct),
         ));
     }
     if (payload.string != null) {
@@ -845,7 +863,7 @@ class KitchenSinkAwsJson11Serializer
         ..add('StructWithJsonName')
         ..add(serializers.serialize(
           payload.structWithJsonName!,
-          specifiedType: const FullType(_i9.StructWithJsonName),
+          specifiedType: const FullType(_i7.StructWithJsonName),
         ));
     }
     if (payload.timestamp != null) {

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/kitchen_sink.g.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/kitchen_sink.g.dart
@@ -24,37 +24,37 @@ class _$KitchenSink extends KitchenSink {
   @override
   final DateTime? iso8601Timestamp;
   @override
-  final _i5.JsonObject? jsonValue;
+  final _i8.JsonObject? jsonValue;
   @override
-  final _i6.BuiltList<_i6.BuiltList<String>>? listOfLists;
+  final _i9.BuiltList<_i9.BuiltList<String>>? listOfLists;
   @override
-  final _i6.BuiltList<_i6.BuiltMap<String, String>>? listOfMapsOfStrings;
+  final _i9.BuiltList<_i9.BuiltMap<String, String>>? listOfMapsOfStrings;
   @override
-  final _i6.BuiltList<String>? listOfStrings;
+  final _i9.BuiltList<String>? listOfStrings;
   @override
-  final _i6.BuiltList<_i7.SimpleStruct>? listOfStructs;
+  final _i9.BuiltList<_i5.SimpleStruct>? listOfStructs;
   @override
-  final _i8.Int64? long;
+  final _i6.Int64? long;
   @override
-  final _i6.BuiltListMultimap<String, String>? mapOfListsOfStrings;
+  final _i9.BuiltListMultimap<String, String>? mapOfListsOfStrings;
   @override
-  final _i6.BuiltMap<String, _i6.BuiltMap<String, String>>? mapOfMaps;
+  final _i9.BuiltMap<String, _i9.BuiltMap<String, String>>? mapOfMaps;
   @override
-  final _i6.BuiltMap<String, String>? mapOfStrings;
+  final _i9.BuiltMap<String, String>? mapOfStrings;
   @override
-  final _i6.BuiltMap<String, _i7.SimpleStruct>? mapOfStructs;
+  final _i9.BuiltMap<String, _i5.SimpleStruct>? mapOfStructs;
   @override
-  final _i6.BuiltList<KitchenSink>? recursiveList;
+  final _i9.BuiltList<KitchenSink>? recursiveList;
   @override
-  final _i6.BuiltMap<String, KitchenSink>? recursiveMap;
+  final _i9.BuiltMap<String, KitchenSink>? recursiveMap;
   @override
   final KitchenSink? recursiveStruct;
   @override
-  final _i7.SimpleStruct? simpleStruct;
+  final _i5.SimpleStruct? simpleStruct;
   @override
   final String? string;
   @override
-  final _i9.StructWithJsonName? structWithJsonName;
+  final _i7.StructWithJsonName? structWithJsonName;
   @override
   final DateTime? timestamp;
   @override
@@ -213,78 +213,78 @@ class KitchenSinkBuilder implements Builder<KitchenSink, KitchenSinkBuilder> {
   set iso8601Timestamp(DateTime? iso8601Timestamp) =>
       _$this._iso8601Timestamp = iso8601Timestamp;
 
-  _i5.JsonObject? _jsonValue;
-  _i5.JsonObject? get jsonValue => _$this._jsonValue;
-  set jsonValue(_i5.JsonObject? jsonValue) => _$this._jsonValue = jsonValue;
+  _i8.JsonObject? _jsonValue;
+  _i8.JsonObject? get jsonValue => _$this._jsonValue;
+  set jsonValue(_i8.JsonObject? jsonValue) => _$this._jsonValue = jsonValue;
 
-  _i6.ListBuilder<_i6.BuiltList<String>>? _listOfLists;
-  _i6.ListBuilder<_i6.BuiltList<String>> get listOfLists =>
-      _$this._listOfLists ??= new _i6.ListBuilder<_i6.BuiltList<String>>();
-  set listOfLists(_i6.ListBuilder<_i6.BuiltList<String>>? listOfLists) =>
+  _i9.ListBuilder<_i9.BuiltList<String>>? _listOfLists;
+  _i9.ListBuilder<_i9.BuiltList<String>> get listOfLists =>
+      _$this._listOfLists ??= new _i9.ListBuilder<_i9.BuiltList<String>>();
+  set listOfLists(_i9.ListBuilder<_i9.BuiltList<String>>? listOfLists) =>
       _$this._listOfLists = listOfLists;
 
-  _i6.ListBuilder<_i6.BuiltMap<String, String>>? _listOfMapsOfStrings;
-  _i6.ListBuilder<_i6.BuiltMap<String, String>> get listOfMapsOfStrings =>
+  _i9.ListBuilder<_i9.BuiltMap<String, String>>? _listOfMapsOfStrings;
+  _i9.ListBuilder<_i9.BuiltMap<String, String>> get listOfMapsOfStrings =>
       _$this._listOfMapsOfStrings ??=
-          new _i6.ListBuilder<_i6.BuiltMap<String, String>>();
+          new _i9.ListBuilder<_i9.BuiltMap<String, String>>();
   set listOfMapsOfStrings(
-          _i6.ListBuilder<_i6.BuiltMap<String, String>>? listOfMapsOfStrings) =>
+          _i9.ListBuilder<_i9.BuiltMap<String, String>>? listOfMapsOfStrings) =>
       _$this._listOfMapsOfStrings = listOfMapsOfStrings;
 
-  _i6.ListBuilder<String>? _listOfStrings;
-  _i6.ListBuilder<String> get listOfStrings =>
-      _$this._listOfStrings ??= new _i6.ListBuilder<String>();
-  set listOfStrings(_i6.ListBuilder<String>? listOfStrings) =>
+  _i9.ListBuilder<String>? _listOfStrings;
+  _i9.ListBuilder<String> get listOfStrings =>
+      _$this._listOfStrings ??= new _i9.ListBuilder<String>();
+  set listOfStrings(_i9.ListBuilder<String>? listOfStrings) =>
       _$this._listOfStrings = listOfStrings;
 
-  _i6.ListBuilder<_i7.SimpleStruct>? _listOfStructs;
-  _i6.ListBuilder<_i7.SimpleStruct> get listOfStructs =>
-      _$this._listOfStructs ??= new _i6.ListBuilder<_i7.SimpleStruct>();
-  set listOfStructs(_i6.ListBuilder<_i7.SimpleStruct>? listOfStructs) =>
+  _i9.ListBuilder<_i5.SimpleStruct>? _listOfStructs;
+  _i9.ListBuilder<_i5.SimpleStruct> get listOfStructs =>
+      _$this._listOfStructs ??= new _i9.ListBuilder<_i5.SimpleStruct>();
+  set listOfStructs(_i9.ListBuilder<_i5.SimpleStruct>? listOfStructs) =>
       _$this._listOfStructs = listOfStructs;
 
-  _i8.Int64? _long;
-  _i8.Int64? get long => _$this._long;
-  set long(_i8.Int64? long) => _$this._long = long;
+  _i6.Int64? _long;
+  _i6.Int64? get long => _$this._long;
+  set long(_i6.Int64? long) => _$this._long = long;
 
-  _i6.ListMultimapBuilder<String, String>? _mapOfListsOfStrings;
-  _i6.ListMultimapBuilder<String, String> get mapOfListsOfStrings =>
+  _i9.ListMultimapBuilder<String, String>? _mapOfListsOfStrings;
+  _i9.ListMultimapBuilder<String, String> get mapOfListsOfStrings =>
       _$this._mapOfListsOfStrings ??=
-          new _i6.ListMultimapBuilder<String, String>();
+          new _i9.ListMultimapBuilder<String, String>();
   set mapOfListsOfStrings(
-          _i6.ListMultimapBuilder<String, String>? mapOfListsOfStrings) =>
+          _i9.ListMultimapBuilder<String, String>? mapOfListsOfStrings) =>
       _$this._mapOfListsOfStrings = mapOfListsOfStrings;
 
-  _i6.MapBuilder<String, _i6.BuiltMap<String, String>>? _mapOfMaps;
-  _i6.MapBuilder<String, _i6.BuiltMap<String, String>> get mapOfMaps =>
+  _i9.MapBuilder<String, _i9.BuiltMap<String, String>>? _mapOfMaps;
+  _i9.MapBuilder<String, _i9.BuiltMap<String, String>> get mapOfMaps =>
       _$this._mapOfMaps ??=
-          new _i6.MapBuilder<String, _i6.BuiltMap<String, String>>();
+          new _i9.MapBuilder<String, _i9.BuiltMap<String, String>>();
   set mapOfMaps(
-          _i6.MapBuilder<String, _i6.BuiltMap<String, String>>? mapOfMaps) =>
+          _i9.MapBuilder<String, _i9.BuiltMap<String, String>>? mapOfMaps) =>
       _$this._mapOfMaps = mapOfMaps;
 
-  _i6.MapBuilder<String, String>? _mapOfStrings;
-  _i6.MapBuilder<String, String> get mapOfStrings =>
-      _$this._mapOfStrings ??= new _i6.MapBuilder<String, String>();
-  set mapOfStrings(_i6.MapBuilder<String, String>? mapOfStrings) =>
+  _i9.MapBuilder<String, String>? _mapOfStrings;
+  _i9.MapBuilder<String, String> get mapOfStrings =>
+      _$this._mapOfStrings ??= new _i9.MapBuilder<String, String>();
+  set mapOfStrings(_i9.MapBuilder<String, String>? mapOfStrings) =>
       _$this._mapOfStrings = mapOfStrings;
 
-  _i6.MapBuilder<String, _i7.SimpleStruct>? _mapOfStructs;
-  _i6.MapBuilder<String, _i7.SimpleStruct> get mapOfStructs =>
-      _$this._mapOfStructs ??= new _i6.MapBuilder<String, _i7.SimpleStruct>();
-  set mapOfStructs(_i6.MapBuilder<String, _i7.SimpleStruct>? mapOfStructs) =>
+  _i9.MapBuilder<String, _i5.SimpleStruct>? _mapOfStructs;
+  _i9.MapBuilder<String, _i5.SimpleStruct> get mapOfStructs =>
+      _$this._mapOfStructs ??= new _i9.MapBuilder<String, _i5.SimpleStruct>();
+  set mapOfStructs(_i9.MapBuilder<String, _i5.SimpleStruct>? mapOfStructs) =>
       _$this._mapOfStructs = mapOfStructs;
 
-  _i6.ListBuilder<KitchenSink>? _recursiveList;
-  _i6.ListBuilder<KitchenSink> get recursiveList =>
-      _$this._recursiveList ??= new _i6.ListBuilder<KitchenSink>();
-  set recursiveList(_i6.ListBuilder<KitchenSink>? recursiveList) =>
+  _i9.ListBuilder<KitchenSink>? _recursiveList;
+  _i9.ListBuilder<KitchenSink> get recursiveList =>
+      _$this._recursiveList ??= new _i9.ListBuilder<KitchenSink>();
+  set recursiveList(_i9.ListBuilder<KitchenSink>? recursiveList) =>
       _$this._recursiveList = recursiveList;
 
-  _i6.MapBuilder<String, KitchenSink>? _recursiveMap;
-  _i6.MapBuilder<String, KitchenSink> get recursiveMap =>
-      _$this._recursiveMap ??= new _i6.MapBuilder<String, KitchenSink>();
-  set recursiveMap(_i6.MapBuilder<String, KitchenSink>? recursiveMap) =>
+  _i9.MapBuilder<String, KitchenSink>? _recursiveMap;
+  _i9.MapBuilder<String, KitchenSink> get recursiveMap =>
+      _$this._recursiveMap ??= new _i9.MapBuilder<String, KitchenSink>();
+  set recursiveMap(_i9.MapBuilder<String, KitchenSink>? recursiveMap) =>
       _$this._recursiveMap = recursiveMap;
 
   KitchenSinkBuilder? _recursiveStruct;
@@ -293,20 +293,20 @@ class KitchenSinkBuilder implements Builder<KitchenSink, KitchenSinkBuilder> {
   set recursiveStruct(KitchenSinkBuilder? recursiveStruct) =>
       _$this._recursiveStruct = recursiveStruct;
 
-  _i7.SimpleStructBuilder? _simpleStruct;
-  _i7.SimpleStructBuilder get simpleStruct =>
-      _$this._simpleStruct ??= new _i7.SimpleStructBuilder();
-  set simpleStruct(_i7.SimpleStructBuilder? simpleStruct) =>
+  _i5.SimpleStructBuilder? _simpleStruct;
+  _i5.SimpleStructBuilder get simpleStruct =>
+      _$this._simpleStruct ??= new _i5.SimpleStructBuilder();
+  set simpleStruct(_i5.SimpleStructBuilder? simpleStruct) =>
       _$this._simpleStruct = simpleStruct;
 
   String? _string;
   String? get string => _$this._string;
   set string(String? string) => _$this._string = string;
 
-  _i9.StructWithJsonNameBuilder? _structWithJsonName;
-  _i9.StructWithJsonNameBuilder get structWithJsonName =>
-      _$this._structWithJsonName ??= new _i9.StructWithJsonNameBuilder();
-  set structWithJsonName(_i9.StructWithJsonNameBuilder? structWithJsonName) =>
+  _i7.StructWithJsonNameBuilder? _structWithJsonName;
+  _i7.StructWithJsonNameBuilder get structWithJsonName =>
+      _$this._structWithJsonName ??= new _i7.StructWithJsonNameBuilder();
+  set structWithJsonName(_i7.StructWithJsonNameBuilder? structWithJsonName) =>
       _$this._structWithJsonName = structWithJsonName;
 
   DateTime? _timestamp;

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/null_operation_input_output.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/null_operation_input_output.dart
@@ -17,13 +17,15 @@ abstract class NullOperationInputOutput
     implements
         Built<NullOperationInputOutput, NullOperationInputOutputBuilder> {
   factory NullOperationInputOutput({
-    _i3.BuiltList<String?>? sparseStringList,
-    _i3.BuiltMap<String, String?>? sparseStringMap,
+    List<String?>? sparseStringList,
+    Map<String, String?>? sparseStringMap,
     String? string,
   }) {
     return _$NullOperationInputOutput._(
-      sparseStringList: sparseStringList,
-      sparseStringMap: sparseStringMap,
+      sparseStringList:
+          sparseStringList == null ? null : _i3.BuiltList(sparseStringList),
+      sparseStringMap:
+          sparseStringMap == null ? null : _i3.BuiltMap(sparseStringMap),
       string: string,
     );
   }

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/put_and_get_inline_documents_input_output.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/put_and_get_inline_documents_input_output.dart
@@ -17,10 +17,10 @@ abstract class PutAndGetInlineDocumentsInputOutput
     implements
         Built<PutAndGetInlineDocumentsInputOutput,
             PutAndGetInlineDocumentsInputOutputBuilder> {
-  factory PutAndGetInlineDocumentsInputOutput(
-      {_i3.JsonObject? inlineDocument}) {
+  factory PutAndGetInlineDocumentsInputOutput({Object? inlineDocument}) {
     return _$PutAndGetInlineDocumentsInputOutput._(
-        inlineDocument: inlineDocument);
+        inlineDocument:
+            inlineDocument == null ? null : _i3.JsonObject(inlineDocument));
   }
 
   factory PutAndGetInlineDocumentsInputOutput.build(

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/scoped_config.dart
@@ -6,12 +6,12 @@ import 'package:aws_common/aws_common.dart' as _i1;
 import 'package:aws_json1_1_v2/src/json_protocol/model/client_config.dart'
     as _i2;
 import 'package:aws_json1_1_v2/src/json_protocol/model/environment_config.dart'
-    as _i5;
-import 'package:aws_json1_1_v2/src/json_protocol/model/file_config_settings.dart'
     as _i4;
+import 'package:aws_json1_1_v2/src/json_protocol/model/file_config_settings.dart'
+    as _i3;
 import 'package:aws_json1_1_v2/src/json_protocol/model/operation_config.dart'
-    as _i6;
-import 'package:built_collection/built_collection.dart' as _i3;
+    as _i5;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i7;
@@ -25,15 +25,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -56,16 +57,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -143,13 +144,13 @@ class ScopedConfigAwsJson11Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -157,29 +158,29 @@ class ScopedConfigAwsJson11Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -210,10 +211,10 @@ class ScopedConfigAwsJson11Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -224,10 +225,10 @@ class ScopedConfigAwsJson11Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -237,7 +238,7 @@ class ScopedConfigAwsJson11Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -245,7 +246,7 @@ class ScopedConfigAwsJson11Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/model/predict_input.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/model/predict_input.dart
@@ -16,12 +16,12 @@ abstract class PredictInput
   factory PredictInput({
     required String mlModelId,
     required String predictEndpoint,
-    required _i3.BuiltMap<String, String> record,
+    required Map<String, String> record,
   }) {
     return _$PredictInput._(
       mlModelId: mlModelId,
       predictEndpoint: predictEndpoint,
-      record: record,
+      record: _i3.BuiltMap(record),
     );
   }
 

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/model/prediction.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/model/prediction.dart
@@ -4,8 +4,8 @@ library aws_json1_1_v2.machine_learning.model.prediction; // ignore_for_file: no
 
 import 'package:aws_common/aws_common.dart' as _i1;
 import 'package:aws_json1_1_v2/src/machine_learning/model/details_attributes.dart'
-    as _i3;
-import 'package:built_collection/built_collection.dart' as _i2;
+    as _i2;
+import 'package:built_collection/built_collection.dart' as _i3;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i4;
@@ -16,15 +16,16 @@ abstract class Prediction
     with _i1.AWSEquatable<Prediction>
     implements Built<Prediction, PredictionBuilder> {
   factory Prediction({
-    _i2.BuiltMap<_i3.DetailsAttributes, String>? details,
+    Map<_i2.DetailsAttributes, String>? details,
     String? predictedLabel,
-    _i2.BuiltMap<String, double>? predictedScores,
+    Map<String, double>? predictedScores,
     double? predictedValue,
   }) {
     return _$Prediction._(
-      details: details,
+      details: details == null ? null : _i3.BuiltMap(details),
       predictedLabel: predictedLabel,
-      predictedScores: predictedScores,
+      predictedScores:
+          predictedScores == null ? null : _i3.BuiltMap(predictedScores),
       predictedValue: predictedValue,
     );
   }
@@ -40,9 +41,9 @@ abstract class Prediction
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(PredictionBuilder b) {}
-  _i2.BuiltMap<_i3.DetailsAttributes, String>? get details;
+  _i3.BuiltMap<_i2.DetailsAttributes, String>? get details;
   String? get predictedLabel;
-  _i2.BuiltMap<String, double>? get predictedScores;
+  _i3.BuiltMap<String, double>? get predictedScores;
   double? get predictedValue;
   @override
   List<Object?> get props => [
@@ -108,13 +109,13 @@ class PredictionAwsJson11Serializer
             result.details.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltMap,
+                _i3.BuiltMap,
                 [
-                  FullType(_i3.DetailsAttributes),
+                  FullType(_i2.DetailsAttributes),
                   FullType(String),
                 ],
               ),
-            ) as _i2.BuiltMap<_i3.DetailsAttributes, String>));
+            ) as _i3.BuiltMap<_i2.DetailsAttributes, String>));
           }
           break;
         case 'predictedLabel':
@@ -130,13 +131,13 @@ class PredictionAwsJson11Serializer
             result.predictedScores.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltMap,
+                _i3.BuiltMap,
                 [
                   FullType(String),
                   FullType(double),
                 ],
               ),
-            ) as _i2.BuiltMap<String, double>));
+            ) as _i3.BuiltMap<String, double>));
           }
           break;
         case 'predictedValue':
@@ -167,9 +168,9 @@ class PredictionAwsJson11Serializer
         ..add(serializers.serialize(
           payload.details!,
           specifiedType: const FullType(
-            _i2.BuiltMap,
+            _i3.BuiltMap,
             [
-              FullType(_i3.DetailsAttributes),
+              FullType(_i2.DetailsAttributes),
               FullType(String),
             ],
           ),
@@ -189,7 +190,7 @@ class PredictionAwsJson11Serializer
         ..add(serializers.serialize(
           payload.predictedScores!,
           specifiedType: const FullType(
-            _i2.BuiltMap,
+            _i3.BuiltMap,
             [
               FullType(String),
               FullType(double),

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/model/prediction.g.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/model/prediction.g.dart
@@ -8,11 +8,11 @@ part of aws_json1_1_v2.machine_learning.model.prediction;
 
 class _$Prediction extends Prediction {
   @override
-  final _i2.BuiltMap<_i3.DetailsAttributes, String>? details;
+  final _i3.BuiltMap<_i2.DetailsAttributes, String>? details;
   @override
   final String? predictedLabel;
   @override
-  final _i2.BuiltMap<String, double>? predictedScores;
+  final _i3.BuiltMap<String, double>? predictedScores;
   @override
   final double? predictedValue;
 
@@ -55,10 +55,10 @@ class _$Prediction extends Prediction {
 class PredictionBuilder implements Builder<Prediction, PredictionBuilder> {
   _$Prediction? _$v;
 
-  _i2.MapBuilder<_i3.DetailsAttributes, String>? _details;
-  _i2.MapBuilder<_i3.DetailsAttributes, String> get details =>
-      _$this._details ??= new _i2.MapBuilder<_i3.DetailsAttributes, String>();
-  set details(_i2.MapBuilder<_i3.DetailsAttributes, String>? details) =>
+  _i3.MapBuilder<_i2.DetailsAttributes, String>? _details;
+  _i3.MapBuilder<_i2.DetailsAttributes, String> get details =>
+      _$this._details ??= new _i3.MapBuilder<_i2.DetailsAttributes, String>();
+  set details(_i3.MapBuilder<_i2.DetailsAttributes, String>? details) =>
       _$this._details = details;
 
   String? _predictedLabel;
@@ -66,10 +66,10 @@ class PredictionBuilder implements Builder<Prediction, PredictionBuilder> {
   set predictedLabel(String? predictedLabel) =>
       _$this._predictedLabel = predictedLabel;
 
-  _i2.MapBuilder<String, double>? _predictedScores;
-  _i2.MapBuilder<String, double> get predictedScores =>
-      _$this._predictedScores ??= new _i2.MapBuilder<String, double>();
-  set predictedScores(_i2.MapBuilder<String, double>? predictedScores) =>
+  _i3.MapBuilder<String, double>? _predictedScores;
+  _i3.MapBuilder<String, double> get predictedScores =>
+      _$this._predictedScores ??= new _i3.MapBuilder<String, double>();
+  set predictedScores(_i3.MapBuilder<String, double>? predictedScores) =>
       _$this._predictedScores = predictedScores;
 
   double? _predictedValue;

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/model/scoped_config.dart
@@ -6,12 +6,12 @@ import 'package:aws_common/aws_common.dart' as _i1;
 import 'package:aws_json1_1_v2/src/machine_learning/model/client_config.dart'
     as _i2;
 import 'package:aws_json1_1_v2/src/machine_learning/model/environment_config.dart'
-    as _i5;
-import 'package:aws_json1_1_v2/src/machine_learning/model/file_config_settings.dart'
     as _i4;
+import 'package:aws_json1_1_v2/src/machine_learning/model/file_config_settings.dart'
+    as _i3;
 import 'package:aws_json1_1_v2/src/machine_learning/model/operation_config.dart'
-    as _i6;
-import 'package:built_collection/built_collection.dart' as _i3;
+    as _i5;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i7;
@@ -25,15 +25,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -56,16 +57,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -143,13 +144,13 @@ class ScopedConfigAwsJson11Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -157,29 +158,29 @@ class ScopedConfigAwsJson11Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -210,10 +211,10 @@ class ScopedConfigAwsJson11Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -224,10 +225,10 @@ class ScopedConfigAwsJson11Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -237,7 +238,7 @@ class ScopedConfigAwsJson11Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -245,7 +246,7 @@ class ScopedConfigAwsJson11Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib2/custom/lib/custom_service.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/custom_service.dart
@@ -14,6 +14,7 @@ export 'package:custom_v2/src/custom_service/model/http_checksum_really_not_requ
 export 'package:custom_v2/src/custom_service/model/http_checksum_really_required_input.dart';
 export 'package:custom_v2/src/custom_service/model/http_checksum_required_input.dart';
 export 'package:custom_v2/src/custom_service/model/http_checksum_required_with_member_input.dart';
+export 'package:custom_v2/src/custom_service/model/nested_collections_input.dart';
 export 'package:custom_v2/src/custom_service/model/operation_config.dart';
 export 'package:custom_v2/src/custom_service/model/retry_config.dart';
 export 'package:custom_v2/src/custom_service/model/retry_mode.dart';

--- a/packages/smithy/goldens/lib2/custom/lib/src/custom_service/common/serializers.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/custom_service/common/serializers.dart
@@ -2,16 +2,16 @@
 
 library custom_v2.custom_service.common.serializers; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
-import 'package:built_collection/built_collection.dart' as _i18;
+import 'package:built_collection/built_collection.dart' as _i19;
 import 'package:built_value/serializer.dart';
-import 'package:custom_v2/src/custom_service/model/aws_config.dart' as _i17;
+import 'package:custom_v2/src/custom_service/model/aws_config.dart' as _i18;
 import 'package:custom_v2/src/custom_service/model/checksum_algorithm.dart'
     as _i3;
-import 'package:custom_v2/src/custom_service/model/client_config.dart' as _i14;
+import 'package:custom_v2/src/custom_service/model/client_config.dart' as _i15;
 import 'package:custom_v2/src/custom_service/model/environment_config.dart'
-    as _i9;
+    as _i10;
 import 'package:custom_v2/src/custom_service/model/file_config_settings.dart'
-    as _i12;
+    as _i13;
 import 'package:custom_v2/src/custom_service/model/http_checksum_not_required_with_member_input.dart'
     as _i2;
 import 'package:custom_v2/src/custom_service/model/http_checksum_really_not_required_input.dart'
@@ -22,14 +22,16 @@ import 'package:custom_v2/src/custom_service/model/http_checksum_required_input.
     as _i6;
 import 'package:custom_v2/src/custom_service/model/http_checksum_required_with_member_input.dart'
     as _i7;
+import 'package:custom_v2/src/custom_service/model/nested_collections_input.dart'
+    as _i8;
 import 'package:custom_v2/src/custom_service/model/operation_config.dart'
-    as _i15;
-import 'package:custom_v2/src/custom_service/model/retry_config.dart' as _i13;
-import 'package:custom_v2/src/custom_service/model/retry_mode.dart' as _i8;
+    as _i16;
+import 'package:custom_v2/src/custom_service/model/retry_config.dart' as _i14;
+import 'package:custom_v2/src/custom_service/model/retry_mode.dart' as _i9;
 import 'package:custom_v2/src/custom_service/model/s3_addressing_style.dart'
-    as _i10;
-import 'package:custom_v2/src/custom_service/model/s3_config.dart' as _i11;
-import 'package:custom_v2/src/custom_service/model/scoped_config.dart' as _i16;
+    as _i11;
+import 'package:custom_v2/src/custom_service/model/s3_config.dart' as _i12;
+import 'package:custom_v2/src/custom_service/model/scoped_config.dart' as _i17;
 import 'package:smithy/smithy.dart' as _i1;
 
 const List<_i1.SmithySerializer> serializers = [
@@ -39,23 +41,45 @@ const List<_i1.SmithySerializer> serializers = [
   ..._i5.HttpChecksumReallyRequiredInput.serializers,
   ..._i6.HttpChecksumRequiredInput.serializers,
   ..._i7.HttpChecksumRequiredWithMemberInput.serializers,
-  ..._i8.RetryMode.serializers,
-  ..._i9.EnvironmentConfig.serializers,
-  ..._i10.S3AddressingStyle.serializers,
-  ..._i11.S3Config.serializers,
-  ..._i12.FileConfigSettings.serializers,
-  ..._i13.RetryConfig.serializers,
-  ..._i14.ClientConfig.serializers,
-  ..._i15.OperationConfig.serializers,
-  ..._i16.ScopedConfig.serializers,
-  ..._i17.AwsConfig.serializers,
+  ..._i8.NestedCollectionsInput.serializers,
+  ..._i9.RetryMode.serializers,
+  ..._i10.EnvironmentConfig.serializers,
+  ..._i11.S3AddressingStyle.serializers,
+  ..._i12.S3Config.serializers,
+  ..._i13.FileConfigSettings.serializers,
+  ..._i14.RetryConfig.serializers,
+  ..._i15.ClientConfig.serializers,
+  ..._i16.OperationConfig.serializers,
+  ..._i17.ScopedConfig.serializers,
+  ..._i18.AwsConfig.serializers,
 ];
 final Map<FullType, Function> builderFactories = {
   const FullType(
-    _i18.BuiltMap,
+    _i19.BuiltListMultimap,
     [
       FullType(String),
-      FullType(_i12.FileConfigSettings),
+      FullType(String),
     ],
-  ): _i18.MapBuilder<String, _i12.FileConfigSettings>.new
+  ): _i19.ListMultimapBuilder<String, String>.new,
+  const FullType(
+    _i19.BuiltListMultimap,
+    [
+      FullType(String),
+      FullType.nullable(
+        _i19.BuiltListMultimap,
+        [
+          FullType(String),
+          FullType(String),
+        ],
+      ),
+    ],
+  ): _i19.ListMultimapBuilder<String, _i19.BuiltListMultimap<String, String>?>
+      .new,
+  const FullType(
+    _i19.BuiltMap,
+    [
+      FullType(String),
+      FullType(_i13.FileConfigSettings),
+    ],
+  ): _i19.MapBuilder<String, _i13.FileConfigSettings>.new,
 };

--- a/packages/smithy/goldens/lib2/custom/lib/src/custom_service/custom_client.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/custom_service/custom_client.dart
@@ -14,6 +14,8 @@ import 'package:custom_v2/src/custom_service/model/http_checksum_required_input.
     as _i9;
 import 'package:custom_v2/src/custom_service/model/http_checksum_required_with_member_input.dart'
     as _i11;
+import 'package:custom_v2/src/custom_service/model/nested_collections_input.dart'
+    as _i13;
 import 'package:custom_v2/src/custom_service/operation/http_checksum_not_required_with_member_operation.dart'
     as _i4;
 import 'package:custom_v2/src/custom_service/operation/http_checksum_really_not_required_operation.dart'
@@ -24,6 +26,8 @@ import 'package:custom_v2/src/custom_service/operation/http_checksum_required_op
     as _i10;
 import 'package:custom_v2/src/custom_service/operation/http_checksum_required_with_member_operation.dart'
     as _i12;
+import 'package:custom_v2/src/custom_service/operation/nested_collections_operation.dart'
+    as _i14;
 import 'package:smithy/smithy.dart' as _i1;
 
 class CustomClient {
@@ -100,6 +104,19 @@ class CustomClient {
     _i1.HttpClient? client,
   }) {
     return _i12.HttpChecksumRequiredWithMemberOperation(
+      region: _region,
+      baseUri: _baseUri,
+    ).run(
+      input,
+      client: client ?? _client,
+    );
+  }
+
+  _i2.Future<void> nestedCollections(
+    _i13.NestedCollectionsInput input, {
+    _i1.HttpClient? client,
+  }) {
+    return _i14.NestedCollectionsOperation(
       region: _region,
       baseUri: _baseUri,
     ).run(

--- a/packages/smithy/goldens/lib2/custom/lib/src/custom_service/custom_server.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/custom_service/custom_server.dart
@@ -3,7 +3,7 @@
 library custom_v2.custom_service.custom_client; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'dart:async' as _i4;
-import 'dart:typed_data' as _i11;
+import 'dart:typed_data' as _i12;
 
 import 'package:built_value/serializer.dart';
 import 'package:custom_v2/src/custom_service/common/serializers.dart' as _i3;
@@ -17,7 +17,9 @@ import 'package:custom_v2/src/custom_service/model/http_checksum_required_input.
     as _i8;
 import 'package:custom_v2/src/custom_service/model/http_checksum_required_with_member_input.dart'
     as _i9;
-import 'package:shelf/shelf.dart' as _i10;
+import 'package:custom_v2/src/custom_service/model/nested_collections_input.dart'
+    as _i10;
+import 'package:shelf/shelf.dart' as _i11;
 import 'package:shelf_router/shelf_router.dart';
 import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
@@ -57,6 +59,11 @@ abstract class CustomServerBase extends _i1.HttpServerBase {
       r'/requiredWithMember',
       service.httpChecksumRequiredWithMember,
     );
+    router.add(
+      'POST',
+      r'/nestedCollections',
+      service.nestedCollections,
+    );
     return router;
   }();
 
@@ -80,7 +87,11 @@ abstract class CustomServerBase extends _i1.HttpServerBase {
     _i9.HttpChecksumRequiredWithMemberInput input,
     _i1.Context context,
   );
-  _i4.Future<_i10.Response> call(_i10.Request request) => _router(request);
+  _i4.Future<_i1.Unit> nestedCollections(
+    _i10.NestedCollectionsInput input,
+    _i1.Context context,
+  );
+  _i4.Future<_i11.Response> call(_i11.Request request) => _router(request);
 }
 
 class _CustomServer extends _i1.HttpServer<CustomServerBase> {
@@ -89,7 +100,7 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
   @override
   final CustomServerBase service;
 
-  late final _i1.HttpProtocol<_i11.Uint8List,
+  late final _i1.HttpProtocol<_i12.Uint8List,
           _i5.HttpChecksumNotRequiredWithMemberInput, _i1.Unit, _i1.Unit>
       _httpChecksumNotRequiredWithMemberProtocol = _i2.RestJson1Protocol(
     serializers: _i3.serializers,
@@ -97,7 +108,7 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
   );
 
   late final _i1.HttpProtocol<
-      _i11.Uint8List,
+      _i12.Uint8List,
       _i6.HttpChecksumReallyNotRequiredInput,
       _i1.Unit,
       _i1.Unit> _httpChecksumReallyNotRequiredProtocol = _i2.RestJson1Protocol(
@@ -106,7 +117,7 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
   );
 
   late final _i1.HttpProtocol<
-      _i11.Uint8List,
+      _i12.Uint8List,
       _i7.HttpChecksumReallyRequiredInput,
       _i1.Unit,
       _i1.Unit> _httpChecksumReallyRequiredProtocol = _i2.RestJson1Protocol(
@@ -114,14 +125,14 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
     builderFactories: _i3.builderFactories,
   );
 
-  late final _i1.HttpProtocol<_i11.Uint8List, _i8.HttpChecksumRequiredInput,
+  late final _i1.HttpProtocol<_i12.Uint8List, _i8.HttpChecksumRequiredInput,
       _i1.Unit, _i1.Unit> _httpChecksumRequiredProtocol = _i2.RestJson1Protocol(
     serializers: _i3.serializers,
     builderFactories: _i3.builderFactories,
   );
 
   late final _i1.HttpProtocol<
-      _i11.Uint8List,
+      _i12.Uint8List,
       _i9.HttpChecksumRequiredWithMemberInput,
       _i1.Unit,
       _i1.Unit> _httpChecksumRequiredWithMemberProtocol = _i2.RestJson1Protocol(
@@ -129,8 +140,17 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
     builderFactories: _i3.builderFactories,
   );
 
-  _i4.Future<_i10.Response> httpChecksumNotRequiredWithMember(
-      _i10.Request request) async {
+  late final _i1.HttpProtocol<
+      _i10.NestedCollectionsInput,
+      _i10.NestedCollectionsInput,
+      _i1.Unit,
+      _i1.Unit> _nestedCollectionsProtocol = _i2.RestJson1Protocol(
+    serializers: _i3.serializers,
+    builderFactories: _i3.builderFactories,
+  );
+
+  _i4.Future<_i11.Response> httpChecksumNotRequiredWithMember(
+      _i11.Request request) async {
     final awsRequest = request.awsRequest;
     final context = _i1.Context(awsRequest);
     context.response.headers['Content-Type'] =
@@ -139,8 +159,8 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
       final payload =
           (await _httpChecksumNotRequiredWithMemberProtocol.deserialize(
         awsRequest.split(),
-        specifiedType: const FullType.nullable(_i11.Uint8List),
-      ) as _i11.Uint8List?);
+        specifiedType: const FullType.nullable(_i12.Uint8List),
+      ) as _i12.Uint8List?);
       final input = _i5.HttpChecksumNotRequiredWithMemberInput.fromRequest(
         payload,
         awsRequest,
@@ -158,7 +178,7 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
           [FullType(_i1.Unit)],
         ),
       );
-      return _i10.Response(
+      return _i11.Response(
         statusCode,
         body: body,
         headers: context.response.build().headers.toMap(),
@@ -171,8 +191,8 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
     }
   }
 
-  _i4.Future<_i10.Response> httpChecksumReallyNotRequired(
-      _i10.Request request) async {
+  _i4.Future<_i11.Response> httpChecksumReallyNotRequired(
+      _i11.Request request) async {
     final awsRequest = request.awsRequest;
     final context = _i1.Context(awsRequest);
     context.response.headers['Content-Type'] =
@@ -180,8 +200,8 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
     try {
       final payload = (await _httpChecksumReallyNotRequiredProtocol.deserialize(
         awsRequest.split(),
-        specifiedType: const FullType.nullable(_i11.Uint8List),
-      ) as _i11.Uint8List?);
+        specifiedType: const FullType.nullable(_i12.Uint8List),
+      ) as _i12.Uint8List?);
       final input = _i6.HttpChecksumReallyNotRequiredInput.fromRequest(
         payload,
         awsRequest,
@@ -199,7 +219,7 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
           [FullType(_i1.Unit)],
         ),
       );
-      return _i10.Response(
+      return _i11.Response(
         statusCode,
         body: body,
         headers: context.response.build().headers.toMap(),
@@ -212,8 +232,8 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
     }
   }
 
-  _i4.Future<_i10.Response> httpChecksumReallyRequired(
-      _i10.Request request) async {
+  _i4.Future<_i11.Response> httpChecksumReallyRequired(
+      _i11.Request request) async {
     final awsRequest = request.awsRequest;
     final context = _i1.Context(awsRequest);
     context.response.headers['Content-Type'] =
@@ -221,8 +241,8 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
     try {
       final payload = (await _httpChecksumReallyRequiredProtocol.deserialize(
         awsRequest.split(),
-        specifiedType: const FullType.nullable(_i11.Uint8List),
-      ) as _i11.Uint8List?);
+        specifiedType: const FullType.nullable(_i12.Uint8List),
+      ) as _i12.Uint8List?);
       final input = _i7.HttpChecksumReallyRequiredInput.fromRequest(
         payload,
         awsRequest,
@@ -240,7 +260,7 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
           [FullType(_i1.Unit)],
         ),
       );
-      return _i10.Response(
+      return _i11.Response(
         statusCode,
         body: body,
         headers: context.response.build().headers.toMap(),
@@ -253,7 +273,7 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
     }
   }
 
-  _i4.Future<_i10.Response> httpChecksumRequired(_i10.Request request) async {
+  _i4.Future<_i11.Response> httpChecksumRequired(_i11.Request request) async {
     final awsRequest = request.awsRequest;
     final context = _i1.Context(awsRequest);
     context.response.headers['Content-Type'] =
@@ -261,8 +281,8 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
     try {
       final payload = (await _httpChecksumRequiredProtocol.deserialize(
         awsRequest.split(),
-        specifiedType: const FullType.nullable(_i11.Uint8List),
-      ) as _i11.Uint8List?);
+        specifiedType: const FullType.nullable(_i12.Uint8List),
+      ) as _i12.Uint8List?);
       final input = _i8.HttpChecksumRequiredInput.fromRequest(
         payload,
         awsRequest,
@@ -280,7 +300,7 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
           [FullType(_i1.Unit)],
         ),
       );
-      return _i10.Response(
+      return _i11.Response(
         statusCode,
         body: body,
         headers: context.response.build().headers.toMap(),
@@ -293,8 +313,8 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
     }
   }
 
-  _i4.Future<_i10.Response> httpChecksumRequiredWithMember(
-      _i10.Request request) async {
+  _i4.Future<_i11.Response> httpChecksumRequiredWithMember(
+      _i11.Request request) async {
     final awsRequest = request.awsRequest;
     final context = _i1.Context(awsRequest);
     context.response.headers['Content-Type'] =
@@ -303,8 +323,8 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
       final payload =
           (await _httpChecksumRequiredWithMemberProtocol.deserialize(
         awsRequest.split(),
-        specifiedType: const FullType.nullable(_i11.Uint8List),
-      ) as _i11.Uint8List?);
+        specifiedType: const FullType.nullable(_i12.Uint8List),
+      ) as _i12.Uint8List?);
       final input = _i9.HttpChecksumRequiredWithMemberInput.fromRequest(
         payload,
         awsRequest,
@@ -322,7 +342,47 @@ class _CustomServer extends _i1.HttpServer<CustomServerBase> {
           [FullType(_i1.Unit)],
         ),
       );
-      return _i10.Response(
+      return _i11.Response(
+        statusCode,
+        body: body,
+        headers: context.response.build().headers.toMap(),
+      );
+    } on Object catch (e, st) {
+      return service.handleUncaughtError(
+        e,
+        st,
+      );
+    }
+  }
+
+  _i4.Future<_i11.Response> nestedCollections(_i11.Request request) async {
+    final awsRequest = request.awsRequest;
+    final context = _i1.Context(awsRequest);
+    context.response.headers['Content-Type'] =
+        _nestedCollectionsProtocol.contentType;
+    try {
+      final payload = (await _nestedCollectionsProtocol.deserialize(
+        awsRequest.split(),
+        specifiedType: const FullType(_i10.NestedCollectionsInput),
+      ) as _i10.NestedCollectionsInput);
+      final input = _i10.NestedCollectionsInput.fromRequest(
+        payload,
+        awsRequest,
+        labels: {},
+      );
+      final output = await service.nestedCollections(
+        input,
+        context,
+      );
+      const statusCode = 200;
+      final body = _nestedCollectionsProtocol.serialize(
+        output,
+        specifiedType: const FullType(
+          _i1.Unit,
+          [FullType(_i1.Unit)],
+        ),
+      );
+      return _i11.Response(
         statusCode,
         body: body,
         headers: context.response.build().headers.toMap(),

--- a/packages/smithy/goldens/lib2/custom/lib/src/custom_service/model/nested_collections_input.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/custom_service/model/nested_collections_input.dart
@@ -1,0 +1,157 @@
+// Generated with smithy-dart 0.1.0. DO NOT MODIFY.
+
+library custom_v2.custom_service.model.nested_collections_input; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i2;
+import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i1;
+
+part 'nested_collections_input.g.dart';
+
+abstract class NestedCollectionsInput
+    with
+        _i1.HttpInput<NestedCollectionsInput>,
+        _i2.AWSEquatable<NestedCollectionsInput>
+    implements Built<NestedCollectionsInput, NestedCollectionsInputBuilder> {
+  factory NestedCollectionsInput(
+      {Map<String, List<Map<String, List<String>>?>>? mapOfListOfMapOfLists}) {
+    return _$NestedCollectionsInput._(
+        mapOfListOfMapOfLists: mapOfListOfMapOfLists == null
+            ? null
+            : _i3.BuiltListMultimap(mapOfListOfMapOfLists.map((
+                key,
+                value,
+              ) =>
+                MapEntry(
+                  key,
+                  value.map(
+                      (el) => el == null ? null : _i3.BuiltListMultimap(value)),
+                ))));
+  }
+
+  factory NestedCollectionsInput.build(
+          [void Function(NestedCollectionsInputBuilder) updates]) =
+      _$NestedCollectionsInput;
+
+  const NestedCollectionsInput._();
+
+  factory NestedCollectionsInput.fromRequest(
+    NestedCollectionsInput payload,
+    _i2.AWSBaseHttpRequest request, {
+    Map<String, String> labels = const {},
+  }) =>
+      payload;
+
+  static const List<_i1.SmithySerializer> serializers = [
+    NestedCollectionsInputRestJson1Serializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(NestedCollectionsInputBuilder b) {}
+  _i3.BuiltListMultimap<String, _i3.BuiltListMultimap<String, String>?>?
+      get mapOfListOfMapOfLists;
+  @override
+  NestedCollectionsInput getPayload() => this;
+  @override
+  List<Object?> get props => [mapOfListOfMapOfLists];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('NestedCollectionsInput');
+    helper.add(
+      'mapOfListOfMapOfLists',
+      mapOfListOfMapOfLists,
+    );
+    return helper.toString();
+  }
+}
+
+class NestedCollectionsInputRestJson1Serializer
+    extends _i1.StructuredSmithySerializer<NestedCollectionsInput> {
+  const NestedCollectionsInputRestJson1Serializer()
+      : super('NestedCollectionsInput');
+
+  @override
+  Iterable<Type> get types => const [
+        NestedCollectionsInput,
+        _$NestedCollectionsInput,
+      ];
+  @override
+  Iterable<_i1.ShapeId> get supportedProtocols => const [
+        _i1.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'restJson1',
+        )
+      ];
+  @override
+  NestedCollectionsInput deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = NestedCollectionsInputBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'mapOfListOfMapOfLists':
+          if (value != null) {
+            result.mapOfListOfMapOfLists.replace((serializers.deserialize(
+              value,
+              specifiedType: const FullType(
+                _i3.BuiltListMultimap,
+                [
+                  FullType(String),
+                  FullType.nullable(
+                    _i3.BuiltListMultimap,
+                    [
+                      FullType(String),
+                      FullType(String),
+                    ],
+                  ),
+                ],
+              ),
+            ) as _i3.BuiltListMultimap<String,
+                _i3.BuiltListMultimap<String, String>?>));
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = (object as NestedCollectionsInput);
+    final result = <Object?>[];
+    if (payload.mapOfListOfMapOfLists != null) {
+      result
+        ..add('mapOfListOfMapOfLists')
+        ..add(serializers.serialize(
+          payload.mapOfListOfMapOfLists!,
+          specifiedType: const FullType(
+            _i3.BuiltListMultimap,
+            [
+              FullType(String),
+              FullType.nullable(
+                _i3.BuiltListMultimap,
+                [
+                  FullType(String),
+                  FullType(String),
+                ],
+              ),
+            ],
+          ),
+        ));
+    }
+    return result;
+  }
+}

--- a/packages/smithy/goldens/lib2/custom/lib/src/custom_service/model/nested_collections_input.g.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/custom_service/model/nested_collections_input.g.dart
@@ -1,0 +1,107 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of custom_v2.custom_service.model.nested_collections_input;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$NestedCollectionsInput extends NestedCollectionsInput {
+  @override
+  final _i3.BuiltListMultimap<String, _i3.BuiltListMultimap<String, String>?>?
+      mapOfListOfMapOfLists;
+
+  factory _$NestedCollectionsInput(
+          [void Function(NestedCollectionsInputBuilder)? updates]) =>
+      (new NestedCollectionsInputBuilder()..update(updates))._build();
+
+  _$NestedCollectionsInput._({this.mapOfListOfMapOfLists}) : super._();
+
+  @override
+  NestedCollectionsInput rebuild(
+          void Function(NestedCollectionsInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  NestedCollectionsInputBuilder toBuilder() =>
+      new NestedCollectionsInputBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is NestedCollectionsInput &&
+        mapOfListOfMapOfLists == other.mapOfListOfMapOfLists;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, mapOfListOfMapOfLists.hashCode));
+  }
+}
+
+class NestedCollectionsInputBuilder
+    implements Builder<NestedCollectionsInput, NestedCollectionsInputBuilder> {
+  _$NestedCollectionsInput? _$v;
+
+  _i3.ListMultimapBuilder<String, _i3.BuiltListMultimap<String, String>?>?
+      _mapOfListOfMapOfLists;
+  _i3.ListMultimapBuilder<String, _i3.BuiltListMultimap<String, String>?>
+      get mapOfListOfMapOfLists =>
+          _$this._mapOfListOfMapOfLists ??= new _i3.ListMultimapBuilder<String,
+              _i3.BuiltListMultimap<String, String>?>();
+  set mapOfListOfMapOfLists(
+          _i3.ListMultimapBuilder<String,
+                  _i3.BuiltListMultimap<String, String>?>?
+              mapOfListOfMapOfLists) =>
+      _$this._mapOfListOfMapOfLists = mapOfListOfMapOfLists;
+
+  NestedCollectionsInputBuilder() {
+    NestedCollectionsInput._init(this);
+  }
+
+  NestedCollectionsInputBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _mapOfListOfMapOfLists = $v.mapOfListOfMapOfLists?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(NestedCollectionsInput other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$NestedCollectionsInput;
+  }
+
+  @override
+  void update(void Function(NestedCollectionsInputBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  NestedCollectionsInput build() => _build();
+
+  _$NestedCollectionsInput _build() {
+    _$NestedCollectionsInput _$result;
+    try {
+      _$result = _$v ??
+          new _$NestedCollectionsInput._(
+              mapOfListOfMapOfLists: _mapOfListOfMapOfLists?.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'mapOfListOfMapOfLists';
+        _mapOfListOfMapOfLists?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'NestedCollectionsInput', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/smithy/goldens/lib2/custom/lib/src/custom_service/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/custom_service/model/scoped_config.dart
@@ -3,16 +3,16 @@
 library custom_v2.custom_service.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:custom_v2/src/custom_service/model/client_config.dart' as _i2;
 import 'package:custom_v2/src/custom_service/model/environment_config.dart'
-    as _i5;
-import 'package:custom_v2/src/custom_service/model/file_config_settings.dart'
     as _i4;
+import 'package:custom_v2/src/custom_service/model/file_config_settings.dart'
+    as _i3;
 import 'package:custom_v2/src/custom_service/model/operation_config.dart'
-    as _i6;
+    as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -24,15 +24,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -55,16 +56,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -142,13 +143,13 @@ class ScopedConfigRestJson1Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -156,29 +157,29 @@ class ScopedConfigRestJson1Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -209,10 +210,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -223,10 +224,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -236,7 +237,7 @@ class ScopedConfigRestJson1Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -244,7 +245,7 @@ class ScopedConfigRestJson1Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/custom/lib/src/custom_service/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/custom_service/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib2/custom/lib/src/custom_service/operation/nested_collections_operation.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/custom_service/operation/nested_collections_operation.dart
@@ -1,0 +1,94 @@
+// Generated with smithy-dart 0.1.0. DO NOT MODIFY.
+
+library custom_v2.custom_service.operation.nested_collections_operation; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'dart:async' as _i7;
+
+import 'package:aws_common/aws_common.dart' as _i6;
+import 'package:custom_v2/src/custom_service/common/endpoint_resolver.dart'
+    as _i5;
+import 'package:custom_v2/src/custom_service/common/serializers.dart' as _i4;
+import 'package:custom_v2/src/custom_service/model/nested_collections_input.dart'
+    as _i2;
+import 'package:smithy/smithy.dart' as _i1;
+import 'package:smithy_aws/smithy_aws.dart' as _i3;
+
+class NestedCollectionsOperation extends _i1.HttpOperation<
+    _i2.NestedCollectionsInput,
+    _i2.NestedCollectionsInput,
+    _i1.Unit,
+    _i1.Unit> {
+  NestedCollectionsOperation({
+    required String region,
+    Uri? baseUri,
+  })  : _region = region,
+        _baseUri = baseUri;
+
+  @override
+  late final List<
+      _i1.HttpProtocol<_i2.NestedCollectionsInput, _i2.NestedCollectionsInput,
+          _i1.Unit, _i1.Unit>> protocols = [
+    _i3.RestJson1Protocol(
+      serializers: _i4.serializers,
+      builderFactories: _i4.builderFactories,
+      requestInterceptors: [
+        const _i1.WithHost(),
+        const _i1.WithContentLength(),
+        const _i1.WithUserAgent('aws-sdk-dart/0.1.0'),
+        const _i3.WithSdkInvocationId(),
+        const _i3.WithSdkRequest(),
+      ],
+      responseInterceptors: [],
+    )
+  ];
+
+  late final _i3.AWSEndpoint _awsEndpoint = _i5.endpointResolver.resolve(
+    _i5.sdkId,
+    _region,
+  );
+
+  final String _region;
+
+  final Uri? _baseUri;
+
+  @override
+  _i1.HttpRequest buildRequest(_i2.NestedCollectionsInput input) =>
+      _i1.HttpRequest((b) {
+        b.method = 'POST';
+        b.path = r'/nestedCollections';
+      });
+  @override
+  int successCode([_i1.Unit? output]) => 200;
+  @override
+  _i1.Unit buildOutput(
+    _i1.Unit payload,
+    _i6.AWSStreamedHttpResponse response,
+  ) =>
+      payload;
+  @override
+  List<_i1.SmithyError> get errorTypes => const [];
+  @override
+  _i3.AWSRetryer get retryer => _i3.AWSRetryer();
+  @override
+  Uri get baseUri => _baseUri ?? endpoint.uri;
+  @override
+  _i1.Endpoint get endpoint => _awsEndpoint.endpoint;
+  @override
+  _i7.Future<_i1.Unit> run(
+    _i2.NestedCollectionsInput input, {
+    _i1.HttpClient? client,
+    _i1.ShapeId? useProtocol,
+  }) {
+    return _i7.runZoned(
+      () => super.run(
+        input,
+        client: client,
+        useProtocol: useProtocol,
+      ),
+      zoneValues: {
+        ...?_awsEndpoint.credentialScope?.zoneValues,
+        ...{_i6.AWSHeaders.sdkInvocationId: _i6.uuid(secure: true)}
+      },
+    );
+  }
+}

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/endpoint_configuration.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/endpoint_configuration.dart
@@ -3,10 +3,10 @@
 library rest_json1_v2.api_gateway.model.endpoint_configuration; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i2;
+import 'package:built_collection/built_collection.dart' as _i3;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:rest_json1_v2/src/api_gateway/model/endpoint_type.dart' as _i3;
+import 'package:rest_json1_v2/src/api_gateway/model/endpoint_type.dart' as _i2;
 import 'package:smithy/smithy.dart' as _i4;
 
 part 'endpoint_configuration.g.dart';
@@ -15,12 +15,13 @@ abstract class EndpointConfiguration
     with _i1.AWSEquatable<EndpointConfiguration>
     implements Built<EndpointConfiguration, EndpointConfigurationBuilder> {
   factory EndpointConfiguration({
-    _i2.BuiltList<_i3.EndpointType>? types,
-    _i2.BuiltList<String>? vpcEndpointIds,
+    List<_i2.EndpointType>? types,
+    List<String>? vpcEndpointIds,
   }) {
     return _$EndpointConfiguration._(
-      types: types,
-      vpcEndpointIds: vpcEndpointIds,
+      types: types == null ? null : _i3.BuiltList(types),
+      vpcEndpointIds:
+          vpcEndpointIds == null ? null : _i3.BuiltList(vpcEndpointIds),
     );
   }
 
@@ -36,8 +37,8 @@ abstract class EndpointConfiguration
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(EndpointConfigurationBuilder b) {}
-  _i2.BuiltList<_i3.EndpointType>? get types;
-  _i2.BuiltList<String>? get vpcEndpointIds;
+  _i3.BuiltList<_i2.EndpointType>? get types;
+  _i3.BuiltList<String>? get vpcEndpointIds;
   @override
   List<Object?> get props => [
         types,
@@ -93,10 +94,10 @@ class EndpointConfigurationRestJson1Serializer
             result.types.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltList,
-                [FullType(_i3.EndpointType)],
+                _i3.BuiltList,
+                [FullType(_i2.EndpointType)],
               ),
-            ) as _i2.BuiltList<_i3.EndpointType>));
+            ) as _i3.BuiltList<_i2.EndpointType>));
           }
           break;
         case 'vpcEndpointIds':
@@ -104,10 +105,10 @@ class EndpointConfigurationRestJson1Serializer
             result.vpcEndpointIds.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltList,
+                _i3.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i2.BuiltList<String>));
+            ) as _i3.BuiltList<String>));
           }
           break;
       }
@@ -130,8 +131,8 @@ class EndpointConfigurationRestJson1Serializer
         ..add(serializers.serialize(
           payload.types!,
           specifiedType: const FullType(
-            _i2.BuiltList,
-            [FullType(_i3.EndpointType)],
+            _i3.BuiltList,
+            [FullType(_i2.EndpointType)],
           ),
         ));
     }
@@ -141,7 +142,7 @@ class EndpointConfigurationRestJson1Serializer
         ..add(serializers.serialize(
           payload.vpcEndpointIds!,
           specifiedType: const FullType(
-            _i2.BuiltList,
+            _i3.BuiltList,
             [FullType(String)],
           ),
         ));

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/endpoint_configuration.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/endpoint_configuration.g.dart
@@ -8,9 +8,9 @@ part of rest_json1_v2.api_gateway.model.endpoint_configuration;
 
 class _$EndpointConfiguration extends EndpointConfiguration {
   @override
-  final _i2.BuiltList<_i3.EndpointType>? types;
+  final _i3.BuiltList<_i2.EndpointType>? types;
   @override
-  final _i2.BuiltList<String>? vpcEndpointIds;
+  final _i3.BuiltList<String>? vpcEndpointIds;
 
   factory _$EndpointConfiguration(
           [void Function(EndpointConfigurationBuilder)? updates]) =>
@@ -45,15 +45,15 @@ class EndpointConfigurationBuilder
     implements Builder<EndpointConfiguration, EndpointConfigurationBuilder> {
   _$EndpointConfiguration? _$v;
 
-  _i2.ListBuilder<_i3.EndpointType>? _types;
-  _i2.ListBuilder<_i3.EndpointType> get types =>
-      _$this._types ??= new _i2.ListBuilder<_i3.EndpointType>();
-  set types(_i2.ListBuilder<_i3.EndpointType>? types) => _$this._types = types;
+  _i3.ListBuilder<_i2.EndpointType>? _types;
+  _i3.ListBuilder<_i2.EndpointType> get types =>
+      _$this._types ??= new _i3.ListBuilder<_i2.EndpointType>();
+  set types(_i3.ListBuilder<_i2.EndpointType>? types) => _$this._types = types;
 
-  _i2.ListBuilder<String>? _vpcEndpointIds;
-  _i2.ListBuilder<String> get vpcEndpointIds =>
-      _$this._vpcEndpointIds ??= new _i2.ListBuilder<String>();
-  set vpcEndpointIds(_i2.ListBuilder<String>? vpcEndpointIds) =>
+  _i3.ListBuilder<String>? _vpcEndpointIds;
+  _i3.ListBuilder<String> get vpcEndpointIds =>
+      _$this._vpcEndpointIds ??= new _i3.ListBuilder<String>();
+  set vpcEndpointIds(_i3.ListBuilder<String>? vpcEndpointIds) =>
       _$this._vpcEndpointIds = vpcEndpointIds;
 
   EndpointConfigurationBuilder() {

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/rest_api.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/rest_api.dart
@@ -3,13 +3,13 @@
 library rest_json1_v2.api_gateway.model.rest_api; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v2/src/api_gateway/model/api_key_source_type.dart'
     as _i2;
 import 'package:rest_json1_v2/src/api_gateway/model/endpoint_configuration.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i5;
 
 part 'rest_api.g.dart';
@@ -19,22 +19,23 @@ abstract class RestApi
     implements Built<RestApi, RestApiBuilder> {
   factory RestApi({
     _i2.ApiKeySourceType? apiKeySource,
-    _i3.BuiltList<String>? binaryMediaTypes,
+    List<String>? binaryMediaTypes,
     DateTime? createdDate,
     String? description,
     bool? disableExecuteApiEndpoint,
-    _i4.EndpointConfiguration? endpointConfiguration,
+    _i3.EndpointConfiguration? endpointConfiguration,
     String? id,
     int? minimumCompressionSize,
     String? name,
     String? policy,
-    _i3.BuiltMap<String, String>? tags,
+    Map<String, String>? tags,
     String? version,
-    _i3.BuiltList<String>? warnings,
+    List<String>? warnings,
   }) {
     return _$RestApi._(
       apiKeySource: apiKeySource,
-      binaryMediaTypes: binaryMediaTypes,
+      binaryMediaTypes:
+          binaryMediaTypes == null ? null : _i4.BuiltList(binaryMediaTypes),
       createdDate: createdDate,
       description: description,
       disableExecuteApiEndpoint: disableExecuteApiEndpoint,
@@ -43,9 +44,9 @@ abstract class RestApi
       minimumCompressionSize: minimumCompressionSize,
       name: name,
       policy: policy,
-      tags: tags,
+      tags: tags == null ? null : _i4.BuiltMap(tags),
       version: version,
-      warnings: warnings,
+      warnings: warnings == null ? null : _i4.BuiltList(warnings),
     );
   }
 
@@ -60,18 +61,18 @@ abstract class RestApi
   @BuiltValueHook(initializeBuilder: true)
   static void _init(RestApiBuilder b) {}
   _i2.ApiKeySourceType? get apiKeySource;
-  _i3.BuiltList<String>? get binaryMediaTypes;
+  _i4.BuiltList<String>? get binaryMediaTypes;
   DateTime? get createdDate;
   String? get description;
   bool? get disableExecuteApiEndpoint;
-  _i4.EndpointConfiguration? get endpointConfiguration;
+  _i3.EndpointConfiguration? get endpointConfiguration;
   String? get id;
   int? get minimumCompressionSize;
   String? get name;
   String? get policy;
-  _i3.BuiltMap<String, String>? get tags;
+  _i4.BuiltMap<String, String>? get tags;
   String? get version;
-  _i3.BuiltList<String>? get warnings;
+  _i4.BuiltList<String>? get warnings;
   @override
   List<Object?> get props => [
         apiKeySource,
@@ -189,10 +190,10 @@ class RestApiRestJson1Serializer
             result.binaryMediaTypes.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i4.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltList<String>));
+            ) as _i4.BuiltList<String>));
           }
           break;
         case 'createdDate':
@@ -223,8 +224,8 @@ class RestApiRestJson1Serializer
           if (value != null) {
             result.endpointConfiguration.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i4.EndpointConfiguration),
-            ) as _i4.EndpointConfiguration));
+              specifiedType: const FullType(_i3.EndpointConfiguration),
+            ) as _i3.EndpointConfiguration));
           }
           break;
         case 'id':
@@ -264,13 +265,13 @@ class RestApiRestJson1Serializer
             result.tags.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i3.BuiltMap<String, String>));
+            ) as _i4.BuiltMap<String, String>));
           }
           break;
         case 'version':
@@ -286,10 +287,10 @@ class RestApiRestJson1Serializer
             result.warnings.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i4.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltList<String>));
+            ) as _i4.BuiltList<String>));
           }
           break;
       }
@@ -320,7 +321,7 @@ class RestApiRestJson1Serializer
         ..add(serializers.serialize(
           payload.binaryMediaTypes!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i4.BuiltList,
             [FullType(String)],
           ),
         ));
@@ -354,7 +355,7 @@ class RestApiRestJson1Serializer
         ..add('endpointConfiguration')
         ..add(serializers.serialize(
           payload.endpointConfiguration!,
-          specifiedType: const FullType(_i4.EndpointConfiguration),
+          specifiedType: const FullType(_i3.EndpointConfiguration),
         ));
     }
     if (payload.id != null) {
@@ -395,7 +396,7 @@ class RestApiRestJson1Serializer
         ..add(serializers.serialize(
           payload.tags!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -417,7 +418,7 @@ class RestApiRestJson1Serializer
         ..add(serializers.serialize(
           payload.warnings!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i4.BuiltList,
             [FullType(String)],
           ),
         ));

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/rest_api.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/rest_api.g.dart
@@ -10,7 +10,7 @@ class _$RestApi extends RestApi {
   @override
   final _i2.ApiKeySourceType? apiKeySource;
   @override
-  final _i3.BuiltList<String>? binaryMediaTypes;
+  final _i4.BuiltList<String>? binaryMediaTypes;
   @override
   final DateTime? createdDate;
   @override
@@ -18,7 +18,7 @@ class _$RestApi extends RestApi {
   @override
   final bool? disableExecuteApiEndpoint;
   @override
-  final _i4.EndpointConfiguration? endpointConfiguration;
+  final _i3.EndpointConfiguration? endpointConfiguration;
   @override
   final String? id;
   @override
@@ -28,11 +28,11 @@ class _$RestApi extends RestApi {
   @override
   final String? policy;
   @override
-  final _i3.BuiltMap<String, String>? tags;
+  final _i4.BuiltMap<String, String>? tags;
   @override
   final String? version;
   @override
-  final _i3.BuiltList<String>? warnings;
+  final _i4.BuiltList<String>? warnings;
 
   factory _$RestApi([void Function(RestApiBuilder)? updates]) =>
       (new RestApiBuilder()..update(updates))._build();
@@ -118,10 +118,10 @@ class RestApiBuilder implements Builder<RestApi, RestApiBuilder> {
   set apiKeySource(_i2.ApiKeySourceType? apiKeySource) =>
       _$this._apiKeySource = apiKeySource;
 
-  _i3.ListBuilder<String>? _binaryMediaTypes;
-  _i3.ListBuilder<String> get binaryMediaTypes =>
-      _$this._binaryMediaTypes ??= new _i3.ListBuilder<String>();
-  set binaryMediaTypes(_i3.ListBuilder<String>? binaryMediaTypes) =>
+  _i4.ListBuilder<String>? _binaryMediaTypes;
+  _i4.ListBuilder<String> get binaryMediaTypes =>
+      _$this._binaryMediaTypes ??= new _i4.ListBuilder<String>();
+  set binaryMediaTypes(_i4.ListBuilder<String>? binaryMediaTypes) =>
       _$this._binaryMediaTypes = binaryMediaTypes;
 
   DateTime? _createdDate;
@@ -137,11 +137,11 @@ class RestApiBuilder implements Builder<RestApi, RestApiBuilder> {
   set disableExecuteApiEndpoint(bool? disableExecuteApiEndpoint) =>
       _$this._disableExecuteApiEndpoint = disableExecuteApiEndpoint;
 
-  _i4.EndpointConfigurationBuilder? _endpointConfiguration;
-  _i4.EndpointConfigurationBuilder get endpointConfiguration =>
-      _$this._endpointConfiguration ??= new _i4.EndpointConfigurationBuilder();
+  _i3.EndpointConfigurationBuilder? _endpointConfiguration;
+  _i3.EndpointConfigurationBuilder get endpointConfiguration =>
+      _$this._endpointConfiguration ??= new _i3.EndpointConfigurationBuilder();
   set endpointConfiguration(
-          _i4.EndpointConfigurationBuilder? endpointConfiguration) =>
+          _i3.EndpointConfigurationBuilder? endpointConfiguration) =>
       _$this._endpointConfiguration = endpointConfiguration;
 
   String? _id;
@@ -161,19 +161,19 @@ class RestApiBuilder implements Builder<RestApi, RestApiBuilder> {
   String? get policy => _$this._policy;
   set policy(String? policy) => _$this._policy = policy;
 
-  _i3.MapBuilder<String, String>? _tags;
-  _i3.MapBuilder<String, String> get tags =>
-      _$this._tags ??= new _i3.MapBuilder<String, String>();
-  set tags(_i3.MapBuilder<String, String>? tags) => _$this._tags = tags;
+  _i4.MapBuilder<String, String>? _tags;
+  _i4.MapBuilder<String, String> get tags =>
+      _$this._tags ??= new _i4.MapBuilder<String, String>();
+  set tags(_i4.MapBuilder<String, String>? tags) => _$this._tags = tags;
 
   String? _version;
   String? get version => _$this._version;
   set version(String? version) => _$this._version = version;
 
-  _i3.ListBuilder<String>? _warnings;
-  _i3.ListBuilder<String> get warnings =>
-      _$this._warnings ??= new _i3.ListBuilder<String>();
-  set warnings(_i3.ListBuilder<String>? warnings) =>
+  _i4.ListBuilder<String>? _warnings;
+  _i4.ListBuilder<String> get warnings =>
+      _$this._warnings ??= new _i4.ListBuilder<String>();
+  set warnings(_i4.ListBuilder<String>? warnings) =>
       _$this._warnings = warnings;
 
   RestApiBuilder() {

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/rest_apis.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/rest_apis.dart
@@ -3,10 +3,10 @@
 library rest_json1_v2.api_gateway.model.rest_apis; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i2;
+import 'package:built_collection/built_collection.dart' as _i3;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:rest_json1_v2/src/api_gateway/model/rest_api.dart' as _i3;
+import 'package:rest_json1_v2/src/api_gateway/model/rest_api.dart' as _i2;
 import 'package:smithy/smithy.dart' as _i4;
 
 part 'rest_apis.g.dart';
@@ -15,11 +15,11 @@ abstract class RestApis
     with _i1.AWSEquatable<RestApis>
     implements Built<RestApis, RestApisBuilder> {
   factory RestApis({
-    _i2.BuiltList<_i3.RestApi>? items,
+    List<_i2.RestApi>? items,
     String? position,
   }) {
     return _$RestApis._(
-      items: items,
+      items: items == null ? null : _i3.BuiltList(items),
       position: position,
     );
   }
@@ -41,7 +41,7 @@ abstract class RestApis
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(RestApisBuilder b) {}
-  _i2.BuiltList<_i3.RestApi>? get items;
+  _i3.BuiltList<_i2.RestApi>? get items;
   String? get position;
   @override
   List<Object?> get props => [
@@ -97,10 +97,10 @@ class RestApisRestJson1Serializer
             result.items.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i2.BuiltList,
-                [FullType(_i3.RestApi)],
+                _i3.BuiltList,
+                [FullType(_i2.RestApi)],
               ),
-            ) as _i2.BuiltList<_i3.RestApi>));
+            ) as _i3.BuiltList<_i2.RestApi>));
           }
           break;
         case 'position':
@@ -131,8 +131,8 @@ class RestApisRestJson1Serializer
         ..add(serializers.serialize(
           payload.items!,
           specifiedType: const FullType(
-            _i2.BuiltList,
-            [FullType(_i3.RestApi)],
+            _i3.BuiltList,
+            [FullType(_i2.RestApi)],
           ),
         ));
     }

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/rest_apis.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/rest_apis.g.dart
@@ -8,7 +8,7 @@ part of rest_json1_v2.api_gateway.model.rest_apis;
 
 class _$RestApis extends RestApis {
   @override
-  final _i2.BuiltList<_i3.RestApi>? items;
+  final _i3.BuiltList<_i2.RestApi>? items;
   @override
   final String? position;
 
@@ -41,10 +41,10 @@ class _$RestApis extends RestApis {
 class RestApisBuilder implements Builder<RestApis, RestApisBuilder> {
   _$RestApis? _$v;
 
-  _i2.ListBuilder<_i3.RestApi>? _items;
-  _i2.ListBuilder<_i3.RestApi> get items =>
-      _$this._items ??= new _i2.ListBuilder<_i3.RestApi>();
-  set items(_i2.ListBuilder<_i3.RestApi>? items) => _$this._items = items;
+  _i3.ListBuilder<_i2.RestApi>? _items;
+  _i3.ListBuilder<_i2.RestApi> get items =>
+      _$this._items ??= new _i3.ListBuilder<_i2.RestApi>();
+  set items(_i3.ListBuilder<_i2.RestApi>? items) => _$this._items = items;
 
   String? _position;
   String? get position => _$this._position;

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/scoped_config.dart
@@ -3,16 +3,16 @@
 library rest_json1_v2.api_gateway.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v2/src/api_gateway/model/client_config.dart' as _i2;
 import 'package:rest_json1_v2/src/api_gateway/model/environment_config.dart'
-    as _i5;
-import 'package:rest_json1_v2/src/api_gateway/model/file_config_settings.dart'
     as _i4;
+import 'package:rest_json1_v2/src/api_gateway/model/file_config_settings.dart'
+    as _i3;
 import 'package:rest_json1_v2/src/api_gateway/model/operation_config.dart'
-    as _i6;
+    as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -24,15 +24,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -55,16 +56,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -142,13 +143,13 @@ class ScopedConfigRestJson1Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -156,29 +157,29 @@ class ScopedConfigRestJson1Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -209,10 +210,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -223,10 +224,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -236,7 +237,7 @@ class ScopedConfigRestJson1Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -244,7 +245,7 @@ class ScopedConfigRestJson1Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/glacier/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/glacier/model/scoped_config.dart
@@ -3,14 +3,14 @@
 library rest_json1_v2.glacier.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v2/src/glacier/model/client_config.dart' as _i2;
-import 'package:rest_json1_v2/src/glacier/model/environment_config.dart' as _i5;
+import 'package:rest_json1_v2/src/glacier/model/environment_config.dart' as _i4;
 import 'package:rest_json1_v2/src/glacier/model/file_config_settings.dart'
-    as _i4;
-import 'package:rest_json1_v2/src/glacier/model/operation_config.dart' as _i6;
+    as _i3;
+import 'package:rest_json1_v2/src/glacier/model/operation_config.dart' as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -22,15 +22,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -53,16 +54,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -140,13 +141,13 @@ class ScopedConfigRestJson1Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -154,29 +155,29 @@ class ScopedConfigRestJson1Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -207,10 +208,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -221,10 +222,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -234,7 +235,7 @@ class ScopedConfigRestJson1Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -242,7 +243,7 @@ class ScopedConfigRestJson1Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/glacier/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/glacier/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/all_query_string_types_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/all_query_string_types_input.dart
@@ -3,13 +3,13 @@
 library rest_json1_v2.rest_json_protocol.model.all_query_string_types_input; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:fixnum/fixnum.dart' as _i5;
+import 'package:fixnum/fixnum.dart' as _i4;
 import 'package:meta/meta.dart' as _i6;
 import 'package:rest_json1_v2/src/rest_json_protocol/model/foo_enum.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'all_query_string_types_input.g.dart';
@@ -24,45 +24,55 @@ abstract class AllQueryStringTypesInput
         _i1.HasPayload<AllQueryStringTypesInputPayload> {
   factory AllQueryStringTypesInput({
     bool? queryBoolean,
-    _i3.BuiltList<bool>? queryBooleanList,
+    List<bool>? queryBooleanList,
     int? queryByte,
     double? queryDouble,
-    _i3.BuiltList<double>? queryDoubleList,
-    _i4.FooEnum? queryEnum,
-    _i3.BuiltList<_i4.FooEnum>? queryEnumList,
+    List<double>? queryDoubleList,
+    _i3.FooEnum? queryEnum,
+    List<_i3.FooEnum>? queryEnumList,
     double? queryFloat,
     int? queryInteger,
-    _i3.BuiltList<int>? queryIntegerList,
-    _i3.BuiltSet<int>? queryIntegerSet,
-    _i5.Int64? queryLong,
-    _i3.BuiltListMultimap<String, String>? queryParamsMapOfStringList,
+    List<int>? queryIntegerList,
+    Set<int>? queryIntegerSet,
+    _i4.Int64? queryLong,
+    Map<String, List<String>>? queryParamsMapOfStringList,
     int? queryShort,
     String? queryString,
-    _i3.BuiltList<String>? queryStringList,
-    _i3.BuiltSet<String>? queryStringSet,
+    List<String>? queryStringList,
+    Set<String>? queryStringSet,
     DateTime? queryTimestamp,
-    _i3.BuiltList<DateTime>? queryTimestampList,
+    List<DateTime>? queryTimestampList,
   }) {
     return _$AllQueryStringTypesInput._(
       queryBoolean: queryBoolean,
-      queryBooleanList: queryBooleanList,
+      queryBooleanList:
+          queryBooleanList == null ? null : _i5.BuiltList(queryBooleanList),
       queryByte: queryByte,
       queryDouble: queryDouble,
-      queryDoubleList: queryDoubleList,
+      queryDoubleList:
+          queryDoubleList == null ? null : _i5.BuiltList(queryDoubleList),
       queryEnum: queryEnum,
-      queryEnumList: queryEnumList,
+      queryEnumList:
+          queryEnumList == null ? null : _i5.BuiltList(queryEnumList),
       queryFloat: queryFloat,
       queryInteger: queryInteger,
-      queryIntegerList: queryIntegerList,
-      queryIntegerSet: queryIntegerSet,
+      queryIntegerList:
+          queryIntegerList == null ? null : _i5.BuiltList(queryIntegerList),
+      queryIntegerSet:
+          queryIntegerSet == null ? null : _i5.BuiltSet(queryIntegerSet),
       queryLong: queryLong,
-      queryParamsMapOfStringList: queryParamsMapOfStringList,
+      queryParamsMapOfStringList: queryParamsMapOfStringList == null
+          ? null
+          : _i5.BuiltListMultimap(queryParamsMapOfStringList),
       queryShort: queryShort,
       queryString: queryString,
-      queryStringList: queryStringList,
-      queryStringSet: queryStringSet,
+      queryStringList:
+          queryStringList == null ? null : _i5.BuiltList(queryStringList),
+      queryStringSet:
+          queryStringSet == null ? null : _i5.BuiltSet(queryStringSet),
       queryTimestamp: queryTimestamp,
-      queryTimestampList: queryTimestampList,
+      queryTimestampList:
+          queryTimestampList == null ? null : _i5.BuiltList(queryTimestampList),
     );
   }
 
@@ -111,7 +121,7 @@ abstract class AllQueryStringTypesInput
               .map((el) => int.parse(el.trim())));
         }
         if (request.queryParameters['Long'] != null) {
-          b.queryLong = _i5.Int64.parseInt(request.queryParameters['Long']!);
+          b.queryLong = _i4.Int64.parseInt(request.queryParameters['Long']!);
         }
         if (request.queryParameters['Float'] != null) {
           b.queryFloat = double.parse(request.queryParameters['Float']!);
@@ -151,12 +161,12 @@ abstract class AllQueryStringTypesInput
         }
         if (request.queryParameters['Enum'] != null) {
           b.queryEnum =
-              _i4.FooEnum.values.byValue(request.queryParameters['Enum']!);
+              _i3.FooEnum.values.byValue(request.queryParameters['Enum']!);
         }
         if (request.queryParameters['EnumList'] != null) {
           b.queryEnumList.addAll(_i1
               .parseHeader(request.queryParameters['EnumList']!)
-              .map((el) => _i4.FooEnum.values.byValue(el.trim())));
+              .map((el) => _i3.FooEnum.values.byValue(el.trim())));
         }
       });
 
@@ -167,24 +177,24 @@ abstract class AllQueryStringTypesInput
   @BuiltValueHook(initializeBuilder: true)
   static void _init(AllQueryStringTypesInputBuilder b) {}
   bool? get queryBoolean;
-  _i3.BuiltList<bool>? get queryBooleanList;
+  _i5.BuiltList<bool>? get queryBooleanList;
   int? get queryByte;
   double? get queryDouble;
-  _i3.BuiltList<double>? get queryDoubleList;
-  _i4.FooEnum? get queryEnum;
-  _i3.BuiltList<_i4.FooEnum>? get queryEnumList;
+  _i5.BuiltList<double>? get queryDoubleList;
+  _i3.FooEnum? get queryEnum;
+  _i5.BuiltList<_i3.FooEnum>? get queryEnumList;
   double? get queryFloat;
   int? get queryInteger;
-  _i3.BuiltList<int>? get queryIntegerList;
-  _i3.BuiltSet<int>? get queryIntegerSet;
-  _i5.Int64? get queryLong;
-  _i3.BuiltListMultimap<String, String>? get queryParamsMapOfStringList;
+  _i5.BuiltList<int>? get queryIntegerList;
+  _i5.BuiltSet<int>? get queryIntegerSet;
+  _i4.Int64? get queryLong;
+  _i5.BuiltListMultimap<String, String>? get queryParamsMapOfStringList;
   int? get queryShort;
   String? get queryString;
-  _i3.BuiltList<String>? get queryStringList;
-  _i3.BuiltSet<String>? get queryStringSet;
+  _i5.BuiltList<String>? get queryStringList;
+  _i5.BuiltSet<String>? get queryStringSet;
   DateTime? get queryTimestamp;
-  _i3.BuiltList<DateTime>? get queryTimestampList;
+  _i5.BuiltList<DateTime>? get queryTimestampList;
   @override
   AllQueryStringTypesInputPayload getPayload() =>
       AllQueryStringTypesInputPayload();

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/all_query_string_types_input.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/all_query_string_types_input.g.dart
@@ -10,41 +10,41 @@ class _$AllQueryStringTypesInput extends AllQueryStringTypesInput {
   @override
   final bool? queryBoolean;
   @override
-  final _i3.BuiltList<bool>? queryBooleanList;
+  final _i5.BuiltList<bool>? queryBooleanList;
   @override
   final int? queryByte;
   @override
   final double? queryDouble;
   @override
-  final _i3.BuiltList<double>? queryDoubleList;
+  final _i5.BuiltList<double>? queryDoubleList;
   @override
-  final _i4.FooEnum? queryEnum;
+  final _i3.FooEnum? queryEnum;
   @override
-  final _i3.BuiltList<_i4.FooEnum>? queryEnumList;
+  final _i5.BuiltList<_i3.FooEnum>? queryEnumList;
   @override
   final double? queryFloat;
   @override
   final int? queryInteger;
   @override
-  final _i3.BuiltList<int>? queryIntegerList;
+  final _i5.BuiltList<int>? queryIntegerList;
   @override
-  final _i3.BuiltSet<int>? queryIntegerSet;
+  final _i5.BuiltSet<int>? queryIntegerSet;
   @override
-  final _i5.Int64? queryLong;
+  final _i4.Int64? queryLong;
   @override
-  final _i3.BuiltListMultimap<String, String>? queryParamsMapOfStringList;
+  final _i5.BuiltListMultimap<String, String>? queryParamsMapOfStringList;
   @override
   final int? queryShort;
   @override
   final String? queryString;
   @override
-  final _i3.BuiltList<String>? queryStringList;
+  final _i5.BuiltList<String>? queryStringList;
   @override
-  final _i3.BuiltSet<String>? queryStringSet;
+  final _i5.BuiltSet<String>? queryStringSet;
   @override
   final DateTime? queryTimestamp;
   @override
-  final _i3.BuiltList<DateTime>? queryTimestampList;
+  final _i5.BuiltList<DateTime>? queryTimestampList;
 
   factory _$AllQueryStringTypesInput(
           [void Function(AllQueryStringTypesInputBuilder)? updates]) =>
@@ -164,10 +164,10 @@ class AllQueryStringTypesInputBuilder
   bool? get queryBoolean => _$this._queryBoolean;
   set queryBoolean(bool? queryBoolean) => _$this._queryBoolean = queryBoolean;
 
-  _i3.ListBuilder<bool>? _queryBooleanList;
-  _i3.ListBuilder<bool> get queryBooleanList =>
-      _$this._queryBooleanList ??= new _i3.ListBuilder<bool>();
-  set queryBooleanList(_i3.ListBuilder<bool>? queryBooleanList) =>
+  _i5.ListBuilder<bool>? _queryBooleanList;
+  _i5.ListBuilder<bool> get queryBooleanList =>
+      _$this._queryBooleanList ??= new _i5.ListBuilder<bool>();
+  set queryBooleanList(_i5.ListBuilder<bool>? queryBooleanList) =>
       _$this._queryBooleanList = queryBooleanList;
 
   int? _queryByte;
@@ -178,20 +178,20 @@ class AllQueryStringTypesInputBuilder
   double? get queryDouble => _$this._queryDouble;
   set queryDouble(double? queryDouble) => _$this._queryDouble = queryDouble;
 
-  _i3.ListBuilder<double>? _queryDoubleList;
-  _i3.ListBuilder<double> get queryDoubleList =>
-      _$this._queryDoubleList ??= new _i3.ListBuilder<double>();
-  set queryDoubleList(_i3.ListBuilder<double>? queryDoubleList) =>
+  _i5.ListBuilder<double>? _queryDoubleList;
+  _i5.ListBuilder<double> get queryDoubleList =>
+      _$this._queryDoubleList ??= new _i5.ListBuilder<double>();
+  set queryDoubleList(_i5.ListBuilder<double>? queryDoubleList) =>
       _$this._queryDoubleList = queryDoubleList;
 
-  _i4.FooEnum? _queryEnum;
-  _i4.FooEnum? get queryEnum => _$this._queryEnum;
-  set queryEnum(_i4.FooEnum? queryEnum) => _$this._queryEnum = queryEnum;
+  _i3.FooEnum? _queryEnum;
+  _i3.FooEnum? get queryEnum => _$this._queryEnum;
+  set queryEnum(_i3.FooEnum? queryEnum) => _$this._queryEnum = queryEnum;
 
-  _i3.ListBuilder<_i4.FooEnum>? _queryEnumList;
-  _i3.ListBuilder<_i4.FooEnum> get queryEnumList =>
-      _$this._queryEnumList ??= new _i3.ListBuilder<_i4.FooEnum>();
-  set queryEnumList(_i3.ListBuilder<_i4.FooEnum>? queryEnumList) =>
+  _i5.ListBuilder<_i3.FooEnum>? _queryEnumList;
+  _i5.ListBuilder<_i3.FooEnum> get queryEnumList =>
+      _$this._queryEnumList ??= new _i5.ListBuilder<_i3.FooEnum>();
+  set queryEnumList(_i5.ListBuilder<_i3.FooEnum>? queryEnumList) =>
       _$this._queryEnumList = queryEnumList;
 
   double? _queryFloat;
@@ -202,28 +202,28 @@ class AllQueryStringTypesInputBuilder
   int? get queryInteger => _$this._queryInteger;
   set queryInteger(int? queryInteger) => _$this._queryInteger = queryInteger;
 
-  _i3.ListBuilder<int>? _queryIntegerList;
-  _i3.ListBuilder<int> get queryIntegerList =>
-      _$this._queryIntegerList ??= new _i3.ListBuilder<int>();
-  set queryIntegerList(_i3.ListBuilder<int>? queryIntegerList) =>
+  _i5.ListBuilder<int>? _queryIntegerList;
+  _i5.ListBuilder<int> get queryIntegerList =>
+      _$this._queryIntegerList ??= new _i5.ListBuilder<int>();
+  set queryIntegerList(_i5.ListBuilder<int>? queryIntegerList) =>
       _$this._queryIntegerList = queryIntegerList;
 
-  _i3.SetBuilder<int>? _queryIntegerSet;
-  _i3.SetBuilder<int> get queryIntegerSet =>
-      _$this._queryIntegerSet ??= new _i3.SetBuilder<int>();
-  set queryIntegerSet(_i3.SetBuilder<int>? queryIntegerSet) =>
+  _i5.SetBuilder<int>? _queryIntegerSet;
+  _i5.SetBuilder<int> get queryIntegerSet =>
+      _$this._queryIntegerSet ??= new _i5.SetBuilder<int>();
+  set queryIntegerSet(_i5.SetBuilder<int>? queryIntegerSet) =>
       _$this._queryIntegerSet = queryIntegerSet;
 
-  _i5.Int64? _queryLong;
-  _i5.Int64? get queryLong => _$this._queryLong;
-  set queryLong(_i5.Int64? queryLong) => _$this._queryLong = queryLong;
+  _i4.Int64? _queryLong;
+  _i4.Int64? get queryLong => _$this._queryLong;
+  set queryLong(_i4.Int64? queryLong) => _$this._queryLong = queryLong;
 
-  _i3.ListMultimapBuilder<String, String>? _queryParamsMapOfStringList;
-  _i3.ListMultimapBuilder<String, String> get queryParamsMapOfStringList =>
+  _i5.ListMultimapBuilder<String, String>? _queryParamsMapOfStringList;
+  _i5.ListMultimapBuilder<String, String> get queryParamsMapOfStringList =>
       _$this._queryParamsMapOfStringList ??=
-          new _i3.ListMultimapBuilder<String, String>();
+          new _i5.ListMultimapBuilder<String, String>();
   set queryParamsMapOfStringList(
-          _i3.ListMultimapBuilder<String, String>?
+          _i5.ListMultimapBuilder<String, String>?
               queryParamsMapOfStringList) =>
       _$this._queryParamsMapOfStringList = queryParamsMapOfStringList;
 
@@ -235,16 +235,16 @@ class AllQueryStringTypesInputBuilder
   String? get queryString => _$this._queryString;
   set queryString(String? queryString) => _$this._queryString = queryString;
 
-  _i3.ListBuilder<String>? _queryStringList;
-  _i3.ListBuilder<String> get queryStringList =>
-      _$this._queryStringList ??= new _i3.ListBuilder<String>();
-  set queryStringList(_i3.ListBuilder<String>? queryStringList) =>
+  _i5.ListBuilder<String>? _queryStringList;
+  _i5.ListBuilder<String> get queryStringList =>
+      _$this._queryStringList ??= new _i5.ListBuilder<String>();
+  set queryStringList(_i5.ListBuilder<String>? queryStringList) =>
       _$this._queryStringList = queryStringList;
 
-  _i3.SetBuilder<String>? _queryStringSet;
-  _i3.SetBuilder<String> get queryStringSet =>
-      _$this._queryStringSet ??= new _i3.SetBuilder<String>();
-  set queryStringSet(_i3.SetBuilder<String>? queryStringSet) =>
+  _i5.SetBuilder<String>? _queryStringSet;
+  _i5.SetBuilder<String> get queryStringSet =>
+      _$this._queryStringSet ??= new _i5.SetBuilder<String>();
+  set queryStringSet(_i5.SetBuilder<String>? queryStringSet) =>
       _$this._queryStringSet = queryStringSet;
 
   DateTime? _queryTimestamp;
@@ -252,10 +252,10 @@ class AllQueryStringTypesInputBuilder
   set queryTimestamp(DateTime? queryTimestamp) =>
       _$this._queryTimestamp = queryTimestamp;
 
-  _i3.ListBuilder<DateTime>? _queryTimestampList;
-  _i3.ListBuilder<DateTime> get queryTimestampList =>
-      _$this._queryTimestampList ??= new _i3.ListBuilder<DateTime>();
-  set queryTimestampList(_i3.ListBuilder<DateTime>? queryTimestampList) =>
+  _i5.ListBuilder<DateTime>? _queryTimestampList;
+  _i5.ListBuilder<DateTime> get queryTimestampList =>
+      _$this._queryTimestampList ??= new _i5.ListBuilder<DateTime>();
+  set queryTimestampList(_i5.ListBuilder<DateTime>? queryTimestampList) =>
       _$this._queryTimestampList = queryTimestampList;
 
   AllQueryStringTypesInputBuilder() {

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/document_type_as_payload_input_output.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/document_type_as_payload_input_output.dart
@@ -18,8 +18,10 @@ abstract class DocumentTypeAsPayloadInputOutput
         Built<DocumentTypeAsPayloadInputOutput,
             DocumentTypeAsPayloadInputOutputBuilder>,
         _i1.HasPayload<_i2.JsonObject> {
-  factory DocumentTypeAsPayloadInputOutput({_i2.JsonObject? documentValue}) {
-    return _$DocumentTypeAsPayloadInputOutput._(documentValue: documentValue);
+  factory DocumentTypeAsPayloadInputOutput({Object? documentValue}) {
+    return _$DocumentTypeAsPayloadInputOutput._(
+        documentValue:
+            documentValue == null ? null : _i2.JsonObject(documentValue));
   }
 
   factory DocumentTypeAsPayloadInputOutput.build(

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/document_type_input_output.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/document_type_input_output.dart
@@ -16,11 +16,12 @@ abstract class DocumentTypeInputOutput
         _i2.AWSEquatable<DocumentTypeInputOutput>
     implements Built<DocumentTypeInputOutput, DocumentTypeInputOutputBuilder> {
   factory DocumentTypeInputOutput({
-    _i3.JsonObject? documentValue,
+    Object? documentValue,
     String? stringValue,
   }) {
     return _$DocumentTypeInputOutput._(
-      documentValue: documentValue,
+      documentValue:
+          documentValue == null ? null : _i3.JsonObject(documentValue),
       stringValue: stringValue,
     );
   }

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/http_prefix_headers_in_response_output.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/http_prefix_headers_in_response_output.dart
@@ -20,8 +20,10 @@ abstract class HttpPrefixHeadersInResponseOutput
         _i2.EmptyPayload,
         _i2.HasPayload<HttpPrefixHeadersInResponseOutputPayload> {
   factory HttpPrefixHeadersInResponseOutput(
-      {_i3.BuiltMap<String, String>? prefixHeaders}) {
-    return _$HttpPrefixHeadersInResponseOutput._(prefixHeaders: prefixHeaders);
+      {Map<String, String>? prefixHeaders}) {
+    return _$HttpPrefixHeadersInResponseOutput._(
+        prefixHeaders:
+            prefixHeaders == null ? null : _i3.BuiltMap(prefixHeaders));
   }
 
   factory HttpPrefixHeadersInResponseOutput.build(

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/http_prefix_headers_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/http_prefix_headers_input.dart
@@ -21,11 +21,11 @@ abstract class HttpPrefixHeadersInput
         _i1.HasPayload<HttpPrefixHeadersInputPayload> {
   factory HttpPrefixHeadersInput({
     String? foo,
-    _i3.BuiltMap<String, String>? fooMap,
+    Map<String, String>? fooMap,
   }) {
     return _$HttpPrefixHeadersInput._(
       foo: foo,
-      fooMap: fooMap,
+      fooMap: fooMap == null ? null : _i3.BuiltMap(fooMap),
     );
   }
 

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/http_prefix_headers_output.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/http_prefix_headers_output.dart
@@ -19,11 +19,11 @@ abstract class HttpPrefixHeadersOutput
         _i2.HasPayload<HttpPrefixHeadersOutputPayload> {
   factory HttpPrefixHeadersOutput({
     String? foo,
-    _i3.BuiltMap<String, String>? fooMap,
+    Map<String, String>? fooMap,
   }) {
     return _$HttpPrefixHeadersOutput._(
       foo: foo,
-      fooMap: fooMap,
+      fooMap: fooMap == null ? null : _i3.BuiltMap(fooMap),
     );
   }
 

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/input_and_output_with_headers_io.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/input_and_output_with_headers_io.dart
@@ -3,13 +3,13 @@
 library rest_json1_v2.rest_json_protocol.model.input_and_output_with_headers_io; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:fixnum/fixnum.dart' as _i5;
+import 'package:fixnum/fixnum.dart' as _i4;
 import 'package:meta/meta.dart' as _i6;
 import 'package:rest_json1_v2/src/rest_json_protocol/model/foo_enum.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'input_and_output_with_headers_io.g.dart';
@@ -23,39 +23,46 @@ abstract class InputAndOutputWithHeadersIo
         _i1.EmptyPayload,
         _i1.HasPayload<InputAndOutputWithHeadersIoPayload> {
   factory InputAndOutputWithHeadersIo({
-    _i3.BuiltList<bool>? headerBooleanList,
+    List<bool>? headerBooleanList,
     int? headerByte,
     double? headerDouble,
-    _i4.FooEnum? headerEnum,
-    _i3.BuiltList<_i4.FooEnum>? headerEnumList,
+    _i3.FooEnum? headerEnum,
+    List<_i3.FooEnum>? headerEnumList,
     bool? headerFalseBool,
     double? headerFloat,
     int? headerInteger,
-    _i3.BuiltList<int>? headerIntegerList,
-    _i5.Int64? headerLong,
+    List<int>? headerIntegerList,
+    _i4.Int64? headerLong,
     int? headerShort,
     String? headerString,
-    _i3.BuiltList<String>? headerStringList,
-    _i3.BuiltSet<String>? headerStringSet,
-    _i3.BuiltList<DateTime>? headerTimestampList,
+    List<String>? headerStringList,
+    Set<String>? headerStringSet,
+    List<DateTime>? headerTimestampList,
     bool? headerTrueBool,
   }) {
     return _$InputAndOutputWithHeadersIo._(
-      headerBooleanList: headerBooleanList,
+      headerBooleanList:
+          headerBooleanList == null ? null : _i5.BuiltList(headerBooleanList),
       headerByte: headerByte,
       headerDouble: headerDouble,
       headerEnum: headerEnum,
-      headerEnumList: headerEnumList,
+      headerEnumList:
+          headerEnumList == null ? null : _i5.BuiltList(headerEnumList),
       headerFalseBool: headerFalseBool,
       headerFloat: headerFloat,
       headerInteger: headerInteger,
-      headerIntegerList: headerIntegerList,
+      headerIntegerList:
+          headerIntegerList == null ? null : _i5.BuiltList(headerIntegerList),
       headerLong: headerLong,
       headerShort: headerShort,
       headerString: headerString,
-      headerStringList: headerStringList,
-      headerStringSet: headerStringSet,
-      headerTimestampList: headerTimestampList,
+      headerStringList:
+          headerStringList == null ? null : _i5.BuiltList(headerStringList),
+      headerStringSet:
+          headerStringSet == null ? null : _i5.BuiltSet(headerStringSet),
+      headerTimestampList: headerTimestampList == null
+          ? null
+          : _i5.BuiltList(headerTimestampList),
       headerTrueBool: headerTrueBool,
     );
   }
@@ -85,7 +92,7 @@ abstract class InputAndOutputWithHeadersIo
           b.headerInteger = int.parse(request.headers['X-Integer']!);
         }
         if (request.headers['X-Long'] != null) {
-          b.headerLong = _i5.Int64.parseInt(request.headers['X-Long']!);
+          b.headerLong = _i4.Int64.parseInt(request.headers['X-Long']!);
         }
         if (request.headers['X-Float'] != null) {
           b.headerFloat = double.parse(request.headers['X-Float']!);
@@ -131,12 +138,12 @@ abstract class InputAndOutputWithHeadersIo
                   ).asDateTime));
         }
         if (request.headers['X-Enum'] != null) {
-          b.headerEnum = _i4.FooEnum.values.byValue(request.headers['X-Enum']!);
+          b.headerEnum = _i3.FooEnum.values.byValue(request.headers['X-Enum']!);
         }
         if (request.headers['X-EnumList'] != null) {
           b.headerEnumList.addAll(_i1
               .parseHeader(request.headers['X-EnumList']!)
-              .map((el) => _i4.FooEnum.values.byValue(el.trim())));
+              .map((el) => _i3.FooEnum.values.byValue(el.trim())));
         }
       });
 
@@ -159,7 +166,7 @@ abstract class InputAndOutputWithHeadersIo
           b.headerInteger = int.parse(response.headers['X-Integer']!);
         }
         if (response.headers['X-Long'] != null) {
-          b.headerLong = _i5.Int64.parseInt(response.headers['X-Long']!);
+          b.headerLong = _i4.Int64.parseInt(response.headers['X-Long']!);
         }
         if (response.headers['X-Float'] != null) {
           b.headerFloat = double.parse(response.headers['X-Float']!);
@@ -206,12 +213,12 @@ abstract class InputAndOutputWithHeadersIo
         }
         if (response.headers['X-Enum'] != null) {
           b.headerEnum =
-              _i4.FooEnum.values.byValue(response.headers['X-Enum']!);
+              _i3.FooEnum.values.byValue(response.headers['X-Enum']!);
         }
         if (response.headers['X-EnumList'] != null) {
           b.headerEnumList.addAll(_i1
               .parseHeader(response.headers['X-EnumList']!)
-              .map((el) => _i4.FooEnum.values.byValue(el.trim())));
+              .map((el) => _i3.FooEnum.values.byValue(el.trim())));
         }
       });
 
@@ -221,21 +228,21 @@ abstract class InputAndOutputWithHeadersIo
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(InputAndOutputWithHeadersIoBuilder b) {}
-  _i3.BuiltList<bool>? get headerBooleanList;
+  _i5.BuiltList<bool>? get headerBooleanList;
   int? get headerByte;
   double? get headerDouble;
-  _i4.FooEnum? get headerEnum;
-  _i3.BuiltList<_i4.FooEnum>? get headerEnumList;
+  _i3.FooEnum? get headerEnum;
+  _i5.BuiltList<_i3.FooEnum>? get headerEnumList;
   bool? get headerFalseBool;
   double? get headerFloat;
   int? get headerInteger;
-  _i3.BuiltList<int>? get headerIntegerList;
-  _i5.Int64? get headerLong;
+  _i5.BuiltList<int>? get headerIntegerList;
+  _i4.Int64? get headerLong;
   int? get headerShort;
   String? get headerString;
-  _i3.BuiltList<String>? get headerStringList;
-  _i3.BuiltSet<String>? get headerStringSet;
-  _i3.BuiltList<DateTime>? get headerTimestampList;
+  _i5.BuiltList<String>? get headerStringList;
+  _i5.BuiltSet<String>? get headerStringSet;
+  _i5.BuiltList<DateTime>? get headerTimestampList;
   bool? get headerTrueBool;
   @override
   InputAndOutputWithHeadersIoPayload getPayload() =>

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/input_and_output_with_headers_io.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/input_and_output_with_headers_io.g.dart
@@ -8,15 +8,15 @@ part of rest_json1_v2.rest_json_protocol.model.input_and_output_with_headers_io;
 
 class _$InputAndOutputWithHeadersIo extends InputAndOutputWithHeadersIo {
   @override
-  final _i3.BuiltList<bool>? headerBooleanList;
+  final _i5.BuiltList<bool>? headerBooleanList;
   @override
   final int? headerByte;
   @override
   final double? headerDouble;
   @override
-  final _i4.FooEnum? headerEnum;
+  final _i3.FooEnum? headerEnum;
   @override
-  final _i3.BuiltList<_i4.FooEnum>? headerEnumList;
+  final _i5.BuiltList<_i3.FooEnum>? headerEnumList;
   @override
   final bool? headerFalseBool;
   @override
@@ -24,19 +24,19 @@ class _$InputAndOutputWithHeadersIo extends InputAndOutputWithHeadersIo {
   @override
   final int? headerInteger;
   @override
-  final _i3.BuiltList<int>? headerIntegerList;
+  final _i5.BuiltList<int>? headerIntegerList;
   @override
-  final _i5.Int64? headerLong;
+  final _i4.Int64? headerLong;
   @override
   final int? headerShort;
   @override
   final String? headerString;
   @override
-  final _i3.BuiltList<String>? headerStringList;
+  final _i5.BuiltList<String>? headerStringList;
   @override
-  final _i3.BuiltSet<String>? headerStringSet;
+  final _i5.BuiltSet<String>? headerStringSet;
   @override
-  final _i3.BuiltList<DateTime>? headerTimestampList;
+  final _i5.BuiltList<DateTime>? headerTimestampList;
   @override
   final bool? headerTrueBool;
 
@@ -141,10 +141,10 @@ class InputAndOutputWithHeadersIoBuilder
             InputAndOutputWithHeadersIoBuilder> {
   _$InputAndOutputWithHeadersIo? _$v;
 
-  _i3.ListBuilder<bool>? _headerBooleanList;
-  _i3.ListBuilder<bool> get headerBooleanList =>
-      _$this._headerBooleanList ??= new _i3.ListBuilder<bool>();
-  set headerBooleanList(_i3.ListBuilder<bool>? headerBooleanList) =>
+  _i5.ListBuilder<bool>? _headerBooleanList;
+  _i5.ListBuilder<bool> get headerBooleanList =>
+      _$this._headerBooleanList ??= new _i5.ListBuilder<bool>();
+  set headerBooleanList(_i5.ListBuilder<bool>? headerBooleanList) =>
       _$this._headerBooleanList = headerBooleanList;
 
   int? _headerByte;
@@ -155,14 +155,14 @@ class InputAndOutputWithHeadersIoBuilder
   double? get headerDouble => _$this._headerDouble;
   set headerDouble(double? headerDouble) => _$this._headerDouble = headerDouble;
 
-  _i4.FooEnum? _headerEnum;
-  _i4.FooEnum? get headerEnum => _$this._headerEnum;
-  set headerEnum(_i4.FooEnum? headerEnum) => _$this._headerEnum = headerEnum;
+  _i3.FooEnum? _headerEnum;
+  _i3.FooEnum? get headerEnum => _$this._headerEnum;
+  set headerEnum(_i3.FooEnum? headerEnum) => _$this._headerEnum = headerEnum;
 
-  _i3.ListBuilder<_i4.FooEnum>? _headerEnumList;
-  _i3.ListBuilder<_i4.FooEnum> get headerEnumList =>
-      _$this._headerEnumList ??= new _i3.ListBuilder<_i4.FooEnum>();
-  set headerEnumList(_i3.ListBuilder<_i4.FooEnum>? headerEnumList) =>
+  _i5.ListBuilder<_i3.FooEnum>? _headerEnumList;
+  _i5.ListBuilder<_i3.FooEnum> get headerEnumList =>
+      _$this._headerEnumList ??= new _i5.ListBuilder<_i3.FooEnum>();
+  set headerEnumList(_i5.ListBuilder<_i3.FooEnum>? headerEnumList) =>
       _$this._headerEnumList = headerEnumList;
 
   bool? _headerFalseBool;
@@ -179,15 +179,15 @@ class InputAndOutputWithHeadersIoBuilder
   set headerInteger(int? headerInteger) =>
       _$this._headerInteger = headerInteger;
 
-  _i3.ListBuilder<int>? _headerIntegerList;
-  _i3.ListBuilder<int> get headerIntegerList =>
-      _$this._headerIntegerList ??= new _i3.ListBuilder<int>();
-  set headerIntegerList(_i3.ListBuilder<int>? headerIntegerList) =>
+  _i5.ListBuilder<int>? _headerIntegerList;
+  _i5.ListBuilder<int> get headerIntegerList =>
+      _$this._headerIntegerList ??= new _i5.ListBuilder<int>();
+  set headerIntegerList(_i5.ListBuilder<int>? headerIntegerList) =>
       _$this._headerIntegerList = headerIntegerList;
 
-  _i5.Int64? _headerLong;
-  _i5.Int64? get headerLong => _$this._headerLong;
-  set headerLong(_i5.Int64? headerLong) => _$this._headerLong = headerLong;
+  _i4.Int64? _headerLong;
+  _i4.Int64? get headerLong => _$this._headerLong;
+  set headerLong(_i4.Int64? headerLong) => _$this._headerLong = headerLong;
 
   int? _headerShort;
   int? get headerShort => _$this._headerShort;
@@ -197,22 +197,22 @@ class InputAndOutputWithHeadersIoBuilder
   String? get headerString => _$this._headerString;
   set headerString(String? headerString) => _$this._headerString = headerString;
 
-  _i3.ListBuilder<String>? _headerStringList;
-  _i3.ListBuilder<String> get headerStringList =>
-      _$this._headerStringList ??= new _i3.ListBuilder<String>();
-  set headerStringList(_i3.ListBuilder<String>? headerStringList) =>
+  _i5.ListBuilder<String>? _headerStringList;
+  _i5.ListBuilder<String> get headerStringList =>
+      _$this._headerStringList ??= new _i5.ListBuilder<String>();
+  set headerStringList(_i5.ListBuilder<String>? headerStringList) =>
       _$this._headerStringList = headerStringList;
 
-  _i3.SetBuilder<String>? _headerStringSet;
-  _i3.SetBuilder<String> get headerStringSet =>
-      _$this._headerStringSet ??= new _i3.SetBuilder<String>();
-  set headerStringSet(_i3.SetBuilder<String>? headerStringSet) =>
+  _i5.SetBuilder<String>? _headerStringSet;
+  _i5.SetBuilder<String> get headerStringSet =>
+      _$this._headerStringSet ??= new _i5.SetBuilder<String>();
+  set headerStringSet(_i5.SetBuilder<String>? headerStringSet) =>
       _$this._headerStringSet = headerStringSet;
 
-  _i3.ListBuilder<DateTime>? _headerTimestampList;
-  _i3.ListBuilder<DateTime> get headerTimestampList =>
-      _$this._headerTimestampList ??= new _i3.ListBuilder<DateTime>();
-  set headerTimestampList(_i3.ListBuilder<DateTime>? headerTimestampList) =>
+  _i5.ListBuilder<DateTime>? _headerTimestampList;
+  _i5.ListBuilder<DateTime> get headerTimestampList =>
+      _$this._headerTimestampList ??= new _i5.ListBuilder<DateTime>();
+  set headerTimestampList(_i5.ListBuilder<DateTime>? headerTimestampList) =>
       _$this._headerTimestampList = headerTimestampList;
 
   bool? _headerTrueBool;

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/json_enums_input_output.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/json_enums_input_output.dart
@@ -21,17 +21,17 @@ abstract class JsonEnumsInputOutput
     _i3.FooEnum? fooEnum1,
     _i3.FooEnum? fooEnum2,
     _i3.FooEnum? fooEnum3,
-    _i4.BuiltList<_i3.FooEnum>? fooEnumList,
-    _i4.BuiltMap<String, _i3.FooEnum>? fooEnumMap,
-    _i4.BuiltSet<_i3.FooEnum>? fooEnumSet,
+    List<_i3.FooEnum>? fooEnumList,
+    Map<String, _i3.FooEnum>? fooEnumMap,
+    Set<_i3.FooEnum>? fooEnumSet,
   }) {
     return _$JsonEnumsInputOutput._(
       fooEnum1: fooEnum1,
       fooEnum2: fooEnum2,
       fooEnum3: fooEnum3,
-      fooEnumList: fooEnumList,
-      fooEnumMap: fooEnumMap,
-      fooEnumSet: fooEnumSet,
+      fooEnumList: fooEnumList == null ? null : _i4.BuiltList(fooEnumList),
+      fooEnumMap: fooEnumMap == null ? null : _i4.BuiltMap(fooEnumMap),
+      fooEnumSet: fooEnumSet == null ? null : _i4.BuiltSet(fooEnumSet),
     );
   }
 

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/json_lists_input_output.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/json_lists_input_output.dart
@@ -3,13 +3,13 @@
 library rest_json1_v2.rest_json_protocol.model.json_lists_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v2/src/rest_json_protocol/model/foo_enum.dart'
-    as _i4;
+    as _i3;
 import 'package:rest_json1_v2/src/rest_json_protocol/model/structure_list_member.dart'
-    as _i5;
+    as _i4;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'json_lists_input_output.g.dart';
@@ -20,26 +20,31 @@ abstract class JsonListsInputOutput
         _i2.AWSEquatable<JsonListsInputOutput>
     implements Built<JsonListsInputOutput, JsonListsInputOutputBuilder> {
   factory JsonListsInputOutput({
-    _i3.BuiltList<bool>? booleanList,
-    _i3.BuiltList<_i4.FooEnum>? enumList,
-    _i3.BuiltList<int>? integerList,
-    _i3.BuiltList<_i3.BuiltList<String>>? nestedStringList,
-    _i3.BuiltList<String?>? sparseStringList,
-    _i3.BuiltList<String>? stringList,
-    _i3.BuiltSet<String>? stringSet,
-    _i3.BuiltList<_i5.StructureListMember>? structureList,
-    _i3.BuiltList<DateTime>? timestampList,
+    List<bool>? booleanList,
+    List<_i3.FooEnum>? enumList,
+    List<int>? integerList,
+    List<List<String>>? nestedStringList,
+    List<String?>? sparseStringList,
+    List<String>? stringList,
+    Set<String>? stringSet,
+    List<_i4.StructureListMember>? structureList,
+    List<DateTime>? timestampList,
   }) {
     return _$JsonListsInputOutput._(
-      booleanList: booleanList,
-      enumList: enumList,
-      integerList: integerList,
-      nestedStringList: nestedStringList,
-      sparseStringList: sparseStringList,
-      stringList: stringList,
-      stringSet: stringSet,
-      structureList: structureList,
-      timestampList: timestampList,
+      booleanList: booleanList == null ? null : _i5.BuiltList(booleanList),
+      enumList: enumList == null ? null : _i5.BuiltList(enumList),
+      integerList: integerList == null ? null : _i5.BuiltList(integerList),
+      nestedStringList: nestedStringList == null
+          ? null
+          : _i5.BuiltList(nestedStringList.map((el) => _i5.BuiltList(el))),
+      sparseStringList:
+          sparseStringList == null ? null : _i5.BuiltList(sparseStringList),
+      stringList: stringList == null ? null : _i5.BuiltList(stringList),
+      stringSet: stringSet == null ? null : _i5.BuiltSet(stringSet),
+      structureList:
+          structureList == null ? null : _i5.BuiltList(structureList),
+      timestampList:
+          timestampList == null ? null : _i5.BuiltList(timestampList),
     );
   }
 
@@ -69,17 +74,17 @@ abstract class JsonListsInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(JsonListsInputOutputBuilder b) {}
-  _i3.BuiltList<bool>? get booleanList;
-  _i3.BuiltList<_i4.FooEnum>? get enumList;
-  _i3.BuiltList<int>? get integerList;
+  _i5.BuiltList<bool>? get booleanList;
+  _i5.BuiltList<_i3.FooEnum>? get enumList;
+  _i5.BuiltList<int>? get integerList;
 
   /// A list of lists of strings.
-  _i3.BuiltList<_i3.BuiltList<String>>? get nestedStringList;
-  _i3.BuiltList<String?>? get sparseStringList;
-  _i3.BuiltList<String>? get stringList;
-  _i3.BuiltSet<String>? get stringSet;
-  _i3.BuiltList<_i5.StructureListMember>? get structureList;
-  _i3.BuiltList<DateTime>? get timestampList;
+  _i5.BuiltList<_i5.BuiltList<String>>? get nestedStringList;
+  _i5.BuiltList<String?>? get sparseStringList;
+  _i5.BuiltList<String>? get stringList;
+  _i5.BuiltSet<String>? get stringSet;
+  _i5.BuiltList<_i4.StructureListMember>? get structureList;
+  _i5.BuiltList<DateTime>? get timestampList;
   @override
   JsonListsInputOutput getPayload() => this;
   @override
@@ -172,10 +177,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.booleanList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(bool)],
               ),
-            ) as _i3.BuiltList<bool>));
+            ) as _i5.BuiltList<bool>));
           }
           break;
         case 'enumList':
@@ -183,10 +188,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.enumList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
-                [FullType(_i4.FooEnum)],
+                _i5.BuiltList,
+                [FullType(_i3.FooEnum)],
               ),
-            ) as _i3.BuiltList<_i4.FooEnum>));
+            ) as _i5.BuiltList<_i3.FooEnum>));
           }
           break;
         case 'integerList':
@@ -194,10 +199,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.integerList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(int)],
               ),
-            ) as _i3.BuiltList<int>));
+            ) as _i5.BuiltList<int>));
           }
           break;
         case 'nestedStringList':
@@ -205,15 +210,15 @@ class JsonListsInputOutputRestJson1Serializer
             result.nestedStringList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [
                   FullType(
-                    _i3.BuiltList,
+                    _i5.BuiltList,
                     [FullType(String)],
                   )
                 ],
               ),
-            ) as _i3.BuiltList<_i3.BuiltList<String>>));
+            ) as _i5.BuiltList<_i5.BuiltList<String>>));
           }
           break;
         case 'sparseStringList':
@@ -221,10 +226,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.sparseStringList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType.nullable(String)],
               ),
-            ) as _i3.BuiltList<String?>));
+            ) as _i5.BuiltList<String?>));
           }
           break;
         case 'stringList':
@@ -232,10 +237,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.stringList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltList<String>));
+            ) as _i5.BuiltList<String>));
           }
           break;
         case 'stringSet':
@@ -243,10 +248,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.stringSet.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltSet,
+                _i5.BuiltSet,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltSet<String>));
+            ) as _i5.BuiltSet<String>));
           }
           break;
         case 'myStructureList':
@@ -254,10 +259,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.structureList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
-                [FullType(_i5.StructureListMember)],
+                _i5.BuiltList,
+                [FullType(_i4.StructureListMember)],
               ),
-            ) as _i3.BuiltList<_i5.StructureListMember>));
+            ) as _i5.BuiltList<_i4.StructureListMember>));
           }
           break;
         case 'timestampList':
@@ -265,10 +270,10 @@ class JsonListsInputOutputRestJson1Serializer
             result.timestampList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(DateTime)],
               ),
-            ) as _i3.BuiltList<DateTime>));
+            ) as _i5.BuiltList<DateTime>));
           }
           break;
       }
@@ -291,7 +296,7 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.booleanList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(bool)],
           ),
         ));
@@ -302,8 +307,8 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.enumList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
-            [FullType(_i4.FooEnum)],
+            _i5.BuiltList,
+            [FullType(_i3.FooEnum)],
           ),
         ));
     }
@@ -313,7 +318,7 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.integerList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(int)],
           ),
         ));
@@ -324,10 +329,10 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.nestedStringList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [
               FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(String)],
               )
             ],
@@ -340,7 +345,7 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.sparseStringList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType.nullable(String)],
           ),
         ));
@@ -351,7 +356,7 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.stringList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(String)],
           ),
         ));
@@ -362,7 +367,7 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.stringSet!,
           specifiedType: const FullType(
-            _i3.BuiltSet,
+            _i5.BuiltSet,
             [FullType(String)],
           ),
         ));
@@ -373,8 +378,8 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.structureList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
-            [FullType(_i5.StructureListMember)],
+            _i5.BuiltList,
+            [FullType(_i4.StructureListMember)],
           ),
         ));
     }
@@ -384,7 +389,7 @@ class JsonListsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.timestampList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(DateTime)],
           ),
         ));

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/json_lists_input_output.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/json_lists_input_output.g.dart
@@ -8,23 +8,23 @@ part of rest_json1_v2.rest_json_protocol.model.json_lists_input_output;
 
 class _$JsonListsInputOutput extends JsonListsInputOutput {
   @override
-  final _i3.BuiltList<bool>? booleanList;
+  final _i5.BuiltList<bool>? booleanList;
   @override
-  final _i3.BuiltList<_i4.FooEnum>? enumList;
+  final _i5.BuiltList<_i3.FooEnum>? enumList;
   @override
-  final _i3.BuiltList<int>? integerList;
+  final _i5.BuiltList<int>? integerList;
   @override
-  final _i3.BuiltList<_i3.BuiltList<String>>? nestedStringList;
+  final _i5.BuiltList<_i5.BuiltList<String>>? nestedStringList;
   @override
-  final _i3.BuiltList<String?>? sparseStringList;
+  final _i5.BuiltList<String?>? sparseStringList;
   @override
-  final _i3.BuiltList<String>? stringList;
+  final _i5.BuiltList<String>? stringList;
   @override
-  final _i3.BuiltSet<String>? stringSet;
+  final _i5.BuiltSet<String>? stringSet;
   @override
-  final _i3.BuiltList<_i5.StructureListMember>? structureList;
+  final _i5.BuiltList<_i4.StructureListMember>? structureList;
   @override
-  final _i3.BuiltList<DateTime>? timestampList;
+  final _i5.BuiltList<DateTime>? timestampList;
 
   factory _$JsonListsInputOutput(
           [void Function(JsonListsInputOutputBuilder)? updates]) =>
@@ -91,59 +91,59 @@ class JsonListsInputOutputBuilder
     implements Builder<JsonListsInputOutput, JsonListsInputOutputBuilder> {
   _$JsonListsInputOutput? _$v;
 
-  _i3.ListBuilder<bool>? _booleanList;
-  _i3.ListBuilder<bool> get booleanList =>
-      _$this._booleanList ??= new _i3.ListBuilder<bool>();
-  set booleanList(_i3.ListBuilder<bool>? booleanList) =>
+  _i5.ListBuilder<bool>? _booleanList;
+  _i5.ListBuilder<bool> get booleanList =>
+      _$this._booleanList ??= new _i5.ListBuilder<bool>();
+  set booleanList(_i5.ListBuilder<bool>? booleanList) =>
       _$this._booleanList = booleanList;
 
-  _i3.ListBuilder<_i4.FooEnum>? _enumList;
-  _i3.ListBuilder<_i4.FooEnum> get enumList =>
-      _$this._enumList ??= new _i3.ListBuilder<_i4.FooEnum>();
-  set enumList(_i3.ListBuilder<_i4.FooEnum>? enumList) =>
+  _i5.ListBuilder<_i3.FooEnum>? _enumList;
+  _i5.ListBuilder<_i3.FooEnum> get enumList =>
+      _$this._enumList ??= new _i5.ListBuilder<_i3.FooEnum>();
+  set enumList(_i5.ListBuilder<_i3.FooEnum>? enumList) =>
       _$this._enumList = enumList;
 
-  _i3.ListBuilder<int>? _integerList;
-  _i3.ListBuilder<int> get integerList =>
-      _$this._integerList ??= new _i3.ListBuilder<int>();
-  set integerList(_i3.ListBuilder<int>? integerList) =>
+  _i5.ListBuilder<int>? _integerList;
+  _i5.ListBuilder<int> get integerList =>
+      _$this._integerList ??= new _i5.ListBuilder<int>();
+  set integerList(_i5.ListBuilder<int>? integerList) =>
       _$this._integerList = integerList;
 
-  _i3.ListBuilder<_i3.BuiltList<String>>? _nestedStringList;
-  _i3.ListBuilder<_i3.BuiltList<String>> get nestedStringList =>
-      _$this._nestedStringList ??= new _i3.ListBuilder<_i3.BuiltList<String>>();
+  _i5.ListBuilder<_i5.BuiltList<String>>? _nestedStringList;
+  _i5.ListBuilder<_i5.BuiltList<String>> get nestedStringList =>
+      _$this._nestedStringList ??= new _i5.ListBuilder<_i5.BuiltList<String>>();
   set nestedStringList(
-          _i3.ListBuilder<_i3.BuiltList<String>>? nestedStringList) =>
+          _i5.ListBuilder<_i5.BuiltList<String>>? nestedStringList) =>
       _$this._nestedStringList = nestedStringList;
 
-  _i3.ListBuilder<String?>? _sparseStringList;
-  _i3.ListBuilder<String?> get sparseStringList =>
-      _$this._sparseStringList ??= new _i3.ListBuilder<String?>();
-  set sparseStringList(_i3.ListBuilder<String?>? sparseStringList) =>
+  _i5.ListBuilder<String?>? _sparseStringList;
+  _i5.ListBuilder<String?> get sparseStringList =>
+      _$this._sparseStringList ??= new _i5.ListBuilder<String?>();
+  set sparseStringList(_i5.ListBuilder<String?>? sparseStringList) =>
       _$this._sparseStringList = sparseStringList;
 
-  _i3.ListBuilder<String>? _stringList;
-  _i3.ListBuilder<String> get stringList =>
-      _$this._stringList ??= new _i3.ListBuilder<String>();
-  set stringList(_i3.ListBuilder<String>? stringList) =>
+  _i5.ListBuilder<String>? _stringList;
+  _i5.ListBuilder<String> get stringList =>
+      _$this._stringList ??= new _i5.ListBuilder<String>();
+  set stringList(_i5.ListBuilder<String>? stringList) =>
       _$this._stringList = stringList;
 
-  _i3.SetBuilder<String>? _stringSet;
-  _i3.SetBuilder<String> get stringSet =>
-      _$this._stringSet ??= new _i3.SetBuilder<String>();
-  set stringSet(_i3.SetBuilder<String>? stringSet) =>
+  _i5.SetBuilder<String>? _stringSet;
+  _i5.SetBuilder<String> get stringSet =>
+      _$this._stringSet ??= new _i5.SetBuilder<String>();
+  set stringSet(_i5.SetBuilder<String>? stringSet) =>
       _$this._stringSet = stringSet;
 
-  _i3.ListBuilder<_i5.StructureListMember>? _structureList;
-  _i3.ListBuilder<_i5.StructureListMember> get structureList =>
-      _$this._structureList ??= new _i3.ListBuilder<_i5.StructureListMember>();
-  set structureList(_i3.ListBuilder<_i5.StructureListMember>? structureList) =>
+  _i5.ListBuilder<_i4.StructureListMember>? _structureList;
+  _i5.ListBuilder<_i4.StructureListMember> get structureList =>
+      _$this._structureList ??= new _i5.ListBuilder<_i4.StructureListMember>();
+  set structureList(_i5.ListBuilder<_i4.StructureListMember>? structureList) =>
       _$this._structureList = structureList;
 
-  _i3.ListBuilder<DateTime>? _timestampList;
-  _i3.ListBuilder<DateTime> get timestampList =>
-      _$this._timestampList ??= new _i3.ListBuilder<DateTime>();
-  set timestampList(_i3.ListBuilder<DateTime>? timestampList) =>
+  _i5.ListBuilder<DateTime>? _timestampList;
+  _i5.ListBuilder<DateTime> get timestampList =>
+      _$this._timestampList ??= new _i5.ListBuilder<DateTime>();
+  set timestampList(_i5.ListBuilder<DateTime>? timestampList) =>
       _$this._timestampList = timestampList;
 
   JsonListsInputOutputBuilder() {

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/json_maps_input_output.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/json_maps_input_output.dart
@@ -3,11 +3,11 @@
 library rest_json1_v2.rest_json_protocol.model.json_maps_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v2/src/rest_json_protocol/model/greeting_struct.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'json_maps_input_output.g.dart';
@@ -18,28 +18,38 @@ abstract class JsonMapsInputOutput
         _i2.AWSEquatable<JsonMapsInputOutput>
     implements Built<JsonMapsInputOutput, JsonMapsInputOutputBuilder> {
   factory JsonMapsInputOutput({
-    _i3.BuiltMap<String, bool>? denseBooleanMap,
-    _i3.BuiltMap<String, int>? denseNumberMap,
-    _i3.BuiltSetMultimap<String, String>? denseSetMap,
-    _i3.BuiltMap<String, String>? denseStringMap,
-    _i3.BuiltMap<String, _i4.GreetingStruct>? denseStructMap,
-    _i3.BuiltMap<String, bool?>? sparseBooleanMap,
-    _i3.BuiltMap<String, int?>? sparseNumberMap,
-    _i3.BuiltSetMultimap<String, String>? sparseSetMap,
-    _i3.BuiltMap<String, String?>? sparseStringMap,
-    _i3.BuiltMap<String, _i4.GreetingStruct?>? sparseStructMap,
+    Map<String, bool>? denseBooleanMap,
+    Map<String, int>? denseNumberMap,
+    Map<String, Set<String>>? denseSetMap,
+    Map<String, String>? denseStringMap,
+    Map<String, _i3.GreetingStruct>? denseStructMap,
+    Map<String, bool?>? sparseBooleanMap,
+    Map<String, int?>? sparseNumberMap,
+    Map<String, Set<String>>? sparseSetMap,
+    Map<String, String?>? sparseStringMap,
+    Map<String, _i3.GreetingStruct?>? sparseStructMap,
   }) {
     return _$JsonMapsInputOutput._(
-      denseBooleanMap: denseBooleanMap,
-      denseNumberMap: denseNumberMap,
-      denseSetMap: denseSetMap,
-      denseStringMap: denseStringMap,
-      denseStructMap: denseStructMap,
-      sparseBooleanMap: sparseBooleanMap,
-      sparseNumberMap: sparseNumberMap,
-      sparseSetMap: sparseSetMap,
-      sparseStringMap: sparseStringMap,
-      sparseStructMap: sparseStructMap,
+      denseBooleanMap:
+          denseBooleanMap == null ? null : _i4.BuiltMap(denseBooleanMap),
+      denseNumberMap:
+          denseNumberMap == null ? null : _i4.BuiltMap(denseNumberMap),
+      denseSetMap:
+          denseSetMap == null ? null : _i4.BuiltSetMultimap(denseSetMap),
+      denseStringMap:
+          denseStringMap == null ? null : _i4.BuiltMap(denseStringMap),
+      denseStructMap:
+          denseStructMap == null ? null : _i4.BuiltMap(denseStructMap),
+      sparseBooleanMap:
+          sparseBooleanMap == null ? null : _i4.BuiltMap(sparseBooleanMap),
+      sparseNumberMap:
+          sparseNumberMap == null ? null : _i4.BuiltMap(sparseNumberMap),
+      sparseSetMap:
+          sparseSetMap == null ? null : _i4.BuiltSetMultimap(sparseSetMap),
+      sparseStringMap:
+          sparseStringMap == null ? null : _i4.BuiltMap(sparseStringMap),
+      sparseStructMap:
+          sparseStructMap == null ? null : _i4.BuiltMap(sparseStructMap),
     );
   }
 
@@ -69,16 +79,16 @@ abstract class JsonMapsInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(JsonMapsInputOutputBuilder b) {}
-  _i3.BuiltMap<String, bool>? get denseBooleanMap;
-  _i3.BuiltMap<String, int>? get denseNumberMap;
-  _i3.BuiltSetMultimap<String, String>? get denseSetMap;
-  _i3.BuiltMap<String, String>? get denseStringMap;
-  _i3.BuiltMap<String, _i4.GreetingStruct>? get denseStructMap;
-  _i3.BuiltMap<String, bool?>? get sparseBooleanMap;
-  _i3.BuiltMap<String, int?>? get sparseNumberMap;
-  _i3.BuiltSetMultimap<String, String>? get sparseSetMap;
-  _i3.BuiltMap<String, String?>? get sparseStringMap;
-  _i3.BuiltMap<String, _i4.GreetingStruct?>? get sparseStructMap;
+  _i4.BuiltMap<String, bool>? get denseBooleanMap;
+  _i4.BuiltMap<String, int>? get denseNumberMap;
+  _i4.BuiltSetMultimap<String, String>? get denseSetMap;
+  _i4.BuiltMap<String, String>? get denseStringMap;
+  _i4.BuiltMap<String, _i3.GreetingStruct>? get denseStructMap;
+  _i4.BuiltMap<String, bool?>? get sparseBooleanMap;
+  _i4.BuiltMap<String, int?>? get sparseNumberMap;
+  _i4.BuiltSetMultimap<String, String>? get sparseSetMap;
+  _i4.BuiltMap<String, String?>? get sparseStringMap;
+  _i4.BuiltMap<String, _i3.GreetingStruct?>? get sparseStructMap;
   @override
   JsonMapsInputOutput getPayload() => this;
   @override
@@ -175,13 +185,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.denseBooleanMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(bool),
                 ],
               ),
-            ) as _i3.BuiltMap<String, bool>));
+            ) as _i4.BuiltMap<String, bool>));
           }
           break;
         case 'denseNumberMap':
@@ -189,13 +199,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.denseNumberMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(int),
                 ],
               ),
-            ) as _i3.BuiltMap<String, int>));
+            ) as _i4.BuiltMap<String, int>));
           }
           break;
         case 'denseSetMap':
@@ -203,13 +213,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.denseSetMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltSetMultimap,
+                _i4.BuiltSetMultimap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i3.BuiltSetMultimap<String, String>));
+            ) as _i4.BuiltSetMultimap<String, String>));
           }
           break;
         case 'denseStringMap':
@@ -217,13 +227,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.denseStringMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i3.BuiltMap<String, String>));
+            ) as _i4.BuiltMap<String, String>));
           }
           break;
         case 'denseStructMap':
@@ -231,13 +241,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.denseStructMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.GreetingStruct),
+                  FullType(_i3.GreetingStruct),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.GreetingStruct>));
+            ) as _i4.BuiltMap<String, _i3.GreetingStruct>));
           }
           break;
         case 'sparseBooleanMap':
@@ -245,13 +255,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.sparseBooleanMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType.nullable(bool),
                 ],
               ),
-            ) as _i3.BuiltMap<String, bool?>));
+            ) as _i4.BuiltMap<String, bool?>));
           }
           break;
         case 'sparseNumberMap':
@@ -259,13 +269,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.sparseNumberMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType.nullable(int),
                 ],
               ),
-            ) as _i3.BuiltMap<String, int?>));
+            ) as _i4.BuiltMap<String, int?>));
           }
           break;
         case 'sparseSetMap':
@@ -273,13 +283,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.sparseSetMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltSetMultimap,
+                _i4.BuiltSetMultimap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i3.BuiltSetMultimap<String, String>));
+            ) as _i4.BuiltSetMultimap<String, String>));
           }
           break;
         case 'sparseStringMap':
@@ -287,13 +297,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.sparseStringMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType.nullable(String),
                 ],
               ),
-            ) as _i3.BuiltMap<String, String?>));
+            ) as _i4.BuiltMap<String, String?>));
           }
           break;
         case 'sparseStructMap':
@@ -301,13 +311,13 @@ class JsonMapsInputOutputRestJson1Serializer
             result.sparseStructMap.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
-                  FullType.nullable(_i4.GreetingStruct),
+                  FullType.nullable(_i3.GreetingStruct),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.GreetingStruct?>));
+            ) as _i4.BuiltMap<String, _i3.GreetingStruct?>));
           }
           break;
       }
@@ -330,7 +340,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.denseBooleanMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(bool),
@@ -344,7 +354,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.denseNumberMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(int),
@@ -358,7 +368,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.denseSetMap!,
           specifiedType: const FullType(
-            _i3.BuiltSetMultimap,
+            _i4.BuiltSetMultimap,
             [
               FullType(String),
               FullType(String),
@@ -372,7 +382,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.denseStringMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -386,10 +396,10 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.denseStructMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.GreetingStruct),
+              FullType(_i3.GreetingStruct),
             ],
           ),
         ));
@@ -400,7 +410,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.sparseBooleanMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType.nullable(bool),
@@ -414,7 +424,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.sparseNumberMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType.nullable(int),
@@ -428,7 +438,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.sparseSetMap!,
           specifiedType: const FullType(
-            _i3.BuiltSetMultimap,
+            _i4.BuiltSetMultimap,
             [
               FullType(String),
               FullType(String),
@@ -442,7 +452,7 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.sparseStringMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType.nullable(String),
@@ -456,10 +466,10 @@ class JsonMapsInputOutputRestJson1Serializer
         ..add(serializers.serialize(
           payload.sparseStructMap!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
-              FullType.nullable(_i4.GreetingStruct),
+              FullType.nullable(_i3.GreetingStruct),
             ],
           ),
         ));

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/json_maps_input_output.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/json_maps_input_output.g.dart
@@ -8,25 +8,25 @@ part of rest_json1_v2.rest_json_protocol.model.json_maps_input_output;
 
 class _$JsonMapsInputOutput extends JsonMapsInputOutput {
   @override
-  final _i3.BuiltMap<String, bool>? denseBooleanMap;
+  final _i4.BuiltMap<String, bool>? denseBooleanMap;
   @override
-  final _i3.BuiltMap<String, int>? denseNumberMap;
+  final _i4.BuiltMap<String, int>? denseNumberMap;
   @override
-  final _i3.BuiltSetMultimap<String, String>? denseSetMap;
+  final _i4.BuiltSetMultimap<String, String>? denseSetMap;
   @override
-  final _i3.BuiltMap<String, String>? denseStringMap;
+  final _i4.BuiltMap<String, String>? denseStringMap;
   @override
-  final _i3.BuiltMap<String, _i4.GreetingStruct>? denseStructMap;
+  final _i4.BuiltMap<String, _i3.GreetingStruct>? denseStructMap;
   @override
-  final _i3.BuiltMap<String, bool?>? sparseBooleanMap;
+  final _i4.BuiltMap<String, bool?>? sparseBooleanMap;
   @override
-  final _i3.BuiltMap<String, int?>? sparseNumberMap;
+  final _i4.BuiltMap<String, int?>? sparseNumberMap;
   @override
-  final _i3.BuiltSetMultimap<String, String>? sparseSetMap;
+  final _i4.BuiltSetMultimap<String, String>? sparseSetMap;
   @override
-  final _i3.BuiltMap<String, String?>? sparseStringMap;
+  final _i4.BuiltMap<String, String?>? sparseStringMap;
   @override
-  final _i3.BuiltMap<String, _i4.GreetingStruct?>? sparseStructMap;
+  final _i4.BuiltMap<String, _i3.GreetingStruct?>? sparseStructMap;
 
   factory _$JsonMapsInputOutput(
           [void Function(JsonMapsInputOutputBuilder)? updates]) =>
@@ -97,68 +97,68 @@ class JsonMapsInputOutputBuilder
     implements Builder<JsonMapsInputOutput, JsonMapsInputOutputBuilder> {
   _$JsonMapsInputOutput? _$v;
 
-  _i3.MapBuilder<String, bool>? _denseBooleanMap;
-  _i3.MapBuilder<String, bool> get denseBooleanMap =>
-      _$this._denseBooleanMap ??= new _i3.MapBuilder<String, bool>();
-  set denseBooleanMap(_i3.MapBuilder<String, bool>? denseBooleanMap) =>
+  _i4.MapBuilder<String, bool>? _denseBooleanMap;
+  _i4.MapBuilder<String, bool> get denseBooleanMap =>
+      _$this._denseBooleanMap ??= new _i4.MapBuilder<String, bool>();
+  set denseBooleanMap(_i4.MapBuilder<String, bool>? denseBooleanMap) =>
       _$this._denseBooleanMap = denseBooleanMap;
 
-  _i3.MapBuilder<String, int>? _denseNumberMap;
-  _i3.MapBuilder<String, int> get denseNumberMap =>
-      _$this._denseNumberMap ??= new _i3.MapBuilder<String, int>();
-  set denseNumberMap(_i3.MapBuilder<String, int>? denseNumberMap) =>
+  _i4.MapBuilder<String, int>? _denseNumberMap;
+  _i4.MapBuilder<String, int> get denseNumberMap =>
+      _$this._denseNumberMap ??= new _i4.MapBuilder<String, int>();
+  set denseNumberMap(_i4.MapBuilder<String, int>? denseNumberMap) =>
       _$this._denseNumberMap = denseNumberMap;
 
-  _i3.SetMultimapBuilder<String, String>? _denseSetMap;
-  _i3.SetMultimapBuilder<String, String> get denseSetMap =>
-      _$this._denseSetMap ??= new _i3.SetMultimapBuilder<String, String>();
-  set denseSetMap(_i3.SetMultimapBuilder<String, String>? denseSetMap) =>
+  _i4.SetMultimapBuilder<String, String>? _denseSetMap;
+  _i4.SetMultimapBuilder<String, String> get denseSetMap =>
+      _$this._denseSetMap ??= new _i4.SetMultimapBuilder<String, String>();
+  set denseSetMap(_i4.SetMultimapBuilder<String, String>? denseSetMap) =>
       _$this._denseSetMap = denseSetMap;
 
-  _i3.MapBuilder<String, String>? _denseStringMap;
-  _i3.MapBuilder<String, String> get denseStringMap =>
-      _$this._denseStringMap ??= new _i3.MapBuilder<String, String>();
-  set denseStringMap(_i3.MapBuilder<String, String>? denseStringMap) =>
+  _i4.MapBuilder<String, String>? _denseStringMap;
+  _i4.MapBuilder<String, String> get denseStringMap =>
+      _$this._denseStringMap ??= new _i4.MapBuilder<String, String>();
+  set denseStringMap(_i4.MapBuilder<String, String>? denseStringMap) =>
       _$this._denseStringMap = denseStringMap;
 
-  _i3.MapBuilder<String, _i4.GreetingStruct>? _denseStructMap;
-  _i3.MapBuilder<String, _i4.GreetingStruct> get denseStructMap =>
+  _i4.MapBuilder<String, _i3.GreetingStruct>? _denseStructMap;
+  _i4.MapBuilder<String, _i3.GreetingStruct> get denseStructMap =>
       _$this._denseStructMap ??=
-          new _i3.MapBuilder<String, _i4.GreetingStruct>();
+          new _i4.MapBuilder<String, _i3.GreetingStruct>();
   set denseStructMap(
-          _i3.MapBuilder<String, _i4.GreetingStruct>? denseStructMap) =>
+          _i4.MapBuilder<String, _i3.GreetingStruct>? denseStructMap) =>
       _$this._denseStructMap = denseStructMap;
 
-  _i3.MapBuilder<String, bool?>? _sparseBooleanMap;
-  _i3.MapBuilder<String, bool?> get sparseBooleanMap =>
-      _$this._sparseBooleanMap ??= new _i3.MapBuilder<String, bool?>();
-  set sparseBooleanMap(_i3.MapBuilder<String, bool?>? sparseBooleanMap) =>
+  _i4.MapBuilder<String, bool?>? _sparseBooleanMap;
+  _i4.MapBuilder<String, bool?> get sparseBooleanMap =>
+      _$this._sparseBooleanMap ??= new _i4.MapBuilder<String, bool?>();
+  set sparseBooleanMap(_i4.MapBuilder<String, bool?>? sparseBooleanMap) =>
       _$this._sparseBooleanMap = sparseBooleanMap;
 
-  _i3.MapBuilder<String, int?>? _sparseNumberMap;
-  _i3.MapBuilder<String, int?> get sparseNumberMap =>
-      _$this._sparseNumberMap ??= new _i3.MapBuilder<String, int?>();
-  set sparseNumberMap(_i3.MapBuilder<String, int?>? sparseNumberMap) =>
+  _i4.MapBuilder<String, int?>? _sparseNumberMap;
+  _i4.MapBuilder<String, int?> get sparseNumberMap =>
+      _$this._sparseNumberMap ??= new _i4.MapBuilder<String, int?>();
+  set sparseNumberMap(_i4.MapBuilder<String, int?>? sparseNumberMap) =>
       _$this._sparseNumberMap = sparseNumberMap;
 
-  _i3.SetMultimapBuilder<String, String>? _sparseSetMap;
-  _i3.SetMultimapBuilder<String, String> get sparseSetMap =>
-      _$this._sparseSetMap ??= new _i3.SetMultimapBuilder<String, String>();
-  set sparseSetMap(_i3.SetMultimapBuilder<String, String>? sparseSetMap) =>
+  _i4.SetMultimapBuilder<String, String>? _sparseSetMap;
+  _i4.SetMultimapBuilder<String, String> get sparseSetMap =>
+      _$this._sparseSetMap ??= new _i4.SetMultimapBuilder<String, String>();
+  set sparseSetMap(_i4.SetMultimapBuilder<String, String>? sparseSetMap) =>
       _$this._sparseSetMap = sparseSetMap;
 
-  _i3.MapBuilder<String, String?>? _sparseStringMap;
-  _i3.MapBuilder<String, String?> get sparseStringMap =>
-      _$this._sparseStringMap ??= new _i3.MapBuilder<String, String?>();
-  set sparseStringMap(_i3.MapBuilder<String, String?>? sparseStringMap) =>
+  _i4.MapBuilder<String, String?>? _sparseStringMap;
+  _i4.MapBuilder<String, String?> get sparseStringMap =>
+      _$this._sparseStringMap ??= new _i4.MapBuilder<String, String?>();
+  set sparseStringMap(_i4.MapBuilder<String, String?>? sparseStringMap) =>
       _$this._sparseStringMap = sparseStringMap;
 
-  _i3.MapBuilder<String, _i4.GreetingStruct?>? _sparseStructMap;
-  _i3.MapBuilder<String, _i4.GreetingStruct?> get sparseStructMap =>
+  _i4.MapBuilder<String, _i3.GreetingStruct?>? _sparseStructMap;
+  _i4.MapBuilder<String, _i3.GreetingStruct?> get sparseStructMap =>
       _$this._sparseStructMap ??=
-          new _i3.MapBuilder<String, _i4.GreetingStruct?>();
+          new _i4.MapBuilder<String, _i3.GreetingStruct?>();
   set sparseStructMap(
-          _i3.MapBuilder<String, _i4.GreetingStruct?>? sparseStructMap) =>
+          _i4.MapBuilder<String, _i3.GreetingStruct?>? sparseStructMap) =>
       _$this._sparseStructMap = sparseStructMap;
 
   JsonMapsInputOutputBuilder() {

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/malformed_list_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/malformed_list_input.dart
@@ -13,8 +13,9 @@ part 'malformed_list_input.g.dart';
 abstract class MalformedListInput
     with _i1.HttpInput<MalformedListInput>, _i2.AWSEquatable<MalformedListInput>
     implements Built<MalformedListInput, MalformedListInputBuilder> {
-  factory MalformedListInput({_i3.BuiltList<String>? bodyList}) {
-    return _$MalformedListInput._(bodyList: bodyList);
+  factory MalformedListInput({List<String>? bodyList}) {
+    return _$MalformedListInput._(
+        bodyList: bodyList == null ? null : _i3.BuiltList(bodyList));
   }
 
   factory MalformedListInput.build(

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/malformed_map_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/malformed_map_input.dart
@@ -13,8 +13,9 @@ part 'malformed_map_input.g.dart';
 abstract class MalformedMapInput
     with _i1.HttpInput<MalformedMapInput>, _i2.AWSEquatable<MalformedMapInput>
     implements Built<MalformedMapInput, MalformedMapInputBuilder> {
-  factory MalformedMapInput({_i3.BuiltMap<String, String>? bodyMap}) {
-    return _$MalformedMapInput._(bodyMap: bodyMap);
+  factory MalformedMapInput({Map<String, String>? bodyMap}) {
+    return _$MalformedMapInput._(
+        bodyMap: bodyMap == null ? null : _i3.BuiltMap(bodyMap));
   }
 
   factory MalformedMapInput.build(

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/malformed_string_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/malformed_string_input.dart
@@ -21,8 +21,9 @@ abstract class MalformedStringInput
         Built<MalformedStringInput, MalformedStringInputBuilder>,
         _i1.EmptyPayload,
         _i1.HasPayload<MalformedStringInputPayload> {
-  factory MalformedStringInput({_i3.JsonObject? blob}) {
-    return _$MalformedStringInput._(blob: blob);
+  factory MalformedStringInput({Object? blob}) {
+    return _$MalformedStringInput._(
+        blob: blob == null ? null : _i3.JsonObject(blob));
   }
 
   factory MalformedStringInput.build(

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/media_type_header_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/media_type_header_input.dart
@@ -21,8 +21,9 @@ abstract class MediaTypeHeaderInput
         Built<MediaTypeHeaderInput, MediaTypeHeaderInputBuilder>,
         _i1.EmptyPayload,
         _i1.HasPayload<MediaTypeHeaderInputPayload> {
-  factory MediaTypeHeaderInput({_i3.JsonObject? json}) {
-    return _$MediaTypeHeaderInput._(json: json);
+  factory MediaTypeHeaderInput({Object? json}) {
+    return _$MediaTypeHeaderInput._(
+        json: json == null ? null : _i3.JsonObject(json));
   }
 
   factory MediaTypeHeaderInput.build(

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/media_type_header_output.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/media_type_header_output.dart
@@ -19,8 +19,9 @@ abstract class MediaTypeHeaderOutput
         Built<MediaTypeHeaderOutput, MediaTypeHeaderOutputBuilder>,
         _i2.EmptyPayload,
         _i2.HasPayload<MediaTypeHeaderOutputPayload> {
-  factory MediaTypeHeaderOutput({_i3.JsonObject? json}) {
-    return _$MediaTypeHeaderOutput._(json: json);
+  factory MediaTypeHeaderOutput({Object? json}) {
+    return _$MediaTypeHeaderOutput._(
+        json: json == null ? null : _i3.JsonObject(json));
   }
 
   factory MediaTypeHeaderOutput.build(

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/null_and_empty_headers_io.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/null_and_empty_headers_io.dart
@@ -22,12 +22,12 @@ abstract class NullAndEmptyHeadersIo
   factory NullAndEmptyHeadersIo({
     String? a,
     String? b,
-    _i3.BuiltList<String>? c,
+    List<String>? c,
   }) {
     return _$NullAndEmptyHeadersIo._(
       a: a,
       b: b,
-      c: c,
+      c: c == null ? null : _i3.BuiltList(c),
     );
   }
 

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/query_params_as_string_list_map_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/query_params_as_string_list_map_input.dart
@@ -21,11 +21,11 @@ abstract class QueryParamsAsStringListMapInput
         _i1.EmptyPayload,
         _i1.HasPayload<QueryParamsAsStringListMapInputPayload> {
   factory QueryParamsAsStringListMapInput({
-    _i3.BuiltListMultimap<String, String>? foo,
+    Map<String, List<String>>? foo,
     String? qux,
   }) {
     return _$QueryParamsAsStringListMapInput._(
-      foo: foo,
+      foo: foo == null ? null : _i3.BuiltListMultimap(foo),
       qux: qux,
     );
   }

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/query_precedence_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/query_precedence_input.dart
@@ -20,11 +20,11 @@ abstract class QueryPrecedenceInput
         _i1.EmptyPayload,
         _i1.HasPayload<QueryPrecedenceInputPayload> {
   factory QueryPrecedenceInput({
-    _i3.BuiltMap<String, String>? baz,
+    Map<String, String>? baz,
     String? foo,
   }) {
     return _$QueryPrecedenceInput._(
-      baz: baz,
+      baz: baz == null ? null : _i3.BuiltMap(baz),
       foo: foo,
     );
   }

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/scoped_config.dart
@@ -3,17 +3,17 @@
 library rest_json1_v2.rest_json_protocol.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v2/src/rest_json_protocol/model/client_config.dart'
     as _i2;
 import 'package:rest_json1_v2/src/rest_json_protocol/model/environment_config.dart'
-    as _i5;
-import 'package:rest_json1_v2/src/rest_json_protocol/model/file_config_settings.dart'
     as _i4;
+import 'package:rest_json1_v2/src/rest_json_protocol/model/file_config_settings.dart'
+    as _i3;
 import 'package:rest_json1_v2/src/rest_json_protocol/model/operation_config.dart'
-    as _i6;
+    as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -25,15 +25,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -56,16 +57,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -143,13 +144,13 @@ class ScopedConfigRestJson1Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -157,29 +158,29 @@ class ScopedConfigRestJson1Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -210,10 +211,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -224,10 +225,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -237,7 +238,7 @@ class ScopedConfigRestJson1Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -245,7 +246,7 @@ class ScopedConfigRestJson1Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_enum_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_enum_input.dart
@@ -3,13 +3,13 @@
 library rest_json1_v2.rest_json_validation_protocol.model.malformed_enum_input; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v2/src/rest_json_validation_protocol/model/enum_string.dart'
-    as _i4;
+    as _i3;
 import 'package:rest_json1_v2/src/rest_json_validation_protocol/model/enum_union.dart'
-    as _i5;
+    as _i4;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'malformed_enum_input.g.dart';
@@ -18,14 +18,14 @@ abstract class MalformedEnumInput
     with _i1.HttpInput<MalformedEnumInput>, _i2.AWSEquatable<MalformedEnumInput>
     implements Built<MalformedEnumInput, MalformedEnumInputBuilder> {
   factory MalformedEnumInput({
-    _i3.BuiltList<_i4.EnumString>? list,
-    _i3.BuiltMap<_i4.EnumString, _i4.EnumString>? map,
-    _i4.EnumString? string,
-    _i5.EnumUnion? union,
+    List<_i3.EnumString>? list,
+    Map<_i3.EnumString, _i3.EnumString>? map,
+    _i3.EnumString? string,
+    _i4.EnumUnion? union,
   }) {
     return _$MalformedEnumInput._(
-      list: list,
-      map: map,
+      list: list == null ? null : _i5.BuiltList(list),
+      map: map == null ? null : _i5.BuiltMap(map),
       string: string,
       union: union,
     );
@@ -50,10 +50,10 @@ abstract class MalformedEnumInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(MalformedEnumInputBuilder b) {}
-  _i3.BuiltList<_i4.EnumString>? get list;
-  _i3.BuiltMap<_i4.EnumString, _i4.EnumString>? get map;
-  _i4.EnumString? get string;
-  _i5.EnumUnion? get union;
+  _i5.BuiltList<_i3.EnumString>? get list;
+  _i5.BuiltMap<_i3.EnumString, _i3.EnumString>? get map;
+  _i3.EnumString? get string;
+  _i4.EnumUnion? get union;
   @override
   MalformedEnumInput getPayload() => this;
   @override
@@ -120,10 +120,10 @@ class MalformedEnumInputRestJson1Serializer
             result.list.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
-                [FullType(_i4.EnumString)],
+                _i5.BuiltList,
+                [FullType(_i3.EnumString)],
               ),
-            ) as _i3.BuiltList<_i4.EnumString>));
+            ) as _i5.BuiltList<_i3.EnumString>));
           }
           break;
         case 'map':
@@ -131,29 +131,29 @@ class MalformedEnumInputRestJson1Serializer
             result.map.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i5.BuiltMap,
                 [
-                  FullType(_i4.EnumString),
-                  FullType(_i4.EnumString),
+                  FullType(_i3.EnumString),
+                  FullType(_i3.EnumString),
                 ],
               ),
-            ) as _i3.BuiltMap<_i4.EnumString, _i4.EnumString>));
+            ) as _i5.BuiltMap<_i3.EnumString, _i3.EnumString>));
           }
           break;
         case 'string':
           if (value != null) {
             result.string = (serializers.deserialize(
               value,
-              specifiedType: const FullType(_i4.EnumString),
-            ) as _i4.EnumString);
+              specifiedType: const FullType(_i3.EnumString),
+            ) as _i3.EnumString);
           }
           break;
         case 'union':
           if (value != null) {
             result.union = (serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnumUnion),
-            ) as _i5.EnumUnion);
+              specifiedType: const FullType(_i4.EnumUnion),
+            ) as _i4.EnumUnion);
           }
           break;
       }
@@ -176,8 +176,8 @@ class MalformedEnumInputRestJson1Serializer
         ..add(serializers.serialize(
           payload.list!,
           specifiedType: const FullType(
-            _i3.BuiltList,
-            [FullType(_i4.EnumString)],
+            _i5.BuiltList,
+            [FullType(_i3.EnumString)],
           ),
         ));
     }
@@ -187,10 +187,10 @@ class MalformedEnumInputRestJson1Serializer
         ..add(serializers.serialize(
           payload.map!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i5.BuiltMap,
             [
-              FullType(_i4.EnumString),
-              FullType(_i4.EnumString),
+              FullType(_i3.EnumString),
+              FullType(_i3.EnumString),
             ],
           ),
         ));
@@ -200,7 +200,7 @@ class MalformedEnumInputRestJson1Serializer
         ..add('string')
         ..add(serializers.serialize(
           payload.string!,
-          specifiedType: const FullType(_i4.EnumString),
+          specifiedType: const FullType(_i3.EnumString),
         ));
     }
     if (payload.union != null) {
@@ -208,7 +208,7 @@ class MalformedEnumInputRestJson1Serializer
         ..add('union')
         ..add(serializers.serialize(
           payload.union!,
-          specifiedType: const FullType(_i5.EnumUnion),
+          specifiedType: const FullType(_i4.EnumUnion),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_enum_input.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_enum_input.g.dart
@@ -8,13 +8,13 @@ part of rest_json1_v2.rest_json_validation_protocol.model.malformed_enum_input;
 
 class _$MalformedEnumInput extends MalformedEnumInput {
   @override
-  final _i3.BuiltList<_i4.EnumString>? list;
+  final _i5.BuiltList<_i3.EnumString>? list;
   @override
-  final _i3.BuiltMap<_i4.EnumString, _i4.EnumString>? map;
+  final _i5.BuiltMap<_i3.EnumString, _i3.EnumString>? map;
   @override
-  final _i4.EnumString? string;
+  final _i3.EnumString? string;
   @override
-  final _i5.EnumUnion? union;
+  final _i4.EnumUnion? union;
 
   factory _$MalformedEnumInput(
           [void Function(MalformedEnumInputBuilder)? updates]) =>
@@ -54,24 +54,24 @@ class MalformedEnumInputBuilder
     implements Builder<MalformedEnumInput, MalformedEnumInputBuilder> {
   _$MalformedEnumInput? _$v;
 
-  _i3.ListBuilder<_i4.EnumString>? _list;
-  _i3.ListBuilder<_i4.EnumString> get list =>
-      _$this._list ??= new _i3.ListBuilder<_i4.EnumString>();
-  set list(_i3.ListBuilder<_i4.EnumString>? list) => _$this._list = list;
+  _i5.ListBuilder<_i3.EnumString>? _list;
+  _i5.ListBuilder<_i3.EnumString> get list =>
+      _$this._list ??= new _i5.ListBuilder<_i3.EnumString>();
+  set list(_i5.ListBuilder<_i3.EnumString>? list) => _$this._list = list;
 
-  _i3.MapBuilder<_i4.EnumString, _i4.EnumString>? _map;
-  _i3.MapBuilder<_i4.EnumString, _i4.EnumString> get map =>
-      _$this._map ??= new _i3.MapBuilder<_i4.EnumString, _i4.EnumString>();
-  set map(_i3.MapBuilder<_i4.EnumString, _i4.EnumString>? map) =>
+  _i5.MapBuilder<_i3.EnumString, _i3.EnumString>? _map;
+  _i5.MapBuilder<_i3.EnumString, _i3.EnumString> get map =>
+      _$this._map ??= new _i5.MapBuilder<_i3.EnumString, _i3.EnumString>();
+  set map(_i5.MapBuilder<_i3.EnumString, _i3.EnumString>? map) =>
       _$this._map = map;
 
-  _i4.EnumString? _string;
-  _i4.EnumString? get string => _$this._string;
-  set string(_i4.EnumString? string) => _$this._string = string;
+  _i3.EnumString? _string;
+  _i3.EnumString? get string => _$this._string;
+  set string(_i3.EnumString? string) => _$this._string = string;
 
-  _i5.EnumUnion? _union;
-  _i5.EnumUnion? get union => _$this._union;
-  set union(_i5.EnumUnion? union) => _$this._union = union;
+  _i4.EnumUnion? _union;
+  _i4.EnumUnion? get union => _$this._union;
+  set union(_i4.EnumUnion? union) => _$this._union = union;
 
   MalformedEnumInputBuilder() {
     MalformedEnumInput._init(this);

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_length_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_length_input.dart
@@ -19,16 +19,16 @@ abstract class MalformedLengthInput
     implements Built<MalformedLengthInput, MalformedLengthInputBuilder> {
   factory MalformedLengthInput({
     _i3.Uint8List? blob,
-    _i4.BuiltList<String>? list,
-    _i4.BuiltListMultimap<String, String>? map,
+    List<String>? list,
+    Map<String, List<String>>? map,
     String? maxString,
     String? minString,
     String? string,
   }) {
     return _$MalformedLengthInput._(
       blob: blob,
-      list: list,
-      map: map,
+      list: list == null ? null : _i4.BuiltList(list),
+      map: map == null ? null : _i4.BuiltListMultimap(map),
       maxString: maxString,
       minString: minString,
       string: string,

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_length_override_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_length_override_input.dart
@@ -21,16 +21,16 @@ abstract class MalformedLengthOverrideInput
             MalformedLengthOverrideInputBuilder> {
   factory MalformedLengthOverrideInput({
     _i3.Uint8List? blob,
-    _i4.BuiltList<String>? list,
-    _i4.BuiltListMultimap<String, String>? map,
+    List<String>? list,
+    Map<String, List<String>>? map,
     String? maxString,
     String? minString,
     String? string,
   }) {
     return _$MalformedLengthOverrideInput._(
       blob: blob,
-      list: list,
-      map: map,
+      list: list == null ? null : _i4.BuiltList(list),
+      map: map == null ? null : _i4.BuiltListMultimap(map),
       maxString: maxString,
       minString: minString,
       string: string,

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_pattern_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_pattern_input.dart
@@ -3,11 +3,11 @@
 library rest_json1_v2.rest_json_validation_protocol.model.malformed_pattern_input; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v2/src/rest_json_validation_protocol/model/pattern_union.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'malformed_pattern_input.g.dart';
@@ -19,15 +19,15 @@ abstract class MalformedPatternInput
     implements Built<MalformedPatternInput, MalformedPatternInputBuilder> {
   factory MalformedPatternInput({
     String? evilString,
-    _i3.BuiltList<String>? list,
-    _i3.BuiltMap<String, String>? map,
+    List<String>? list,
+    Map<String, String>? map,
     String? string,
-    _i4.PatternUnion? union,
+    _i3.PatternUnion? union,
   }) {
     return _$MalformedPatternInput._(
       evilString: evilString,
-      list: list,
-      map: map,
+      list: list == null ? null : _i4.BuiltList(list),
+      map: map == null ? null : _i4.BuiltMap(map),
       string: string,
       union: union,
     );
@@ -53,10 +53,10 @@ abstract class MalformedPatternInput
   @BuiltValueHook(initializeBuilder: true)
   static void _init(MalformedPatternInputBuilder b) {}
   String? get evilString;
-  _i3.BuiltList<String>? get list;
-  _i3.BuiltMap<String, String>? get map;
+  _i4.BuiltList<String>? get list;
+  _i4.BuiltMap<String, String>? get map;
   String? get string;
-  _i4.PatternUnion? get union;
+  _i3.PatternUnion? get union;
   @override
   MalformedPatternInput getPayload() => this;
   @override
@@ -137,10 +137,10 @@ class MalformedPatternInputRestJson1Serializer
             result.list.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i4.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltList<String>));
+            ) as _i4.BuiltList<String>));
           }
           break;
         case 'map':
@@ -148,13 +148,13 @@ class MalformedPatternInputRestJson1Serializer
             result.map.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i3.BuiltMap<String, String>));
+            ) as _i4.BuiltMap<String, String>));
           }
           break;
         case 'string':
@@ -169,8 +169,8 @@ class MalformedPatternInputRestJson1Serializer
           if (value != null) {
             result.union = (serializers.deserialize(
               value,
-              specifiedType: const FullType(_i4.PatternUnion),
-            ) as _i4.PatternUnion);
+              specifiedType: const FullType(_i3.PatternUnion),
+            ) as _i3.PatternUnion);
           }
           break;
       }
@@ -201,7 +201,7 @@ class MalformedPatternInputRestJson1Serializer
         ..add(serializers.serialize(
           payload.list!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i4.BuiltList,
             [FullType(String)],
           ),
         ));
@@ -212,7 +212,7 @@ class MalformedPatternInputRestJson1Serializer
         ..add(serializers.serialize(
           payload.map!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -233,7 +233,7 @@ class MalformedPatternInputRestJson1Serializer
         ..add('union')
         ..add(serializers.serialize(
           payload.union!,
-          specifiedType: const FullType(_i4.PatternUnion),
+          specifiedType: const FullType(_i3.PatternUnion),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_pattern_input.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_pattern_input.g.dart
@@ -10,13 +10,13 @@ class _$MalformedPatternInput extends MalformedPatternInput {
   @override
   final String? evilString;
   @override
-  final _i3.BuiltList<String>? list;
+  final _i4.BuiltList<String>? list;
   @override
-  final _i3.BuiltMap<String, String>? map;
+  final _i4.BuiltMap<String, String>? map;
   @override
   final String? string;
   @override
-  final _i4.PatternUnion? union;
+  final _i3.PatternUnion? union;
 
   factory _$MalformedPatternInput(
           [void Function(MalformedPatternInputBuilder)? updates]) =>
@@ -63,23 +63,23 @@ class MalformedPatternInputBuilder
   String? get evilString => _$this._evilString;
   set evilString(String? evilString) => _$this._evilString = evilString;
 
-  _i3.ListBuilder<String>? _list;
-  _i3.ListBuilder<String> get list =>
-      _$this._list ??= new _i3.ListBuilder<String>();
-  set list(_i3.ListBuilder<String>? list) => _$this._list = list;
+  _i4.ListBuilder<String>? _list;
+  _i4.ListBuilder<String> get list =>
+      _$this._list ??= new _i4.ListBuilder<String>();
+  set list(_i4.ListBuilder<String>? list) => _$this._list = list;
 
-  _i3.MapBuilder<String, String>? _map;
-  _i3.MapBuilder<String, String> get map =>
-      _$this._map ??= new _i3.MapBuilder<String, String>();
-  set map(_i3.MapBuilder<String, String>? map) => _$this._map = map;
+  _i4.MapBuilder<String, String>? _map;
+  _i4.MapBuilder<String, String> get map =>
+      _$this._map ??= new _i4.MapBuilder<String, String>();
+  set map(_i4.MapBuilder<String, String>? map) => _$this._map = map;
 
   String? _string;
   String? get string => _$this._string;
   set string(String? string) => _$this._string = string;
 
-  _i4.PatternUnion? _union;
-  _i4.PatternUnion? get union => _$this._union;
-  set union(_i4.PatternUnion? union) => _$this._union = union;
+  _i3.PatternUnion? _union;
+  _i3.PatternUnion? get union => _$this._union;
+  set union(_i3.PatternUnion? union) => _$this._union = union;
 
   MalformedPatternInputBuilder() {
     MalformedPatternInput._init(this);

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_pattern_override_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_pattern_override_input.dart
@@ -3,11 +3,11 @@
 library rest_json1_v2.rest_json_validation_protocol.model.malformed_pattern_override_input; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v2/src/rest_json_validation_protocol/model/pattern_union_override.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'malformed_pattern_override_input.g.dart';
@@ -20,14 +20,14 @@ abstract class MalformedPatternOverrideInput
         Built<MalformedPatternOverrideInput,
             MalformedPatternOverrideInputBuilder> {
   factory MalformedPatternOverrideInput({
-    _i3.BuiltList<String>? list,
-    _i3.BuiltMap<String, String>? map,
+    List<String>? list,
+    Map<String, String>? map,
     String? string,
-    _i4.PatternUnionOverride? union,
+    _i3.PatternUnionOverride? union,
   }) {
     return _$MalformedPatternOverrideInput._(
-      list: list,
-      map: map,
+      list: list == null ? null : _i4.BuiltList(list),
+      map: map == null ? null : _i4.BuiltMap(map),
       string: string,
       union: union,
     );
@@ -52,10 +52,10 @@ abstract class MalformedPatternOverrideInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(MalformedPatternOverrideInputBuilder b) {}
-  _i3.BuiltList<String>? get list;
-  _i3.BuiltMap<String, String>? get map;
+  _i4.BuiltList<String>? get list;
+  _i4.BuiltMap<String, String>? get map;
   String? get string;
-  _i4.PatternUnionOverride? get union;
+  _i3.PatternUnionOverride? get union;
   @override
   MalformedPatternOverrideInput getPayload() => this;
   @override
@@ -123,10 +123,10 @@ class MalformedPatternOverrideInputRestJson1Serializer
             result.list.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i4.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltList<String>));
+            ) as _i4.BuiltList<String>));
           }
           break;
         case 'map':
@@ -134,13 +134,13 @@ class MalformedPatternOverrideInputRestJson1Serializer
             result.map.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(String),
                 ],
               ),
-            ) as _i3.BuiltMap<String, String>));
+            ) as _i4.BuiltMap<String, String>));
           }
           break;
         case 'string':
@@ -155,8 +155,8 @@ class MalformedPatternOverrideInputRestJson1Serializer
           if (value != null) {
             result.union = (serializers.deserialize(
               value,
-              specifiedType: const FullType(_i4.PatternUnionOverride),
-            ) as _i4.PatternUnionOverride);
+              specifiedType: const FullType(_i3.PatternUnionOverride),
+            ) as _i3.PatternUnionOverride);
           }
           break;
       }
@@ -179,7 +179,7 @@ class MalformedPatternOverrideInputRestJson1Serializer
         ..add(serializers.serialize(
           payload.list!,
           specifiedType: const FullType(
-            _i3.BuiltList,
+            _i4.BuiltList,
             [FullType(String)],
           ),
         ));
@@ -190,7 +190,7 @@ class MalformedPatternOverrideInputRestJson1Serializer
         ..add(serializers.serialize(
           payload.map!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(String),
@@ -211,7 +211,7 @@ class MalformedPatternOverrideInputRestJson1Serializer
         ..add('union')
         ..add(serializers.serialize(
           payload.union!,
-          specifiedType: const FullType(_i4.PatternUnionOverride),
+          specifiedType: const FullType(_i3.PatternUnionOverride),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_pattern_override_input.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/malformed_pattern_override_input.g.dart
@@ -8,13 +8,13 @@ part of rest_json1_v2.rest_json_validation_protocol.model.malformed_pattern_over
 
 class _$MalformedPatternOverrideInput extends MalformedPatternOverrideInput {
   @override
-  final _i3.BuiltList<String>? list;
+  final _i4.BuiltList<String>? list;
   @override
-  final _i3.BuiltMap<String, String>? map;
+  final _i4.BuiltMap<String, String>? map;
   @override
   final String? string;
   @override
-  final _i4.PatternUnionOverride? union;
+  final _i3.PatternUnionOverride? union;
 
   factory _$MalformedPatternOverrideInput(
           [void Function(MalformedPatternOverrideInputBuilder)? updates]) =>
@@ -57,23 +57,23 @@ class MalformedPatternOverrideInputBuilder
             MalformedPatternOverrideInputBuilder> {
   _$MalformedPatternOverrideInput? _$v;
 
-  _i3.ListBuilder<String>? _list;
-  _i3.ListBuilder<String> get list =>
-      _$this._list ??= new _i3.ListBuilder<String>();
-  set list(_i3.ListBuilder<String>? list) => _$this._list = list;
+  _i4.ListBuilder<String>? _list;
+  _i4.ListBuilder<String> get list =>
+      _$this._list ??= new _i4.ListBuilder<String>();
+  set list(_i4.ListBuilder<String>? list) => _$this._list = list;
 
-  _i3.MapBuilder<String, String>? _map;
-  _i3.MapBuilder<String, String> get map =>
-      _$this._map ??= new _i3.MapBuilder<String, String>();
-  set map(_i3.MapBuilder<String, String>? map) => _$this._map = map;
+  _i4.MapBuilder<String, String>? _map;
+  _i4.MapBuilder<String, String> get map =>
+      _$this._map ??= new _i4.MapBuilder<String, String>();
+  set map(_i4.MapBuilder<String, String>? map) => _$this._map = map;
 
   String? _string;
   String? get string => _$this._string;
   set string(String? string) => _$this._string = string;
 
-  _i4.PatternUnionOverride? _union;
-  _i4.PatternUnionOverride? get union => _$this._union;
-  set union(_i4.PatternUnionOverride? union) => _$this._union = union;
+  _i3.PatternUnionOverride? _union;
+  _i3.PatternUnionOverride? get union => _$this._union;
+  set union(_i3.PatternUnionOverride? union) => _$this._union = union;
 
   MalformedPatternOverrideInputBuilder() {
     MalformedPatternOverrideInput._init(this);

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/scoped_config.dart
@@ -3,17 +3,17 @@
 library rest_json1_v2.rest_json_validation_protocol.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v2/src/rest_json_validation_protocol/model/client_config.dart'
     as _i2;
 import 'package:rest_json1_v2/src/rest_json_validation_protocol/model/environment_config.dart'
-    as _i5;
-import 'package:rest_json1_v2/src/rest_json_validation_protocol/model/file_config_settings.dart'
     as _i4;
+import 'package:rest_json1_v2/src/rest_json_validation_protocol/model/file_config_settings.dart'
+    as _i3;
 import 'package:rest_json1_v2/src/rest_json_validation_protocol/model/operation_config.dart'
-    as _i6;
+    as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -25,15 +25,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -56,16 +57,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -143,13 +144,13 @@ class ScopedConfigRestJson1Serializer
             result.configFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'credentialsFile':
@@ -157,29 +158,29 @@ class ScopedConfigRestJson1Serializer
             result.credentialsFile.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
-            ) as _i3.BuiltMap<String, _i4.FileConfigSettings>));
+            ) as _i6.BuiltMap<String, _i3.FileConfigSettings>));
           }
           break;
         case 'environment':
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -210,10 +211,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.configFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -224,10 +225,10 @@ class ScopedConfigRestJson1Serializer
         ..add(serializers.serialize(
           payload.credentialsFile!,
           specifiedType: const FullType(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -237,7 +238,7 @@ class ScopedConfigRestJson1Serializer
         ..add('environment')
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -245,7 +246,7 @@ class ScopedConfigRestJson1Serializer
         ..add('operation')
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/validation_exception.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/validation_exception.dart
@@ -3,11 +3,11 @@
 library rest_json1_v2.rest_json_validation_protocol.model.validation_exception; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_json1_v2/src/rest_json_validation_protocol/model/validation_exception_field.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i2;
 
 part 'validation_exception.g.dart';
@@ -20,11 +20,11 @@ abstract class ValidationException
         _i2.SmithyHttpException {
   /// A standard error for input validation failures. This should be thrown by services when a member of the input structure falls outside of the modeled or documented constraints.
   factory ValidationException({
-    _i3.BuiltList<_i4.ValidationExceptionField>? fieldList,
+    List<_i3.ValidationExceptionField>? fieldList,
     required String message,
   }) {
     return _$ValidationException._(
-      fieldList: fieldList,
+      fieldList: fieldList == null ? null : _i4.BuiltList(fieldList),
       message: message,
     );
   }
@@ -54,7 +54,7 @@ abstract class ValidationException
   static void _init(ValidationExceptionBuilder b) {}
 
   /// A list of specific failures encountered while validating the input. A member can appear in this list more than once if it failed to satisfy multiple constraints.
-  _i3.BuiltList<_i4.ValidationExceptionField>? get fieldList;
+  _i4.BuiltList<_i3.ValidationExceptionField>? get fieldList;
 
   /// A summary of the validation failure.
   @override
@@ -128,10 +128,10 @@ class ValidationExceptionRestJson1Serializer
             result.fieldList.replace((serializers.deserialize(
               value,
               specifiedType: const FullType(
-                _i3.BuiltList,
-                [FullType(_i4.ValidationExceptionField)],
+                _i4.BuiltList,
+                [FullType(_i3.ValidationExceptionField)],
               ),
-            ) as _i3.BuiltList<_i4.ValidationExceptionField>));
+            ) as _i4.BuiltList<_i3.ValidationExceptionField>));
           }
           break;
         case 'message':
@@ -166,8 +166,8 @@ class ValidationExceptionRestJson1Serializer
         ..add(serializers.serialize(
           payload.fieldList!,
           specifiedType: const FullType(
-            _i3.BuiltList,
-            [FullType(_i4.ValidationExceptionField)],
+            _i4.BuiltList,
+            [FullType(_i3.ValidationExceptionField)],
           ),
         ));
     }

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/validation_exception.g.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/model/validation_exception.g.dart
@@ -8,7 +8,7 @@ part of rest_json1_v2.rest_json_validation_protocol.model.validation_exception;
 
 class _$ValidationException extends ValidationException {
   @override
-  final _i3.BuiltList<_i4.ValidationExceptionField>? fieldList;
+  final _i4.BuiltList<_i3.ValidationExceptionField>? fieldList;
   @override
   final String message;
   @override
@@ -54,10 +54,10 @@ class ValidationExceptionBuilder
     implements Builder<ValidationException, ValidationExceptionBuilder> {
   _$ValidationException? _$v;
 
-  _i3.ListBuilder<_i4.ValidationExceptionField>? _fieldList;
-  _i3.ListBuilder<_i4.ValidationExceptionField> get fieldList =>
-      _$this._fieldList ??= new _i3.ListBuilder<_i4.ValidationExceptionField>();
-  set fieldList(_i3.ListBuilder<_i4.ValidationExceptionField>? fieldList) =>
+  _i4.ListBuilder<_i3.ValidationExceptionField>? _fieldList;
+  _i4.ListBuilder<_i3.ValidationExceptionField> get fieldList =>
+      _$this._fieldList ??= new _i4.ListBuilder<_i3.ValidationExceptionField>();
+  set fieldList(_i4.ListBuilder<_i3.ValidationExceptionField>? fieldList) =>
       _$this._fieldList = fieldList;
 
   String? _message;

--- a/packages/smithy/goldens/lib2/restJson1/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restJson1/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   aws_common:
     path: ../../../../aws_common
   built_value: ">=8.4.0 <8.5.0"
-  built_collection: ^5.0.0
   fixnum: ^1.0.0
+  built_collection: ^5.0.0
   meta: ^1.7.0
   shelf_router: ^1.1.0
   shelf: ^1.1.0

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/all_query_string_types_input.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/all_query_string_types_input.dart
@@ -3,12 +3,12 @@
 library rest_xml_v2.rest_xml_protocol.model.all_query_string_types_input; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:fixnum/fixnum.dart' as _i5;
+import 'package:fixnum/fixnum.dart' as _i4;
 import 'package:meta/meta.dart' as _i6;
-import 'package:rest_xml_v2/src/rest_xml_protocol/model/foo_enum.dart' as _i4;
+import 'package:rest_xml_v2/src/rest_xml_protocol/model/foo_enum.dart' as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'all_query_string_types_input.g.dart';
@@ -23,45 +23,55 @@ abstract class AllQueryStringTypesInput
         _i1.HasPayload<AllQueryStringTypesInputPayload> {
   factory AllQueryStringTypesInput({
     bool? queryBoolean,
-    _i3.BuiltList<bool>? queryBooleanList,
+    List<bool>? queryBooleanList,
     int? queryByte,
     double? queryDouble,
-    _i3.BuiltList<double>? queryDoubleList,
-    _i4.FooEnum? queryEnum,
-    _i3.BuiltList<_i4.FooEnum>? queryEnumList,
+    List<double>? queryDoubleList,
+    _i3.FooEnum? queryEnum,
+    List<_i3.FooEnum>? queryEnumList,
     double? queryFloat,
     int? queryInteger,
-    _i3.BuiltList<int>? queryIntegerList,
-    _i3.BuiltSet<int>? queryIntegerSet,
-    _i5.Int64? queryLong,
-    _i3.BuiltMap<String, String>? queryParamsMapOfStrings,
+    List<int>? queryIntegerList,
+    Set<int>? queryIntegerSet,
+    _i4.Int64? queryLong,
+    Map<String, String>? queryParamsMapOfStrings,
     int? queryShort,
     String? queryString,
-    _i3.BuiltList<String>? queryStringList,
-    _i3.BuiltSet<String>? queryStringSet,
+    List<String>? queryStringList,
+    Set<String>? queryStringSet,
     DateTime? queryTimestamp,
-    _i3.BuiltList<DateTime>? queryTimestampList,
+    List<DateTime>? queryTimestampList,
   }) {
     return _$AllQueryStringTypesInput._(
       queryBoolean: queryBoolean,
-      queryBooleanList: queryBooleanList,
+      queryBooleanList:
+          queryBooleanList == null ? null : _i5.BuiltList(queryBooleanList),
       queryByte: queryByte,
       queryDouble: queryDouble,
-      queryDoubleList: queryDoubleList,
+      queryDoubleList:
+          queryDoubleList == null ? null : _i5.BuiltList(queryDoubleList),
       queryEnum: queryEnum,
-      queryEnumList: queryEnumList,
+      queryEnumList:
+          queryEnumList == null ? null : _i5.BuiltList(queryEnumList),
       queryFloat: queryFloat,
       queryInteger: queryInteger,
-      queryIntegerList: queryIntegerList,
-      queryIntegerSet: queryIntegerSet,
+      queryIntegerList:
+          queryIntegerList == null ? null : _i5.BuiltList(queryIntegerList),
+      queryIntegerSet:
+          queryIntegerSet == null ? null : _i5.BuiltSet(queryIntegerSet),
       queryLong: queryLong,
-      queryParamsMapOfStrings: queryParamsMapOfStrings,
+      queryParamsMapOfStrings: queryParamsMapOfStrings == null
+          ? null
+          : _i5.BuiltMap(queryParamsMapOfStrings),
       queryShort: queryShort,
       queryString: queryString,
-      queryStringList: queryStringList,
-      queryStringSet: queryStringSet,
+      queryStringList:
+          queryStringList == null ? null : _i5.BuiltList(queryStringList),
+      queryStringSet:
+          queryStringSet == null ? null : _i5.BuiltSet(queryStringSet),
       queryTimestamp: queryTimestamp,
-      queryTimestampList: queryTimestampList,
+      queryTimestampList:
+          queryTimestampList == null ? null : _i5.BuiltList(queryTimestampList),
     );
   }
 
@@ -110,7 +120,7 @@ abstract class AllQueryStringTypesInput
               .map((el) => int.parse(el.trim())));
         }
         if (request.queryParameters['Long'] != null) {
-          b.queryLong = _i5.Int64.parseInt(request.queryParameters['Long']!);
+          b.queryLong = _i4.Int64.parseInt(request.queryParameters['Long']!);
         }
         if (request.queryParameters['Float'] != null) {
           b.queryFloat = double.parse(request.queryParameters['Float']!);
@@ -150,12 +160,12 @@ abstract class AllQueryStringTypesInput
         }
         if (request.queryParameters['Enum'] != null) {
           b.queryEnum =
-              _i4.FooEnum.values.byValue(request.queryParameters['Enum']!);
+              _i3.FooEnum.values.byValue(request.queryParameters['Enum']!);
         }
         if (request.queryParameters['EnumList'] != null) {
           b.queryEnumList.addAll(_i1
               .parseHeader(request.queryParameters['EnumList']!)
-              .map((el) => _i4.FooEnum.values.byValue(el.trim())));
+              .map((el) => _i3.FooEnum.values.byValue(el.trim())));
         }
       });
 
@@ -166,24 +176,24 @@ abstract class AllQueryStringTypesInput
   @BuiltValueHook(initializeBuilder: true)
   static void _init(AllQueryStringTypesInputBuilder b) {}
   bool? get queryBoolean;
-  _i3.BuiltList<bool>? get queryBooleanList;
+  _i5.BuiltList<bool>? get queryBooleanList;
   int? get queryByte;
   double? get queryDouble;
-  _i3.BuiltList<double>? get queryDoubleList;
-  _i4.FooEnum? get queryEnum;
-  _i3.BuiltList<_i4.FooEnum>? get queryEnumList;
+  _i5.BuiltList<double>? get queryDoubleList;
+  _i3.FooEnum? get queryEnum;
+  _i5.BuiltList<_i3.FooEnum>? get queryEnumList;
   double? get queryFloat;
   int? get queryInteger;
-  _i3.BuiltList<int>? get queryIntegerList;
-  _i3.BuiltSet<int>? get queryIntegerSet;
-  _i5.Int64? get queryLong;
-  _i3.BuiltMap<String, String>? get queryParamsMapOfStrings;
+  _i5.BuiltList<int>? get queryIntegerList;
+  _i5.BuiltSet<int>? get queryIntegerSet;
+  _i4.Int64? get queryLong;
+  _i5.BuiltMap<String, String>? get queryParamsMapOfStrings;
   int? get queryShort;
   String? get queryString;
-  _i3.BuiltList<String>? get queryStringList;
-  _i3.BuiltSet<String>? get queryStringSet;
+  _i5.BuiltList<String>? get queryStringList;
+  _i5.BuiltSet<String>? get queryStringSet;
   DateTime? get queryTimestamp;
-  _i3.BuiltList<DateTime>? get queryTimestampList;
+  _i5.BuiltList<DateTime>? get queryTimestampList;
   @override
   AllQueryStringTypesInputPayload getPayload() =>
       AllQueryStringTypesInputPayload();

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/all_query_string_types_input.g.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/all_query_string_types_input.g.dart
@@ -10,41 +10,41 @@ class _$AllQueryStringTypesInput extends AllQueryStringTypesInput {
   @override
   final bool? queryBoolean;
   @override
-  final _i3.BuiltList<bool>? queryBooleanList;
+  final _i5.BuiltList<bool>? queryBooleanList;
   @override
   final int? queryByte;
   @override
   final double? queryDouble;
   @override
-  final _i3.BuiltList<double>? queryDoubleList;
+  final _i5.BuiltList<double>? queryDoubleList;
   @override
-  final _i4.FooEnum? queryEnum;
+  final _i3.FooEnum? queryEnum;
   @override
-  final _i3.BuiltList<_i4.FooEnum>? queryEnumList;
+  final _i5.BuiltList<_i3.FooEnum>? queryEnumList;
   @override
   final double? queryFloat;
   @override
   final int? queryInteger;
   @override
-  final _i3.BuiltList<int>? queryIntegerList;
+  final _i5.BuiltList<int>? queryIntegerList;
   @override
-  final _i3.BuiltSet<int>? queryIntegerSet;
+  final _i5.BuiltSet<int>? queryIntegerSet;
   @override
-  final _i5.Int64? queryLong;
+  final _i4.Int64? queryLong;
   @override
-  final _i3.BuiltMap<String, String>? queryParamsMapOfStrings;
+  final _i5.BuiltMap<String, String>? queryParamsMapOfStrings;
   @override
   final int? queryShort;
   @override
   final String? queryString;
   @override
-  final _i3.BuiltList<String>? queryStringList;
+  final _i5.BuiltList<String>? queryStringList;
   @override
-  final _i3.BuiltSet<String>? queryStringSet;
+  final _i5.BuiltSet<String>? queryStringSet;
   @override
   final DateTime? queryTimestamp;
   @override
-  final _i3.BuiltList<DateTime>? queryTimestampList;
+  final _i5.BuiltList<DateTime>? queryTimestampList;
 
   factory _$AllQueryStringTypesInput(
           [void Function(AllQueryStringTypesInputBuilder)? updates]) =>
@@ -164,10 +164,10 @@ class AllQueryStringTypesInputBuilder
   bool? get queryBoolean => _$this._queryBoolean;
   set queryBoolean(bool? queryBoolean) => _$this._queryBoolean = queryBoolean;
 
-  _i3.ListBuilder<bool>? _queryBooleanList;
-  _i3.ListBuilder<bool> get queryBooleanList =>
-      _$this._queryBooleanList ??= new _i3.ListBuilder<bool>();
-  set queryBooleanList(_i3.ListBuilder<bool>? queryBooleanList) =>
+  _i5.ListBuilder<bool>? _queryBooleanList;
+  _i5.ListBuilder<bool> get queryBooleanList =>
+      _$this._queryBooleanList ??= new _i5.ListBuilder<bool>();
+  set queryBooleanList(_i5.ListBuilder<bool>? queryBooleanList) =>
       _$this._queryBooleanList = queryBooleanList;
 
   int? _queryByte;
@@ -178,20 +178,20 @@ class AllQueryStringTypesInputBuilder
   double? get queryDouble => _$this._queryDouble;
   set queryDouble(double? queryDouble) => _$this._queryDouble = queryDouble;
 
-  _i3.ListBuilder<double>? _queryDoubleList;
-  _i3.ListBuilder<double> get queryDoubleList =>
-      _$this._queryDoubleList ??= new _i3.ListBuilder<double>();
-  set queryDoubleList(_i3.ListBuilder<double>? queryDoubleList) =>
+  _i5.ListBuilder<double>? _queryDoubleList;
+  _i5.ListBuilder<double> get queryDoubleList =>
+      _$this._queryDoubleList ??= new _i5.ListBuilder<double>();
+  set queryDoubleList(_i5.ListBuilder<double>? queryDoubleList) =>
       _$this._queryDoubleList = queryDoubleList;
 
-  _i4.FooEnum? _queryEnum;
-  _i4.FooEnum? get queryEnum => _$this._queryEnum;
-  set queryEnum(_i4.FooEnum? queryEnum) => _$this._queryEnum = queryEnum;
+  _i3.FooEnum? _queryEnum;
+  _i3.FooEnum? get queryEnum => _$this._queryEnum;
+  set queryEnum(_i3.FooEnum? queryEnum) => _$this._queryEnum = queryEnum;
 
-  _i3.ListBuilder<_i4.FooEnum>? _queryEnumList;
-  _i3.ListBuilder<_i4.FooEnum> get queryEnumList =>
-      _$this._queryEnumList ??= new _i3.ListBuilder<_i4.FooEnum>();
-  set queryEnumList(_i3.ListBuilder<_i4.FooEnum>? queryEnumList) =>
+  _i5.ListBuilder<_i3.FooEnum>? _queryEnumList;
+  _i5.ListBuilder<_i3.FooEnum> get queryEnumList =>
+      _$this._queryEnumList ??= new _i5.ListBuilder<_i3.FooEnum>();
+  set queryEnumList(_i5.ListBuilder<_i3.FooEnum>? queryEnumList) =>
       _$this._queryEnumList = queryEnumList;
 
   double? _queryFloat;
@@ -202,27 +202,27 @@ class AllQueryStringTypesInputBuilder
   int? get queryInteger => _$this._queryInteger;
   set queryInteger(int? queryInteger) => _$this._queryInteger = queryInteger;
 
-  _i3.ListBuilder<int>? _queryIntegerList;
-  _i3.ListBuilder<int> get queryIntegerList =>
-      _$this._queryIntegerList ??= new _i3.ListBuilder<int>();
-  set queryIntegerList(_i3.ListBuilder<int>? queryIntegerList) =>
+  _i5.ListBuilder<int>? _queryIntegerList;
+  _i5.ListBuilder<int> get queryIntegerList =>
+      _$this._queryIntegerList ??= new _i5.ListBuilder<int>();
+  set queryIntegerList(_i5.ListBuilder<int>? queryIntegerList) =>
       _$this._queryIntegerList = queryIntegerList;
 
-  _i3.SetBuilder<int>? _queryIntegerSet;
-  _i3.SetBuilder<int> get queryIntegerSet =>
-      _$this._queryIntegerSet ??= new _i3.SetBuilder<int>();
-  set queryIntegerSet(_i3.SetBuilder<int>? queryIntegerSet) =>
+  _i5.SetBuilder<int>? _queryIntegerSet;
+  _i5.SetBuilder<int> get queryIntegerSet =>
+      _$this._queryIntegerSet ??= new _i5.SetBuilder<int>();
+  set queryIntegerSet(_i5.SetBuilder<int>? queryIntegerSet) =>
       _$this._queryIntegerSet = queryIntegerSet;
 
-  _i5.Int64? _queryLong;
-  _i5.Int64? get queryLong => _$this._queryLong;
-  set queryLong(_i5.Int64? queryLong) => _$this._queryLong = queryLong;
+  _i4.Int64? _queryLong;
+  _i4.Int64? get queryLong => _$this._queryLong;
+  set queryLong(_i4.Int64? queryLong) => _$this._queryLong = queryLong;
 
-  _i3.MapBuilder<String, String>? _queryParamsMapOfStrings;
-  _i3.MapBuilder<String, String> get queryParamsMapOfStrings =>
-      _$this._queryParamsMapOfStrings ??= new _i3.MapBuilder<String, String>();
+  _i5.MapBuilder<String, String>? _queryParamsMapOfStrings;
+  _i5.MapBuilder<String, String> get queryParamsMapOfStrings =>
+      _$this._queryParamsMapOfStrings ??= new _i5.MapBuilder<String, String>();
   set queryParamsMapOfStrings(
-          _i3.MapBuilder<String, String>? queryParamsMapOfStrings) =>
+          _i5.MapBuilder<String, String>? queryParamsMapOfStrings) =>
       _$this._queryParamsMapOfStrings = queryParamsMapOfStrings;
 
   int? _queryShort;
@@ -233,16 +233,16 @@ class AllQueryStringTypesInputBuilder
   String? get queryString => _$this._queryString;
   set queryString(String? queryString) => _$this._queryString = queryString;
 
-  _i3.ListBuilder<String>? _queryStringList;
-  _i3.ListBuilder<String> get queryStringList =>
-      _$this._queryStringList ??= new _i3.ListBuilder<String>();
-  set queryStringList(_i3.ListBuilder<String>? queryStringList) =>
+  _i5.ListBuilder<String>? _queryStringList;
+  _i5.ListBuilder<String> get queryStringList =>
+      _$this._queryStringList ??= new _i5.ListBuilder<String>();
+  set queryStringList(_i5.ListBuilder<String>? queryStringList) =>
       _$this._queryStringList = queryStringList;
 
-  _i3.SetBuilder<String>? _queryStringSet;
-  _i3.SetBuilder<String> get queryStringSet =>
-      _$this._queryStringSet ??= new _i3.SetBuilder<String>();
-  set queryStringSet(_i3.SetBuilder<String>? queryStringSet) =>
+  _i5.SetBuilder<String>? _queryStringSet;
+  _i5.SetBuilder<String> get queryStringSet =>
+      _$this._queryStringSet ??= new _i5.SetBuilder<String>();
+  set queryStringSet(_i5.SetBuilder<String>? queryStringSet) =>
       _$this._queryStringSet = queryStringSet;
 
   DateTime? _queryTimestamp;
@@ -250,10 +250,10 @@ class AllQueryStringTypesInputBuilder
   set queryTimestamp(DateTime? queryTimestamp) =>
       _$this._queryTimestamp = queryTimestamp;
 
-  _i3.ListBuilder<DateTime>? _queryTimestampList;
-  _i3.ListBuilder<DateTime> get queryTimestampList =>
-      _$this._queryTimestampList ??= new _i3.ListBuilder<DateTime>();
-  set queryTimestampList(_i3.ListBuilder<DateTime>? queryTimestampList) =>
+  _i5.ListBuilder<DateTime>? _queryTimestampList;
+  _i5.ListBuilder<DateTime> get queryTimestampList =>
+      _$this._queryTimestampList ??= new _i5.ListBuilder<DateTime>();
+  set queryTimestampList(_i5.ListBuilder<DateTime>? queryTimestampList) =>
       _$this._queryTimestampList = queryTimestampList;
 
   AllQueryStringTypesInputBuilder() {

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_input_output.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_input_output.dart
@@ -3,10 +3,10 @@
 library rest_xml_v2.rest_xml_protocol.model.flattened_xml_map_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:rest_xml_v2/src/rest_xml_protocol/model/foo_enum.dart' as _i4;
+import 'package:rest_xml_v2/src/rest_xml_protocol/model/foo_enum.dart' as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'flattened_xml_map_input_output.g.dart';
@@ -17,9 +17,9 @@ abstract class FlattenedXmlMapInputOutput
         _i2.AWSEquatable<FlattenedXmlMapInputOutput>
     implements
         Built<FlattenedXmlMapInputOutput, FlattenedXmlMapInputOutputBuilder> {
-  factory FlattenedXmlMapInputOutput(
-      {_i3.BuiltMap<String, _i4.FooEnum>? myMap}) {
-    return _$FlattenedXmlMapInputOutput._(myMap: myMap);
+  factory FlattenedXmlMapInputOutput({Map<String, _i3.FooEnum>? myMap}) {
+    return _$FlattenedXmlMapInputOutput._(
+        myMap: myMap == null ? null : _i4.BuiltMap(myMap));
   }
 
   factory FlattenedXmlMapInputOutput.build(
@@ -48,7 +48,7 @@ abstract class FlattenedXmlMapInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(FlattenedXmlMapInputOutputBuilder b) {}
-  _i3.BuiltMap<String, _i4.FooEnum>? get myMap;
+  _i4.BuiltMap<String, _i3.FooEnum>? get myMap;
   @override
   FlattenedXmlMapInputOutput getPayload() => this;
   @override
@@ -102,10 +102,10 @@ class FlattenedXmlMapInputOutputRestXmlSerializer
                       serializers,
                       (value as Iterable<Object?>),
                       specifiedType: const FullType(
-                        _i3.BuiltMap,
+                        _i4.BuiltMap,
                         [
                           FullType(String),
-                          FullType(_i4.FooEnum),
+                          FullType(_i3.FooEnum),
                         ],
                       ),
                     )
@@ -135,10 +135,10 @@ class FlattenedXmlMapInputOutputRestXmlSerializer
         serializers,
         payload.myMap!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltMap,
+          _i4.BuiltMap,
           [
             FullType(String),
-            FullType(_i4.FooEnum),
+            FullType(_i3.FooEnum),
           ],
         ),
       ));

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_input_output.g.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_input_output.g.dart
@@ -8,7 +8,7 @@ part of rest_xml_v2.rest_xml_protocol.model.flattened_xml_map_input_output;
 
 class _$FlattenedXmlMapInputOutput extends FlattenedXmlMapInputOutput {
   @override
-  final _i3.BuiltMap<String, _i4.FooEnum>? myMap;
+  final _i4.BuiltMap<String, _i3.FooEnum>? myMap;
 
   factory _$FlattenedXmlMapInputOutput(
           [void Function(FlattenedXmlMapInputOutputBuilder)? updates]) =>
@@ -42,10 +42,10 @@ class FlattenedXmlMapInputOutputBuilder
         Builder<FlattenedXmlMapInputOutput, FlattenedXmlMapInputOutputBuilder> {
   _$FlattenedXmlMapInputOutput? _$v;
 
-  _i3.MapBuilder<String, _i4.FooEnum>? _myMap;
-  _i3.MapBuilder<String, _i4.FooEnum> get myMap =>
-      _$this._myMap ??= new _i3.MapBuilder<String, _i4.FooEnum>();
-  set myMap(_i3.MapBuilder<String, _i4.FooEnum>? myMap) =>
+  _i4.MapBuilder<String, _i3.FooEnum>? _myMap;
+  _i4.MapBuilder<String, _i3.FooEnum> get myMap =>
+      _$this._myMap ??= new _i4.MapBuilder<String, _i3.FooEnum>();
+  set myMap(_i4.MapBuilder<String, _i3.FooEnum>? myMap) =>
       _$this._myMap = myMap;
 
   FlattenedXmlMapInputOutputBuilder() {

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_with_xml_name_input_output.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_with_xml_name_input_output.dart
@@ -17,9 +17,9 @@ abstract class FlattenedXmlMapWithXmlNameInputOutput
     implements
         Built<FlattenedXmlMapWithXmlNameInputOutput,
             FlattenedXmlMapWithXmlNameInputOutputBuilder> {
-  factory FlattenedXmlMapWithXmlNameInputOutput(
-      {_i3.BuiltMap<String, String>? myMap}) {
-    return _$FlattenedXmlMapWithXmlNameInputOutput._(myMap: myMap);
+  factory FlattenedXmlMapWithXmlNameInputOutput({Map<String, String>? myMap}) {
+    return _$FlattenedXmlMapWithXmlNameInputOutput._(
+        myMap: myMap == null ? null : _i3.BuiltMap(myMap));
   }
 
   factory FlattenedXmlMapWithXmlNameInputOutput.build(

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_with_xml_namespace_output.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/flattened_xml_map_with_xml_namespace_output.dart
@@ -16,9 +16,9 @@ abstract class FlattenedXmlMapWithXmlNamespaceOutput
     implements
         Built<FlattenedXmlMapWithXmlNamespaceOutput,
             FlattenedXmlMapWithXmlNamespaceOutputBuilder> {
-  factory FlattenedXmlMapWithXmlNamespaceOutput(
-      {_i2.BuiltMap<String, String>? myMap}) {
-    return _$FlattenedXmlMapWithXmlNamespaceOutput._(myMap: myMap);
+  factory FlattenedXmlMapWithXmlNamespaceOutput({Map<String, String>? myMap}) {
+    return _$FlattenedXmlMapWithXmlNamespaceOutput._(
+        myMap: myMap == null ? null : _i2.BuiltMap(myMap));
   }
 
   factory FlattenedXmlMapWithXmlNamespaceOutput.build(

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/http_prefix_headers_input_output.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/http_prefix_headers_input_output.dart
@@ -22,11 +22,11 @@ abstract class HttpPrefixHeadersInputOutput
         _i1.HasPayload<HttpPrefixHeadersInputOutputPayload> {
   factory HttpPrefixHeadersInputOutput({
     String? foo,
-    _i3.BuiltMap<String, String>? fooMap,
+    Map<String, String>? fooMap,
   }) {
     return _$HttpPrefixHeadersInputOutput._(
       foo: foo,
-      fooMap: fooMap,
+      fooMap: fooMap == null ? null : _i3.BuiltMap(fooMap),
     );
   }
 

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/input_and_output_with_headers_io.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/input_and_output_with_headers_io.dart
@@ -3,12 +3,12 @@
 library rest_xml_v2.rest_xml_protocol.model.input_and_output_with_headers_io; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:fixnum/fixnum.dart' as _i5;
+import 'package:fixnum/fixnum.dart' as _i4;
 import 'package:meta/meta.dart' as _i6;
-import 'package:rest_xml_v2/src/rest_xml_protocol/model/foo_enum.dart' as _i4;
+import 'package:rest_xml_v2/src/rest_xml_protocol/model/foo_enum.dart' as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'input_and_output_with_headers_io.g.dart';
@@ -22,39 +22,46 @@ abstract class InputAndOutputWithHeadersIo
         _i1.EmptyPayload,
         _i1.HasPayload<InputAndOutputWithHeadersIoPayload> {
   factory InputAndOutputWithHeadersIo({
-    _i3.BuiltList<bool>? headerBooleanList,
+    List<bool>? headerBooleanList,
     int? headerByte,
     double? headerDouble,
-    _i4.FooEnum? headerEnum,
-    _i3.BuiltList<_i4.FooEnum>? headerEnumList,
+    _i3.FooEnum? headerEnum,
+    List<_i3.FooEnum>? headerEnumList,
     bool? headerFalseBool,
     double? headerFloat,
     int? headerInteger,
-    _i3.BuiltList<int>? headerIntegerList,
-    _i5.Int64? headerLong,
+    List<int>? headerIntegerList,
+    _i4.Int64? headerLong,
     int? headerShort,
     String? headerString,
-    _i3.BuiltList<String>? headerStringList,
-    _i3.BuiltSet<String>? headerStringSet,
-    _i3.BuiltList<DateTime>? headerTimestampList,
+    List<String>? headerStringList,
+    Set<String>? headerStringSet,
+    List<DateTime>? headerTimestampList,
     bool? headerTrueBool,
   }) {
     return _$InputAndOutputWithHeadersIo._(
-      headerBooleanList: headerBooleanList,
+      headerBooleanList:
+          headerBooleanList == null ? null : _i5.BuiltList(headerBooleanList),
       headerByte: headerByte,
       headerDouble: headerDouble,
       headerEnum: headerEnum,
-      headerEnumList: headerEnumList,
+      headerEnumList:
+          headerEnumList == null ? null : _i5.BuiltList(headerEnumList),
       headerFalseBool: headerFalseBool,
       headerFloat: headerFloat,
       headerInteger: headerInteger,
-      headerIntegerList: headerIntegerList,
+      headerIntegerList:
+          headerIntegerList == null ? null : _i5.BuiltList(headerIntegerList),
       headerLong: headerLong,
       headerShort: headerShort,
       headerString: headerString,
-      headerStringList: headerStringList,
-      headerStringSet: headerStringSet,
-      headerTimestampList: headerTimestampList,
+      headerStringList:
+          headerStringList == null ? null : _i5.BuiltList(headerStringList),
+      headerStringSet:
+          headerStringSet == null ? null : _i5.BuiltSet(headerStringSet),
+      headerTimestampList: headerTimestampList == null
+          ? null
+          : _i5.BuiltList(headerTimestampList),
       headerTrueBool: headerTrueBool,
     );
   }
@@ -84,7 +91,7 @@ abstract class InputAndOutputWithHeadersIo
           b.headerInteger = int.parse(request.headers['X-Integer']!);
         }
         if (request.headers['X-Long'] != null) {
-          b.headerLong = _i5.Int64.parseInt(request.headers['X-Long']!);
+          b.headerLong = _i4.Int64.parseInt(request.headers['X-Long']!);
         }
         if (request.headers['X-Float'] != null) {
           b.headerFloat = double.parse(request.headers['X-Float']!);
@@ -130,12 +137,12 @@ abstract class InputAndOutputWithHeadersIo
                   ).asDateTime));
         }
         if (request.headers['X-Enum'] != null) {
-          b.headerEnum = _i4.FooEnum.values.byValue(request.headers['X-Enum']!);
+          b.headerEnum = _i3.FooEnum.values.byValue(request.headers['X-Enum']!);
         }
         if (request.headers['X-EnumList'] != null) {
           b.headerEnumList.addAll(_i1
               .parseHeader(request.headers['X-EnumList']!)
-              .map((el) => _i4.FooEnum.values.byValue(el.trim())));
+              .map((el) => _i3.FooEnum.values.byValue(el.trim())));
         }
       });
 
@@ -158,7 +165,7 @@ abstract class InputAndOutputWithHeadersIo
           b.headerInteger = int.parse(response.headers['X-Integer']!);
         }
         if (response.headers['X-Long'] != null) {
-          b.headerLong = _i5.Int64.parseInt(response.headers['X-Long']!);
+          b.headerLong = _i4.Int64.parseInt(response.headers['X-Long']!);
         }
         if (response.headers['X-Float'] != null) {
           b.headerFloat = double.parse(response.headers['X-Float']!);
@@ -205,12 +212,12 @@ abstract class InputAndOutputWithHeadersIo
         }
         if (response.headers['X-Enum'] != null) {
           b.headerEnum =
-              _i4.FooEnum.values.byValue(response.headers['X-Enum']!);
+              _i3.FooEnum.values.byValue(response.headers['X-Enum']!);
         }
         if (response.headers['X-EnumList'] != null) {
           b.headerEnumList.addAll(_i1
               .parseHeader(response.headers['X-EnumList']!)
-              .map((el) => _i4.FooEnum.values.byValue(el.trim())));
+              .map((el) => _i3.FooEnum.values.byValue(el.trim())));
         }
       });
 
@@ -220,21 +227,21 @@ abstract class InputAndOutputWithHeadersIo
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(InputAndOutputWithHeadersIoBuilder b) {}
-  _i3.BuiltList<bool>? get headerBooleanList;
+  _i5.BuiltList<bool>? get headerBooleanList;
   int? get headerByte;
   double? get headerDouble;
-  _i4.FooEnum? get headerEnum;
-  _i3.BuiltList<_i4.FooEnum>? get headerEnumList;
+  _i3.FooEnum? get headerEnum;
+  _i5.BuiltList<_i3.FooEnum>? get headerEnumList;
   bool? get headerFalseBool;
   double? get headerFloat;
   int? get headerInteger;
-  _i3.BuiltList<int>? get headerIntegerList;
-  _i5.Int64? get headerLong;
+  _i5.BuiltList<int>? get headerIntegerList;
+  _i4.Int64? get headerLong;
   int? get headerShort;
   String? get headerString;
-  _i3.BuiltList<String>? get headerStringList;
-  _i3.BuiltSet<String>? get headerStringSet;
-  _i3.BuiltList<DateTime>? get headerTimestampList;
+  _i5.BuiltList<String>? get headerStringList;
+  _i5.BuiltSet<String>? get headerStringSet;
+  _i5.BuiltList<DateTime>? get headerTimestampList;
   bool? get headerTrueBool;
   @override
   InputAndOutputWithHeadersIoPayload getPayload() =>

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/input_and_output_with_headers_io.g.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/input_and_output_with_headers_io.g.dart
@@ -8,15 +8,15 @@ part of rest_xml_v2.rest_xml_protocol.model.input_and_output_with_headers_io;
 
 class _$InputAndOutputWithHeadersIo extends InputAndOutputWithHeadersIo {
   @override
-  final _i3.BuiltList<bool>? headerBooleanList;
+  final _i5.BuiltList<bool>? headerBooleanList;
   @override
   final int? headerByte;
   @override
   final double? headerDouble;
   @override
-  final _i4.FooEnum? headerEnum;
+  final _i3.FooEnum? headerEnum;
   @override
-  final _i3.BuiltList<_i4.FooEnum>? headerEnumList;
+  final _i5.BuiltList<_i3.FooEnum>? headerEnumList;
   @override
   final bool? headerFalseBool;
   @override
@@ -24,19 +24,19 @@ class _$InputAndOutputWithHeadersIo extends InputAndOutputWithHeadersIo {
   @override
   final int? headerInteger;
   @override
-  final _i3.BuiltList<int>? headerIntegerList;
+  final _i5.BuiltList<int>? headerIntegerList;
   @override
-  final _i5.Int64? headerLong;
+  final _i4.Int64? headerLong;
   @override
   final int? headerShort;
   @override
   final String? headerString;
   @override
-  final _i3.BuiltList<String>? headerStringList;
+  final _i5.BuiltList<String>? headerStringList;
   @override
-  final _i3.BuiltSet<String>? headerStringSet;
+  final _i5.BuiltSet<String>? headerStringSet;
   @override
-  final _i3.BuiltList<DateTime>? headerTimestampList;
+  final _i5.BuiltList<DateTime>? headerTimestampList;
   @override
   final bool? headerTrueBool;
 
@@ -141,10 +141,10 @@ class InputAndOutputWithHeadersIoBuilder
             InputAndOutputWithHeadersIoBuilder> {
   _$InputAndOutputWithHeadersIo? _$v;
 
-  _i3.ListBuilder<bool>? _headerBooleanList;
-  _i3.ListBuilder<bool> get headerBooleanList =>
-      _$this._headerBooleanList ??= new _i3.ListBuilder<bool>();
-  set headerBooleanList(_i3.ListBuilder<bool>? headerBooleanList) =>
+  _i5.ListBuilder<bool>? _headerBooleanList;
+  _i5.ListBuilder<bool> get headerBooleanList =>
+      _$this._headerBooleanList ??= new _i5.ListBuilder<bool>();
+  set headerBooleanList(_i5.ListBuilder<bool>? headerBooleanList) =>
       _$this._headerBooleanList = headerBooleanList;
 
   int? _headerByte;
@@ -155,14 +155,14 @@ class InputAndOutputWithHeadersIoBuilder
   double? get headerDouble => _$this._headerDouble;
   set headerDouble(double? headerDouble) => _$this._headerDouble = headerDouble;
 
-  _i4.FooEnum? _headerEnum;
-  _i4.FooEnum? get headerEnum => _$this._headerEnum;
-  set headerEnum(_i4.FooEnum? headerEnum) => _$this._headerEnum = headerEnum;
+  _i3.FooEnum? _headerEnum;
+  _i3.FooEnum? get headerEnum => _$this._headerEnum;
+  set headerEnum(_i3.FooEnum? headerEnum) => _$this._headerEnum = headerEnum;
 
-  _i3.ListBuilder<_i4.FooEnum>? _headerEnumList;
-  _i3.ListBuilder<_i4.FooEnum> get headerEnumList =>
-      _$this._headerEnumList ??= new _i3.ListBuilder<_i4.FooEnum>();
-  set headerEnumList(_i3.ListBuilder<_i4.FooEnum>? headerEnumList) =>
+  _i5.ListBuilder<_i3.FooEnum>? _headerEnumList;
+  _i5.ListBuilder<_i3.FooEnum> get headerEnumList =>
+      _$this._headerEnumList ??= new _i5.ListBuilder<_i3.FooEnum>();
+  set headerEnumList(_i5.ListBuilder<_i3.FooEnum>? headerEnumList) =>
       _$this._headerEnumList = headerEnumList;
 
   bool? _headerFalseBool;
@@ -179,15 +179,15 @@ class InputAndOutputWithHeadersIoBuilder
   set headerInteger(int? headerInteger) =>
       _$this._headerInteger = headerInteger;
 
-  _i3.ListBuilder<int>? _headerIntegerList;
-  _i3.ListBuilder<int> get headerIntegerList =>
-      _$this._headerIntegerList ??= new _i3.ListBuilder<int>();
-  set headerIntegerList(_i3.ListBuilder<int>? headerIntegerList) =>
+  _i5.ListBuilder<int>? _headerIntegerList;
+  _i5.ListBuilder<int> get headerIntegerList =>
+      _$this._headerIntegerList ??= new _i5.ListBuilder<int>();
+  set headerIntegerList(_i5.ListBuilder<int>? headerIntegerList) =>
       _$this._headerIntegerList = headerIntegerList;
 
-  _i5.Int64? _headerLong;
-  _i5.Int64? get headerLong => _$this._headerLong;
-  set headerLong(_i5.Int64? headerLong) => _$this._headerLong = headerLong;
+  _i4.Int64? _headerLong;
+  _i4.Int64? get headerLong => _$this._headerLong;
+  set headerLong(_i4.Int64? headerLong) => _$this._headerLong = headerLong;
 
   int? _headerShort;
   int? get headerShort => _$this._headerShort;
@@ -197,22 +197,22 @@ class InputAndOutputWithHeadersIoBuilder
   String? get headerString => _$this._headerString;
   set headerString(String? headerString) => _$this._headerString = headerString;
 
-  _i3.ListBuilder<String>? _headerStringList;
-  _i3.ListBuilder<String> get headerStringList =>
-      _$this._headerStringList ??= new _i3.ListBuilder<String>();
-  set headerStringList(_i3.ListBuilder<String>? headerStringList) =>
+  _i5.ListBuilder<String>? _headerStringList;
+  _i5.ListBuilder<String> get headerStringList =>
+      _$this._headerStringList ??= new _i5.ListBuilder<String>();
+  set headerStringList(_i5.ListBuilder<String>? headerStringList) =>
       _$this._headerStringList = headerStringList;
 
-  _i3.SetBuilder<String>? _headerStringSet;
-  _i3.SetBuilder<String> get headerStringSet =>
-      _$this._headerStringSet ??= new _i3.SetBuilder<String>();
-  set headerStringSet(_i3.SetBuilder<String>? headerStringSet) =>
+  _i5.SetBuilder<String>? _headerStringSet;
+  _i5.SetBuilder<String> get headerStringSet =>
+      _$this._headerStringSet ??= new _i5.SetBuilder<String>();
+  set headerStringSet(_i5.SetBuilder<String>? headerStringSet) =>
       _$this._headerStringSet = headerStringSet;
 
-  _i3.ListBuilder<DateTime>? _headerTimestampList;
-  _i3.ListBuilder<DateTime> get headerTimestampList =>
-      _$this._headerTimestampList ??= new _i3.ListBuilder<DateTime>();
-  set headerTimestampList(_i3.ListBuilder<DateTime>? headerTimestampList) =>
+  _i5.ListBuilder<DateTime>? _headerTimestampList;
+  _i5.ListBuilder<DateTime> get headerTimestampList =>
+      _$this._headerTimestampList ??= new _i5.ListBuilder<DateTime>();
+  set headerTimestampList(_i5.ListBuilder<DateTime>? headerTimestampList) =>
       _$this._headerTimestampList = headerTimestampList;
 
   bool? _headerTrueBool;

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/nested_xml_maps_input_output.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/nested_xml_maps_input_output.dart
@@ -3,10 +3,10 @@
 library rest_xml_v2.rest_xml_protocol.model.nested_xml_maps_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:rest_xml_v2/src/rest_xml_protocol/model/foo_enum.dart' as _i4;
+import 'package:rest_xml_v2/src/rest_xml_protocol/model/foo_enum.dart' as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'nested_xml_maps_input_output.g.dart';
@@ -18,12 +18,30 @@ abstract class NestedXmlMapsInputOutput
     implements
         Built<NestedXmlMapsInputOutput, NestedXmlMapsInputOutputBuilder> {
   factory NestedXmlMapsInputOutput({
-    _i3.BuiltMap<String, _i3.BuiltMap<String, _i4.FooEnum>>? flatNestedMap,
-    _i3.BuiltMap<String, _i3.BuiltMap<String, _i4.FooEnum>>? nestedMap,
+    Map<String, Map<String, _i3.FooEnum>>? flatNestedMap,
+    Map<String, Map<String, _i3.FooEnum>>? nestedMap,
   }) {
     return _$NestedXmlMapsInputOutput._(
-      flatNestedMap: flatNestedMap,
-      nestedMap: nestedMap,
+      flatNestedMap: flatNestedMap == null
+          ? null
+          : _i4.BuiltMap(flatNestedMap.map((
+              key,
+              value,
+            ) =>
+              MapEntry(
+                key,
+                _i4.BuiltMap(value),
+              ))),
+      nestedMap: nestedMap == null
+          ? null
+          : _i4.BuiltMap(nestedMap.map((
+              key,
+              value,
+            ) =>
+              MapEntry(
+                key,
+                _i4.BuiltMap(value),
+              ))),
     );
   }
 
@@ -53,8 +71,8 @@ abstract class NestedXmlMapsInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(NestedXmlMapsInputOutputBuilder b) {}
-  _i3.BuiltMap<String, _i3.BuiltMap<String, _i4.FooEnum>>? get flatNestedMap;
-  _i3.BuiltMap<String, _i3.BuiltMap<String, _i4.FooEnum>>? get nestedMap;
+  _i4.BuiltMap<String, _i4.BuiltMap<String, _i3.FooEnum>>? get flatNestedMap;
+  _i4.BuiltMap<String, _i4.BuiltMap<String, _i3.FooEnum>>? get nestedMap;
   @override
   NestedXmlMapsInputOutput getPayload() => this;
   @override
@@ -115,14 +133,14 @@ class NestedXmlMapsInputOutputRestXmlSerializer
                       serializers,
                       (value as Iterable<Object?>),
                       specifiedType: const FullType(
-                        _i3.BuiltMap,
+                        _i4.BuiltMap,
                         [
                           FullType(String),
                           FullType(
-                            _i3.BuiltMap,
+                            _i4.BuiltMap,
                             [
                               FullType(String),
-                              FullType(_i4.FooEnum),
+                              FullType(_i3.FooEnum),
                             ],
                           ),
                         ],
@@ -139,14 +157,14 @@ class NestedXmlMapsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
                   FullType(
-                    _i3.BuiltMap,
+                    _i4.BuiltMap,
                     [
                       FullType(String),
-                      FullType(_i4.FooEnum),
+                      FullType(_i3.FooEnum),
                     ],
                   ),
                 ],
@@ -177,14 +195,14 @@ class NestedXmlMapsInputOutputRestXmlSerializer
         serializers,
         payload.flatNestedMap!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltMap,
+          _i4.BuiltMap,
           [
             FullType(String),
             FullType(
-              _i3.BuiltMap,
+              _i4.BuiltMap,
               [
                 FullType(String),
-                FullType(_i4.FooEnum),
+                FullType(_i3.FooEnum),
               ],
             ),
           ],
@@ -198,14 +216,14 @@ class NestedXmlMapsInputOutputRestXmlSerializer
           serializers,
           payload.nestedMap!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
               FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FooEnum),
+                  FullType(_i3.FooEnum),
                 ],
               ),
             ],

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/nested_xml_maps_input_output.g.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/nested_xml_maps_input_output.g.dart
@@ -8,9 +8,9 @@ part of rest_xml_v2.rest_xml_protocol.model.nested_xml_maps_input_output;
 
 class _$NestedXmlMapsInputOutput extends NestedXmlMapsInputOutput {
   @override
-  final _i3.BuiltMap<String, _i3.BuiltMap<String, _i4.FooEnum>>? flatNestedMap;
+  final _i4.BuiltMap<String, _i4.BuiltMap<String, _i3.FooEnum>>? flatNestedMap;
   @override
-  final _i3.BuiltMap<String, _i3.BuiltMap<String, _i4.FooEnum>>? nestedMap;
+  final _i4.BuiltMap<String, _i4.BuiltMap<String, _i3.FooEnum>>? nestedMap;
 
   factory _$NestedXmlMapsInputOutput(
           [void Function(NestedXmlMapsInputOutputBuilder)? updates]) =>
@@ -47,21 +47,21 @@ class NestedXmlMapsInputOutputBuilder
         Builder<NestedXmlMapsInputOutput, NestedXmlMapsInputOutputBuilder> {
   _$NestedXmlMapsInputOutput? _$v;
 
-  _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>>? _flatNestedMap;
-  _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>> get flatNestedMap =>
+  _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>>? _flatNestedMap;
+  _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>> get flatNestedMap =>
       _$this._flatNestedMap ??=
-          new _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>>();
+          new _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>>();
   set flatNestedMap(
-          _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>>?
+          _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>>?
               flatNestedMap) =>
       _$this._flatNestedMap = flatNestedMap;
 
-  _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>>? _nestedMap;
-  _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>> get nestedMap =>
+  _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>>? _nestedMap;
+  _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>> get nestedMap =>
       _$this._nestedMap ??=
-          new _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>>();
+          new _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>>();
   set nestedMap(
-          _i3.MapBuilder<String, _i3.BuiltMap<String, _i4.FooEnum>>?
+          _i4.MapBuilder<String, _i4.BuiltMap<String, _i3.FooEnum>>?
               nestedMap) =>
       _$this._nestedMap = nestedMap;
 

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/null_and_empty_headers_io.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/null_and_empty_headers_io.dart
@@ -22,12 +22,12 @@ abstract class NullAndEmptyHeadersIo
   factory NullAndEmptyHeadersIo({
     String? a,
     String? b,
-    _i3.BuiltList<String>? c,
+    List<String>? c,
   }) {
     return _$NullAndEmptyHeadersIo._(
       a: a,
       b: b,
-      c: c,
+      c: c == null ? null : _i3.BuiltList(c),
     );
   }
 

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/query_params_as_string_list_map_input.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/query_params_as_string_list_map_input.dart
@@ -21,11 +21,11 @@ abstract class QueryParamsAsStringListMapInput
         _i1.EmptyPayload,
         _i1.HasPayload<QueryParamsAsStringListMapInputPayload> {
   factory QueryParamsAsStringListMapInput({
-    _i3.BuiltListMultimap<String, String>? foo,
+    Map<String, List<String>>? foo,
     String? qux,
   }) {
     return _$QueryParamsAsStringListMapInput._(
-      foo: foo,
+      foo: foo == null ? null : _i3.BuiltListMultimap(foo),
       qux: qux,
     );
   }

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/query_precedence_input.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/query_precedence_input.dart
@@ -20,11 +20,11 @@ abstract class QueryPrecedenceInput
         _i1.EmptyPayload,
         _i1.HasPayload<QueryPrecedenceInputPayload> {
   factory QueryPrecedenceInput({
-    _i3.BuiltMap<String, String>? baz,
+    Map<String, String>? baz,
     String? foo,
   }) {
     return _$QueryPrecedenceInput._(
-      baz: baz,
+      baz: baz == null ? null : _i3.BuiltMap(baz),
       foo: foo,
     );
   }

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/scoped_config.dart
@@ -3,17 +3,17 @@
 library rest_xml_v2.rest_xml_protocol.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_xml_v2/src/rest_xml_protocol/model/client_config.dart'
     as _i2;
 import 'package:rest_xml_v2/src/rest_xml_protocol/model/environment_config.dart'
-    as _i5;
-import 'package:rest_xml_v2/src/rest_xml_protocol/model/file_config_settings.dart'
     as _i4;
+import 'package:rest_xml_v2/src/rest_xml_protocol/model/file_config_settings.dart'
+    as _i3;
 import 'package:rest_xml_v2/src/rest_xml_protocol/model/operation_config.dart'
-    as _i6;
+    as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -25,15 +25,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -56,16 +57,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -145,10 +146,10 @@ class ScopedConfigRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
             ));
@@ -161,10 +162,10 @@ class ScopedConfigRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
             ));
@@ -174,16 +175,16 @@ class ScopedConfigRestXmlSerializer
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -215,10 +216,10 @@ class ScopedConfigRestXmlSerializer
           serializers,
           payload.configFile!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -230,10 +231,10 @@ class ScopedConfigRestXmlSerializer
           serializers,
           payload.credentialsFile!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -243,7 +244,7 @@ class ScopedConfigRestXmlSerializer
         ..add(const _i7.XmlElementName('environment'))
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -251,7 +252,7 @@ class ScopedConfigRestXmlSerializer
         ..add(const _i7.XmlElementName('operation'))
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_enums_input_output.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_enums_input_output.dart
@@ -20,17 +20,17 @@ abstract class XmlEnumsInputOutput
     _i3.FooEnum? fooEnum1,
     _i3.FooEnum? fooEnum2,
     _i3.FooEnum? fooEnum3,
-    _i4.BuiltList<_i3.FooEnum>? fooEnumList,
-    _i4.BuiltMap<String, _i3.FooEnum>? fooEnumMap,
-    _i4.BuiltSet<_i3.FooEnum>? fooEnumSet,
+    List<_i3.FooEnum>? fooEnumList,
+    Map<String, _i3.FooEnum>? fooEnumMap,
+    Set<_i3.FooEnum>? fooEnumSet,
   }) {
     return _$XmlEnumsInputOutput._(
       fooEnum1: fooEnum1,
       fooEnum2: fooEnum2,
       fooEnum3: fooEnum3,
-      fooEnumList: fooEnumList,
-      fooEnumMap: fooEnumMap,
-      fooEnumSet: fooEnumSet,
+      fooEnumList: fooEnumList == null ? null : _i4.BuiltList(fooEnumList),
+      fooEnumMap: fooEnumMap == null ? null : _i4.BuiltMap(fooEnumMap),
+      fooEnumSet: fooEnumSet == null ? null : _i4.BuiltSet(fooEnumSet),
     );
   }
 

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_lists_input_output.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_lists_input_output.dart
@@ -3,12 +3,12 @@
 library rest_xml_v2.rest_xml_protocol.model.xml_lists_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:rest_xml_v2/src/rest_xml_protocol/model/foo_enum.dart' as _i4;
+import 'package:rest_xml_v2/src/rest_xml_protocol/model/foo_enum.dart' as _i3;
 import 'package:rest_xml_v2/src/rest_xml_protocol/model/structure_list_member.dart'
-    as _i5;
+    as _i4;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'xml_lists_input_output.g.dart';
@@ -19,36 +19,49 @@ abstract class XmlListsInputOutput
         _i2.AWSEquatable<XmlListsInputOutput>
     implements Built<XmlListsInputOutput, XmlListsInputOutputBuilder> {
   factory XmlListsInputOutput({
-    _i3.BuiltList<bool>? booleanList,
-    _i3.BuiltList<_i4.FooEnum>? enumList,
-    _i3.BuiltList<String>? flattenedList,
-    _i3.BuiltList<String>? flattenedList2,
-    _i3.BuiltList<String>? flattenedListWithMemberNamespace,
-    _i3.BuiltList<String>? flattenedListWithNamespace,
-    _i3.BuiltList<_i5.StructureListMember>? flattenedStructureList,
-    _i3.BuiltList<int>? integerList,
-    _i3.BuiltList<_i3.BuiltList<String>>? nestedStringList,
-    _i3.BuiltList<String>? renamedListMembers,
-    _i3.BuiltList<String>? stringList,
-    _i3.BuiltSet<String>? stringSet,
-    _i3.BuiltList<_i5.StructureListMember>? structureList,
-    _i3.BuiltList<DateTime>? timestampList,
+    List<bool>? booleanList,
+    List<_i3.FooEnum>? enumList,
+    List<String>? flattenedList,
+    List<String>? flattenedList2,
+    List<String>? flattenedListWithMemberNamespace,
+    List<String>? flattenedListWithNamespace,
+    List<_i4.StructureListMember>? flattenedStructureList,
+    List<int>? integerList,
+    List<List<String>>? nestedStringList,
+    List<String>? renamedListMembers,
+    List<String>? stringList,
+    Set<String>? stringSet,
+    List<_i4.StructureListMember>? structureList,
+    List<DateTime>? timestampList,
   }) {
     return _$XmlListsInputOutput._(
-      booleanList: booleanList,
-      enumList: enumList,
-      flattenedList: flattenedList,
-      flattenedList2: flattenedList2,
-      flattenedListWithMemberNamespace: flattenedListWithMemberNamespace,
-      flattenedListWithNamespace: flattenedListWithNamespace,
-      flattenedStructureList: flattenedStructureList,
-      integerList: integerList,
-      nestedStringList: nestedStringList,
-      renamedListMembers: renamedListMembers,
-      stringList: stringList,
-      stringSet: stringSet,
-      structureList: structureList,
-      timestampList: timestampList,
+      booleanList: booleanList == null ? null : _i5.BuiltList(booleanList),
+      enumList: enumList == null ? null : _i5.BuiltList(enumList),
+      flattenedList:
+          flattenedList == null ? null : _i5.BuiltList(flattenedList),
+      flattenedList2:
+          flattenedList2 == null ? null : _i5.BuiltList(flattenedList2),
+      flattenedListWithMemberNamespace: flattenedListWithMemberNamespace == null
+          ? null
+          : _i5.BuiltList(flattenedListWithMemberNamespace),
+      flattenedListWithNamespace: flattenedListWithNamespace == null
+          ? null
+          : _i5.BuiltList(flattenedListWithNamespace),
+      flattenedStructureList: flattenedStructureList == null
+          ? null
+          : _i5.BuiltList(flattenedStructureList),
+      integerList: integerList == null ? null : _i5.BuiltList(integerList),
+      nestedStringList: nestedStringList == null
+          ? null
+          : _i5.BuiltList(nestedStringList.map((el) => _i5.BuiltList(el))),
+      renamedListMembers:
+          renamedListMembers == null ? null : _i5.BuiltList(renamedListMembers),
+      stringList: stringList == null ? null : _i5.BuiltList(stringList),
+      stringSet: stringSet == null ? null : _i5.BuiltSet(stringSet),
+      structureList:
+          structureList == null ? null : _i5.BuiltList(structureList),
+      timestampList:
+          timestampList == null ? null : _i5.BuiltList(timestampList),
     );
   }
 
@@ -78,22 +91,22 @@ abstract class XmlListsInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(XmlListsInputOutputBuilder b) {}
-  _i3.BuiltList<bool>? get booleanList;
-  _i3.BuiltList<_i4.FooEnum>? get enumList;
-  _i3.BuiltList<String>? get flattenedList;
-  _i3.BuiltList<String>? get flattenedList2;
-  _i3.BuiltList<String>? get flattenedListWithMemberNamespace;
-  _i3.BuiltList<String>? get flattenedListWithNamespace;
-  _i3.BuiltList<_i5.StructureListMember>? get flattenedStructureList;
-  _i3.BuiltList<int>? get integerList;
+  _i5.BuiltList<bool>? get booleanList;
+  _i5.BuiltList<_i3.FooEnum>? get enumList;
+  _i5.BuiltList<String>? get flattenedList;
+  _i5.BuiltList<String>? get flattenedList2;
+  _i5.BuiltList<String>? get flattenedListWithMemberNamespace;
+  _i5.BuiltList<String>? get flattenedListWithNamespace;
+  _i5.BuiltList<_i4.StructureListMember>? get flattenedStructureList;
+  _i5.BuiltList<int>? get integerList;
 
   /// A list of lists of strings.
-  _i3.BuiltList<_i3.BuiltList<String>>? get nestedStringList;
-  _i3.BuiltList<String>? get renamedListMembers;
-  _i3.BuiltList<String>? get stringList;
-  _i3.BuiltSet<String>? get stringSet;
-  _i3.BuiltList<_i5.StructureListMember>? get structureList;
-  _i3.BuiltList<DateTime>? get timestampList;
+  _i5.BuiltList<_i5.BuiltList<String>>? get nestedStringList;
+  _i5.BuiltList<String>? get renamedListMembers;
+  _i5.BuiltList<String>? get stringList;
+  _i5.BuiltSet<String>? get stringSet;
+  _i5.BuiltList<_i4.StructureListMember>? get structureList;
+  _i5.BuiltList<DateTime>? get timestampList;
   @override
   XmlListsInputOutput getPayload() => this;
   @override
@@ -212,10 +225,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(bool)],
               ),
-            ) as _i3.BuiltList<bool>));
+            ) as _i5.BuiltList<bool>));
           }
           break;
         case 'enumList':
@@ -225,10 +238,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
-                [FullType(_i4.FooEnum)],
+                _i5.BuiltList,
+                [FullType(_i3.FooEnum)],
               ),
-            ) as _i3.BuiltList<_i4.FooEnum>));
+            ) as _i5.BuiltList<_i3.FooEnum>));
           }
           break;
         case 'flattenedList':
@@ -268,8 +281,8 @@ class XmlListsInputOutputRestXmlSerializer
           if (value != null) {
             result.flattenedStructureList.add((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.StructureListMember),
-            ) as _i5.StructureListMember));
+              specifiedType: const FullType(_i4.StructureListMember),
+            ) as _i4.StructureListMember));
           }
           break;
         case 'integerList':
@@ -279,10 +292,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(int)],
               ),
-            ) as _i3.BuiltList<int>));
+            ) as _i5.BuiltList<int>));
           }
           break;
         case 'nestedStringList':
@@ -292,15 +305,15 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [
                   FullType(
-                    _i3.BuiltList,
+                    _i5.BuiltList,
                     [FullType(String)],
                   )
                 ],
               ),
-            ) as _i3.BuiltList<_i3.BuiltList<String>>));
+            ) as _i5.BuiltList<_i5.BuiltList<String>>));
           }
           break;
         case 'renamed':
@@ -311,10 +324,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltList<String>));
+            ) as _i5.BuiltList<String>));
           }
           break;
         case 'stringList':
@@ -324,10 +337,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltList<String>));
+            ) as _i5.BuiltList<String>));
           }
           break;
         case 'stringSet':
@@ -337,10 +350,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltSet,
+                _i5.BuiltSet,
                 [FullType(String)],
               ),
-            ) as _i3.BuiltSet<String>));
+            ) as _i5.BuiltSet<String>));
           }
           break;
         case 'myStructureList':
@@ -351,10 +364,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
-                [FullType(_i5.StructureListMember)],
+                _i5.BuiltList,
+                [FullType(_i4.StructureListMember)],
               ),
-            ) as _i3.BuiltList<_i5.StructureListMember>));
+            ) as _i5.BuiltList<_i4.StructureListMember>));
           }
           break;
         case 'timestampList':
@@ -364,10 +377,10 @@ class XmlListsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(DateTime)],
               ),
-            ) as _i3.BuiltList<DateTime>));
+            ) as _i5.BuiltList<DateTime>));
           }
           break;
       }
@@ -391,7 +404,7 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.booleanList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(bool)],
           ),
         ));
@@ -403,8 +416,8 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.enumList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
-            [FullType(_i4.FooEnum)],
+            _i5.BuiltList,
+            [FullType(_i3.FooEnum)],
           ),
         ));
     }
@@ -415,7 +428,7 @@ class XmlListsInputOutputRestXmlSerializer
         serializers,
         payload.flattenedList!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltList,
+          _i5.BuiltList,
           [FullType(String)],
         ),
       ));
@@ -426,7 +439,7 @@ class XmlListsInputOutputRestXmlSerializer
         serializers,
         payload.flattenedList2!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltList,
+          _i5.BuiltList,
           [FullType(String)],
         ),
       ));
@@ -439,7 +452,7 @@ class XmlListsInputOutputRestXmlSerializer
         serializers,
         payload.flattenedListWithMemberNamespace!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltList,
+          _i5.BuiltList,
           [FullType(String)],
         ),
       ));
@@ -451,7 +464,7 @@ class XmlListsInputOutputRestXmlSerializer
         serializers,
         payload.flattenedListWithNamespace!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltList,
+          _i5.BuiltList,
           [FullType(String)],
         ),
       ));
@@ -463,8 +476,8 @@ class XmlListsInputOutputRestXmlSerializer
         serializers,
         payload.flattenedStructureList!,
         specifiedType: const FullType.nullable(
-          _i3.BuiltList,
-          [FullType(_i5.StructureListMember)],
+          _i5.BuiltList,
+          [FullType(_i4.StructureListMember)],
         ),
       ));
     }
@@ -475,7 +488,7 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.integerList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(int)],
           ),
         ));
@@ -487,10 +500,10 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.nestedStringList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [
               FullType(
-                _i3.BuiltList,
+                _i5.BuiltList,
                 [FullType(String)],
               )
             ],
@@ -504,7 +517,7 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.renamedListMembers!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(String)],
           ),
         ));
@@ -516,7 +529,7 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.stringList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(String)],
           ),
         ));
@@ -528,7 +541,7 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.stringSet!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltSet,
+            _i5.BuiltSet,
             [FullType(String)],
           ),
         ));
@@ -540,8 +553,8 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.structureList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
-            [FullType(_i5.StructureListMember)],
+            _i5.BuiltList,
+            [FullType(_i4.StructureListMember)],
           ),
         ));
     }
@@ -552,7 +565,7 @@ class XmlListsInputOutputRestXmlSerializer
           serializers,
           payload.timestampList!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltList,
+            _i5.BuiltList,
             [FullType(DateTime)],
           ),
         ));

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_lists_input_output.g.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_lists_input_output.g.dart
@@ -8,33 +8,33 @@ part of rest_xml_v2.rest_xml_protocol.model.xml_lists_input_output;
 
 class _$XmlListsInputOutput extends XmlListsInputOutput {
   @override
-  final _i3.BuiltList<bool>? booleanList;
+  final _i5.BuiltList<bool>? booleanList;
   @override
-  final _i3.BuiltList<_i4.FooEnum>? enumList;
+  final _i5.BuiltList<_i3.FooEnum>? enumList;
   @override
-  final _i3.BuiltList<String>? flattenedList;
+  final _i5.BuiltList<String>? flattenedList;
   @override
-  final _i3.BuiltList<String>? flattenedList2;
+  final _i5.BuiltList<String>? flattenedList2;
   @override
-  final _i3.BuiltList<String>? flattenedListWithMemberNamespace;
+  final _i5.BuiltList<String>? flattenedListWithMemberNamespace;
   @override
-  final _i3.BuiltList<String>? flattenedListWithNamespace;
+  final _i5.BuiltList<String>? flattenedListWithNamespace;
   @override
-  final _i3.BuiltList<_i5.StructureListMember>? flattenedStructureList;
+  final _i5.BuiltList<_i4.StructureListMember>? flattenedStructureList;
   @override
-  final _i3.BuiltList<int>? integerList;
+  final _i5.BuiltList<int>? integerList;
   @override
-  final _i3.BuiltList<_i3.BuiltList<String>>? nestedStringList;
+  final _i5.BuiltList<_i5.BuiltList<String>>? nestedStringList;
   @override
-  final _i3.BuiltList<String>? renamedListMembers;
+  final _i5.BuiltList<String>? renamedListMembers;
   @override
-  final _i3.BuiltList<String>? stringList;
+  final _i5.BuiltList<String>? stringList;
   @override
-  final _i3.BuiltSet<String>? stringSet;
+  final _i5.BuiltSet<String>? stringSet;
   @override
-  final _i3.BuiltList<_i5.StructureListMember>? structureList;
+  final _i5.BuiltList<_i4.StructureListMember>? structureList;
   @override
-  final _i3.BuiltList<DateTime>? timestampList;
+  final _i5.BuiltList<DateTime>? timestampList;
 
   factory _$XmlListsInputOutput(
           [void Function(XmlListsInputOutputBuilder)? updates]) =>
@@ -127,95 +127,95 @@ class XmlListsInputOutputBuilder
     implements Builder<XmlListsInputOutput, XmlListsInputOutputBuilder> {
   _$XmlListsInputOutput? _$v;
 
-  _i3.ListBuilder<bool>? _booleanList;
-  _i3.ListBuilder<bool> get booleanList =>
-      _$this._booleanList ??= new _i3.ListBuilder<bool>();
-  set booleanList(_i3.ListBuilder<bool>? booleanList) =>
+  _i5.ListBuilder<bool>? _booleanList;
+  _i5.ListBuilder<bool> get booleanList =>
+      _$this._booleanList ??= new _i5.ListBuilder<bool>();
+  set booleanList(_i5.ListBuilder<bool>? booleanList) =>
       _$this._booleanList = booleanList;
 
-  _i3.ListBuilder<_i4.FooEnum>? _enumList;
-  _i3.ListBuilder<_i4.FooEnum> get enumList =>
-      _$this._enumList ??= new _i3.ListBuilder<_i4.FooEnum>();
-  set enumList(_i3.ListBuilder<_i4.FooEnum>? enumList) =>
+  _i5.ListBuilder<_i3.FooEnum>? _enumList;
+  _i5.ListBuilder<_i3.FooEnum> get enumList =>
+      _$this._enumList ??= new _i5.ListBuilder<_i3.FooEnum>();
+  set enumList(_i5.ListBuilder<_i3.FooEnum>? enumList) =>
       _$this._enumList = enumList;
 
-  _i3.ListBuilder<String>? _flattenedList;
-  _i3.ListBuilder<String> get flattenedList =>
-      _$this._flattenedList ??= new _i3.ListBuilder<String>();
-  set flattenedList(_i3.ListBuilder<String>? flattenedList) =>
+  _i5.ListBuilder<String>? _flattenedList;
+  _i5.ListBuilder<String> get flattenedList =>
+      _$this._flattenedList ??= new _i5.ListBuilder<String>();
+  set flattenedList(_i5.ListBuilder<String>? flattenedList) =>
       _$this._flattenedList = flattenedList;
 
-  _i3.ListBuilder<String>? _flattenedList2;
-  _i3.ListBuilder<String> get flattenedList2 =>
-      _$this._flattenedList2 ??= new _i3.ListBuilder<String>();
-  set flattenedList2(_i3.ListBuilder<String>? flattenedList2) =>
+  _i5.ListBuilder<String>? _flattenedList2;
+  _i5.ListBuilder<String> get flattenedList2 =>
+      _$this._flattenedList2 ??= new _i5.ListBuilder<String>();
+  set flattenedList2(_i5.ListBuilder<String>? flattenedList2) =>
       _$this._flattenedList2 = flattenedList2;
 
-  _i3.ListBuilder<String>? _flattenedListWithMemberNamespace;
-  _i3.ListBuilder<String> get flattenedListWithMemberNamespace =>
+  _i5.ListBuilder<String>? _flattenedListWithMemberNamespace;
+  _i5.ListBuilder<String> get flattenedListWithMemberNamespace =>
       _$this._flattenedListWithMemberNamespace ??=
-          new _i3.ListBuilder<String>();
+          new _i5.ListBuilder<String>();
   set flattenedListWithMemberNamespace(
-          _i3.ListBuilder<String>? flattenedListWithMemberNamespace) =>
+          _i5.ListBuilder<String>? flattenedListWithMemberNamespace) =>
       _$this._flattenedListWithMemberNamespace =
           flattenedListWithMemberNamespace;
 
-  _i3.ListBuilder<String>? _flattenedListWithNamespace;
-  _i3.ListBuilder<String> get flattenedListWithNamespace =>
-      _$this._flattenedListWithNamespace ??= new _i3.ListBuilder<String>();
+  _i5.ListBuilder<String>? _flattenedListWithNamespace;
+  _i5.ListBuilder<String> get flattenedListWithNamespace =>
+      _$this._flattenedListWithNamespace ??= new _i5.ListBuilder<String>();
   set flattenedListWithNamespace(
-          _i3.ListBuilder<String>? flattenedListWithNamespace) =>
+          _i5.ListBuilder<String>? flattenedListWithNamespace) =>
       _$this._flattenedListWithNamespace = flattenedListWithNamespace;
 
-  _i3.ListBuilder<_i5.StructureListMember>? _flattenedStructureList;
-  _i3.ListBuilder<_i5.StructureListMember> get flattenedStructureList =>
+  _i5.ListBuilder<_i4.StructureListMember>? _flattenedStructureList;
+  _i5.ListBuilder<_i4.StructureListMember> get flattenedStructureList =>
       _$this._flattenedStructureList ??=
-          new _i3.ListBuilder<_i5.StructureListMember>();
+          new _i5.ListBuilder<_i4.StructureListMember>();
   set flattenedStructureList(
-          _i3.ListBuilder<_i5.StructureListMember>? flattenedStructureList) =>
+          _i5.ListBuilder<_i4.StructureListMember>? flattenedStructureList) =>
       _$this._flattenedStructureList = flattenedStructureList;
 
-  _i3.ListBuilder<int>? _integerList;
-  _i3.ListBuilder<int> get integerList =>
-      _$this._integerList ??= new _i3.ListBuilder<int>();
-  set integerList(_i3.ListBuilder<int>? integerList) =>
+  _i5.ListBuilder<int>? _integerList;
+  _i5.ListBuilder<int> get integerList =>
+      _$this._integerList ??= new _i5.ListBuilder<int>();
+  set integerList(_i5.ListBuilder<int>? integerList) =>
       _$this._integerList = integerList;
 
-  _i3.ListBuilder<_i3.BuiltList<String>>? _nestedStringList;
-  _i3.ListBuilder<_i3.BuiltList<String>> get nestedStringList =>
-      _$this._nestedStringList ??= new _i3.ListBuilder<_i3.BuiltList<String>>();
+  _i5.ListBuilder<_i5.BuiltList<String>>? _nestedStringList;
+  _i5.ListBuilder<_i5.BuiltList<String>> get nestedStringList =>
+      _$this._nestedStringList ??= new _i5.ListBuilder<_i5.BuiltList<String>>();
   set nestedStringList(
-          _i3.ListBuilder<_i3.BuiltList<String>>? nestedStringList) =>
+          _i5.ListBuilder<_i5.BuiltList<String>>? nestedStringList) =>
       _$this._nestedStringList = nestedStringList;
 
-  _i3.ListBuilder<String>? _renamedListMembers;
-  _i3.ListBuilder<String> get renamedListMembers =>
-      _$this._renamedListMembers ??= new _i3.ListBuilder<String>();
-  set renamedListMembers(_i3.ListBuilder<String>? renamedListMembers) =>
+  _i5.ListBuilder<String>? _renamedListMembers;
+  _i5.ListBuilder<String> get renamedListMembers =>
+      _$this._renamedListMembers ??= new _i5.ListBuilder<String>();
+  set renamedListMembers(_i5.ListBuilder<String>? renamedListMembers) =>
       _$this._renamedListMembers = renamedListMembers;
 
-  _i3.ListBuilder<String>? _stringList;
-  _i3.ListBuilder<String> get stringList =>
-      _$this._stringList ??= new _i3.ListBuilder<String>();
-  set stringList(_i3.ListBuilder<String>? stringList) =>
+  _i5.ListBuilder<String>? _stringList;
+  _i5.ListBuilder<String> get stringList =>
+      _$this._stringList ??= new _i5.ListBuilder<String>();
+  set stringList(_i5.ListBuilder<String>? stringList) =>
       _$this._stringList = stringList;
 
-  _i3.SetBuilder<String>? _stringSet;
-  _i3.SetBuilder<String> get stringSet =>
-      _$this._stringSet ??= new _i3.SetBuilder<String>();
-  set stringSet(_i3.SetBuilder<String>? stringSet) =>
+  _i5.SetBuilder<String>? _stringSet;
+  _i5.SetBuilder<String> get stringSet =>
+      _$this._stringSet ??= new _i5.SetBuilder<String>();
+  set stringSet(_i5.SetBuilder<String>? stringSet) =>
       _$this._stringSet = stringSet;
 
-  _i3.ListBuilder<_i5.StructureListMember>? _structureList;
-  _i3.ListBuilder<_i5.StructureListMember> get structureList =>
-      _$this._structureList ??= new _i3.ListBuilder<_i5.StructureListMember>();
-  set structureList(_i3.ListBuilder<_i5.StructureListMember>? structureList) =>
+  _i5.ListBuilder<_i4.StructureListMember>? _structureList;
+  _i5.ListBuilder<_i4.StructureListMember> get structureList =>
+      _$this._structureList ??= new _i5.ListBuilder<_i4.StructureListMember>();
+  set structureList(_i5.ListBuilder<_i4.StructureListMember>? structureList) =>
       _$this._structureList = structureList;
 
-  _i3.ListBuilder<DateTime>? _timestampList;
-  _i3.ListBuilder<DateTime> get timestampList =>
-      _$this._timestampList ??= new _i3.ListBuilder<DateTime>();
-  set timestampList(_i3.ListBuilder<DateTime>? timestampList) =>
+  _i5.ListBuilder<DateTime>? _timestampList;
+  _i5.ListBuilder<DateTime> get timestampList =>
+      _$this._timestampList ??= new _i5.ListBuilder<DateTime>();
+  set timestampList(_i5.ListBuilder<DateTime>? timestampList) =>
       _$this._timestampList = timestampList;
 
   XmlListsInputOutputBuilder() {

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_maps_input_output.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_maps_input_output.dart
@@ -3,11 +3,11 @@
 library rest_xml_v2.rest_xml_protocol.model.xml_maps_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_xml_v2/src/rest_xml_protocol/model/greeting_struct.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'xml_maps_input_output.g.dart';
@@ -15,9 +15,9 @@ part 'xml_maps_input_output.g.dart';
 abstract class XmlMapsInputOutput
     with _i1.HttpInput<XmlMapsInputOutput>, _i2.AWSEquatable<XmlMapsInputOutput>
     implements Built<XmlMapsInputOutput, XmlMapsInputOutputBuilder> {
-  factory XmlMapsInputOutput(
-      {_i3.BuiltMap<String, _i4.GreetingStruct>? myMap}) {
-    return _$XmlMapsInputOutput._(myMap: myMap);
+  factory XmlMapsInputOutput({Map<String, _i3.GreetingStruct>? myMap}) {
+    return _$XmlMapsInputOutput._(
+        myMap: myMap == null ? null : _i4.BuiltMap(myMap));
   }
 
   factory XmlMapsInputOutput.build(
@@ -46,7 +46,7 @@ abstract class XmlMapsInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(XmlMapsInputOutputBuilder b) {}
-  _i3.BuiltMap<String, _i4.GreetingStruct>? get myMap;
+  _i4.BuiltMap<String, _i3.GreetingStruct>? get myMap;
   @override
   XmlMapsInputOutput getPayload() => this;
   @override
@@ -97,10 +97,10 @@ class XmlMapsInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.GreetingStruct),
+                  FullType(_i3.GreetingStruct),
                 ],
               ),
             ));
@@ -127,10 +127,10 @@ class XmlMapsInputOutputRestXmlSerializer
           serializers,
           payload.myMap!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.GreetingStruct),
+              FullType(_i3.GreetingStruct),
             ],
           ),
         ));

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_maps_input_output.g.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_maps_input_output.g.dart
@@ -8,7 +8,7 @@ part of rest_xml_v2.rest_xml_protocol.model.xml_maps_input_output;
 
 class _$XmlMapsInputOutput extends XmlMapsInputOutput {
   @override
-  final _i3.BuiltMap<String, _i4.GreetingStruct>? myMap;
+  final _i4.BuiltMap<String, _i3.GreetingStruct>? myMap;
 
   factory _$XmlMapsInputOutput(
           [void Function(XmlMapsInputOutputBuilder)? updates]) =>
@@ -41,10 +41,10 @@ class XmlMapsInputOutputBuilder
     implements Builder<XmlMapsInputOutput, XmlMapsInputOutputBuilder> {
   _$XmlMapsInputOutput? _$v;
 
-  _i3.MapBuilder<String, _i4.GreetingStruct>? _myMap;
-  _i3.MapBuilder<String, _i4.GreetingStruct> get myMap =>
-      _$this._myMap ??= new _i3.MapBuilder<String, _i4.GreetingStruct>();
-  set myMap(_i3.MapBuilder<String, _i4.GreetingStruct>? myMap) =>
+  _i4.MapBuilder<String, _i3.GreetingStruct>? _myMap;
+  _i4.MapBuilder<String, _i3.GreetingStruct> get myMap =>
+      _$this._myMap ??= new _i4.MapBuilder<String, _i3.GreetingStruct>();
+  set myMap(_i4.MapBuilder<String, _i3.GreetingStruct>? myMap) =>
       _$this._myMap = myMap;
 
   XmlMapsInputOutputBuilder() {

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_maps_xml_name_input_output.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_maps_xml_name_input_output.dart
@@ -3,11 +3,11 @@
 library rest_xml_v2.rest_xml_protocol.model.xml_maps_xml_name_input_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i4;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_xml_v2/src/rest_xml_protocol/model/greeting_struct.dart'
-    as _i4;
+    as _i3;
 import 'package:smithy/smithy.dart' as _i1;
 
 part 'xml_maps_xml_name_input_output.g.dart';
@@ -18,9 +18,9 @@ abstract class XmlMapsXmlNameInputOutput
         _i2.AWSEquatable<XmlMapsXmlNameInputOutput>
     implements
         Built<XmlMapsXmlNameInputOutput, XmlMapsXmlNameInputOutputBuilder> {
-  factory XmlMapsXmlNameInputOutput(
-      {_i3.BuiltMap<String, _i4.GreetingStruct>? myMap}) {
-    return _$XmlMapsXmlNameInputOutput._(myMap: myMap);
+  factory XmlMapsXmlNameInputOutput({Map<String, _i3.GreetingStruct>? myMap}) {
+    return _$XmlMapsXmlNameInputOutput._(
+        myMap: myMap == null ? null : _i4.BuiltMap(myMap));
   }
 
   factory XmlMapsXmlNameInputOutput.build(
@@ -49,7 +49,7 @@ abstract class XmlMapsXmlNameInputOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(XmlMapsXmlNameInputOutputBuilder b) {}
-  _i3.BuiltMap<String, _i4.GreetingStruct>? get myMap;
+  _i4.BuiltMap<String, _i3.GreetingStruct>? get myMap;
   @override
   XmlMapsXmlNameInputOutput getPayload() => this;
   @override
@@ -104,10 +104,10 @@ class XmlMapsXmlNameInputOutputRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i4.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.GreetingStruct),
+                  FullType(_i3.GreetingStruct),
                 ],
               ),
             ));
@@ -139,10 +139,10 @@ class XmlMapsXmlNameInputOutputRestXmlSerializer
           serializers,
           payload.myMap!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i4.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.GreetingStruct),
+              FullType(_i3.GreetingStruct),
             ],
           ),
         ));

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_maps_xml_name_input_output.g.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_maps_xml_name_input_output.g.dart
@@ -8,7 +8,7 @@ part of rest_xml_v2.rest_xml_protocol.model.xml_maps_xml_name_input_output;
 
 class _$XmlMapsXmlNameInputOutput extends XmlMapsXmlNameInputOutput {
   @override
-  final _i3.BuiltMap<String, _i4.GreetingStruct>? myMap;
+  final _i4.BuiltMap<String, _i3.GreetingStruct>? myMap;
 
   factory _$XmlMapsXmlNameInputOutput(
           [void Function(XmlMapsXmlNameInputOutputBuilder)? updates]) =>
@@ -42,10 +42,10 @@ class XmlMapsXmlNameInputOutputBuilder
         Builder<XmlMapsXmlNameInputOutput, XmlMapsXmlNameInputOutputBuilder> {
   _$XmlMapsXmlNameInputOutput? _$v;
 
-  _i3.MapBuilder<String, _i4.GreetingStruct>? _myMap;
-  _i3.MapBuilder<String, _i4.GreetingStruct> get myMap =>
-      _$this._myMap ??= new _i3.MapBuilder<String, _i4.GreetingStruct>();
-  set myMap(_i3.MapBuilder<String, _i4.GreetingStruct>? myMap) =>
+  _i4.MapBuilder<String, _i3.GreetingStruct>? _myMap;
+  _i4.MapBuilder<String, _i3.GreetingStruct> get myMap =>
+      _$this._myMap ??= new _i4.MapBuilder<String, _i3.GreetingStruct>();
+  set myMap(_i4.MapBuilder<String, _i3.GreetingStruct>? myMap) =>
       _$this._myMap = myMap;
 
   XmlMapsXmlNameInputOutputBuilder() {

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_namespace_nested.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_namespace_nested.dart
@@ -15,11 +15,11 @@ abstract class XmlNamespaceNested
     implements Built<XmlNamespaceNested, XmlNamespaceNestedBuilder> {
   factory XmlNamespaceNested({
     String? foo,
-    _i2.BuiltList<String>? values,
+    List<String>? values,
   }) {
     return _$XmlNamespaceNested._(
       foo: foo,
-      values: values,
+      values: values == null ? null : _i2.BuiltList(values),
     );
   }
 

--- a/packages/smithy/goldens/lib2/restXml/lib/src/s3/model/list_objects_v2_output.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/s3/model/list_objects_v2_output.dart
@@ -3,12 +3,12 @@
 library rest_xml_v2.s3.model.list_objects_v2_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i2;
+import 'package:built_collection/built_collection.dart' as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:rest_xml_v2/src/s3/model/common_prefix.dart' as _i3;
-import 'package:rest_xml_v2/src/s3/model/encoding_type.dart' as _i5;
-import 'package:rest_xml_v2/src/s3/model/object.dart' as _i4;
+import 'package:rest_xml_v2/src/s3/model/common_prefix.dart' as _i2;
+import 'package:rest_xml_v2/src/s3/model/encoding_type.dart' as _i4;
+import 'package:rest_xml_v2/src/s3/model/object.dart' as _i3;
 import 'package:smithy/smithy.dart' as _i6;
 
 part 'list_objects_v2_output.g.dart';
@@ -17,11 +17,11 @@ abstract class ListObjectsV2Output
     with _i1.AWSEquatable<ListObjectsV2Output>
     implements Built<ListObjectsV2Output, ListObjectsV2OutputBuilder> {
   factory ListObjectsV2Output({
-    _i2.BuiltList<_i3.CommonPrefix>? commonPrefixes,
-    _i2.BuiltList<_i4.S3Object>? contents,
+    List<_i2.CommonPrefix>? commonPrefixes,
+    List<_i3.S3Object>? contents,
     String? continuationToken,
     String? delimiter,
-    _i5.EncodingType? encodingType,
+    _i4.EncodingType? encodingType,
     bool? isTruncated,
     int? keyCount,
     int? maxKeys,
@@ -31,8 +31,9 @@ abstract class ListObjectsV2Output
     String? startAfter,
   }) {
     return _$ListObjectsV2Output._(
-      commonPrefixes: commonPrefixes,
-      contents: contents,
+      commonPrefixes:
+          commonPrefixes == null ? null : _i5.BuiltList(commonPrefixes),
+      contents: contents == null ? null : _i5.BuiltList(contents),
       continuationToken: continuationToken,
       delimiter: delimiter,
       encodingType: encodingType,
@@ -65,11 +66,11 @@ abstract class ListObjectsV2Output
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(ListObjectsV2OutputBuilder b) {}
-  _i2.BuiltList<_i3.CommonPrefix>? get commonPrefixes;
-  _i2.BuiltList<_i4.S3Object>? get contents;
+  _i5.BuiltList<_i2.CommonPrefix>? get commonPrefixes;
+  _i5.BuiltList<_i3.S3Object>? get contents;
   String? get continuationToken;
   String? get delimiter;
-  _i5.EncodingType? get encodingType;
+  _i4.EncodingType? get encodingType;
   bool? get isTruncated;
   int? get keyCount;
   int? get maxKeys;
@@ -180,16 +181,16 @@ class ListObjectsV2OutputRestXmlSerializer
           if (value != null) {
             result.commonPrefixes.add((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i3.CommonPrefix),
-            ) as _i3.CommonPrefix));
+              specifiedType: const FullType(_i2.CommonPrefix),
+            ) as _i2.CommonPrefix));
           }
           break;
         case 'Contents':
           if (value != null) {
             result.contents.add((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i4.S3Object),
-            ) as _i4.S3Object));
+              specifiedType: const FullType(_i3.S3Object),
+            ) as _i3.S3Object));
           }
           break;
         case 'ContinuationToken':
@@ -212,8 +213,8 @@ class ListObjectsV2OutputRestXmlSerializer
           if (value != null) {
             result.encodingType = (serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EncodingType),
-            ) as _i5.EncodingType);
+              specifiedType: const FullType(_i4.EncodingType),
+            ) as _i4.EncodingType);
           }
           break;
         case 'IsTruncated':
@@ -298,8 +299,8 @@ class ListObjectsV2OutputRestXmlSerializer
         serializers,
         payload.commonPrefixes!,
         specifiedType: const FullType.nullable(
-          _i2.BuiltList,
-          [FullType(_i3.CommonPrefix)],
+          _i5.BuiltList,
+          [FullType(_i2.CommonPrefix)],
         ),
       ));
     }
@@ -309,8 +310,8 @@ class ListObjectsV2OutputRestXmlSerializer
         serializers,
         payload.contents!,
         specifiedType: const FullType.nullable(
-          _i2.BuiltList,
-          [FullType(_i4.S3Object)],
+          _i5.BuiltList,
+          [FullType(_i3.S3Object)],
         ),
       ));
     }
@@ -335,7 +336,7 @@ class ListObjectsV2OutputRestXmlSerializer
         ..add(const _i6.XmlElementName('EncodingType'))
         ..add(serializers.serialize(
           payload.encodingType!,
-          specifiedType: const FullType.nullable(_i5.EncodingType),
+          specifiedType: const FullType.nullable(_i4.EncodingType),
         ));
     }
     if (payload.isTruncated != null) {

--- a/packages/smithy/goldens/lib2/restXml/lib/src/s3/model/list_objects_v2_output.g.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/s3/model/list_objects_v2_output.g.dart
@@ -8,15 +8,15 @@ part of rest_xml_v2.s3.model.list_objects_v2_output;
 
 class _$ListObjectsV2Output extends ListObjectsV2Output {
   @override
-  final _i2.BuiltList<_i3.CommonPrefix>? commonPrefixes;
+  final _i5.BuiltList<_i2.CommonPrefix>? commonPrefixes;
   @override
-  final _i2.BuiltList<_i4.S3Object>? contents;
+  final _i5.BuiltList<_i3.S3Object>? contents;
   @override
   final String? continuationToken;
   @override
   final String? delimiter;
   @override
-  final _i5.EncodingType? encodingType;
+  final _i4.EncodingType? encodingType;
   @override
   final bool? isTruncated;
   @override
@@ -109,16 +109,16 @@ class ListObjectsV2OutputBuilder
     implements Builder<ListObjectsV2Output, ListObjectsV2OutputBuilder> {
   _$ListObjectsV2Output? _$v;
 
-  _i2.ListBuilder<_i3.CommonPrefix>? _commonPrefixes;
-  _i2.ListBuilder<_i3.CommonPrefix> get commonPrefixes =>
-      _$this._commonPrefixes ??= new _i2.ListBuilder<_i3.CommonPrefix>();
-  set commonPrefixes(_i2.ListBuilder<_i3.CommonPrefix>? commonPrefixes) =>
+  _i5.ListBuilder<_i2.CommonPrefix>? _commonPrefixes;
+  _i5.ListBuilder<_i2.CommonPrefix> get commonPrefixes =>
+      _$this._commonPrefixes ??= new _i5.ListBuilder<_i2.CommonPrefix>();
+  set commonPrefixes(_i5.ListBuilder<_i2.CommonPrefix>? commonPrefixes) =>
       _$this._commonPrefixes = commonPrefixes;
 
-  _i2.ListBuilder<_i4.S3Object>? _contents;
-  _i2.ListBuilder<_i4.S3Object> get contents =>
-      _$this._contents ??= new _i2.ListBuilder<_i4.S3Object>();
-  set contents(_i2.ListBuilder<_i4.S3Object>? contents) =>
+  _i5.ListBuilder<_i3.S3Object>? _contents;
+  _i5.ListBuilder<_i3.S3Object> get contents =>
+      _$this._contents ??= new _i5.ListBuilder<_i3.S3Object>();
+  set contents(_i5.ListBuilder<_i3.S3Object>? contents) =>
       _$this._contents = contents;
 
   String? _continuationToken;
@@ -130,9 +130,9 @@ class ListObjectsV2OutputBuilder
   String? get delimiter => _$this._delimiter;
   set delimiter(String? delimiter) => _$this._delimiter = delimiter;
 
-  _i5.EncodingType? _encodingType;
-  _i5.EncodingType? get encodingType => _$this._encodingType;
-  set encodingType(_i5.EncodingType? encodingType) =>
+  _i4.EncodingType? _encodingType;
+  _i4.EncodingType? get encodingType => _$this._encodingType;
+  set encodingType(_i4.EncodingType? encodingType) =>
       _$this._encodingType = encodingType;
 
   bool? _isTruncated;

--- a/packages/smithy/goldens/lib2/restXml/lib/src/s3/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/s3/model/scoped_config.dart
@@ -3,13 +3,13 @@
 library rest_xml_v2.s3.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_xml_v2/src/s3/model/client_config.dart' as _i2;
-import 'package:rest_xml_v2/src/s3/model/environment_config.dart' as _i5;
-import 'package:rest_xml_v2/src/s3/model/file_config_settings.dart' as _i4;
-import 'package:rest_xml_v2/src/s3/model/operation_config.dart' as _i6;
+import 'package:rest_xml_v2/src/s3/model/environment_config.dart' as _i4;
+import 'package:rest_xml_v2/src/s3/model/file_config_settings.dart' as _i3;
+import 'package:rest_xml_v2/src/s3/model/operation_config.dart' as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -21,15 +21,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -52,16 +53,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -141,10 +142,10 @@ class ScopedConfigRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
             ));
@@ -157,10 +158,10 @@ class ScopedConfigRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
             ));
@@ -170,16 +171,16 @@ class ScopedConfigRestXmlSerializer
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -216,10 +217,10 @@ class ScopedConfigRestXmlSerializer
           serializers,
           payload.configFile!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -231,10 +232,10 @@ class ScopedConfigRestXmlSerializer
           serializers,
           payload.credentialsFile!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -244,7 +245,7 @@ class ScopedConfigRestXmlSerializer
         ..add(const _i7.XmlElementName('environment'))
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -252,7 +253,7 @@ class ScopedConfigRestXmlSerializer
         ..add(const _i7.XmlElementName('operation'))
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/restXml/lib/src/s3/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/s3/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/lib2/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXml/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   aws_common:
     path: ../../../../aws_common
   built_value: ">=8.4.0 <8.5.0"
-  built_collection: ^5.0.0
   fixnum: ^1.0.0
+  built_collection: ^5.0.0
   meta: ^1.7.0
   xml: 6.1.0
   shelf_router: ^1.1.0

--- a/packages/smithy/goldens/lib2/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/scoped_config.dart
+++ b/packages/smithy/goldens/lib2/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/scoped_config.dart
@@ -3,17 +3,17 @@
 library rest_xml_with_namespace_v2.rest_xml_protocol_namespace.model.scoped_config; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:built_collection/built_collection.dart' as _i3;
+import 'package:built_collection/built_collection.dart' as _i6;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:rest_xml_with_namespace_v2/src/rest_xml_protocol_namespace/model/client_config.dart'
     as _i2;
 import 'package:rest_xml_with_namespace_v2/src/rest_xml_protocol_namespace/model/environment_config.dart'
-    as _i5;
-import 'package:rest_xml_with_namespace_v2/src/rest_xml_protocol_namespace/model/file_config_settings.dart'
     as _i4;
+import 'package:rest_xml_with_namespace_v2/src/rest_xml_protocol_namespace/model/file_config_settings.dart'
+    as _i3;
 import 'package:rest_xml_with_namespace_v2/src/rest_xml_protocol_namespace/model/operation_config.dart'
-    as _i6;
+    as _i5;
 import 'package:smithy/smithy.dart' as _i7;
 
 part 'scoped_config.g.dart';
@@ -25,15 +25,16 @@ abstract class ScopedConfig
   /// Config settings that are scoped to different sources, such as environment variables or the AWS config file.
   factory ScopedConfig({
     _i2.ClientConfig? client,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile,
-    _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile,
-    _i5.EnvironmentConfig? environment,
-    _i6.OperationConfig? operation,
+    Map<String, _i3.FileConfigSettings>? configFile,
+    Map<String, _i3.FileConfigSettings>? credentialsFile,
+    _i4.EnvironmentConfig? environment,
+    _i5.OperationConfig? operation,
   }) {
     return _$ScopedConfig._(
       client: client,
-      configFile: configFile,
-      credentialsFile: credentialsFile,
+      configFile: configFile == null ? null : _i6.BuiltMap(configFile),
+      credentialsFile:
+          credentialsFile == null ? null : _i6.BuiltMap(credentialsFile),
       environment: environment,
       operation: operation,
     );
@@ -56,16 +57,16 @@ abstract class ScopedConfig
   _i2.ClientConfig? get client;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get configFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get configFile;
 
   /// A shape representing a parsed config file, which is a map of profile names to configuration sets.
-  _i3.BuiltMap<String, _i4.FileConfigSettings>? get credentialsFile;
+  _i6.BuiltMap<String, _i3.FileConfigSettings>? get credentialsFile;
 
   /// Config settings that can be set as environment variables.
-  _i5.EnvironmentConfig? get environment;
+  _i4.EnvironmentConfig? get environment;
 
   /// Configuration that is set for the scope of a single operation.
-  _i6.OperationConfig? get operation;
+  _i5.OperationConfig? get operation;
   @override
   List<Object?> get props => [
         client,
@@ -145,10 +146,10 @@ class ScopedConfigRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
             ));
@@ -161,10 +162,10 @@ class ScopedConfigRestXmlSerializer
               serializers,
               (value as Iterable<Object?>),
               specifiedType: const FullType(
-                _i3.BuiltMap,
+                _i6.BuiltMap,
                 [
                   FullType(String),
-                  FullType(_i4.FileConfigSettings),
+                  FullType(_i3.FileConfigSettings),
                 ],
               ),
             ));
@@ -174,16 +175,16 @@ class ScopedConfigRestXmlSerializer
           if (value != null) {
             result.environment.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i5.EnvironmentConfig),
-            ) as _i5.EnvironmentConfig));
+              specifiedType: const FullType(_i4.EnvironmentConfig),
+            ) as _i4.EnvironmentConfig));
           }
           break;
         case 'operation':
           if (value != null) {
             result.operation.replace((serializers.deserialize(
               value,
-              specifiedType: const FullType(_i6.OperationConfig),
-            ) as _i6.OperationConfig));
+              specifiedType: const FullType(_i5.OperationConfig),
+            ) as _i5.OperationConfig));
           }
           break;
       }
@@ -220,10 +221,10 @@ class ScopedConfigRestXmlSerializer
           serializers,
           payload.configFile!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -235,10 +236,10 @@ class ScopedConfigRestXmlSerializer
           serializers,
           payload.credentialsFile!,
           specifiedType: const FullType.nullable(
-            _i3.BuiltMap,
+            _i6.BuiltMap,
             [
               FullType(String),
-              FullType(_i4.FileConfigSettings),
+              FullType(_i3.FileConfigSettings),
             ],
           ),
         ));
@@ -248,7 +249,7 @@ class ScopedConfigRestXmlSerializer
         ..add(const _i7.XmlElementName('environment'))
         ..add(serializers.serialize(
           payload.environment!,
-          specifiedType: const FullType(_i5.EnvironmentConfig),
+          specifiedType: const FullType(_i4.EnvironmentConfig),
         ));
     }
     if (payload.operation != null) {
@@ -256,7 +257,7 @@ class ScopedConfigRestXmlSerializer
         ..add(const _i7.XmlElementName('operation'))
         ..add(serializers.serialize(
           payload.operation!,
-          specifiedType: const FullType(_i6.OperationConfig),
+          specifiedType: const FullType(_i5.OperationConfig),
         ));
     }
     return result;

--- a/packages/smithy/goldens/lib2/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/scoped_config.g.dart
+++ b/packages/smithy/goldens/lib2/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/scoped_config.g.dart
@@ -10,13 +10,13 @@ class _$ScopedConfig extends ScopedConfig {
   @override
   final _i2.ClientConfig? client;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? configFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? configFile;
   @override
-  final _i3.BuiltMap<String, _i4.FileConfigSettings>? credentialsFile;
+  final _i6.BuiltMap<String, _i3.FileConfigSettings>? credentialsFile;
   @override
-  final _i5.EnvironmentConfig? environment;
+  final _i4.EnvironmentConfig? environment;
   @override
-  final _i6.OperationConfig? operation;
+  final _i5.OperationConfig? operation;
 
   factory _$ScopedConfig([void Function(ScopedConfigBuilder)? updates]) =>
       (new ScopedConfigBuilder()..update(updates))._build();
@@ -67,31 +67,31 @@ class ScopedConfigBuilder
       _$this._client ??= new _i2.ClientConfigBuilder();
   set client(_i2.ClientConfigBuilder? client) => _$this._client = client;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _configFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get configFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _configFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get configFile =>
       _$this._configFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
-  set configFile(_i3.MapBuilder<String, _i4.FileConfigSettings>? configFile) =>
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
+  set configFile(_i6.MapBuilder<String, _i3.FileConfigSettings>? configFile) =>
       _$this._configFile = configFile;
 
-  _i3.MapBuilder<String, _i4.FileConfigSettings>? _credentialsFile;
-  _i3.MapBuilder<String, _i4.FileConfigSettings> get credentialsFile =>
+  _i6.MapBuilder<String, _i3.FileConfigSettings>? _credentialsFile;
+  _i6.MapBuilder<String, _i3.FileConfigSettings> get credentialsFile =>
       _$this._credentialsFile ??=
-          new _i3.MapBuilder<String, _i4.FileConfigSettings>();
+          new _i6.MapBuilder<String, _i3.FileConfigSettings>();
   set credentialsFile(
-          _i3.MapBuilder<String, _i4.FileConfigSettings>? credentialsFile) =>
+          _i6.MapBuilder<String, _i3.FileConfigSettings>? credentialsFile) =>
       _$this._credentialsFile = credentialsFile;
 
-  _i5.EnvironmentConfigBuilder? _environment;
-  _i5.EnvironmentConfigBuilder get environment =>
-      _$this._environment ??= new _i5.EnvironmentConfigBuilder();
-  set environment(_i5.EnvironmentConfigBuilder? environment) =>
+  _i4.EnvironmentConfigBuilder? _environment;
+  _i4.EnvironmentConfigBuilder get environment =>
+      _$this._environment ??= new _i4.EnvironmentConfigBuilder();
+  set environment(_i4.EnvironmentConfigBuilder? environment) =>
       _$this._environment = environment;
 
-  _i6.OperationConfigBuilder? _operation;
-  _i6.OperationConfigBuilder get operation =>
-      _$this._operation ??= new _i6.OperationConfigBuilder();
-  set operation(_i6.OperationConfigBuilder? operation) =>
+  _i5.OperationConfigBuilder? _operation;
+  _i5.OperationConfigBuilder get operation =>
+      _$this._operation ??= new _i5.OperationConfigBuilder();
+  set operation(_i5.OperationConfigBuilder? operation) =>
       _$this._operation = operation;
 
   ScopedConfigBuilder() {

--- a/packages/smithy/goldens/models2/custom/main.smithy
+++ b/packages/smithy/goldens/models2/custom/main.smithy
@@ -16,7 +16,8 @@ service CustomService {
         HttpChecksumRequiredWithMember,
         HttpChecksumNotRequiredWithMember,
         HttpChecksumReallyRequired,
-        HttpChecksumReallyNotRequired
+        HttpChecksumReallyNotRequired,
+        NestedCollections
     ]
 }
 

--- a/packages/smithy/goldens/models2/custom/nested-collections.smithy
+++ b/packages/smithy/goldens/models2/custom/nested-collections.smithy
@@ -1,0 +1,36 @@
+$version: "2.0"
+
+namespace com.example.custom
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@http(method: "POST", uri: "/nestedCollections")
+operation NestedCollections {
+    input: NestedCollectionsInput
+}
+
+@input
+structure NestedCollectionsInput {
+    mapOfListOfMapOfLists:MapOfListOfMapOfLists
+}
+
+list AList {
+    member: String
+}
+
+map NestedMap {
+    key: String
+    value: AList
+}
+
+@sparse
+list NestedList {
+    member: NestedMap
+}
+
+map MapOfListOfMapOfLists {
+    key: String
+    value: NestedList
+}
+

--- a/packages/smithy/smithy/lib/smithy.dart
+++ b/packages/smithy/smithy/lib/smithy.dart
@@ -15,6 +15,9 @@
 /// Smithy client runtime for Dart.
 library smithy;
 
+// External types used in public APIs
+export 'package:fixnum/fixnum.dart';
+
 // AST types
 export 'package:aws_common/aws_common.dart' show AlpnProtocol;
 export 'ast.dart'

--- a/packages/smithy/smithy_codegen/lib/src/generator/structure_generator.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/structure_generator.dart
@@ -158,22 +158,143 @@ class StructureGenerator extends LibraryGenerator<StructureShape>
           ..name = '_',
       );
 
+  /// Whether [symbol] requires transformation in the factory constructor.
+  bool _requiresTransformation(Reference symbol) {
+    return symbol.url == BuiltValueType.collectionUrl ||
+        symbol.url == BuiltValueType.jsonUrl;
+  }
+
+  /// Recursively converts `dart:core` types like lists, maps, and sets into the
+  /// built value types expected by constructors.
+  Expression _constructorExpressionForSymbol(
+    Reference symbol,
+    String name, {
+    bool? isNullable,
+  }) {
+    Expression ref = refer(name);
+    if (!_requiresTransformation(symbol)) {
+      return ref;
+    }
+    isNullable ??= symbol.typeRef.isNullable!;
+    final types = symbol.typeRef.types;
+    switch (symbol.symbol) {
+      case 'BuiltList':
+      case 'BuiltSet':
+        final childSymbol = types.single;
+        if (_requiresTransformation(childSymbol)) {
+          final childExpression = _constructorExpressionForSymbol(
+            childSymbol,
+            'el',
+          );
+          ref = ref.property('map').call([
+            Method(
+              (m) => m
+                ..requiredParameters.add(Parameter((p) => p.name = 'el'))
+                ..body = (childSymbol.typeRef.isNullable!
+                        ? refer('el')
+                            .equalTo(literalNull)
+                            .conditional(literalNull, childExpression)
+                        : childExpression)
+                    .code,
+            ).closure,
+          ]);
+        }
+        break;
+      case 'BuiltMap':
+        final valueSymbol = types[1];
+        if (_requiresTransformation(valueSymbol)) {
+          final childExpression = _constructorExpressionForSymbol(
+            valueSymbol,
+            'value',
+          );
+          final valueExpression = valueSymbol.typeRef.isNullable!
+              ? refer('value')
+                  .equalTo(literalNull)
+                  .conditional(literalNull, childExpression)
+              : childExpression;
+          ref = ref.property('map').call([
+            Method(
+              (m) => m
+                ..requiredParameters.addAll([
+                  Parameter((p) => p.name = 'key'),
+                  Parameter((p) => p.name = 'value'),
+                ])
+                ..body = DartTypes.core.mapEntry
+                    .newInstance([refer('key'), valueExpression]).code,
+            ).closure,
+          ]);
+        }
+        break;
+      case 'BuiltListMultimap':
+      case 'BuiltSetMultimap':
+        final valueSymbol = types[1];
+        if (_requiresTransformation(valueSymbol)) {
+          final childExpression = _constructorExpressionForSymbol(
+            valueSymbol,
+            'value',
+          );
+          final valueExpression = refer('value').property('map').call([
+            Method(
+              (m) => m
+                ..requiredParameters.add(Parameter((p) => p.name = 'el'))
+                ..body = (valueSymbol.typeRef.isNullable!
+                        ? refer('el')
+                            .equalTo(literalNull)
+                            .conditional(literalNull, childExpression)
+                        : childExpression)
+                    .code,
+            ).closure,
+          ]);
+          ref = ref.property('map').call([
+            Method(
+              (m) => m
+                ..requiredParameters.addAll([
+                  Parameter((p) => p.name = 'key'),
+                  Parameter((p) => p.name = 'value'),
+                ])
+                ..body = DartTypes.core.mapEntry
+                    .newInstance([refer('key'), valueExpression]).code,
+            ).closure,
+          ]);
+        }
+        break;
+    }
+    return refer(symbol.symbol!, symbol.url).newInstance([ref]);
+  }
+
   /// The parameter-based factory constructor.
   Constructor get factoryConstructor {
     final body = Block((b) {
-      final memberNames = <String>[];
+      final memberExpressions = <String, Expression>{};
       for (final member in sortedMembers) {
         final propertyName = member.dartName(ShapeType.structure);
-        memberNames.add(propertyName);
+        final memberSymbol = memberSymbols[member]!;
         final defaultValue = _defaultValueAssignment(member);
+        final isNullable =
+            memberSymbol.typeRef.isNullable! && defaultValue == null;
+        if (_requiresTransformation(memberSymbol)) {
+          final expression = _constructorExpressionForSymbol(
+            memberSymbol,
+            propertyName,
+            isNullable: isNullable,
+          );
+          memberExpressions[propertyName] = isNullable
+              ? refer(propertyName)
+                  .equalTo(literalNull)
+                  .conditional(literalNull, expression)
+              : expression;
+        } else {
+          memberExpressions[propertyName] = refer(propertyName);
+        }
         if (defaultValue != null) {
           b.statements.add(defaultValue);
         }
       }
       b.addExpression(
-        refer('${builtSymbol.symbol}._').newInstance([], {
-          for (final member in memberNames) member: refer(member),
-        }).returned,
+        refer('${builtSymbol.symbol}._').newInstance(
+          [],
+          memberExpressions,
+        ).returned,
       );
     });
     return Constructor(
@@ -213,13 +334,61 @@ class StructureGenerator extends LibraryGenerator<StructureShape>
           ..redirect = builtSymbol,
       );
 
+  /// Transforms `built_collection` symbols to their `dart:core` counterpart,
+  /// e.g. BuiltList -> List, BuiltSet -> Set, etc for use in factory
+  /// constructors so that users do not need to concern themselves with built
+  /// types when constructing instances.
+  Reference _transformBuiltSymbol(Reference ref) {
+    if (!_requiresTransformation(ref)) {
+      return ref;
+    }
+    final Reference transformed;
+    switch (ref.symbol!) {
+      case 'JsonObject':
+        transformed = DartTypes.core.object;
+        break;
+      case 'BuiltList':
+        transformed = DartTypes.core.list(
+          _transformBuiltSymbol(ref.typeRef.types.single),
+        );
+        break;
+      case 'BuiltSet':
+        transformed = DartTypes.core.set(
+          _transformBuiltSymbol(ref.typeRef.types.single),
+        );
+        break;
+      case 'BuiltMap':
+        transformed = DartTypes.core.map(
+          _transformBuiltSymbol(ref.typeRef.types[0]),
+          _transformBuiltSymbol(ref.typeRef.types[1]),
+        );
+        break;
+      case 'BuiltListMultimap':
+        transformed = DartTypes.core.map(
+          _transformBuiltSymbol(ref.typeRef.types[0]),
+          DartTypes.core.list(_transformBuiltSymbol(ref.typeRef.types[1])),
+        );
+        break;
+      case 'BuiltSetMultimap':
+        transformed = DartTypes.core.map(
+          _transformBuiltSymbol(ref.typeRef.types[0]),
+          DartTypes.core.set(_transformBuiltSymbol(ref.typeRef.types[1])),
+        );
+        break;
+      default:
+        throw ArgumentError('Bad type: ${ref.symbol}');
+    }
+    return transformed.typeRef.rebuild(
+      (t) => t.isNullable = ref.typeRef.isNullable!,
+    );
+  }
+
   /// Creates a constructor [Parameter] for [member].
   Parameter _memberParameter(MemberShape member) {
     final deprecatedAnnotation = member.deprecatedAnnotation ??
         context.shapeFor(member.target).deprecatedAnnotation;
-    final symbol = memberSymbols[member]!;
-    final defaultValue = member.defaultValue(context) ??
-        context.shapeFor(member.target).defaultValue(context);
+    final symbol = _transformBuiltSymbol(memberSymbols[member]!);
+    final defaultValue = member.defaultValue(context);
     final isNullable = symbol.typeRef.isNullable! ||
         defaultValue != null ||
         _defaultValueAssignment(member) != null;

--- a/packages/smithy/smithy_codegen/lib/src/generator/types.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/types.dart
@@ -55,7 +55,7 @@ abstract class DartTypes {
   static const convert = _Convert();
 
   /// `package:fixnum` types.
-  static const fixNum = _FixNum();
+  static const fixNum = FixNum();
 
   /// `package:meta` types.
   static const meta = _Meta();
@@ -289,9 +289,8 @@ class BuiltValueType {
 
   static const mainUrl = 'package:built_value/built_value.dart';
   static const serializerUrl = 'package:built_value/serializer.dart';
-  static const _jsonUrl = 'package:built_value/json_object.dart';
-  static const _collectionUrl =
-      'package:built_collection/built_collection.dart';
+  static const jsonUrl = 'package:built_value/json_object.dart';
+  static const collectionUrl = 'package:built_collection/built_collection.dart';
 
   /// A [built_value.BuiltValue] reference.
   Reference get builtValue => const Reference('BuiltValue', mainUrl);
@@ -315,7 +314,7 @@ class BuiltValueType {
   Reference builtList(Reference ref) => TypeReference(
         (t) => t
           ..symbol = 'BuiltList'
-          ..url = _collectionUrl
+          ..url = collectionUrl
           ..types.add(ref),
       );
 
@@ -328,7 +327,7 @@ class BuiltValueType {
   Reference builtListMultimap(Reference key, Reference value) => TypeReference(
         (t) => t
           ..symbol = 'BuiltListMultimap'
-          ..url = _collectionUrl
+          ..url = collectionUrl
           ..types.addAll([key, value]),
       );
 
@@ -337,7 +336,7 @@ class BuiltValueType {
   Reference builtMap(Reference key, Reference value) => TypeReference(
         (t) => t
           ..symbol = 'BuiltMap'
-          ..url = _collectionUrl
+          ..url = collectionUrl
           ..types.add(key)
           ..types.add(value),
       );
@@ -346,7 +345,7 @@ class BuiltValueType {
   Reference builtSet(Reference ref) => TypeReference(
         (t) => t
           ..symbol = 'BuiltSet'
-          ..url = _collectionUrl
+          ..url = collectionUrl
           ..types.add(ref),
       );
 
@@ -359,7 +358,7 @@ class BuiltValueType {
   Reference builtSetMultimap(Reference key, Reference value) => TypeReference(
         (t) => t
           ..symbol = 'BuiltSetMultimap'
-          ..url = _collectionUrl
+          ..url = collectionUrl
           ..types.addAll([key, value]),
       );
 
@@ -367,13 +366,13 @@ class BuiltValueType {
   Reference get fullType => const Reference('FullType', serializerUrl);
 
   /// Creates a [built_value_json_object.JsonObject] reference.
-  Reference get jsonObject => const Reference('JsonObject', _jsonUrl);
+  Reference get jsonObject => const Reference('JsonObject', jsonUrl);
 
   /// The builder for [built_collection.ListBuilder].
   Reference listBuilder(Reference ref) => TypeReference(
         (t) => t
           ..symbol = 'ListBuilder'
-          ..url = _collectionUrl
+          ..url = collectionUrl
           ..types.add(ref),
       );
 
@@ -382,7 +381,7 @@ class BuiltValueType {
       TypeReference(
         (t) => t
           ..symbol = 'ListMultimapBuilder'
-          ..url = _collectionUrl
+          ..url = collectionUrl
           ..types.addAll([key, value]),
       );
 
@@ -390,7 +389,7 @@ class BuiltValueType {
   Reference mapBuilder(Reference key, Reference value) => TypeReference(
         (t) => t
           ..symbol = 'MapBuilder'
-          ..url = _collectionUrl
+          ..url = collectionUrl
           ..types.addAll([key, value]),
       );
 
@@ -411,7 +410,7 @@ class BuiltValueType {
   Reference setBuilder(Reference ref) => TypeReference(
         (t) => t
           ..symbol = 'SetBuilder'
-          ..url = _collectionUrl
+          ..url = collectionUrl
           ..types.add(ref),
       );
 
@@ -419,7 +418,7 @@ class BuiltValueType {
   Reference setMultimapBuilder(Reference key, Reference value) => TypeReference(
         (t) => t
           ..symbol = 'SetMultimapBuilder'
-          ..url = _collectionUrl
+          ..url = collectionUrl
           ..types.addAll([key, value]),
       );
 
@@ -450,13 +449,13 @@ class _Convert {
 }
 
 /// `package:fixnum` types
-class _FixNum {
-  const _FixNum();
+class FixNum {
+  const FixNum();
 
-  static const _url = 'package:fixnum/fixnum.dart';
+  static const url = 'package:fixnum/fixnum.dart';
 
   /// Creates an [Int64] reference.
-  Reference get int64 => const Reference('Int64', _url);
+  Reference get int64 => const Reference('Int64', url);
 }
 
 /// `package:meta` types.

--- a/packages/smithy/smithy_test/lib/src/http/serializers.dart
+++ b/packages/smithy/smithy_test/lib/src/http/serializers.dart
@@ -20,7 +20,6 @@ import 'package:built_value/src/bool_serializer.dart';
 import 'package:built_value/src/built_list_serializer.dart';
 import 'package:built_value/src/built_map_serializer.dart';
 import 'package:built_value/src/built_set_serializer.dart';
-import 'package:fixnum/fixnum.dart';
 import 'package:smithy/smithy.dart' hide Serializer;
 
 /// Built [Serializers] used when running Smithy tests, normalizing all types


### PR DESCRIPTION
Needing to use built types like `BuiltList` or `BuiltMap` when constructing Smithy types is cumbersome when most of the time we are dealing with core Dart collection types like List and Map.

This change removes all built references from factory constructors and transforms them internally.

Before:
```dart
factory GetCredentialsForIdentityInput({
  String? customRoleArn,
  required String identityId,
  _i3.BuiltMap<String, String>? logins,
})
```

After:
```dart
factory GetCredentialsForIdentityInput({
  String? customRoleArn,
  required String identityId,
  Map<String, String>? logins,
})
```
