### PR TITLE
chore: add analytics to platform support tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We are iterating and looking for feedback and collaboration, so please [**let us
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
 | -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
-| Analytics      |   🔴    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| Analytics      |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (REST)     |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (GraphQL)  |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | Authentication |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |

--- a/packages/amplify/amplify_flutter/README.md
+++ b/packages/amplify/amplify_flutter/README.md
@@ -12,7 +12,7 @@ For production use cases please use the latest, non-tagged versions of amplify-f
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
 | -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
-| Analytics      |   🔴    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| Analytics      |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (REST)     |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (GraphQL)  |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | Authentication |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |

--- a/packages/amplify_core/README.md
+++ b/packages/amplify_core/README.md
@@ -12,7 +12,7 @@ For production use cases please use the latest, non-tagged versions of amplify-f
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
 | -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
-| Analytics      |   🔴    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| Analytics      |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (REST)     |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (GraphQL)  |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | Authentication |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |

--- a/packages/amplify_datastore/README.md
+++ b/packages/amplify_datastore/README.md
@@ -12,7 +12,7 @@ For production use cases please use the latest, non-tagged versions of amplify-f
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
 | -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
-| Analytics      |   🔴    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| Analytics      |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (REST)     |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (GraphQL)  |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | Authentication |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |

--- a/packages/analytics/amplify_analytics_pinpoint/README.md
+++ b/packages/analytics/amplify_analytics_pinpoint/README.md
@@ -14,7 +14,7 @@ Please note that the Analytics category is only available on iOS in the develope
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
 | -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
-| Analytics      |   🔴    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| Analytics      |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (REST)     |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (GraphQL)  |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | Authentication |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |

--- a/packages/api/amplify_api/README.md
+++ b/packages/api/amplify_api/README.md
@@ -12,7 +12,7 @@ For production use cases please use the latest, non-tagged versions of amplify-f
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
 | -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
-| Analytics      |   🔴    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| Analytics      |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (REST)     |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (GraphQL)  |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | Authentication |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |

--- a/packages/auth/amplify_auth_cognito/README.md
+++ b/packages/auth/amplify_auth_cognito/README.md
@@ -12,7 +12,7 @@ For production use cases please use the latest, non-tagged versions of amplify-f
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
 | -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
-| Analytics      |   🔴    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| Analytics      |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (REST)     |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (GraphQL)  |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | Authentication |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |

--- a/packages/storage/amplify_storage_s3/README.md
+++ b/packages/storage/amplify_storage_s3/README.md
@@ -12,7 +12,7 @@ For production use cases please use the latest, non-tagged versions of amplify-f
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
 | -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
-| Analytics      |   🔴    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| Analytics      |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (REST)     |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | API (GraphQL)  |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | Authentication |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |


### PR DESCRIPTION
Adds Analytics to green checks in platform support to the tables that were previously only modified for API/Storage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
