### PR TITLE
chore(repo): Update dependencies

### DIFF
--- a/aft.yaml
+++ b/aft.yaml
@@ -10,6 +10,7 @@ dependencies:
   built_value: ">=8.4.0 <8.5.0"
   built_value_generator: 8.4.2
   code_builder: 4.3.0
+  drift: ^2.0.0
   json_annotation: ^4.6.0
   json_serializable: 6.3.1
   uuid: 3.0.6

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -32,12 +32,12 @@ dependencies:
   plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
-  amplify_analytics_pinpoint: 1.0.0-next.0
-  amplify_api: 1.0.0-next.0
-  amplify_auth_cognito: 1.0.0-next.0
-  amplify_datastore: 1.0.0-next.0
+  amplify_analytics_pinpoint:
+  amplify_api:
+  amplify_auth_cognito:
+  amplify_datastore:
   amplify_lints: ^2.0.0
-  amplify_storage_s3: 1.0.0-next.0
+  amplify_storage_s3:
   amplify_test:
     path: ../../amplify_test
   build_runner: ^2.0.0

--- a/packages/amplify_test/pubspec.yaml
+++ b/packages/amplify_test/pubspec.yaml
@@ -9,11 +9,11 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_api: 1.0.0-next.0
-  amplify_auth_cognito: 1.0.0-next.0
-  amplify_core: 1.0.0-next.0
-  amplify_flutter: 1.0.0-next.0
-  aws_common: ^0.2.0
+  amplify_api:
+  amplify_auth_cognito:
+  amplify_core:
+  amplify_flutter:
+  aws_common:
   collection: ^1.15.0
   flutter:
     sdk: flutter

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   amplify_analytics_pinpoint_dart: ">=0.1.0 <0.2.0"
   amplify_core: ">=1.0.0-next.1 <1.0.0-next.2"
   amplify_db_common: ">=0.1.1 <0.2.0"
-  amplify_secure_storage: ^0.1.0
+  amplify_secure_storage: ">=0.1.3 <0.2.0"
   aws_common: ">=0.3.1 <0.4.0"
   device_info_plus: ^6.0.0
   flutter:

--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -11,19 +11,18 @@ environment:
 dependencies:
   amplify_core: ">=1.0.0-next.1 <1.0.0-next.2"
   amplify_db_common_dart: ">=0.1.1 <0.2.0"
-  amplify_secure_storage_dart: ^0.1.0
+  amplify_secure_storage_dart: ">=0.1.3 <0.2.0"
   aws_common: ">=0.3.1 <0.4.0"
-  aws_signature_v4: ^0.1.0
+  aws_signature_v4: ">=0.3.0 <0.4.0"
   built_collection: ^5.0.0
-  built_value: ^8.4.0
-  # Constraint determined by amplify_db_common
-  drift: any
+  built_value: ">=8.4.0 <8.5.0"
+  drift: ^2.0.0
   intl: ^0.17.0
   meta: ^1.7.0
-  path: ^1.8.1
-  smithy: ^0.1.0
-  smithy_aws: ^0.1.0
-  uuid: ^3.0.0
+  path: ^1.8.0
+  smithy: ">=0.3.0 <0.4.0"
+  smithy_aws: ">=0.3.0 <0.4.0"
+  uuid: 3.0.6
 
 dev_dependencies:
   amplify_lints:

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -41,7 +41,6 @@ dev_dependencies:
   amplify_test:
     path: ../../amplify_test
   aws_signature_v4:
-    path: ../../aws_signature_v4 
   build_runner: ^2.0.0
   connectivity_plus_platform_interface: any
   flutter_test:

--- a/packages/common/amplify_db_common/example/pubspec.yaml
+++ b/packages/common/amplify_db_common/example/pubspec.yaml
@@ -8,8 +8,7 @@ environment:
 dependencies:
   amplify_db_common:
     path: ../
-  # Use version from amplify_db_common
-  drift: any
+  drift: ^2.0.0
   flutter:
     sdk: flutter
 

--- a/packages/common/amplify_db_common/pubspec.yaml
+++ b/packages/common/amplify_db_common/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   amplify_db_common_dart: ">=0.1.1 <0.2.0"
-  drift: ^2.2.0
+  drift: ^2.0.0
   flutter:
     sdk: flutter
   path: ^1.8.2

--- a/packages/common/amplify_db_common_dart/example/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/example/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 dependencies:
   amplify_db_common_dart:
     path: ../
-  drift: ^2.2.0
+  drift: ^2.0.0
   example_common:
     path: ../../../example_common
 

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   amplify_core: ">=1.0.0-next.1 <1.0.0-next.2"
   async: ^2.8.0
   aws_common: ">=0.3.1 <0.4.0"
-  drift: ^2.2.0
+  drift: ^2.0.0
   meta: ^1.7.0
   path: ^1.8.0
   sqlite3: ^1.9.0

--- a/packages/storage/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/example/pubspec.yaml
@@ -30,13 +30,13 @@ dependencies:
   go_router: ^5.0.5
 
 dev_dependencies:
-  amplify_storage_s3_dart:
-    path: ../../amplify_storage_s3_dart
   amplify_lints:
     path: ../../../amplify_lints
+  amplify_storage_s3_dart:
+    path: ../../amplify_storage_s3_dart
   amplify_test:
     path: ../../../amplify_test
-  drift: any
+  drift: ^2.0.0
   flutter_driver:
     sdk: flutter
   flutter_test:

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -21,7 +21,7 @@ platforms:
 dependencies:
   amplify_core: ">=1.0.0-next.1 <1.0.0-next.2"
   amplify_db_common: ">=0.1.1 <0.2.0"
-  amplify_storage_s3_dart: ">=0.1.1 <0.2.0"
+  amplify_storage_s3_dart: ">=0.1.0 <0.2.0"
   aws_common: ">=0.3.1 <0.4.0"
   flutter:
     sdk: flutter
@@ -32,7 +32,7 @@ dev_dependencies:
   amplify_lints: ^2.0.0
   amplify_test:
     path: ../../amplify_test
-  aws_signature_v4: ^0.2.0
+  aws_signature_v4:
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -13,15 +13,15 @@ dependencies:
   amplify_db_common_dart: ">=0.1.1 <0.2.0"
   async: ^2.8.2
   aws_common: ">=0.3.1 <0.4.0"
-  aws_signature_v4: ^0.2.0
+  aws_signature_v4: ">=0.3.0 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
-  # Constraint determined by amplify_db_common
-  drift: any
+  drift: ^2.0.0
+  fixnum: ^1.0.0
   meta: ^1.7.0
-  path: any
-  smithy: ^0.1.0
-  smithy_aws: ^0.1.0
+  path: ^1.8.0
+  smithy: ">=0.3.0 <0.4.0"
+  smithy_aws: ">=0.3.0 <0.4.0"
 
 dev_dependencies:
   amplify_lints:
@@ -30,6 +30,5 @@ dev_dependencies:
   build_verify: ^3.0.0
   built_value_generator: 8.4.2
   drift_dev: ^2.2.0+1
-  fixnum: ^1.0.1
   mocktail: ^0.3.0
   test: ^1.16.0


### PR DESCRIPTION
Updates dependencies throughout the repo. `pub` does not approve of setting version constraints to `any` as we were doing before. `aft.yaml` is leveraged to keep `drift` dependency in sync.

`dev_dependencies` versions are conflicting with `dependencies` versions on publish. New rule is don't list a version for repo packages in `dev_dependencies` since it will be handled by `pubspec_overrides` anyway.