### PR TITLE
fix(auth): Device credential caching

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/backend/bin/backend.ts
+++ b/packages/auth/amplify_auth_cognito/example/backend/bin/backend.ts
@@ -34,8 +34,8 @@ new AuthIntegrationTestStack(app, {
 new AuthIntegrationTestStack(app, {
   environmentName: "device-tracking-opt-in",
   deviceTracking: {
-    // Do not trust remembered devices (always prompt MFA)
-    challengeRequiredOnNewDevice: false,
+    // Trust remembered devices (allow MFA bypass)
+    challengeRequiredOnNewDevice: true,
     // Opt-in to tracking
     deviceOnlyRememberedOnUserPrompt: true,
   },

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -1034,15 +1034,6 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
         const CredentialStoreEvent.clearCredentials(),
       );
 
-      // Clear device secrets if unconfirmed
-      final username = tokens.username;
-      final deviceSecrets = await _deviceRepo.get(username);
-      if (deviceSecrets != null &&
-          deviceSecrets.deviceStatus ==
-              cognito.DeviceRememberedStatusType.notRemembered) {
-        await _deviceRepo.remove(username);
-      }
-
       _hubEventController.add(AuthHubEvent.signedOut());
     }
     return const SignOutResult();


### PR DESCRIPTION
Device credential caching is updated in accordance with [Cognito docs](https://aws.amazon.com/blogs/mobile/tracking-and-remembering-devices-using-amazon-cognito-your-user-pools/) around when device credentials are cleared:

> The credentials provided to the device should be persistent and will be stored by the AWS Mobile SDKs, so any logic you build on top of the device key as an identifier can assume it will not change. The only way it could change is if the user wipes the device’s storage, if the user uninstalls the application, or if the ForgetDevice API is called for a device (this API removes all tracked devices for a user).
