### PR TITLE
chore(api): add `targetName` to generated models used in tests

### DIFF
--- a/packages/amplify_test/lib/test_models/Comment.dart
+++ b/packages/amplify_test/lib/test_models/Comment.dart
@@ -173,6 +173,9 @@ class Comment extends Model {
     modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
         key: Comment.POST,
         isRequired: false,
+        // TODO(Jordan-Nelson): Remove `targetName` when API category has been
+        // updated to  support CPK changes. This was added manually.
+        targetName: "postID",
         targetNames: ["postID"],
         ofModelName: (Post).toString()));
 

--- a/packages/amplify_test/lib/test_models/Comment.dart
+++ b/packages/amplify_test/lib/test_models/Comment.dart
@@ -174,7 +174,7 @@ class Comment extends Model {
         key: Comment.POST,
         isRequired: false,
         // TODO(Jordan-Nelson): Remove `targetName` when API category has been
-        // updated to  support CPK changes. This was added manually.
+        // updated to support CPK changes. This was added manually.
         targetName: "postID",
         targetNames: ["postID"],
         ofModelName: (Post).toString()));

--- a/packages/amplify_test/lib/test_models/Post.dart
+++ b/packages/amplify_test/lib/test_models/Post.dart
@@ -321,7 +321,7 @@ class Post extends Model {
         key: Post.BLOG,
         isRequired: false,
         // TODO(Jordan-Nelson): Remove `targetName` when API category has been
-        // updated to  support CPK changes. This was added manually.
+        // updated to support CPK changes. This was added manually.
         targetName: "blogID",
         targetNames: ["blogID"],
         ofModelName: (Blog).toString()));

--- a/packages/amplify_test/lib/test_models/Post.dart
+++ b/packages/amplify_test/lib/test_models/Post.dart
@@ -320,8 +320,8 @@ class Post extends Model {
     modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
         key: Post.BLOG,
         isRequired: false,
-        // TODO: Remove when API category has been updated to support
-        // CPK changes. This was added manually.
+        // TODO(Jordan-Nelson): Remove `targetName` when API category has been
+        // updated to  support CPK changes. This was added manually.
         targetName: "blogID",
         targetNames: ["blogID"],
         ofModelName: (Blog).toString()));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds a field back to a generated model that was removed in https://github.com/aws-amplify/amplify-flutter/pull/2043

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
