### PR TITLE
 fix(api): do not signBody for REST IAM

### DIFF
--- a/packages/amplify_core/lib/amplify_core.dart
+++ b/packages/amplify_core/lib/amplify_core.dart
@@ -19,7 +19,8 @@ import 'src/amplify_class.dart';
 
 /// Common types
 export 'package:aws_common/aws_common.dart';
-export 'package:aws_signature_v4/aws_signature_v4.dart' show AWSCredentials;
+export 'package:aws_signature_v4/aws_signature_v4.dart'
+    show AWSCredentials, ServiceConfiguration;
 
 export 'src/amplify_class.dart';
 

--- a/packages/amplify_core/lib/src/types/common/amplify_auth_provider.dart
+++ b/packages/amplify_core/lib/src/types/common/amplify_auth_provider.dart
@@ -38,10 +38,12 @@ class IamAuthProviderOptions extends AuthProviderOptions {
   const IamAuthProviderOptions({
     required this.region,
     required this.service,
+    this.serviceConfiguration,
   });
 
   final String region;
   final AWSService service;
+  final ServiceConfiguration? serviceConfiguration;
 }
 
 class ApiKeyAuthProviderOptions extends AuthProviderOptions {

--- a/packages/api/amplify_api/example/integration_test/rest_test.dart
+++ b/packages/api/amplify_api/example/integration_test/rest_test.dart
@@ -68,6 +68,9 @@ void main({bool useExistingTestUser = false}) {
           expect(res.statusCode, 200);
           expect(body, 'test header set');
         },
+        // Skip on web because CORS does not allow this custom header without
+        // manually adding to allow list in API gateway.
+        skip: zIsWeb,
       );
 
       testWidgets('should throw a RestException for POST',
@@ -120,8 +123,5 @@ void main({bool useExistingTestUser = false}) {
         validateRestResponse(res);
       });
     });
-  },
-      // Skip because CLI issue for web https://github.com/aws-amplify/amplify-category-api/issues/519
-      // which requires manual backend changes.
-      skip: zIsWeb);
+  });
 }

--- a/packages/api/amplify_api/lib/src/api_plugin_impl.dart
+++ b/packages/api/amplify_api/lib/src/api_plugin_impl.dart
@@ -17,9 +17,9 @@ library amplify_api;
 import 'dart:io';
 
 import 'package:amplify_api/amplify_api.dart';
+import 'package:amplify_api/src/graphql/helpers/send_graphql_request.dart';
 import 'package:amplify_api/src/graphql/providers/app_sync_api_key_auth_provider.dart';
 import 'package:amplify_api/src/graphql/providers/oidc_function_api_auth_provider.dart';
-import 'package:amplify_api/src/graphql/helpers/send_graphql_request.dart';
 import 'package:amplify_api/src/graphql/ws/web_socket_connection.dart';
 import 'package:amplify_api/src/native_api_plugin.dart';
 import 'package:amplify_api/src/util/amplify_api_config.dart';

--- a/packages/api/amplify_api/lib/src/decorators/authorize_http_request.dart
+++ b/packages/api/amplify_api/lib/src/decorators/authorize_http_request.dart
@@ -60,15 +60,20 @@ Future<AWSBaseHttpRequest> authorizeHttpRequest(
             .getAuthProvider(APIAuthorizationType.iam.authProviderToken),
         authType,
       );
-      final service = endpointConfig.endpointType == EndpointType.graphQL
+      final isGraphQL = endpointConfig.endpointType == EndpointType.graphQL;
+      final service = isGraphQL
           ? AWSService.appSync
           : AWSService.apiGatewayManagementApi; // resolves to "execute-api"
+      // Do not sign body for REST to avoid CORS issue on web.
+      final serviceConfiguration =
+          isGraphQL ? null : const ServiceConfiguration(signBody: false);
 
       final authorizedRequest = await authProvider.authorizeRequest(
         request,
         options: IamAuthProviderOptions(
           region: endpointConfig.region,
           service: service,
+          serviceConfiguration: serviceConfiguration,
         ),
       );
       return authorizedRequest;

