### PR TITLE
fix(auth): Support Cognito proxies

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
@@ -172,12 +172,18 @@ class WrappedCognitoIdentityProviderClient
   /// {@macro amplify_auth_cognito_dart.sdk.wrapped_cognito_identity_provider_client}
   WrappedCognitoIdentityProviderClient({
     required String region,
+    String? endpoint,
     required AWSCredentialsProvider credentialsProvider,
     required DependencyManager dependencyManager,
   }) : _base = CognitoIdentityProviderClient(
           region: region,
           credentialsProvider: credentialsProvider,
           client: dependencyManager.getOrCreate(),
+          baseUri: endpoint == null
+              ? null
+              : (endpoint.startsWith('http')
+                  ? Uri.parse(endpoint)
+                  : Uri.parse('https://$endpoint')),
         );
 
   final CognitoIdentityProviderClient _base;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/auth_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/auth_state_machine.dart
@@ -63,6 +63,7 @@ class AuthStateMachine extends AuthStateMachineBase {
           region: userPoolConfig.region,
           credentialsProvider: _credentialsProvider,
           dependencyManager: this,
+          endpoint: userPoolConfig.endpoint,
         ),
       );
     }


### PR DESCRIPTION
Supports a custom Cognito endpoint as described here: https://aws.amazon.com/blogs/security/protect-public-clients-for-amazon-cognito-by-using-an-amazon-cloudfront-proxy/
