### PR TITLE
fix(storage): make resume ineffective when a download has completed

### DIFF
--- a/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
@@ -112,7 +112,7 @@ class S3StorageException extends StorageException {
   factory S3StorageException.invalidBytesRange() {
     return const S3StorageException(
       'Invalid bytes range of `S3DataBytesRange`.',
-      recoverySuggestion: '`start` needs to be less than or equal to `end`.',
+      recoverySuggestion: '`start` needs to be less than `end`.',
     );
   }
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_transfer_progress.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_transfer_progress.dart
@@ -26,6 +26,12 @@ enum S3TransferState {
 
   /// The download task is canceled.
   canceled,
+
+  /// The download task completed successfully.
+  success,
+
+  /// The download task failed.
+  failure,
 }
 
 /// {@template storage.amplify_storage_s3.transfer_progress}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
