### PR TITLE
chore(http): Do not automatically read responses

### DIFF
--- a/packages/aws_common/lib/src/http/aws_http_client_io.dart
+++ b/packages/aws_common/lib/src/http/aws_http_client_io.dart
@@ -148,12 +148,7 @@ class AWSHttpClientImpl extends AWSHttpClient {
         },
       ),
     );
-    if (response.headers.contentLength >= 0 &&
-        !response.headers.chunkedTransferEncoding) {
-      completer.complete(streamedResponse.read());
-    } else {
-      completer.complete(streamedResponse);
-    }
+    completer.complete(streamedResponse);
   }
 
   // Copied from `dart:io`.
@@ -418,11 +413,7 @@ class AWSHttpClientImpl extends AWSHttpClient {
 
     final response = await makeRequest(request.method, request.uri);
     if (response != null) {
-      if (response.headers.containsKey(AWSHeaders.contentLength)) {
-        completer.complete(response.read());
-      } else {
-        completer.complete(response);
-      }
+      completer.complete(response);
     }
   }
 

--- a/packages/aws_common/test/http/client_conformance_tests/response_body_test.dart
+++ b/packages/aws_common/test/http/client_conformance_tests/response_body_test.dart
@@ -35,9 +35,7 @@ void main() {
     test('response with content length', () async {
       final request = AWSHttpRequest.get(createUri(''));
       final response = await client().send(request).response;
-      expect(response, isA<AWSHttpResponse>());
-      expect(response.decodeBody(), message);
-      expect(response.bodyBytes, message.codeUnits);
+      expect(await response.decodeBody(), message);
       expect(response.headers[AWSHeaders.contentLength], '${message.length}');
       expect(response.headers[AWSHeaders.contentType], 'text/plain');
     });


### PR DESCRIPTION
The heuristics here for automatically reading a response body were based off internal discussions with the team for how a general-purpose HTTP client should behave.

In HTTP/1.1, the streaming mechanism is called [chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding) - the idea with the previous behavior was to ensure that non-streaming responses would complete with an `AWSHttpResponse` instead of an `AWSStreamedHttpResponse`. However, the heuristic seems incomplete, at best. While several resources point to this being the sole way of differentiating a streaming from non-streaming responses, like [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding), practical experience with S3 shows that it may not always be accurate. And hardcoding this logic at the client level removes the ability to configure it.

This behavior can easily be added to any client wishing to have it using `transformResponse`.