### PR TITLE
chore(aft): Speed up bootstrap

### DIFF
--- a/packages/aft/lib/src/commands/bootstrap_command.dart
+++ b/packages/aft/lib/src/commands/bootstrap_command.dart
@@ -93,7 +93,14 @@ const amplifyEnvironments = <String, String>{};
     ]);
     if (build) {
       for (final package in allPackages.values) {
-        await runBuildRunner(package, logger: logger, verbose: verbose);
+        // Only run build_runner for packages which need it for development,
+        // i.e. those packages which specify worker JS files in their assets.
+        final needsBuild = package.needsBuildRunner &&
+            (package.pubspecInfo.pubspec.flutter?.containsKey('assets') ??
+                false);
+        if (needsBuild) {
+          await runBuildRunner(package, logger: logger, verbose: verbose);
+        }
       }
     }
 


### PR DESCRIPTION
`build_runner` only needs to run for packages which require assets built for development. The other packages only need it run on publish.
