### PR TITLE
feat(datastore): Temporary codegen (part 1)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -548,16 +548,16 @@ jobs:
         working-directory: packages/secure_storage/amplify_secure_storage_test
         run: dart analyze --fatal-infos lib test
   job_009:
-    name: "analyze_and_format; Dart stable; PKGS: packages/aft, packages/amplify_core, packages/auth/amplify_auth_cognito_test, packages/aws_common, packages/aws_signature_v4/example, packages/example_common, packages/secure_storage/amplify_secure_storage_dart/example, packages/smithy/goldens/lib/awsJson1_0, packages/smithy/goldens/lib/awsJson1_1, packages/smithy/goldens/lib/restJson1, packages/smithy/goldens/lib/restXml, packages/smithy/goldens/lib/restXmlWithNamespace, packages/smithy/smithy, packages/smithy/smithy_aws, packages/smithy/smithy_codegen, packages/smithy/smithy_test, packages/worker_bee/e2e, packages/worker_bee/e2e_test, packages/worker_bee/worker_bee, packages/worker_bee/worker_bee_builder; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; Dart stable; PKGS: packages/aft, packages/amplify_core, packages/auth/amplify_auth_cognito_test, packages/aws_common, packages/aws_signature_v4/example, packages/datastore/amplify_codegen, packages/example_common, packages/secure_storage/amplify_secure_storage_dart/example, packages/smithy/goldens/lib/awsJson1_0, packages/smithy/goldens/lib/awsJson1_1, packages/smithy/goldens/lib/restJson1, packages/smithy/goldens/lib/restXml, packages/smithy/goldens/lib/restXmlWithNamespace, packages/smithy/smithy, packages/smithy/smithy_aws, packages/smithy/smithy_codegen, packages/smithy/smithy_test, packages/worker_bee/e2e, packages/worker_bee/e2e_test, packages/worker_bee/worker_bee, packages/worker_bee/worker_bee_builder; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aft-packages/amplify_core-packages/auth/amplify_auth_cognito_test-packages/aws_common-packages/aws_signature_v4/example-packages/example_common-packages/secure_storage/amplify_secure_storage_dart/example-packages/smithy/goldens/lib/awsJson1_0-packages/smithy/goldens/lib/awsJson1_1-packages/smithy/goldens/lib/restJson1-packages/smithy/goldens/lib/restXml-packages/smithy/goldens/lib/restXmlWithNamespace-packages/smithy/s-!!too_long!!-725-339769703"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aft-packages/amplify_core-packages/auth/amplify_auth_cognito_test-packages/aws_common-packages/aws_signature_v4/example-packages/datastore/amplify_codegen-packages/example_common-packages/secure_storage/amplify_secure_storage_dart/example-packages/smithy/goldens/lib/awsJson1_0-packages/smithy/goldens/lib/awsJson1_1-packages/smithy/goldens/lib/restJson1-packages/smithy/goldens/lib/restXml-packages/smithy/goldens/lib/res-!!too_long!!-760-374930231"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aft-packages/amplify_core-packages/auth/amplify_auth_cognito_test-packages/aws_common-packages/aws_signature_v4/example-packages/example_common-packages/secure_storage/amplify_secure_storage_dart/example-packages/smithy/goldens/lib/awsJson1_0-packages/smithy/goldens/lib/awsJson1_1-packages/smithy/goldens/lib/restJson1-packages/smithy/goldens/lib/restXml-packages/smithy/goldens/lib/restXmlWithNamespace-packages/smithy/s-!!too_long!!-699-852681108
+            os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aft-packages/amplify_core-packages/auth/amplify_auth_cognito_test-packages/aws_common-packages/aws_signature_v4/example-packages/datastore/amplify_codegen-packages/example_common-packages/secure_storage/amplify_secure_storage_dart/example-packages/smithy/goldens/lib/awsJson1_0-packages/smithy/goldens/lib/awsJson1_1-packages/smithy/goldens/lib/restJson1-packages/smithy/goldens/lib/restXml-packages/smithy/goldens/lib/res-!!too_long!!-734-471768725
             os:ubuntu-latest;pub-cache-hosted;sdk:stable
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -630,6 +630,19 @@ jobs:
       - name: "packages/aws_signature_v4/example; dart analyze --fatal-infos ."
         if: "always() && steps.packages_aws_signature_v4_example_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_signature_v4/example
+        run: dart analyze --fatal-infos .
+      - id: packages_datastore_amplify_codegen_pub_upgrade
+        name: packages/datastore/amplify_codegen; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/datastore/amplify_codegen
+        run: dart pub upgrade
+      - name: "packages/datastore/amplify_codegen; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.packages_datastore_amplify_codegen_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/datastore/amplify_codegen
+        run: "dart format --output=none --set-exit-if-changed ."
+      - name: "packages/datastore/amplify_codegen; dart analyze --fatal-infos ."
+        if: "always() && steps.packages_datastore_amplify_codegen_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/datastore/amplify_codegen
         run: dart analyze --fatal-infos .
       - id: packages_example_common_pub_upgrade
         name: packages/example_common; dart pub upgrade

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -724,16 +724,16 @@ jobs:
         working-directory: packages/worker_bee/e2e_test
         run: "dart run build_runner test --release --delete-conflicting-outputs --verbose -- -p chrome,firefox"
   job_017:
-    name: "unit_test; linux; Dart stable; PKGS: packages/aft, packages/amplify_core, packages/auth/amplify_auth_cognito_test, packages/aws_common, packages/smithy/goldens/lib/awsJson1_0, packages/smithy/goldens/lib/awsJson1_1, packages/smithy/goldens/lib/restJson1, packages/smithy/goldens/lib/restXml, packages/smithy/goldens/lib/restXmlWithNamespace, packages/smithy/smithy, packages/smithy/smithy_aws, packages/smithy/smithy_codegen, packages/worker_bee/e2e_test; `dart test`"
+    name: "unit_test; linux; Dart stable; PKGS: packages/aft, packages/amplify_core, packages/auth/amplify_auth_cognito_test, packages/aws_common, packages/datastore/amplify_codegen, packages/smithy/goldens/lib/awsJson1_0, packages/smithy/goldens/lib/awsJson1_1, packages/smithy/goldens/lib/restJson1, packages/smithy/goldens/lib/restXml, packages/smithy/goldens/lib/restXmlWithNamespace, packages/smithy/smithy, packages/smithy/smithy_aws, packages/smithy/smithy_codegen, packages/worker_bee/e2e_test; `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aft-packages/amplify_core-packages/auth/amplify_auth_cognito_test-packages/aws_common-packages/smithy/goldens/lib/awsJson1_0-packages/smithy/goldens/lib/awsJson1_1-packages/smithy/goldens/lib/restJson1-packages/smithy/goldens/lib/restXml-packages/smithy/goldens/lib/restXmlWithNamespace-packages/smithy/smithy-packages/smithy/smithy_aws-packages/smithy/smithy_codegen-packages/worker_bee/e2e_test;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aft-packages/amplify_core-packages/auth/amplify_auth_cognito_test-packages/aws_common-packages/datastore/amplify_codegen-packages/smithy/goldens/lib/awsJson1_0-packages/smithy/goldens/lib/awsJson1_1-packages/smithy/goldens/lib/restJson1-packages/smithy/goldens/lib/restXml-packages/smithy/goldens/lib/restXmlWithNamespace-packages/smithy/smithy-packages/smithy/smithy_aws-packages/smithy/smithy_codegen-packages/worker_bee/e2e_test;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aft-packages/amplify_core-packages/auth/amplify_auth_cognito_test-packages/aws_common-packages/smithy/goldens/lib/awsJson1_0-packages/smithy/goldens/lib/awsJson1_1-packages/smithy/goldens/lib/restJson1-packages/smithy/goldens/lib/restXml-packages/smithy/goldens/lib/restXmlWithNamespace-packages/smithy/smithy-packages/smithy/smithy_aws-packages/smithy/smithy_codegen-packages/worker_bee/e2e_test
+            os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:packages/aft-packages/amplify_core-packages/auth/amplify_auth_cognito_test-packages/aws_common-packages/datastore/amplify_codegen-packages/smithy/goldens/lib/awsJson1_0-packages/smithy/goldens/lib/awsJson1_1-packages/smithy/goldens/lib/restJson1-packages/smithy/goldens/lib/restXml-packages/smithy/goldens/lib/restXmlWithNamespace-packages/smithy/smithy-packages/smithy/smithy_aws-packages/smithy/smithy_codegen-packages/worker_bee/e2e_test
             os:ubuntu-latest;pub-cache-hosted;sdk:stable
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -777,6 +777,15 @@ jobs:
       - name: packages/aws_common; dart test
         if: "always() && steps.packages_aws_common_pub_upgrade.conclusion == 'success'"
         working-directory: packages/aws_common
+        run: dart test
+      - id: packages_datastore_amplify_codegen_pub_upgrade
+        name: packages/datastore/amplify_codegen; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: packages/datastore/amplify_codegen
+        run: dart pub upgrade
+      - name: packages/datastore/amplify_codegen; dart test
+        if: "always() && steps.packages_datastore_amplify_codegen_pub_upgrade.conclusion == 'success'"
+        working-directory: packages/datastore/amplify_codegen
         run: dart test
       - id: packages_smithy_goldens_lib_awsJson1_0_pub_upgrade
         name: packages/smithy/goldens/lib/awsJson1_0; dart pub upgrade

--- a/packages/amplify_core/lib/amplify_core.dart
+++ b/packages/amplify_core/lib/amplify_core.dart
@@ -87,6 +87,7 @@ export 'src/types/exception/codegen_exception.dart';
 export 'src/types/exception/url_launcher_exception.dart';
 
 /// Model-based types used in datastore and API
+export 'src/types/models/async_model.dart';
 export 'src/types/models/mipr/auth_rule.dart';
 export 'src/types/models/mipr/model.dart';
 export 'src/types/models/mipr/model_association.dart';

--- a/packages/amplify_core/lib/src/types/api/graphql/graphql_request.dart
+++ b/packages/amplify_core/lib/src/types/api/graphql/graphql_request.dart
@@ -18,7 +18,7 @@ import 'package:amplify_core/amplify_core.dart';
 /// A GraphQL request with a few extra properties used to decode the response or use the correct API if the backend has multiple.
 abstract class GraphQLRequest<T>
     with AWSSerializable<Map<String, Object?>>, AWSDebuggable {
-  GraphQLRequest._({
+  GraphQLRequest({
     this.apiName,
     required this.document,
     this.variables = const <String, dynamic>{},
@@ -53,7 +53,7 @@ abstract class GraphQLRequest<T>
           ModelIdentifier extends Object,
           M extends Model<ModelIdentifier, M>,
           P extends PartialModel<ModelIdentifier, M>,
-          T extends PartialModel<ModelIdentifier, M>>({
+          T extends P>({
     String? apiName,
     required String document,
     required ModelType<ModelIdentifier, M, P> modelType,
@@ -78,7 +78,7 @@ abstract class GraphQLRequest<T>
           ModelIdentifier extends Object,
           M extends Model<ModelIdentifier, M>,
           P extends PartialModel<ModelIdentifier, M>,
-          T extends PartialModel<ModelIdentifier, M>>({
+          T extends P>({
     String? apiName,
     required String document,
     required ModelType<ModelIdentifier, M, P> modelType,
@@ -155,7 +155,7 @@ class _RawGraphQLRequest extends GraphQLRequest<Map<String, Object?>> {
     super.variables,
     super.headers,
     super.decodePath,
-  }) : super._();
+  });
 
   @override
   Map<String, Object?> decode(Map<String, Object?> json) {
@@ -177,7 +177,7 @@ class _ModelGraphQLRequest<
     super.headers,
     super.decodePath,
     required this.modelType,
-  }) : super._();
+  });
 
   final ModelType<ModelIdentifier, M, dynamic> modelType;
 
@@ -200,7 +200,7 @@ class _ListGraphQLRequest<
     super.headers,
     super.decodePath,
     required this.modelType,
-  }) : super._();
+  });
 
   /// The GraphQL parameter for locating the next pagination token.
   static const _nextToken = 'nextToken';

--- a/packages/amplify_core/lib/src/types/models/mipr.dart
+++ b/packages/amplify_core/lib/src/types/models/mipr.dart
@@ -24,5 +24,6 @@ export 'mipr/model.dart';
 export 'mipr/model_association.dart';
 export 'mipr/model_field.dart';
 export 'mipr/model_index.dart';
+export 'mipr/schema.dart';
 export 'mipr/schema_type.dart';
 export 'mipr/serializers.dart';

--- a/packages/amplify_core/lib/src/types/models/mipr/model.g.dart
+++ b/packages/amplify_core/lib/src/types/models/mipr/model.g.dart
@@ -10,6 +10,8 @@ Serializer<ModelTypeDefinition> _$modelTypeDefinitionSerializer =
     new _$ModelTypeDefinitionSerializer();
 Serializer<NonModelTypeDefinition> _$nonModelTypeDefinitionSerializer =
     new _$NonModelTypeDefinitionSerializer();
+Serializer<EnumTypeDefinition> _$enumTypeDefinitionSerializer =
+    new _$EnumTypeDefinitionSerializer();
 
 class _$ModelTypeDefinitionSerializer
     implements StructuredSerializer<ModelTypeDefinition> {
@@ -150,14 +152,74 @@ class _$NonModelTypeDefinitionSerializer
   }
 }
 
+class _$EnumTypeDefinitionSerializer
+    implements StructuredSerializer<EnumTypeDefinition> {
+  @override
+  final Iterable<Type> types = const [EnumTypeDefinition, _$EnumTypeDefinition];
+  @override
+  final String wireName = 'EnumTypeDefinition';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, EnumTypeDefinition object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'values',
+      serializers.serialize(object.values,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(String)])),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  EnumTypeDefinition deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new EnumTypeDefinitionBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'values':
+          result.values.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(String)]))!
+              as BuiltList<Object?>);
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 abstract class SchemaTypeDefinitionBuilder {
   void replace(SchemaTypeDefinition other);
   void update(void Function(SchemaTypeDefinitionBuilder) updates);
   String? get name;
   set name(String? name);
+}
 
