### PR TITLE
fix(api): MockAmplifyAPI `addPlugin` call

### DIFF
--- a/packages/api/amplify_api/test/graphql_helpers_test.dart
+++ b/packages/api/amplify_api/test/graphql_helpers_test.dart
@@ -34,11 +34,10 @@ class MockAmplifyAPI extends AmplifyAPIMethodChannel {
   void registerAuthProvider(APIAuthProvider authProvider) {}
 
   @override
+  // ignore: must_call_super
   Future<void> addPlugin({
     required AmplifyAuthProviderRepository authProviderRepo,
-  }) async {
-    await super.addPlugin(authProviderRepo: authProviderRepo);
-  }
+  }) async {}
 }
 
 void main() {


### PR DESCRIPTION
Fixes a call to `addPlugin` which is expected to fail when extending from MethodChannelAPI in tests
