### PR TITLE
test(smithy): Add HttpOperation tests

### DIFF
--- a/packages/aws_common/lib/src/http/aws_http_client.dart
+++ b/packages/aws_common/lib/src/http/aws_http_client.dart
@@ -184,6 +184,7 @@ abstract class AWSBaseHttpClient extends AWSCustomHttpClient {
       completer.operation,
       requestProgress: requestProgressController.stream,
       responseProgress: responseProgressController.stream,
+      onCancel: onCancel,
     );
   }
 

--- a/packages/aws_common/lib/src/http/aws_http_request.dart
+++ b/packages/aws_common/lib/src/http/aws_http_request.dart
@@ -132,9 +132,10 @@ abstract class AWSBaseHttpRequest
   ///
   /// If [client] is not provided, a short-lived one is created for this
   /// request.
-  AWSHttpOperation send([
+  AWSHttpOperation send({
     AWSHttpClient? client,
-  ]) {
+    FutureOr<void> Function()? onCancel,
+  }) {
     final useClient = client ?? AWSHttpClient();
 
     // Closes the HTTP client, but only if we created it.
@@ -164,7 +165,10 @@ abstract class AWSBaseHttpRequest
       ),
       requestProgress: awsOperation.requestProgress,
       responseProgress: awsOperation.responseProgress,
-      onCancel: awsOperation.cancel,
+      onCancel: () {
+        closeClient();
+        return onCancel?.call();
+      },
     );
   }
 

--- a/packages/aws_common/lib/src/http/aws_http_request.dart
+++ b/packages/aws_common/lib/src/http/aws_http_request.dart
@@ -164,6 +164,7 @@ abstract class AWSBaseHttpRequest
       ),
       requestProgress: awsOperation.requestProgress,
       responseProgress: awsOperation.responseProgress,
+      onCancel: awsOperation.cancel,
     );
   }
 

--- a/packages/aws_common/lib/src/http/mock.dart
+++ b/packages/aws_common/lib/src/http/mock.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 
 import 'package:aws_common/aws_common.dart';
+import 'package:stream_transform/stream_transform.dart';
 
 /// A mock request handler for use with [MockAWSHttpClient].
 typedef MockRequestHandler = FutureOr<AWSBaseHttpResponse> Function(
@@ -35,14 +36,38 @@ class MockAWSHttpClient extends AWSCustomHttpClient {
     AWSBaseHttpRequest request, {
     FutureOr<void> Function()? onCancel,
   }) {
+    final requestProgress = StreamController<int>.broadcast();
+    final responseProgress = StreamController<int>.broadcast();
     return AWSHttpOperation(
       CancelableOperation.fromFuture(
         Future(() async {
-          return _handler(await request.read());
+          final readRequest = await request.read();
+          requestProgress.add(readRequest.bodyBytes.length);
+          unawaited(requestProgress.close());
+          final response = await _handler(readRequest);
+          if (response is AWSHttpResponse) {
+            responseProgress.add(response.bodyBytes.length);
+            unawaited(responseProgress.close());
+            return response;
+          }
+          return AWSStreamedHttpResponse(
+            statusCode: response.statusCode,
+            headers: response.headers,
+            body: response.body.tap(
+              (event) => responseProgress.add(event.length),
+              onDone: responseProgress.close,
+            ),
+          );
         }),
+        onCancel: () {
+          requestProgress.close();
+          responseProgress.close();
+          return onCancel?.call();
+        },
       ),
-      requestProgress: const Stream.empty(),
-      responseProgress: const Stream.empty(),
+      requestProgress: requestProgress.stream,
+      responseProgress: responseProgress.stream,
+      onCancel: onCancel,
     );
   }
 }

--- a/packages/aws_common/test/http/aws_http_request_test.dart
+++ b/packages/aws_common/test/http/aws_http_request_test.dart
@@ -54,7 +54,7 @@ void main() {
 
       request.headers[AWSHeaders.contentLength] =
           request.contentLength.toString();
-      await request.send(client).response;
+      await request.send(client: client).response;
     });
 
     test('factories', () async {
@@ -144,7 +144,7 @@ void main() {
 
       request.headers[AWSHeaders.contentLength] =
           (await request.contentLength).toString();
-      await request.send(client).response;
+      await request.send(client: client).response;
     });
 
     test('factories', () async {

--- a/packages/aws_common/test/http/http_client_test.dart
+++ b/packages/aws_common/test/http/http_client_test.dart
@@ -34,7 +34,7 @@ void main() {
       final request = AWSHttpRequest.get(
         Uri.parse('https://amazon.com/ping'),
       );
-      expect(request.send(client).response, completes);
+      expect(request.send(client: client).response, completes);
     });
   });
 }

--- a/packages/aws_signature_v4/test/s3/testdata/e2e_test.dart
+++ b/packages/aws_signature_v4/test/s3/testdata/e2e_test.dart
@@ -56,7 +56,7 @@ void main() {
           body: HttpPayload.string('OK'),
         );
       });
-      final resp = await signedReq.send(client).response;
+      final resp = await signedReq.send(client: client).response;
 
       expect(resp.statusCode, equals(200));
       expect(await utf8.decodeStream(resp.body), equals('OK'));

--- a/packages/aws_signature_v4/test/streamed_request_test.dart
+++ b/packages/aws_signature_v4/test/streamed_request_test.dart
@@ -53,7 +53,7 @@ void main() {
             service: 'service',
           ),
         );
-        await signedRequest.send(mockClient).response;
+        await signedRequest.send(client: mockClient).response;
 
         // Body is split twice, once to hash the payload, then again to read the
         // body which cannot be read from the original body stream.
