### PR TITLE
feat(smithy): Expose `nextContinuationToken` from `PaginatedResult`

### DIFF
--- a/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/api_gateway_client.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/api_gateway/api_gateway_client.dart
@@ -31,8 +31,8 @@ class ApiGatewayClient {
 
   final _i2.AWSCredentialsProvider _credentialsProvider;
 
-  _i3.SmithyOperation<_i3.PaginatedResult<_i4.BuiltList<_i5.RestApi>, int>>
-      getRestApis(
+  _i3.SmithyOperation<
+      _i3.PaginatedResult<_i4.BuiltList<_i5.RestApi>, int, String>> getRestApis(
     _i6.GetRestApisRequest input, {
     _i1.AWSHttpClient? client,
   }) {

--- a/packages/smithy/goldens/lib/restXml/lib/src/s3/s3_client.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/s3/s3_client.dart
@@ -55,7 +55,7 @@ class S3Client {
     );
   }
 
-  _i4.SmithyOperation<_i4.PaginatedResult<_i8.ListObjectsV2Output, int>>
+  _i4.SmithyOperation<_i4.PaginatedResult<_i8.ListObjectsV2Output, int, String>>
       listObjectsV2(
     _i9.ListObjectsV2Request input, {
     _i1.AWSHttpClient? client,

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/api_gateway_client.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/api_gateway/api_gateway_client.dart
@@ -31,8 +31,8 @@ class ApiGatewayClient {
 
   final _i2.AWSCredentialsProvider _credentialsProvider;
 
-  _i3.SmithyOperation<_i3.PaginatedResult<_i4.BuiltList<_i5.RestApi>, int>>
-      getRestApis(
+  _i3.SmithyOperation<
+      _i3.PaginatedResult<_i4.BuiltList<_i5.RestApi>, int, String>> getRestApis(
     _i6.GetRestApisRequest input, {
     _i1.AWSHttpClient? client,
   }) {

--- a/packages/smithy/goldens/lib2/restXml/lib/src/s3/s3_client.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/s3/s3_client.dart
@@ -55,7 +55,7 @@ class S3Client {
     );
   }
 
-  _i4.SmithyOperation<_i4.PaginatedResult<_i8.ListObjectsV2Output, int>>
+  _i4.SmithyOperation<_i4.PaginatedResult<_i8.ListObjectsV2Output, int, String>>
       listObjectsV2(
     _i9.ListObjectsV2Request input, {
     _i1.AWSHttpClient? client,

--- a/packages/smithy/smithy/lib/src/behavior/paginated_result.dart
+++ b/packages/smithy/smithy/lib/src/behavior/paginated_result.dart
@@ -14,24 +14,48 @@
 
 import 'package:smithy/smithy.dart';
 
-typedef NextPaginatedResultFn<Items, PageSize>
-    = SmithyOperation<PaginatedResult<Items, PageSize>> Function([
+/// Retrieves the next set of result items for a [PaginatedResult].
+typedef NextPaginatedResultFn<Items, PageSize, Token>
+    = SmithyOperation<PaginatedResult<Items, PageSize, Token>> Function([
   PageSize?,
 ]);
 
-class PaginatedResult<Items, PageSize> {
+/// {@template smithy.behavior.paginated_result}
+/// The result of invoking an operation which paginates its result list.
+///
+/// This represents a single chunk of [items] with helpers for retrieving
+/// further pages of items.
+/// {@endtemplate}
+class PaginatedResult<Items, PageSize, Token> {
+  /// {@macro smithy.behavior.paginated_result}
   const PaginatedResult(
     this.items, {
-    required this.hasNext,
-    required NextPaginatedResultFn<Items, PageSize> next,
+    required this.nextContinuationToken,
+    required NextPaginatedResultFn<Items, PageSize, Token> next,
   }) : _next = next;
 
+  /// The items of the current result.
   final Items items;
-  final bool hasNext;
-  final NextPaginatedResultFn<Items, PageSize> _next;
 
-  /// Retrieves the next set of results.
-  SmithyOperation<PaginatedResult<Items, PageSize>> next([
+  /// The token from the current output which can be used as input to the next
+  /// request to the service.
+  ///
+  /// If `null`, there are no more results for the request.
+  final Token? nextContinuationToken;
+
+  /// Whether the response contained a [nextContinuationToken] and, thus, has
+  /// more results available.
+  ///
+  /// From the Smithy [docs](https://awslabs.github.io/smithy/2.0/spec/behavior-traits.html#pagination):
+  /// > If the received response does not contain a continuation token in the
+  ///   referenced outputToken member, then there are no more results to retrieve
+  ///   and the process is complete.
+  bool get hasNext => nextContinuationToken != null;
+
+  final NextPaginatedResultFn<Items, PageSize, Token> _next;
+
+  /// Retrieves the next set of result items.
+  SmithyOperation<PaginatedResult<Items, PageSize, Token>> next([
     PageSize? pageSize,
   ]) =>
       _next(pageSize);

--- a/packages/smithy/smithy/lib/src/http/http_operation.dart
+++ b/packages/smithy/smithy/lib/src/http/http_operation.dart
@@ -351,7 +351,7 @@ abstract class PaginatedHttpOperation<
   Input rebuildInput(Input input, Token token, PageSize? pageSize);
 
   /// Runs the operation returning a [PaginatedResult] which can be paged.
-  SmithyOperation<PaginatedResult<Items, PageSize>> runPaginated(
+  SmithyOperation<PaginatedResult<Items, PageSize, Token>> runPaginated(
     Input input, {
     AWSHttpClient? client,
     ShapeId? useProtocol,
@@ -363,17 +363,11 @@ abstract class PaginatedHttpOperation<
     );
     final paginatedOperation = operation.operation.then((output) {
       final token = getToken(output);
-
-      // If the received response does not contain a continuation token in the
-      // referenced outputToken member, then there are no more results to retrieve
-      // and the process is complete.
-      final hasNext = token != null;
-
       final items = getItems(output);
-      late PaginatedResult<Items, PageSize> result;
+      late PaginatedResult<Items, PageSize, Token> result;
       result = PaginatedResult(
         items,
-        hasNext: hasNext,
+        nextContinuationToken: token,
 
         // If there is a continuation token in the referenced outputToken member
         // of the response, then the client sends a subsequent request using the

--- a/packages/smithy/smithy_codegen/lib/src/generator/service_client_generator.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/service_client_generator.dart
@@ -134,12 +134,14 @@ class ServiceClientGenerator extends LibraryGenerator<ServiceShape> {
             if (operation.hasDocs(context)) operation.formattedDocs(context),
           ])
           ..returns = isPaginated
-              ? DartTypes.smithy
-                  .smithyOperation(DartTypes.smithy.paginatedResult(
-                  paginatedTraits.items?.symbol.unboxed ?? operationOutput,
-                  paginatedTraits.pageSize?.symbol.unboxed ??
-                      DartTypes.core.void$,
-                ))
+              ? DartTypes.smithy.smithyOperation(
+                  DartTypes.smithy.paginatedResult(
+                    paginatedTraits.items?.symbol.unboxed ?? operationOutput,
+                    paginatedTraits.pageSize?.symbol.unboxed ??
+                        DartTypes.core.void$,
+                    paginatedTraits.outputToken!.symbol.unboxed,
+                  ),
+                )
               : DartTypes.smithy.smithyOperation(operationOutput)
           ..name = operation.shapeId.shape.camelCase
           ..lambda = false

--- a/packages/smithy/smithy_codegen/lib/src/generator/types.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/types.dart
@@ -647,12 +647,16 @@ class _Smithy {
       );
 
   /// Creates a [smithy.PaginatedResult] reference.
-  Reference paginatedResult(Reference itemsRef, Reference pageSizeRef) =>
+  Reference paginatedResult(
+    Reference itemsRef,
+    Reference pageSizeRef,
+    Reference tokenRef,
+  ) =>
       TypeReference(
         (t) => t
           ..url = _url
           ..symbol = 'PaginatedResult'
-          ..types.addAll([itemsRef, pageSizeRef]),
+          ..types.addAll([itemsRef, pageSizeRef, tokenRef]),
       );
 
   /// Creates a [smithy.parseHeader] reference.


### PR DESCRIPTION
Support a larger variety of use cases by exposing the `nextContinuationToken` which can be used to make further requests to the service as needed.