### PR TITLE
fix(api): fix model helper util on web

### DIFF
--- a/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
@@ -80,6 +80,7 @@ void main({bool useExistingTestUser = false}) {
           final eventResponse = await establishSubscriptionAndMutate(
             subscriptionRequest,
             () => addBlog(name),
+            eventFilter: (Blog? blog) => blog?.name == name,
           );
           Blog? blogFromEvent = eventResponse.data;
 

--- a/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
@@ -289,6 +289,7 @@ void main({bool useExistingTestUser = false}) {
           final eventResponse = await establishSubscriptionAndMutate(
             subscriptionRequest,
             () => addBlog(name),
+            eventFilter: (Blog? blog) => blog?.name == name,
           );
           Blog? blogFromEvent = eventResponse.data;
 
@@ -313,6 +314,7 @@ void main({bool useExistingTestUser = false}) {
                   ModelMutations.update(blogToUpdate));
               await Amplify.API.mutate(request: updateReq).response;
             },
+            eventFilter: (Blog? blog) => blog?.id == blogToUpdate.id,
           );
           Blog? blogFromEvent = eventResponse.data;
 
@@ -330,6 +332,7 @@ void main({bool useExistingTestUser = false}) {
           final eventResponse = await establishSubscriptionAndMutate(
             subscriptionRequest,
             () => deleteBlog(blogToDelete.id),
+            eventFilter: (Blog? blog) => blog?.id == blogToDelete.id,
           );
           Blog? blogFromEvent = eventResponse.data;
 
@@ -365,6 +368,7 @@ void main({bool useExistingTestUser = false}) {
           final eventResponse = await establishSubscriptionAndMutate(
             subscriptionRequest,
             () => addPostAndBlog(title, 0),
+            eventFilter: (Post? post) => post?.title == title,
           );
           Post? postFromEvent = eventResponse.data;
 

--- a/packages/api/amplify_api/example/integration_test/graphql/user_pools_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/user_pools_test.dart
@@ -259,6 +259,7 @@ void main({bool useExistingTestUser = false}) {
           final eventResponse = await establishSubscriptionAndMutate(
             subscriptionRequest,
             () => addBlog(name),
+            eventFilter: (Blog? blog) => blog?.name == name,
           );
           Blog? blogFromEvent = eventResponse.data;
 

--- a/packages/api/amplify_api/example/integration_test/rest_test.dart
+++ b/packages/api/amplify_api/example/integration_test/rest_test.dart
@@ -120,5 +120,8 @@ void main({bool useExistingTestUser = false}) {
         validateRestResponse(res);
       });
     });
-  });
+  },
+      // Skip because CLI issue for web https://github.com/aws-amplify/amplify-category-api/issues/519
+      // which requires manual backend changes.
+      skip: zIsWeb);
 }

--- a/packages/api/amplify_api/example/test_driver/integration_test.dart
+++ b/packages/api/amplify_api/example/test_driver/integration_test.dart
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:integration_test/integration_test_driver.dart';
+
+// Required for running integration tests in the browser
+// https://docs.flutter.dev/cookbook/testing/integration/introduction#5b-web
+Future<void> main() => integrationDriver();

--- a/packages/api/amplify_api/lib/src/graphql/utils.dart
+++ b/packages/api/amplify_api/lib/src/graphql/utils.dart
@@ -80,6 +80,7 @@ ModelSchema getModelSchemaByModelName(
   }
   // In web, the modelName runtime type conversion will add "$" to returned string.
   // If ends with "$" on web, strip last character.
+  // TODO(ragingsquirrel3): fix underlying issue with modelName
   if (zIsWeb && modelName.endsWith(r'$')) {
     modelName = modelName.substring(0, modelName.length - 1);
   }

--- a/packages/api/amplify_api/lib/src/graphql/utils.dart
+++ b/packages/api/amplify_api/lib/src/graphql/utils.dart
@@ -78,6 +78,11 @@ ModelSchema getModelSchemaByModelName(
           'Pass in a modelProvider instance while instantiating APIPlugin',
     );
   }
+  // In web, the modelName runtime type conversion will add "$" to returned string.
+  // If ends with "$" on web, strip last character.
+  if (zIsWeb && modelName.endsWith(r'$')) {
+    modelName = modelName.substring(0, modelName.length - 1);
+  }
   final schema =
       (provider.modelSchemas + provider.customTypeSchemas).firstWhere(
     (elem) => elem.name == modelName,


### PR DESCRIPTION
This PR does 2 things:
1) fixes issue with API model helpers in web due to "$" added to name conversion in dart on web
2) adds web support for integration tests and some changes to integ test utils


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
