### PR TITLE
chore(datastore): run integ tests in CI on next

### DIFF
--- a/.github/composite_actions/fetch_backends/action.yaml
+++ b/.github/composite_actions/fetch_backends/action.yaml
@@ -43,6 +43,11 @@ runs:
       run: melos exec --scope=${{ inputs.scope }} ./tool/pull_test_backend.sh
       shell: bash
 
+    - name: Undo any codegen changes from amplify pull
+      run: |    
+        melos exec --scope=${{ inputs.scope }} "[ -d "lib/models" ] && git checkout lib/models/ || exit 0"
+      shell: bash
+
     - name: Delete AWS profile
       run: rm -rf ~/.aws
       shell: bash

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Run integration tests
         run: |
-          melos exec -c 1 --scope ${{ matrix.scope }} -- "retries=1 \$MELOS_ROOT_PATH/build-support/integ_test_ios.sh"
+          melos exec -c 1 --scope ${{ matrix.scope }} -- "retries=1 small=true \$MELOS_ROOT_PATH/build-support/integ_test_ios.sh"
 
   web:
     runs-on: ubuntu-latest

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -20,7 +20,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scope: ["amplify_api_example", "amplify_storage_s3_example", "amplify_auth_cognito_example"]
+        scope:
+          - "amplify_api_example"
+          - "amplify_auth_cognito_example"
+          - "amplify_datastore_example"
+          - "amplify_storage_s3_example"
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
         with:
@@ -49,11 +53,11 @@ jobs:
 
       - name: Run Android integration tests
         uses: reactivecircus/android-emulator-runner@e790971012b979513b4e2fe70d4079bc0ca8a1ae # 2.24.0
-        timeout-minutes: 25
+        timeout-minutes: 45
         with:
           # API levels 30+ too slow https://github.com/ReactiveCircus/android-emulator-runner/issues/222
           api-level: 29
-          script: melos exec -c 1 --scope ${{ matrix.scope }} -- "deviceId=emulator-5554 retries=1 \$MELOS_ROOT_PATH/build-support/integ_test_android.sh"
+          script: melos exec -c 1 --scope ${{ matrix.scope }} -- "deviceId=emulator-5554 retries=1 small=true \$MELOS_ROOT_PATH/build-support/integ_test_android.sh"
 
   ios:
     runs-on: macos-latest
@@ -64,7 +68,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scope: ["amplify_api_example", "amplify_storage_s3_example", "amplify_auth_cognito_example"]
+        scope:
+          - "amplify_api_example"
+          - "amplify_auth_cognito_example"
+          - "amplify_datastore_example"
+          - "amplify_storage_s3_example"
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
         with:

--- a/build-support/integ_test_android.sh
+++ b/build-support/integ_test_android.sh
@@ -8,6 +8,7 @@ fi
 DEFAULT_DEVICE_ID="sdk"
 DEFAULT_ENABLE_CLOUD_SYNC="true"
 DEFAULT_RETRIES=0
+DEFAULT_SMALL="false"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -35,6 +36,7 @@ done
 deviceId=${deviceId:-$DEFAULT_DEVICE_ID}
 enableCloudSync=${enableCloudSync:-$DEFAULT_ENABLE_CLOUD_SYNC}
 retries=${retries:-$DEFAULT_RETRIES}
+small=${small:-$DEFAULT_SMALL}
 
 declare -a testsList
 declare -a resultsList
@@ -70,6 +72,12 @@ do
 done
 
 TEST_ENTRIES="integration_test/separate_integration_tests/*.dart"
+# For small option (summarized) just test basic cloud operation.
+if [ $small == "true" ]
+then
+  TEST_ENTRIES="integration_test/separate_integration_tests/basic_model_operation_test.dart"
+fi
+
 for ENTRY in $TEST_ENTRIES; do
     if [ ! -f "${ENTRY}" ]; then
         continue

--- a/build-support/integ_test_ios.sh
+++ b/build-support/integ_test_ios.sh
@@ -10,6 +10,7 @@ fi
 DEFAULT_DEVICE_ID="iPhone"
 DEFAULT_ENABLE_CLOUD_SYNC="true"
 DEFAULT_RETRIES=0
+DEFAULT_SMALL="false"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -37,6 +38,7 @@ done
 deviceId=${deviceId:-$DEFAULT_DEVICE_ID}
 enableCloudSync=${enableCloudSync:-$DEFAULT_ENABLE_CLOUD_SYNC}
 retries=${retries:-$DEFAULT_RETRIES}
