### PR TITLE
revert(auth): "fix(auth): Retain unauthenticated identities"

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -17,6 +17,7 @@ import 'dart:convert';
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart'
     hide UpdateUserAttributesRequest;
+import 'package:amplify_auth_cognito_dart/src/credentials/cognito_keys.dart';
 import 'package:amplify_auth_cognito_dart/src/credentials/device_metadata_repository.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/constants.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/device/confirm_device_worker.dart';
@@ -588,12 +589,18 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState> {
       ),
     );
 
-    // Upgrade anonymous credentials, if there were any, or fetch authenticated
+    // Clear anonymous credentials, if there were any, and fetch authenticated
     // credentials.
     if (hasIdentityPool) {
       await dispatch(
+        CredentialStoreEvent.clearCredentials(
+          CognitoIdentityPoolKeys(identityPoolConfig!),
+        ),
+      );
+
+      await dispatch(
         const FetchAuthSessionEvent.fetch(
-          CognitoSessionOptions(getAWSCredentials: true, forceRefresh: true),
+          CognitoSessionOptions(getAWSCredentials: true),
         ),
       );
 


### PR DESCRIPTION
Reverts part of f050f3b99da6d5631b35c4dbefb1feef2dfb2bc8. The reason for the initial change was a faulty assumption about unauthenticated identities and how they should be retained during a transition from signed out to signed in.

Since unauthenticated identities are vended at the start of most sessions, upgrading each unauthenticated identity to an authenticated identity would create many disparate identities. Instead, we want a singular authenticated identity to be assigned per user.
