### PR TITLE
chore(auth): change WAF for integ test stack

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/backend/lib/stack.ts
+++ b/packages/auth/amplify_auth_cognito/example/backend/lib/stack.ts
@@ -25,7 +25,6 @@ import * as appsync from "@aws-cdk/aws-appsync-alpha";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as kms from "aws-cdk-lib/aws-kms";
 import * as wafv2 from "aws-cdk-lib/aws-wafv2";
-import * as waf_regional from "aws-cdk-lib/aws-waf";
 import {
   CfnOutput,
   Duration,
@@ -243,49 +242,7 @@ export class AuthIntegrationTestStack extends cdk.Stack {
       defaultAction: {
         allow: {},
       },
-      rules: [
-        // AWS IP Reputation list includes known malicious actors/bots and is regularly updated
-        // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-ip-rep.html#aws-managed-rule-groups-ip-rep-amazon
-        {
-          name: "AWS-AWSManagedRulesAmazonIpReputationList",
-          priority: 0,
-          statement: {
-            managedRuleGroupStatement: {
-              vendorName: "AWS",
-              name: "AWSManagedRulesAmazonIpReputationList",
-            },
-          },
-          overrideAction: {
-            none: {},
-          },
-          visibilityConfig: {
-            sampledRequestsEnabled: true,
-            cloudWatchMetricsEnabled: true,
-            metricName: "AWS-AWSManagedRulesAmazonIpReputationList",
-          },
-        },
-
-        // Anonymous IP list blocks IP addresses from obscuring services like VPNs/proxies
-        // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-ip-rep.html#aws-managed-rule-groups-ip-rep-anonymous
-        {
-          name: "AWS-AWSManagedRulesAnonymousIpList",
-          priority: 10,
-          statement: {
-            managedRuleGroupStatement: {
-              vendorName: "AWS",
-              name: "AWSManagedRulesAnonymousIpList",
-            },
-          },
-          overrideAction: {
-            none: {},
-          },
-          visibilityConfig: {
-            sampledRequestsEnabled: true,
-            cloudWatchMetricsEnabled: true,
-            metricName: "AWS-AWSManagedRulesAnonymousIpList",
-          },
-        },
-
+      rules: [      
         // Basic rate limiting to prevent overuse of endpoints
         {
           name: "RateLimit",


### PR DESCRIPTION
This PR removes some WAF rules that are causing CI integ tests to fail bc auth requests are blocked by the firewall.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
