### PR TITLE
fix(core): Configure all plugins

### DIFF
--- a/packages/amplify/amplify_flutter/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-next.1+1
+
+### Fixes
+- fix(core): Configure all plugins
+
 ## 1.0.0-next.1
 
 ### Breaking Changes

--- a/packages/amplify/amplify_flutter/lib/src/hybrid_impl.dart
+++ b/packages/amplify/amplify_flutter/lib/src/hybrid_impl.dart
@@ -37,6 +37,8 @@ class AmplifyHybridImpl extends AmplifyClassImpl {
         ...API.plugins,
         ...Auth.plugins,
         ...Analytics.plugins,
+        ...Storage.plugins,
+        ...DataStore.plugins,
       ].map(
         (p) => p.configure(
           config: amplifyConfig,

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter
 description: The top level Flutter package for the AWS Amplify libraries.
-version: 1.0.0-next.1
+version: 1.0.0-next.1+1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues


### PR DESCRIPTION
Configure all plugins in hybrid impl. That this was not done originally for all plugins was a miss due to earlier implementations of the `configure` method.