--- a/packages/api/amplify_api/lib/src/graphql/ws/web_socket_connection.dart
+++ b/packages/api/amplify_api/lib/src/graphql/ws/web_socket_connection.dart
@@ -17,8 +17,8 @@ import 'dart:collection';
 import 'dart:convert';
 
 import 'package:amplify_api/src/decorators/web_socket_auth_utils.dart';
-import 'package:amplify_api/src/graphql/ws/web_socket_message_stream_transformer.dart';
 import 'package:amplify_api/src/graphql/ws/types/web_socket_types.dart';
+import 'package:amplify_api/src/graphql/ws/web_socket_message_stream_transformer.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:async/async.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -4,11 +4,19 @@ version: 1.0.0-next.0+3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
-publish_to: none # until finalized
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
   flutter: ">=3.0.0"
+
+# Helps `pana` since we do not use Flutter plugins for most platforms
+platforms:
+  ios:
+  android:
+  macos:
+  windows:
+  linux:
+  web:
 
 dependencies:
   amplify_api_android: ">=1.0.0-next.0 <1.0.0-next.1"

--- a/packages/api/amplify_api/test/util.dart
+++ b/packages/api/amplify_api/test/util.dart
@@ -55,6 +55,8 @@ class TestIamAuthProvider extends AWSIamAmplifyAuthProvider {
     return signer.sign(
       request,
       credentialScope: scope,
+      serviceConfiguration:
+          options.serviceConfiguration ?? const BaseServiceConfiguration(),
     );
   }
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/util/cognito_iam_auth_provider.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/util/cognito_iam_auth_provider.dart
@@ -60,6 +60,7 @@ class CognitoIamAuthProvider extends AWSIamAmplifyAuthProvider {
       request,
       region: options.region,
       service: options.service,
+      serviceConfiguration: options.serviceConfiguration,
       credentials: await retrieve(),
     );
   }
@@ -70,6 +71,7 @@ class CognitoIamAuthProvider extends AWSIamAmplifyAuthProvider {
     required String region,
     required AWSService service,
     required AWSCredentials credentials,
+    ServiceConfiguration? serviceConfiguration,
   }) {
     // Create signer helper params.
     final signer = AWSSigV4Signer(
@@ -84,6 +86,8 @@ class CognitoIamAuthProvider extends AWSIamAmplifyAuthProvider {
     return signer.sign(
       request,
       credentialScope: scope,
+      serviceConfiguration:
+          serviceConfiguration ?? const BaseServiceConfiguration(),
     );
   }
 }

--- a/packages/auth/amplify_auth_cognito_test/test/plugin/auth_providers_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/plugin/auth_providers_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart'
     hide InternalErrorException;
@@ -160,6 +161,33 @@ void main() {
         expect(
           authorizedRequest.headers[userAgentHeader],
           contains('aws-sigv4'),
+        );
+      });
+
+      test('does not sign body when ServiceConfiguration signBody false',
+          () async {
+        const authProvider = CognitoIamAuthProvider();
+        const region = 'us-east-1';
+        final inputRequest = AWSHttpRequest(
+          method: AWSHttpMethod.post,
+          body: json.encode({
+            'foo': 'bar',
+          }).codeUnits,
+          uri: Uri.parse(
+            'https://xyz456.execute-api.$region.amazonaws.com/test',
+          ),
+        );
+        final authorizedRequest = await authProvider.authorizeRequest(
+          inputRequest,
+          options: const IamAuthProviderOptions(
+            region: region,
+            service: AWSService.apiGateway,
+            serviceConfiguration: ServiceConfiguration(signBody: false),
+          ),
+        );
+        expect(
+          authorizedRequest.headers.containsKey(AWSHeaders.contentSHA256),
+          isFalse,
         );
       });
 


### PR DESCRIPTION
This PR fixes an issue for REST API on web in IAM auth mode where requests with bodies are signed with the `signBody` option that generates an HTTP header `x-amz-content-sha256` that is not allowed by default CORS policies of Amplify API Gateway endpoints. The end user gets a CORS error for any request with a body on web with IAM mode (without manually changing API Gateway CORS policies).

This PR changes the signer settings for REST API gateway so that the body is not signed and this header is never added. The result is that REST API works on web without manual API Gateway changes. The majority of REST integration tests are thus enabled here on web.

There is also a small change to the pubspec file for API to prep for release and some import sorting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