+abstract class StructureTypeDefinitionBuilder
+    implements SchemaTypeDefinitionBuilder {
+  void replace(covariant StructureTypeDefinition other);
+  void update(void Function(StructureTypeDefinitionBuilder) updates);
   MapBuilder<String, ModelField> get fields;
-  set fields(MapBuilder<String, ModelField>? fields);
+  set fields(covariant MapBuilder<String, ModelField>? fields);
+
+  String? get name;
+  set name(covariant String? name);
 }
 
 class _$ModelTypeDefinition extends ModelTypeDefinition {
@@ -239,7 +301,7 @@ class _$ModelTypeDefinition extends ModelTypeDefinition {
 class ModelTypeDefinitionBuilder
     implements
         Builder<ModelTypeDefinition, ModelTypeDefinitionBuilder>,
-        SchemaTypeDefinitionBuilder {
+        StructureTypeDefinitionBuilder {
   _$ModelTypeDefinition? _$v;
 
   String? _name;
@@ -382,7 +444,7 @@ class _$NonModelTypeDefinition extends NonModelTypeDefinition {
 class NonModelTypeDefinitionBuilder
     implements
         Builder<NonModelTypeDefinition, NonModelTypeDefinitionBuilder>,
-        SchemaTypeDefinitionBuilder {
+        StructureTypeDefinitionBuilder {
   _$NonModelTypeDefinition? _$v;
 
   String? _name;
@@ -437,6 +499,119 @@ class NonModelTypeDefinitionBuilder
       } catch (e) {
         throw new BuiltValueNestedFieldError(
             r'NonModelTypeDefinition', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$EnumTypeDefinition extends EnumTypeDefinition {
+  @override
+  final BuiltList<String> values;
+  @override
+  final String name;
+
+  factory _$EnumTypeDefinition(
+          [void Function(EnumTypeDefinitionBuilder)? updates]) =>
+      (new EnumTypeDefinitionBuilder()..update(updates))._build();
+
+  _$EnumTypeDefinition._({required this.values, required this.name})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        values, r'EnumTypeDefinition', 'values');
+    BuiltValueNullFieldError.checkNotNull(name, r'EnumTypeDefinition', 'name');
+  }
+
+  @override
+  EnumTypeDefinition rebuild(
+          void Function(EnumTypeDefinitionBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  EnumTypeDefinitionBuilder toBuilder() =>
+      new EnumTypeDefinitionBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is EnumTypeDefinition &&
+        values == other.values &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc($jc(0, values.hashCode), name.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'EnumTypeDefinition')
+          ..add('values', values)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class EnumTypeDefinitionBuilder
+    implements
+        Builder<EnumTypeDefinition, EnumTypeDefinitionBuilder>,
+        SchemaTypeDefinitionBuilder {
+  _$EnumTypeDefinition? _$v;
+
+  ListBuilder<String>? _values;
+  ListBuilder<String> get values =>
+      _$this._values ??= new ListBuilder<String>();
+  set values(covariant ListBuilder<String>? values) => _$this._values = values;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(covariant String? name) => _$this._name = name;
+
+  EnumTypeDefinitionBuilder();
+
+  EnumTypeDefinitionBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _values = $v.values.toBuilder();
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant EnumTypeDefinition other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$EnumTypeDefinition;
+  }
+
+  @override
+  void update(void Function(EnumTypeDefinitionBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  EnumTypeDefinition build() => _build();
+
+  _$EnumTypeDefinition _build() {
+    _$EnumTypeDefinition _$result;
+    try {
+      _$result = _$v ??
+          new _$EnumTypeDefinition._(
+              values: values.build(),
+              name: BuiltValueNullFieldError.checkNotNull(
+                  name, r'EnumTypeDefinition', 'name'));
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'values';
+        values.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'EnumTypeDefinition', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/packages/amplify_core/lib/src/types/models/mipr/model_association.dart
+++ b/packages/amplify_core/lib/src/types/models/mipr/model_association.dart
@@ -82,15 +82,50 @@ abstract class ModelAssociation
   /// {@macro amplify_core.models.mipr.model_association}
   factory ModelAssociation({
     required ModelAssociationType associationType,
-    List<String>? targetNames,
     required String associatedType,
-    String? associatedName,
+    List<String>? associatedFields,
+    List<String>? targetNames,
   }) =>
       _$ModelAssociation._(
         associationType: associationType,
-        targetNames: targetNames?.toBuiltList(),
-        associatedName: associatedName,
         associatedType: associatedType,
+        associatedFields: associatedFields?.toBuiltList(),
+        targetNames: targetNames?.toBuiltList(),
+      );
+
+  /// Creates a `hasOne` association.
+  factory ModelAssociation.hasOne({
+    required String associatedType,
+    required List<String> associatedFields,
+    required List<String> targetNames,
+  }) =>
+      ModelAssociation(
+        associationType: ModelAssociationType.hasOne,
+        associatedType: associatedType,
+        associatedFields: associatedFields,
+        targetNames: targetNames,
+      );
+
+  /// Creates a `hasMany` association.
+  factory ModelAssociation.hasMany({
+    required String associatedType,
+    required List<String> associatedFields,
+  }) =>
+      ModelAssociation(
+        associationType: ModelAssociationType.hasMany,
+        associatedType: associatedType,
+        associatedFields: associatedFields,
+      );
+
+  /// Creates a `belongsTo` association.
+  factory ModelAssociation.belongsTo({
+    required String associatedType,
+    required List<String> targetNames,
+  }) =>
+      ModelAssociation(
+        associationType: ModelAssociationType.belongsTo,
+        associatedType: associatedType,
+        targetNames: targetNames,
       );
 
   /// {@template amplify_core.models.mipr.model_association}
@@ -108,14 +143,14 @@ abstract class ModelAssociation
   /// {@macro amplify_core.models.mipr.model_association}
   ModelAssociationType get associationType;
 
-  /// The foreign key, i.e. the field(s) targeted by this association.
-  BuiltList<String>? get targetNames;
-
   /// The name of the associated model.
   String get associatedType;
 
-  /// The name of the related field in the associated model.
-  String? get associatedName;
+  /// The names of the related fields in the associated model.
+  BuiltList<String>? get associatedFields;
+
+  /// The foreign key, i.e. the local field(s) targeted by this association.
+  BuiltList<String>? get targetNames;
 
   @override
   Map<String, Object?> toJson() {

--- a/packages/amplify_core/lib/src/types/models/mipr/model_association.g.dart
+++ b/packages/amplify_core/lib/src/types/models/mipr/model_association.g.dart
@@ -92,6 +92,14 @@ class _$ModelAssociationSerializer
           specifiedType: const FullType(String)),
     ];
     Object? value;
+    value = object.associatedFields;
+    if (value != null) {
+      result
+        ..add('associatedFields')
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(String)])));
+    }
     value = object.targetNames;
     if (value != null) {
       result
@@ -99,13 +107,6 @@ class _$ModelAssociationSerializer
         ..add(serializers.serialize(value,
             specifiedType:
                 const FullType(BuiltList, const [const FullType(String)])));
-    }
-    value = object.associatedName;
-    if (value != null) {
-      result
-        ..add('associatedName')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(String)));
     }
     return result;
   }
@@ -127,19 +128,21 @@ class _$ModelAssociationSerializer
                   specifiedType: const FullType(ModelAssociationType))!
               as ModelAssociationType;
           break;
+        case 'associatedType':
+          result.associatedType = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'associatedFields':
+          result.associatedFields.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(String)]))!
+              as BuiltList<Object?>);
+          break;
         case 'targetNames':
           result.targetNames.replace(serializers.deserialize(value,
                   specifiedType: const FullType(
                       BuiltList, const [const FullType(String)]))!
               as BuiltList<Object?>);
-          break;
-        case 'associatedType':
-          result.associatedType = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
-        case 'associatedName':
-          result.associatedName = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -152,11 +155,11 @@ class _$ModelAssociation extends ModelAssociation {
   @override
   final ModelAssociationType associationType;
   @override
-  final BuiltList<String>? targetNames;
-  @override
   final String associatedType;
   @override
-  final String? associatedName;
+  final BuiltList<String>? associatedFields;
+  @override
+  final BuiltList<String>? targetNames;
 
   factory _$ModelAssociation(
           [void Function(ModelAssociationBuilder)? updates]) =>
@@ -164,9 +167,9 @@ class _$ModelAssociation extends ModelAssociation {
 
   _$ModelAssociation._(
       {required this.associationType,
-      this.targetNames,
       required this.associatedType,
-      this.associatedName})
+      this.associatedFields,
+      this.targetNames})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
         associationType, r'ModelAssociation', 'associationType');
@@ -187,26 +190,26 @@ class _$ModelAssociation extends ModelAssociation {
     if (identical(other, this)) return true;
     return other is ModelAssociation &&
         associationType == other.associationType &&
-        targetNames == other.targetNames &&
         associatedType == other.associatedType &&
-        associatedName == other.associatedName;
+        associatedFields == other.associatedFields &&
+        targetNames == other.targetNames;
   }
 
   @override
   int get hashCode {
     return $jf($jc(
-        $jc($jc($jc(0, associationType.hashCode), targetNames.hashCode),
-            associatedType.hashCode),
-        associatedName.hashCode));
+        $jc($jc($jc(0, associationType.hashCode), associatedType.hashCode),
+            associatedFields.hashCode),
+        targetNames.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'ModelAssociation')
           ..add('associationType', associationType)
-          ..add('targetNames', targetNames)
           ..add('associatedType', associatedType)
-          ..add('associatedName', associatedName))
+          ..add('associatedFields', associatedFields)
+          ..add('targetNames', targetNames))
         .toString();
   }
 }
@@ -220,21 +223,22 @@ class ModelAssociationBuilder
   set associationType(ModelAssociationType? associationType) =>
       _$this._associationType = associationType;
 
-  ListBuilder<String>? _targetNames;
-  ListBuilder<String> get targetNames =>
-      _$this._targetNames ??= new ListBuilder<String>();
-  set targetNames(ListBuilder<String>? targetNames) =>
-      _$this._targetNames = targetNames;
-
   String? _associatedType;
   String? get associatedType => _$this._associatedType;
   set associatedType(String? associatedType) =>
       _$this._associatedType = associatedType;
 
-  String? _associatedName;
-  String? get associatedName => _$this._associatedName;
-  set associatedName(String? associatedName) =>
-      _$this._associatedName = associatedName;
+  ListBuilder<String>? _associatedFields;
+  ListBuilder<String> get associatedFields =>
+      _$this._associatedFields ??= new ListBuilder<String>();
+  set associatedFields(ListBuilder<String>? associatedFields) =>
+      _$this._associatedFields = associatedFields;
+
+  ListBuilder<String>? _targetNames;
+  ListBuilder<String> get targetNames =>
+      _$this._targetNames ??= new ListBuilder<String>();
+  set targetNames(ListBuilder<String>? targetNames) =>
+      _$this._targetNames = targetNames;
 
   ModelAssociationBuilder();
 
@@ -242,9 +246,9 @@ class ModelAssociationBuilder
     final $v = _$v;
     if ($v != null) {
       _associationType = $v.associationType;
-      _targetNames = $v.targetNames?.toBuilder();
       _associatedType = $v.associatedType;
-      _associatedName = $v.associatedName;
+      _associatedFields = $v.associatedFields?.toBuilder();
+      _targetNames = $v.targetNames?.toBuilder();
       _$v = null;
     }
     return this;
@@ -271,13 +275,15 @@ class ModelAssociationBuilder
           new _$ModelAssociation._(
               associationType: BuiltValueNullFieldError.checkNotNull(
                   associationType, r'ModelAssociation', 'associationType'),
-              targetNames: _targetNames?.build(),
               associatedType: BuiltValueNullFieldError.checkNotNull(
                   associatedType, r'ModelAssociation', 'associatedType'),
-              associatedName: associatedName);
+              associatedFields: _associatedFields?.build(),
+              targetNames: _targetNames?.build());
     } catch (_) {
       late String _$failedField;
       try {
+        _$failedField = 'associatedFields';
+        _associatedFields?.build();
         _$failedField = 'targetNames';
         _targetNames?.build();
       } catch (e) {

--- a/packages/amplify_core/lib/src/types/models/mipr/model_index.dart
+++ b/packages/amplify_core/lib/src/types/models/mipr/model_index.dart
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_core/src/types/models/mipr.dart';
+import 'package:aws_common/aws_common.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
@@ -35,7 +35,7 @@ abstract class ModelIndex
   }) =>
       _$ModelIndex._(
         name: name,
-        field: field,
+        primaryField: field,
         sortKeyFields: BuiltList(sortKeyFields),
       );
 
@@ -45,8 +45,21 @@ abstract class ModelIndex
     List<String> sortKeyFields = const [],
   }) =>
       _$ModelIndex._(
-        field: field,
+        primaryField: field,
         sortKeyFields: BuiltList(sortKeyFields),
+      );
+
+  /// Creates a foreign key on a model, used to hold the composite key of
+  /// another model. Unlike a normal [ModelIndex], a foreign key index must
+  /// specify a [field] which points to a [ModelType].
+  factory ModelIndex.foreignKey({
+    required String field,
+    required List<String> keyFields,
+  }) =>
+      _$ModelIndex._(
+        name: '${field}ForeignKey',
+        primaryField: field,
+        sortKeyFields: BuiltList(keyFields),
       );
 
   /// {@macro amplify_core.models.mipr.model_index}
@@ -70,10 +83,10 @@ abstract class ModelIndex
   ///
   /// This is the field to which the `@index` or `@primaryKey` directive is
   /// attached.
-  String get field;
+  String get primaryField;
 
