### PR TITLE
fix(smithy): Add check for 2xx errors in S3 client

### DIFF
--- a/packages/smithy/goldens/lib2/custom/lib/s3.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/s3.dart
@@ -5,6 +5,11 @@ library custom_v2.s3;
 
 export 'package:custom_v2/src/s3/model/aws_config.dart';
 export 'package:custom_v2/src/s3/model/client_config.dart';
+export 'package:custom_v2/src/s3/model/copy_object_error.dart';
+export 'package:custom_v2/src/s3/model/copy_object_output.dart';
+export 'package:custom_v2/src/s3/model/copy_object_request.dart'
+    hide CopyObjectRequestPayload;
+export 'package:custom_v2/src/s3/model/copy_object_result.dart';
 export 'package:custom_v2/src/s3/model/environment_config.dart';
 export 'package:custom_v2/src/s3/model/file_config_settings.dart';
 export 'package:custom_v2/src/s3/model/get_object_output.dart';

--- a/packages/smithy/goldens/lib2/custom/lib/src/s3/common/serializers.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/s3/common/serializers.dart
@@ -2,42 +2,50 @@
 
 library custom_v2.s3.common.serializers; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
-import 'package:built_collection/built_collection.dart' as _i14;
+import 'package:built_collection/built_collection.dart' as _i18;
 import 'package:built_value/serializer.dart';
-import 'package:custom_v2/src/s3/model/aws_config.dart' as _i13;
-import 'package:custom_v2/src/s3/model/client_config.dart' as _i10;
-import 'package:custom_v2/src/s3/model/environment_config.dart' as _i5;
-import 'package:custom_v2/src/s3/model/file_config_settings.dart' as _i8;
-import 'package:custom_v2/src/s3/model/get_object_output.dart' as _i2;
-import 'package:custom_v2/src/s3/model/get_object_request.dart' as _i3;
-import 'package:custom_v2/src/s3/model/operation_config.dart' as _i11;
-import 'package:custom_v2/src/s3/model/retry_config.dart' as _i9;
-import 'package:custom_v2/src/s3/model/retry_mode.dart' as _i4;
-import 'package:custom_v2/src/s3/model/s3_addressing_style.dart' as _i6;
-import 'package:custom_v2/src/s3/model/s3_config.dart' as _i7;
-import 'package:custom_v2/src/s3/model/scoped_config.dart' as _i12;
+import 'package:custom_v2/src/s3/model/aws_config.dart' as _i17;
+import 'package:custom_v2/src/s3/model/client_config.dart' as _i14;
+import 'package:custom_v2/src/s3/model/copy_object_error.dart' as _i4;
+import 'package:custom_v2/src/s3/model/copy_object_output.dart' as _i2;
+import 'package:custom_v2/src/s3/model/copy_object_request.dart' as _i5;
+import 'package:custom_v2/src/s3/model/copy_object_result.dart' as _i3;
+import 'package:custom_v2/src/s3/model/environment_config.dart' as _i9;
+import 'package:custom_v2/src/s3/model/file_config_settings.dart' as _i12;
+import 'package:custom_v2/src/s3/model/get_object_output.dart' as _i6;
+import 'package:custom_v2/src/s3/model/get_object_request.dart' as _i7;
+import 'package:custom_v2/src/s3/model/operation_config.dart' as _i15;
+import 'package:custom_v2/src/s3/model/retry_config.dart' as _i13;
+import 'package:custom_v2/src/s3/model/retry_mode.dart' as _i8;
+import 'package:custom_v2/src/s3/model/s3_addressing_style.dart' as _i10;
+import 'package:custom_v2/src/s3/model/s3_config.dart' as _i11;
+import 'package:custom_v2/src/s3/model/scoped_config.dart' as _i16;
 import 'package:smithy/smithy.dart' as _i1;
 
 const List<_i1.SmithySerializer> serializers = [
-  ..._i2.GetObjectOutput.serializers,
-  ..._i3.GetObjectRequest.serializers,
-  ..._i4.RetryMode.serializers,
-  ..._i5.EnvironmentConfig.serializers,
-  ..._i6.S3AddressingStyle.serializers,
-  ..._i7.S3Config.serializers,
-  ..._i8.FileConfigSettings.serializers,
-  ..._i9.RetryConfig.serializers,
-  ..._i10.ClientConfig.serializers,
-  ..._i11.OperationConfig.serializers,
-  ..._i12.ScopedConfig.serializers,
-  ..._i13.AwsConfig.serializers,
+  ..._i2.CopyObjectOutput.serializers,
+  ..._i3.CopyObjectResult.serializers,
+  ..._i4.CopyObjectError.serializers,
+  ..._i5.CopyObjectRequest.serializers,
+  ..._i6.GetObjectOutput.serializers,
+  ..._i7.GetObjectRequest.serializers,
+  ..._i8.RetryMode.serializers,
+  ..._i9.EnvironmentConfig.serializers,
+  ..._i10.S3AddressingStyle.serializers,
+  ..._i11.S3Config.serializers,
+  ..._i12.FileConfigSettings.serializers,
+  ..._i13.RetryConfig.serializers,
+  ..._i14.ClientConfig.serializers,
+  ..._i15.OperationConfig.serializers,
+  ..._i16.ScopedConfig.serializers,
+  ..._i17.AwsConfig.serializers,
 ];
 final Map<FullType, Function> builderFactories = {
   const FullType(
-    _i14.BuiltMap,
+    _i18.BuiltMap,
     [
       FullType(String),
-      FullType(_i8.FileConfigSettings),
+      FullType(_i12.FileConfigSettings),
     ],
-  ): _i14.MapBuilder<String, _i8.FileConfigSettings>.new
+  ): _i18.MapBuilder<String, _i12.FileConfigSettings>.new
 };

