### PR TITLE
fix(authenticator): remove unnecessary assertion in PendingVerificationCheckState constructor

### DIFF
--- a/packages/amplify_authenticator/lib/src/state/auth_state.dart
+++ b/packages/amplify_authenticator/lib/src/state/auth_state.dart
@@ -94,10 +94,5 @@ class ConfirmSignInCustom extends UnauthenticatedState {
 class PendingVerificationCheckState extends UnauthenticatedState {
   const PendingVerificationCheckState({
     required AuthenticatorStep step,
-  })  : assert(
-          step == AuthenticatorStep.signIn ||
-              step == AuthenticatorStep.confirmSignUp,
-          'Invalid AuthenticatorStep type: $step',
-        ),
-        super(step: step);
+  }) : super(step: step);
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/2311

*Description of changes:*
- Remove an unnecessary assertion in PendingVerificationCheckState. This assertion checked that current step was signIn or confirmSignUp. There is no reason to have this assertion, and it was problematic after a password reset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
