### PR TITLE
feat(http): Downgrade to HTTP/1.1 when possible

### DIFF
--- a/packages/aws_common/lib/src/http/aws_http_client.dart
+++ b/packages/aws_common/lib/src/http/aws_http_client.dart
@@ -46,8 +46,8 @@ abstract class AWSHttpClient implements Closeable {
 
   /// The supported HTTP protocols, used for negotiating with remote servers.
   ///
-  /// By default, only HTTP/2 and HTTP/3 servers are supported.
-  SupportedProtocols supportedProtocols = SupportedProtocols.http2_3;
+  /// By default, all protocols are supported.
+  SupportedProtocols supportedProtocols = SupportedProtocols.http1_2_3;
 
   /// Sends [request] using the underlying HTTP protocol and returns the
   /// streaming response.

--- a/packages/aws_common/lib/src/http/aws_http_client_io.dart
+++ b/packages/aws_common/lib/src/http/aws_http_client_io.dart
@@ -225,17 +225,34 @@ class AWSHttpClientImpl extends AWSHttpClient {
       AWSHttpMethod method,
       Uri uri,
     ) async {
+      final socket = await SecureSocket.connect(
+        uri.host,
+        uri.port,
+        supportedProtocols: supportedProtocols.alpnValues,
+        onBadCertificate: (cert) {
+          return onBadCertificate(cert.asInternalCert(), uri.host, uri.port);
+        },
+      );
+      logger.verbose('Negotiated ALPN: ${socket.selectedProtocol}');
+      if (socket.selectedProtocol != 'h2' &&
+          supportedProtocols.supports(AlpnProtocol.http1_1)) {
+        logger.verbose('Could not negotiate HTTP/2. Falling back to HTTP/1.1');
+        socket.destroy();
+        unawaited(
+          _sendH1(
+            logger: logger,
+            request: request,
+            completer: completer,
+            cancelTrigger: cancelTrigger,
+            requestProgress: requestProgress,
+            responseProgress: responseProgress,
+          ),
+        );
+        return null;
+      }
       final transport = _http2Connections[uri.authority] ??=
-          ClientTransportConnection.viaSocket(
-        await SecureSocket.connect(
-          uri.host,
-          uri.port,
-          supportedProtocols: supportedProtocols.alpnValues,
-          onBadCertificate: (cert) {
-            return onBadCertificate(cert.asInternalCert(), uri.host, uri.port);
-          },
-        ),
-      )..onActiveStateChanged = (isActive) {
+          ClientTransportConnection.viaSocket(socket)
+            ..onActiveStateChanged = (isActive) {
               if (!isActive) {
                 _logger.verbose('Closing transport: ${uri.authority}');
                 _http2Connections.remove(uri.authority)?.finish();
@@ -445,6 +462,21 @@ class AWSHttpClientImpl extends AWSHttpClient {
     );
 
     Future<void>(() async {
+      if (supportedProtocols.supports(AlpnProtocol.http2)) {
+        if (request.scheme == 'https') {
+          return _sendH2(
+            request: request,
+            logger: operation.logger,
+            completer: completer,
+            cancelTrigger: cancelTrigger.future,
+            requestProgress: requestProgressController,
+            responseProgress: responseProgressController,
+          );
+        }
+        operation.logger.warn(
+          'HTTP/2 does not support insecure "http://" requests',
+        );
+      }
       if (supportedProtocols.supports(AlpnProtocol.http1_1)) {
         return _sendH1(
           logger: operation.logger,
@@ -454,16 +486,13 @@ class AWSHttpClientImpl extends AWSHttpClient {
           requestProgress: requestProgressController,
           responseProgress: responseProgressController,
         );
-      } else {
-        return _sendH2(
-          request: request,
-          logger: operation.logger,
-          completer: completer,
-          cancelTrigger: cancelTrigger.future,
-          requestProgress: requestProgressController,
-          responseProgress: responseProgressController,
-        );
       }
+      completer.completeError(
+        AWSHttpException(
+          request,
+          const SocketException('Unsupported protocol/scheme combination'),
+        ),
+      );
     }).catchError((Object e, StackTrace st) {
       completer.completeError(AWSHttpException(request, e), st);
     });

--- a/packages/aws_common/test/http/downgrade_server.dart
+++ b/packages/aws_common/test/http/downgrade_server.dart
@@ -1,0 +1,45 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:http2/http2.dart';
+import 'package:stream_channel/stream_channel.dart';
+
+import 'http_server.dart';
+
+/// Starts an HTTP/1.1 server which returns "OK"
+Future<void> hybridMain(StreamChannel<Object?> channel) =>
+    clientHybridMain(channel, _handleH1, _handleH2);
+
+void _handleH1(
+  StreamChannel<Object?> channel,
+  HttpRequest request,
+  int port,
+) {
+  request.response
+    ..add('OK'.codeUnits)
+    ..close();
+}
+
+Future<void> _handleH2(
+  StreamChannel<Object?> channel,
+  ServerTransportStream request,
+  Stream<List<int>> body,
+  Map<String, String> headers,
+  int port,
+) async {
+  throw Exception('Should not connect to HTTP/2');
+}

--- a/packages/aws_common/test/http/downgrade_server_vm.dart
+++ b/packages/aws_common/test/http/downgrade_server_vm.dart
@@ -1,0 +1,26 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:stream_channel/stream_channel.dart';
+
+import 'downgrade_server.dart';
+
+/// Starts the redirect test HTTP server in the same process.
+Future<StreamChannel<Object?>> startServer() async {
+  final controller = StreamChannelController<Object?>(sync: true);
+  unawaited(hybridMain(controller.foreign));
+  return controller.local;
+}

--- a/packages/aws_common/test/http/downgrade_server_web.dart
+++ b/packages/aws_common/test/http/downgrade_server_web.dart
@@ -1,0 +1,20 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/test.dart';
+
+/// Starts the redirect test HTTP server out-of-process.
+Future<StreamChannel<Object?>> startServer() async =>
+    spawnHybridUri('downgrade_server.dart');

--- a/packages/aws_common/test/http/downgrade_test.dart
+++ b/packages/aws_common/test/http/downgrade_test.dart
@@ -1,0 +1,78 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:async/async.dart';
+import 'package:aws_common/aws_common.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/test.dart';
+
+import 'downgrade_server_vm.dart'
+    if (dart.library.html) 'downgrade_server_web.dart';
+import 'http_common.dart';
+
+void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
+  const isSecure = !zIsWeb;
+
+  group('AWSHttpClient', () {
+    late final String host;
+    late final StreamChannel<Object?> httpServerChannel;
+    late final StreamQueue<Object?> httpServerQueue;
+
+    AWSHttpRequest makeRequest() => AWSHttpRequest.get(
+          (isSecure ? Uri.https : Uri.http)(host, '/'),
+        );
+
+    setUpAll(() async {
+      httpServerChannel = await startServer()
+        ..sink.add(AlpnProtocol.http1_1.value)
+        ..sink.add(isSecure);
+      httpServerQueue = StreamQueue(httpServerChannel.stream);
+      host = 'localhost:${await httpServerQueue.next}';
+    });
+
+    tearDownAll(() {
+      httpServerChannel.sink.add(null);
+    });
+
+    test(
+      'downgrades to HTTP/1.1 when HTTP/2 is unavailable and '
+      'supportedProtocols contains HTTP/1.1',
+      () async {
+        final client = debugClient
+          ..supportedProtocols = SupportedProtocols.http1_2_3;
+        expect(
+          client.send(makeRequest()).response,
+          completes,
+          reason: 'supportedProtocols allows downgrade to HTTP/1.1',
+        );
+      },
+    );
+
+    test(
+      'fails when HTTP/2 is unavailable and supportedProtocols '
+      'does not contain HTTP/1.1',
+      () async {
+        final client = debugClient
+          ..supportedProtocols = SupportedProtocols.http2_3;
+        expect(
+          client.send(makeRequest()).response,
+          throwsA(isA<Exception>()),
+          reason: 'supportedProtocols does not allow HTTP/1.1',
+        );
+      },
+      skip: zIsWeb ? 'Web client cannot select protocols' : null,
+    );
+  });
+}

--- a/packages/aws_common/test/http/http_common.dart
+++ b/packages/aws_common/test/http/http_common.dart
@@ -84,13 +84,13 @@ void clientTest(
   innerTest(
     AlpnProtocol.http1_1,
     secure: false,
-    supportedProtocols: SupportedProtocols.http1_2_3,
+    supportedProtocols: SupportedProtocols.http1,
     skip: skip,
   );
   innerTest(
     AlpnProtocol.http1_1,
     secure: true,
-    supportedProtocols: SupportedProtocols.http1_2_3,
+    supportedProtocols: SupportedProtocols.http1,
     skip: zIsWeb ? 'Secure web servers cannot be tested on Web' : skip,
   );
   innerTest(


### PR DESCRIPTION
Improve usability of the HTTP client by downgrading to HTTP/1.1 when HTTP/2 is unavailable. This allows setting the default to a more reasonable 1/2/3 setting so that things will _generally_ work as expected.
