### PR TITLE
feat(storage): cancel SmithyOperation on upload pause and cancel

### DIFF
--- a/packages/amplify_core/lib/src/types/storage/base/storage_controllable_operation.dart
+++ b/packages/amplify_core/lib/src/types/storage/base/storage_controllable_operation.dart
@@ -12,14 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-abstract class StorageControllableOperation {
-  /// {@template amplify_core.storage.controllable_operation.cancel}
-  /// Cancels the operation.
-  ///
-  /// A cancelled operation cannot be resumed.
-  /// {@endtemplate}
-  Future<void> cancel();
-
+abstract class StorageResumableOperation {
   /// {@template amplify_core.storage.controllable_operation.pause}
   /// Pauses the operation that is in progress.
   /// {@endtemplate}
@@ -29,4 +22,13 @@ abstract class StorageControllableOperation {
   /// Resumes the operation that is in a paused state.
   /// {@endtemplate}
   Future<void> resume();
+}
+
+abstract class StorageCancelableOperation {
+  /// {@template amplify_core.storage.controllable_operation.cancel}
+  /// Cancels the operation.
+  ///
+  /// A cancelled operation cannot be resumed.
+  /// {@endtemplate}
+  Future<void> cancel();
 }

--- a/packages/amplify_core/lib/src/types/storage/download_data_operation.dart
+++ b/packages/amplify_core/lib/src/types/storage/download_data_operation.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'package:amplify_core/amplify_core.dart';
-import 'base/storage_controllable_operation.dart';
 import 'base/storage_operation.dart';
 
 /// {@template amplify_core.storage.download_data_operation}
@@ -23,7 +22,9 @@ abstract class StorageDownloadDataOperation<
         Request extends StorageDownloadDataRequest,
         Result extends StorageDownloadDataResult>
     extends StorageOperation<Request, Result>
-    implements StorageControllableOperation {
+// TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
+// can cancel underlying http request.
+/* implements StorageControllableOperation */ {
   /// {@macro amplify_core.storage.download_data_operation}
   StorageDownloadDataOperation({
     required super.request,

--- a/packages/amplify_core/lib/src/types/storage/download_data_operation.dart
+++ b/packages/amplify_core/lib/src/types/storage/download_data_operation.dart
@@ -24,7 +24,7 @@ abstract class StorageDownloadDataOperation<
     extends StorageOperation<Request, Result>
 // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
 // can cancel underlying http request.
-/* implements StorageControllableOperation */ {
+/* implements StorageResumableOperation, StorageCancelableOperation */ {
   /// {@macro amplify_core.storage.download_data_operation}
   StorageDownloadDataOperation({
     required super.request,

--- a/packages/amplify_core/lib/src/types/storage/download_file_operation.dart
+++ b/packages/amplify_core/lib/src/types/storage/download_file_operation.dart
@@ -24,7 +24,7 @@ abstract class StorageDownloadFileOperation<
     extends StorageOperation<Request, Result>
 // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
 // can cancel underlying http request.
-/* implements StorageControllableOperation */ {
+/* implements StorageResumableOperation, StorageCancelableOperation */ {
   /// {@macro amplify_core.storage.download_file_operation}
   StorageDownloadFileOperation({
     required super.request,

--- a/packages/amplify_core/lib/src/types/storage/download_file_operation.dart
+++ b/packages/amplify_core/lib/src/types/storage/download_file_operation.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'package:amplify_core/amplify_core.dart';
-import 'base/storage_controllable_operation.dart';
 import 'base/storage_operation.dart';
 
 /// {@template amplify_core.storage.download_file_operation}
@@ -23,7 +22,9 @@ abstract class StorageDownloadFileOperation<
         Request extends StorageDownloadFileRequest,
         Result extends StorageDownloadFileResult>
     extends StorageOperation<Request, Result>
-    implements StorageControllableOperation {
+// TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
+// can cancel underlying http request.
+/* implements StorageControllableOperation */ {
   /// {@macro amplify_core.storage.download_file_operation}
   StorageDownloadFileOperation({
     required super.request,

--- a/packages/amplify_core/lib/src/types/storage/upload_data_operation.dart
+++ b/packages/amplify_core/lib/src/types/storage/upload_data_operation.dart
@@ -23,7 +23,7 @@ abstract class StorageUploadDataOperation<
         Request extends StorageUploadDataRequest,
         Result extends StorageUploadDataResult>
     extends StorageOperation<Request, Result>
-    implements StorageControllableOperation {
+    implements StorageCancelableOperation {
   /// {@macro amplify_core.storage.upload_data_operation}
   StorageUploadDataOperation({
     required super.request,

--- a/packages/amplify_core/lib/src/types/storage/upload_data_operation.dart
+++ b/packages/amplify_core/lib/src/types/storage/upload_data_operation.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import 'package:amplify_core/amplify_core.dart';
-// import 'base/storage_controllable_operation.dart';
+import 'base/storage_controllable_operation.dart';
 import 'base/storage_operation.dart';
 
 /// {@template amplify_core.storage.upload_data_operation}
@@ -23,9 +23,7 @@ abstract class StorageUploadDataOperation<
         Request extends StorageUploadDataRequest,
         Result extends StorageUploadDataResult>
     extends StorageOperation<Request, Result>
-// TODO(HuiSF): implement controllable operation APIs when AWSHttpOperation
-//  is returned from S3Client APIs.
-/* implements StorageControllableOperation */ {
+    implements StorageControllableOperation {
   /// {@macro amplify_core.storage.upload_data_operation}
   StorageUploadDataOperation({
     required super.request,

--- a/packages/amplify_core/lib/src/types/storage/upload_file_operation.dart
+++ b/packages/amplify_core/lib/src/types/storage/upload_file_operation.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import 'package:amplify_core/amplify_core.dart';
-// import 'base/storage_controllable_operation.dart';
+import 'base/storage_controllable_operation.dart';
 import 'base/storage_operation.dart';
 
 /// {@template amplify_core.storage.upload_file_operation}
@@ -23,9 +23,7 @@ abstract class StorageUploadFileOperation<
         Request extends StorageUploadFileRequest,
         Result extends StorageUploadFileResult>
     extends StorageOperation<Request, Result>
-// TODO(HuiSF): implement controllable operation APIs when AWSHttpOperation
-//  is returned from S3Client APIs.
-/* implements StorageControllableOperation */ {
+    implements StorageControllableOperation {
   /// {@macro amplify_core.storage.upload_file_operation}
   StorageUploadFileOperation({
     required super.request,

--- a/packages/amplify_core/lib/src/types/storage/upload_file_operation.dart
+++ b/packages/amplify_core/lib/src/types/storage/upload_file_operation.dart
@@ -23,7 +23,7 @@ abstract class StorageUploadFileOperation<
         Request extends StorageUploadFileRequest,
         Result extends StorageUploadFileResult>
     extends StorageOperation<Request, Result>
-    implements StorageControllableOperation {
+    implements StorageResumableOperation, StorageCancelableOperation {
   /// {@macro amplify_core.storage.upload_file_operation}
   StorageUploadFileOperation({
     required super.request,

--- a/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
+++ b/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
@@ -237,11 +237,13 @@ Future<void> downloadDataOperation() async {
   );
 
   stdout.writeln('Downloading...');
-  await Future<void>.delayed(const Duration(seconds: 1));
-  await downloadDataOperation.pause();
+  // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
+  // can cancel underlying http request.
+  // await Future<void>.delayed(const Duration(seconds: 1));
+  // await downloadDataOperation.pause();
 
-  await Future<void>.delayed(const Duration(seconds: 4));
-  await downloadDataOperation.resume();
+  // await Future<void>.delayed(const Duration(seconds: 4));
+  // await downloadDataOperation.resume();
 
   try {
     final result = await downloadDataOperation.result;
@@ -277,11 +279,13 @@ Future<void> downloadFileOperation() async {
   );
 
   stdout.writeln('Downloading...');
-  await Future<void>.delayed(const Duration(seconds: 1));
-  await downloadFileOperation.pause();
+  // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
+  // can cancel underlying http request.
+  // await Future<void>.delayed(const Duration(seconds: 1));
+  // await downloadFileOperation.pause();
 
-  await Future<void>.delayed(const Duration(seconds: 4));
-  await downloadFileOperation.resume();
+  // await Future<void>.delayed(const Duration(seconds: 4));
+  // await downloadFileOperation.resume();
 
   try {
     final result = await downloadFileOperation.result;

--- a/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
+++ b/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
@@ -359,11 +359,11 @@ Future<void> uploadFileOperation() async {
   );
 
   stdout.writeln('Uploading...');
-  // await Future<void>.delayed(const Duration(seconds: 1));
-  // await uploadFileOperation.pause();
+  await Future<void>.delayed(const Duration(seconds: 3));
+  await uploadFileOperation.pause();
 
-  // await Future<void>.delayed(const Duration(seconds: 4));
-  // await uploadFileOperation.resume();
+  await Future<void>.delayed(const Duration(seconds: 4));
+  await uploadFileOperation.resume();
 
   try {
     final result = await uploadFileOperation.result;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -332,8 +332,6 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
       result: uploadTask.result.then(
         (uploadedItem) => S3UploadDataResult(uploadedItem: uploadedItem),
       ),
-      resume: uploadTask.resume,
-      pause: uploadTask.pause,
       cancel: uploadTask.cancel,
     );
   }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_data_operation.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_data_operation.dart
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO(HuiSF): remove
+// ignore_for_file: unused_field
+
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 
@@ -35,12 +38,14 @@ class S3DownloadDataOperation extends StorageDownloadDataOperation<
   final Future<void> Function() _pause;
   final Future<void> Function() _cancel;
 
-  @override
-  Future<void> resume() => _resume();
+  // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
+  // can cancel underlying http request.
+  // @override
+  // Future<void> resume() => _resume();
 
-  @override
-  Future<void> pause() => _pause();
+  // @override
+  // Future<void> pause() => _pause();
 
-  @override
-  Future<void> cancel() => _cancel();
+  // @override
+  // Future<void> cancel() => _cancel();
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_file_operation.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_file_operation.dart
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO(HuiSF): remove
+// ignore_for_file: unused_field
+
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 
@@ -35,16 +38,18 @@ class S3DownloadFileOperation extends StorageDownloadFileOperation<
   final Future<void> Function() _pause;
   final Future<void> Function() _cancel;
 
-  /// When using Amplify Storage S3 plugin in a Web App, this doesn't do
-  /// anything as the download is managed by browser.
-  @override
-  Future<void> resume() => _resume();
+  // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
+  // can cancel underlying http request.
+  // /// When using Amplify Storage S3 plugin in a Web App, this doesn't do
+  // /// anything as the download is managed by browser.
+  // @override
+  // Future<void> resume() => _resume();
 
-  /// When using Amplify Storage S3 plugin in a Web App, this doesn't do
-  /// anything as the download is managed by browser.
-  @override
-  Future<void> pause() => _pause();
+  // /// When using Amplify Storage S3 plugin in a Web App, this doesn't do
+  // /// anything as the download is managed by browser.
+  // @override
+  // Future<void> pause() => _pause();
 
-  @override
-  Future<void> cancel() => _cancel();
+  // @override
+  // Future<void> cancel() => _cancel();
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_options.dart
@@ -22,7 +22,7 @@ class S3GetUrlOptions extends StorageGetUrlOptions {
   /// {@macro storage.amplify_storage_s3.get_url_options}
   const S3GetUrlOptions({
     StorageAccessLevel accessLevel = StorageAccessLevel.guest,
-    Duration expiresIn = const Duration(days: 1),
+    Duration expiresIn = const Duration(minutes: 15),
     bool checkObjectExistence = false,
   }) : this._(
           accessLevel: accessLevel,

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_transfer_progress.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_transfer_progress.dart
@@ -36,6 +36,10 @@ enum S3TransferState {
 
 /// {@template storage.amplify_storage_s3.transfer_progress}
 /// The transfer progress.
+///
+/// In a [S3TransferProgress] emitted by a upload data operation , the field
+/// [totalBytes] always has value `-1`, as the file size is unknown when upload
+/// was initiated.
 /// {@endtemplate}
 class S3TransferProgress extends StorageTransferProgress {
   /// {@macro storage.amplify_storage_s3.transfer_progress}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_data_operation.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_data_operation.dart
@@ -24,24 +24,10 @@ class S3UploadDataOperation extends StorageUploadDataOperation<
   S3UploadDataOperation({
     required super.request,
     required super.result,
-    required Future<void> Function() resume,
-    required Future<void> Function() pause,
     required Future<void> Function() cancel,
-  })  : _resume = resume,
-        _pause = pause,
-        _cancel = cancel;
+  }) : _cancel = cancel;
 
-  final Future<void> Function() _resume;
-  final Future<void> Function() _pause;
   final Future<void> Function() _cancel;
-
-  /// Resume takes no effect for a [S3UploadDataOperation].
-  @override
-  Future<void> resume() => _resume();
-
-  /// Pause takes no effect for a [S3UploadDataOperation] .
-  @override
-  Future<void> pause() => _pause();
 
   @override
   Future<void> cancel() => _cancel();

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_data_operation.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_data_operation.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ignore_for_file: unused_field
-
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 
@@ -37,19 +35,14 @@ class S3UploadDataOperation extends StorageUploadDataOperation<
   final Future<void> Function() _pause;
   final Future<void> Function() _cancel;
 
-  // TODO(HuiSF): enable controllable operation APIs when AWSHttpOperation
-  //  is returned from S3Client APIs.
-  // /// Resumes the operation that is in paused state.
-  // @override
-  // Future<void> resume() => _resume();
+  /// Resume takes no effect for a [S3UploadDataOperation].
+  @override
+  Future<void> resume() => _resume();
 
-  // /// Pauses the operation that is in progress.
-  // @override
-  // Future<void> pause() => _pause();
+  /// Pause takes no effect for a [S3UploadDataOperation] .
+  @override
+  Future<void> pause() => _pause();
 
-  // /// Cancels the operation.
-  // ///
-  // /// A cancelled operation cannot be resumed.
-  // @override
-  // Future<void> cancel() => _cancel();
+  @override
+  Future<void> cancel() => _cancel();
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_file_operation.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_file_operation.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ignore_for_file: unused_field
-
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 
@@ -37,19 +35,12 @@ class S3UploadFileOperation extends StorageUploadFileOperation<
   final Future<void> Function() _pause;
   final Future<void> Function() _cancel;
 
-  // TODO(HuiSF): enable controllable operation APIs when AWSHttpOperation
-  //  is returned from S3Client APIs.
-  // /// Resumes the operation that is in paused state.
-  // @override
-  // Future<void> resume() => _resume();
+  @override
+  Future<void> resume() => _resume();
 
-  // /// Pauses the operation that is in progress.
-  // @override
-  // Future<void> pause() => _pause();
+  @override
+  Future<void> pause() => _pause();
 
-  // /// Cancels the operation.
-  // ///
-  // /// A cancelled operation cannot be resumed.
-  // @override
-  // Future<void> cancel() => _cancel();
+  @override
+  Future<void> cancel() => _cancel();
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_html.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_html.dart
@@ -50,23 +50,21 @@ Future<S3DownloadFileResult> _downloadFromUrl({
   required S3PluginConfig s3pluginConfig,
   required StorageS3Service storageS3Service,
 }) async {
-  const defaultExpiresIn = Duration(minutes: 5);
   final s3Options = request.options as S3DownloadFileOptions? ??
       S3DownloadFileOptions(
         accessLevel: s3pluginConfig.defaultAccessLevel,
       );
   final targetIdentityId = s3Options.targetIdentityId;
+  // download url expires in 15 mins by default, see [S3GetUrlOptions]
   final url = (await storageS3Service.getUrl(
     key: request.key,
     options: targetIdentityId == null
         ? S3GetUrlOptions(
             accessLevel: s3Options.accessLevel,
-            expiresIn: defaultExpiresIn,
             checkObjectExistence: true,
           )
         : S3GetUrlOptions.forIdentity(
             targetIdentityId,
-            expiresIn: defaultExpiresIn,
             checkObjectExistence: true,
           ),
   ))

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -362,21 +362,23 @@ void main() {
         expect(result.downloadedItem, testItem);
       });
 
-      test(
-          'S3DownloadDataOperation pause resume and cancel APIs should interact with S3DownloadTask',
-          () async {
-        when(testS3DownloadTask.pause).thenAnswer((_) async {});
-        when(testS3DownloadTask.resume).thenAnswer((_) async {});
-        when(testS3DownloadTask.cancel).thenAnswer((_) async {});
+      // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
+      // can cancel underlying http request.
+      // test(
+      //     'S3DownloadDataOperation pause resume and cancel APIs should interact with S3DownloadTask',
+      //     () async {
+      //   when(testS3DownloadTask.pause).thenAnswer((_) async {});
+      //   when(testS3DownloadTask.resume).thenAnswer((_) async {});
+      //   when(testS3DownloadTask.cancel).thenAnswer((_) async {});
 
-        await downloadDataOperation.pause();
-        await downloadDataOperation.resume();
-        await downloadDataOperation.cancel();
+      //   await downloadDataOperation.pause();
+      //   await downloadDataOperation.resume();
+      //   await downloadDataOperation.cancel();
 
-        verify(testS3DownloadTask.pause).called(1);
-        verify(testS3DownloadTask.resume).called(1);
-        verify(testS3DownloadTask.cancel).called(1);
-      });
+      //   verify(testS3DownloadTask.pause).called(1);
+      //   verify(testS3DownloadTask.resume).called(1);
+      //   verify(testS3DownloadTask.cancel).called(1);
+      // });
     });
 
     group('uploadData() API', () {

--- a/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
@@ -304,34 +304,36 @@ void main() {
       });
     });
 
-    test(
-        'returned S3DownloadFileOperation pause resume and cancel APIs should interact with S3DownloadTask',
-        () async {
-      when(() => downloadTask.result).thenAnswer((_) async => testItem);
-      when(downloadTask.pause).thenAnswer((_) async {});
-      when(downloadTask.resume).thenAnswer((_) async {});
-      when(downloadTask.cancel).thenAnswer((_) async {});
+    // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
+    // can cancel underlying http request.
+    // test(
+    //     'returned S3DownloadFileOperation pause resume and cancel APIs should interact with S3DownloadTask',
+    //     () async {
+    //   when(() => downloadTask.result).thenAnswer((_) async => testItem);
+    //   when(downloadTask.pause).thenAnswer((_) async {});
+    //   when(downloadTask.resume).thenAnswer((_) async {});
+    //   when(downloadTask.cancel).thenAnswer((_) async {});
 
-      final downloadFileOperation = downloadFile(
-        request: StorageDownloadFileRequest(
-          key: testKey,
-          localFile: AWSFile.fromPath('path'),
-        ),
-        s3pluginConfig: testS3pluginConfig,
-        storageS3Service: storageS3Service,
-        appPathProvider: appPathProvider,
-        onProgress: (progress) {
-          expectedProgress = progress;
-        },
-      );
+    //   final downloadFileOperation = downloadFile(
+    //     request: StorageDownloadFileRequest(
+    //       key: testKey,
+    //       localFile: AWSFile.fromPath('path'),
+    //     ),
+    //     s3pluginConfig: testS3pluginConfig,
+    //     storageS3Service: storageS3Service,
+    //     appPathProvider: appPathProvider,
+    //     onProgress: (progress) {
+    //       expectedProgress = progress;
+    //     },
+    //   );
 
-      await downloadFileOperation.pause();
-      await downloadFileOperation.resume();
-      await downloadFileOperation.cancel();
+    //   await downloadFileOperation.pause();
+    //   await downloadFileOperation.resume();
+    //   await downloadFileOperation.cancel();
 
-      verify(downloadTask.pause).called(1);
-      verify(downloadTask.resume).called(1);
-      verify(downloadTask.cancel).called(1);
-    });
+    //   verify(downloadTask.pause).called(1);
+    //   verify(downloadTask.resume).called(1);
+    //   verify(downloadTask.cancel).called(1);
+    // });
   });
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Calling `SmithyOperation.cancel` to cancel underlying http requests on upload operation pause and cancel.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