+small=${small:-$DEFAULT_SMALL}
 
 declare -a testsList
 declare -a resultsList
@@ -86,6 +88,12 @@ else
 fi
 
 TEST_ENTRIES="integration_test/separate_integration_tests/*.dart"
+# For small option (summarized) just test basic cloud operation.
+if [ $small == "true" ]
+then
+  TEST_ENTRIES="integration_test/separate_integration_tests/basic_model_operation_test.dart"
+fi
+
 for ENTRY in $TEST_ENTRIES; do
     if [ ! -f "${ENTRY}" ]; then
         continue

--- a/packages/amplify_datastore/example/integration_test/model_type_test.dart
+++ b/packages/amplify_datastore/example/integration_test/model_type_test.dart
@@ -166,6 +166,7 @@ void main() {
       testModelOperations(
         models: models,
         skips: {
+          // Skip bc AWSTime issue on Android https://github.com/aws-amplify/amplify-flutter/issues/2214
           DataStoreOperation.save: Platform.isAndroid,
           DataStoreOperation.query: Platform.isAndroid,
           DataStoreOperation.delete: Platform.isAndroid,

--- a/packages/amplify_datastore/example/integration_test/model_type_test.dart
+++ b/packages/amplify_datastore/example/integration_test/model_type_test.dart
@@ -167,6 +167,7 @@ void main() {
         models: models,
         skips: {
           // Skip bc AWSTime issue on Android https://github.com/aws-amplify/amplify-flutter/issues/2214
+          // TODO(ragingsquirrel3): remove skip when issue fixed or implementation ported to Dart.
           DataStoreOperation.save: Platform.isAndroid,
           DataStoreOperation.query: Platform.isAndroid,
           DataStoreOperation.delete: Platform.isAndroid,

--- a/packages/amplify_datastore/example/integration_test/model_type_test.dart
+++ b/packages/amplify_datastore/example/integration_test/model_type_test.dart
@@ -14,6 +14,7 @@
  */
 
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math';
 
 import 'package:amplify_datastore/amplify_datastore.dart';
@@ -162,7 +163,15 @@ void main() {
           .map((value) =>
               ModelWithAppsyncScalarTypes(awsTimeValue: TemporalTime(value)))
           .toList();
-      testModelOperations(models: models);
+      testModelOperations(
+        models: models,
+        skips: {
+          DataStoreOperation.save: Platform.isAndroid,
+          DataStoreOperation.query: Platform.isAndroid,
+          DataStoreOperation.delete: Platform.isAndroid,
+          DataStoreOperation.observe: Platform.isAndroid,
+        },
+      );
     });
 
     group('List<AWSTime>', () {

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
@@ -150,5 +150,6 @@ void main() {
       );
     });
     // Skip bc AWSTime issue on Android https://github.com/aws-amplify/amplify-flutter/issues/2214
+    // TODO(ragingsquirrel3): remove skip when issue fixed or implementation ported to Dart.
   }, skip: Platform.isAndroid);
 }

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
@@ -149,5 +149,6 @@ void main() {
         expectedModels: rangeMatchModels,
       );
     });
+    // Skip bc AWSTime issue on Android https://github.com/aws-amplify/amplify-flutter/issues/2214
   }, skip: Platform.isAndroid);
 }

--- a/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/query_predicate_test/aws_time_query_predicate_test.dart
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+import 'dart:io';
+
 import 'package:amplify_datastore_example/models/ModelProvider.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -147,5 +149,5 @@ void main() {
         expectedModels: rangeMatchModels,
       );
     });
-  });
+  }, skip: Platform.isAndroid);
 }

--- a/packages/amplify_datastore/example/integration_test/query_test/sort_order_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/sort_order_test.dart
@@ -162,6 +162,7 @@ void main() {
         queryField: ModelWithAppsyncScalarTypes.AWSTIMEVALUE,
         sort: sortAWSTimeTypeModel,
         // Skip bc AWSTime issue on Android https://github.com/aws-amplify/amplify-flutter/issues/2214
+        // TODO(ragingsquirrel3): remove skip when issue fixed or implementation ported to Dart.
         skip: Platform.isAndroid,
       );
     });

