### PR TITLE
chore(authenticator): remove navigator from tree for AuthenticatedState

### DIFF
--- a/packages/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/amplify_authenticator/lib/amplify_authenticator.dart
@@ -762,23 +762,22 @@ class _AuthenticatorBody extends StatelessWidget {
     return _AuthStateBuilder(
       child: child,
       builder: (state, child) {
+        if (state is AuthenticatedState) return child;
         return Navigator(
           onPopPage: (_, dynamic __) => true,
           pages: [
-            if (state is AuthenticatedState) MaterialPage<void>(child: child),
-            if (state is! AuthenticatedState)
-              MaterialPage<void>(
-                child: ScaffoldMessenger(
-                  key: _AuthenticatorState.scaffoldMessengerKey,
-                  child: Scaffold(
-                    body: SizedBox.expand(
-                      child: child is AuthenticatorScreen
-                          ? SingleChildScrollView(child: child)
-                          : child,
-                    ),
+            MaterialPage<void>(
+              child: ScaffoldMessenger(
+                key: _AuthenticatorState.scaffoldMessengerKey,
+                child: Scaffold(
+                  body: SizedBox.expand(
+                    child: child is AuthenticatorScreen
+                        ? SingleChildScrollView(child: child)
+                        : child,
                   ),
                 ),
               ),
+            ),
           ],
         );
       },


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/2332

*Description of changes:*
- Only place a `Navigator` widget in the tree for Unauthenticated states

Note: This does not solve the issue for customers using `AuthenticatedView`. To solve this, `Localizations.override()` needs to be removed from `AuthenticatedView`, but this leads to a new issue - https://github.com/flutter/flutter/issues/115159. Future changes related to navigation in the Authenticator may resolve this issue though.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
