### PR TITLE
chore(auth): Export Cognito JWT helpers

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
@@ -25,6 +25,7 @@ export 'src/exception/srp_exception.dart';
 
 export 'src/flows/hosted_ui/hosted_ui_platform.dart';
 
+export 'src/jwt/src/cognito.dart';
 export 'src/jwt/src/token.dart';
 
 // Models

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -21,7 +21,6 @@ import 'package:amplify_auth_cognito_dart/src/flows/constants.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/helpers.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/initial_parameters_stub.dart'
     if (dart.library.html) 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/initial_parameters_html.dart';
-import 'package:amplify_auth_cognito_dart/src/jwt/jwt.dart';
 import 'package:amplify_auth_cognito_dart/src/model/auth_user_ext.dart';
 import 'package:amplify_auth_cognito_dart/src/model/sign_in_parameters.dart';
 import 'package:amplify_auth_cognito_dart/src/model/sign_up_parameters.dart';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/auth_user_ext.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/auth_user_ext.dart
@@ -16,7 +16,6 @@
 library amplify_auth_cognito_dart.model.auth_user_ext;
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
-import 'package:amplify_auth_cognito_dart/src/jwt/jwt.dart';
 import 'package:amplify_auth_cognito_dart/src/model/cognito_user.dart';
 import 'package:meta/meta.dart';
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
@@ -19,7 +19,6 @@ import 'package:amplify_auth_cognito_dart/src/credentials/auth_plugin_credential
 import 'package:amplify_auth_cognito_dart/src/credentials/cognito_keys.dart';
 import 'package:amplify_auth_cognito_dart/src/credentials/device_metadata_repository.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/constants.dart';
-import 'package:amplify_auth_cognito_dart/src/jwt/jwt.dart';
 import 'package:amplify_auth_cognito_dart/src/model/auth_user_ext.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity.dart'
     hide NotAuthorizedException;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -25,7 +25,6 @@ import 'package:amplify_auth_cognito_dart/src/flows/srp/srp_device_password_veri
 import 'package:amplify_auth_cognito_dart/src/flows/srp/srp_init_result.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/srp/srp_init_worker.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/srp/srp_password_verifier_worker.dart';
-import 'package:amplify_auth_cognito_dart/src/jwt/jwt.dart';
 import 'package:amplify_auth_cognito_dart/src/model/cognito_device_secrets.dart';
 import 'package:amplify_auth_cognito_dart/src/model/cognito_user.dart';
 import 'package:amplify_auth_cognito_dart/src/model/sign_in_parameters.dart';


### PR DESCRIPTION
Makes getting Cognito items from JWTs easier, e.g. Cognito groups (https://github.com/aws-amplify/amplify-flutter/discussions/2221):

Before
```dart
final session =
    await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
final idToken = session.userPoolTokens!.idToken;
final userGroups =
    (idToken.claims.customClaims['cognito:groups'] as List?)
            ?.cast<String>() ??
        const [];
```

After
```dart
final session =
    await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
final idToken = session.userPoolTokens!.idToken;
final userGroups = idToken.groups;
```
