### PR TITLE
chore: bump amplify-ios to 1.28.3

### DIFF
--- a/packages/amplify/amplify_flutter_ios/ios/amplify_flutter_ios.podspec
+++ b/packages/amplify/amplify_flutter_ios/ios/amplify_flutter_ios.podspec
@@ -17,9 +17,9 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.2'
-  s.dependency 'AWSPluginsCore', '1.28.2'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.28.2'
+  s.dependency 'Amplify', '1.28.3'
+  s.dependency 'AWSPluginsCore', '1.28.3'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.28.3'
   s.dependency 'amplify_core'
   s.dependency 'SwiftLint', '0.48.0'
   s.dependency 'SwiftFormat/CLI'

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,8 +15,8 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.2'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.28.2'
+  s.dependency 'Amplify', '1.28.3'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.28.3'
   s.dependency 'amplify_core'
   s.platform = :ios, '13.0'
 

--- a/packages/analytics/amplify_analytics_pinpoint_ios/ios/amplify_analytics_pinpoint_ios.podspec
+++ b/packages/analytics/amplify_analytics_pinpoint_ios/ios/amplify_analytics_pinpoint_ios.podspec
@@ -15,8 +15,8 @@ This code is the iOS part of the Amplify Flutter Pinpoint Analytics Plugin.  The
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.2'
-  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.28.2'
+  s.dependency 'Amplify', '1.28.3'
+  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.28.3'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/api/amplify_api_ios/ios/amplify_api_ios.podspec
+++ b/packages/api/amplify_api_ios/ios/amplify_api_ios.podspec
@@ -15,8 +15,8 @@ The API module for Amplify Flutter.
   s.source           = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.2'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.28.2'
+  s.dependency 'Amplify', '1.28.3'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.28.3'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
+++ b/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.2'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.28.2'
+  s.dependency 'Amplify', '1.28.3'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.28.3'
   s.dependency 'ObjectMapper'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'

--- a/packages/storage/amplify_storage_s3_ios/ios/amplify_storage_s3_ios.podspec
+++ b/packages/storage/amplify_storage_s3_ios/ios/amplify_storage_s3_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.2'
-  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.28.2'
+  s.dependency 'Amplify', '1.28.3'
+  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.28.3'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
  - fixing DataStore not syncing records after network reconnection

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