--- a/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_error.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_error.dart
@@ -1,0 +1,107 @@
+// Generated with smithy-dart 0.1.1. DO NOT MODIFY.
+
+library custom_v2.s3.model.copy_object_error; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i2;
+
+part 'copy_object_error.g.dart';
+
+abstract class CopyObjectError
+    with _i1.AWSEquatable<CopyObjectError>
+    implements
+        Built<CopyObjectError, CopyObjectErrorBuilder>,
+        _i2.EmptyPayload,
+        _i2.SmithyHttpException {
+  factory CopyObjectError() {
+    return _$CopyObjectError._();
+  }
+
+  factory CopyObjectError.build(
+      [void Function(CopyObjectErrorBuilder) updates]) = _$CopyObjectError;
+
+  const CopyObjectError._();
+
+  /// Constructs a [CopyObjectError] from a [payload] and [response].
+  factory CopyObjectError.fromResponse(
+    CopyObjectError payload,
+    _i1.AWSBaseHttpResponse response,
+  ) =>
+      payload.rebuild((b) {
+        b.headers = response.headers;
+      });
+
+  static const List<_i2.SmithySerializer> serializers = [
+    CopyObjectErrorRestXmlSerializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(CopyObjectErrorBuilder b) {}
+  @override
+  _i2.ShapeId get shapeId => const _i2.ShapeId(
+        namespace: 'com.amazonaws.s3',
+        shape: 'CopyObjectError',
+      );
+  @override
+  String? get message => null;
+  @override
+  _i2.RetryConfig? get retryConfig => null;
+  @override
+  @BuiltValueField(compare: false)
+  int get statusCode => 500;
+  @override
+  @BuiltValueField(compare: false)
+  Map<String, String>? get headers;
+  @override
+  Exception? get underlyingException => null;
+  @override
+  List<Object?> get props => [];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('CopyObjectError');
+    return helper.toString();
+  }
+}
+
+class CopyObjectErrorRestXmlSerializer
+    extends _i2.StructuredSmithySerializer<CopyObjectError> {
+  const CopyObjectErrorRestXmlSerializer() : super('CopyObjectError');
+
+  @override
+  Iterable<Type> get types => const [
+        CopyObjectError,
+        _$CopyObjectError,
+      ];
+  @override
+  Iterable<_i2.ShapeId> get supportedProtocols => const [
+        _i2.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'restXml',
+        )
+      ];
+  @override
+  CopyObjectError deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return CopyObjectErrorBuilder().build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      const _i2.XmlElementName(
+        'CopyObjectError',
+        _i2.XmlNamespace('http://s3.amazonaws.com/doc/2006-03-01/'),
+      )
+    ];
+    return result;
+  }
+}

