### PR TITLE
fix(smithy): Incorrect port/scheme

### DIFF
--- a/packages/smithy/smithy/lib/src/http/http_operation.dart
+++ b/packages/smithy/smithy/lib/src/http/http_operation.dart
@@ -191,7 +191,7 @@ abstract class HttpOperation<InputPayload, Input, OutputPayload, Output>
       method: AWSHttpMethod.fromString(request.method),
       scheme: uri.scheme,
       host: host,
-      port: uri.port,
+      port: uri.hasPort ? uri.port : null,
       path: path,
       body: body,
       queryParameters: queryParameters,

--- a/packages/smithy/smithy_aws/lib/src/endpoint/partition.dart
+++ b/packages/smithy/smithy_aws/lib/src/endpoint/partition.dart
@@ -91,9 +91,9 @@ class EndpointDefinition with AWSSerializable {
     final sortedProtocols = [...merged.protocols]..sort((a, b) {
         final aIdx = _protocolPriority.indexOf(a);
         final bIdx = _protocolPriority.indexOf(b);
-        return (aIdx > 0 && bIdx > 0)
+        return (aIdx > -1 && bIdx > -1)
             ? aIdx.compareTo(bIdx)
-            : aIdx > 0
+            : aIdx > -1
                 ? -1
                 : 1;
       });


### PR DESCRIPTION
The logic for choosing a protocol from the partition's supported protocols was incorrect resulting in `http` taking precedence over `https`.