--- a/packages/amplify_datastore/example/integration_test/query_test/sort_order_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/sort_order_test.dart
@@ -104,7 +104,7 @@ void main() {
         DateTime(0000, 01, 01, 00, 00, 00),
         DateTime(1970, 01, 01, 00, 00, 00),
         DateTime(2020, 01, 01, 00, 00, 00),
-        DateTime(2020, 01, 01, 23, 59, 59),
+        DateTime(2020, 01, 02, 23, 59, 59),
         DateTime(2999, 12, 31, 23, 59, 59, 999, 999),
       ];
       var models = values

--- a/packages/amplify_datastore/example/integration_test/query_test/sort_order_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/sort_order_test.dart
@@ -161,6 +161,7 @@ void main() {
         models: models,
         queryField: ModelWithAppsyncScalarTypes.AWSTIMEVALUE,
         sort: sortAWSTimeTypeModel,
+        // Skip bc AWSTime issue on Android https://github.com/aws-amplify/amplify-flutter/issues/2214
         skip: Platform.isAndroid,
       );
     });

--- a/packages/amplify_datastore/example/integration_test/query_test/sort_order_test.dart
+++ b/packages/amplify_datastore/example/integration_test/query_test/sort_order_test.dart
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+import 'dart:io';
 import 'dart:math';
 
 import 'package:amplify_datastore_example/models/ModelProvider.dart';
@@ -160,6 +161,7 @@ void main() {
         models: models,
         queryField: ModelWithAppsyncScalarTypes.AWSTIMEVALUE,
         sort: sortAWSTimeTypeModel,
+        skip: Platform.isAndroid,
       );
     });
 

--- a/packages/amplify_datastore/example/integration_test/utils/sort_order_utils.dart
+++ b/packages/amplify_datastore/example/integration_test/utils/sort_order_utils.dart
@@ -26,6 +26,7 @@ testSortOperations<T extends Model>({
   required List<T> models,
   required QueryField queryField,
   required int sort(T a, T b),
+  bool skip = false,
 }) {
   var classType = getModelType<T>();
   var ascendingSortedModels = models..sort(sort);
@@ -39,17 +40,25 @@ testSortOperations<T extends Model>({
     }
   });
 
-  testWidgets('ascending()', (WidgetTester tester) async {
-    var actualModels = await Amplify.DataStore.query(classType,
-        sortBy: [queryField.ascending()]);
-    expect(actualModels, orderedEquals(ascendingSortedModels));
-  });
+  testWidgets(
+    'ascending()',
+    (WidgetTester tester) async {
+      var actualModels = await Amplify.DataStore.query(classType,
+          sortBy: [queryField.ascending()]);
+      expect(actualModels, orderedEquals(ascendingSortedModels));
+    },
+    skip: skip,
+  );
 
-  testWidgets('descending()', (WidgetTester tester) async {
-    var actualModels = await Amplify.DataStore.query(classType,
-        sortBy: [queryField.descending()]);
-    expect(actualModels, orderedEquals(descendingSortedModels));
-  });
+  testWidgets(
+    'descending()',
+    (WidgetTester tester) async {
+      var actualModels = await Amplify.DataStore.query(classType,
+          sortBy: [queryField.descending()]);
+      expect(actualModels, orderedEquals(descendingSortedModels));
+    },
+    skip: skip,
+  );
 }
 
 /// sort [ModelWithAppsyncScalarTypes] by [ModelWithAppsyncScalarTypes.STRINGVALUE], accounting for nulls

--- a/packages/amplify_datastore/example/tool/pull_test_backend.sh
+++ b/packages/amplify_datastore/example/tool/pull_test_backend.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-APP_ID=$DATASTORE_APP_ID ../../../build-support/pull_backend_by_app_id.sh 
+APP_ID=$AFS_DATASTORE_APP_ID ../../../build-support/pull_backend_by_app_id.sh 

--- a/packages/amplify_datastore/example/tool/pull_test_backend.sh
+++ b/packages/amplify_datastore/example/tool/pull_test_backend.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+APP_ID=$DATASTORE_APP_ID ../../../build-support/pull_backend_by_app_id.sh 


### PR DESCRIPTION
Cherry picks 7307233838d9acd323b614242477c74596429e3f off main and adds another commit to skip tests on android for tests related to `AWSTime` which are failing due to https://github.com/aws-amplify/amplify-flutter/issues/2214


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
