### PR TITLE
fix(storage): refactor codebase for SDK changes returning SmithyOperation

### DIFF
--- a/packages/amplify_core/lib/src/types/storage/list_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/list_options.dart
@@ -22,8 +22,12 @@ class StorageListOptions extends StorageOperationOptions {
   const StorageListOptions({
     required super.accessLevel,
     required this.pageSize,
+    this.nextToken,
   });
 
   /// The number of object to be listed in each page.
   final int pageSize;
+
+  /// Token used to list the next page.
+  final String? nextToken;
 }

--- a/packages/amplify_core/lib/src/types/storage/list_result.dart
+++ b/packages/amplify_core/lib/src/types/storage/list_result.dart
@@ -21,18 +21,16 @@ class StorageListResult<Items extends List<StorageItem>> {
   /// {@macro amplify_core.storage.list_result}
   const StorageListResult(
     this.items, {
-    required this.hasNext,
-    required Future<StorageListResult<Items>> Function() next,
-  }) : _next = next;
+    required this.hasNextPage,
+    this.nextToken,
+  });
 
   /// The objects listed in the current page.
   final Items items;
 
-  /// Flag that indicates if there is any more page can be listed.
-  final bool hasNext;
+  /// Whether has next page that can be listed using [nextToken].
+  final bool hasNextPage;
 
-  /// Function to list the next page.
-  Future<StorageListResult<Items>> next() => _next();
-
-  final Future<StorageListResult<Items>> Function() _next;
+  /// Token used to list the next page.
+  final String? nextToken;
 }

--- a/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
+++ b/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
@@ -105,13 +105,15 @@ Future<void> listOperation() async {
     'Choose the storage access level associated with the path: ',
   );
 
+  const pageSize = 5;
+
   // get plugin with plugin key to gain S3 specific interface
   final s3Plugin = Amplify.Storage.getPlugin(AmplifyStorageS3Dart.pluginKey);
   final operation = s3Plugin.list(
     path: path,
     options: S3ListOptions(
       accessLevel: accessLevel,
-      pageSize: 5,
+      pageSize: pageSize,
     ),
   );
 
