### PR TITLE
fix(sigv4): Make body signing configurable

### DIFF
--- a/packages/aws_signature_v4/lib/src/signer/aws_signer.dart
+++ b/packages/aws_signature_v4/lib/src/signer/aws_signer.dart
@@ -205,7 +205,7 @@ class AWSSigV4Signer {
       canonicalRequest: canonicalRequest,
     );
     final seedSignature = algorithm.sign(sts, signingKey);
-    final signedBody = serviceConfiguration.signBody(
+    final signedBody = serviceConfiguration.transformBody(
       algorithm: algorithm,
       contentLength: contentLength,
       signingKey: signingKey,

--- a/packages/aws_signature_v4/test/c_test_suite/test_data.dart
+++ b/packages/aws_signature_v4/test/c_test_suite/test_data.dart
@@ -132,6 +132,7 @@ class SignerTest {
               // tests expect single encoding like S3.
               // https://github.com/awslabs/aws-c-auth/issues/162
               doubleEncodePathSegments: false,
+              signBody: context.signBody,
             );
 
   factory SignerTest.fromJson(Map<String, Object?> json) {

--- a/packages/aws_signature_v4/test/s3/s3_service_configuration_test.dart
+++ b/packages/aws_signature_v4/test/s3/s3_service_configuration_test.dart
@@ -111,7 +111,7 @@ void main() {
           for (final serviceConfiguration in serviceConfigurations) {
             test(
               'chunked=${serviceConfiguration.chunked}, '
-              'signPayload=${serviceConfiguration.signPayload}',
+              'signPayload=${serviceConfiguration.signBody}',
               () async {
                 final signedRequest = await signer.sign(
                   request,
@@ -130,7 +130,7 @@ void main() {
           for (final serviceConfiguration in serviceConfigurations) {
             test(
               'chunked=${serviceConfiguration.chunked}, '
-              'signPayload=${serviceConfiguration.signPayload}',
+              'signPayload=${serviceConfiguration.signBody}',
               () {
                 final signedRequest = signer.signSync(
                   request,


### PR DESCRIPTION
Adds `signBody` as a parameter to `ServiceConfiguration` so that it can be configured on a per-client basis, as suggested by the test suite.
