### PR TITLE
chore: enable linux/macos integ tests in CI

### DIFF
--- a/.github/composite_actions/fetch_backends/action.yaml
+++ b/.github/composite_actions/fetch_backends/action.yaml
@@ -16,7 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # 1.6.1
+      uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # 1.7.0
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
@@ -24,12 +24,6 @@ runs:
 
     - name: Create AWS profile
       run: ./build-support/create_integration_test_profile.sh
-      shell: bash
-
-    # The dummy configuration produced by aft has some characters which cause the
-    # Amplify CLI to throw when running pull, so just delete the dummy file.
-    - name: Remove config file created by aft
-      run: melos exec --scope=${{ inputs.scope }} rm lib/amplifyconfiguration.dart
       shell: bash
     
     - name: Get Amplify App IDs / bucket ARNs from Secrets Manager

--- a/.github/composite_actions/install_dependencies/action.yaml
+++ b/.github/composite_actions/install_dependencies/action.yaml
@@ -10,18 +10,19 @@ runs:
         yarn global add @aws-amplify/cli --network-timeout 100000 || yarn global add @aws-amplify/cli --network-timeout 100000
       shell: bash
 
-    - uses: subosito/flutter-action@d8687e6979e8ef66d2b2970e2c92c1d8e801d7bf # 2.4.0
+    - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d # 2.8.0
       with:
         channel: 'stable'
-        architecture: x64 # needed to prevent "Bad CPU type" error
-
-    - name: Run AFT
-      run: |
-        flutter pub global activate -spath packages/aft
-        aft bs
-      shell: bash
-
+    
     - name: Install Melos
       run: |
-        flutter pub global activate melos 2.4.0
+        flutter pub global activate melos 2.8.0
+      shell: bash
+
+    #  Install aft from path, links packages and runs build runner where needed.
+    - name: Partial aft bootstrap
+      run: |
+        flutter pub global activate -spath packages/aft
+        aft link
+        melos exec -c 1 --scope="amplify_secure_storage_dart,amplify_auth_cognito_dart" -- dart run build_runner build --delete-conflicting-outputs
       shell: bash

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -125,3 +125,38 @@ jobs:
         run: |
           chromedriver --port=4444 &
           melos exec -c 1 --scope ${{ matrix.scope }} -- flutter drive --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d web-server
+
+  linux:
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        scope: ["amplify_auth_cognito_example"]
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+        with:
+          persist-credentials: false
+      
+      - name: Install dependencies
+        uses: ./.github/composite_actions/install_dependencies
+
+      - name: Fetch Amplify backend configurations
+        uses: ./.github/composite_actions/fetch_backends
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          scope: ${{ matrix.scope }}
+          secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
+
+      # Headless tests require virtual display for the linux tests to run.
+      # from https://github.com/fluttercommunity/plus_plugins/blob/main/.github/workflows/scripts/integration-test.sh
+      - name: Run integration tests
+        run: |
+          flutter config --enable-linux-desktop
+          export DISPLAY=:99
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+          melos exec -c 1 --scope ${{ matrix.scope }} -- retries=1 \$MELOS_ROOT_PATH/build-support/integ_test.sh -d linux

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -26,12 +26,12 @@ jobs:
           - "amplify_datastore_example"
           - "amplify_storage_s3_example"
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
         with:
           persist-credentials: false
 
       # Flutter requires Java 11 to build android apps with Gradle.
-      - uses: actions/setup-java@860f60056505705214d223b91ed7a30f173f6142 # 3.3.0
+      - uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # 3.6.0
         with:
           distribution: 'corretto' # Amazon Corretto Build of OpenJDK
           java-version: '11'
@@ -47,17 +47,13 @@ jobs:
           scope: ${{ matrix.scope }}
           secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
 
-      - name: Build example app with integration tests
-        run: |
-          melos exec --scope=${{ matrix.scope }} --file-exists="integration_test/main_test.dart" --fail-fast flutter build apk --verbose
-
       - name: Run Android integration tests
-        uses: reactivecircus/android-emulator-runner@e790971012b979513b4e2fe70d4079bc0ca8a1ae # 2.24.0
+        uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0 # 2.27.0
         timeout-minutes: 45
         with:
           # API levels 30+ too slow https://github.com/ReactiveCircus/android-emulator-runner/issues/222
           api-level: 29
-          script: melos exec -c 1 --scope ${{ matrix.scope }} -- "deviceId=emulator-5554 retries=1 small=true \$MELOS_ROOT_PATH/build-support/integ_test_android.sh"
+          script: melos exec -c 1 --scope ${{ matrix.scope }} -- "retries=1 small=true \$MELOS_ROOT_PATH/build-support/integ_test.sh -d emulator-554"
 
   ios:
     runs-on: macos-latest
@@ -74,7 +70,7 @@ jobs:
           - "amplify_datastore_example"
           - "amplify_storage_s3_example"
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
         with:
           persist-credentials: false
       
@@ -93,10 +89,6 @@ jobs:
           scope: ${{ matrix.scope }}
           secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
 
-      - name: Build example app with integration tests
-        run: |
-          melos exec --scope=${{ matrix.scope }} flutter build ios --simulator
-
       - name: Run integration tests
         run: |
           melos exec -c 1 --scope ${{ matrix.scope }} -- "retries=1 small=true \$MELOS_ROOT_PATH/build-support/integ_test_ios.sh"