--- a/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_error.g.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_error.g.dart
@@ -1,0 +1,80 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of custom_v2.s3.model.copy_object_error;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$CopyObjectError extends CopyObjectError {
+  @override
+  final Map<String, String>? headers;
+
+  factory _$CopyObjectError([void Function(CopyObjectErrorBuilder)? updates]) =>
+      (new CopyObjectErrorBuilder()..update(updates))._build();
+
+  _$CopyObjectError._({this.headers}) : super._();
+
+  @override
+  CopyObjectError rebuild(void Function(CopyObjectErrorBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CopyObjectErrorBuilder toBuilder() =>
+      new CopyObjectErrorBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CopyObjectError;
+  }
+
+  @override
+  int get hashCode {
+    return 1014735209;
+  }
+}
+
+class CopyObjectErrorBuilder
+    implements Builder<CopyObjectError, CopyObjectErrorBuilder> {
+  _$CopyObjectError? _$v;
+
+  Map<String, String>? _headers;
+  Map<String, String>? get headers => _$this._headers;
+  set headers(Map<String, String>? headers) => _$this._headers = headers;
+
+  CopyObjectErrorBuilder() {
+    CopyObjectError._init(this);
+  }
+
+  CopyObjectErrorBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _headers = $v.headers;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CopyObjectError other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CopyObjectError;
+  }
+
+  @override
+  void update(void Function(CopyObjectErrorBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CopyObjectError build() => _build();
+
+  _$CopyObjectError _build() {
+    final _$result = _$v ?? new _$CopyObjectError._(headers: headers);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_output.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_output.dart
@@ -1,0 +1,132 @@
+// Generated with smithy-dart 0.1.1. DO NOT MODIFY.
+
+library custom_v2.s3.model.copy_object_output; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:custom_v2/src/s3/model/copy_object_result.dart' as _i3;
+import 'package:smithy/smithy.dart' as _i2;
+
+part 'copy_object_output.g.dart';
+
+abstract class CopyObjectOutput
+    with _i1.AWSEquatable<CopyObjectOutput>
+    implements
+        Built<CopyObjectOutput, CopyObjectOutputBuilder>,
+        _i2.HasPayload<_i3.CopyObjectResult> {
+  factory CopyObjectOutput({_i3.CopyObjectResult? copyObjectResult}) {
+    return _$CopyObjectOutput._(copyObjectResult: copyObjectResult);
+  }
+
+  factory CopyObjectOutput.build(
+      [void Function(CopyObjectOutputBuilder) updates]) = _$CopyObjectOutput;
+
+  const CopyObjectOutput._();
+
+  /// Constructs a [CopyObjectOutput] from a [payload] and [response].
+  factory CopyObjectOutput.fromResponse(
+    _i3.CopyObjectResult? payload,
+    _i1.AWSBaseHttpResponse response,
+  ) =>
+      CopyObjectOutput.build((b) {
+        if (payload != null) {
+          b.copyObjectResult.replace(payload);
+        }
+      });
+
+  static const List<_i2.SmithySerializer> serializers = [
+    CopyObjectOutputRestXmlSerializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(CopyObjectOutputBuilder b) {}
+  _i3.CopyObjectResult? get copyObjectResult;
+  @override
+  _i3.CopyObjectResult? getPayload() =>
+      copyObjectResult ?? _i3.CopyObjectResult();
+  @override
+  List<Object?> get props => [copyObjectResult];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('CopyObjectOutput');
+    helper.add(
+      'copyObjectResult',
+      copyObjectResult,
+    );
+    return helper.toString();
+  }
+}
+
+class CopyObjectOutputRestXmlSerializer
+    extends _i2.StructuredSmithySerializer<_i3.CopyObjectResult> {
+  const CopyObjectOutputRestXmlSerializer() : super('CopyObjectOutput');
+
+  @override
+  Iterable<Type> get types => const [
+        CopyObjectOutput,
+        _$CopyObjectOutput,
+      ];
+  @override
+  Iterable<_i2.ShapeId> get supportedProtocols => const [
+        _i2.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'restXml',
+        )
+      ];
+  @override
+  _i3.CopyObjectResult deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = _i3.CopyObjectResultBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key as String) {
+        case 'ETag':
+          if (value != null) {
+            result.eTag = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = object is CopyObjectOutput
+        ? object.getPayload()
+        : (object as _i3.CopyObjectResult?);
+    final result = <Object?>[
+      const _i2.XmlElementName(
+        'CopyObjectResult',
+        _i2.XmlNamespace('http://s3.amazonaws.com/doc/2006-03-01/'),
+      )
+    ];
+    if (payload == null) {
+      return result;
+    }
+    if (payload.eTag != null) {
+      result
+        ..add(const _i2.XmlElementName('ETag'))
+        ..add(serializers.serialize(
+          payload.eTag!,
+          specifiedType: const FullType(String),
+        ));
+    }
+    return result;
+  }
+}

--- a/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_output.g.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_output.g.dart
@@ -1,0 +1,99 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of custom_v2.s3.model.copy_object_output;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$CopyObjectOutput extends CopyObjectOutput {
+  @override
+  final _i3.CopyObjectResult? copyObjectResult;
+
+  factory _$CopyObjectOutput(
+          [void Function(CopyObjectOutputBuilder)? updates]) =>
+      (new CopyObjectOutputBuilder()..update(updates))._build();
+
+  _$CopyObjectOutput._({this.copyObjectResult}) : super._();
+
+  @override
+  CopyObjectOutput rebuild(void Function(CopyObjectOutputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CopyObjectOutputBuilder toBuilder() =>
+      new CopyObjectOutputBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CopyObjectOutput &&
+        copyObjectResult == other.copyObjectResult;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, copyObjectResult.hashCode));
+  }
+}
+
+class CopyObjectOutputBuilder
+    implements Builder<CopyObjectOutput, CopyObjectOutputBuilder> {
+  _$CopyObjectOutput? _$v;
+
+  _i3.CopyObjectResultBuilder? _copyObjectResult;
+  _i3.CopyObjectResultBuilder get copyObjectResult =>
+      _$this._copyObjectResult ??= new _i3.CopyObjectResultBuilder();
+  set copyObjectResult(_i3.CopyObjectResultBuilder? copyObjectResult) =>
+      _$this._copyObjectResult = copyObjectResult;
+
+  CopyObjectOutputBuilder() {
+    CopyObjectOutput._init(this);
+  }
+
+  CopyObjectOutputBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _copyObjectResult = $v.copyObjectResult?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CopyObjectOutput other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CopyObjectOutput;
+  }
+
+  @override
+  void update(void Function(CopyObjectOutputBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CopyObjectOutput build() => _build();
+
+  _$CopyObjectOutput _build() {
+    _$CopyObjectOutput _$result;
+    try {
+      _$result = _$v ??
+          new _$CopyObjectOutput._(
+              copyObjectResult: _copyObjectResult?.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'copyObjectResult';
+        _copyObjectResult?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'CopyObjectOutput', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_request.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_request.dart
@@ -1,0 +1,169 @@
+// Generated with smithy-dart 0.1.1. DO NOT MODIFY.
+
+library custom_v2.s3.model.copy_object_request; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i2;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:meta/meta.dart' as _i3;
+import 'package:smithy/smithy.dart' as _i1;
+
+part 'copy_object_request.g.dart';
+
+abstract class CopyObjectRequest
+    with
+        _i1.HttpInput<CopyObjectRequestPayload>,
+        _i2.AWSEquatable<CopyObjectRequest>
+    implements
+        Built<CopyObjectRequest, CopyObjectRequestBuilder>,
+        _i1.EmptyPayload,
+        _i1.HasPayload<CopyObjectRequestPayload> {
+  factory CopyObjectRequest({
+    required String bucket,
+    required String copySource,
+    required String key,
+  }) {
+    return _$CopyObjectRequest._(
+      bucket: bucket,
+      copySource: copySource,
+      key: key,
+    );
+  }
+
+  factory CopyObjectRequest.build(
+      [void Function(CopyObjectRequestBuilder) updates]) = _$CopyObjectRequest;
+
+  const CopyObjectRequest._();
+
+  factory CopyObjectRequest.fromRequest(
+    CopyObjectRequestPayload payload,
+    _i2.AWSBaseHttpRequest request, {
+    Map<String, String> labels = const {},
+  }) =>
+      CopyObjectRequest.build((b) {
+        if (request.headers['x-amz-copy-source'] != null) {
+          b.copySource = request.headers['x-amz-copy-source']!;
+        }
+        if (labels['bucket'] != null) {
+          b.bucket = labels['bucket']!;
+        }
+        if (labels['key'] != null) {
+          b.key = labels['key']!;
+        }
+      });
+
+  static const List<_i1.SmithySerializer> serializers = [
+    CopyObjectRequestRestXmlSerializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(CopyObjectRequestBuilder b) {}
+  String get bucket;
+  String get copySource;
+  String get key;
+  @override
+  String labelFor(String key) {
+    switch (key) {
+      case 'Bucket':
+        return bucket;
+      case 'Key':
+        return this.key;
+    }
+    throw _i1.MissingLabelException(
+      this,
+      key,
+    );
+  }
+
+  @override
+  CopyObjectRequestPayload getPayload() => CopyObjectRequestPayload();
+  @override
+  List<Object?> get props => [
+        bucket,
+        copySource,
+        key,
+      ];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('CopyObjectRequest');
+    helper.add(
+      'bucket',
+      bucket,
+    );
+    helper.add(
+      'copySource',
+      copySource,
+    );
+    helper.add(
+      'key',
+      key,
+    );
+    return helper.toString();
+  }
+}
+
+@_i3.internal
+abstract class CopyObjectRequestPayload
+    with _i2.AWSEquatable<CopyObjectRequestPayload>
+    implements
+        Built<CopyObjectRequestPayload, CopyObjectRequestPayloadBuilder>,
+        _i1.EmptyPayload {
+  factory CopyObjectRequestPayload(
+          [void Function(CopyObjectRequestPayloadBuilder) updates]) =
+      _$CopyObjectRequestPayload;
+
+  const CopyObjectRequestPayload._();
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(CopyObjectRequestPayloadBuilder b) {}
+  @override
+  List<Object?> get props => [];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('CopyObjectRequestPayload');
+    return helper.toString();
+  }
+}
+
+class CopyObjectRequestRestXmlSerializer
+    extends _i1.StructuredSmithySerializer<CopyObjectRequestPayload> {
+  const CopyObjectRequestRestXmlSerializer() : super('CopyObjectRequest');
+
+  @override
+  Iterable<Type> get types => const [
+        CopyObjectRequest,
+        _$CopyObjectRequest,
+        CopyObjectRequestPayload,
+        _$CopyObjectRequestPayload,
+      ];
+  @override
+  Iterable<_i1.ShapeId> get supportedProtocols => const [
+        _i1.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'restXml',
+        )
+      ];
+  @override
+  CopyObjectRequestPayload deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return CopyObjectRequestPayloadBuilder().build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      const _i1.XmlElementName(
+        'CopyObjectRequest',
+        _i1.XmlNamespace('http://s3.amazonaws.com/doc/2006-03-01/'),
+      )
+    ];
+    return result;
+  }
+}

--- a/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_request.g.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_request.g.dart
@@ -1,0 +1,172 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of custom_v2.s3.model.copy_object_request;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$CopyObjectRequest extends CopyObjectRequest {
+  @override
+  final String bucket;
+  @override
+  final String copySource;
+  @override
+  final String key;
+
+  factory _$CopyObjectRequest(
+          [void Function(CopyObjectRequestBuilder)? updates]) =>
+      (new CopyObjectRequestBuilder()..update(updates))._build();
+
+  _$CopyObjectRequest._(
+      {required this.bucket, required this.copySource, required this.key})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        bucket, r'CopyObjectRequest', 'bucket');
+    BuiltValueNullFieldError.checkNotNull(
+        copySource, r'CopyObjectRequest', 'copySource');
+    BuiltValueNullFieldError.checkNotNull(key, r'CopyObjectRequest', 'key');
+  }
+
+  @override
+  CopyObjectRequest rebuild(void Function(CopyObjectRequestBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CopyObjectRequestBuilder toBuilder() =>
+      new CopyObjectRequestBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CopyObjectRequest &&
+        bucket == other.bucket &&
+        copySource == other.copySource &&
+        key == other.key;
+  }
+
+  @override
+  int get hashCode {
+    return $jf(
+        $jc($jc($jc(0, bucket.hashCode), copySource.hashCode), key.hashCode));
+  }
+}
+
+class CopyObjectRequestBuilder
+    implements Builder<CopyObjectRequest, CopyObjectRequestBuilder> {
+  _$CopyObjectRequest? _$v;
+
+  String? _bucket;
+  String? get bucket => _$this._bucket;
+  set bucket(String? bucket) => _$this._bucket = bucket;
+
+  String? _copySource;
+  String? get copySource => _$this._copySource;
+  set copySource(String? copySource) => _$this._copySource = copySource;
+
+  String? _key;
+  String? get key => _$this._key;
+  set key(String? key) => _$this._key = key;
+
+  CopyObjectRequestBuilder() {
+    CopyObjectRequest._init(this);
+  }
+
+  CopyObjectRequestBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _bucket = $v.bucket;
+      _copySource = $v.copySource;
+      _key = $v.key;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CopyObjectRequest other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CopyObjectRequest;
+  }
+
+  @override
+  void update(void Function(CopyObjectRequestBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CopyObjectRequest build() => _build();
+
+  _$CopyObjectRequest _build() {
+    final _$result = _$v ??
+        new _$CopyObjectRequest._(
+            bucket: BuiltValueNullFieldError.checkNotNull(
+                bucket, r'CopyObjectRequest', 'bucket'),
+            copySource: BuiltValueNullFieldError.checkNotNull(
+                copySource, r'CopyObjectRequest', 'copySource'),
+            key: BuiltValueNullFieldError.checkNotNull(
+                key, r'CopyObjectRequest', 'key'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CopyObjectRequestPayload extends CopyObjectRequestPayload {
+  factory _$CopyObjectRequestPayload(
+          [void Function(CopyObjectRequestPayloadBuilder)? updates]) =>
+      (new CopyObjectRequestPayloadBuilder()..update(updates))._build();
+
+  _$CopyObjectRequestPayload._() : super._();
+
+  @override
+  CopyObjectRequestPayload rebuild(
+          void Function(CopyObjectRequestPayloadBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CopyObjectRequestPayloadBuilder toBuilder() =>
+      new CopyObjectRequestPayloadBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CopyObjectRequestPayload;
+  }
+
+  @override
+  int get hashCode {
+    return 528129857;
+  }
+}
+
+class CopyObjectRequestPayloadBuilder
+    implements
+        Builder<CopyObjectRequestPayload, CopyObjectRequestPayloadBuilder> {
+  _$CopyObjectRequestPayload? _$v;
+
+  CopyObjectRequestPayloadBuilder() {
+    CopyObjectRequestPayload._init(this);
+  }
+
+  @override
+  void replace(CopyObjectRequestPayload other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CopyObjectRequestPayload;
+  }
+
+  @override
+  void update(void Function(CopyObjectRequestPayloadBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CopyObjectRequestPayload build() => _build();
+
+  _$CopyObjectRequestPayload _build() {
+    final _$result = _$v ?? new _$CopyObjectRequestPayload._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_result.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_result.dart
@@ -1,0 +1,110 @@
+// Generated with smithy-dart 0.1.1. DO NOT MODIFY.
+
+library custom_v2.s3.model.copy_object_result; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i2;
+
+part 'copy_object_result.g.dart';
+
+abstract class CopyObjectResult
+    with _i1.AWSEquatable<CopyObjectResult>
+    implements Built<CopyObjectResult, CopyObjectResultBuilder> {
+  factory CopyObjectResult({String? eTag}) {
+    return _$CopyObjectResult._(eTag: eTag);
+  }
+
+  factory CopyObjectResult.build(
+      [void Function(CopyObjectResultBuilder) updates]) = _$CopyObjectResult;
+
+  const CopyObjectResult._();
+
+  static const List<_i2.SmithySerializer> serializers = [
+    CopyObjectResultRestXmlSerializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(CopyObjectResultBuilder b) {}
+  String? get eTag;
+  @override
+  List<Object?> get props => [eTag];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('CopyObjectResult');
+    helper.add(
+      'eTag',
+      eTag,
+    );
+    return helper.toString();
+  }
+}
+
+class CopyObjectResultRestXmlSerializer
+    extends _i2.StructuredSmithySerializer<CopyObjectResult> {
+  const CopyObjectResultRestXmlSerializer() : super('CopyObjectResult');
+
+  @override
+  Iterable<Type> get types => const [
+        CopyObjectResult,
+        _$CopyObjectResult,
+      ];
+  @override
+  Iterable<_i2.ShapeId> get supportedProtocols => const [
+        _i2.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'restXml',
+        )
+      ];
+  @override
+  CopyObjectResult deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = CopyObjectResultBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key as String) {
+        case 'ETag':
+          if (value != null) {
+            result.eTag = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = (object as CopyObjectResult);
+    final result = <Object?>[
+      const _i2.XmlElementName(
+        'CopyObjectResult',
+        _i2.XmlNamespace('http://s3.amazonaws.com/doc/2006-03-01/'),
+      )
+    ];
+    if (payload.eTag != null) {
+      result
+        ..add(const _i2.XmlElementName('ETag'))
+        ..add(serializers.serialize(
+          payload.eTag!,
+          specifiedType: const FullType(String),
+        ));
+    }
+    return result;
+  }
+}

--- a/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_result.g.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/s3/model/copy_object_result.g.dart
@@ -1,0 +1,81 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of custom_v2.s3.model.copy_object_result;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$CopyObjectResult extends CopyObjectResult {
+  @override
+  final String? eTag;
+
+  factory _$CopyObjectResult(
+          [void Function(CopyObjectResultBuilder)? updates]) =>
+      (new CopyObjectResultBuilder()..update(updates))._build();
+
+  _$CopyObjectResult._({this.eTag}) : super._();
+
+  @override
+  CopyObjectResult rebuild(void Function(CopyObjectResultBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CopyObjectResultBuilder toBuilder() =>
+      new CopyObjectResultBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CopyObjectResult && eTag == other.eTag;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, eTag.hashCode));
+  }
+}
+
+class CopyObjectResultBuilder
+    implements Builder<CopyObjectResult, CopyObjectResultBuilder> {
+  _$CopyObjectResult? _$v;
+
+  String? _eTag;
+  String? get eTag => _$this._eTag;
+  set eTag(String? eTag) => _$this._eTag = eTag;
+
+  CopyObjectResultBuilder() {
+    CopyObjectResult._init(this);
+  }
+
+  CopyObjectResultBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _eTag = $v.eTag;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CopyObjectResult other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CopyObjectResult;
+  }
+
+  @override
+  void update(void Function(CopyObjectResultBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CopyObjectResult build() => _build();
+
+  _$CopyObjectResult _build() {
+    final _$result = _$v ?? new _$CopyObjectResult._(eTag: eTag);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/smithy/goldens/lib2/custom/lib/src/s3/operation/copy_object_operation.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/s3/operation/copy_object_operation.dart
@@ -1,0 +1,148 @@
+// Generated with smithy-dart 0.1.1. DO NOT MODIFY.
+
+library custom_v2.s3.operation.copy_object_operation; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'dart:async' as _i11;
+
+import 'package:aws_common/aws_common.dart' as _i8;
+import 'package:aws_signature_v4/aws_signature_v4.dart' as _i6;
+import 'package:custom_v2/src/s3/common/endpoint_resolver.dart' as _i9;
+import 'package:custom_v2/src/s3/common/serializers.dart' as _i7;
+import 'package:custom_v2/src/s3/model/copy_object_error.dart' as _i10;
+import 'package:custom_v2/src/s3/model/copy_object_output.dart' as _i4;
+import 'package:custom_v2/src/s3/model/copy_object_request.dart' as _i2;
+import 'package:custom_v2/src/s3/model/copy_object_result.dart' as _i3;
+import 'package:smithy/smithy.dart' as _i1;
+import 'package:smithy_aws/smithy_aws.dart' as _i5;
+
+class CopyObjectOperation extends _i1.HttpOperation<
+    _i2.CopyObjectRequestPayload,
+    _i2.CopyObjectRequest,
+    _i3.CopyObjectResult,
+    _i4.CopyObjectOutput> {
+  CopyObjectOperation({
+    required String region,
+    Uri? baseUri,
+    _i5.S3ClientConfig s3ClientConfig = const _i5.S3ClientConfig(),
+    _i6.AWSCredentialsProvider credentialsProvider =
+        const _i6.AWSCredentialsProvider.environment(),
+  })  : _region = region,
+        _baseUri = baseUri,
+        _s3ClientConfig = s3ClientConfig,
+        _credentialsProvider = credentialsProvider;
+
+  @override
+  late final List<
+      _i1.HttpProtocol<_i2.CopyObjectRequestPayload, _i2.CopyObjectRequest,
+          _i3.CopyObjectResult, _i4.CopyObjectOutput>> protocols = [
+    _i5.RestXmlProtocol(
+      serializers: _i7.serializers,
+      builderFactories: _i7.builderFactories,
+      requestInterceptors: [
+        const _i1.WithHost(),
+        _i5.WithSigV4(
+          region: _region,
+          service: _i8.AWSService.s3,
+          credentialsProvider: _credentialsProvider,
+          serviceConfiguration: _s3ClientConfig.signerConfiguration ??
+              _i6.S3ServiceConfiguration(),
+        ),
+        const _i1.WithUserAgent('aws-sdk-dart/0.1.1'),
+        const _i5.WithSdkInvocationId(),
+        const _i5.WithSdkRequest(),
+      ],
+      responseInterceptors: [const _i5.CheckErrorOnSuccess()],
+      noErrorWrapping: true,
+    )
+  ];
+
+  late final _i5.AWSEndpoint _awsEndpoint = _i9.endpointResolver.resolve(
+    _i9.sdkId,
+    _region,
+  );
+
+  final String _region;
+
+  final Uri? _baseUri;
+
+  final _i5.S3ClientConfig _s3ClientConfig;
+
+  final _i6.AWSCredentialsProvider _credentialsProvider;
+
+  @override
+  _i1.HttpRequest buildRequest(_i2.CopyObjectRequest input) =>
+      _i1.HttpRequest((b) {
+        b.method = 'PUT';
+        b.path = _s3ClientConfig.usePathStyle
+            ? r'/{Bucket}/{Key+}?x-id=CopyObject'
+            : r'/{Key+}?x-id=CopyObject';
+        b.hostPrefix = _s3ClientConfig.usePathStyle ? null : '{Bucket}.';
+        if (input.copySource.isNotEmpty) {
+          b.headers['x-amz-copy-source'] = input.copySource;
+        }
+      });
+  @override
+  int successCode([_i4.CopyObjectOutput? output]) => 200;
+  @override
+  _i4.CopyObjectOutput buildOutput(
+    _i3.CopyObjectResult? payload,
+    _i8.AWSBaseHttpResponse response,
+  ) =>
+      _i4.CopyObjectOutput.fromResponse(
+        payload,
+        response,
+      );
+  @override
+  List<_i1.SmithyError> get errorTypes => const [
+        _i1.SmithyError(
+          _i1.ShapeId(
+            namespace: 'com.amazonaws.s3',
+            shape: 'CopyObjectError',
+          ),
+          _i1.ErrorKind.server,
+          _i10.CopyObjectError,
+          statusCode: 500,
+          builder: _i10.CopyObjectError.fromResponse,
+        )
+      ];
+  @override
+  _i5.AWSRetryer get retryer => _i5.AWSRetryer();
+  @override
+  Uri get baseUri {
+    var baseUri = _baseUri ?? endpoint.uri;
+    if (_s3ClientConfig.useDualStack) {
+      baseUri = baseUri.replace(
+        host: baseUri.host.replaceFirst(RegExp(r'^s3\.'), 's3.dualstack.'),
+      );
+    }
+    if (_s3ClientConfig.useAcceleration) {
+      baseUri = baseUri.replace(
+        host: baseUri.host
+            .replaceFirst(RegExp('$_region\\.'), '')
+            .replaceFirst(RegExp(r'^s3\.'), 's3-accelerate.'),
+      );
+    }
+    return baseUri;
+  }
+
+  @override
+  _i1.Endpoint get endpoint => _awsEndpoint.endpoint;
+  @override
+  _i11.Future<_i4.CopyObjectOutput> run(
+    _i2.CopyObjectRequest input, {
+    _i1.HttpClient? client,
+    _i1.ShapeId? useProtocol,
+  }) {
+    return _i11.runZoned(
+      () => super.run(
+        input,
+        client: client,
+        useProtocol: useProtocol,
+      ),
+      zoneValues: {
+        ...?_awsEndpoint.credentialScope?.zoneValues,
+        ...{_i8.AWSHeaders.sdkInvocationId: _i8.uuid(secure: true)}
+      },
+    );
+  }
+}

--- a/packages/smithy/goldens/lib2/custom/lib/src/s3/s3_client.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/s3/s3_client.dart
@@ -5,9 +5,12 @@ library custom_v2.s3.s3_client; // ignore_for_file: no_leading_underscores_for_l
 import 'dart:async' as _i4;
 
 import 'package:aws_signature_v4/aws_signature_v4.dart' as _i3;
-import 'package:custom_v2/src/s3/model/get_object_output.dart' as _i5;
-import 'package:custom_v2/src/s3/model/get_object_request.dart' as _i6;
-import 'package:custom_v2/src/s3/operation/get_object_operation.dart' as _i7;
+import 'package:custom_v2/src/s3/model/copy_object_output.dart' as _i5;
+import 'package:custom_v2/src/s3/model/copy_object_request.dart' as _i6;
+import 'package:custom_v2/src/s3/model/get_object_output.dart' as _i8;
+import 'package:custom_v2/src/s3/model/get_object_request.dart' as _i9;
+import 'package:custom_v2/src/s3/operation/copy_object_operation.dart' as _i7;
+import 'package:custom_v2/src/s3/operation/get_object_operation.dart' as _i10;
 import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
@@ -34,11 +37,26 @@ class S3Client {
 
   final _i3.AWSCredentialsProvider _credentialsProvider;
 
-  _i4.Future<_i5.GetObjectOutput> getObject(
-    _i6.GetObjectRequest input, {
+  _i4.Future<_i5.CopyObjectOutput> copyObject(
+    _i6.CopyObjectRequest input, {
     _i1.HttpClient? client,
   }) {
-    return _i7.GetObjectOperation(
+    return _i7.CopyObjectOperation(
+      region: _region,
+      baseUri: _baseUri,
+      s3ClientConfig: _s3ClientConfig,
+      credentialsProvider: _credentialsProvider,
+    ).run(
+      input,
+      client: client ?? _client,
+    );
+  }
+
+  _i4.Future<_i8.GetObjectOutput> getObject(
+    _i9.GetObjectRequest input, {
+    _i1.HttpClient? client,
+  }) {
+    return _i10.GetObjectOperation(
       region: _region,
       baseUri: _baseUri,
       s3ClientConfig: _s3ClientConfig,

--- a/packages/smithy/goldens/lib2/custom/lib/src/s3/s3_server.dart
+++ b/packages/smithy/goldens/lib2/custom/lib/src/s3/s3_server.dart
@@ -6,9 +6,13 @@ import 'dart:async' as _i4;
 
 import 'package:built_value/serializer.dart';
 import 'package:custom_v2/src/s3/common/serializers.dart' as _i3;
-import 'package:custom_v2/src/s3/model/get_object_output.dart' as _i5;
-import 'package:custom_v2/src/s3/model/get_object_request.dart' as _i6;
-import 'package:shelf/shelf.dart' as _i7;
+import 'package:custom_v2/src/s3/model/copy_object_error.dart' as _i11;
+import 'package:custom_v2/src/s3/model/copy_object_output.dart' as _i5;
+import 'package:custom_v2/src/s3/model/copy_object_request.dart' as _i6;
+import 'package:custom_v2/src/s3/model/copy_object_result.dart' as _i10;
+import 'package:custom_v2/src/s3/model/get_object_output.dart' as _i7;
+import 'package:custom_v2/src/s3/model/get_object_request.dart' as _i8;
+import 'package:shelf/shelf.dart' as _i9;
 import 'package:shelf_router/shelf_router.dart';
 import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
@@ -24,6 +28,11 @@ abstract class S3ServerBase extends _i1.HttpServerBase {
     final service = _S3Server(this);
     final router = Router();
     router.add(
+      'PUT',
+      r'/<Bucket>/<Key>?x-id=CopyObject',
+      service.copyObject,
+    );
+    router.add(
       'GET',
       r'/<Bucket>/<Key>?x-id=GetObject',
       service.getObject,
@@ -31,11 +40,15 @@ abstract class S3ServerBase extends _i1.HttpServerBase {
     return router;
   }();
 
-  _i4.Future<_i5.GetObjectOutput> getObject(
-    _i6.GetObjectRequest input,
+  _i4.Future<_i5.CopyObjectOutput> copyObject(
+    _i6.CopyObjectRequest input,
     _i1.Context context,
   );
-  _i4.Future<_i7.Response> call(_i7.Request request) => _router(request);
+  _i4.Future<_i7.GetObjectOutput> getObject(
+    _i8.GetObjectRequest input,
+    _i1.Context context,
+  );
+  _i4.Future<_i9.Response> call(_i9.Request request) => _router(request);
 }
 
 class _S3Server extends _i1.HttpServer<S3ServerBase> {
@@ -45,17 +58,88 @@ class _S3Server extends _i1.HttpServer<S3ServerBase> {
   final S3ServerBase service;
 
   late final _i1.HttpProtocol<
-      _i6.GetObjectRequestPayload,
-      _i6.GetObjectRequest,
-      _i4.Stream<List<int>>,
-      _i5.GetObjectOutput> _getObjectProtocol = _i2.RestXmlProtocol(
+      _i6.CopyObjectRequestPayload,
+      _i6.CopyObjectRequest,
+      _i10.CopyObjectResult,
+      _i5.CopyObjectOutput> _copyObjectProtocol = _i2.RestXmlProtocol(
     serializers: _i3.serializers,
     builderFactories: _i3.builderFactories,
     noErrorWrapping: true,
   );
 
-  _i4.Future<_i7.Response> getObject(
-    _i7.Request request,
+  late final _i1.HttpProtocol<
+      _i8.GetObjectRequestPayload,
+      _i8.GetObjectRequest,
+      _i4.Stream<List<int>>,
+      _i7.GetObjectOutput> _getObjectProtocol = _i2.RestXmlProtocol(
+    serializers: _i3.serializers,
+    builderFactories: _i3.builderFactories,
+    noErrorWrapping: true,
+  );
+
+  _i4.Future<_i9.Response> copyObject(
+    _i9.Request request,
+    String Bucket,
+    String Key,
+  ) async {
+    final awsRequest = request.awsRequest;
+    final context = _i1.Context(awsRequest);
+    context.response.headers['Content-Type'] = _copyObjectProtocol.contentType;
+    try {
+      final payload = (await _copyObjectProtocol.deserialize(
+        awsRequest.split(),
+        specifiedType: const FullType(_i6.CopyObjectRequestPayload),
+      ) as _i6.CopyObjectRequestPayload);
+      final input = _i6.CopyObjectRequest.fromRequest(
+        payload,
+        awsRequest,
+        labels: {
+          'Bucket': Bucket,
+          'Key': Key,
+        },
+      );
+      final output = await service.copyObject(
+        input,
+        context,
+      );
+      const statusCode = 200;
+      final body = _copyObjectProtocol.serialize(
+        output,
+        specifiedType: const FullType(
+          _i5.CopyObjectOutput,
+          [FullType.nullable(_i10.CopyObjectResult)],
+        ),
+      );
+      return _i9.Response(
+        statusCode,
+        body: body,
+        headers: context.response.build().headers.toMap(),
+      );
+    } on _i11.CopyObjectError catch (e) {
+      context.response.headers['X-Amzn-Errortype'] = 'CopyObjectError';
+      final body = _copyObjectProtocol.serialize(
+        e,
+        specifiedType: const FullType(
+          _i11.CopyObjectError,
+          [FullType(_i11.CopyObjectError)],
+        ),
+      );
+      const statusCode = 500;
+      return _i9.Response(
+        statusCode,
+        body: body,
+        headers: context.response.build().headers.toMap(),
+      );
+    } on Object catch (e, st) {
+      return service.handleUncaughtError(
+        e,
+        st,
+      );
+    }
+  }
+
+  _i4.Future<_i9.Response> getObject(
+    _i9.Request request,
     String Bucket,
     String Key,
   ) async {
@@ -65,9 +149,9 @@ class _S3Server extends _i1.HttpServer<S3ServerBase> {
     try {
       final payload = (await _getObjectProtocol.deserialize(
         awsRequest.split(),
-        specifiedType: const FullType(_i6.GetObjectRequestPayload),
-      ) as _i6.GetObjectRequestPayload);
-      final input = _i6.GetObjectRequest.fromRequest(
+        specifiedType: const FullType(_i8.GetObjectRequestPayload),
+      ) as _i8.GetObjectRequestPayload);
+      final input = _i8.GetObjectRequest.fromRequest(
         payload,
         awsRequest,
         labels: {
@@ -83,7 +167,7 @@ class _S3Server extends _i1.HttpServer<S3ServerBase> {
       final body = _getObjectProtocol.serialize(
         output,
         specifiedType: const FullType(
-          _i5.GetObjectOutput,
+          _i7.GetObjectOutput,
           [
             FullType.nullable(
               _i4.Stream,
@@ -97,7 +181,7 @@ class _S3Server extends _i1.HttpServer<S3ServerBase> {
           ],
         ),
       );
-      return _i7.Response(
+      return _i9.Response(
         statusCode,
         body: body,
         headers: context.response.build().headers.toMap(),

--- a/packages/smithy/goldens/lib2/custom/test/s3/copy_object_operation_test.dart
+++ b/packages/smithy/goldens/lib2/custom/test/s3/copy_object_operation_test.dart
@@ -1,0 +1,303 @@
+// Generated with smithy-dart 0.1.1. DO NOT MODIFY.
+
+// ignore_for_file: unused_element
+library custom_v2.s3.test.copy_object_operation_test_test; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_signature_v4/aws_signature_v4.dart' as _i5;
+import 'package:built_value/serializer.dart';
+import 'package:custom_v2/src/s3/model/copy_object_error.dart' as _i10;
+import 'package:custom_v2/src/s3/model/copy_object_output.dart' as _i9;
+import 'package:custom_v2/src/s3/model/copy_object_request.dart' as _i7;
+import 'package:custom_v2/src/s3/model/copy_object_result.dart' as _i8;
+import 'package:custom_v2/src/s3/operation/copy_object_operation.dart' as _i4;
+import 'package:smithy/smithy.dart' as _i6;
+import 'package:smithy_aws/smithy_aws.dart' as _i2;
+import 'package:smithy_test/smithy_test.dart' as _i3;
+import 'package:test/test.dart' as _i1;
+
+void main() {
+  _i1.test(
+    'CopyObjectSuccess (response)',
+    () async {
+      const s3ClientConfig = _i2.S3ClientConfig();
+      await _i3.httpResponseTest(
+        operation: _i4.CopyObjectOperation(
+          region: 'us-east-1',
+          baseUri: Uri.parse('https://example.com'),
+          s3ClientConfig: s3ClientConfig,
+          credentialsProvider:
+              const _i5.AWSCredentialsProvider(_i5.AWSCredentials(
+            'DUMMY-ACCESS-KEY-ID',
+            'DUMMY-SECRET-ACCESS-KEY',
+          )),
+        ),
+        testCase: const _i3.HttpResponseTestCase(
+          id: 'CopyObjectSuccess',
+          documentation:
+              '    S3 clients should properly decode a successful response.\n',
+          protocol: _i6.ShapeId(
+            namespace: 'aws.protocols',
+            shape: 'restXml',
+          ),
+          authScheme: null,
+          body:
+              '<?xml version="1.0" encoding="UTF-8"?><CopyObjectResult><ETag>123</ETag></CopyObjectResult>',
+          bodyMediaType: null,
+          params: {
+            'CopyObjectResult': {'ETag': '123'}
+          },
+          vendorParamsShape: null,
+          vendorParams: {},
+          headers: {},
+          forbidHeaders: [],
+          requireHeaders: [],
+          tags: [],
+          appliesTo: null,
+          code: 200,
+        ),
+        outputSerializers: const [
+          CopyObjectOutputRestXmlSerializer(),
+          CopyObjectResultRestXmlSerializer(),
+        ],
+      );
+    },
+  );
+  _i1.test(
+    'CopyObjectErrorOnSuccess (error)',
+    () async {
+      const s3ClientConfig = _i2.S3ClientConfig();
+      await _i3.httpErrorResponseTest<
+          _i7.CopyObjectRequestPayload,
+          _i7.CopyObjectRequest,
+          _i8.CopyObjectResult?,
+          _i9.CopyObjectOutput,
+          _i10.CopyObjectError>(
+        operation: _i4.CopyObjectOperation(
+          region: 'us-east-1',
+          baseUri: Uri.parse('https://example.com'),
+          s3ClientConfig: s3ClientConfig,
+          credentialsProvider:
+              const _i5.AWSCredentialsProvider(_i5.AWSCredentials(
+            'DUMMY-ACCESS-KEY-ID',
+            'DUMMY-SECRET-ACCESS-KEY',
+          )),
+        ),
+        testCase: const _i3.HttpResponseTestCase(
+          id: 'CopyObjectErrorOnSuccess',
+          documentation:
+              '    S3 clients should properly decode an error response on a 200 status code.\n',
+          protocol: _i6.ShapeId(
+            namespace: 'aws.protocols',
+            shape: 'restXml',
+          ),
+          authScheme: null,
+          body:
+              '<?xml version="1.0" encoding="UTF-8"?><Error><Code>CopyObjectError</Code></Error>',
+          bodyMediaType: null,
+          params: {},
+          vendorParamsShape: null,
+          vendorParams: {},
+          headers: {},
+          forbidHeaders: [],
+          requireHeaders: [],
+          tags: [],
+          appliesTo: null,
+          code: 200,
+        ),
+        errorSerializers: const [CopyObjectErrorRestXmlSerializer()],
+      );
+    },
+  );
+}
+
+class CopyObjectRequestRestXmlSerializer
+    extends _i6.StructuredSmithySerializer<_i7.CopyObjectRequest> {
+  const CopyObjectRequestRestXmlSerializer() : super('CopyObjectRequest');
+
+  @override
+  Iterable<Type> get types => const [_i7.CopyObjectRequest];
+  @override
+  Iterable<_i6.ShapeId> get supportedProtocols => const [
+        _i6.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'restXml',
+        )
+      ];
+  @override
+  _i7.CopyObjectRequest deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = _i7.CopyObjectRequestBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'Bucket':
+          result.bucket = (serializers.deserialize(
+            value!,
+            specifiedType: const FullType(String),
+          ) as String);
+          break;
+        case 'CopySource':
+          result.copySource = (serializers.deserialize(
+            value!,
+            specifiedType: const FullType(String),
+          ) as String);
+          break;
+        case 'Key':
+          result.key = (serializers.deserialize(
+            value!,
+            specifiedType: const FullType(String),
+          ) as String);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    throw StateError('Not supported for tests');
+  }
+}
+
+class CopyObjectOutputRestXmlSerializer
+    extends _i6.StructuredSmithySerializer<_i9.CopyObjectOutput> {
+  const CopyObjectOutputRestXmlSerializer() : super('CopyObjectOutput');
+
+  @override
+  Iterable<Type> get types => const [_i9.CopyObjectOutput];
+  @override
+  Iterable<_i6.ShapeId> get supportedProtocols => const [
+        _i6.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'restXml',
+        )
+      ];
+  @override
+  _i9.CopyObjectOutput deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = _i9.CopyObjectOutputBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'CopyObjectResult':
+          if (value != null) {
+            result.copyObjectResult.replace((serializers.deserialize(
+              value,
+              specifiedType: const FullType(_i8.CopyObjectResult),
+            ) as _i8.CopyObjectResult));
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    throw StateError('Not supported for tests');
+  }
+}
+
+class CopyObjectResultRestXmlSerializer
+    extends _i6.StructuredSmithySerializer<_i8.CopyObjectResult> {
+  const CopyObjectResultRestXmlSerializer() : super('CopyObjectResult');
+
+  @override
+  Iterable<Type> get types => const [_i8.CopyObjectResult];
+  @override
+  Iterable<_i6.ShapeId> get supportedProtocols => const [
+        _i6.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'restXml',
+        )
+      ];
+  @override
+  _i8.CopyObjectResult deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = _i8.CopyObjectResultBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'ETag':
+          if (value != null) {
+            result.eTag = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    throw StateError('Not supported for tests');
+  }
+}
+
+class CopyObjectErrorRestXmlSerializer
+    extends _i6.StructuredSmithySerializer<_i10.CopyObjectError> {
+  const CopyObjectErrorRestXmlSerializer() : super('CopyObjectError');
+
+  @override
+  Iterable<Type> get types => const [_i10.CopyObjectError];
+  @override
+  Iterable<_i6.ShapeId> get supportedProtocols => const [
+        _i6.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'restXml',
+        )
+      ];
+  @override
+  _i10.CopyObjectError deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return _i10.CopyObjectErrorBuilder().build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    throw StateError('Not supported for tests');
+  }
+}

--- a/packages/smithy/smithy_aws/lib/smithy_aws.dart
+++ b/packages/smithy/smithy_aws/lib/smithy_aws.dart
@@ -22,6 +22,7 @@ export 'src/endpoint/credential_scope.dart';
 export 'src/endpoint/partition.dart';
 
 // HTTP
+export 'src/http/interceptors/s3/check_error_on_success.dart';
 export 'src/http/interceptors/s3/check_partial_response.dart';
 export 'src/http/interceptors/with_checksum.dart';
 export 'src/http/interceptors/with_sdk_invocation.dart';

--- a/packages/smithy/smithy_aws/lib/src/http/interceptors/s3/check_error_on_success.dart
+++ b/packages/smithy/smithy_aws/lib/src/http/interceptors/s3/check_error_on_success.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:aws_common/aws_common.dart';
+import 'package:smithy/smithy.dart';
+import 'package:smithy_aws/smithy_aws.dart';
+
+/// {@template smithy_aws.interceptors.check_error_on_success}
+/// Checks for errors in the body of successful 2xx responses.
+///
+/// Some S3 operations complete with a 2xx status code but embed errors in the
+/// body. These must be manually captured since there is no automated
+/// mechanism for this behavior in Smithy.
+///
+/// See, for example, the [CopyObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html)
+/// API docs which describe this behavior fully:
+///
+/// > A copy request might return an error when Amazon S3 receives the copy
+///   request or while Amazon S3 is copying the files. If the error occurs
+///   before the copy action starts, you receive a standard Amazon S3 error.
+///   If the error occurs during the copy operation, the error response is
+///   embedded in the `200 OK` response. This means that a `200 OK` response can
+///   contain either a success or an error. Design your application to parse
+///   the contents of the response and handle it appropriately.
+/// {@endtemplate}
+class CheckErrorOnSuccess extends HttpResponseInterceptor {
+  /// {@macro smithy_aws.interceptors.check_error_on_success}
+  const CheckErrorOnSuccess();
+
+  @override
+  Future<AWSBaseHttpResponse> intercept(AWSBaseHttpResponse response) async {
+    final isSuccess = response.statusCode >= 200 && response.statusCode < 300;
+    if (!isSuccess) {
+      return response;
+    }
+    try {
+      if (await RestXmlProtocol.resolveError(response) == null) {
+        return response;
+      }
+    } on Object {
+      return response;
+    }
+    if (response is AWSHttpResponse) {
+      return AWSHttpResponse(
+        // According to https://aws.amazon.com/premiumsupport/knowledge-center/s3-resolve-200-internalerror/
+        // 200 error responses are similar to 5xx errors.
+        statusCode: 500,
+        headers: response.headers,
+        body: response.bodyBytes,
+      );
+    }
+    return AWSStreamedHttpResponse(
+      statusCode: 500,
+      headers: response.headers,
+      body: response.body,
+    );
+  }
+}

--- a/packages/smithy/smithy_aws/lib/src/protocol/rest_xml.dart
+++ b/packages/smithy/smithy_aws/lib/src/protocol/rest_xml.dart
@@ -79,8 +79,7 @@ class RestXmlProtocol<InputPayload, Input, OutputPayload, Output>
   late final FullSerializer<List<int>> wireSerializer =
       XmlSerializer(serializers);
 
-  @override
-  Future<String?> resolveErrorType(AWSBaseHttpResponse response) async {
+  static Future<String?> resolveError(AWSBaseHttpResponse response) async {
     try {
       final body = await utf8.decodeStream(response.split());
       final el = XmlDocument.parse(body).rootElement;
@@ -95,5 +94,10 @@ class RestXmlProtocol<InputPayload, Input, OutputPayload, Output>
     } on Exception {
       return null;
     }
+  }
+
+  @override
+  Future<String?> resolveErrorType(AWSBaseHttpResponse response) async {
+    return resolveError(response);
   }
 }

--- a/packages/smithy/smithy_codegen/lib/src/generator/types.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/types.dart
@@ -830,6 +830,10 @@ class _SmithyAws {
   Reference get awsSignatureVersion =>
       const Reference('AWSSignatureVersion', _url);
 
+  /// Creates a [smithy_aws.CheckErrorOnSuccess] refererence.
+  Reference get checkErrorOnSuccess =>
+      const Reference('CheckErrorOnSuccess', _url);
+
   /// Creates a [smithy_aws.CheckPartialResponse] refererence.
   Reference get checkPartialResponse =>
       const Reference('CheckPartialResponse', _url);

--- a/packages/smithy/smithy_codegen/lib/src/util/protocol_ext.dart
+++ b/packages/smithy/smithy_codegen/lib/src/util/protocol_ext.dart
@@ -245,6 +245,13 @@ extension ProtocolUtils on ProtocolDefinitionTrait {
           if (operationName == 'GetObject') {
             yield DartTypes.smithyAws.checkPartialResponse.constInstance([]);
           }
+          // These S3 operations require checking for errors on 2xx responses:
+          // https://aws.amazon.com/premiumsupport/knowledge-center/s3-resolve-200-internalerror/
+          if (operationName == 'CopyObject' ||
+              operationName == 'CompleteMultipartUpload' ||
+              operationName == 'UploadPartCopy') {
+            yield DartTypes.smithyAws.checkErrorOnSuccess.constInstance([]);
+          }
       }
     }
   }


### PR DESCRIPTION
Some S3 operations return an error in a 2xx response. Since this mechanism is not supported in Smithy, we need to add a manual check, as is done in other S3 clients (e.g. https://github.com/aws/aws-sdk-go-v2/blob/76d88204196e5d5513fb1845e0cc50ec84ffeada/service/s3/internal/customizations/handle_200_error.go#L21)