-  /// The list of field names which, combined with [field], form a composite
-  /// key or index.
+  /// The list of field names which, combined with [primaryField], form a
+  /// composite key or index.
   ///
   /// This is the list of fields specified by the `sortKeyFields` argument
   /// to the `@index` or `@primaryKey` directive.
@@ -81,6 +94,9 @@ abstract class ModelIndex
 
   /// Whether this index represents the primary key/index.
   bool get isPrimaryIndex => name == null;
+
+  /// All the fields of the index.
+  List<String> get fields => [primaryField, ...sortKeyFields];
 
   @override
   Map<String, Object?> toJson() {

--- a/packages/amplify_core/lib/src/types/models/mipr/model_index.g.dart
+++ b/packages/amplify_core/lib/src/types/models/mipr/model_index.g.dart
@@ -18,8 +18,8 @@ class _$ModelIndexSerializer implements StructuredSerializer<ModelIndex> {
   Iterable<Object?> serialize(Serializers serializers, ModelIndex object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'field',
-      serializers.serialize(object.field,
+      'primaryField',
+      serializers.serialize(object.primaryField,
           specifiedType: const FullType(String)),
       'sortKeyFields',
       serializers.serialize(object.sortKeyFields,
@@ -52,8 +52,8 @@ class _$ModelIndexSerializer implements StructuredSerializer<ModelIndex> {
           result.name = serializers.deserialize(value,
               specifiedType: const FullType(String)) as String?;
           break;
-        case 'field':
-          result.field = serializers.deserialize(value,
+        case 'primaryField':
+          result.primaryField = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
         case 'sortKeyFields':
@@ -73,16 +73,18 @@ class _$ModelIndex extends ModelIndex {
   @override
   final String? name;
   @override
-  final String field;
+  final String primaryField;
   @override
   final BuiltList<String> sortKeyFields;
 
   factory _$ModelIndex([void Function(ModelIndexBuilder)? updates]) =>
       (new ModelIndexBuilder()..update(updates))._build();
 
-  _$ModelIndex._({this.name, required this.field, required this.sortKeyFields})
+  _$ModelIndex._(
+      {this.name, required this.primaryField, required this.sortKeyFields})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(field, r'ModelIndex', 'field');
+    BuiltValueNullFieldError.checkNotNull(
+        primaryField, r'ModelIndex', 'primaryField');
     BuiltValueNullFieldError.checkNotNull(
         sortKeyFields, r'ModelIndex', 'sortKeyFields');
   }
@@ -99,21 +101,21 @@ class _$ModelIndex extends ModelIndex {
     if (identical(other, this)) return true;
     return other is ModelIndex &&
         name == other.name &&
-        field == other.field &&
+        primaryField == other.primaryField &&
         sortKeyFields == other.sortKeyFields;
   }
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc(0, name.hashCode), field.hashCode), sortKeyFields.hashCode));
+    return $jf($jc($jc($jc(0, name.hashCode), primaryField.hashCode),
+        sortKeyFields.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'ModelIndex')
           ..add('name', name)
-          ..add('field', field)
+          ..add('primaryField', primaryField)
           ..add('sortKeyFields', sortKeyFields))
         .toString();
   }
@@ -126,9 +128,9 @@ class ModelIndexBuilder implements Builder<ModelIndex, ModelIndexBuilder> {
   String? get name => _$this._name;
   set name(String? name) => _$this._name = name;
 
-  String? _field;
-  String? get field => _$this._field;
-  set field(String? field) => _$this._field = field;
+  String? _primaryField;
+  String? get primaryField => _$this._primaryField;
+  set primaryField(String? primaryField) => _$this._primaryField = primaryField;
 
   ListBuilder<String>? _sortKeyFields;
   ListBuilder<String> get sortKeyFields =>
@@ -142,7 +144,7 @@ class ModelIndexBuilder implements Builder<ModelIndex, ModelIndexBuilder> {
     final $v = _$v;
     if ($v != null) {
       _name = $v.name;
-      _field = $v.field;
+      _primaryField = $v.primaryField;
       _sortKeyFields = $v.sortKeyFields.toBuilder();
       _$v = null;
     }
@@ -169,8 +171,8 @@ class ModelIndexBuilder implements Builder<ModelIndex, ModelIndexBuilder> {
       _$result = _$v ??
           new _$ModelIndex._(
               name: name,
-              field: BuiltValueNullFieldError.checkNotNull(
-                  field, r'ModelIndex', 'field'),
+              primaryField: BuiltValueNullFieldError.checkNotNull(
+                  primaryField, r'ModelIndex', 'primaryField'),
               sortKeyFields: sortKeyFields.build());
     } catch (_) {
       late String _$failedField;

--- a/packages/amplify_core/lib/src/types/models/mipr/schema.dart
+++ b/packages/amplify_core/lib/src/types/models/mipr/schema.dart
@@ -1,0 +1,83 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/src/types/models/mipr/model.dart';
+import 'package:amplify_core/src/types/models/mipr/model_association.dart';
+import 'package:amplify_core/src/types/models/mipr/serializers.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'schema.g.dart';
+
+/// {@template amplify_core.models.mipr.schema_definition}
+/// A full Amplify schema with all [typeDefinitions].
+///
+/// This is the result of parsing and analyzing a GraphQL schema for
+/// relationships, and creating necessary synthetic types, fields and indexes.
+/// {@endtemplate}
+abstract class SchemaDefinition
+    implements Built<SchemaDefinition, SchemaDefinitionBuilder> {
+  /// {@macro amplify_core.models.mipr.schema_definition}
+  factory SchemaDefinition(Map<String, SchemaTypeDefinition> typeDefinitions) =>
+      _$SchemaDefinition._(
+        typeDefinitions: BuiltMap(typeDefinitions),
+      );
+
+  /// {@macro amplify_core.models.mipr.schema_definition}
+  factory SchemaDefinition.fromJson(Map<String, Object?> json) {
+    return serializers.deserializeWith(serializer, json) as SchemaDefinition;
+  }
+
+  /// {@macro amplify_core.models.mipr.schema_definition}
+  factory SchemaDefinition.build([
+    void Function(SchemaDefinitionBuilder) updates,
+  ]) = _$SchemaDefinition;
+
+  const SchemaDefinition._();
+
+  /// All type definitions in the schema.
+  BuiltMap<String, SchemaTypeDefinition> get typeDefinitions;
+
+  /// The adjacency list representation of the model graph, indexed by
+  /// model name with the values representing the dependent model types.
+  BuiltSetMultimap<String, String> get modelGraph =>
+      BuiltSetMultimap.build((map) {
+        final modelDefinitions =
+            typeDefinitions.values.whereType<ModelTypeDefinition>();
+        for (final model in modelDefinitions) {
+          for (final field in model.fields.values) {
+            final fieldAssociation = field.association;
+            if (fieldAssociation == null) {
+              continue;
+            }
+            final associatedType = fieldAssociation.associatedType;
+            switch (fieldAssociation.associationType) {
+              case ModelAssociationType.belongsTo:
+                map.add(associatedType, model.name);
+                break;
+              case ModelAssociationType.hasMany:
+              case ModelAssociationType.hasOne:
+              case ModelAssociationType.manyToMany:
+                map.add(model.name, associatedType);
+                break;
+            }
+          }
+        }
+      });
+
+  /// The serializer for [SchemaDefinition].
+  static Serializer<SchemaDefinition> get serializer =>
+      _$schemaDefinitionSerializer;
+}

--- a/packages/amplify_core/lib/src/types/models/mipr/schema.g.dart
+++ b/packages/amplify_core/lib/src/types/models/mipr/schema.g.dart
@@ -1,0 +1,159 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'schema.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<SchemaDefinition> _$schemaDefinitionSerializer =
+    new _$SchemaDefinitionSerializer();
+
+class _$SchemaDefinitionSerializer
+    implements StructuredSerializer<SchemaDefinition> {
+  @override
+  final Iterable<Type> types = const [SchemaDefinition, _$SchemaDefinition];
+  @override
+  final String wireName = 'SchemaDefinition';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, SchemaDefinition object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'typeDefinitions',
+      serializers.serialize(object.typeDefinitions,
+          specifiedType: const FullType(BuiltMap, const [
+            const FullType(String),
+            const FullType(SchemaTypeDefinition)
+          ])),
+    ];
+
+    return result;
+  }
+
+  @override
+  SchemaDefinition deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new SchemaDefinitionBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'typeDefinitions':
+          result.typeDefinitions.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, const [
+                const FullType(String),
+                const FullType(SchemaTypeDefinition)
+              ]))!);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SchemaDefinition extends SchemaDefinition {
+  @override
+  final BuiltMap<String, SchemaTypeDefinition> typeDefinitions;
+
+  factory _$SchemaDefinition(
+          [void Function(SchemaDefinitionBuilder)? updates]) =>
+      (new SchemaDefinitionBuilder()..update(updates))._build();
+
+  _$SchemaDefinition._({required this.typeDefinitions}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        typeDefinitions, r'SchemaDefinition', 'typeDefinitions');
+  }
+
+  @override
+  SchemaDefinition rebuild(void Function(SchemaDefinitionBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SchemaDefinitionBuilder toBuilder() =>
+      new SchemaDefinitionBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SchemaDefinition &&
+        typeDefinitions == other.typeDefinitions;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, typeDefinitions.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SchemaDefinition')
+          ..add('typeDefinitions', typeDefinitions))
+        .toString();
+  }
+}
+
+class SchemaDefinitionBuilder
+    implements Builder<SchemaDefinition, SchemaDefinitionBuilder> {
+  _$SchemaDefinition? _$v;
+
+  MapBuilder<String, SchemaTypeDefinition>? _typeDefinitions;
+  MapBuilder<String, SchemaTypeDefinition> get typeDefinitions =>
+      _$this._typeDefinitions ??=
+          new MapBuilder<String, SchemaTypeDefinition>();
+  set typeDefinitions(
+          MapBuilder<String, SchemaTypeDefinition>? typeDefinitions) =>
+      _$this._typeDefinitions = typeDefinitions;
+
+  SchemaDefinitionBuilder();
+
+  SchemaDefinitionBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _typeDefinitions = $v.typeDefinitions.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SchemaDefinition other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$SchemaDefinition;
+  }
+
+  @override
+  void update(void Function(SchemaDefinitionBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SchemaDefinition build() => _build();
+
+  _$SchemaDefinition _build() {
+    _$SchemaDefinition _$result;
+    try {
+      _$result = _$v ??
+          new _$SchemaDefinition._(typeDefinitions: typeDefinitions.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'typeDefinitions';
+        typeDefinitions.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'SchemaDefinition', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/amplify_core/lib/src/types/models/mipr/serializers.dart
+++ b/packages/amplify_core/lib/src/types/models/mipr/serializers.dart
@@ -32,6 +32,8 @@ part 'serializers.g.dart';
   ModelField,
   ModelTypeDefinition,
   NonModelTypeDefinition,
+  EnumTypeDefinition,
+  SchemaDefinition,
 ])
 final Serializers serializers = (_$serializers.toBuilder()
       ..add(SchemaType.serializer)

--- a/packages/amplify_core/lib/src/types/models/mipr/serializers.g.dart
+++ b/packages/amplify_core/lib/src/types/models/mipr/serializers.g.dart
@@ -11,6 +11,7 @@ Serializers _$serializers = (new Serializers().toBuilder()
       ..add(AuthRule.serializer)
       ..add(AuthRuleProvider.serializer)
       ..add(AuthStrategy.serializer)
+      ..add(EnumTypeDefinition.serializer)
       ..add(ModelAssociation.serializer)
       ..add(ModelAssociationType.serializer)
       ..add(ModelField.serializer)
@@ -18,9 +19,16 @@ Serializers _$serializers = (new Serializers().toBuilder()
       ..add(ModelOperation.serializer)
       ..add(ModelTypeDefinition.serializer)
       ..add(NonModelTypeDefinition.serializer)
+      ..add(SchemaDefinition.serializer)
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(AuthRule)]),
           () => new ListBuilder<AuthRule>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(String)]),
           () => new ListBuilder<String>())
@@ -41,6 +49,12 @@ Serializers _$serializers = (new Serializers().toBuilder()
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(ModelIndex)]),
           () => new ListBuilder<ModelIndex>())
+      ..addBuilderFactory(
+          const FullType(BuiltMap, const [
+            const FullType(String),
+            const FullType(SchemaTypeDefinition)
+          ]),
+          () => new MapBuilder<String, SchemaTypeDefinition>())
       ..addBuilderFactory(
           const FullType(BuiltSet, const [const FullType(String)]),
           () => new SetBuilder<String>())

--- a/packages/amplify_core/lib/src/types/models/model_field_definition.dart
+++ b/packages/amplify_core/lib/src/types/models/model_field_definition.dart
@@ -124,10 +124,10 @@ class ModelFieldDefinition {
         isArray: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.collection,
             ofModelName: ofModelName),
