### PR TITLE
fix(storage): include storage in ios/android plugins

### DIFF
--- a/packages/amplify/amplify_flutter/lib/src/hybrid_impl.dart
+++ b/packages/amplify/amplify_flutter/lib/src/hybrid_impl.dart
@@ -35,6 +35,7 @@ class AmplifyHybridImpl extends AmplifyClassImpl {
     await Future.wait(
       [
         ...Auth.plugins,
+        ...Storage.plugins,
       ].map((p) => p.configure(
           config: amplifyConfig, authProviderRepo: authProviderRepo)),
       eagerError: true,


### PR DESCRIPTION
I was testing new storage plugin in flutter app and noticed did not work in iOS/Android and this PR has a 1 line fix.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
