### PR TITLE
chore(datastore): enable DataStore plugin interface tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,6 +437,7 @@ workflows:
                     "amplify_authenticator",
                     "amplify_core",
                     "amplify_datastore",
+                    "amplify_datastore_plugin_interface",
                     "amplify_flutter",
                     "amplify_storage_s3"
                 ]

--- a/packages/amplify_datastore_plugin_interface/test/amplify_modelschema_to_map_test.dart
+++ b/packages/amplify_datastore_plugin_interface/test/amplify_modelschema_to_map_test.dart
@@ -125,7 +125,10 @@ void main() {
           'isReadOnly': false,
           'association': {
             'associationType': 'BelongsTo',
+            // TODO(Jordan-Nelson): Remove `targetName` when API category has been
+            // updated to support CPK changes.
             'targetName': 'postID',
+            'targetNames': ['postID'],
             'associatedType': 'Post'
           },
         },
@@ -211,7 +214,10 @@ void main() {
           'isReadOnly': false,
           'association': {
             'associationType': 'BelongsTo',
+            // TODO(Jordan-Nelson): Remove `targetName` when API category has been
+            // updated to support CPK changes.
             'targetName': 'blogID',
+            'targetNames': ['blogID'],
             'associatedType': 'Blog'
           }
         },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- enable DataStore plugin interface tests in CI
- fix failing tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
