### PR TITLE
test(auth): Enable lints for integration tests

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/analysis_options.yaml
+++ b/packages/auth/amplify_auth_cognito/example/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:amplify_lints/app_core.yaml
+include: package:amplify_lints/app.yaml

--- a/packages/auth/amplify_auth_cognito/example/backend/tool/create_config.dart
+++ b/packages/auth/amplify_auth_cognito/example/backend/tool/create_config.dart
@@ -54,17 +54,19 @@ String createConfig({
           CognitoUserAttributeKey.phoneNumber,
         ],
       ),
-      api: ApiConfig(plugins: {
-        AWSApiPluginConfig.pluginKey: AWSApiPluginConfig({
-          'authIntegrationTest': AWSApiConfig(
-            endpointType: EndpointType.graphQL,
-            authorizationType: APIAuthorizationType.apiKey,
-            endpoint: graphQLApiEndpoint,
-            apiKey: graphQLApiKey,
-            region: region,
-          ),
-        })
-      }),
+      api: ApiConfig(
+        plugins: {
+          AWSApiPluginConfig.pluginKey: AWSApiPluginConfig({
+            'authIntegrationTest': AWSApiConfig(
+              endpointType: EndpointType.graphQL,
+              authorizationType: APIAuthorizationType.apiKey,
+              endpoint: graphQLApiEndpoint,
+              apiKey: graphQLApiKey,
+              region: region,
+            ),
+          })
+        },
+      ),
     ),
   );
   return '''

--- a/packages/auth/amplify_auth_cognito/example/integration_test/delete_user_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/delete_user_test.dart
@@ -44,53 +44,52 @@ void main() {
         verifyAttributes: true,
       );
 
-      // Sign the user in
-      SignInResult preDeleteSignIn = await Amplify.Auth.signIn(
+      final res = await Amplify.Auth.signIn(
         username: username,
         password: password,
       );
-      expect(preDeleteSignIn.isSignedIn, true);
+      expect(res.isSignedIn, true);
 
-      // Delete the user
       await Amplify.Auth.deleteUser();
 
-      // Expect subsequent sign in to fail
       expect(
         Amplify.Auth.signIn(
           username: username,
           password: password,
         ),
         throwsA(isA<UserNotFoundException>()),
+        reason: 'Subsequent signIn calls should fail',
       );
     });
 
     test(
-        'fetchAuthSession should throw NotAuthorizedException '
-        'after user deletion', () async {
-      final username = generateUsername();
-      final password = generatePassword();
+      'fetchAuthSession should show signed out after user deletion',
+      () async {
+        final username = generateUsername();
+        final password = generatePassword();
 
-      // Create a confirmed user
-      await adminCreateUser(
-        username,
-        password,
-        autoConfirm: true,
-        verifyAttributes: true,
-      );
+        await adminCreateUser(
+          username,
+          password,
+          autoConfirm: true,
+          verifyAttributes: true,
+        );
 
-      // Sign the user in
-      SignInResult preDeleteSignIn = await Amplify.Auth.signIn(
-        username: username,
-        password: password,
-      );
-      expect(preDeleteSignIn.isSignedIn, true);
+        final res = await Amplify.Auth.signIn(
+          username: username,
+          password: password,
+        );
+        expect(res.isSignedIn, true);
 
-      // Delete the user
-      await Amplify.Auth.deleteUser();
+        await Amplify.Auth.deleteUser();
 
-      // Expect user to be signed out
-      final session = await Amplify.Auth.fetchAuthSession();
-      expect(session.isSignedIn, false);
-    });
+        final session = await Amplify.Auth.fetchAuthSession();
+        expect(
+          session.isSignedIn,
+          isFalse,
+          reason: 'deleteUser should sign out user',
+        );
+      },
+    );
   });
 }

--- a/packages/auth/amplify_auth_cognito/example/integration_test/fetch_auth_session_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/fetch_auth_session_test.dart
@@ -26,14 +26,13 @@ import 'utils/validation_utils.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  final username = generateUsername();
-  final password = generatePassword();
+  group('fetchAuthSession', () {
+    final username = generateUsername();
+    final password = generatePassword();
 
-  group('fetchSession', () {
     setUpAll(() async {
       await configureAuth();
 
-      // create one confirmed user for all tests
       await adminCreateUser(
         username,
         password,
@@ -44,27 +43,29 @@ void main() {
 
     tearDownAll(Amplify.reset);
 
-    // sign in prior to each test
     setUp(() async {
       await signOutUser();
-      await Amplify.Auth.signIn(
+      final res = await Amplify.Auth.signIn(
         username: username,
         password: password,
       );
-    });
-
-    test('should return user credentials if getAWSCredentials is true',
-        () async {
-      final res = await Amplify.Auth.fetchAuthSession(
-        options: const CognitoSessionOptions(getAWSCredentials: true),
-      ) as CognitoAuthSession;
-
       expect(res.isSignedIn, isTrue);
-      expect(isValidUserSub(res.userSub), isTrue);
-      expect(isValidIdentityId(res.identityId), isTrue);
-      expect(isValidAWSCredentials(res.credentials), isTrue);
-      expect(isValidAWSCognitoUserPoolTokens(res.userPoolTokens), isTrue);
     });
+
+    test(
+      'should return user credentials if getAWSCredentials is true',
+      () async {
+        final res = await Amplify.Auth.fetchAuthSession(
+          options: const CognitoSessionOptions(getAWSCredentials: true),
+        ) as CognitoAuthSession;
+
+        expect(res.isSignedIn, isTrue);
+        expect(isValidUserSub(res.userSub), isTrue);
+        expect(isValidIdentityId(res.identityId), isTrue);
+        expect(isValidAWSCredentials(res.credentials), isTrue);
+        expect(isValidAWSCognitoUserPoolTokens(res.userPoolTokens), isTrue);
+      },
+    );
 
     test('should return user credentials without getAWSCredentials', () async {
       final res = await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
@@ -80,7 +81,8 @@ void main() {
       'should return isSignedIn as false if the user is signed out',
       () async {
         await Amplify.Auth.signOut();
-        var res = await Amplify.Auth.fetchAuthSession();
+
+        final res = await Amplify.Auth.fetchAuthSession();
         expect(res.isSignedIn, isFalse);
       },
     );

--- a/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
@@ -25,14 +25,13 @@ import 'utils/validation_utils.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  final username = generateUsername();
-  final password = generatePassword();
-
   group('getCurrentUser', () {
+    final username = generateUsername();
+    final password = generatePassword();
+
     setUpAll(() async {
       await configureAuth();
 
-      // create one user for all tests
       await adminCreateUser(
         username,
         password,
@@ -43,7 +42,6 @@ void main() {
 
     tearDownAll(Amplify.reset);
 
-    // sign in prior to each test
     setUp(() async {
       await signOutUser();
       await Amplify.Auth.signIn(
@@ -53,10 +51,8 @@ void main() {
     });
 
     test('should return the current user', () async {
-      var authUser = await Amplify.Auth.getCurrentUser();
-      // usernames need to be compared case insensitive due to
-      // https://github.com/aws-amplify/amplify-flutter/issues/723
-      expect(authUser.username.toLowerCase(), username.toLowerCase());
+      final authUser = await Amplify.Auth.getCurrentUser();
+      expect(authUser.username, username);
       expect(isValidUserSub(authUser.userId), isTrue);
     });
 

--- a/packages/auth/amplify_auth_cognito/example/integration_test/main_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/main_test.dart
@@ -17,12 +17,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'delete_user_test.dart' as delete_user_tests;
-import 'federated_sign_in_test.dart' as federated_sign_in;
-import 'fetch_session_test.dart' as fetch_session_tests;
-import 'force_refresh_test.dart' as force_refresh;
+import 'federated_sign_in_test.dart' as federated_sign_in_tests;
+import 'fetch_auth_session_test.dart' as fetch_auth_session_tests;
+import 'force_refresh_test.dart' as force_refresh_tests;
 import 'get_current_user_test.dart' as get_current_user_tests;
 import 'hub_events_test.dart' as hub_events_tests;
-import 'mfa_sms_test.dart' as mfa_sms;
+import 'mfa_sms_test.dart' as mfa_sms_tests;
 import 'sign_in_sign_out_test.dart' as sign_in_sign_out_tests;
 import 'sign_up_test.dart' as sign_up_tests;
 import 'update_password_test.dart' as update_password_tests;
@@ -33,12 +33,12 @@ void main() async {
 
   group('amplify_auth_cognito', () {
     delete_user_tests.main();
-    federated_sign_in.main();
-    fetch_session_tests.main();
-    force_refresh.main();
+    federated_sign_in_tests.main();
+    fetch_auth_session_tests.main();
+    force_refresh_tests.main();
     get_current_user_tests.main();
     hub_events_tests.main();
-    mfa_sms.main();
+    mfa_sms_tests.main();
     sign_in_sign_out_tests.main();
     sign_up_tests.main();
     update_password_tests.main();

--- a/packages/auth/amplify_auth_cognito/example/integration_test/update_password_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/update_password_test.dart
@@ -25,10 +25,10 @@ import 'utils/setup_utils.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  late String username;
-  late String password;
-
   group('updatePassword', () {
+    late String username;
+    late String password;
+
     setUpAll(() async {
       await configureAuth();
     });
@@ -36,9 +36,9 @@ void main() {
     tearDownAll(Amplify.reset);
 
     setUp(() async {
-      // create new user for each test
       username = generateUsername();
       password = generatePassword();
+
       await adminCreateUser(
         username,
         password,
@@ -47,11 +47,13 @@ void main() {
       );
 
       await signOutUser();
-      // sign in with current password
-      await Amplify.Auth.signIn(
+
+      // Sign in with current password
+      final res = await Amplify.Auth.signIn(
         username: username,
         password: password,
       );
+      expect(res.isSignedIn, isTrue);
     });
 
     test('should update a user\'s password', () async {
@@ -68,36 +70,38 @@ void main() {
         username: username,
         password: newPassword,
       );
-      expect(res.isSignedIn, true);
+      expect(res.isSignedIn, isTrue);
     });
 
     test(
-        'should throw a NotAuthorizedException for an incorrect current password',
-        () async {
-      // attempt to change password using an incorrect password
-      final incorrectPassword = generatePassword();
-      final newPassword = generatePassword();
-      expect(
-        Amplify.Auth.updatePassword(
-          oldPassword: incorrectPassword,
-          newPassword: newPassword,
-        ),
-        throwsA(isA<NotAuthorizedException>()),
-      );
-    });
+      'should throw a NotAuthorizedException for an incorrect '
+      'current password',
+      () async {
+        final incorrectPassword = generatePassword();
+        final newPassword = generatePassword();
+        expect(
+          Amplify.Auth.updatePassword(
+            oldPassword: incorrectPassword,
+            newPassword: newPassword,
+          ),
+          throwsA(isA<NotAuthorizedException>()),
+        );
+      },
+    );
 
     test(
-        'should throw an InvalidPasswordException for a new password that doesn\'t meet password requirements',
-        () async {
-      // attempt to change password to an invalid password
-      const invalidPassword = '123';
-      expect(
-        Amplify.Auth.updatePassword(
-          oldPassword: password,
-          newPassword: invalidPassword,
-        ),
-        throwsA(isA<InvalidPasswordException>()),
-      );
-    });
+      'should throw an InvalidPasswordException for a new password that '
+      "doesn't meet password requirements",
+      () async {
+        const invalidPassword = '123';
+        expect(
+          Amplify.Auth.updatePassword(
+            oldPassword: password,
+            newPassword: invalidPassword,
+          ),
+          throwsA(isA<InvalidPasswordException>()),
+        );
+      },
+    );
   });
 }

--- a/packages/auth/amplify_auth_cognito/example/integration_test/utils/setup_utils.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/utils/setup_utils.dart
@@ -17,8 +17,9 @@ import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 
-Future<void> configureAuth(
-    {List<AmplifyPluginInterface> additionalPlugins = const []}) async {
+Future<void> configureAuth({
+  List<AmplifyPluginInterface> additionalPlugins = const [],
+}) async {
   if (!Amplify.isConfigured) {
     final authPlugin = AmplifyAuthCognito();
     await Amplify.addPlugins([authPlugin, ...additionalPlugins]);

--- a/packages/auth/amplify_auth_cognito/example/lib/main.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/main.dart
@@ -37,50 +37,52 @@ void main() {
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   State<MyApp> createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
-  static final _router = GoRouter(routes: [
-    GoRoute(
-      path: '/',
-      builder: (BuildContext _, GoRouterState __) => const HomeScreen(),
-    ),
-    GoRoute(
-      path: '/view-user-attributes',
-      builder: (BuildContext _, GoRouterState __) =>
-          const ViewUserAttributesScreen(),
-    ),
-    GoRoute(
-      path: '/update-user-attribute',
-      builder: (BuildContext _, GoRouterState state) =>
-          UpdateUserAttributeScreen(
-        userAttributeKey: state.extra as CognitoUserAttributeKey?,
+  static final _router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (BuildContext _, GoRouterState __) => const HomeScreen(),
       ),
-    ),
-    GoRoute(
-      path: '/update-user-attributes',
-      builder: (BuildContext _, GoRouterState state) =>
-          const UpdateUserAttributesScreen(),
-    ),
-    GoRoute(
-      path: '/confirm-user-attribute/email',
-      builder: (BuildContext _, GoRouterState state) =>
-          const ConfirmUserAttributeScreen(
-        userAttributeKey: CognitoUserAttributeKey.email,
+      GoRoute(
+        path: '/view-user-attributes',
+        builder: (BuildContext _, GoRouterState __) =>
+            const ViewUserAttributesScreen(),
       ),
-    ),
-    GoRoute(
-      path: '/confirm-user-attribute/phone_number',
-      builder: (BuildContext _, GoRouterState state) =>
-          const ConfirmUserAttributeScreen(
-        userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+      GoRoute(
+        path: '/update-user-attribute',
+        builder: (BuildContext _, GoRouterState state) =>
+            UpdateUserAttributeScreen(
+          userAttributeKey: state.extra as CognitoUserAttributeKey?,
+        ),
       ),
-    ),
-  ]);
+      GoRoute(
+        path: '/update-user-attributes',
+        builder: (BuildContext _, GoRouterState state) =>
+            const UpdateUserAttributesScreen(),
+      ),
+      GoRoute(
+        path: '/confirm-user-attribute/email',
+        builder: (BuildContext _, GoRouterState state) =>
+            const ConfirmUserAttributeScreen(
+          userAttributeKey: CognitoUserAttributeKey.email,
+        ),
+      ),
+      GoRoute(
+        path: '/confirm-user-attribute/phone_number',
+        builder: (BuildContext _, GoRouterState state) =>
+            const ConfirmUserAttributeScreen(
+          userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+        ),
+      ),
+    ],
+  );
 
   @override
   void initState() {

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/confirm_reset.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/confirm_reset.dart
@@ -17,11 +17,6 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter/material.dart';
 
 class ConfirmResetWidget extends StatefulWidget {
-  final Function showResult;
-  final Function changeDisplay;
-  final Function setError;
-  final VoidCallback backToSignIn;
-
   const ConfirmResetWidget(
     this.showResult,
     this.changeDisplay,
@@ -29,6 +24,11 @@ class ConfirmResetWidget extends StatefulWidget {
     this.backToSignIn, {
     super.key,
   });
+
+  final void Function(String) showResult;
+  final void Function(String) changeDisplay;
+  final void Function(Object?) setError;
+  final VoidCallback backToSignIn;
 
   @override
   State<ConfirmResetWidget> createState() => _ConfirmWidgetState();
@@ -42,12 +42,13 @@ class _ConfirmWidgetState extends State<ConfirmResetWidget> {
   void _confirmReset() async {
     try {
       await Amplify.Auth.confirmResetPassword(
-          username: usernameController.text.trim(),
-          newPassword: newPasswordController.text.trim(),
-          confirmationCode: confirmationCodeController.text.trim());
+        username: usernameController.text.trim(),
+        newPassword: newPasswordController.text.trim(),
+        confirmationCode: confirmationCodeController.text.trim(),
+      );
       widget.showResult('Password Confirmed');
       widget.changeDisplay('SHOW_SIGN_IN');
-    } on AmplifyException catch (e) {
+    } on Exception catch (e) {
       widget.setError(e);
     }
   }
@@ -61,35 +62,38 @@ class _ConfirmWidgetState extends State<ConfirmResetWidget> {
           // wrap your Column in Expanded
           child: Column(
             children: [
-              const Padding(padding: EdgeInsets.all(10.0)),
+              const Padding(padding: EdgeInsets.all(10)),
               TextFormField(
-                  controller: usernameController,
-                  decoration: const InputDecoration(
-                    icon: Icon(Icons.verified_user),
-                    hintText: 'Your old username',
-                    labelText: 'Username *',
-                  )),
+                controller: usernameController,
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.verified_user),
+                  hintText: 'Your old username',
+                  labelText: 'Username *',
+                ),
+              ),
               TextFormField(
-                  controller: newPasswordController,
-                  obscureText: true,
-                  decoration: const InputDecoration(
-                    icon: Icon(Icons.question_answer),
-                    hintText: 'Your new password',
-                    labelText: 'New Password *',
-                  )),
+                controller: newPasswordController,
+                obscureText: true,
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.question_answer),
+                  hintText: 'Your new password',
+                  labelText: 'New Password *',
+                ),
+              ),
               TextFormField(
-                  controller: confirmationCodeController,
-                  decoration: const InputDecoration(
-                    icon: Icon(Icons.confirmation_number),
-                    hintText: 'The confirmation code we sent you',
-                    labelText: 'Confirmation Code *',
-                  )),
-              const Padding(padding: EdgeInsets.all(10.0)),
+                controller: confirmationCodeController,
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.confirmation_number),
+                  hintText: 'The confirmation code we sent you',
+                  labelText: 'Confirmation Code *',
+                ),
+              ),
+              const Padding(padding: EdgeInsets.all(10)),
               ElevatedButton(
                 onPressed: _confirmReset,
                 child: const Text('Confirm Password Reset'),
               ),
-              const Padding(padding: EdgeInsets.all(10.0)),
+              const Padding(padding: EdgeInsets.all(10)),
               ElevatedButton(
                 key: const Key('goto-signin-button'),
                 onPressed: widget.backToSignIn,

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/confirm_sign_in.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/confirm_sign_in.dart
@@ -17,11 +17,6 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter/material.dart';
 
 class ConfirmSignInWidget extends StatefulWidget {
-  final Function showResult;
-  final Function changeDisplay;
-  final Function setError;
-  final VoidCallback backToSignIn;
-
   const ConfirmSignInWidget(
     this.showResult,
     this.changeDisplay,
@@ -29,6 +24,11 @@ class ConfirmSignInWidget extends StatefulWidget {
     this.backToSignIn, {
     super.key,
   });
+
+  final void Function(String) showResult;
+  final void Function(String) changeDisplay;
+  final void Function(Object?) setError;
+  final VoidCallback backToSignIn;
 
   @override
   State<ConfirmSignInWidget> createState() => _ConfirmSignInWidgetState();
@@ -40,13 +40,18 @@ class _ConfirmSignInWidgetState extends State<ConfirmSignInWidget> {
 
   void _confirmSignIn() async {
     try {
-      var res = await Amplify.Auth.confirmSignIn(
-          confirmationValue: confirmationCodeController.text.trim());
-      widget.showResult('Confirm Sign In Status = ${res.nextStep?.signInStep}');
-      widget.changeDisplay(res.nextStep?.signInStep == 'DONE'
-          ? 'SIGNED_IN'
-          : 'SHOW_CONFIRM_SIGN_IN');
-    } on AmplifyException catch (e) {
+      final res = await Amplify.Auth.confirmSignIn(
+        confirmationValue: confirmationCodeController.text.trim(),
+      );
+      widget.showResult(
+        'Confirm Sign In Status = ${res.nextStep?.signInStep}',
+      );
+      widget.changeDisplay(
+        res.nextStep?.signInStep == 'DONE'
+            ? 'SIGNED_IN'
+            : 'SHOW_CONFIRM_SIGN_IN',
+      );
+    } on Exception catch (e) {
       widget.setError(e);
     }
   }
@@ -60,20 +65,21 @@ class _ConfirmSignInWidgetState extends State<ConfirmSignInWidget> {
           // wrap your Column in Expanded
           child: Column(
             children: [
-              const Padding(padding: EdgeInsets.all(10.0)),
+              const Padding(padding: EdgeInsets.all(10)),
               TextFormField(
-                  controller: confirmationCodeController,
-                  decoration: const InputDecoration(
-                    icon: Icon(Icons.question_answer),
-                    hintText: 'The secret answer to the auth challange',
-                    labelText: 'Challange Response *',
-                  )),
-              const Padding(padding: EdgeInsets.all(10.0)),
+                controller: confirmationCodeController,
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.question_answer),
+                  hintText: 'The secret answer to the auth challange',
+                  labelText: 'Challange Response *',
+                ),
+              ),
+              const Padding(padding: EdgeInsets.all(10)),
               ElevatedButton(
                 onPressed: _confirmSignIn,
                 child: const Text('Confirm SignIn'),
               ),
-              const Padding(padding: EdgeInsets.all(10.0)),
+              const Padding(padding: EdgeInsets.all(10)),
               ElevatedButton(
                 key: const Key('goto-signin-button'),
                 onPressed: widget.backToSignIn,

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/confirm_sign_up.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/confirm_sign_up.dart
@@ -17,11 +17,6 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter/material.dart';
 
 class ConfirmSignUpWidget extends StatefulWidget {
-  final Function showResult;
-  final Function changeDisplay;
-  final Function setError;
-  final VoidCallback backToSignIn;
-
   const ConfirmSignUpWidget(
     this.showResult,
     this.changeDisplay,
@@ -29,6 +24,11 @@ class ConfirmSignUpWidget extends StatefulWidget {
     this.backToSignIn, {
     super.key,
   });
+
+  final void Function(String) showResult;
+  final void Function(String) changeDisplay;
+  final void Function(Object?) setError;
+  final VoidCallback backToSignIn;
 
   @override
   State<ConfirmSignUpWidget> createState() => _ConfirmSignUpWidgetState();
@@ -40,25 +40,30 @@ class _ConfirmSignUpWidgetState extends State<ConfirmSignUpWidget> {
 
   void _confirmSignUp() async {
     try {
-      var res = await Amplify.Auth.confirmSignUp(
-          username: usernameController.text.trim(),
-          confirmationCode: confirmationCodeController.text.trim());
-      widget.showResult('Confirm Sign Up Status = ${res.nextStep.signUpStep}');
+      final res = await Amplify.Auth.confirmSignUp(
+        username: usernameController.text.trim(),
+        confirmationCode: confirmationCodeController.text.trim(),
+      );
+      widget.showResult(
+        'Confirm Sign Up Status = ${res.nextStep.signUpStep}',
+      );
       widget.changeDisplay(
-          res.nextStep.signUpStep != 'DONE' ? 'SHOW_CONFIRM' : 'SHOW_SIGN_IN');
-    } on AmplifyException catch (e) {
+        res.nextStep.signUpStep != 'DONE' ? 'SHOW_CONFIRM' : 'SHOW_SIGN_IN',
+      );
+    } on Exception catch (e) {
       widget.setError(e);
     }
   }
 
   void _resendSignUpCode() async {
     try {
-      var res = await Amplify.Auth.resendSignUpCode(
+      final res = await Amplify.Auth.resendSignUpCode(
         username: usernameController.text.trim(),
       );
       widget.showResult(
-          'Sign Up Code Resent to ${res.codeDeliveryDetails.destination}');
-    } on AmplifyException catch (e) {
+        'Sign Up Code Resent to ${res.codeDeliveryDetails.destination}',
+      );
+    } on Exception catch (e) {
       widget.setError(e);
     }
   }
@@ -73,35 +78,37 @@ class _ConfirmSignUpWidgetState extends State<ConfirmSignUpWidget> {
           // wrap your Column in Expanded
           child: Column(
             children: [
-              const Padding(padding: EdgeInsets.all(10.0)),
+              const Padding(padding: EdgeInsets.all(10)),
               TextFormField(
-                  key: const Key('confirm-signup-username-input'),
-                  controller: usernameController,
-                  decoration: const InputDecoration(
-                    icon: Icon(Icons.person),
-                    hintText: 'Your username',
-                    labelText: 'Username *',
-                  )),
+                key: const Key('confirm-signup-username-input'),
+                controller: usernameController,
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.person),
+                  hintText: 'Your username',
+                  labelText: 'Username *',
+                ),
+              ),
               TextFormField(
-                  key: const Key('confirm-signup-code-input'),
-                  controller: confirmationCodeController,
-                  decoration: const InputDecoration(
-                    icon: Icon(Icons.confirmation_number),
-                    hintText: 'The code we sent you',
-                    labelText: 'Confirmation Code *',
-                  )),
-              const Padding(padding: EdgeInsets.all(10.0)),
+                key: const Key('confirm-signup-code-input'),
+                controller: confirmationCodeController,
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.confirmation_number),
+                  hintText: 'The code we sent you',
+                  labelText: 'Confirmation Code *',
+                ),
+              ),
+              const Padding(padding: EdgeInsets.all(10)),
               ElevatedButton(
                 key: const Key('confirm-user-button'),
                 onPressed: _confirmSignUp,
                 child: const Text('Confirm SignUp'),
               ),
-              const Padding(padding: EdgeInsets.all(10.0)),
+              const Padding(padding: EdgeInsets.all(10)),
               ElevatedButton(
                 onPressed: _resendSignUpCode,
                 child: const Text('ResendCode'),
               ),
-              const Padding(padding: EdgeInsets.all(10.0)),
+              const Padding(padding: EdgeInsets.all(10)),
               ElevatedButton(
                 key: const Key('goto-signin-button'),
                 onPressed: widget.backToSignIn,

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/confirm_user_attribute.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/confirm_user_attribute.dart
@@ -35,17 +35,20 @@ class _ConfirmUserAttributeScreenState
 
   void _showSuccess(String message) {
     ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(backgroundColor: Colors.green[800], content: Text(message)));
+      SnackBar(backgroundColor: Colors.green[800], content: Text(message)),
+    );
   }
 
   void _showInfo(String message) {
     ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(backgroundColor: Colors.blue[800], content: Text(message)));
+      SnackBar(backgroundColor: Colors.blue[800], content: Text(message)),
+    );
   }
 
   void _showError(String message) {
     ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(backgroundColor: Colors.red[900], content: Text(message)));
+      SnackBar(backgroundColor: Colors.red[900], content: Text(message)),
+    );
   }
 
   Future<void> _confirmUpdate() async {

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/sign_in.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/sign_in.dart
@@ -17,14 +17,6 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter/material.dart';
 
 class SignInWidget extends StatefulWidget {
-  final Function showResult;
-  final Function changeDisplay;
-  final VoidCallback showCreateUser;
-  final VoidCallback signOut;
-  final VoidCallback fetchSession;
-  final VoidCallback getCurrentUser;
-  final Function setError;
-
   const SignInWidget(
     this.showResult,
     this.changeDisplay,
@@ -35,6 +27,14 @@ class SignInWidget extends StatefulWidget {
     this.setError, {
     super.key,
   });
+
+  final void Function(String) showResult;
+  final void Function(String) changeDisplay;
+  final VoidCallback showCreateUser;
+  final VoidCallback signOut;
+  final VoidCallback fetchSession;
+  final VoidCallback getCurrentUser;
+  final void Function(Object?) setError;
 
   @override
   State<SignInWidget> createState() => _SignInWidgetState();
@@ -47,48 +47,51 @@ class _SignInWidgetState extends State<SignInWidget> {
 
   void _signIn() async {
     try {
-      var res = await Amplify.Auth.signIn(
-          username: usernameController.text.trim(),
-          password: passwordController.text.trim());
-      widget
-          .showResult('Sign In Status = ${res.nextStep?.signInStep ?? 'null'}');
-      widget
-          .changeDisplay(res.isSignedIn ? 'SIGNED_IN' : 'SHOW_CONFIRM_SIGN_IN');
-    } on AmplifyException catch (e) {
+      final res = await Amplify.Auth.signIn(
+        username: usernameController.text.trim(),
+        password: passwordController.text.trim(),
+      );
+      widget.showResult(
+        'Sign In Status = ${res.nextStep?.signInStep ?? 'null'}',
+      );
+      widget.changeDisplay(
+        res.isSignedIn ? 'SIGNED_IN' : 'SHOW_CONFIRM_SIGN_IN',
+      );
+    } on Exception catch (e) {
       widget.setError(e);
     }
   }
 
   void _signInWithWebUI() async {
     try {
-      var res = await Amplify.Auth.signInWithWebUI();
+      final res = await Amplify.Auth.signInWithWebUI();
       widget.showResult('Social Sign In Success = $res');
       widget.changeDisplay(res.isSignedIn ? 'SIGNED_IN' : 'SHOW_SIGN_IN');
       safePrint(res);
-    } on AmplifyException catch (e) {
+    } on Exception catch (e) {
       widget.setError(e);
     }
   }
 
   void _signInWithSocialWebUI() async {
     try {
-      var res = await Amplify.Auth.signInWithWebUI(provider: provider);
+      final res = await Amplify.Auth.signInWithWebUI(provider: provider);
       widget.showResult('Social Sign In Success = $res');
       widget.changeDisplay(res.isSignedIn ? 'SIGNED_IN' : 'SHOW_SIGN_IN');
       safePrint(res);
-    } on AmplifyException catch (e) {
+    } on Exception catch (e) {
       widget.setError(e);
     }
   }
 
   void _resetPassword() async {
     try {
-      var res = await Amplify.Auth.resetPassword(
+      final res = await Amplify.Auth.resetPassword(
         username: usernameController.text.trim(),
       );
       widget.showResult('Reset Password Status = ${res.nextStep.updateStep}');
       widget.changeDisplay('SHOW_CONFIRM_RESET');
-    } on AmplifyException catch (e) {
+    } on Exception catch (e) {
       widget.setError(e);
       safePrint(e);
     }
@@ -105,30 +108,32 @@ class _SignInWidgetState extends State<SignInWidget> {
           child: Column(
             children: [
               TextFormField(
-                  key: const Key('signin-username-input'),
-                  controller: usernameController,
-                  decoration: const InputDecoration(
-                    icon: Icon(Icons.person),
-                    hintText: 'Your username',
-                    labelText: 'Username *',
-                  )),
+                key: const Key('signin-username-input'),
+                controller: usernameController,
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.person),
+                  hintText: 'Your username',
+                  labelText: 'Username *',
+                ),
+              ),
               TextFormField(
-                  key: const Key('signin-password-input'),
-                  obscureText: true,
-                  controller: passwordController,
-                  decoration: const InputDecoration(
-                    icon: Icon(Icons.lock),
-                    hintText: 'Your password',
-                    labelText: 'Password *',
-                  )),
-              const Padding(padding: EdgeInsets.all(5.0)),
+                key: const Key('signin-password-input'),
+                obscureText: true,
+                controller: passwordController,
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.lock),
+                  hintText: 'Your password',
+                  labelText: 'Password *',
+                ),
+              ),
+              const Padding(padding: EdgeInsets.all(5)),
               GridView.count(
                 shrinkWrap: true,
                 crossAxisCount: 3,
                 crossAxisSpacing: 3,
                 mainAxisSpacing: 4,
                 childAspectRatio: 3,
-                padding: const EdgeInsets.all(5.0),
+                padding: const EdgeInsets.all(5),
                 children: [
                   ElevatedButton(
                     key: const Key('signin-button'),
@@ -168,44 +173,44 @@ class _SignInWidgetState extends State<SignInWidget> {
                 ],
               ),
               ListView(
-                  shrinkWrap: true,
-                  padding: const EdgeInsets.all(5.0),
-                  children: [
-                    ElevatedButton(
-                      key: const Key('signin-webui-button'),
-                      onPressed: _signInWithSocialWebUI,
-                      child: const Text('Sign In With Social Provider'),
+                shrinkWrap: true,
+                padding: const EdgeInsets.all(5),
+                children: [
+                  ElevatedButton(
+                    key: const Key('signin-webui-button'),
+                    onPressed: _signInWithSocialWebUI,
+                    child: const Text('Sign In With Social Provider'),
+                  ),
+                  DropdownButton<AuthProvider>(
+                    value: provider,
+                    icon: const Icon(Icons.arrow_downward),
+                    iconSize: 24,
+                    elevation: 16,
+                    style: const TextStyle(color: Colors.deepPurple),
+                    underline: Container(
+                      height: 2,
+                      color: Colors.deepPurpleAccent,
                     ),
-                    DropdownButton<AuthProvider>(
-                      value: provider,
-                      icon: const Icon(Icons.arrow_downward),
-                      iconSize: 24,
-                      elevation: 16,
-                      style: const TextStyle(color: Colors.deepPurple),
-                      underline: Container(
-                        height: 2,
-                        color: Colors.deepPurpleAccent,
-                      ),
-                      onChanged: (AuthProvider? newValue) {
-                        setState(() {
-                          if (newValue != null) {
-                            provider = newValue;
-                          }
-                        });
-                      },
-                      items: <AuthProvider>[
-                        AuthProvider.google,
-                        AuthProvider.facebook,
-                        AuthProvider.amazon
-                      ].map<DropdownMenuItem<AuthProvider>>(
-                          (AuthProvider value) {
-                        return DropdownMenuItem<AuthProvider>(
-                          value: value,
-                          child: Text(value.toString()),
-                        );
-                      }).toList(),
-                    ),
-                  ])
+                    onChanged: (AuthProvider? newValue) {
+                      setState(() {
+                        if (newValue != null) {
+                          provider = newValue;
+                        }
+                      });
+                    },
+                    items: <AuthProvider>[
+                      AuthProvider.google,
+                      AuthProvider.facebook,
+                      AuthProvider.amazon
+                    ].map<DropdownMenuItem<AuthProvider>>((AuthProvider value) {
+                      return DropdownMenuItem<AuthProvider>(
+                        value: value,
+                        child: Text(value.toString()),
+                      );
+                    }).toList(),
+                  ),
+                ],
+              )
             ],
           ),
         ),

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/sign_up.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/sign_up.dart
@@ -18,11 +18,6 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter/material.dart';
 
 class SignUpWidget extends StatefulWidget {
-  final Function showResult;
-  final Function changeDisplay;
-  final Function setError;
-  final VoidCallback backToSignIn;
-
   const SignUpWidget(
     this.showResult,
     this.changeDisplay,
@@ -30,6 +25,11 @@ class SignUpWidget extends StatefulWidget {
     this.backToSignIn, {
     super.key,
   });
+
+  final void Function(String) showResult;
+  final void Function(String) changeDisplay;
+  final void Function(Object?) setError;
+  final VoidCallback backToSignIn;
 
   @override
   State<SignUpWidget> createState() => _SignUpWidgetState();
@@ -42,19 +42,21 @@ class _SignUpWidgetState extends State<SignUpWidget> {
   final phoneController = TextEditingController();
 
   void _signUp() async {
-    var userAttributes = {
+    final userAttributes = {
       CognitoUserAttributeKey.email: emailController.text,
       CognitoUserAttributeKey.phoneNumber: phoneController.text,
     };
     try {
-      var res = await Amplify.Auth.signUp(
-          username: usernameController.text.trim(),
-          password: passwordController.text.trim(),
-          options: CognitoSignUpOptions(userAttributes: userAttributes));
+      final res = await Amplify.Auth.signUp(
+        username: usernameController.text.trim(),
+        password: passwordController.text.trim(),
+        options: CognitoSignUpOptions(userAttributes: userAttributes),
+      );
       widget.showResult('Sign Up Status = ${res.nextStep.signUpStep}');
       widget.changeDisplay(
-          res.nextStep.signUpStep != 'DONE' ? 'SHOW_CONFIRM' : 'SHOW_SIGN_UP');
-    } on AmplifyException catch (e) {
+        res.nextStep.signUpStep != 'DONE' ? 'SHOW_CONFIRM' : 'SHOW_SIGN_UP',
+      );
+    } on Exception catch (e) {
       widget.setError(e);
     }
   }
@@ -106,13 +108,13 @@ class _SignUpWidgetState extends State<SignUpWidget> {
                   labelText: 'Phone number *',
                 ),
               ),
-              const Padding(padding: EdgeInsets.all(10.0)),
+              const Padding(padding: EdgeInsets.all(10)),
               ElevatedButton(
                 key: const Key('signup-button'),
                 onPressed: _signUp,
                 child: const Text('Sign Up'),
               ),
-              const Padding(padding: EdgeInsets.all(10.0)),
+              const Padding(padding: EdgeInsets.all(10)),
               ElevatedButton(
                 key: const Key('goto-signin-button'),
                 onPressed: widget.backToSignIn,

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/update_password.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/update_password.dart
@@ -17,15 +17,20 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter/material.dart';
 
 class UpdatePasswordWidget extends StatefulWidget {
-  final Function showResult;
-  final Function changeDisplay;
-  final Function setError;
+  const UpdatePasswordWidget(
+    this.showResult,
+    this.changeDisplay,
+    this.setError,
+    this.backToSignIn,
+    this.backToApp, {
+    super.key,
+  });
+
+  final void Function(String) showResult;
+  final void Function(String) changeDisplay;
+  final void Function(Object) setError;
   final VoidCallback backToSignIn;
   final VoidCallback backToApp;
-
-  const UpdatePasswordWidget(this.showResult, this.changeDisplay, this.setError,
-      this.backToSignIn, this.backToApp,
-      {super.key});
 
   @override
   State<UpdatePasswordWidget> createState() => _UpdatePasswordWidgetState();
@@ -38,11 +43,12 @@ class _UpdatePasswordWidgetState extends State<UpdatePasswordWidget> {
   void _updatePassword() async {
     try {
       await Amplify.Auth.updatePassword(
-          newPassword: newPasswordController.text.trim(),
-          oldPassword: oldPasswordController.text.trim());
+        newPassword: newPasswordController.text.trim(),
+        oldPassword: oldPasswordController.text.trim(),
+      );
       widget.showResult('Password Updated');
       widget.changeDisplay('SIGNED_IN');
-    } on AmplifyException catch (e) {
+    } on Exception catch (e) {
       widget.setError(e);
     }
   }
@@ -56,34 +62,36 @@ class _UpdatePasswordWidgetState extends State<UpdatePasswordWidget> {
           // wrap your Column in Expanded
           child: Column(
             children: [
-              const Padding(padding: EdgeInsets.all(10.0)),
+              const Padding(padding: EdgeInsets.all(10)),
               TextFormField(
-                  controller: oldPasswordController,
-                  obscureText: true,
-                  decoration: const InputDecoration(
-                    icon: Icon(Icons.question_answer),
-                    hintText: 'Your old password',
-                    labelText: 'Old Password *',
-                  )),
+                controller: oldPasswordController,
+                obscureText: true,
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.question_answer),
+                  hintText: 'Your old password',
+                  labelText: 'Old Password *',
+                ),
+              ),
               TextFormField(
-                  controller: newPasswordController,
-                  obscureText: true,
-                  decoration: const InputDecoration(
-                    icon: Icon(Icons.question_answer),
-                    hintText: 'Your new password',
-                    labelText: 'New Password *',
-                  )),
-              const Padding(padding: EdgeInsets.all(10.0)),
+                controller: newPasswordController,
+                obscureText: true,
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.question_answer),
+                  hintText: 'Your new password',
+                  labelText: 'New Password *',
+                ),
+              ),
+              const Padding(padding: EdgeInsets.all(10)),
               ElevatedButton(
                 onPressed: _updatePassword,
                 child: const Text('Update Password'),
               ),
-              const Padding(padding: EdgeInsets.all(10.0)),
+              const Padding(padding: EdgeInsets.all(10)),
               ElevatedButton(
                 onPressed: widget.backToApp,
                 child: const Text('Back to App'),
               ),
-              const Padding(padding: EdgeInsets.all(10.0)),
+              const Padding(padding: EdgeInsets.all(10)),
               ElevatedButton(
                 key: const Key('goto-signin-button'),
                 onPressed: widget.backToSignIn,

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/update_user_attributes.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/update_user_attributes.dart
@@ -18,12 +18,17 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 class _UserAttributeController {
-  late TextEditingController keyController;
-  late TextEditingController valueController;
-  _UserAttributeController({String? keyValue}) {
-    keyController = TextEditingController(text: keyValue);
-    valueController = TextEditingController();
+  factory _UserAttributeController({String? keyValue}) {
+    return _UserAttributeController._(
+      TextEditingController(text: keyValue),
+      TextEditingController(),
+    );
   }
+
+  const _UserAttributeController._(this.keyController, this.valueController);
+
+  final TextEditingController keyController;
+  final TextEditingController valueController;
 }
 
 class UpdateUserAttributesScreen extends StatefulWidget {
@@ -138,54 +143,59 @@ class _UpdateUserAttributesScreenState
             children: [
               ..._userAttributeControllers.map((element) {
                 return Card(
-                    child: Stack(children: [
-                  Padding(
-                    padding: const EdgeInsets.only(
-                      left: 16,
-                      bottom: 24,
-                      right: 16,
-                    ),
-                    child: Column(children: [
-                      TextFormField(
-                        controller: element.keyController,
-                        decoration: const InputDecoration(
-                          labelText: 'Attribute Name',
-                        ),
-                        validator: (value) {
-                          if (value == null) {
-                            return 'An Attribute name is required.';
-                          }
-                          return null;
-                        },
-                      ),
-                      TextFormField(
-                        controller: element.valueController,
-                        decoration: const InputDecoration(
-                          labelText: 'Attribute Value',
-                        ),
-                        validator: (value) {
-                          if (value == null) {
-                            return 'An Attribute value is required.';
-                          }
-                          return null;
-                        },
-                      ),
-                    ]),
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
+                  child: Stack(
                     children: [
-                      IconButton(
-                        padding: EdgeInsets.zero,
-                        icon: const Icon(
-                          Icons.close,
-                          size: 18,
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          left: 16,
+                          bottom: 24,
+                          right: 16,
                         ),
-                        onPressed: () => _removeAttribute(element),
-                      )
+                        child: Column(
+                          children: [
+                            TextFormField(
+                              controller: element.keyController,
+                              decoration: const InputDecoration(
+                                labelText: 'Attribute Name',
+                              ),
+                              validator: (value) {
+                                if (value == null) {
+                                  return 'An Attribute name is required.';
+                                }
+                                return null;
+                              },
+                            ),
+                            TextFormField(
+                              controller: element.valueController,
+                              decoration: const InputDecoration(
+                                labelText: 'Attribute Value',
+                              ),
+                              validator: (value) {
+                                if (value == null) {
+                                  return 'An Attribute value is required.';
+                                }
+                                return null;
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          IconButton(
+                            padding: EdgeInsets.zero,
+                            icon: const Icon(
+                              Icons.close,
+                              size: 18,
+                            ),
+                            onPressed: () => _removeAttribute(element),
+                          )
+                        ],
+                      ),
                     ],
                   ),
-                ]));
+                );
               }),
               const SizedBox(height: 12),
               ElevatedButton(

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/view_user_attributes.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/view_user_attributes.dart
@@ -32,12 +32,14 @@ class _ViewUserAttributesScreenState extends State<ViewUserAttributesScreen> {
 
   void _showSuccess(String message) {
     ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(backgroundColor: Colors.green[800], content: Text(message)));
+      SnackBar(backgroundColor: Colors.green[800], content: Text(message)),
+    );
   }
 
   void _showError(String message) {
     ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(backgroundColor: Colors.red[900], content: Text(message)));
+      SnackBar(backgroundColor: Colors.red[900], content: Text(message)),
+    );
   }
 
   Future<void> _fetchAttributes({bool isRefresh = false}) async {
@@ -102,10 +104,10 @@ class _ViewUserAttributesScreenState extends State<ViewUserAttributesScreen> {
               child: ListView.builder(
                 itemCount: _userAttributes.length,
                 itemBuilder: (context, index) {
-                  AuthUserAttribute attribute = _userAttributes[index];
-                  CognitoUserAttributeKey userAttributeKey =
+                  final attribute = _userAttributes[index];
+                  final userAttributeKey =
                       attribute.userAttributeKey as CognitoUserAttributeKey;
-                  String value = attribute.value;
+                  final value = attribute.value;
                   return ListTile(
                     title: Text(userAttributeKey.key),
                     subtitle: Text(value),

--- a/packages/auth/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec.yaml
@@ -34,6 +34,7 @@ dev_dependencies:
     path: ../../../amplify_lints
   amplify_test:
     path: ../../../amplify_test
+  collection: any
   flutter_driver:
     sdk: flutter
   flutter_test:


### PR DESCRIPTION
Enables amplify_lints in Auth integration tests and example app. Cleans up a few incorrect integration tests.