@@ -130,12 +132,12 @@ Future<void> listOperation() async {
 
   while (true) {
     stdout.writeln('Listed ${result.items.length} objects.');
-    stdout.writeln('${result.pluginMetadata}');
+    stdout.writeln('Sub directories: ${result.metadata.subPaths}');
     result.items.asMap().forEach((index, item) {
       stdout.writeln('$index. key: ${item.key} | size: ${item.size}');
     });
 
-    if (!result.hasNext) {
+    if (!result.hasNextPage) {
       break;
     }
 
@@ -147,7 +149,16 @@ Future<void> listOperation() async {
       break;
     }
 
-    result = await result.next();
+    result = await s3Plugin
+        .list(
+          path: path,
+          options: S3ListOptions(
+            accessLevel: accessLevel,
+            pageSize: pageSize,
+            nextToken: result.nextToken,
+          ),
+        )
+        .result;
   }
 }
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -173,6 +173,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
           credentialsProvider: credentialsProvider,
           defaultBucket: s3pluginConfig.bucket,
           defaultRegion: s3pluginConfig.region,
+          delimiter: _delimiter,
           prefixResolver: _prefixResolver!,
           logger: logger,
           dependencyManager: dependencyManager,

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_options.dart
@@ -22,15 +22,21 @@ class S3ListOptions extends StorageListOptions {
   const S3ListOptions({
     StorageAccessLevel accessLevel = StorageAccessLevel.guest,
     int pageSize = 1000,
+    bool excludeSubPaths = false,
+    String? nextToken,
   }) : this._(
           accessLevel: accessLevel,
           pageSize: pageSize,
+          nextToken: nextToken,
+          excludeSubPaths: excludeSubPaths,
         );
 
   const S3ListOptions._({
     super.accessLevel = StorageAccessLevel.guest,
     super.pageSize = 1000,
+    super.nextToken,
     this.targetIdentityId,
+    this.excludeSubPaths = false,
   });
 
   /// {@macro storage.amplify_storage_s3.list_options}
@@ -40,10 +46,14 @@ class S3ListOptions extends StorageListOptions {
   const S3ListOptions.forIdentity(
     String targetIdentityId, {
     int pageSize = 1000,
+    bool excludeSubPaths = false,
+    String? nextToken,
   }) : this._(
           accessLevel: StorageAccessLevel.protected,
           pageSize: pageSize,
           targetIdentityId: targetIdentityId,
+          nextToken: nextToken,
+          excludeSubPaths: excludeSubPaths,
         );
 
   /// The identity id of another user who uploaded the objects that to be
@@ -51,4 +61,8 @@ class S3ListOptions extends StorageListOptions {
   ///
   /// This can be set by calling the [S3ListOptions.forIdentity].
   final String? targetIdentityId;
+
+  /// Whether to exclude objects under the sub paths of the path to list. The
+  /// default value is `false`.
+  final bool excludeSubPaths;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_result.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_result.dart
@@ -34,7 +34,7 @@ class S3ListResult extends StorageListResult<List<S3Item>> {
   /// smithy. This named constructor should be used internally only.
   @internal
   factory S3ListResult.fromPaginatedResult(
-    PaginatedResult<ListObjectsV2Output, int> paginatedResult, {
+    PaginatedResult<ListObjectsV2Output, int, String> paginatedResult, {
     required String prefixToDrop,
   }) {
     final output = paginatedResult.items;
@@ -58,7 +58,8 @@ class S3ListResult extends StorageListResult<List<S3Item>> {
       items,
       hasNext: paginatedResult.hasNext,
       next: () async {
-        final nextPageResult = await paginatedResult.next(requestedPageSize);
+        final nextPageResult =
+            await paginatedResult.next(requestedPageSize).result;
         return S3ListResult.fromPaginatedResult(
           nextPageResult,
           prefixToDrop: prefixToDrop,

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -45,9 +45,11 @@ class StorageS3Service {
     required S3PrefixResolver prefixResolver,
     required AWSIamAmplifyAuthProvider credentialsProvider,
     required AWSLogger logger,
+    String? delimiter,
     required DependencyManager dependencyManager,
   })  : _defaultBucket = defaultBucket,
         _defaultRegion = defaultRegion,
+        _delimiter = delimiter ?? '/',
         // dependencyManager.get() => S3Client is used for unit tests
         _defaultS3Client = dependencyManager.get() ??
             s3.S3Client(
@@ -72,6 +74,7 @@ class StorageS3Service {
 
   final String _defaultBucket;
   final String _defaultRegion;
+  final String _delimiter;
   final s3.S3Client _defaultS3Client;
   final S3PrefixResolver _prefixResolver;
   final AWSLogger _logger;
@@ -109,7 +112,9 @@ class StorageS3Service {
       builder
         ..bucket = _defaultBucket
         ..prefix = listTargetPrefix
-        ..maxKeys = options.pageSize;
+        ..maxKeys = options.pageSize
+        ..continuationToken = options.nextToken
+        ..delimiter = options.excludeSubPaths ? _delimiter : null;
     });
 
     try {

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -114,7 +114,7 @@ class StorageS3Service {
 
     try {
       return S3ListResult.fromPaginatedResult(
-        await _defaultS3Client.listObjectsV2(request),
+        await _defaultS3Client.listObjectsV2(request).result,
         prefixToDrop: resolvedPrefix,
       );
     } on smithy.UnknownSmithyHttpException catch (error) {
@@ -354,7 +354,7 @@ class StorageS3Service {
     });
 
     try {
-      await _defaultS3Client.copyObject(copyRequest);
+      await _defaultS3Client.copyObject(copyRequest).result;
     } on smithy.UnknownSmithyHttpException catch (error) {
       // S3Client.copyObject may return 403 or 404 error
       throw S3Exception.fromUnknownSmithyHttpException(error);
@@ -507,7 +507,7 @@ class StorageS3Service {
           }).toBuilder();
       });
       try {
-        final output = await _defaultS3Client.deleteObjects(request);
+        final output = await _defaultS3Client.deleteObjects(request).result;
         removedItems.addAll(
           output.deleted?.toList().map(
                     (removedObject) => S3Item.fromS3Object(
@@ -546,7 +546,7 @@ class StorageS3Service {
     try {
       // The current capability of the `remove` API doesn't require parsing
       // the [DeleteObjectOutput] returned by [S3Client.deleteObject].
-      return await s3client.deleteObject(request);
+      return await s3client.deleteObject(request).result;
     } on smithy.UnknownSmithyHttpException catch (error) {
       // S3Client.deleteObject may return 403, for deleting a non-existing
       // object, the API call returns a successful response
@@ -607,7 +607,7 @@ class StorageS3Service {
     });
 
     try {
-      return await s3client.headObject(request);
+      return await s3client.headObject(request).result;
     } on smithy.UnknownSmithyHttpException catch (error) {
       // S3Client.headObject may return 403 or 404 error
       throw S3Exception.fromUnknownSmithyHttpException(error);
@@ -633,7 +633,7 @@ class StorageS3Service {
       });
 
       try {
-        await _defaultS3Client.abortMultipartUpload(request);
+        await _defaultS3Client.abortMultipartUpload(request).result;
         await _transferDatabase.deleteTransferRecords(record.uploadId);
       } on Exception catch (error) {
         _logger.error('Failed to abort multipart upload due to: $error');

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
@@ -330,7 +330,7 @@ class S3DownloadTask {
     });
 
     try {
-      return await _s3Client.getObject(request);
+      return await _s3Client.getObject(request).result;
     } on smithy.UnknownSmithyHttpException catch (error) {
       // S3Client.getObject may return 403 error
       throw S3Exception.fromUnknownSmithyHttpException(error);

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -293,7 +293,7 @@ class S3UploadTask {
     try {
       // TODO(HuiSF): invoke onProgress here to emit upload progres when
       //  AWSHttpOperation is returned from the putObject API.
-      await _s3Client.putObject(putObjectRequest);
+      await _s3Client.putObject(putObjectRequest).result;
       _uploadCompleter.complete(
         _options.getProperties
             ? S3Item.fromHeadObjectOutput(
@@ -431,7 +431,7 @@ class S3UploadTask {
     final createdAt = DateTime.now().toIso8601String();
 
     try {
-      final output = await _s3Client.createMultipartUpload(request);
+      final output = await _s3Client.createMultipartUpload(request).result;
       final uploadId = output.uploadId;
 
       if (uploadId == null) {
@@ -478,7 +478,7 @@ class S3UploadTask {
     });
 
     try {
-      await _s3Client.completeMultipartUpload(request);
+      await _s3Client.completeMultipartUpload(request).result;
       await _transferDatabase.deleteTransferRecords(_multipartUploadId);
     } on UnknownSmithyHttpException catch (error) {
       // TODO(HuiSF): verify if s3Client sdk throws different exception type
@@ -554,7 +554,7 @@ class S3UploadTask {
       //  when _terminateMultipartUploadOnError is called.
       // TODO(HuiSF): add finer upload progress emitter when AWSHttpOperation
       //  is available from uploadPart.
-      final result = await _s3Client.uploadPart(request);
+      final result = await _s3Client.uploadPart(request).result;
       final eTag = result.eTag;
 
       if (eTag == null) {
@@ -595,7 +595,7 @@ class S3UploadTask {
         ..uploadId = _multipartUploadId;
     });
 
-    await _s3Client.abortMultipartUpload(request);
+    await _s3Client.abortMultipartUpload(request).result;
 
     if (isCancel) {
       _uploadCompleter.completeError(error);

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -143,16 +143,11 @@ void main() {
       const testPath = 'some/path';
       final testResult = S3ListResult(
         <S3Item>[],
-        hasNext: false,
-        next: () async {
-          return S3ListResult(
-            [],
-            hasNext: false,
-            next: () async {
-              throw UnimplementedError();
-            },
-          );
-        },
+        hasNextPage: false,
+        metadata: S3ListMetadata.fromS3CommonPrefixes(
+          commonPrefixes: [],
+          prefixToDrop: 'prefix',
+        ),
       );
 
       setUpAll(() {

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
@@ -85,11 +85,16 @@ void main() {
           contentLength: Int64(testBodyBytes.length),
           body: Stream.value(testBodyBytes),
         );
+        final smithyOperation = MockSmithyOperation<GetObjectOutput>();
         late S3TransferState finalState;
 
         when(
-          () => s3Client.getObject(any()),
+          () => smithyOperation.result,
         ).thenAnswer((_) async => testGetObjectOutput);
+
+        when(
+          () => s3Client.getObject(any()),
+        ).thenAnswer((_) => smithyOperation);
 
         final downloadTask = S3DownloadTask(
           s3Client: s3Client,
@@ -132,11 +137,16 @@ void main() {
         final testGetObjectOutput = GetObjectOutput(
           body: Stream.value([101]),
         );
+        final smithyOperation = MockSmithyOperation<GetObjectOutput>();
         var onErrorHasBeenCalled = false;
 
         when(
-          () => s3Client.getObject(any()),
+          () => smithyOperation.result,
         ).thenAnswer((_) async => testGetObjectOutput);
+
+        when(
+          () => s3Client.getObject(any()),
+        ).thenAnswer((_) => smithyOperation);
 
         final downloadTask = S3DownloadTask(
           s3Client: s3Client,
@@ -170,11 +180,15 @@ void main() {
             (_) => [101],
           ).take(1024),
         );
+        final smithyOperation = MockSmithyOperation<GetObjectOutput>();
         final receivedState = <S3TransferState>[];
 
         when(
-          () => s3Client.getObject(any()),
+          () => smithyOperation.result,
         ).thenAnswer((_) async => testGetObjectOutput);
+        when(
+          () => s3Client.getObject(any()),
+        ).thenAnswer((_) => smithyOperation);
 
         final downloadTask = S3DownloadTask(
           s3Client: s3Client,
@@ -205,11 +219,16 @@ void main() {
             (_) => [101],
           ).take(1024),
         );
+        final smithyOperation1 = MockSmithyOperation<GetObjectOutput>();
         final receivedState = <S3TransferState>[];
 
         when(
-          () => s3Client.getObject(any()),
+          () => smithyOperation1.result,
         ).thenAnswer((_) async => testGetObjectOutput1);
+
+        when(
+          () => s3Client.getObject(any()),
+        ).thenAnswer((_) => smithyOperation1);
 
         final downloadTask = S3DownloadTask(
           s3Client: s3Client,
@@ -233,9 +252,15 @@ void main() {
             (_) => [102],
           ).take(1024),
         );
+        final smithyOperation2 = MockSmithyOperation<GetObjectOutput>();
+
+        when(
+          () => smithyOperation2.result,
+        ).thenAnswer((_) async => testGetObjectOutput2);
+
         when(
           () => s3Client.getObject(any()),
-        ).thenAnswer((_) async => testGetObjectOutput2);
+        ).thenAnswer((_) => smithyOperation2);
 
         await downloadTask.resume();
 
@@ -252,11 +277,16 @@ void main() {
             (_) => [101],
           ).take(1024),
         );
+        final smithyOperation = MockSmithyOperation<GetObjectOutput>();
         final receivedState = <S3TransferState>[];
 
         when(
-          () => s3Client.getObject(any()),
+          () => smithyOperation.result,
         ).thenAnswer((_) async => testGetObjectOutput);
+
+        when(
+          () => s3Client.getObject(any()),
+        ).thenAnswer((_) => smithyOperation);
 
         final downloadTask = S3DownloadTask(
           s3Client: s3Client,
@@ -288,11 +318,16 @@ void main() {
             (_) => [101],
           ).take(1024),
         );
+        final smithyOperation = MockSmithyOperation<GetObjectOutput>();
         final receivedState = <S3TransferState>[];
 
         when(
-          () => s3Client.getObject(any()),
+          () => smithyOperation.result,
         ).thenAnswer((_) async => testGetObjectOutput);
+
+        when(
+          () => s3Client.getObject(any()),
+        ).thenAnswer((_) => smithyOperation);
 
         final downloadTask = S3DownloadTask(
           s3Client: s3Client,
@@ -317,10 +352,15 @@ void main() {
       test('should forward S3Exception when getObject returns no body', () {
         const testOptions = S3DownloadDataOptions();
         final testGetObjectOutput = GetObjectOutput(contentLength: Int64(1024));
+        final smithyOperation = MockSmithyOperation<GetObjectOutput>();
+
+        when(
+          () => smithyOperation.result,
+        ).thenAnswer((_) async => testGetObjectOutput);
 
         when(
           () => s3Client.getObject(any()),
-        ).thenAnswer((_) async => testGetObjectOutput);
+        ).thenAnswer((_) => smithyOperation);
 
         final downloadTask = S3DownloadTask(
           s3Client: s3Client,
@@ -382,11 +422,16 @@ void main() {
                 (_) => [101],
               ).take(1024),
             );
+            final smithyOperation1 = MockSmithyOperation<GetObjectOutput>();
             final receivedState = <S3TransferState>[];
 
             when(
-              () => s3Client.getObject(any()),
+              () => smithyOperation1.result,
             ).thenAnswer((_) async => testGetObjectOutput1);
+
+            when(
+              () => s3Client.getObject(any()),
+            ).thenAnswer((_) => smithyOperation1);
 
             final downloadTask = S3DownloadTask(
               s3Client: s3Client,
@@ -425,11 +470,16 @@ void main() {
           contentLength: Int64(testBodyBytes.length),
           body: Stream.value(testBodyBytes),
         );
+        final smithOperation = MockSmithyOperation<GetObjectOutput>();
         late S3TransferState finalState;
 
         when(
-          () => s3Client.getObject(any()),
+          () => smithOperation.result,
         ).thenAnswer((_) async => testGetObjectOutput);
+
+        when(
+          () => s3Client.getObject(any()),
+        ).thenAnswer((_) => smithOperation);
 
         final downloadTask = S3DownloadTask(
           s3Client: s3Client,
@@ -457,13 +507,18 @@ void main() {
           contentLength: Int64(testBodyBytes.length),
           body: Stream.value(testBodyBytes),
         );
+        final smithyOperation = MockSmithyOperation<GetObjectOutput>();
         final testOnDoneException = Exception('some exception');
         var onDoneHasBeenCalled = false;
         late S3TransferState finalState;
 
         when(
-          () => s3Client.getObject(any()),
+          () => smithyOperation.result,
         ).thenAnswer((_) async => testGetObjectOutput);
+
+        when(
+          () => s3Client.getObject(any()),
+        ).thenAnswer((_) => smithyOperation);
 
         final downloadTask = S3DownloadTask(
           s3Client: s3Client,
@@ -501,15 +556,26 @@ void main() {
           contentLength: Int64(testBodyBytes.length),
           body: Stream.value(testBodyBytes),
         );
+        final getSmithyOperation = MockSmithyOperation<GetObjectOutput>();
         const testETag = '123';
         final testHeadObjectOutput = HeadObjectOutput(eTag: testETag);
+        final headSmithyOperation = MockSmithyOperation<HeadObjectOutput>();
+
         when(
-          () => s3Client.getObject(any()),
+          () => getSmithyOperation.result,
         ).thenAnswer((_) async => testGetObjectOutput);
 
         when(
-          () => s3Client.headObject(any()),
+          () => headSmithyOperation.result,
         ).thenAnswer((_) async => testHeadObjectOutput);
+
+        when(
+          () => s3Client.getObject(any()),
+        ).thenAnswer((_) => getSmithyOperation);
+
+        when(
+          () => s3Client.headObject(any()),
+        ).thenAnswer((_) => headSmithyOperation);
 
         final downloadTask = S3DownloadTask(
           s3Client: s3Client,

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
@@ -94,10 +94,15 @@ void main() {
           accessLevel: StorageAccessLevel.private,
         );
         final testPutObjectOutput = s3.PutObjectOutput();
+        final smithyOperation = MockSmithyOperation<s3.PutObjectOutput>();
+
+        when(
+          () => smithyOperation.result,
+        ).thenAnswer((_) async => testPutObjectOutput);
 
         when(
           () => s3Client.putObject(any()),
-        ).thenAnswer((_) async => testPutObjectOutput);
+        ).thenAnswer((_) => smithyOperation);
 
         final uploadDataTask = S3UploadTask.fromDataPayload(
           testDataPayload,
@@ -140,15 +145,25 @@ void main() {
           getProperties: true,
         );
         final testPutObjectOutput = s3.PutObjectOutput();
+        final putSmithyOperation = MockSmithyOperation<s3.PutObjectOutput>();
         final testHeadObjectOutput = s3.HeadObjectOutput();
+        final headSmithyOperation = MockSmithyOperation<s3.HeadObjectOutput>();
 
         when(
-          () => s3Client.putObject(any()),
+          () => putSmithyOperation.result,
         ).thenAnswer((_) async => testPutObjectOutput);
 
         when(
-          () => s3Client.headObject(any()),
+          () => headSmithyOperation.result,
         ).thenAnswer((_) async => testHeadObjectOutput);
+
+        when(
+          () => s3Client.putObject(any()),
+        ).thenAnswer((_) => putSmithyOperation);
+
+        when(
+          () => s3Client.headObject(any()),
+        ).thenAnswer((_) => headSmithyOperation);
 
         final uploadDataTask = S3UploadTask.fromDataPayload(
           testDataPayload,
@@ -245,9 +260,15 @@ void main() {
           accessLevel: StorageAccessLevel.private,
         );
         final testPutObjectOutput = s3.PutObjectOutput();
+        final smithyOperation = MockSmithyOperation<s3.PutObjectOutput>();
+
+        when(
+          () => smithyOperation.result,
+        ).thenAnswer((_) async => testPutObjectOutput);
+
         when(
           () => s3Client.putObject(any()),
-        ).thenAnswer((_) async => testPutObjectOutput);
+        ).thenAnswer((_) => smithyOperation);
 
         final uploadDataTask = S3UploadTask.fromAWSFile(
           testLocalFile,
@@ -316,9 +337,16 @@ void main() {
         final testCreateMultipartUploadOutput = s3.CreateMultipartUploadOutput(
           uploadId: testMultipartUploadId,
         );
+        final createMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.CreateMultipartUploadOutput>();
+
+        when(
+          () => createMultipartUploadSmithyOperation.result,
+        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
+
         when(
           () => s3Client.createMultipartUpload(any()),
-        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
+        ).thenAnswer((_) => createMultipartUploadSmithyOperation);
 
         when(
           () => transferDatabase.insertTransferRecord(any()),
@@ -327,19 +355,36 @@ void main() {
         final testUploadPartOutput1 = s3.UploadPartOutput(eTag: 'eTag-part-1');
         final testUploadPartOutput2 = s3.UploadPartOutput(eTag: 'eTag-part-2');
         final testUploadPartOutput3 = s3.UploadPartOutput(eTag: 'eTag-part-3');
+        final uploadPartSmithyOperation1 =
+            MockSmithyOperation<s3.UploadPartOutput>();
+        final uploadPartSmithyOperation2 =
+            MockSmithyOperation<s3.UploadPartOutput>();
+        final uploadPartSmithyOperation3 =
+            MockSmithyOperation<s3.UploadPartOutput>();
+
+        when(
+          () => uploadPartSmithyOperation1.result,
+        ).thenAnswer((_) async => testUploadPartOutput1);
+        when(
+          () => uploadPartSmithyOperation2.result,
+        ).thenAnswer((_) async => testUploadPartOutput2);
+        when(
+          () => uploadPartSmithyOperation3.result,
+        ).thenAnswer((_) async => testUploadPartOutput3);
+
         when(
           () => s3Client.uploadPart(any()),
-        ).thenAnswer((invocation) async {
+        ).thenAnswer((invocation) {
           final request =
               invocation.positionalArguments.first as s3.UploadPartRequest;
 
           switch (request.partNumber) {
             case 1:
-              return testUploadPartOutput1;
+              return uploadPartSmithyOperation1;
             case 2:
-              return testUploadPartOutput2;
+              return uploadPartSmithyOperation2;
             case 3:
-              return testUploadPartOutput3;
+              return uploadPartSmithyOperation3;
           }
 
           throw Exception('this is not going to happen in this test setup');
@@ -347,18 +392,31 @@ void main() {
 
         final testCompleteMultipartUploadOutput =
             s3.CompleteMultipartUploadOutput();
+        final completeMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.CompleteMultipartUploadOutput>();
+
+        when(
+          () => completeMultipartUploadSmithyOperation.result,
+        ).thenAnswer((_) async => testCompleteMultipartUploadOutput);
+
         when(
           () => s3Client.completeMultipartUpload(any()),
-        ).thenAnswer((_) async => testCompleteMultipartUploadOutput);
+        ).thenAnswer((_) => completeMultipartUploadSmithyOperation);
 
         when(
           () => transferDatabase.deleteTransferRecords(any()),
         ).thenAnswer((_) async => 1);
 
         final testHeadObjectOutput = s3.HeadObjectOutput();
+        final headSmithyOperation = MockSmithyOperation<s3.HeadObjectOutput>();
+
+        when(
+          () => headSmithyOperation.result,
+        ).thenAnswer((_) async => testHeadObjectOutput);
+
         when(
           () => s3Client.headObject(any()),
-        ).thenAnswer((_) async => testHeadObjectOutput);
+        ).thenAnswer((_) => headSmithyOperation);
 
         final uploadTask = S3UploadTask.fromAWSFile(
           testLocalFile,
@@ -574,9 +632,16 @@ void main() {
         final testCreateMultipartUploadOutput = s3.CreateMultipartUploadOutput(
           uploadId: null, // response should always contain valid uploadId
         );
+        final createMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.CreateMultipartUploadOutput>();
+
+        when(
+          () => createMultipartUploadSmithyOperation.result,
+        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
+
         when(
           () => s3Client.createMultipartUpload(any()),
-        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
+        ).thenAnswer((_) => createMultipartUploadSmithyOperation);
 
         unawaited(uploadTask.start());
 
@@ -608,26 +673,46 @@ void main() {
         final testCreateMultipartUploadOutput = s3.CreateMultipartUploadOutput(
           uploadId: 'some-upload-id',
         );
+        final createMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.CreateMultipartUploadOutput>();
+
+        when(
+          () => createMultipartUploadSmithyOperation.result,
+        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
+
         when(
           () => s3Client.createMultipartUpload(any()),
-        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
+        ).thenAnswer((_) => createMultipartUploadSmithyOperation);
 
         when(
           () => transferDatabase.insertTransferRecord(any()),
         ).thenAnswer((_) async => 1);
 
         final testUploadPartOutput = s3.UploadPartOutput(eTag: 'eTag-part-1');
+        final uploadPartSmithyOperation =
+            MockSmithyOperation<s3.UploadPartOutput>();
+
+        when(
+          () => uploadPartSmithyOperation.result,
+        ).thenAnswer((_) async => testUploadPartOutput);
+
         when(
           () => s3Client.uploadPart(any()),
-        ).thenAnswer((_) async => testUploadPartOutput);
+        ).thenAnswer((_) => uploadPartSmithyOperation);
 
         const testException = smithy.UnknownSmithyHttpException(
           statusCode: 403,
           body: 'Access denied!',
         );
+        final completeMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.CompleteMultipartUploadOutput>();
+
+        when(
+          () => completeMultipartUploadSmithyOperation.result,
+        ).thenThrow(testException);
         when(
           () => s3Client.completeMultipartUpload(any()),
-        ).thenThrow(testException);
+        ).thenAnswer((_) => completeMultipartUploadSmithyOperation);
 
         unawaited(uploadTask.start());
 
@@ -667,9 +752,15 @@ void main() {
         final testCreateMultipartUploadOutput = s3.CreateMultipartUploadOutput(
           uploadId: testMultipartUploadId,
         );
+        final createMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.CreateMultipartUploadOutput>();
+
+        when(
+          () => createMultipartUploadSmithyOperation.result,
+        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
         when(
           () => s3Client.createMultipartUpload(any()),
-        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
+        ).thenAnswer((_) => createMultipartUploadSmithyOperation);
 
         when(
           () => transferDatabase.insertTransferRecord(any()),
@@ -686,9 +777,14 @@ void main() {
         unawaited(uploadTask.start());
 
         final testAbortMultipartUploadOutput = s3.AbortMultipartUploadOutput();
+        final abortMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.AbortMultipartUploadOutput>();
+        when(
+          () => abortMultipartUploadSmithyOperation.result,
+        ).thenAnswer((_) async => testAbortMultipartUploadOutput);
         when(
           () => s3Client.abortMultipartUpload(any()),
-        ).thenAnswer((_) async => testAbortMultipartUploadOutput);
+        ).thenAnswer((_) => abortMultipartUploadSmithyOperation);
 
         await expectLater(
           uploadTask.result,
@@ -741,25 +837,41 @@ void main() {
         final testCreateMultipartUploadOutput = s3.CreateMultipartUploadOutput(
           uploadId: testMultipartUploadId,
         );
+        final createMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.CreateMultipartUploadOutput>();
+        when(
+          () => createMultipartUploadSmithyOperation.result,
+        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
         when(
           () => s3Client.createMultipartUpload(any()),
-        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
+        ).thenAnswer((_) => createMultipartUploadSmithyOperation);
 
         when(
           () => transferDatabase.insertTransferRecord(any()),
         ).thenAnswer((_) async => 1);
 
         final testUploadPartOutput = s3.UploadPartOutput(eTag: null);
+        final uploadPartSmithyOperation =
+            MockSmithyOperation<s3.UploadPartOutput>();
+
+        when(
+          () => uploadPartSmithyOperation.result,
+        ).thenAnswer((_) async => testUploadPartOutput);
         when(
           () => s3Client.uploadPart(any()),
-        ).thenAnswer((_) async => testUploadPartOutput);
+        ).thenAnswer((_) => uploadPartSmithyOperation);
 
         unawaited(uploadTask.start());
 
         final testAbortMultipartUploadOutput = s3.AbortMultipartUploadOutput();
+        final abortMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.AbortMultipartUploadOutput>();
+        when(
+          () => abortMultipartUploadSmithyOperation.result,
+        ).thenAnswer((_) async => testAbortMultipartUploadOutput);
         when(
           () => s3Client.abortMultipartUpload(any()),
-        ).thenAnswer((_) async => testAbortMultipartUploadOutput);
+        ).thenAnswer((_) => abortMultipartUploadSmithyOperation);
 
         await expectLater(
           uploadTask.result,
@@ -791,9 +903,14 @@ void main() {
         final testCreateMultipartUploadOutput = s3.CreateMultipartUploadOutput(
           uploadId: testMultipartUploadId,
         );
+        final createMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.CreateMultipartUploadOutput>();
+        when(
+          () => createMultipartUploadSmithyOperation.result,
+        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
         when(
           () => s3Client.createMultipartUpload(any()),
-        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
+        ).thenAnswer((_) => createMultipartUploadSmithyOperation);
 
         when(
           () => transferDatabase.insertTransferRecord(any()),
@@ -807,9 +924,14 @@ void main() {
         unawaited(uploadTask.start());
 
         final testAbortMultipartUploadOutput = s3.AbortMultipartUploadOutput();
+        final abortMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.AbortMultipartUploadOutput>();
+        when(
+          () => abortMultipartUploadSmithyOperation.result,
+        ).thenAnswer((_) async => testAbortMultipartUploadOutput);
         when(
           () => s3Client.abortMultipartUpload(any()),
-        ).thenAnswer((_) async => testAbortMultipartUploadOutput);
+        ).thenAnswer((_) => abortMultipartUploadSmithyOperation);
 
         await expectLater(
           uploadTask.result,
@@ -831,32 +953,60 @@ void main() {
               s3.CreateMultipartUploadOutput(
             uploadId: 'some-upload-id',
           );
+          final createMultipartUploadSmithyOperation =
+              MockSmithyOperation<s3.CreateMultipartUploadOutput>();
+          when(
+            () => createMultipartUploadSmithyOperation.result,
+          ).thenAnswer((_) async => testCreateMultipartUploadOutput);
           when(
             () => s3Client.createMultipartUpload(any()),
-          ).thenAnswer((_) async => testCreateMultipartUploadOutput);
+          ).thenAnswer((_) => createMultipartUploadSmithyOperation);
 
           when(
             () => transferDatabase.insertTransferRecord(any()),
           ).thenAnswer((_) async => 1);
 
-          final testUploadPartOutput = s3.UploadPartOutput(eTag: 'eTag-part-1');
+          final testUploadPartOutput1 =
+              s3.UploadPartOutput(eTag: 'eTag-part-1');
+          final testUploadPartOutput2 =
+              s3.UploadPartOutput(eTag: 'eTag-part-2');
+          final uploadPartSmithyOperation1 =
+              MockSmithyOperation<s3.UploadPartOutput>();
+          final uploadPartSmithyOperation2 =
+              MockSmithyOperation<s3.UploadPartOutput>();
+
+          when(
+            () => uploadPartSmithyOperation1.result,
+          ).thenAnswer((_) async => testUploadPartOutput1);
+          when(
+            () => uploadPartSmithyOperation2.result,
+          ).thenAnswer((_) async {
+            await Future<void>.delayed(const Duration(milliseconds: 500));
+            return testUploadPartOutput2;
+          });
+
           when(
             () => s3Client.uploadPart(any()),
-          ).thenAnswer((invocation) async {
+          ).thenAnswer((invocation) {
             final request =
                 invocation.positionalArguments.first as s3.UploadPartRequest;
 
-            if (request.partNumber == 2) {
-              await Future<void>.delayed(const Duration(milliseconds: 500));
+            if (request.partNumber == 1) {
+              return uploadPartSmithyOperation1;
             }
-            return testUploadPartOutput;
+            return uploadPartSmithyOperation2;
           });
 
           final testCompleteMultipartUploadOutput =
               s3.CompleteMultipartUploadOutput();
+          final completeMultipartUploadSmithyOperation =
+              MockSmithyOperation<s3.CompleteMultipartUploadOutput>();
+          when(
+            () => completeMultipartUploadSmithyOperation.result,
+          ).thenAnswer((_) async => testCompleteMultipartUploadOutput);
           when(
             () => s3Client.completeMultipartUpload(any()),
-          ).thenAnswer((_) async => testCompleteMultipartUploadOutput);
+          ).thenAnswer((_) => completeMultipartUploadSmithyOperation);
 
           when(
             () => transferDatabase.deleteTransferRecords(any()),
@@ -864,9 +1014,14 @@ void main() {
 
           final testAbortMultipartUploadOutput =
               s3.AbortMultipartUploadOutput();
+          final abortMultipartUploadSmithyOperation =
+              MockSmithyOperation<s3.AbortMultipartUploadOutput>();
+          when(
+            () => abortMultipartUploadSmithyOperation.result,
+          ).thenAnswer((_) async => testAbortMultipartUploadOutput);
           when(
             () => s3Client.abortMultipartUpload(any()),
-          ).thenAnswer((_) async => testAbortMultipartUploadOutput);
+          ).thenAnswer((_) => abortMultipartUploadSmithyOperation);
         });
 
         test('pause()/resume() should emit paused stat and complete the upload',

--- a/packages/storage/amplify_storage_s3_dart/test/test_utils/mocks.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/test_utils/mocks.dart
@@ -18,6 +18,7 @@ import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_servic
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/database/database.dart';
 import 'package:aws_signature_v4/aws_signature_v4.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:smithy/smithy.dart';
 
 class MockStorageS3Service extends Mock implements StorageS3Service {}
 
@@ -32,3 +33,5 @@ class MockS3DownloadTask extends Mock implements S3DownloadTask {}
 class MockS3UploadTask extends Mock implements S3UploadTask {}
 
 class MockTransferDatabase extends Mock implements TransferDatabase {}
+
+class MockSmithyOperation<T> extends Mock implements SmithyOperation<T> {}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. refactored `S3Client` SDK API calls to adapt the `SmithyOperation`
2. Revised `list` API to align with other amplify library Storage `list` API interface

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
