### PR TITLE
chore(repo): Update `libsecret` submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/GNOME/glib.git
 [submodule "packages/secure_storage/amplify_secure_storage_dart/external/libsecret"]
 	path = packages/secure_storage/amplify_secure_storage_dart/external/libsecret
-	url = https://gitlab.gnome.org/GNOME/libsecret.git
+	url = https://github.com/GNOME/libsecret.git
 [submodule "packages/smithy/goldens/smithy"]
 	path = packages/smithy/goldens/smithy
 	url = https://github.com/awslabs/smithy.git


### PR DESCRIPTION
Use github mirror of `libsecret` instead of (what appears to be) a self-hosted gitlab instance which is unreliable