### PR TITLE
chore: fix CI integ tests by removing dummy config

### DIFF
--- a/.github/composite_actions/fetch_backends/action.yaml
+++ b/.github/composite_actions/fetch_backends/action.yaml
@@ -32,6 +32,12 @@ runs:
       run: ./build-support/create_integration_test_profile.sh
       shell: bash
 
+    # The dummy configuration produced by aft has some characters which cause the
+    # Amplify CLI to throw when running pull, so just delete the dummy file.
+    - name: Remove config file created by aft
+      run: melos exec --scope=${{ inputs.scope }} rm lib/amplifyconfiguration.dart
+      shell: bash
+
     - name: Pull Amplify Configurations
       run: |
         API_APP_ID=${{ inputs.api-app-id }} \


### PR DESCRIPTION
Fixes error during `amplify pull` in integ tests in CI.

We changed the dummy config produced by aft and that throws an error from Amplify CLI pull command. This PR just removes those dummy files before running amplify pull.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