@@ -112,7 +104,7 @@ jobs:
       matrix:
         scope: ["amplify_auth_cognito_example"]
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
         with:
           persist-credentials: false
       

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           # API levels 30+ too slow https://github.com/ReactiveCircus/android-emulator-runner/issues/222
           api-level: 29
-          script: melos exec -c 1 --scope ${{ matrix.scope }} -- "retries=1 small=true \$MELOS_ROOT_PATH/build-support/integ_test.sh -d emulator-554"
+          script: melos exec -c 1 --scope ${{ matrix.scope }} -- small=true \$MELOS_ROOT_PATH/build-support/integ_test.sh -d emulator-5554  --retries 1
 
   ios:
     runs-on: macos-latest
@@ -91,7 +91,7 @@ jobs:
 
       - name: Run integration tests
         run: |
-          melos exec -c 1 --scope ${{ matrix.scope }} -- "retries=1 small=true \$MELOS_ROOT_PATH/build-support/integ_test_ios.sh"
+          melos exec -c 1 --scope ${{ matrix.scope }} -- small=true \$MELOS_ROOT_PATH/build-support/integ_test_ios.sh  --retries 1
 
   web:
     runs-on: ubuntu-latest
@@ -126,6 +126,37 @@ jobs:
           chromedriver --port=4444 &
           melos exec -c 1 --scope ${{ matrix.scope }} -- flutter drive --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d web-server
 
+  macos:
+    runs-on: macos-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        scope: ["amplify_auth_cognito_example"]
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+        with:
+          persist-credentials: false
+      
+      - name: Install dependencies
+        uses: ./.github/composite_actions/install_dependencies
+
+      - name: Fetch Amplify backend configurations
+        uses: ./.github/composite_actions/fetch_backends
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          scope: ${{ matrix.scope }}
+          secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
+
+      - name: Run integration tests
+        run: |
+          flutter config --enable-macos-desktop
+          melos exec -c 1 --scope ${{ matrix.scope }} -- \$MELOS_ROOT_PATH/build-support/integ_test.sh -d macos  --retries 1
+
   linux:
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
@@ -152,11 +183,7 @@ jobs:
           scope: ${{ matrix.scope }}
           secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
 
-      # Headless tests require virtual display for the linux tests to run.
-      # from https://github.com/fluttercommunity/plus_plugins/blob/main/.github/workflows/scripts/integration-test.sh
       - name: Run integration tests
         run: |
           flutter config --enable-linux-desktop
-          export DISPLAY=:99
-          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-          melos exec -c 1 --scope ${{ matrix.scope }} -- retries=1 \$MELOS_ROOT_PATH/build-support/integ_test.sh -d linux
+          melos exec -c 1 --scope ${{ matrix.scope }} -- \$MELOS_ROOT_PATH/build-support/integ_test.sh -d linux --retries 1

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -24,7 +24,8 @@ jobs:
           - "amplify_api_example"
           - "amplify_auth_cognito_example"
           - "amplify_datastore_example"
-          - "amplify_storage_s3_example"
+          # TODO(ragingsquirrel3): figure out why this times out
+          # - "amplify_storage_s3_example"
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
         with:
@@ -102,7 +103,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scope: ["amplify_auth_cognito_example"]
+        scope:
+          - "amplify_auth_cognito_example"
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
         with:
@@ -135,7 +137,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scope: ["amplify_auth_cognito_example"]
+        scope: 
+          - "amplify_auth_cognito_example"
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
         with:
@@ -166,7 +169,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scope: ["amplify_auth_cognito_example"]
+        scope: 
+          - "amplify_auth_cognito_example"
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
         with:

--- a/build-support/integ_test.sh
+++ b/build-support/integ_test.sh
@@ -57,7 +57,9 @@ if [ ! -e $TARGET ]; then
     exit
 fi
 
-flutter pub get
+if [ -n $CI ]; then
+    flutter pub get
+fi
 
 testsList+=("$TARGET")
 # Run tests with retry.

--- a/build-support/integ_test_ios.sh
+++ b/build-support/integ_test_ios.sh
@@ -27,6 +27,9 @@ while [ $# -gt 0 ]; do
                     exit 1
             esac
             ;;
+        --retries)
+            retries="$2"
+            ;;
         *)
             echo "Invalid arguments"
             exit 1

--- a/build-support/integ_test_ios.sh
+++ b/build-support/integ_test_ios.sh
@@ -49,7 +49,9 @@ if [ ! -e $TARGET ]; then
     exit
 fi
 
-
+if [ -n $CI ]; then
+    flutter pub get
+fi
 
 # Use xcodebuild if 'RunnerTests' scheme exists, else `flutter test`
 if xcodebuild -workspace ios/Runner.xcworkspace -list -json | jq -e '.workspace.schemes | index("RunnerTests")' >/dev/null; then

--- a/melos.yaml
+++ b/melos.yaml
@@ -158,7 +158,7 @@ scripts:
       - Requires running Android and iOS simulators.
 
   test:integration:android:
-    run: melos exec -c 1 -- "$MELOS_ROOT_PATH/build-support/integ_test_android.sh" $@
+    run: melos exec -c 1 -- "$MELOS_ROOT_PATH/build-support/integ_test.sh -d sdk" $@
     description:
       Run integration tests for a single package on an Android emulator.
       - Run with `--no-select` to run for all applicable packages.


### PR DESCRIPTION
This PR does the following:
* enables linux integ tests in CI (just auth for now)
* enables macos integ tests in CI (just auth for now)
* various optimizations/cleanups in integ tests scripts/configs like updating community actions, removing unnecessary steps, etc...


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
