### PR TITLE
fix(auth): Add serializers to `SrpDevicePasswordVerifierWorker`

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_device_password_verifier_worker.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_device_password_verifier_worker.dart
@@ -150,5 +150,6 @@ final Serializers serializers = (_$serializers.toBuilder()
         ...AnalyticsMetadataType.serializers,
         ...ChallengeNameType.serializers,
         ...UserContextDataType.serializers,
+        ...DeviceRememberedStatusType.serializers,
       ]))
     .build();

--- a/packages/auth/amplify_auth_cognito_test/test/flows/srp/srp_device_password_verifier_worker_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/srp/srp_device_password_verifier_worker_test.dart
@@ -1,0 +1,118 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:amplify_auth_cognito_dart/src/flows/constants.dart';
+import 'package:amplify_auth_cognito_dart/src/flows/srp/srp_device_password_verifier_worker.dart';
+import 'package:amplify_auth_cognito_dart/src/model/cognito_device_secrets.dart';
+import 'package:amplify_auth_cognito_dart/src/model/sign_in_parameters.dart';
+import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/respond_to_auth_challenge_request.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:test/test.dart';
+import 'package:worker_bee/worker_bee.dart';
+
+import '../../common/mock_config.dart' hide username;
+import 'srp_helper_test.dart';
+
+void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
+
+  // TODO(dnys1): This will skip tests on DDC where they're currently failing.
+  final skipTests = !zAssertsEnabled;
+
+  group('SrpDevicePasswordVerifierWorker', skip: skipTests, () {
+    test('success', () async {
+      final worker = SrpDevicePasswordVerifierWorker.create();
+      addTearDown(worker.close);
+
+      worker.logs.listen(safePrint);
+      await worker.spawn();
+
+      final message = SrpDevicePasswordVerifierMessage(
+        (b) => b
+          ..initResult = initResult
+          ..clientId = testAppClientId
+          ..deviceSecrets = CognitoDeviceSecrets(
+            (b) => b
+              ..deviceKey = deviceKey
+              ..deviceGroupKey = deviceGroupKey
+              ..devicePassword = devicePassword,
+          )
+          ..parameters = SignInParameters(
+            (p) => p
+              ..username = username
+              ..password = password,
+          )
+          ..challengeParameters = BuiltMap({
+            CognitoConstants.challengeParamUsername: username,
+            CognitoConstants.challengeParamUserIdForSrp: username,
+            CognitoConstants.challengeParamSecretBlock: secretBlock,
+            CognitoConstants.challengeParamSalt: salt,
+            CognitoConstants.challengeParamSrpB: publicB,
+            CognitoConstants.challengeParamDeviceKey: deviceKey,
+          }),
+      );
+      worker.add(message);
+
+      expect(
+        worker.stream,
+        emits(
+          isA<RespondToAuthChallengeRequest>().having(
+            (req) => req.challengeResponses?[
+                CognitoConstants.challengeParamPasswordSignature],
+            'signature',
+            isNotNull,
+          ),
+        ),
+      );
+    });
+
+    test('failure', () async {
+      final worker = SrpDevicePasswordVerifierWorker.create();
+
+      worker.logs.listen(safePrint);
+      await worker.spawn();
+      final message = SrpDevicePasswordVerifierMessage(
+        (b) => b
+          ..initResult = initResult
+          ..clientId = testAppClientId
+          ..deviceSecrets = CognitoDeviceSecrets(
+            (b) => b
+              ..deviceKey = deviceKey
+              ..deviceGroupKey = deviceGroupKey
+              ..devicePassword = devicePassword,
+          )
+          ..parameters = SignInParameters(
+            (p) => p
+              ..username = username
+              ..password = password,
+          )
+          ..challengeParameters = BuiltMap(<String, String>{}),
+      );
+      worker.add(message);
+
+      expect(
+        worker.result,
+        completion(isA<ErrorResult>()),
+      );
+      await expectLater(
+        worker.stream,
+        emitsError(isA<WorkerBeeException>()),
+      );
+      unawaited(worker.close());
+    });
+  });
+}


### PR DESCRIPTION
Adds missing serializers to `SrpDevicePasswordVerifierWorker` required by #2220.
