### PR TITLE
chore: integration test improvements

### DIFF
--- a/.github/composite_actions/fetch_backends/action.yaml
+++ b/.github/composite_actions/fetch_backends/action.yaml
@@ -8,14 +8,8 @@ inputs:
   # scope for melos, e.g. "amplify_api_example"
   scope:
     required: true
-  # Amplify app IDs for specific categories
-  api-app-id:
-    required: true
-  auth-app-id:
-    required: true
-  datastore-app-id:
-    required: true
-  storage-app-id:
+  # ARN of secret from AWS Secrets Manger which is a JSON object of app IDs / s3 bucket ARNs
+  secret-identifier:
     required: true
 
 runs:
@@ -37,14 +31,16 @@ runs:
     - name: Remove config file created by aft
       run: melos exec --scope=${{ inputs.scope }} rm lib/amplifyconfiguration.dart
       shell: bash
+    
+    - name: Get Amplify App IDs / bucket ARNs from Secrets Manager
+      uses: aws-actions/aws-secretsmanager-get-secrets@bafac38d78b5f679d35ef3f36f9842a63de59564 # 1.0.0
+      with:
+        secret-ids: |
+          ${{ inputs.secret-identifier }}
+        parse-json-secrets: true
 
     - name: Pull Amplify Configurations
-      run: |
-        API_APP_ID=${{ inputs.api-app-id }} \
-        AUTH_APP_ID=${{ inputs.auth-app-id }} \
-        DATASTORE_APP_ID=${{ inputs.datastore-app-id }} \
-        STORAGE_APP_ID=${{ inputs.storage-app-id }} \
-          melos exec --scope=${{ inputs.scope }} ./tool/pull_test_backend.sh
+      run: melos exec --scope=${{ inputs.scope }} ./tool/pull_test_backend.sh
       shell: bash
 
     - name: Delete AWS profile

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -41,10 +41,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
           scope: ${{ matrix.scope }}
-          api-app-id: ${{ secrets.API_APP_ID }}
-          auth-app-id: ${{ secrets.AUTH_APP_ID }}
-          datastore-app-id: ${{ secrets.DATASTORE_APP_ID }}
-          storage-app-id: ${{ secrets.STORAGE_APP_ID }}
+          secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
 
       - name: Build example app with integration tests
         run: |
@@ -86,10 +83,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
           scope: ${{ matrix.scope }}
-          api-app-id: ${{ secrets.API_APP_ID }}
-          auth-app-id: ${{ secrets.AUTH_APP_ID }}
-          datastore-app-id: ${{ secrets.DATASTORE_APP_ID }}
-          storage-app-id: ${{ secrets.STORAGE_APP_ID }}
+          secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
 
       - name: Build example app with integration tests
         run: |

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -92,3 +92,36 @@ jobs:
       - name: Run integration tests
         run: |
           melos exec -c 1 --scope ${{ matrix.scope }} -- "retries=1 \$MELOS_ROOT_PATH/build-support/integ_test_ios.sh"
+
+  web:
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        scope: ["amplify_auth_cognito_example"]
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+      
+      - name: Install dependencies
+        uses: ./.github/composite_actions/install_dependencies
+
+      - name: Fetch Amplify backend configurations
+        uses: ./.github/composite_actions/fetch_backends
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          scope: ${{ matrix.scope }}
+          secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
+
+      - uses: nanasess/setup-chromedriver@7cbd35794f8ab317f778c3172fb86c1e9b2853f7 # 1.1.0
+
+      - name: Run integration tests
+        run: |
+          chromedriver --port=4444 &
+          melos exec -c 1 --scope ${{ matrix.scope }} -- flutter drive --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d web-server

--- a/packages/api/amplify_api/example/tool/pull_test_backend.sh
+++ b/packages/api/amplify_api/example/tool/pull_test_backend.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-APP_ID=$API_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 
+APP_ID=$AFS_API_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 

--- a/packages/auth/amplify_auth_cognito/example/tool/pull_test_backend.sh
+++ b/packages/auth/amplify_auth_cognito/example/tool/pull_test_backend.sh
@@ -15,4 +15,4 @@
 
 set -e
 
-APP_ID=$AUTH_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 
+APP_ID=$AFS_AUTH_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 

--- a/packages/auth/amplify_auth_cognito/example/tool/pull_test_backend.sh
+++ b/packages/auth/amplify_auth_cognito/example/tool/pull_test_backend.sh
@@ -15,4 +15,4 @@
 
 set -e
 
-APP_ID=$AFS_AUTH_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 
+aws s3 cp s3://$AFS_AUTH_BUCKET_NAME/amplifyconfiguration.dart lib/amplifyconfiguration.dart 

--- a/packages/storage/amplify_storage_s3/example/tool/pull_test_backend.sh
+++ b/packages/storage/amplify_storage_s3/example/tool/pull_test_backend.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-APP_ID=$STORAGE_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 
+APP_ID=$AFS_STORAGE_APP_ID ../../../../build-support/pull_backend_by_app_id.sh 


### PR DESCRIPTION
A few fixes for integration tests:
* cherry-picks https://github.com/aws-amplify/amplify-flutter/commit/66542af4792618fe586e805bad63a48ac3b622b9 off main to start using secrets from AWS secrets manager
* changes auth integration test pull script to get new auth backend config from s3
* runs auth tests on web in CI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
