### PR TITLE
chore: use AWS secrets manager for CI integ secrets

### DIFF
--- a/.github/composite_actions/fetch_backends/action.yaml
+++ b/.github/composite_actions/fetch_backends/action.yaml
@@ -8,14 +8,8 @@ inputs:
   # scope for melos, e.g. "amplify_api_example"
   scope:
     required: true
-  # Amplify app IDs for specific categories
-  api-app-id:
-    required: true
-  auth-app-id:
-    required: true
-  datastore-app-id:
-    required: true
-  storage-app-id:
+  # ARN of secret from AWS Secrets Manger which is a JSON object of app IDs / s3 bucket ARNs
+  secret-identifier:
     required: true
 
 runs:
@@ -32,13 +26,15 @@ runs:
       run: ./build-support/create_integration_test_profile.sh
       shell: bash
 
+    - name: Get Amplify App IDs / bucket ARNs from Secrets Manager
+      uses: aws-actions/aws-secretsmanager-get-secrets@bafac38d78b5f679d35ef3f36f9842a63de59564 # 1.0.0
+      with:
+        secret-ids: |
+          ${{ inputs.secret-identifier }}
+        parse-json-secrets: true
+
     - name: Pull Amplify Configurations
-      run: |
-        API_APP_ID=${{ inputs.api-app-id }} \
-        AUTH_APP_ID=${{ inputs.auth-app-id }} \
-        DATASTORE_APP_ID=${{ inputs.datastore-app-id }} \
-        STORAGE_APP_ID=${{ inputs.storage-app-id }} \
-          melos exec --scope=${{ inputs.scope }} ./tool/pull_test_backend.sh
+      run: melos exec --scope=${{ inputs.scope }} ./tool/pull_test_backend.sh
       shell: bash
 
     - name: Undo any codegen changes from amplify pull

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -45,10 +45,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
           scope: ${{ matrix.scope }}
-          api-app-id: ${{ secrets.API_APP_ID }}
-          auth-app-id: ${{ secrets.AUTH_APP_ID }}
-          datastore-app-id: ${{ secrets.DATASTORE_APP_ID }}
-          storage-app-id: ${{ secrets.STORAGE_APP_ID }}
+          secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
 
       - name: Build example app with integration tests
         run: |
@@ -94,10 +91,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
           scope: ${{ matrix.scope }}
-          api-app-id: ${{ secrets.API_APP_ID }}
-          auth-app-id: ${{ secrets.AUTH_APP_ID }}
-          datastore-app-id: ${{ secrets.DATASTORE_APP_ID }}
-          storage-app-id: ${{ secrets.STORAGE_APP_ID }}
+          secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
 
       - name: Build example app with integration tests
         run: |

--- a/packages/amplify_datastore/example/tool/pull_test_backend.sh
+++ b/packages/amplify_datastore/example/tool/pull_test_backend.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-APP_ID=$DATASTORE_APP_ID ../../../build-support/pull_backend_by_app_id.sh 
+APP_ID=$AFS_DATASTORE_APP_ID ../../../build-support/pull_backend_by_app_id.sh 

--- a/packages/api/amplify_api/example/tool/pull_test_backend.sh
+++ b/packages/api/amplify_api/example/tool/pull_test_backend.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-APP_ID=$API_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 
+APP_ID=$AFS_API_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 

--- a/packages/auth/amplify_auth_cognito/example/tool/pull_test_backend.sh
+++ b/packages/auth/amplify_auth_cognito/example/tool/pull_test_backend.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-APP_ID=$AUTH_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 
+APP_ID=$AFS_AUTH_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 

--- a/packages/storage/amplify_storage_s3/example/tool/pull_test_backend.sh
+++ b/packages/storage/amplify_storage_s3/example/tool/pull_test_backend.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-APP_ID=$STORAGE_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 
+APP_ID=$AFS_STORAGE_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 


### PR DESCRIPTION
Migrates integration test secrets from github action secrets to AWS Secrets Manager.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
