### PR TITLE
chore(repo): Update VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
-  "dart.runPubGetOnPubspecChanges": false,
-  "files.insertFinalNewline": true
+  "dart.runPubGetOnPubspecChanges": "always",
+  "files.insertFinalNewline": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true,
+    "source.organizeImports": true,
+  }
 }


### PR DESCRIPTION
- Enables `runPubGetOnPubspecChanges`. With the use of `pubspec_overrides.yaml` instead of melos, this is now no longer an issue.
- Enables `dart fix` to run on save so that blue squiggles are fixed automatically
- Enables organizing imports on save