@@ -73,7 +73,7 @@ void main() {
             service: 'service',
           ),
         );
-        await signedRequest.send(mockClient).response;
+        await signedRequest.send(client: mockClient).response;
 
         // Body is split thrice, once to hash the payload, once to get the
         // content length, then again to read the body which cannot be read from
@@ -100,7 +100,7 @@ void main() {
           ),
           serviceConfiguration: serviceConfiguration,
         );
-        await signedRequest.send(mockClient).response;
+        await signedRequest.send(client: mockClient).response;
 
         // Body is not split, and the original body stream is used.
         expect(request.debugNumSplits, equals(0));
@@ -120,7 +120,7 @@ void main() {
           ),
           serviceConfiguration: serviceConfiguration,
         );
-        await signedRequest.send(mockClient).response;
+        await signedRequest.send(client: mockClient).response;
 
         // Body is split twice, once to get the content length, then again to
         // read the body which cannot be read from the original body stream.

--- a/packages/smithy/smithy/lib/src/behavior/retryer.dart
+++ b/packages/smithy/smithy/lib/src/behavior/retryer.dart
@@ -36,8 +36,9 @@ class Retryer {
   CancelableOperation<R> retry<R>(
     CancelableOperation<R> Function() fn, {
     FutureOr<void> Function(Exception, [Duration?])? onRetry,
+    FutureOr<void> Function()? onCancel,
   }) {
-    final completer = CancelableCompleter<R>();
+    final completer = CancelableCompleter<R>(onCancel: onCancel);
     Future<void>(() async {
       var attempt = 0;
       while (true) {

--- a/packages/smithy/smithy/test/http/http_operation_test.dart
+++ b/packages/smithy/smithy/test/http/http_operation_test.dart
@@ -1,0 +1,108 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:aws_common/aws_common.dart';
+import 'package:aws_common/testing.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HttpOperation', () {
+    test('can cancel operation', () async {
+      final operation = TestOp1();
+      final shouldCancel = Completer<void>();
+      final client = MockAWSHttpClient((req) async {
+        final stream = () async* {
+          yield [1, 2, 3, 4, 5];
+          shouldCancel.complete();
+          yield [6, 7, 8, 9, 10];
+        }();
+        return AWSStreamedHttpResponse(statusCode: 200, body: stream);
+      });
+      final op = operation.run(const Unit(), client: client);
+      shouldCancel.future.then((_) {
+        op.cancel();
+      });
+      expect(op.requestProgress, emitsThrough(emitsDone));
+      expect(
+        op.responseProgress,
+        emitsInOrder([5, emitsDone]),
+      );
+      expect(op.result, throwsA(isA<CancellationException>()));
+    });
+
+    test('can deserialize output', () async {
+      final operation = TestOp1();
+      final body =
+          GenericJsonProtocol<Unit, Unit, Unit, Unit>().serialize(const Unit());
+      final client = MockAWSHttpClient((req) {
+        return AWSStreamedHttpResponse(statusCode: 200, body: body);
+      });
+      final op = operation.run(const Unit(), client: client);
+      expect(op.requestProgress, emitsThrough(emitsDone));
+      expect(op.responseProgress, emitsThrough(emitsDone));
+      expect(op.result, completion(isA<Unit>()));
+    });
+
+    test('can handle errors', () async {
+      final operation = TestOp1();
+      final client = MockAWSHttpClient((req) async {
+        final stream = Stream.value([1, 2, 3, 4, 5]);
+        return AWSStreamedHttpResponse(statusCode: 200, body: stream);
+      });
+      final op = operation.run(const Unit(), client: client);
+      expect(op.requestProgress, emitsThrough(emitsDone));
+      expect(
+        op.responseProgress,
+        emitsInOrder([5, emitsDone]),
+      );
+      expect(op.result, throwsA(isA<DeserializationError>()));
+    });
+  });
+}
+
+class TestOp1 extends HttpOperation<Unit, Unit, Unit, Unit> {
+  @override
+  Uri get baseUri => Uri.parse('https://service.us-west-2.amazonaws.com/');
+
+  @override
+  HttpRequest buildRequest(Unit input) => HttpRequest((b) {
+        b.method = 'GET';
+        b.path = '/';
+      });
+
+  @override
+  Unit buildOutput(
+    Unit payload,
+    AWSBaseHttpResponse response,
+  ) =>
+      payload;
+
+  @override
+  List<SmithyError> get errorTypes => const [];
+
+  @override
+  Iterable<HttpProtocol<Unit, Unit, Unit, Unit>> get protocols => [
+        GenericJsonProtocol(),
+      ];
+
+  @override
+  int successCode([Unit? output]) => 200;
+
+  @override
+  String get runtimeTypeName => 'TestOp1';
+}

--- a/packages/smithy/smithy_aws/lib/src/http/retry/aws_retryer.dart
+++ b/packages/smithy/smithy_aws/lib/src/http/retry/aws_retryer.dart
@@ -166,8 +166,9 @@ class AWSRetryer implements Retryer {
   CancelableOperation<R> retry<R>(
     CancelableOperation<R> Function() f, {
     FutureOr<void> Function(Exception, [Duration?])? onRetry,
+    FutureOr<void> Function()? onCancel,
   }) {
-    final completer = CancelableCompleter<R>();
+    final completer = CancelableCompleter<R>(onCancel: onCancel);
     Future<void>(() async {
       var attempts = 0;
       int? retryToken;


### PR DESCRIPTION
- Fixes an issue where progress listeners had events added to them after closing.
- Adds tests for `HttpOperation`