### PR TITLE
fix(datastore): enable java8 desugaring for amplify-android datastore…

### DIFF
--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -53,6 +53,8 @@ android {
         htmlReport false
     }
     compileOptions {
+        // Support for Java 8 features
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -69,6 +71,9 @@ android {
 }
 
 dependencies {
+    // Support for Java 8 features
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+
     implementation "com.amplifyframework:aws-datastore:1.37.2"
     implementation "com.amplifyframework:aws-api-appsync:1.37.2"
 


### PR DESCRIPTION
… plugin

*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/1239

*Description of changes:*

Enable java8 desugaring to prevent unexpected crush.
https://docs.amplify.aws/lib/datastore/getting-started/q/platform/android/#install-amplify-libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