-        association: ModelAssociation(
-            associationType: ModelAssociationType.hasMany,
-            associatedName: associatedKey.fieldName,
-            associatedType: ofModelName));
+        association: ModelAssociation.hasMany(
+          associatedFields: [associatedKey.fieldName],
+          associatedType: ofModelName,
+        ));
   }
 
   static ModelFieldDefinition hasOne({
@@ -141,10 +141,11 @@ class ModelFieldDefinition {
         isRequired: isRequired,
         ofType:
             ModelFieldType(ModelFieldTypeEnum.model, ofModelName: ofModelName),
-        association: ModelAssociation(
-            associationType: ModelAssociationType.hasOne,
-            associatedName: associatedKey.fieldName,
-            associatedType: ofModelName));
+        association: ModelAssociation.hasOne(
+          associatedFields: [associatedKey.fieldName],
+          associatedType: ofModelName,
+          targetNames: [],
+        ));
   }
 
   static ModelFieldDefinition belongsTo(
@@ -153,21 +154,15 @@ class ModelFieldDefinition {
       required String ofModelName,
       QueryField? associatedKey,
       String? targetName}) {
-    // Extra code needed due to lack of nullability support
-    String? associatedName;
-
-    associatedName = associatedKey?.fieldName;
-
     return field(
         key: key,
         isRequired: isRequired,
         ofType:
             ModelFieldType(ModelFieldTypeEnum.model, ofModelName: ofModelName),
-        association: ModelAssociation(
-            associationType: ModelAssociationType.belongsTo,
-            targetNames: targetName == null ? null : [targetName],
-            associatedName: associatedName,
-            associatedType: ofModelName));
+        association: ModelAssociation.belongsTo(
+          targetNames: [targetName!],
+          associatedType: ofModelName,
+        ));
   }
 
   ModelField build() {

--- a/packages/api/amplify_api/lib/src/graphql/model_mutations_factory.dart
+++ b/packages/api/amplify_api/lib/src/graphql/model_mutations_factory.dart
@@ -20,8 +20,7 @@ class ModelMutationsFactory extends ModelMutationsInterface {
     // Does not use buildVariablesForMutationRequest because creations don't have conditions.
     final variables = {'input': input};
 
-    return GraphQLRequestFactory.instance
-        .buildRequest<ModelIdentifier, M, PartialModel<ModelIdentifier, M>, M>(
+    return GraphQLRequestFactory.instance.buildRequest<ModelIdentifier, M>(
       model: model,
       variables: variables,
       modelType: model.modelType,
@@ -60,8 +59,7 @@ class ModelMutationsFactory extends ModelMutationsInterface {
     final variables = GraphQLRequestFactory.instance
         .buildVariablesForMutationRequest(input: input, condition: condition);
 
-    return GraphQLRequestFactory.instance
-        .buildRequest<ModelIdentifier, M, P, M>(
+    return GraphQLRequestFactory.instance.buildRequest<ModelIdentifier, M>(
       variables: variables,
       modelType: modelType,
       requestType: GraphQLRequestType.mutation,
@@ -86,7 +84,7 @@ class ModelMutationsFactory extends ModelMutationsInterface {
     final variables = GraphQLRequestFactory.instance
         .buildVariablesForMutationRequest(input: input, condition: condition);
 
-    return GraphQLRequestFactory.instance.buildRequest(
+    return GraphQLRequestFactory.instance.buildRequest<ModelIdentifier, M>(
         model: model,
         variables: variables,
         modelType: model.modelType,

--- a/packages/api/amplify_api/lib/src/graphql/model_queries_factory.dart
+++ b/packages/api/amplify_api/lib/src/graphql/model_queries_factory.dart
@@ -36,7 +36,7 @@ class ModelQueriesFactory extends ModelQueriesInterface {
     ModelIdentifier id,
   ) {
     Map<String, Object> variables = {idFieldName: id};
-    return GraphQLRequestFactory.instance.buildRequest(
+    return GraphQLRequestFactory.instance.buildRequest<ModelIdentifier, M>(
       modelType: modelType,
       variables: variables,
       requestType: GraphQLRequestType.query,
@@ -58,7 +58,8 @@ class ModelQueriesFactory extends ModelQueriesInterface {
     final variables = GraphQLRequestFactory.instance
         .buildVariablesForListRequest(limit: limit, filter: filter);
 
-    return GraphQLRequestFactory.instance.buildListRequest(
+    return GraphQLRequestFactory.instance
+        .buildListRequest<ModelIdentifier, M, P>(
       modelType: modelType,
       variables: variables,
       requestType: GraphQLRequestType.query,

--- a/packages/api/amplify_api/lib/src/graphql/model_subscriptions_factory.dart
+++ b/packages/api/amplify_api/lib/src/graphql/model_subscriptions_factory.dart
@@ -35,7 +35,7 @@ class ModelSubscriptionsFactory extends ModelSubscriptionsInterface {
       P extends PartialModel<ModelIdentifier, M>>(
     ModelType<ModelIdentifier, M, P> modelType,
   ) {
-    return GraphQLRequestFactory.instance.buildRequest(
+    return GraphQLRequestFactory.instance.buildRequest<ModelIdentifier, M>(
       modelType: modelType,
       variables: <String, dynamic>{},
       requestType: GraphQLRequestType.subscription,
@@ -50,7 +50,7 @@ class ModelSubscriptionsFactory extends ModelSubscriptionsInterface {
       P extends PartialModel<ModelIdentifier, M>>(
     ModelType<ModelIdentifier, M, P> modelType,
   ) {
-    return GraphQLRequestFactory.instance.buildRequest(
+    return GraphQLRequestFactory.instance.buildRequest<ModelIdentifier, M>(
       modelType: modelType,
       variables: <String, dynamic>{},
       requestType: GraphQLRequestType.subscription,
@@ -65,7 +65,7 @@ class ModelSubscriptionsFactory extends ModelSubscriptionsInterface {
       P extends PartialModel<ModelIdentifier, M>>(
     ModelType<ModelIdentifier, M, P> modelType,
   ) {
-    return GraphQLRequestFactory.instance.buildRequest(
+    return GraphQLRequestFactory.instance.buildRequest<ModelIdentifier, M>(
       modelType: modelType,
       variables: <String, dynamic>{},
       requestType: GraphQLRequestType.subscription,

--- a/packages/api/amplify_api/lib/src/graphql/utils.dart
+++ b/packages/api/amplify_api/lib/src/graphql/utils.dart
@@ -28,7 +28,7 @@ class _RelatedFields {
   _RelatedFields(this.singleFields, this.hasManyFields);
 }
 
-_RelatedFields _getRelatedFieldsUncached(SchemaTypeDefinition modelSchema) {
+_RelatedFields _getRelatedFieldsUncached(StructureTypeDefinition modelSchema) {
   final singleFields = modelSchema.fields.values.where((field) =>
       field.association?.associationType == ModelAssociationType.hasOne ||
       field.association?.associationType == ModelAssociationType.belongsTo ||
@@ -43,7 +43,7 @@ _RelatedFields _getRelatedFieldsUncached(SchemaTypeDefinition modelSchema) {
 
 final _fieldsMemo = <SchemaTypeDefinition, _RelatedFields>{};
 // cached to avoid repeat iterations over fields in schema to get related fields
-_RelatedFields _getRelatedFields(SchemaTypeDefinition modelSchema) {
+_RelatedFields _getRelatedFields(StructureTypeDefinition modelSchema) {
   if (_fieldsMemo[modelSchema] != null) {
     return _fieldsMemo[modelSchema]!;
   }
@@ -52,13 +52,14 @@ _RelatedFields _getRelatedFields(SchemaTypeDefinition modelSchema) {
   return _fieldsMemo[modelSchema]!;
 }
 
-ModelField? getBelongsToFieldFromModelSchema(SchemaTypeDefinition modelSchema) {
+ModelField? getBelongsToFieldFromModelSchema(
+    StructureTypeDefinition modelSchema) {
   return _getRelatedFields(modelSchema).singleFields.firstWhereOrNull((entry) =>
       entry.association?.associationType == ModelAssociationType.belongsTo);
 }
 
 /// Gets the modelSchema from provider that matches the name and validates its fields.
-SchemaTypeDefinition getModelSchemaByModelName(
+StructureTypeDefinition getModelSchemaByModelName(
     String modelName, GraphQLRequestOperation? operation) {
   // ignore: invalid_use_of_protected_member
   final provider = Amplify.API.defaultPlugin.modelProvider;
@@ -69,7 +70,7 @@ SchemaTypeDefinition getModelSchemaByModelName(
           'Pass in a modelProvider instance while instantiating APIPlugin',
     );
   }
-  final schema = <SchemaTypeDefinition>[
+  final schema = <StructureTypeDefinition>[
     ...provider.modelSchemas,
     ...provider.customTypeSchemas,
   ].firstWhere((elem) => elem.name == modelName,
@@ -95,7 +96,7 @@ SchemaTypeDefinition getModelSchemaByModelName(
 /// 2) Look for list of children under [fieldName]["items"] and hoist up so no more ["items"].
 Map<String, dynamic> transformAppSyncJsonToModelJson(
   Map<String, dynamic> input,
-  SchemaTypeDefinition modelSchema,
+  StructureTypeDefinition modelSchema,
 ) {
   input = <String, dynamic>{...input}; // avoid mutating original
 

--- a/packages/datastore/amplify_codegen/.gitignore
+++ b/packages/datastore/amplify_codegen/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/datastore/amplify_codegen/README.md
+++ b/packages/datastore/amplify_codegen/README.md
@@ -1,0 +1,3 @@
+# amplify_codegen
+
+Temporary codegen for Amplify Flutter. DO NOT USE.

--- a/packages/datastore/amplify_codegen/analysis_options.yaml
+++ b/packages/datastore/amplify_codegen/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:amplify_lints/library.yaml

--- a/packages/datastore/amplify_codegen/analysis_options.yaml
+++ b/packages/datastore/amplify_codegen/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:amplify_lints/library.yaml
+
+analyzer:
+  exclude:
+    - '**/*.g.dart'

--- a/packages/datastore/amplify_codegen/lib/amplify_codegen.dart
+++ b/packages/datastore/amplify_codegen/lib/amplify_codegen.dart
@@ -1,0 +1,17 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Temporary codegen package for vNext.
+library amplify_codegen;
+

--- a/packages/datastore/amplify_codegen/lib/src/parser/connection_info.dart
+++ b/packages/datastore/amplify_codegen/lib/src/parser/connection_info.dart
@@ -1,0 +1,44 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+
+part 'connection_info.g.dart';
+
+/// {@template amplify_codegen.connection_info}
+/// Connection information created when visiting and analyzing connections
+/// (relationships) between models.
+/// {@endtemplate}
+abstract class ConnectionInfo
+    implements Built<ConnectionInfo, ConnectionInfoBuilder> {
+  /// {@macro amplify_codegen.connection_info}
+  factory ConnectionInfo([
+    void Function(ConnectionInfoBuilder) updates,
+  ]) = _$ConnectionInfo;
+  ConnectionInfo._();
+
+  /// New schema types, e.g. a join table for a manyToMany connection.
+  BuiltList<SchemaTypeDefinition> get newTypes;
+
+  /// New fields by model name.
+  BuiltListMultimap<String, ModelField> get newFields;
+
+  /// New indexes by model name.
+  BuiltListMultimap<String, ModelIndex> get newIndexes;
+
+  /// The association built by this field.
+  ModelAssociation get association;
+}

--- a/packages/datastore/amplify_codegen/lib/src/parser/connection_info.g.dart
+++ b/packages/datastore/amplify_codegen/lib/src/parser/connection_info.g.dart
@@ -1,0 +1,162 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'connection_info.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$ConnectionInfo extends ConnectionInfo {
+  @override
+  final BuiltList<SchemaTypeDefinition> newTypes;
+  @override
+  final BuiltListMultimap<String, ModelField> newFields;
+  @override
+  final BuiltListMultimap<String, ModelIndex> newIndexes;
+  @override
+  final ModelAssociation association;
+
+  factory _$ConnectionInfo([void Function(ConnectionInfoBuilder)? updates]) =>
+      (new ConnectionInfoBuilder()..update(updates))._build();
+
+  _$ConnectionInfo._(
+      {required this.newTypes,
+      required this.newFields,
+      required this.newIndexes,
+      required this.association})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        newTypes, r'ConnectionInfo', 'newTypes');
+    BuiltValueNullFieldError.checkNotNull(
+        newFields, r'ConnectionInfo', 'newFields');
+    BuiltValueNullFieldError.checkNotNull(
+        newIndexes, r'ConnectionInfo', 'newIndexes');
+    BuiltValueNullFieldError.checkNotNull(
+        association, r'ConnectionInfo', 'association');
+  }
+
+  @override
+  ConnectionInfo rebuild(void Function(ConnectionInfoBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ConnectionInfoBuilder toBuilder() =>
+      new ConnectionInfoBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ConnectionInfo &&
+        newTypes == other.newTypes &&
+        newFields == other.newFields &&
+        newIndexes == other.newIndexes &&
+        association == other.association;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc($jc($jc(0, newTypes.hashCode), newFields.hashCode),
+            newIndexes.hashCode),
+        association.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ConnectionInfo')
+          ..add('newTypes', newTypes)
+          ..add('newFields', newFields)
+          ..add('newIndexes', newIndexes)
+          ..add('association', association))
+        .toString();
+  }
+}
+
+class ConnectionInfoBuilder
+    implements Builder<ConnectionInfo, ConnectionInfoBuilder> {
+  _$ConnectionInfo? _$v;
+
+  ListBuilder<SchemaTypeDefinition>? _newTypes;
+  ListBuilder<SchemaTypeDefinition> get newTypes =>
+      _$this._newTypes ??= new ListBuilder<SchemaTypeDefinition>();
+  set newTypes(ListBuilder<SchemaTypeDefinition>? newTypes) =>
+      _$this._newTypes = newTypes;
+
+  ListMultimapBuilder<String, ModelField>? _newFields;
+  ListMultimapBuilder<String, ModelField> get newFields =>
+      _$this._newFields ??= new ListMultimapBuilder<String, ModelField>();
+  set newFields(ListMultimapBuilder<String, ModelField>? newFields) =>
+      _$this._newFields = newFields;
+
+  ListMultimapBuilder<String, ModelIndex>? _newIndexes;
+  ListMultimapBuilder<String, ModelIndex> get newIndexes =>
+      _$this._newIndexes ??= new ListMultimapBuilder<String, ModelIndex>();
+  set newIndexes(ListMultimapBuilder<String, ModelIndex>? newIndexes) =>
+      _$this._newIndexes = newIndexes;
+
+  ModelAssociationBuilder? _association;
+  ModelAssociationBuilder get association =>
+      _$this._association ??= new ModelAssociationBuilder();
+  set association(ModelAssociationBuilder? association) =>
+      _$this._association = association;
+
+  ConnectionInfoBuilder();
+
+  ConnectionInfoBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _newTypes = $v.newTypes.toBuilder();
+      _newFields = $v.newFields.toBuilder();
+      _newIndexes = $v.newIndexes.toBuilder();
+      _association = $v.association.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ConnectionInfo other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ConnectionInfo;
+  }
+
+  @override
+  void update(void Function(ConnectionInfoBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ConnectionInfo build() => _build();
+
+  _$ConnectionInfo _build() {
+    _$ConnectionInfo _$result;
+    try {
+      _$result = _$v ??
+          new _$ConnectionInfo._(
+              newTypes: newTypes.build(),
+              newFields: newFields.build(),
+              newIndexes: newIndexes.build(),
+              association: association.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'newTypes';
+        newTypes.build();
+        _$failedField = 'newFields';
+        newFields.build();
+        _$failedField = 'newIndexes';
+        newIndexes.build();
+        _$failedField = 'association';
+        association.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'ConnectionInfo', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/datastore/amplify_codegen/lib/src/parser/enum.dart
+++ b/packages/datastore/amplify_codegen/lib/src/parser/enum.dart
@@ -12,7 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Temporary codegen package for vNext.
-library amplify_codegen;
+import 'package:aws_common/aws_common.dart';
+import 'package:gql/ast.dart';
 
-export 'src/parser/parser.dart' hide makeConnectionAttributeName;
+/// Helpers for [EnumValueDefinitionNode].
+extension EnumHelpers on EnumValueDefinitionNode {
+  /// The name of the enum value as defined in the schema.
+  String get wireValue => name.value;
+
+  /// The Dart name of the enum value.
+  String get dartName => wireValue.camelCase;
+}

--- a/packages/datastore/amplify_codegen/lib/src/parser/field.dart
+++ b/packages/datastore/amplify_codegen/lib/src/parser/field.dart
@@ -1,0 +1,182 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_codegen/src/parser/node.dart';
+import 'package:amplify_core/src/types/models/mipr.dart';
+import 'package:aws_common/aws_common.dart';
+import 'package:collection/collection.dart';
+import 'package:gql/ast.dart';
+
+/// Returns the query field name for [fieldName].
+String queryFieldName(String fieldName) => ('$fieldName\$').camelCase;
+
+/// Helpers for [ModelField].
+extension ModelFieldHelpers on ModelField {
+  /// The wire name as it shows in JSON.
+  String get wireName => name;
+}
+
+/// Helpers for [ArgumentNode].
+extension ArgumentHelpers on ArgumentNode {
+  /// Returns the argument's value as a string.
+  String get stringValue => (value as StringValueNode).value;
+
+  /// Returns the argument's value as a list of strings.
+  List<String> get stringListValue => (value as ListValueNode)
+      .values
+      .cast<StringValueNode>()
+      .map((el) => el.value)
+      .toList();
+}
+
+/// Helpers for [DirectiveNode].
+extension DirectiveHelpers on DirectiveNode {
+  /// Whether the argument named [argumentName] is defined.
+  bool hasArgument(String argumentName) =>
+      arguments.any((arg) => arg.name.value == argumentName);
+
+  /// Gets the argument named [argumentName], if present.
+  ArgumentNode? argumentNamed(String argumentName) =>
+      arguments.firstWhereOrNull((arg) => arg.name.value == argumentName);
+}
+
+/// Helpers for [FieldDefinitionNode].
+extension FieldHelpers on FieldDefinitionNode {
+  /// Whether this field has a directive named [directiveName].
+  bool hasDirective(String directiveName) =>
+      directives.any((directive) => directive.name.value == directiveName);
+
+  /// Locates the directive named [directiveName], if present.
+  DirectiveNode? directiveNamed(String directiveName) => directives
+      .firstWhereOrNull((directive) => directive.name.value == directiveName);
+
+  /// Whether this field has a foreign relationship.
+  bool get hasRelationship =>
+      hasDirective('hasOne') ||
+      hasDirective('belongsTo') ||
+      hasDirective('hasMany') ||
+      hasDirective('manyToMany');
+
+  /// The foreign relationship directive, if any.
+  DirectiveNode? get relationshipDirective {
+    if (!hasRelationship) {
+      return null;
+    }
+    return directives.singleWhere(
+      (directive) =>
+          directive.name.value == 'hasOne' ||
+          directive.name.value == 'belongsTo' ||
+          directive.name.value == 'hasMany' ||
+          directive.name.value == 'manyToMany',
+    );
+  }
+
+  /// The name of the connection, if any.
+  String? get connectionName {
+    if (!hasRelationship) {
+      return null;
+    }
+    return directiveNamed('index')?.argumentNamed('name')?.stringValue;
+  }
+
+  /// The name of the connection's `indexName` property, if any.
+  String? get indexName {
+    if (!hasRelationship) {
+      return null;
+    }
+    return relationshipDirective?.argumentNamed('indexName')?.stringValue;
+  }
+
+  /// The value of the connection `fields` property, if any.
+  List<String>? get connectionFields {
+    if (!hasRelationship) {
+      return null;
+    }
+    return relationshipDirective!.argumentNamed('fields')?.stringListValue;
+  }
+
+  /// Whether this field represents a `hasMany` relationship.
+  bool get isHasMany => hasDirective('hasMany');
+
+  /// Whether this field represents a `hasOne` relationship.
+  bool get isHasOne => hasDirective('hasOne');
+
+  /// Whether this field represents a `belongsTo` relationship.
+  bool get isBelongsTo => hasDirective('belongsTo');
+
+  /// Whether this field represents a `manyToMany` relationship.
+  bool get isManyToMany => hasDirective('manyToMany');
+
+  /// The re-cased Dart name (camelCase).
+  String get dartName => name.value.camelCase;
+
+  /// The wire name as it shows in JSON.
+  String get wireName => name.value;
+}
+
+/// Helpers for [DirectiveNode]s.
+extension AuthRules on List<DirectiveNode> {
+  /// The `@auth` directive, if any.
+  DirectiveNode? get authRuleDirective {
+    return firstWhereOrNull((node) => node.name.value == 'auth');
+  }
+
+  /// The `@auth` rules.
+  ///
+  /// Will be empty if [authRuleDirective] is `null`.
+  Iterable<AuthRule> get authRules sync* {
+    final directive = authRuleDirective;
+    if (directive == null) {
+      return;
+    }
+    final rulesArg = directive.arguments.single.value as ListValueNode;
+    final ruleValues = rulesArg.values.cast<ObjectValueNode>();
+    for (final ruleValue in ruleValues) {
+      final rule = AuthRuleBuilder();
+      for (final field in ruleValue.fields) {
+        final node = field.value;
+        switch (field.name.value) {
+          case 'allow':
+            rule.authStrategy = AuthStrategy.valueOf(node.stringValue);
+            break;
+          case 'provider':
+            rule.provider = AuthRuleProvider.valueOf(node.stringValue);
+            break;
+          case 'ownerField':
+            rule.ownerField = node.stringValue;
+            break;
+          case 'identityClaim':
+            rule.identityClaim = node.stringValue;
+            break;
+          case 'groupClaim':
+            rule.groupClaim = node.stringValue;
+            break;
+          case 'groups':
+            rule.groups.addAll(node.stringListValue);
+            break;
+          case 'groupsField':
+            rule.groupsField = node.stringValue;
+            break;
+          case 'operations':
+            rule.operations
+                .addAll(node.stringListValue.map(ModelOperation.valueOf));
+            break;
+          default:
+            throw StateError('Unknown key: ${field.name.value}');
+        }
+      }
+      yield rule.build();
+    }
+  }
+}

--- a/packages/datastore/amplify_codegen/lib/src/parser/model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/parser/model.dart
@@ -1,0 +1,146 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_codegen/src/parser/field.dart';
+import 'package:amplify_core/src/types/models/mipr.dart';
+import 'package:collection/collection.dart';
+import 'package:gql/ast.dart';
+
+/// Helpers for [StructureTypeDefinition].
+extension ModelHelpers on StructureTypeDefinition {
+  /// Finds the field named [name].
+  ///
+  /// Throws a [StateError] if not present.
+  ModelField fieldNamed(String name) =>
+      fields.values.singleWhere((f) => f.name == name);
+
+  /// Tries to find the field named [name].
+  ModelField? maybeFieldNamed(String name) =>
+      fields.values.singleWhereOrNull((f) => f.name == name);
+}
+
+/// Helpers for [ObjectTypeDefinitionNode].
+extension ModelDefinitionHelpers on ObjectTypeDefinitionNode {
+  /// Whether this type has a directive named [directiveName].
+  bool hasDirective(String directiveName) =>
+      directives.any((directive) => directive.name.value == directiveName);
+
+  /// Locates the directive named [directiveName], if present.
+  DirectiveNode? directiveNamed(String directiveName) => directives
+      .firstWhereOrNull((directive) => directive.name.value == directiveName);
+
+  /// Whether `this` is a [ModelType] (as opposed to a [NonModelType]).
+  bool get isModel => hasDirective('model');
+
+  /// Whether `this` is a [NonModelType].
+  bool get isNonModel => !isModel;
+
+  /// The keys/indexes for this model + their associated `fields` property.
+  /// Unnamed primary keys are indexed by `null` in the returned map.
+  Iterable<ModelIndex> get indexFields sync* {
+    for (final field in fields.where((f) => f.hasDirective('index'))) {
+      final directive = field.directiveNamed('index')!;
+      final indexName = directive.argumentNamed('name')!.stringValue;
+      final indexFields = directive.hasArgument('fields')
+          ? directive.argumentNamed('fields')!.stringListValue
+          : const <String>[];
+      yield ModelIndex(
+        name: indexName,
+        field: field.wireName,
+        sortKeyFields: indexFields,
+      );
+    }
+    // + the primary key, which is the primary index
+    final primaryKey = fields.firstWhereOrNull(
+      (field) => field.hasDirective('primaryKey'),
+    );
+    if (primaryKey != null) {
+      final directive = primaryKey.directiveNamed('primaryKey')!;
+      final sortKeyFields = directive.hasArgument('sortKeyFields')
+          ? directive.argumentNamed('sortKeyFields')!.stringListValue
+          : const <String>[];
+      yield ModelIndex.primaryKey(
+        field: primaryKey.wireName,
+        sortKeyFields: sortKeyFields,
+      );
+    } else {
+      yield ModelIndex.primaryKey(field: 'id');
+    }
+  }
+
+  /// Returns all fields as [ModelField] objects.
+  Iterable<ModelField> modelFields({
+    required Map<String, ObjectTypeDefinitionNode> models,
+  }) sync* {
+    for (final field in fields) {
+      yield ModelField.build((f) {
+        f
+          ..name = field.name.value
+          ..type = _buildTypeFor(field.type, models: models)
+          ..isReadOnly = false
+          ..authRules.addAll(field.directives.authRules);
+      });
+    }
+
+    if (isModel) {
+      // createdAt
+      yield ModelField.build(
+        (f) => f
+          ..name = 'createdAt'
+          ..isReadOnly = true
+          ..type = const SchemaType.scalar(AppSyncScalar.awsDateTime),
+      );
+
+      // updatedAt
+      yield ModelField.build(
+        (f) => f
+          ..name = 'updatedAt'
+          ..isReadOnly = true
+          ..type = const SchemaType.scalar(AppSyncScalar.awsDateTime),
+      );
+    }
+  }
+
+  SchemaType _buildTypeFor(
+    TypeNode node, {
+    required Map<String, ObjectTypeDefinitionNode> models,
+  }) {
+    if (node is NamedTypeNode) {
+      final scalarType = AppSyncScalar.values.firstWhereOrNull(
+        (el) => el.name == node.name.value,
+      );
+      if (scalarType != null) {
+        return SchemaType.scalar(scalarType, isRequired: node.isNonNull);
+      }
+      final modelName = node.name.value;
+      final objectNode = models[modelName];
+      final isEnum = objectNode == null;
+      if (isEnum) {
+        return SchemaType.enum_(modelName, isRequired: node.isNonNull);
+      }
+      final isNonModel = !objectNode.hasDirective('model');
+      if (isNonModel) {
+        return SchemaType.nonModel(modelName, isRequired: node.isNonNull);
+      }
+      return SchemaType.model(modelName, isRequired: node.isNonNull);
+    } else if (node is ListTypeNode) {
+      final valueType = _buildTypeFor(
+        node.type,
+        models: models,
+      );
+      return SchemaType.list(valueType, isRequired: node.isNonNull);
+    }
+    throw ArgumentError(node.runtimeType);
+  }
+}

--- a/packages/datastore/amplify_codegen/lib/src/parser/node.dart
+++ b/packages/datastore/amplify_codegen/lib/src/parser/node.dart
@@ -1,0 +1,43 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:gql/ast.dart';
+
+/// Helpers for [ValueNode].
+extension ValueHelpers on ValueNode {
+  /// The string value of `this`.
+  ///
+  /// Throws [ArgumentError] if `this` does not have a string representation.
+  String get stringValue {
+    if (this is EnumValueNode) {
+      return (this as EnumValueNode).name.value;
+    } else if (this is StringValueNode) {
+      return (this as StringValueNode).value;
+    }
+    throw ArgumentError(runtimeType);
+  }
+
+  /// The string list value of `this`.
+  ///
+  /// Throws [ArgumentError] if `this` is not a list.
+  List<String> get stringListValue {
+    if (this is! ListValueNode) {
+      throw ArgumentError(runtimeType);
+    }
+    return (this as ListValueNode)
+        .values
+        .map((node) => node.stringValue)
+        .toList();
+  }
+}

--- a/packages/datastore/amplify_codegen/lib/src/parser/parser.dart
+++ b/packages/datastore/amplify_codegen/lib/src/parser/parser.dart
@@ -1,0 +1,523 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_codegen/src/parser/connection_info.dart';
+import 'package:amplify_codegen/src/parser/field.dart';
+import 'package:amplify_codegen/src/parser/model.dart';
+import 'package:amplify_codegen/src/parser/types.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:collection/collection.dart';
+import 'package:gql/ast.dart';
+import 'package:gql/language.dart';
+import 'package:meta/meta.dart';
+
+/// Parses the GraphQL [schema] string into a [SchemaDefinition].
+SchemaDefinition parseSchema(String schema) {
+  return _SchemaParser(schema).parse();
+}
+
+/// Creates the field name for a synthetic field on [modelName] which holds
+/// a connection to [connectedFieldName] which is used for retrieving the
+/// model in [fieldName].
+@internal
+String makeConnectionAttributeName(
+  String modelName,
+  String fieldName, [
+  String connectedFieldName = 'id',
+]) {
+  return '${modelName}_${fieldName}_$connectedFieldName'.camelCase;
+}
+
+class _SchemaParser {
+  _SchemaParser(this.schema) {
+    const rootTypes = ['Query', 'Mutation', 'Subscription'];
+    final doc = parseString(schema);
+
+    modelNodes = Map.fromEntries(
+      doc.definitions
+          .where(
+            (definition) =>
+                definition is ObjectTypeDefinitionNode &&
+                !rootTypes.contains(definition.name.value),
+          )
+          .map(
+            (el) => MapEntry((el as ObjectTypeDefinitionNode).name.value, el),
+          ),
+    );
+  }
+
+  final String schema;
+  final SchemaDefinitionBuilder builder = SchemaDefinitionBuilder();
+  late final Map<String, ObjectTypeDefinitionNode> modelNodes;
+
+  SchemaDefinition parse() {
+    // First pass to construct model graph with metadata
+    for (final modelNode in modelNodes.values) {
+      final modelName = modelNode.name.value;
+      final modelFields = Map<String, ModelField>.fromIterable(
+        modelNode.modelFields(
+          models: modelNodes,
+        ),
+        key: (field) => (field as ModelField).name,
+      );
+      if (modelNode.isNonModel) {
+        builder.typeDefinitions[modelName] = NonModelTypeDefinition(
+          name: modelName,
+          fields: modelFields,
+        );
+        continue;
+      }
+      builder.typeDefinitions[modelName] = ModelTypeDefinition.build((b) {
+        final authRules = modelNode.directives.authRules;
+        b
+          ..name = modelName
+          ..pluralName = modelName.endsWith('s') ? modelName : '${modelName}s'
+          ..authRules.addAll(authRules)
+          ..indexes.addAll(modelNode.indexFields)
+          ..fields.addAll(modelFields);
+
+        // Inject primary key field, if unspecified, e.g.
+        //
+        // type Post {
+        //   comments: [Comment] @hasMany(fields: ["id"])
+        // }
+        final primaryIndex =
+            modelNode.indexFields.singleWhere((index) => index.isPrimaryIndex);
+        b.fields[primaryIndex.primaryField] ??= ModelField(
+          name: primaryIndex.primaryField,
+          type: const SchemaType.scalar(
+            AppSyncScalar.id,
+            isRequired: true,
+          ),
+        );
+      });
+    }
+
+    // Second pass to establish relationships.
+    for (final modelNode in modelNodes.values) {
+      if (modelNode.isNonModel) {
+        continue;
+      }
+      final modelName = modelNode.name.value;
+      final nodeFields = modelNode.fields;
+      final model = builder.typeDefinitions[modelName]! as ModelTypeDefinition;
+      final newFields = ListMultimapBuilder<String, ModelField>();
+      final newIndexes = ListMultimapBuilder<String, ModelIndex>();
+      builder.typeDefinitions[modelName] = model.rebuild((m) {
+        m.fields.updateAllValues(
+          (_, field) => field.rebuild((field) {
+            final fieldNode =
+                nodeFields.singleWhereOrNull((f) => f.wireName == field.name);
+            final relationshipDirective = fieldNode?.relationshipDirective;
+
+            // Field node will be null for injected fields such as `createdAt`.
+            // These fields will not have relationships.
+            if (fieldNode == null || relationshipDirective == null) {
+              return;
+            }
+
+            // Get the model referred to by this relationship.
+            final relatedModelName = fieldNode.type.typeName;
+            final relatedModel = builder.typeDefinitions[relatedModelName]!
+                as ModelTypeDefinition;
+            final relatedModelNode = modelNodes[relatedModelName]!;
+
+            final relationship = ModelAssociationType.valueOf(
+              relationshipDirective.name.value,
+            );
+            late ConnectionInfo connectionInfo;
+            switch (relationship) {
+              case ModelAssociationType.belongsTo:
+                connectionInfo = processBelongsTo(
+                  modelName: model.name,
+                  fieldNode: fieldNode,
+                  relatedModel: relatedModel,
+                  relatedModelNode: relatedModelNode,
+                );
+                break;
+              case ModelAssociationType.hasOne:
+                connectionInfo = processHasOne(
+                  modelName: model.name,
+                  fieldNode: fieldNode,
+                  relatedModel: relatedModel,
+                  relatedModelNode: relatedModelNode,
+                );
+                break;
+              case ModelAssociationType.hasMany:
+                connectionInfo = processHasMany(
+                  modelName: model.name,
+                  fieldNode: fieldNode,
+                  relatedModel: relatedModel,
+                  relatedModelNode: relatedModelNode,
+                );
+                break;
+              case ModelAssociationType.manyToMany:
+                connectionInfo = processManyToMany();
+                break;
+            }
+            field.association.replace(connectionInfo.association);
+
+            builder.typeDefinitions.addAll(
+              Map.fromEntries(
+                connectionInfo.newTypes.map((e) => MapEntry(e.name, e)),
+              ),
+            );
+            connectionInfo.newFields.forEach(newFields.add);
+            connectionInfo.newIndexes.forEach(newIndexes.add);
+          }),
+        );
+      });
+
+      // Add new fields and indexes to models
+      newFields.build().forEach((modelName, field) {
+        final model =
+            builder.typeDefinitions[modelName]! as ModelTypeDefinition;
+        builder.typeDefinitions[modelName] =
+            model.rebuild((m) => m.fields[field.name] = field);
+      });
+      newIndexes.build().forEach((modelName, index) {
+        final model =
+            builder.typeDefinitions[modelName]! as ModelTypeDefinition;
+        builder.typeDefinitions[modelName] =
+            model.rebuild((m) => m.indexes.add(index));
+      });
+    }
+
+    return builder.build();
+  }
+
+  /// A `belongsTo` connection forms a 1-1 relationship between two models where
+  /// the foreign key is held by the model with the `@belongsTo` directive.
+  ///
+  /// The foreign key's fields can specified via the `fields` attribute of the
+  /// `@belongsTo` directive, in which case they must exist as part of the
+  /// model's schema. If the foreign key is not explicitly given, then synthetic
+  /// fields are injected into the schema to store the foreign model's primary
+  /// key. For CPK, this may be multiple fields.
+  ///
+  /// The field names which form the foreign key are called "target names" and
+  /// are stored as part of the model association in
+  /// [ModelAssociation.targetNames].
+  ///
+  /// ## Example (w/ `fields`)
+  ///
+  /// ```graphql
+  /// type Blog @model {
+  ///   id: ID!
+  ///   post: Post @hasOne
+  /// }
+  ///
+  /// type Post @model {
+  ///   id: ID!
+  /// }
+  /// ```
+  ///
+  /// When `fields` is specified, no addiitonal work is needed. The
+  /// "target names" contains only "blogID".
+  ///
+  /// ## Example (w/out `fields`)
+  ///
+  /// ```graphql
+  /// type Blog @model {
+  ///   id: ID!
+  /// }
+  ///
+  /// type Post @model {
+  ///   id: ID!
+  ///   blog: Blog! @belongsTo
+  /// }
+  /// ```
+  ///
+  /// When `fields` is absent, a synthetic field is created which follows the
+  /// naming defined by [makeConnectionAttributeName]. The list of target names
+  /// contains just this field, in this case `postBlogId`.
+  ConnectionInfo processBelongsTo({
+    required String modelName,
+    required FieldDefinitionNode fieldNode,
+    required ModelTypeDefinition relatedModel,
+    required ObjectTypeDefinitionNode relatedModelNode,
+  }) {
+    final connectionInfo = ConnectionInfoBuilder();
+    connectionInfo.association
+      ..associationType = ModelAssociationType.belongsTo
+      ..associatedType = relatedModel.name;
+
+    final targetNames = <String>[];
+
+    // Get the associated `@hasMany` field by relationship equality when the
+    // relation is bi-directional.
+    //
+    // In this case, use the foreign keys created by the `@hasMany` field
+    // instead of creating a new set of keys.
+    //
+    // TODO(dnys1): Why not reuse the keys created by `belongsTo` in `hasMany`
+    // model? That would seem to make more sense than complicating the logic
+    // here.
+    final hasManyField = relatedModelNode.fields.singleWhereOrNull((f) {
+      return f.isHasMany && f.type.typeName == modelName;
+    });
+
+    // Look for `fields` argument on `@belongsTo` directive. If present, use
+    // those for the target names.
+    final fields = fieldNode.connectionFields;
+    if (fields != null) {
+      targetNames.addAll(fields);
+    } else {
+      // Create the synthetic fields, one for each of the fields in the related
+      // model's primary key index.
+      for (final fieldName in relatedModel.modelIdentifier.fields) {
+        final fieldType = relatedModel.fields[fieldName]!.type;
+        final syntheticFieldName = hasManyField != null
+            ? makeConnectionAttributeName(
+                relatedModel.name,
+                hasManyField.wireName,
+                fieldName,
+              )
+            : makeConnectionAttributeName(
+                modelName,
+                fieldNode.wireName,
+                fieldName,
+              );
+        targetNames.add(syntheticFieldName);
+        connectionInfo.newFields.add(
+          modelName,
+          ModelField(
+            name: syntheticFieldName,
+            type: fieldType,
+            // Must be writeable.
+            isReadOnly: false,
+          ),
+        );
+      }
+    }
+    connectionInfo.association.targetNames.replace(targetNames);
+
+    // Create the foreign key index on the current model to aid in code
+    // generation.
+    connectionInfo.newIndexes.add(
+      modelName,
+      ModelIndex.foreignKey(
+        field: fieldNode.name.value,
+        keyFields: targetNames,
+      ),
+    );
+
+    return connectionInfo.build();
+  }
+
+  /// A `hasOne` connection, like a `belongsTo`, forms a 1-1 relationship
+  /// between two models where the foreign key is held by the model with the
+  /// `@hasOne` directive.
+  ///
+  /// > **NOTE**: An Amplify `@hasOne` connection is NOT a true hasOne relation
+  ///   where the foreign key is stored on the opposite end of the relationship.
+  ///   It should be thought of as a `belongsTo` with lazy loading behavior.
+  ///   That means that two models target each other via a `hasOne`/`belongsTo`
+  ///   pairing, there are **two** sets of foreign keys stored, one on each
+  ///   model with the opposite model's primary key.
+  ///
+  /// The foreign key's fields can specified via the `fields` attribute of the
+  /// `@hasOne` directive, in which case they must exist as part of the
+  /// model's schema. If the foreign key is not explicitly given, then synthetic
+  /// fields are injected into the schema to store the foreign model's primary
+  /// key. For CPK, this may be multiple fields.
+  ///
+  /// The field names which form the foreign key are called "target names" and
+  /// are stored as part of the model association in
+  /// [ModelAssociation.targetNames].
+  ///
+  /// In addition to the target names, which represent the foreign key on the
+  /// current model, the connected fields of the related model are also stored
+  /// as part of the association in [ModelAssociation.associatedFields].
+  ///
+  /// ### Example (Uni-Directional w/ `fields`)
+  ///
+  /// ```graphql
+  /// type Blog @model {
+  ///   id: ID!
+  ///   postID: ID
+  ///   post: Post @hasOne(fields: ["postID"])
+  /// }
+  ///
+  /// type Post @model {
+  ///   id: ID!
+  /// }
+  /// ```
+  ///
+  /// When `fields` is specified, no addiitonal work is needed. The
+  /// "target names" contains only `postID`. The associated `Post` field is the
+  /// `id` field.
+  ///
+  /// ### Example (Uni-Directional w/out `fields`)
+  ///
+  /// ```graphql
+  /// type Blog @model {
+  ///   id: ID!
+  ///   post: Post @hasOne
+  /// }
+  ///
+  /// type Post @model {
+  ///   id: ID!
+  /// }
+  /// ```
+  ///
+  /// When `fields` is absent, a synthetic field is created which follows the
+  /// naming defined by [makeConnectionAttributeName]. The list of target names
+  /// contains just this field, in this case "blogPostId".
+  ConnectionInfo processHasOne({
+    required String modelName,
+    required FieldDefinitionNode fieldNode,
+    required ModelTypeDefinition relatedModel,
+    required ObjectTypeDefinitionNode relatedModelNode,
+  }) {
+    final connectionInfo = ConnectionInfoBuilder();
+    connectionInfo.association
+      ..associationType = ModelAssociationType.hasOne
+      ..associatedType = relatedModel.name;
+
+    // Get the associated field by relationship equality when the relation
+    // is bi-directional.
+    final bidiField = relatedModelNode.fields.singleWhereOrNull((f) {
+      return f.isBelongsTo && f.type.typeName == modelName;
+    });
+    if (bidiField != null) {
+      connectionInfo.association.associatedFields.add(bidiField.wireName);
+    } else {
+      // Associate to the related model's primary key.
+      connectionInfo.association.associatedFields.replace(
+        relatedModel.modelIdentifier.fields,
+      );
+    }
+
+    // Look for `fields` argument on `@hasOne` directive. If present, use those
+    // for the target names.
+    final fields = fieldNode.connectionFields;
+    if (fields != null) {
+      connectionInfo.association.targetNames.addAll(fields);
+    } else {
+      // Create the foreign key using the related model's primary key.
+      for (final fieldName in relatedModel.modelIdentifier.fields) {
+        final fieldType = relatedModel.fields[fieldName]!.type;
+        final syntheticFieldName = makeConnectionAttributeName(
+          modelName,
+          fieldNode.name.value,
+          fieldName,
+        );
+        connectionInfo.association.targetNames.add(syntheticFieldName);
+        connectionInfo.newFields.add(
+          modelName,
+          ModelField(
+            name: syntheticFieldName,
+            type: fieldType,
+            // Must be writeable.
+            isReadOnly: false,
+          ),
+        );
+      }
+    }
+
+    return connectionInfo.build();
+  }
+
+  /// A `hasMany` connection forms a 1-N relationship between two models where
+  /// the foreign key is held by the model on the opposite side of the
+  /// `@hasMany` directive.
+  ConnectionInfo processHasMany({
+    required String modelName,
+    required FieldDefinitionNode fieldNode,
+    required ModelTypeDefinition relatedModel,
+    required ObjectTypeDefinitionNode relatedModelNode,
+  }) {
+    final connectionInfo = ConnectionInfoBuilder();
+    connectionInfo.association
+      ..associationType = ModelAssociationType.hasMany
+      ..associatedType = relatedModel.name;
+
+    final relatedModelNode = modelNodes[relatedModel.name]!;
+
+    // Look for `fields` argument on the `@hasMany` directive.
+    final fields = fieldNode.connectionFields;
+    if (fields != null) {
+      // If present, find the related fields matching the local `fields`.
+      final indexName = fieldNode.indexName;
+      final directlyRelatedField = indexName != null
+          ? relatedModel.indexNamed(indexName).primaryField
+          : relatedModel.modelIdentifier.primaryField;
+
+      // Get the associated field by relationship equality when the relation
+      // is bi-directional.
+      final bidiField = relatedModelNode.fields.singleWhereOrNull((f) {
+        return f.isBelongsTo &&
+            f.type.typeName == modelName &&
+            f.connectionFields?[0] == directlyRelatedField;
+      });
+      if (bidiField != null) {
+        connectionInfo.association.associatedFields.add(bidiField.wireName);
+      } else {
+        connectionInfo.association.associatedFields.add(
+          relatedModelNode.fields
+              .singleWhere((f) => f.wireName == directlyRelatedField)
+              .wireName,
+        );
+      }
+    } else {
+      // Create the foreign key on the related model using this model's
+      // primary key.
+      final thisModel =
+          builder.typeDefinitions[modelName]! as ModelTypeDefinition;
+      final foreignKeyFields =
+          thisModel.modelIdentifier.fields.map((f) => thisModel.fields[f]!);
+      final targetNames = <String>[];
+      for (final field in foreignKeyFields) {
+        final syntheticFieldName = makeConnectionAttributeName(
+          modelName,
+          fieldNode.name.value,
+          field.name,
+        );
+        targetNames.add(syntheticFieldName);
+        connectionInfo.newFields.add(
+          relatedModel.name,
+          ModelField(
+            name: syntheticFieldName,
+            type: field.type,
+            // Must be writeable.
+            isReadOnly: false,
+          ),
+        );
+      }
+      connectionInfo.association.associatedFields.addAll(targetNames);
+
+      // Create the foreign key index on the related model to aid in code
+      // generation.
+      connectionInfo.newIndexes.add(
+        relatedModel.name,
+        ModelIndex.foreignKey(
+          field: fieldNode.name.value,
+          keyFields: targetNames,
+        ),
+      );
+    }
+
+    return connectionInfo.build();
+  }
+
+  /// A `manyToMany` connection forms a N-N relationship between two models
+  /// where the foreign key is held by both models and points to a synthetic
+  /// join table which is injected into the schema.
+  ConnectionInfo processManyToMany() {
+    throw UnimplementedError();
+  }
+}

--- a/packages/datastore/amplify_codegen/lib/src/parser/types.dart
+++ b/packages/datastore/amplify_codegen/lib/src/parser/types.dart
@@ -1,0 +1,52 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/src/types/models/mipr.dart';
+import 'package:gql/ast.dart';
+
+/// Helpers for [TypeNode].
+extension TypeHelpers on TypeNode {
+  /// Whether `this` is a list type.
+  bool get isList => this is ListTypeNode;
+
+  /// `this` as a list type.
+  ListTypeNode get asList => this as ListTypeNode;
+
+  /// The name of the base type.
+  ///
+  /// If this is a list type, the name of the wrapped type.
+  String get typeName {
+    if (this is NamedTypeNode) {
+      return (this as NamedTypeNode).name.value;
+    } else if (this is ListTypeNode) {
+      return (this as ListTypeNode).type.typeName;
+    }
+    throw ArgumentError(runtimeType);
+  }
+
+  /// The type of model field this represents.
+  AppSyncScalar get awsType => AppSyncScalar.valueOf(typeName);
+}
+
+/// Helpers for [SchemaType].
+extension SchemaTypeHelpers on SchemaType {
+  /// Whether this type represents an enum.
+  bool get isEnum => this is EnumType;
+
+  /// Whether this type represents a Model.
+  bool get isModel => this is ModelType;
+
+  /// Whether this type represents a list.
+  bool get isList => this is ListType;
+}

--- a/packages/datastore/amplify_codegen/mono_pkg.yaml
+++ b/packages/datastore/amplify_codegen/mono_pkg.yaml
@@ -1,0 +1,10 @@
+sdk:
+  - stable
+
+stages:
+  - analyze_and_format:
+      - group:
+          - format
+          - analyze: --fatal-infos .
+  - unit_test:
+      - test:

--- a/packages/datastore/amplify_codegen/pubspec.yaml
+++ b/packages/datastore/amplify_codegen/pubspec.yaml
@@ -1,0 +1,22 @@
+name: amplify_codegen
+description: Temporary codegen package for vNext.
+publish_to: none
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  amplify_core:
+  aws_common:
+  built_collection: ^5.1.1
+  built_value: ">=8.4.0 <8.5.0"
+  collection: ^1.16.0
+  gql: ^0.14.0
+  graphs: ^2.1.0
+  meta: ^1.8.0
+
+dev_dependencies:
+  amplify_lints: ^2.0.0
+  build_runner: ^2.0.0
+  built_value_generator: 8.4.1
+  test: ^1.16.0

--- a/packages/datastore/amplify_codegen/pubspec_overrides.yaml
+++ b/packages/datastore/amplify_codegen/pubspec_overrides.yaml
@@ -1,0 +1,10 @@
+# Generated with `aft`. Do not modify by hand or check into source control.
+dependency_overrides: 
+  amplify_core:
+    path: ../../amplify_core
+  amplify_lints:
+    path: ../../amplify_lints
+  aws_common:
+    path: ../../aws_common
+  aws_signature_v4:
+    path: ../../aws_signature_v4

--- a/packages/datastore/amplify_codegen/test/parser/auth_rule_test.dart
+++ b/packages/datastore/amplify_codegen/test/parser/auth_rule_test.dart
@@ -1,0 +1,227 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_codegen/src/parser/field.dart';
+import 'package:amplify_core/src/types/models/mipr.dart';
+import 'package:gql/ast.dart';
+import 'package:gql/language.dart';
+import 'package:test/test.dart';
+
+void main() {
+  List<AuthRule> parseAuthRules(String schema) {
+    return (parseString(schema).definitions.single as ObjectTypeDefinitionNode)
+        .directives
+        .authRules
+        .toList();
+  }
+
+  group('Parser', () {
+    group('Auth Rules', () {
+      group('Owner Auth', () {
+        test(
+            'should add default owner field when owner auth is missing ownerField',
+            () {
+          const schema = '''
+          type DummyType @auth(rules: [
+            { allow: owner, identityClaim: "owner", operations: [read], provider: userPools}
+          ]) {}
+          ''';
+          final authRule = parseAuthRules(schema).single;
+          expect(
+            authRule,
+            equals(
+              AuthRule.build(
+                (b) => b
+                  ..authStrategy = AuthStrategy.owner
+                  ..identityClaim = 'owner'
+                  ..operations.add(ModelOperation.read)
+                  ..provider = AuthRuleProvider.userPools
+                  ..ownerField = 'owner',
+              ),
+            ),
+          );
+        });
+
+        test(
+            'should add default identityClaim cognito:userName if the directive is missing it',
+            () {
+          const schema = '''
+          type DummyType @auth(rules: [
+            { allow: owner, ownerField: "username", operations: [read], provider: userPools}
+          ]) {}
+          ''';
+          final authRule = parseAuthRules(schema).single;
+          expect(
+            authRule,
+            equals(
+              AuthRule.build(
+                (b) => b
+                  ..authStrategy = AuthStrategy.owner
+                  ..identityClaim = 'sub::username'
+                  ..operations.add(ModelOperation.read)
+                  ..provider = AuthRuleProvider.userPools
+                  ..ownerField = 'username',
+              ),
+            ),
+          );
+        });
+
+        test('should add operations when its missing', () {
+          const schema = '''
+          type DummyType @auth(rules: [
+            { allow: owner, ownerField: "username", provider: userPools, identityClaim: "user_name"}
+          ]) {}
+          ''';
+          final authRule = parseAuthRules(schema).single;
+          expect(
+            authRule,
+            equals(
+              AuthRule.build(
+                (b) => b
+                  ..authStrategy = AuthStrategy.owner
+                  ..identityClaim = 'user_name'
+                  ..operations.addAll([
+                    ModelOperation.create,
+                    ModelOperation.read,
+                    ModelOperation.update,
+                    ModelOperation.delete,
+                  ])
+                  ..provider = AuthRuleProvider.userPools
+                  ..ownerField = 'username',
+              ),
+            ),
+          );
+        });
+
+        test('should add provider when its missing', () {
+          const schema = '''
+          type DummyType @auth(rules: [
+            { allow: owner, ownerField: "username", operations: [create, update, delete], identityClaim: "user_name"}
+          ]) {}
+          ''';
+          final authRule = parseAuthRules(schema).single;
+          expect(
+            authRule,
+            equals(
+              AuthRule.build(
+                (b) => b
+                  ..authStrategy = AuthStrategy.owner
+                  ..identityClaim = 'user_name'
+                  ..operations.addAll([
+                    ModelOperation.create,
+                    ModelOperation.update,
+                    ModelOperation.delete,
+                  ])
+                  ..provider = AuthRuleProvider.userPools
+                  ..ownerField = 'username',
+              ),
+            ),
+          );
+        });
+      });
+
+      group('Group Auth', () {
+        test('should filter dynamic group auth rule', () {
+          const schema = '''
+          type DummyType @auth(rules: [
+            { allow: groups, groupsField: "my-group" }
+          ]) {}
+          ''';
+          final authRule = parseAuthRules(schema).single;
+          expect(
+            authRule,
+            equals(
+              AuthRule.build(
+                (b) => b
+                  ..authStrategy = AuthStrategy.groups
+                  ..groupsField = 'my-group',
+              ),
+            ),
+          );
+        });
+
+        test('should add groupClaim field when its missing', () {
+          const schema = '''
+          type DummyType @auth(rules: [
+            { allow: groups, provider: oidc, groups: ["Foo"], operations: [update] }
+          ]) {}
+          ''';
+          final authRule = parseAuthRules(schema).single;
+          expect(
+            authRule,
+            equals(
+              AuthRule.build(
+                (b) => b
+                  ..authStrategy = AuthStrategy.groups
+                  ..provider = AuthRuleProvider.oidc
+                  ..groups.add('Foo')
+                  ..operations.add(ModelOperation.update)
+                  ..groupClaim = 'cognito:groups',
+              ),
+            ),
+          );
+        });
+
+        test('should add provider field when its missing', () {
+          const schema = '''
+          type DummyType @auth(rules: [
+            { allow: groups, groupClaim: "my:groups", groups: ["Foo"], operations: [update] }
+          ]) {}
+          ''';
+          final authRule = parseAuthRules(schema).single;
+          expect(
+            authRule,
+            equals(
+              AuthRule.build(
+                (b) => b
+                  ..authStrategy = AuthStrategy.groups
+                  ..provider = AuthRuleProvider.userPools
+                  ..groupClaim = 'my:groups'
+                  ..groups.add('Foo')
+                  ..operations.add(ModelOperation.update),
+              ),
+            ),
+          );
+        });
+
+        test('should add default operations when its missing', () {
+          const schema = '''
+          type DummyType @auth(rules: [
+            { allow: groups, groupClaim: "my:groups", groups: ["Foo"] }
+          ]) {}
+          ''';
+          final authRule = parseAuthRules(schema).single;
+          expect(
+            authRule,
+            equals(
+              AuthRule.build(
+                (b) => b
+                  ..authStrategy = AuthStrategy.groups
+                  ..provider = AuthRuleProvider.userPools
+                  ..groupClaim = 'my:groups'
+                  ..groups.add('Foo')
+                  ..operations.addAll([
+                    ModelOperation.create,
+                    ModelOperation.read,
+                    ModelOperation.update,
+                    ModelOperation.delete,
+                  ]),
+              ),
+            ),
+          );
+        });
+      });
+    });
+  });
+}

--- a/packages/datastore/amplify_codegen/test/parser/parser_test.dart
+++ b/packages/datastore/amplify_codegen/test/parser/parser_test.dart
@@ -1,0 +1,533 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_codegen/src/parser/model.dart';
+import 'package:amplify_codegen/src/parser/parser.dart';
+import 'package:amplify_core/src/types/models/mipr.dart';
+import 'package:test/test.dart';
+
+// Follows the tests found in amplify-codegen:
+// https://github.com/aws-amplify/amplify-codegen/blob/main/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections-v2.test.ts
+void main() {
+  Map<String, ModelTypeDefinition> parseModels(String schema) {
+    return {
+      for (final definition in parseSchema(schema)
+          .typeDefinitions
+          .values
+          .whereType<ModelTypeDefinition>())
+        definition.name: definition,
+    };
+  }
+
+  group('Parser', () {
+    group('hasMany', () {
+      late Map<String, ModelTypeDefinition> v2Models;
+      late Map<String, ModelTypeDefinition> v2IndexedModels;
+
+      setUpAll(() {
+        const v2Schema = '''
+          type Post @model {
+            comments: [Comment] @hasMany(fields: ["id"])
+          }
+
+          type Comment @model {
+            postID: ID! @primaryKey(sortKeyFields: ["content"])
+            content: String!
+            post: Post @belongsTo(fields:["postID"])
+          }
+          ''';
+
+        const v2IndexSchema = '''
+          type Post @model {
+            id: ID!
+            title: String!
+            comments: [Comment] @hasMany(indexName: "byPost", fields: ["id"])
+          }
+
+          type Comment @model {
+            id: ID!
+            postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+            content: String!
+          }
+          ''';
+
+        v2Models = parseModels(v2Schema);
+        v2IndexedModels = parseModels(v2IndexSchema);
+      });
+
+      test('should support connection with @primaryKey on BELONGS_TO side', () {
+        final postField = v2Models['Comment']!.fieldNamed('post');
+
+        expect(
+          postField.association,
+          ModelAssociation.belongsTo(
+            associatedType: 'Post',
+            targetNames: ['postID'],
+          ),
+        );
+      });
+
+      test('should support connection with @primaryKey on HAS_MANY side', () {
+        final commentsField = v2Models['Post']!.fieldNamed('comments');
+
+        expect(
+          commentsField.association,
+          ModelAssociation.hasMany(
+            associatedType: 'Comment',
+            associatedFields: ['post'],
+          ),
+        );
+      });
+
+      test('should support connection with @index on HAS_MANY side', () {
+        final commentsField = v2IndexedModels['Post']!.fieldNamed('comments');
+
+        expect(
+          commentsField.association,
+          ModelAssociation.hasMany(
+            associatedType: 'Comment',
+            associatedFields: ['postID'],
+          ),
+        );
+      });
+
+      test('Should support connection with @index on BELONGS_TO side', () {
+        final commentsField = v2IndexedModels['Post']!.fieldNamed('comments');
+
+        expect(
+          commentsField.association,
+          ModelAssociation.hasMany(
+            associatedType: 'Comment',
+            associatedFields: ['postID'],
+          ),
+        );
+      });
+    });
+
+    group('hasOne', () {
+      late Map<String, ModelTypeDefinition> noFields;
+      late Map<String, ModelTypeDefinition> withFields;
+
+      setUpAll(() {
+        const noFieldsSchema = '''
+          type BatteryCharger @model {
+            powerSource: PowerSource @hasOne
+          }
+
+          type PowerSource @model {
+            id: ID!
+            amps: Float!
+            volts: Float!
+          }''';
+
+        const withFieldsSchema = '''
+          type BatteryCharger @model {
+            chargerID: ID!
+            powerSourceID: ID
+            powerSource: PowerSource @hasOne(fields: ["powerSourceID"])
+          }
+
+          type PowerSource @model {
+            sourceID: ID! @primaryKey
+            amps: Float!
+            volts: Float!
+          }''';
+
+        noFields = parseModels(noFieldsSchema);
+        withFields = parseModels(withFieldsSchema);
+      });
+
+      test('Should support @hasOne with no explicit primary key', () {
+        final powerSourceField =
+            noFields['BatteryCharger']!.fieldNamed('powerSource');
+
+        expect(
+          powerSourceField.association,
+          ModelAssociation.hasOne(
+            associatedType: 'PowerSource',
+            associatedFields: ['id'],
+            targetNames: ['batteryChargerPowerSourceId'],
+          ),
+        );
+      });
+
+      test('Should support @hasOne with an explicit primary key', () {
+        final powerSourceField =
+            withFields['BatteryCharger']!.fieldNamed('powerSource');
+
+        expect(
+          powerSourceField.association,
+          ModelAssociation.hasOne(
+            associatedType: 'PowerSource',
+            associatedFields: ['sourceID'],
+            targetNames: ['powerSourceID'],
+          ),
+        );
+      });
+    });
+
+    group('belongsTo', () {
+      late Map<String, ModelTypeDefinition> modelMap;
+
+      setUpAll(() {
+        const schema = '''
+          type Project2 @model {
+            id: ID!
+            name: String
+            team: Team2 @hasOne 
+          } 
+
+          type Team2 @model {
+            id: ID!
+            name: String!
+            project: Project2! @belongsTo
+          }''';
+
+        modelMap = parseModels(schema);
+      });
+
+      test('Should support belongsTo and detect connected field', () {
+        final projectField = modelMap['Team2']!.fieldNamed('project');
+
+        expect(
+          projectField.association,
+          ModelAssociation.belongsTo(
+            associatedType: 'Project2',
+            targetNames: ['team2ProjectId'],
+          ),
+        );
+      });
+    });
+
+    group('hasMany', () {
+      late Map<String, ModelTypeDefinition> modelMap;
+
+      setUpAll(() {
+        const schema = '''
+          type Blog @model {
+            id: ID!
+            name: String!
+            posts: [Post] @hasMany
+          }
+          
+          type Post @model {
+            id: ID!
+            title: String!
+            blog: Blog @belongsTo
+            comments: [Comment] @hasMany
+          }
+          
+          type Comment @model {
+            id: ID!
+            post: Post @belongsTo
+            content: String!
+          }''';
+
+        modelMap = parseModels(schema);
+      });
+
+      test('Should detect first has many', () {
+        final postsField = modelMap['Blog']!.fieldNamed('posts');
+
+        expect(
+          postsField.association,
+          ModelAssociation.hasMany(
+            associatedType: 'Post',
+            associatedFields: ['blogPostsId'],
+          ),
+        );
+      });
+
+      test('Should detect second has many', () {
+        final commentsField = modelMap['Post']!.fieldNamed('comments');
+
+        expect(
+          commentsField.association,
+          ModelAssociation.hasMany(
+            associatedType: 'Comment',
+            associatedFields: ['postCommentsId'],
+          ),
+        );
+      });
+
+      test('Should detect first belongsTo', () {
+        final blogField = modelMap['Post']!.fieldNamed('blog');
+
+        expect(
+          blogField.association,
+          ModelAssociation.belongsTo(
+            associatedType: 'Blog',
+            targetNames: ['blogPostsId'],
+          ),
+        );
+      });
+
+      test('Should detect second belongsTo', () {
+        final postField = modelMap['Comment']!.fieldNamed('post');
+
+        expect(
+          postField.association,
+          ModelAssociation.belongsTo(
+            associatedType: 'Post',
+            targetNames: ['postCommentsId'],
+          ),
+        );
+      });
+    });
+
+    group('CPK', () {
+      group('hasOne', () {
+        test('uni-directional', () {
+          const schema = '''
+            type Project @model {
+              projectId: ID! @primaryKey(sortKeyFields:["name"])
+              name: String!
+              team: Team @hasOne
+            }
+            type Team @model {
+              teamId: ID! @primaryKey(sortKeyFields:["name"])
+              name: String!
+            }
+          ''';
+
+          final models = parseModels(schema);
+          final projectTeamField = models['Project']!.fieldNamed('team');
+          expect(
+            projectTeamField.association,
+            ModelAssociation.hasOne(
+              associatedType: 'Team',
+              associatedFields: ['teamId', 'name'],
+              targetNames: ['projectTeamTeamId', 'projectTeamName'],
+            ),
+          );
+        });
+
+        test('bi-directional', () {
+          const schema = '''
+            type Project @model {
+              projectId: ID! @primaryKey(sortKeyFields:["name"])
+              name: String!
+              team: Team @hasOne
+            }
+            type Team @model {
+              teamId: ID! @primaryKey(sortKeyFields:["name"])
+              name: String!
+              project: Project @belongsTo
+            }
+          ''';
+
+          final models = parseModels(schema);
+
+          final projectTeamField = models['Project']!.fieldNamed('team');
+          expect(
+            projectTeamField.association,
+            ModelAssociation.hasOne(
+              associatedType: 'Team',
+              associatedFields: ['project'],
+              targetNames: ['projectTeamTeamId', 'projectTeamName'],
+            ),
+          );
+
+          final teamProjectField = models['Team']!.fieldNamed('project');
+          expect(
+            teamProjectField.association,
+            ModelAssociation.belongsTo(
+              associatedType: 'Project',
+              targetNames: ['teamProjectProjectId', 'teamProjectName'],
+            ),
+          );
+        });
+      });
+
+      group('hasMany', () {
+        test('uni-directional', () {
+          const schema = '''
+            type Post @model {
+              postId: ID! @primaryKey(sortKeyFields:["title"])
+              title: String!
+              comments: [Comment] @hasMany
+            }
+            type Comment @model {
+              commentId: ID! @primaryKey(sortKeyFields:["content"])
+              content: String!
+            }
+          ''';
+
+          final models = parseModels(schema);
+
+          final postCommentsField = models['Post']!.fieldNamed('comments');
+          expect(
+            postCommentsField.association,
+            ModelAssociation.hasMany(
+              associatedType: 'Comment',
+              associatedFields: ['postCommentsPostId', 'postCommentsTitle'],
+            ),
+          );
+        });
+
+        test('uni-directional w/ index', () {
+          const schema = '''
+            type Post @model {
+              postId: ID! @primaryKey(sortKeyFields:["title"])
+              title: String!
+              comments: [Comment] @hasMany(indexName: "byPost", fields:["postId", "title"])
+            }
+            type Comment @model {
+              commentId: ID! @primaryKey(sortKeyFields:["content"])
+              content: String!
+              postId: ID! @index(name: "byPost", sortKeyFields:["postTitle"])
+              postTitle: String!
+            }
+          ''';
+
+          final models = parseModels(schema);
+
+          final postCommentsField = models['Post']!.fieldNamed('comments');
+          expect(
+            postCommentsField.association,
+            ModelAssociation.hasMany(
+              associatedType: 'Comment',
+              associatedFields: ['postId'],
+            ),
+          );
+        });
+
+        test('bi-directional', () {
+          const schema = '''
+            type Post @model {
+              postId: ID! @primaryKey(sortKeyFields:["title"])
+              title: String!
+              comments: [Comment] @hasMany
+            }
+            type Comment @model {
+              commentId: ID! @primaryKey(sortKeyFields:["content"])
+              content: String!
+              post: Post @belongsTo
+            }
+          ''';
+
+          final models = parseModels(schema);
+
+          final postCommentsField = models['Post']!.fieldNamed('comments');
+          expect(
+            postCommentsField.association,
+            ModelAssociation.hasMany(
+              associatedType: 'Comment',
+              associatedFields: ['postCommentsPostId', 'postCommentsTitle'],
+            ),
+          );
+
+          final commentPostField = models['Comment']!.fieldNamed('post');
+          expect(
+            commentPostField.association,
+            ModelAssociation.belongsTo(
+              associatedType: 'Post',
+              targetNames: ['postCommentsPostId', 'postCommentsTitle'],
+            ),
+          );
+        });
+
+        test('bi-directional w/ index', () {
+          const schema = '''
+            type Post @model {
+              postId: ID! @primaryKey(sortKeyFields:["title"])
+              title: String!
+              comments: [Comment] @hasMany(indexName: "byPost", fields:["postId", "title"])
+            }
+            type Comment @model {
+              commentId: ID! @primaryKey(sortKeyFields:["content"])
+              content: String!
+              post: Post @belongsTo(fields:["postId", "postTitle"])
+              postId: ID! @index(name: "byPost", sortKeyFields:["postTitle"])
+              postTitle: String!
+            }
+          ''';
+
+          final models = parseModels(schema);
+
+          final postCommentsField = models['Post']!.fieldNamed('comments');
+          expect(
+            postCommentsField.association,
+            ModelAssociation.hasMany(
+              associatedType: 'Comment',
+              associatedFields: ['post'],
+            ),
+          );
+
+          final commentPostField = models['Comment']!.fieldNamed('post');
+          expect(
+            commentPostField.association,
+            ModelAssociation.belongsTo(
+              associatedType: 'Post',
+              targetNames: ['postId', 'postTitle'],
+            ),
+          );
+        });
+      });
+
+      group('belongsTo', () {
+        test('multiple hasOne', () {
+          const schema = '''
+            type Project @model {
+              projectId: ID! @primaryKey(sortKeyFields:["name"])
+              name: String!
+              devTeam: Team @hasOne
+              productTeam: Team @hasOne
+            }
+            type Team @model {
+              teamId: ID! @primaryKey(sortKeyFields:["name"])
+              name: String!
+              project: Project @belongsTo
+            }
+          ''';
+
+          final models = parseModels(schema);
+
+          final projectDevTeamField = models['Project']!.fieldNamed('devTeam');
+          expect(
+            projectDevTeamField.association,
+            ModelAssociation.hasOne(
+              associatedType: 'Team',
+              associatedFields: ['project'],
+              targetNames: ['projectDevTeamTeamId', 'projectDevTeamName'],
+            ),
+          );
+
+          final projectProductTeamField =
+              models['Project']!.fieldNamed('productTeam');
+          expect(
+            projectProductTeamField.association,
+            ModelAssociation.hasOne(
+              associatedType: 'Team',
+              associatedFields: ['project'],
+              targetNames: [
+                'projectProductTeamTeamId',
+                'projectProductTeamName'
+              ],
+            ),
+          );
+
+          final teamProjectField = models['Team']!.fieldNamed('project');
+          expect(
+            teamProjectField.association,
+            ModelAssociation.belongsTo(
+              associatedType: 'Project',
+              targetNames: ['teamProjectProjectId', 'teamProjectName'],
+            ),
+          );
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
Adds the first piece of codegen which is parsing a GraphQL schema to a semantic SchemaDefinition. This is done by analyzing relationships of models and injecting synthetic fields to hold foreign key information when it is missing.

Tests are written to match what is tested in amplify-codegen, namely: https://github.com/aws-amplify/amplify-codegen/blob/main/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections-v2.test.ts

