### PR TITLE
fix(http): `transformRequest` results in loop

### DIFF
--- a/packages/aws_common/lib/src/http/aws_http_client.dart
+++ b/packages/aws_common/lib/src/http/aws_http_client.dart
@@ -76,22 +76,32 @@ abstract class AWSBaseHttpClient extends AWSCustomHttpClient {
   /// Overriding this will change the underlying [send] method without
   /// interferring with transformations from [transformRequest] and
   /// [transformResponse].
-  AWSHttpClient get baseClient => this;
+  AWSHttpClient? get baseClient => null;
 
   @override
-  BadCertificateCallback get onBadCertificate => baseClient.onBadCertificate;
+  BadCertificateCallback get onBadCertificate =>
+      baseClient?.onBadCertificate ?? super.onBadCertificate;
 
   @override
   set onBadCertificate(BadCertificateCallback onBadCertificate) {
-    baseClient.onBadCertificate = onBadCertificate;
+    if (baseClient != null) {
+      baseClient!.onBadCertificate = onBadCertificate;
+    } else {
+      super.onBadCertificate = onBadCertificate;
+    }
   }
 
   @override
-  SupportedProtocols get supportedProtocols => baseClient.supportedProtocols;
+  SupportedProtocols get supportedProtocols =>
+      baseClient?.supportedProtocols ?? super.supportedProtocols;
 
   @override
   set supportedProtocols(SupportedProtocols supportedProtocols) {
-    baseClient.supportedProtocols = supportedProtocols;
+    if (baseClient != null) {
+      baseClient!.supportedProtocols = supportedProtocols;
+    } else {
+      super.supportedProtocols = supportedProtocols;
+    }
   }
 
   /// Transforms a [request] before sending.
@@ -126,7 +136,7 @@ abstract class AWSBaseHttpClient extends AWSCustomHttpClient {
       responseProgressCompleter.setEmpty();
       return;
     }
-    final operation = baseClient.send(request);
+    final operation = baseClient?.send(request) ?? super.send(request);
     requestProgressCompleter.setSourceStream(operation.requestProgress);
     responseProgressCompleter.setSourceStream(operation.responseProgress);
     operation.operation.then(
@@ -169,8 +179,7 @@ abstract class AWSBaseHttpClient extends AWSCustomHttpClient {
   @override
   Future<void> close({bool force = false}) {
     return Future.wait<void>([
-      if (!identical(this, baseClient))
-        Future.value(baseClient.close(force: force)),
+      Future.value(baseClient?.close(force: force)),
       super.close(force: force),
     ]);
   }

--- a/packages/aws_common/test/http/http_client_test.dart
+++ b/packages/aws_common/test/http/http_client_test.dart
@@ -1,0 +1,40 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+
+import 'package:aws_common/aws_common.dart';
+import 'package:test/test.dart';
+
+class OverrideTransformRequestClient extends AWSBaseHttpClient {
+  @override
+  Future<AWSBaseHttpRequest> transformRequest(
+    AWSBaseHttpRequest request,
+  ) async {
+    return request;
+  }
+}
+
+void main() {
+  group('AWSBaseHttpClient', () {
+    test('can leave baseClient unspecified', () async {
+      final client = OverrideTransformRequestClient()
+        ..supportedProtocols = SupportedProtocols.http1;
+      final request = AWSHttpRequest.get(
+        Uri.parse('https://amazon.com/ping'),
+      );
+      expect(request.send(client).response, completes);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #2241. Fixes an infinite loop by referencing `super` instead of `this`.