### PR TITLE
feat(datastore): Temporary codegen (part 4)

### DIFF
--- a/packages/amplify_core/lib/src/types/models/mipr/model_index.dart
+++ b/packages/amplify_core/lib/src/types/models/mipr/model_index.dart
@@ -51,16 +51,20 @@ abstract class ModelIndex
 
   /// Creates a foreign key on a model, used to hold the composite key of
   /// another model. Unlike a normal [ModelIndex], a foreign key index must
-  /// specify a [field] which points to a [ModelType].
+  /// specify a [relatedModelName] and [relatedField].
   factory ModelIndex.foreignKey({
-    required String field,
+    required String relatedModelName,
+    required String relatedField,
     required List<String> keyFields,
-  }) =>
-      _$ModelIndex._(
-        name: '${field}ForeignKey',
-        primaryField: field,
-        sortKeyFields: BuiltList(keyFields),
-      );
+  }) {
+    return _$ModelIndex._(
+      // To match `amplify-codegen`:
+      // https://github.com/aws-amplify/amplify-codegen/blob/89f00a5bd74fc30ddb07263d9ac770ccf44df12d/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts#L204
+      name: 'gsi-$relatedModelName.$relatedField',
+      primaryField: keyFields.first,
+      sortKeyFields: keyFields.sublist(1).toBuiltList(),
+    );
+  }
 
   /// {@macro amplify_core.models.mipr.model_index}
   factory ModelIndex.fromJson(Map<String, Object?> json) {

--- a/packages/amplify_core/lib/src/types/models/mipr/schema.dart
+++ b/packages/amplify_core/lib/src/types/models/mipr/schema.dart
@@ -69,9 +69,10 @@ abstract class SchemaDefinition
                 break;
               case ModelAssociationType.hasMany:
               case ModelAssociationType.hasOne:
-              case ModelAssociationType.manyToMany:
                 map.add(model.name, associatedType);
                 break;
+              case ModelAssociationType.manyToMany:
+                throw UnimplementedError();
             }
           }
         }

--- a/packages/aws_common/lib/src/util/recase.dart
+++ b/packages/aws_common/lib/src/util/recase.dart
@@ -41,6 +41,10 @@ extension StringRecase on String {
   String get snakeCase =>
       groupIntoWords().map((word) => word.toLowerCase()).join('_');
 
+  /// The `SCREAMING_CASE` version of `this`.
+  String get screamingCase =>
+      groupIntoWords().map((word) => word.toUpperCase()).join('_');
+
   // "acm-success"-> "acm success"
   static final _nonAlphaNumericChars = RegExp(r'[^A-Za-z0-9+]');
 

--- a/packages/datastore/amplify_codegen/lib/src/generator/generated_library.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/generated_library.dart
@@ -16,8 +16,14 @@ import 'package:amplify_codegen/src/generator/allocator.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 
+/// Lint rules to ignore in generated files.
+const ignores = [
+  // TODO(dnys1): Remove when deprecated fields are removed.
+  'non_constant_identifier_names',
+];
+
 /// Header for generated output.
-const header = '''
+final header = '''
 // Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,6 +41,8 @@ const header = '''
 // NOTE: This file is generated and may not follow lint rules defined in your app
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: ${ignores.join(',')}
 ''';
 
 /// {@template amplify_codegen.generated_library}

--- a/packages/datastore/amplify_codegen/lib/src/generator/model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/model.dart
@@ -150,6 +150,7 @@ class ModelGenerator extends StructureGenerator<ModelTypeDefinition> {
   Library generate() {
     builder.body.addAll([
       modelTypeImpl,
+      _queryFieldsImpl,
       ...partialModelImpl,
       ...modelImpl,
       ...remoteModelImpl,
@@ -508,14 +509,76 @@ return value as T;
         ),
       );
 
+      // Add `_queryFields` for use below.
+      final queryFieldsType = refer('${modelName}QueryFields');
+      c.fields.add(
+        Field(
+          (f) => f
+            ..static = true
+            ..modifier = FieldModifier.constant
+            ..type = queryFieldsType.typeRef.rebuild(
+              (t) => t.types.addAll([modelIdentifierType, modelType]),
+            )
+            ..name = '_queryFields'
+            ..assignment = queryFieldsType.constInstance([]).code,
+        ),
+      );
+
+      void addQueryField(String fieldName, Reference fieldType) {
+        final newFormName = '\$$fieldName';
+        final oldFormName = fieldName.screamingCase;
+
+        // The new `$fieldName` form.
+        c.methods.addAll([
+          Method(
+            (m) => m
+              ..docs.add(
+                '/// Query field for the [$fieldName] field.',
+              )
+              ..returns = DartTypes.amplifyCore.queryField(
+                modelIdentifierType,
+                modelType,
+                fieldType,
+              )
+              ..type = MethodType.getter
+              ..name = newFormName
+              ..lambda = true
+              ..body = refer('_queryFields').property(newFormName).code,
+          ),
+
+          // The deprecated `FIELD_NAME` form.
+          Method(
+            (m) => m
+              ..annotations.add(
+                DartTypes.core.deprecated.newInstance([
+                  literalString('Use $newFormName instead', raw: true),
+                ]),
+              )
+              ..docs.add(
+                '/// Query field for the [$fieldName] field.',
+              )
+              ..returns = DartTypes.amplifyCore.queryField(
+                modelIdentifierType,
+                modelType,
+                fieldType,
+              )
+              ..type = MethodType.getter
+              ..name = oldFormName
+              ..lambda = true
+              ..body = refer(newFormName).code,
+          ),
+        ]);
+      }
+
       final parameters = <Parameter>[];
       for (final field in definition.fields.values) {
         final fieldType = field.type;
+        final fieldTypeRef = field.typeReference(ModelHierarchyType.model);
         c.methods.add(
           Method(
             (m) => m
               ..annotations.add(DartTypes.core.override)
-              ..returns = field.typeReference(ModelHierarchyType.model)
+              ..returns = fieldTypeRef
               ..type = MethodType.getter
               ..name = field.dartName,
           ),
@@ -530,14 +593,18 @@ return value as T;
             (p) => p
               ..named = true
               ..required = fieldType.isRequired && !isIdField
-              ..type = field
-                  .typeReference(ModelHierarchyType.model)
-                  .typeRef
+              ..type = fieldTypeRef.typeRef
                   .rebuild((t) => t.isNullable = t.isNullable! || isIdField)
               ..name = field.dartName,
           ),
         );
+        if (field.hasQueryField) {
+          addQueryField(field.dartName, fieldTypeRef);
+        }
       }
+
+      // Add a query field for the model identifier
+      addQueryField('modelIdentifier', modelIdentifierType);
 
       // The public factory constructor which redirects to the private impl.
       c.constructors.add(
@@ -725,6 +792,127 @@ return value as T;
               hierarchyType: ModelHierarchyType.remote,
             ),
         ),
+      );
+    });
+  }
+
+  /// The query fields implementation.
+  Class get _queryFieldsImpl {
+    return Class((c) {
+      final modelIdentifierTypeParameter = refer('ModelIdentifier');
+      final modelTypeParameter = refer('M');
+      c
+        ..name = '${modelName}QueryFields'
+        ..types.addAll([
+          TypeReference(
+            (t) => t
+              ..symbol = 'ModelIdentifier'
+              ..bound = DartTypes.core.object,
+          ),
+          TypeReference(
+            (t) => t
+              ..symbol = 'M'
+              ..bound = DartTypes.amplifyCore.model(
+                modelIdentifierTypeParameter,
+                modelTypeParameter,
+              ),
+          )
+        ]);
+
+      // const MODELQueryFields([this.root]);
+      c.constructors.add(
+        Constructor(
+          (c) => c
+            ..constant = true
+            ..optionalParameters.add(
+              Parameter(
+                (p) => p
+                  ..toThis = true
+                  ..name = 'root',
+              ),
+            ),
+        ),
+      );
+
+      // final QueryField<ModelIdentifier, M, MODEL>? root;
+      c.fields.add(
+        Field(
+          (f) => f
+            ..modifier = FieldModifier.final$
+            ..type = DartTypes.amplifyCore
+                .queryField(
+                  modelIdentifierTypeParameter,
+                  modelTypeParameter,
+                  modelType,
+                )
+                .nullable
+            ..name = 'root',
+        ),
+      );
+
+      void addQueryField(
+        String schemaName,
+        String dartName,
+        Reference fieldType, {
+        String? docReference,
+      }) {
+        final queryFieldType = DartTypes.amplifyCore.queryField(
+          modelIdentifierType,
+          modelType,
+          fieldType,
+        );
+        final queryField = queryFieldType.constInstance(
+          [],
+          {'fieldName': literalString(schemaName)},
+        );
+        final nestedQueryFieldType = DartTypes.amplifyCore.nestedQueryField(
+          modelIdentifierTypeParameter,
+          modelTypeParameter,
+          modelIdentifierType,
+          modelType,
+          fieldType,
+        );
+
+        final queryFieldName = '\$$dartName';
+        docReference ??= '[$modelName.$dartName]';
+        c.methods.add(
+          Method(
+            (m) => m
+              ..docs.add(
+                '/// Query field for the $docReference field.',
+              )
+              ..returns = DartTypes.amplifyCore.queryField(
+                modelIdentifierTypeParameter,
+                modelTypeParameter,
+                fieldType,
+              )
+              ..type = MethodType.getter
+              ..name = queryFieldName
+              ..lambda = true
+              ..body = nestedQueryFieldType.newInstance(
+                [queryField],
+                {
+                  // TODO(dnys1): Add nested model support
+                  // 'root': nested model fields
+                },
+              ).code,
+          ),
+        );
+      }
+
+      for (final field in definition.fields.values) {
+        final fieldType = field.typeReference();
+        if (field.hasQueryField) {
+          addQueryField(field.name, field.dartName, fieldType);
+        }
+      }
+
+      // Add an additional query field for the model helper
+      addQueryField(
+        'modelIdentifier',
+        'modelIdentifier',
+        modelIdentifierType,
+        docReference: '`modelIdentifier`',
       );
     });
   }

--- a/packages/datastore/amplify_codegen/lib/src/generator/model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/model.dart
@@ -125,7 +125,6 @@ class ModelGenerator extends StructureGenerator<ModelTypeDefinition> {
               for (final field in fields)
                 literalString(field.name): field.toJsonExp(
                   refer(field.dartName),
-                  fieldType: field.type,
                 ),
             }).code,
         ),
@@ -335,7 +334,6 @@ return _${allocate(partialModelType)}.fromJson(json) as T;
                   in definition.allFields(ModelHierarchyType.partial).values)
                 literalString(field.name): field.toJsonExp(
                   refer(field.dartName),
-                  fieldType: field.type,
                 ),
             }).code,
         ),
@@ -449,6 +447,7 @@ return value as T;
       c.constructors.add(
         Constructor(
           (ctor) => ctor
+            ..constant = true
             ..optionalParameters.addAll(parameters)
             ..initializers.add(const Code('super._()')),
         ),
@@ -701,6 +700,7 @@ return value as T;
       c.constructors.add(
         Constructor(
           (ctor) => ctor
+            ..constant = true
             ..optionalParameters.addAll(parameters)
             ..initializers.add(const Code('super._()')),
         ),

--- a/packages/datastore/amplify_codegen/lib/src/generator/model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/model.dart
@@ -515,6 +515,7 @@ return value as T;
         c.methods.add(
           Method(
             (m) => m
+              ..annotations.add(DartTypes.core.override)
               ..returns = field.typeReference(ModelHierarchyType.model)
               ..type = MethodType.getter
               ..name = field.dartName,

--- a/packages/datastore/amplify_codegen/lib/src/generator/model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/model.dart
@@ -60,7 +60,7 @@ class ModelGenerator extends StructureGenerator<ModelTypeDefinition> {
         .toList();
     assert(fields.isNotEmpty, 'Not enough fields');
     if (fields.length == 1) {
-      return fields.single.type.reference;
+      return fields.single.typeReference();
     }
     final modelIdentifierName = '${modelName}Identifier';
     final cls = Class((c) {
@@ -77,7 +77,7 @@ class ModelGenerator extends StructureGenerator<ModelTypeDefinition> {
             Field(
               (f) => f
                 ..name = field.dartName
-                ..type = field.type.reference
+                ..type = field.typeReference()
                 ..modifier = FieldModifier.final$,
             )
         ]);
@@ -123,8 +123,9 @@ class ModelGenerator extends StructureGenerator<ModelTypeDefinition> {
             ..name = 'toJson'
             ..body = literalMap({
               for (final field in fields)
-                literalString(field.name): field.type.toJsonExp(
+                literalString(field.name): field.toJsonExp(
                   refer(field.dartName),
+                  fieldType: field.type,
                 ),
             }).code,
         ),
@@ -264,7 +265,7 @@ return _${allocate(partialModelType)}.fromJson(json) as T;
         c.methods.add(
           Method(
             (m) => m
-              ..returns = field.type.reference
+              ..returns = field.typeReference(ModelHierarchyType.partial)
               ..type = MethodType.getter
               ..name = field.dartName,
           ),
@@ -332,8 +333,9 @@ return _${allocate(partialModelType)}.fromJson(json) as T;
             ..body = literalMap({
               for (final field
                   in definition.allFields(ModelHierarchyType.partial).values)
-                literalString(field.name): field.type.toJsonExp(
+                literalString(field.name): field.toJsonExp(
                   refer(field.dartName),
+                  fieldType: field.type,
                 ),
             }).code,
         ),
@@ -428,7 +430,7 @@ return value as T;
             (f) => f
               ..annotations.add(DartTypes.core.override)
               ..modifier = FieldModifier.final$
-              ..type = field.type.reference
+              ..type = field.typeReference(ModelHierarchyType.partial)
               ..name = field.dartName,
           ),
         );
@@ -466,8 +468,10 @@ return value as T;
               ),
             )
             ..body = fromJson(
-              refer(privateClassName),
-              definition.schemaFields(ModelHierarchyType.partial).values,
+              modelType: refer(privateClassName),
+              fields:
+                  definition.schemaFields(ModelHierarchyType.partial).values,
+              hierarchyType: ModelHierarchyType.partial,
             ),
         ),
       );
@@ -511,7 +515,7 @@ return value as T;
         c.methods.add(
           Method(
             (m) => m
-              ..returns = fieldType.reference
+              ..returns = field.typeReference(ModelHierarchyType.model)
               ..type = MethodType.getter
               ..name = field.dartName,
           ),
@@ -526,7 +530,9 @@ return value as T;
             (p) => p
               ..named = true
               ..required = fieldType.isRequired && !isIdField
-              ..type = fieldType.reference.typeRef
+              ..type = field
+                  .typeReference(ModelHierarchyType.model)
+                  .typeRef
                   .rebuild((t) => t.isNullable = t.isNullable! || isIdField)
               ..name = field.dartName,
           ),
@@ -567,8 +573,9 @@ return value as T;
               ),
             )
             ..body = fromJson(
-              modelType,
-              definition.schemaFields(ModelHierarchyType.model).values,
+              modelType: modelType,
+              fields: definition.schemaFields(ModelHierarchyType.model).values,
+              hierarchyType: ModelHierarchyType.model,
             ),
         ),
       );
@@ -589,7 +596,7 @@ return value as T;
             (f) => f
               ..annotations.add(DartTypes.core.override)
               ..modifier = FieldModifier.final$
-              ..type = fieldType.reference
+              ..type = field.typeReference(ModelHierarchyType.model)
               ..name = field.dartName,
           ),
         );
@@ -674,7 +681,7 @@ return value as T;
             (f) => f
               ..annotations.add(DartTypes.core.override)
               ..modifier = FieldModifier.final$
-              ..type = field.type.reference
+              ..type = field.typeReference(ModelHierarchyType.remote)
               ..name = field.dartName,
           ),
         );
@@ -712,8 +719,9 @@ return value as T;
               ),
             )
             ..body = fromJson(
-              refer(privateClassName),
-              definition.allFields(ModelHierarchyType.remote).values,
+              modelType: refer(privateClassName),
+              fields: definition.allFields(ModelHierarchyType.remote).values,
+              hierarchyType: ModelHierarchyType.remote,
             ),
         ),
       );

--- a/packages/datastore/amplify_codegen/lib/src/generator/non_model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/non_model.dart
@@ -129,7 +129,6 @@ class NonModelGenerator extends StructureGenerator<NonModelTypeDefinition> {
               for (final field in fields)
                 literalString(field.name): field.toJsonExp(
                   refer(field.dartName),
-                  fieldType: field.type,
                 ),
             }).code,
         ),

--- a/packages/datastore/amplify_codegen/lib/src/generator/non_model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/non_model.dart
@@ -53,7 +53,7 @@ class NonModelGenerator extends StructureGenerator<NonModelTypeDefinition> {
           Field(
             (f) => f
               ..name = field.dartName
-              ..type = field.type.reference
+              ..type = field.typeReference()
               ..modifier = FieldModifier.final$,
           ),
         );
@@ -90,7 +90,7 @@ class NonModelGenerator extends StructureGenerator<NonModelTypeDefinition> {
                   ..name = 'json',
               ),
             )
-            ..body = fromJson(refer(className), fields),
+            ..body = fromJson(modelType: refer(className), fields: fields),
         ),
       );
 
@@ -127,8 +127,9 @@ class NonModelGenerator extends StructureGenerator<NonModelTypeDefinition> {
             ..name = 'toJson'
             ..body = literalMap({
               for (final field in fields)
-                literalString(field.name): field.type.toJsonExp(
+                literalString(field.name): field.toJsonExp(
                   refer(field.dartName),
+                  fieldType: field.type,
                 ),
             }).code,
         ),

--- a/packages/datastore/amplify_codegen/lib/src/generator/structure.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/structure.dart
@@ -46,9 +46,10 @@ abstract class StructureGenerator<Definition extends StructureTypeDefinition>
         final json = refer('json').index(literalString(field.name));
         final decodedField = field.fromJsonExp(
           json,
-          fieldType: field.type,
           hierarchyType: hierarchyType,
           orElse: () => CodeExpression(
+            // Wrap the `throw` expression in parentheses so that it can be
+            // used in null cascade (`??`) expressions.
             Block.of([
               const Code('('),
               DartTypes.amplifyCore.modelFieldError

--- a/packages/datastore/amplify_codegen/lib/src/generator/structure.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/structure.dart
@@ -48,10 +48,19 @@ abstract class StructureGenerator<Definition extends StructureTypeDefinition>
           json,
           fieldType: field.type,
           hierarchyType: hierarchyType,
-          orElse: () => DartTypes.amplifyCore.modelFieldError.newInstance([
-            literalString(className),
-            literalString(field.dartName),
-          ]).thrown,
+          orElse: () => CodeExpression(
+            Block.of([
+              const Code('('),
+              DartTypes.amplifyCore.modelFieldError
+                  .newInstance([
+                    literalString(className),
+                    literalString(field.dartName),
+                  ])
+                  .thrown
+                  .code,
+              const Code(')'),
+            ]),
+          ),
         );
         b.addExpression(
           declareFinal(field.dartName).assign(decodedField),

--- a/packages/datastore/amplify_codegen/lib/src/generator/structure.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/structure.dart
@@ -15,7 +15,7 @@
 import 'package:amplify_codegen/src/generator/generator.dart';
 import 'package:amplify_codegen/src/generator/types.dart';
 import 'package:amplify_codegen/src/helpers/field.dart';
-import 'package:amplify_codegen/src/helpers/types.dart';
+import 'package:amplify_codegen/src/helpers/model.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:gql/ast.dart';
@@ -36,13 +36,18 @@ abstract class StructureGenerator<Definition extends StructureTypeDefinition>
   /// Generates the `fromJson` factory's body for the given [modelType] and
   /// list of [fields].
   @protected
-  Code fromJson(Reference modelType, Iterable<ModelField> fields) {
+  Code fromJson({
+    required Reference modelType,
+    required Iterable<ModelField> fields,
+    ModelHierarchyType? hierarchyType,
+  }) {
     return Block((b) {
       for (final field in fields) {
-        final fieldType = field.type;
         final json = refer('json').index(literalString(field.name));
-        final decodedField = fieldType.fromJsonExp(
+        final decodedField = field.fromJsonExp(
           json,
+          fieldType: field.type,
+          hierarchyType: hierarchyType,
           orElse: () => DartTypes.amplifyCore.modelFieldError.newInstance([
             literalString(className),
             literalString(field.dartName),

--- a/packages/datastore/amplify_codegen/lib/src/generator/types.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/types.dart
@@ -203,7 +203,7 @@ class _AmplifyCoreMipr {
 class _AwsCommon {
   const _AwsCommon();
 
-  static const _url = 'package:aws_common/aws_common.dart';
+  static const _url = 'package:amplify_core/amplify_core.dart';
 
   /// Creates an [aws_common.AWSDebuggable] reference.
   Reference get awsDebuggable => const Reference('AWSDebuggable', _url);

--- a/packages/datastore/amplify_codegen/lib/src/generator/types.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/types.dart
@@ -75,6 +75,44 @@ class _AmplifyCore {
 
   static const _url = 'package:amplify_core/amplify_core.dart';
 
+  /// Creates an [amplify_core.AsyncModel] reference.
+  TypeReference asyncModel(
+    Reference modelIdentifierType,
+    Reference modelType,
+    Reference partialModelType,
+    Reference selectedModelType,
+  ) =>
+      TypeReference(
+        (t) => t
+          ..symbol = 'AsyncModel'
+          ..url = _url
+          ..types.addAll([
+            modelIdentifierType,
+            modelType,
+            partialModelType,
+            selectedModelType,
+          ]),
+      );
+
+  /// Creates an [amplify_core.AsyncModelCollection] reference.
+  TypeReference asyncModelCollection(
+    Reference modelIdentifierType,
+    Reference modelType,
+    Reference partialModelType,
+    Reference selectedModelType,
+  ) =>
+      TypeReference(
+        (t) => t
+          ..symbol = 'AsyncModelCollection'
+          ..url = _url
+          ..types.addAll([
+            modelIdentifierType,
+            modelType,
+            partialModelType,
+            selectedModelType,
+          ]),
+      );
+
   _AmplifyCoreMipr get mipr => const _AmplifyCoreMipr();
 
   /// Creates an [amplify_core.Model] reference.

--- a/packages/datastore/amplify_codegen/lib/src/generator/types.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/types.dart
@@ -155,6 +155,27 @@ class _AmplifyCore {
           ..types.addAll([modelIdentifierType, modelType]),
       );
 
+  /// Creates an [amplify_core.NestedQueryField] reference.
+  TypeReference nestedQueryField(
+    Reference rootModelIdentifierType,
+    Reference rootModelType,
+    Reference modelIdentifierType,
+    Reference modelType,
+    Reference fieldType,
+  ) =>
+      TypeReference(
+        (t) => t
+          ..symbol = 'NestedQueryField'
+          ..url = _url
+          ..types.addAll([
+            rootModelIdentifierType,
+            rootModelType,
+            modelIdentifierType,
+            modelType,
+            fieldType,
+          ]),
+      );
+
   /// Creates an [amplify_core.QueryField] reference.
   TypeReference queryField(
     Reference modelIdentifierType,

--- a/packages/datastore/amplify_codegen/lib/src/helpers/field.dart
+++ b/packages/datastore/amplify_codegen/lib/src/helpers/field.dart
@@ -19,6 +19,7 @@ import 'package:amplify_codegen/src/helpers/model.dart';
 import 'package:amplify_codegen/src/helpers/node.dart';
 import 'package:amplify_codegen/src/helpers/types.dart';
 import 'package:amplify_core/src/types/models/mipr.dart';
+import 'package:amplify_core/src/types/query/query_field.dart';
 import 'package:aws_common/aws_common.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
@@ -326,6 +327,14 @@ extension ModelFieldHelpers on ModelField {
   /// Returns the expression needed to encode `this` to JSON.
   Expression toJsonExp(Expression fieldRef) {
     return _ToJsonVisitor(fieldRef).visit(type);
+  }
+
+  /// Whether the field has a corresponding [QueryField].
+  bool get hasQueryField {
+    final fieldType = type;
+    final baseType = fieldType is ListType ? fieldType.elementType : fieldType;
+    // TODO(dnys1): Add support for nested models.
+    return baseType is ScalarType || baseType is EnumType;
   }
 }
 

--- a/packages/datastore/amplify_codegen/lib/src/helpers/language.dart
+++ b/packages/datastore/amplify_codegen/lib/src/helpers/language.dart
@@ -96,3 +96,10 @@ const enumReservedWords = [
   'index',
   'values',
 ];
+
+/// Names which conflict with core types.
+const reservedTypeNames = [
+  'Type',
+  'Function',
+  'Object',
+];

--- a/packages/datastore/amplify_codegen/lib/src/helpers/model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/helpers/model.dart
@@ -15,10 +15,13 @@
 import 'dart:collection';
 
 import 'package:amplify_codegen/src/helpers/field.dart';
+import 'package:amplify_codegen/src/helpers/language.dart';
 import 'package:amplify_codegen/src/helpers/types.dart';
 import 'package:amplify_core/src/types/models/mipr.dart';
 import 'package:amplify_core/src/types/models/model.dart'
     show RemoteModelMetadata;
+import 'package:aws_common/aws_common.dart';
+import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
 import 'package:gql/ast.dart';
 
@@ -32,6 +35,29 @@ enum ModelHierarchyType {
 
   /// A remotely synced model.
   remote,
+}
+
+/// Returns a reference to the model type for [schemaName] at a specific point
+/// in the model hierarchy.
+Reference modelRef(
+  String schemaName, [
+  ModelHierarchyType hierarchyType = ModelHierarchyType.model,
+]) {
+  var modelName = schemaName.pascalCase;
+  if (reservedTypeNames.contains(modelName)) {
+    modelName = '$modelName\$';
+  }
+  switch (hierarchyType) {
+    case ModelHierarchyType.partial:
+      modelName = 'Partial$modelName';
+      break;
+    case ModelHierarchyType.model:
+      break;
+    case ModelHierarchyType.remote:
+      modelName = 'Remote$modelName';
+      break;
+  }
+  return refer(modelName, '${schemaName.snakeCase}.dart');
 }
 
 /// Helpers for [StructureTypeDefinition].

--- a/packages/datastore/amplify_codegen/lib/src/helpers/types.dart
+++ b/packages/datastore/amplify_codegen/lib/src/helpers/types.dart
@@ -100,7 +100,13 @@ extension ScalarTypeHelpers on ScalarType {
 /// Helpers for [EnumType].
 extension EnumTypeHelpers on EnumType {
   /// The Dart name for `this`.
-  String get dartName => name.pascalCase;
+  String get dartName {
+    final name = this.name.pascalCase;
+    if (reservedTypeNames.contains(name)) {
+      return '$name\$';
+    }
+    return name;
+  }
 
   /// The code_builder reference for `this`.
   Reference get reference {
@@ -111,7 +117,13 @@ extension EnumTypeHelpers on EnumType {
 /// Helpers for [NonModelType].
 extension NonModelTypeHelpers on NonModelType {
   /// The Dart name for `this`.
-  String get dartName => name.pascalCase;
+  String get dartName {
+    final name = this.name.pascalCase;
+    if (reservedTypeNames.contains(name)) {
+      return '$name\$';
+    }
+    return name;
+  }
 
   /// The code_builder reference for `this`.
   Reference get reference {

--- a/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
@@ -104,7 +104,7 @@ abstract class PartialEnumModel extends PartialModel<String, EnumModel>
 }
 
 class _PartialEnumModel extends PartialEnumModel {
-  _PartialEnumModel({
+  const _PartialEnumModel({
     required this.id,
     this.enum_,
     this.requiredEnum,
@@ -243,7 +243,7 @@ abstract class RemoteEnumModel extends EnumModel
 }
 
 class _RemoteEnumModel extends RemoteEnumModel {
-  _RemoteEnumModel({
+  const _RemoteEnumModel({
     required this.id,
     this.enum_,
     required this.requiredEnum,

--- a/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
@@ -16,6 +16,8 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
+// ignore_for_file: non_constant_identifier_names
+
 library models.enum_model;
 
 import 'package:amplify_core/amplify_core.dart';
@@ -39,6 +41,48 @@ class EnumModelType extends ModelType<String, EnumModel, PartialEnumModel> {
 
   @override
   String get modelName => 'EnumModel';
+}
+
+class EnumModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const EnumModelQueryFields([this.root]);
+
+  final QueryField<ModelIdentifier, M, EnumModel>? root;
+
+  /// Query field for the [EnumModel.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, EnumModel, String>(
+          const QueryField<String, EnumModel, String>(fieldName: 'id'));
+
+  /// Query field for the [EnumModel.enum_] field.
+  QueryField<ModelIdentifier, M, MyEnum?> get $enum_ =>
+      NestedQueryField<ModelIdentifier, M, String, EnumModel, MyEnum?>(
+          const QueryField<String, EnumModel, MyEnum?>(fieldName: 'enum'));
+
+  /// Query field for the [EnumModel.requiredEnum] field.
+  QueryField<ModelIdentifier, M, MyEnum> get $requiredEnum => NestedQueryField<
+          ModelIdentifier, M, String, EnumModel, MyEnum>(
+      const QueryField<String, EnumModel, MyEnum>(fieldName: 'requiredEnum'));
+
+  /// Query field for the [EnumModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, EnumModel,
+              TemporalDateTime?>(
+          const QueryField<String, EnumModel, TemporalDateTime?>(
+              fieldName: 'createdAt'));
+
+  /// Query field for the [EnumModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, EnumModel,
+              TemporalDateTime?>(
+          const QueryField<String, EnumModel, TemporalDateTime?>(
+              fieldName: 'updatedAt'));
+
+  /// Query field for the `modelIdentifier` field.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, EnumModel, String>(
+          const QueryField<String, EnumModel, String>(
+              fieldName: 'modelIdentifier'));
 }
 
 abstract class PartialEnumModel extends PartialModel<String, EnumModel>
@@ -199,16 +243,66 @@ abstract class EnumModel extends PartialEnumModel
 
   static const EnumModelType classType = EnumModelType();
 
+  static const EnumModelQueryFields<String, EnumModel> _queryFields =
+      EnumModelQueryFields();
+
   @override
   String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, EnumModel, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, EnumModel, String> get ID => $id;
   @override
   MyEnum? get enum_;
+
+  /// Query field for the [enum_] field.
+  QueryField<String, EnumModel, MyEnum?> get $enum_ => _queryFields.$enum_;
+
+  /// Query field for the [enum_] field.
+  @Deprecated(r'Use $enum_ instead')
+  QueryField<String, EnumModel, MyEnum?> get ENUM => $enum_;
   @override
   MyEnum get requiredEnum;
+
+  /// Query field for the [requiredEnum] field.
+  QueryField<String, EnumModel, MyEnum> get $requiredEnum =>
+      _queryFields.$requiredEnum;
+
+  /// Query field for the [requiredEnum] field.
+  @Deprecated(r'Use $requiredEnum instead')
+  QueryField<String, EnumModel, MyEnum> get REQUIRED_ENUM => $requiredEnum;
   @override
   TemporalDateTime? get createdAt;
+
+  /// Query field for the [createdAt] field.
+  QueryField<String, EnumModel, TemporalDateTime?> get $createdAt =>
+      _queryFields.$createdAt;
+
+  /// Query field for the [createdAt] field.
+  @Deprecated(r'Use $createdAt instead')
+  QueryField<String, EnumModel, TemporalDateTime?> get CREATED_AT => $createdAt;
   @override
   TemporalDateTime? get updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  QueryField<String, EnumModel, TemporalDateTime?> get $updatedAt =>
+      _queryFields.$updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  @Deprecated(r'Use $updatedAt instead')
+  QueryField<String, EnumModel, TemporalDateTime?> get UPDATED_AT => $updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, EnumModel, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, EnumModel, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
 }
 
 class _EnumModel extends EnumModel {

--- a/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
@@ -115,10 +115,10 @@ class _PartialEnumModel extends PartialEnumModel {
 
   factory _PartialEnumModel.fromJson(Map<String, Object?> json) {
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'EnumModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     final enum_ =
         json['enum'] == null ? null : MyEnum.fromJson((json['enum'] as String));
@@ -170,18 +170,18 @@ abstract class EnumModel extends PartialEnumModel
 
   factory EnumModel.fromJson(Map<String, Object?> json) {
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'EnumModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     final enum_ =
         json['enum'] == null ? null : MyEnum.fromJson((json['enum'] as String));
     final requiredEnum = json['requiredEnum'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'EnumModel',
             'requiredEnum',
-          )
+          ))
         : MyEnum.fromJson((json['requiredEnum'] as String));
     final createdAt = json['createdAt'] == null
         ? null
@@ -257,18 +257,18 @@ class _RemoteEnumModel extends RemoteEnumModel {
 
   factory _RemoteEnumModel.fromJson(Map<String, Object?> json) {
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'EnumModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     final enum_ =
         json['enum'] == null ? null : MyEnum.fromJson((json['enum'] as String));
     final requiredEnum = json['requiredEnum'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'EnumModel',
             'requiredEnum',
-          )
+          ))
         : MyEnum.fromJson((json['requiredEnum'] as String));
     final createdAt = json['createdAt'] == null
         ? null
@@ -277,22 +277,22 @@ class _RemoteEnumModel extends RemoteEnumModel {
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
     final version = json['version'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'EnumModel',
             'version',
-          )
+          ))
         : (json['version'] as int);
     final deleted = json['deleted'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'EnumModel',
             'deleted',
-          )
+          ))
         : (json['deleted'] as bool);
     final lastChangedAt = json['lastChangedAt'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'EnumModel',
             'lastChangedAt',
-          )
+          ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
     return _RemoteEnumModel(
       id: id,

--- a/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
@@ -200,10 +200,15 @@ abstract class EnumModel extends PartialEnumModel
 
   static const EnumModelType classType = EnumModelType();
 
+  @override
   String get id;
+  @override
   MyEnum? get enum_;
+  @override
   MyEnum get requiredEnum;
+  @override
   TemporalDateTime? get createdAt;
+  @override
   TemporalDateTime? get updatedAt;
 }
 

--- a/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
@@ -19,7 +19,6 @@
 library models.enum_model;
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:aws_common/aws_common.dart';
 
 import 'my_enum.dart';
 

--- a/packages/datastore/amplify_codegen/test/goldens/enums/my_enum.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/my_enum.dart
@@ -18,7 +18,7 @@
 
 library models.my_enum;
 
-import 'package:aws_common/aws_common.dart';
+import 'package:amplify_core/amplify_core.dart';
 
 enum MyEnum with AWSSerializable<String> {
   valueA('value_a'),

--- a/packages/datastore/amplify_codegen/test/goldens/enums/my_enum.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/my_enum.dart
@@ -16,6 +16,8 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
+// ignore_for_file: non_constant_identifier_names
+
 library models.my_enum;
 
 import 'package:amplify_core/amplify_core.dart';

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
@@ -16,6 +16,8 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
+// ignore_for_file: non_constant_identifier_names
+
 library models.my_model;
 
 import 'package:amplify_core/amplify_core.dart';
@@ -39,6 +41,36 @@ class MyModelType extends ModelType<String, MyModel, PartialMyModel> {
 
   @override
   String get modelName => 'MyModel';
+}
+
+class MyModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const MyModelQueryFields([this.root]);
+
+  final QueryField<ModelIdentifier, M, MyModel>? root;
+
+  /// Query field for the [MyModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, MyModel, TemporalDateTime?>(
+          const QueryField<String, MyModel, TemporalDateTime?>(
+              fieldName: 'createdAt'));
+
+  /// Query field for the [MyModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, MyModel, TemporalDateTime?>(
+          const QueryField<String, MyModel, TemporalDateTime?>(
+              fieldName: 'updatedAt'));
+
+  /// Query field for the [MyModel.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, MyModel, String>(
+          const QueryField<String, MyModel, String>(fieldName: 'id'));
+
+  /// Query field for the `modelIdentifier` field.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, MyModel, String>(
+          const QueryField<String, MyModel, String>(
+              fieldName: 'modelIdentifier'));
 }
 
 abstract class PartialMyModel extends PartialModel<String, MyModel>
@@ -205,16 +237,50 @@ abstract class MyModel extends PartialMyModel
 
   static const MyModelType classType = MyModelType();
 
+  static const MyModelQueryFields<String, MyModel> _queryFields =
+      MyModelQueryFields();
+
   @override
   ScalarNonModel? get embeddedNonModel;
   @override
   ScalarNonModel get requiredEmbeddedNonModel;
   @override
   TemporalDateTime? get createdAt;
+
+  /// Query field for the [createdAt] field.
+  QueryField<String, MyModel, TemporalDateTime?> get $createdAt =>
+      _queryFields.$createdAt;
+
+  /// Query field for the [createdAt] field.
+  @Deprecated(r'Use $createdAt instead')
+  QueryField<String, MyModel, TemporalDateTime?> get CREATED_AT => $createdAt;
   @override
   TemporalDateTime? get updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  QueryField<String, MyModel, TemporalDateTime?> get $updatedAt =>
+      _queryFields.$updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  @Deprecated(r'Use $updatedAt instead')
+  QueryField<String, MyModel, TemporalDateTime?> get UPDATED_AT => $updatedAt;
   @override
   String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, MyModel, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, MyModel, String> get ID => $id;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, MyModel, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, MyModel, String> get MODEL_IDENTIFIER => $modelIdentifier;
 }
 
 class _MyModel extends MyModel {

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
@@ -19,7 +19,6 @@
 library models.my_model;
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:aws_common/aws_common.dart';
 
 import 'scalar_non_model.dart';
 

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
@@ -104,7 +104,7 @@ abstract class PartialMyModel extends PartialModel<String, MyModel>
 }
 
 class _PartialMyModel extends PartialMyModel {
-  _PartialMyModel({
+  const _PartialMyModel({
     this.embeddedNonModel,
     this.requiredEmbeddedNonModel,
     this.createdAt,
@@ -249,7 +249,7 @@ abstract class RemoteMyModel extends MyModel
 }
 
 class _RemoteMyModel extends RemoteMyModel {
-  _RemoteMyModel({
+  const _RemoteMyModel({
     this.embeddedNonModel,
     required this.requiredEmbeddedNonModel,
     this.createdAt,

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
@@ -129,10 +129,10 @@ class _PartialMyModel extends PartialMyModel {
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     return _PartialMyModel(
       embeddedNonModel: embeddedNonModel,
@@ -177,10 +177,10 @@ abstract class MyModel extends PartialMyModel
         : ScalarNonModel.fromJson(
             (json['embeddedNonModel'] as Map<String, Object?>));
     final requiredEmbeddedNonModel = json['requiredEmbeddedNonModel'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'requiredEmbeddedNonModel',
-          )
+          ))
         : ScalarNonModel.fromJson(
             (json['requiredEmbeddedNonModel'] as Map<String, Object?>));
     final createdAt = json['createdAt'] == null
@@ -190,10 +190,10 @@ abstract class MyModel extends PartialMyModel
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     return MyModel(
       embeddedNonModel: embeddedNonModel,
@@ -267,10 +267,10 @@ class _RemoteMyModel extends RemoteMyModel {
         : ScalarNonModel.fromJson(
             (json['embeddedNonModel'] as Map<String, Object?>));
     final requiredEmbeddedNonModel = json['requiredEmbeddedNonModel'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'requiredEmbeddedNonModel',
-          )
+          ))
         : ScalarNonModel.fromJson(
             (json['requiredEmbeddedNonModel'] as Map<String, Object?>));
     final createdAt = json['createdAt'] == null
@@ -280,28 +280,28 @@ class _RemoteMyModel extends RemoteMyModel {
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     final version = json['version'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'version',
-          )
+          ))
         : (json['version'] as int);
     final deleted = json['deleted'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'deleted',
-          )
+          ))
         : (json['deleted'] as bool);
     final lastChangedAt = json['lastChangedAt'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'lastChangedAt',
-          )
+          ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
     return _RemoteMyModel(
       embeddedNonModel: embeddedNonModel,

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
@@ -206,10 +206,15 @@ abstract class MyModel extends PartialMyModel
 
   static const MyModelType classType = MyModelType();
 
+  @override
   ScalarNonModel? get embeddedNonModel;
+  @override
   ScalarNonModel get requiredEmbeddedNonModel;
+  @override
   TemporalDateTime? get createdAt;
+  @override
   TemporalDateTime? get updatedAt;
+  @override
   String get id;
 }
 

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
@@ -426,7 +426,7 @@ abstract class PartialScalarListNonModel
 }
 
 class _PartialScalarListNonModel extends PartialScalarListNonModel {
-  _PartialScalarListNonModel({
+  const _PartialScalarListNonModel({
     required this.id,
     this.listOfString,
     this.listOfRequiredString,
@@ -2138,7 +2138,7 @@ abstract class RemoteScalarListNonModel extends ScalarListNonModel
 }
 
 class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
-  _RemoteScalarListNonModel({
+  const _RemoteScalarListNonModel({
     required this.id,
     this.listOfString,
     this.listOfRequiredString,

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
@@ -16,6 +16,8 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
+// ignore_for_file: non_constant_identifier_names
+
 library models.scalar_list_non_model;
 
 import 'package:amplify_core/amplify_core.dart';
@@ -39,6 +41,426 @@ class ScalarListNonModelType
 
   @override
   String get modelName => 'ScalarListNonModel';
+}
+
+class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ScalarListNonModelQueryFields([this.root]);
+
+  final QueryField<ModelIdentifier, M, ScalarListNonModel>? root;
+
+  /// Query field for the [ScalarListNonModel.id] field.
+  QueryField<ModelIdentifier, M, String> get $id => NestedQueryField<
+          ModelIdentifier, M, String, ScalarListNonModel, String>(
+      const QueryField<String, ScalarListNonModel, String>(fieldName: 'id'));
+
+  /// Query field for the [ScalarListNonModel.listOfString] field.
+  QueryField<ModelIdentifier, M, List<String?>?> get $listOfString =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<String?>?>(
+          const QueryField<String, ScalarListNonModel, List<String?>?>(
+              fieldName: 'listOfString'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredString] field.
+  QueryField<ModelIdentifier, M, List<String>?> get $listOfRequiredString =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<String>?>(
+          const QueryField<String, ScalarListNonModel, List<String>?>(
+              fieldName: 'listOfRequiredString'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfString] field.
+  QueryField<ModelIdentifier, M, List<String?>> get $requiredListOfString =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<String?>>(
+          const QueryField<String, ScalarListNonModel, List<String?>>(
+              fieldName: 'requiredListOfString'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredString] field.
+  QueryField<ModelIdentifier, M, List<String>>
+      get $requiredListOfRequiredString => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListNonModel, List<String>>(
+          const QueryField<String, ScalarListNonModel, List<String>>(
+              fieldName: 'requiredListOfRequiredString'));
+
+  /// Query field for the [ScalarListNonModel.listOfInteger] field.
+  QueryField<ModelIdentifier, M, List<int?>?> get $listOfInteger =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<int?>?>(
+          const QueryField<String, ScalarListNonModel, List<int?>?>(
+              fieldName: 'listOfInteger'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredInteger] field.
+  QueryField<ModelIdentifier, M, List<int>?> get $listOfRequiredInteger =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<int>?>(
+          const QueryField<String, ScalarListNonModel, List<int>?>(
+              fieldName: 'listOfRequiredInteger'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfInteger] field.
+  QueryField<ModelIdentifier, M, List<int?>> get $requiredListOfInteger =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<int?>>(
+          const QueryField<String, ScalarListNonModel, List<int?>>(
+              fieldName: 'requiredListOfInteger'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredInteger] field.
+  QueryField<ModelIdentifier, M, List<int>>
+      get $requiredListOfRequiredInteger => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListNonModel, List<int>>(
+          const QueryField<String, ScalarListNonModel, List<int>>(
+              fieldName: 'requiredListOfRequiredInteger'));
+
+  /// Query field for the [ScalarListNonModel.listOfFloat] field.
+  QueryField<ModelIdentifier, M, List<double?>?> get $listOfFloat =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<double?>?>(
+          const QueryField<String, ScalarListNonModel, List<double?>?>(
+              fieldName: 'listOfFloat'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredFloat] field.
+  QueryField<ModelIdentifier, M, List<double>?> get $listOfRequiredFloat =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<double>?>(
+          const QueryField<String, ScalarListNonModel, List<double>?>(
+              fieldName: 'listOfRequiredFloat'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfFloat] field.
+  QueryField<ModelIdentifier, M, List<double?>> get $requiredListOfFloat =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<double?>>(
+          const QueryField<String, ScalarListNonModel, List<double?>>(
+              fieldName: 'requiredListOfFloat'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredFloat] field.
+  QueryField<ModelIdentifier, M, List<double>>
+      get $requiredListOfRequiredFloat => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListNonModel, List<double>>(
+          const QueryField<String, ScalarListNonModel, List<double>>(
+              fieldName: 'requiredListOfRequiredFloat'));
+
+  /// Query field for the [ScalarListNonModel.listOfBoolean] field.
+  QueryField<ModelIdentifier, M, List<bool?>?> get $listOfBoolean =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<bool?>?>(
+          const QueryField<String, ScalarListNonModel, List<bool?>?>(
+              fieldName: 'listOfBoolean'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredBoolean] field.
+  QueryField<ModelIdentifier, M, List<bool>?> get $listOfRequiredBoolean =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<bool>?>(
+          const QueryField<String, ScalarListNonModel, List<bool>?>(
+              fieldName: 'listOfRequiredBoolean'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfBoolean] field.
+  QueryField<ModelIdentifier, M, List<bool?>> get $requiredListOfBoolean =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<bool?>>(
+          const QueryField<String, ScalarListNonModel, List<bool?>>(
+              fieldName: 'requiredListOfBoolean'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredBoolean] field.
+  QueryField<ModelIdentifier, M, List<bool>>
+      get $requiredListOfRequiredBoolean => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListNonModel, List<bool>>(
+          const QueryField<String, ScalarListNonModel, List<bool>>(
+              fieldName: 'requiredListOfRequiredBoolean'));
+
+  /// Query field for the [ScalarListNonModel.listOfAwsDate] field.
+  QueryField<ModelIdentifier, M, List<TemporalDate?>?> get $listOfAwsDate =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<TemporalDate?>?>(
+          const QueryField<String, ScalarListNonModel, List<TemporalDate?>?>(
+              fieldName: 'listOfAWSDate'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredAwsDate] field.
+  QueryField<ModelIdentifier, M, List<TemporalDate>?>
+      get $listOfRequiredAwsDate => NestedQueryField<ModelIdentifier, M, String,
+              ScalarListNonModel, List<TemporalDate>?>(
+          const QueryField<String, ScalarListNonModel, List<TemporalDate>?>(
+              fieldName: 'listOfRequiredAWSDate'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfAwsDate] field.
+  QueryField<ModelIdentifier, M, List<TemporalDate?>>
+      get $requiredListOfAwsDate => NestedQueryField<ModelIdentifier, M, String,
+              ScalarListNonModel, List<TemporalDate?>>(
+          const QueryField<String, ScalarListNonModel, List<TemporalDate?>>(
+              fieldName: 'requiredListOfAWSDate'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredAwsDate] field.
+  QueryField<ModelIdentifier, M, List<TemporalDate>>
+      get $requiredListOfRequiredAwsDate => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListNonModel, List<TemporalDate>>(
+          const QueryField<String, ScalarListNonModel, List<TemporalDate>>(
+              fieldName: 'requiredListOfRequiredAWSDate'));
+
+  /// Query field for the [ScalarListNonModel.listOfAwsDateTime] field.
+  QueryField<ModelIdentifier, M,
+      List<TemporalDateTime?>?> get $listOfAwsDateTime => NestedQueryField<
+          ModelIdentifier,
+          M,
+          String,
+          ScalarListNonModel,
+          List<TemporalDateTime?>?>(
+      const QueryField<String, ScalarListNonModel, List<TemporalDateTime?>?>(
+          fieldName: 'listOfAWSDateTime'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredAwsDateTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalDateTime>?>
+      get $listOfRequiredAwsDateTime => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListNonModel, List<TemporalDateTime>?>(
+          const QueryField<String, ScalarListNonModel, List<TemporalDateTime>?>(
+              fieldName: 'listOfRequiredAWSDateTime'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfAwsDateTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalDateTime?>>
+      get $requiredListOfAwsDateTime => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListNonModel, List<TemporalDateTime?>>(
+          const QueryField<String, ScalarListNonModel, List<TemporalDateTime?>>(
+              fieldName: 'requiredListOfAWSDateTime'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredAwsDateTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalDateTime>>
+      get $requiredListOfRequiredAwsDateTime => NestedQueryField<
+              ModelIdentifier,
+              M,
+              String,
+              ScalarListNonModel,
+              List<TemporalDateTime>>(
+          const QueryField<String, ScalarListNonModel, List<TemporalDateTime>>(
+              fieldName: 'requiredListOfRequiredAWSDateTime'));
+
+  /// Query field for the [ScalarListNonModel.listOfAwsTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalTime?>?> get $listOfAwsTime =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<TemporalTime?>?>(
+          const QueryField<String, ScalarListNonModel, List<TemporalTime?>?>(
+              fieldName: 'listOfAWSTime'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredAwsTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalTime>?>
+      get $listOfRequiredAwsTime => NestedQueryField<ModelIdentifier, M, String,
+              ScalarListNonModel, List<TemporalTime>?>(
+          const QueryField<String, ScalarListNonModel, List<TemporalTime>?>(
+              fieldName: 'listOfRequiredAWSTime'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfAwsTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalTime?>>
+      get $requiredListOfAwsTime => NestedQueryField<ModelIdentifier, M, String,
+              ScalarListNonModel, List<TemporalTime?>>(
+          const QueryField<String, ScalarListNonModel, List<TemporalTime?>>(
+              fieldName: 'requiredListOfAWSTime'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredAwsTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalTime>>
+      get $requiredListOfRequiredAwsTime => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListNonModel, List<TemporalTime>>(
+          const QueryField<String, ScalarListNonModel, List<TemporalTime>>(
+              fieldName: 'requiredListOfRequiredAWSTime'));
+
+  /// Query field for the [ScalarListNonModel.listOfAwsTimestamp] field.
+  QueryField<ModelIdentifier, M,
+      List<TemporalTimestamp?>?> get $listOfAwsTimestamp => NestedQueryField<
+          ModelIdentifier,
+          M,
+          String,
+          ScalarListNonModel,
+          List<TemporalTimestamp?>?>(
+      const QueryField<String, ScalarListNonModel, List<TemporalTimestamp?>?>(
+          fieldName: 'listOfAWSTimestamp'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredAwsTimestamp] field.
+  QueryField<ModelIdentifier, M, List<TemporalTimestamp>?>
+      get $listOfRequiredAwsTimestamp => NestedQueryField<
+          ModelIdentifier,
+          M,
+          String,
+          ScalarListNonModel,
+          List<TemporalTimestamp>?>(const QueryField<String,
+              ScalarListNonModel, List<TemporalTimestamp>?>(
+          fieldName: 'listOfRequiredAWSTimestamp'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfAwsTimestamp] field.
+  QueryField<ModelIdentifier, M, List<TemporalTimestamp?>>
+      get $requiredListOfAwsTimestamp => NestedQueryField<
+          ModelIdentifier,
+          M,
+          String,
+          ScalarListNonModel,
+          List<TemporalTimestamp?>>(const QueryField<String,
+              ScalarListNonModel, List<TemporalTimestamp?>>(
+          fieldName: 'requiredListOfAWSTimestamp'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredAwsTimestamp] field.
+  QueryField<ModelIdentifier, M, List<TemporalTimestamp>>
+      get $requiredListOfRequiredAwsTimestamp => NestedQueryField<
+              ModelIdentifier,
+              M,
+              String,
+              ScalarListNonModel,
+              List<TemporalTimestamp>>(
+          const QueryField<String, ScalarListNonModel, List<TemporalTimestamp>>(
+              fieldName: 'requiredListOfRequiredAWSTimestamp'));
+
+  /// Query field for the [ScalarListNonModel.listOfAwsEmail] field.
+  QueryField<ModelIdentifier, M, List<String?>?> get $listOfAwsEmail =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<String?>?>(
+          const QueryField<String, ScalarListNonModel, List<String?>?>(
+              fieldName: 'listOfAWSEmail'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredAwsEmail] field.
+  QueryField<ModelIdentifier, M, List<String>?> get $listOfRequiredAwsEmail =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<String>?>(
+          const QueryField<String, ScalarListNonModel, List<String>?>(
+              fieldName: 'listOfRequiredAWSEmail'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfAwsEmail] field.
+  QueryField<ModelIdentifier, M, List<String?>> get $requiredListOfAwsEmail =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<String?>>(
+          const QueryField<String, ScalarListNonModel, List<String?>>(
+              fieldName: 'requiredListOfAWSEmail'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredAwsEmail] field.
+  QueryField<ModelIdentifier, M, List<String>>
+      get $requiredListOfRequiredAwsEmail => NestedQueryField<ModelIdentifier,
+              M, String, ScalarListNonModel, List<String>>(
+          const QueryField<String, ScalarListNonModel, List<String>>(
+              fieldName: 'requiredListOfRequiredAWSEmail'));
+
+  /// Query field for the [ScalarListNonModel.listOfAwsjson] field.
+  QueryField<ModelIdentifier, M, List<Object?>?> get $listOfAwsjson =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<Object?>?>(
+          const QueryField<String, ScalarListNonModel, List<Object?>?>(
+              fieldName: 'listOfAWSJSON'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredAwsjson] field.
+  QueryField<ModelIdentifier, M, List<Object>?> get $listOfRequiredAwsjson =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<Object>?>(
+          const QueryField<String, ScalarListNonModel, List<Object>?>(
+              fieldName: 'listOfRequiredAWSJSON'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfAwsjson] field.
+  QueryField<ModelIdentifier, M, List<Object?>> get $requiredListOfAwsjson =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<Object?>>(
+          const QueryField<String, ScalarListNonModel, List<Object?>>(
+              fieldName: 'requiredListOfAWSJSON'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredAwsjson] field.
+  QueryField<ModelIdentifier, M, List<Object>>
+      get $requiredListOfRequiredAwsjson => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListNonModel, List<Object>>(
+          const QueryField<String, ScalarListNonModel, List<Object>>(
+              fieldName: 'requiredListOfRequiredAWSJSON'));
+
+  /// Query field for the [ScalarListNonModel.listOfAwsPhone] field.
+  QueryField<ModelIdentifier, M, List<String?>?> get $listOfAwsPhone =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<String?>?>(
+          const QueryField<String, ScalarListNonModel, List<String?>?>(
+              fieldName: 'listOfAWSPhone'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredAwsPhone] field.
+  QueryField<ModelIdentifier, M, List<String>?> get $listOfRequiredAwsPhone =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<String>?>(
+          const QueryField<String, ScalarListNonModel, List<String>?>(
+              fieldName: 'listOfRequiredAWSPhone'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfAwsPhone] field.
+  QueryField<ModelIdentifier, M, List<String?>> get $requiredListOfAwsPhone =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<String?>>(
+          const QueryField<String, ScalarListNonModel, List<String?>>(
+              fieldName: 'requiredListOfAWSPhone'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredAwsPhone] field.
+  QueryField<ModelIdentifier, M, List<String>>
+      get $requiredListOfRequiredAwsPhone => NestedQueryField<ModelIdentifier,
+              M, String, ScalarListNonModel, List<String>>(
+          const QueryField<String, ScalarListNonModel, List<String>>(
+              fieldName: 'requiredListOfRequiredAWSPhone'));
+
+  /// Query field for the [ScalarListNonModel.listOfAwsUrl] field.
+  QueryField<ModelIdentifier, M, List<Uri?>?>
+      get $listOfAwsUrl => NestedQueryField<ModelIdentifier, M, String,
+              ScalarListNonModel, List<Uri?>?>(
+          const QueryField<String, ScalarListNonModel, List<Uri?>?>(
+              fieldName: 'listOfAWSUrl'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredAwsUrl] field.
+  QueryField<ModelIdentifier, M, List<Uri>?> get $listOfRequiredAwsUrl =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<Uri>?>(
+          const QueryField<String, ScalarListNonModel, List<Uri>?>(
+              fieldName: 'listOfRequiredAWSUrl'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfAwsUrl] field.
+  QueryField<ModelIdentifier, M, List<Uri?>> get $requiredListOfAwsUrl =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<Uri?>>(
+          const QueryField<String, ScalarListNonModel, List<Uri?>>(
+              fieldName: 'requiredListOfAWSUrl'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredAwsUrl] field.
+  QueryField<ModelIdentifier, M, List<Uri>> get $requiredListOfRequiredAwsUrl =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<Uri>>(
+          const QueryField<String, ScalarListNonModel, List<Uri>>(
+              fieldName: 'requiredListOfRequiredAWSUrl'));
+
+  /// Query field for the [ScalarListNonModel.listOfAwsIpAddress] field.
+  QueryField<ModelIdentifier, M, List<String?>?> get $listOfAwsIpAddress =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              List<String?>?>(
+          const QueryField<String, ScalarListNonModel, List<String?>?>(
+              fieldName: 'listOfAWSIpAddress'));
+
+  /// Query field for the [ScalarListNonModel.listOfRequiredAwsIpAddress] field.
+  QueryField<ModelIdentifier, M, List<String>?>
+      get $listOfRequiredAwsIpAddress => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListNonModel, List<String>?>(
+          const QueryField<String, ScalarListNonModel, List<String>?>(
+              fieldName: 'listOfRequiredAWSIpAddress'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfAwsIpAddress] field.
+  QueryField<ModelIdentifier, M, List<String?>>
+      get $requiredListOfAwsIpAddress => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListNonModel, List<String?>>(
+          const QueryField<String, ScalarListNonModel, List<String?>>(
+              fieldName: 'requiredListOfAWSIpAddress'));
+
+  /// Query field for the [ScalarListNonModel.requiredListOfRequiredAwsIpAddress] field.
+  QueryField<ModelIdentifier, M, List<String>>
+      get $requiredListOfRequiredAwsIpAddress => NestedQueryField<
+              ModelIdentifier, M, String, ScalarListNonModel, List<String>>(
+          const QueryField<String, ScalarListNonModel, List<String>>(
+              fieldName: 'requiredListOfRequiredAWSIpAddress'));
+
+  /// Query field for the [ScalarListNonModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              TemporalDateTime?>(
+          const QueryField<String, ScalarListNonModel, TemporalDateTime?>(
+              fieldName: 'createdAt'));
+
+  /// Query field for the [ScalarListNonModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
+              TemporalDateTime?>(
+          const QueryField<String, ScalarListNonModel, TemporalDateTime?>(
+              fieldName: 'updatedAt'));
+
+  /// Query field for the `modelIdentifier` field.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String>(
+          const QueryField<String, ScalarListNonModel, String>(
+              fieldName: 'modelIdentifier'));
 }
 
 abstract class PartialScalarListNonModel
@@ -1794,116 +2216,643 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
 
   static const ScalarListNonModelType classType = ScalarListNonModelType();
 
+  static const ScalarListNonModelQueryFields<String, ScalarListNonModel>
+      _queryFields = ScalarListNonModelQueryFields();
+
   @override
   String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, ScalarListNonModel, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, ScalarListNonModel, String> get ID => $id;
   @override
   List<String?>? get listOfString;
+
+  /// Query field for the [listOfString] field.
+  QueryField<String, ScalarListNonModel, List<String?>?> get $listOfString =>
+      _queryFields.$listOfString;
+
+  /// Query field for the [listOfString] field.
+  @Deprecated(r'Use $listOfString instead')
+  QueryField<String, ScalarListNonModel, List<String?>?> get LIST_OF_STRING =>
+      $listOfString;
   @override
   List<String>? get listOfRequiredString;
+
+  /// Query field for the [listOfRequiredString] field.
+  QueryField<String, ScalarListNonModel, List<String>?>
+      get $listOfRequiredString => _queryFields.$listOfRequiredString;
+
+  /// Query field for the [listOfRequiredString] field.
+  @Deprecated(r'Use $listOfRequiredString instead')
+  QueryField<String, ScalarListNonModel, List<String>?>
+      get LIST_OF_REQUIRED_STRING => $listOfRequiredString;
   @override
   List<String?> get requiredListOfString;
+
+  /// Query field for the [requiredListOfString] field.
+  QueryField<String, ScalarListNonModel, List<String?>>
+      get $requiredListOfString => _queryFields.$requiredListOfString;
+
+  /// Query field for the [requiredListOfString] field.
+  @Deprecated(r'Use $requiredListOfString instead')
+  QueryField<String, ScalarListNonModel, List<String?>>
+      get REQUIRED_LIST_OF_STRING => $requiredListOfString;
   @override
   List<String> get requiredListOfRequiredString;
+
+  /// Query field for the [requiredListOfRequiredString] field.
+  QueryField<String, ScalarListNonModel, List<String>>
+      get $requiredListOfRequiredString =>
+          _queryFields.$requiredListOfRequiredString;
+
+  /// Query field for the [requiredListOfRequiredString] field.
+  @Deprecated(r'Use $requiredListOfRequiredString instead')
+  QueryField<String, ScalarListNonModel, List<String>>
+      get REQUIRED_LIST_OF_REQUIRED_STRING => $requiredListOfRequiredString;
   @override
   List<int?>? get listOfInteger;
+
+  /// Query field for the [listOfInteger] field.
+  QueryField<String, ScalarListNonModel, List<int?>?> get $listOfInteger =>
+      _queryFields.$listOfInteger;
+
+  /// Query field for the [listOfInteger] field.
+  @Deprecated(r'Use $listOfInteger instead')
+  QueryField<String, ScalarListNonModel, List<int?>?> get LIST_OF_INTEGER =>
+      $listOfInteger;
   @override
   List<int>? get listOfRequiredInteger;
+
+  /// Query field for the [listOfRequiredInteger] field.
+  QueryField<String, ScalarListNonModel, List<int>?>
+      get $listOfRequiredInteger => _queryFields.$listOfRequiredInteger;
+
+  /// Query field for the [listOfRequiredInteger] field.
+  @Deprecated(r'Use $listOfRequiredInteger instead')
+  QueryField<String, ScalarListNonModel, List<int>?>
+      get LIST_OF_REQUIRED_INTEGER => $listOfRequiredInteger;
   @override
   List<int?> get requiredListOfInteger;
+
+  /// Query field for the [requiredListOfInteger] field.
+  QueryField<String, ScalarListNonModel, List<int?>>
+      get $requiredListOfInteger => _queryFields.$requiredListOfInteger;
+
+  /// Query field for the [requiredListOfInteger] field.
+  @Deprecated(r'Use $requiredListOfInteger instead')
+  QueryField<String, ScalarListNonModel, List<int?>>
+      get REQUIRED_LIST_OF_INTEGER => $requiredListOfInteger;
   @override
   List<int> get requiredListOfRequiredInteger;
+
+  /// Query field for the [requiredListOfRequiredInteger] field.
+  QueryField<String, ScalarListNonModel, List<int>>
+      get $requiredListOfRequiredInteger =>
+          _queryFields.$requiredListOfRequiredInteger;
+
+  /// Query field for the [requiredListOfRequiredInteger] field.
+  @Deprecated(r'Use $requiredListOfRequiredInteger instead')
+  QueryField<String, ScalarListNonModel, List<int>>
+      get REQUIRED_LIST_OF_REQUIRED_INTEGER => $requiredListOfRequiredInteger;
   @override
   List<double?>? get listOfFloat;
+
+  /// Query field for the [listOfFloat] field.
+  QueryField<String, ScalarListNonModel, List<double?>?> get $listOfFloat =>
+      _queryFields.$listOfFloat;
+
+  /// Query field for the [listOfFloat] field.
+  @Deprecated(r'Use $listOfFloat instead')
+  QueryField<String, ScalarListNonModel, List<double?>?> get LIST_OF_FLOAT =>
+      $listOfFloat;
   @override
   List<double>? get listOfRequiredFloat;
+
+  /// Query field for the [listOfRequiredFloat] field.
+  QueryField<String, ScalarListNonModel, List<double>?>
+      get $listOfRequiredFloat => _queryFields.$listOfRequiredFloat;
+
+  /// Query field for the [listOfRequiredFloat] field.
+  @Deprecated(r'Use $listOfRequiredFloat instead')
+  QueryField<String, ScalarListNonModel, List<double>?>
+      get LIST_OF_REQUIRED_FLOAT => $listOfRequiredFloat;
   @override
   List<double?> get requiredListOfFloat;
+
+  /// Query field for the [requiredListOfFloat] field.
+  QueryField<String, ScalarListNonModel, List<double?>>
+      get $requiredListOfFloat => _queryFields.$requiredListOfFloat;
+
+  /// Query field for the [requiredListOfFloat] field.
+  @Deprecated(r'Use $requiredListOfFloat instead')
+  QueryField<String, ScalarListNonModel, List<double?>>
+      get REQUIRED_LIST_OF_FLOAT => $requiredListOfFloat;
   @override
   List<double> get requiredListOfRequiredFloat;
+
+  /// Query field for the [requiredListOfRequiredFloat] field.
+  QueryField<String, ScalarListNonModel, List<double>>
+      get $requiredListOfRequiredFloat =>
+          _queryFields.$requiredListOfRequiredFloat;
+
+  /// Query field for the [requiredListOfRequiredFloat] field.
+  @Deprecated(r'Use $requiredListOfRequiredFloat instead')
+  QueryField<String, ScalarListNonModel, List<double>>
+      get REQUIRED_LIST_OF_REQUIRED_FLOAT => $requiredListOfRequiredFloat;
   @override
   List<bool?>? get listOfBoolean;
+
+  /// Query field for the [listOfBoolean] field.
+  QueryField<String, ScalarListNonModel, List<bool?>?> get $listOfBoolean =>
+      _queryFields.$listOfBoolean;
+
+  /// Query field for the [listOfBoolean] field.
+  @Deprecated(r'Use $listOfBoolean instead')
+  QueryField<String, ScalarListNonModel, List<bool?>?> get LIST_OF_BOOLEAN =>
+      $listOfBoolean;
   @override
   List<bool>? get listOfRequiredBoolean;
+
+  /// Query field for the [listOfRequiredBoolean] field.
+  QueryField<String, ScalarListNonModel, List<bool>?>
+      get $listOfRequiredBoolean => _queryFields.$listOfRequiredBoolean;
+
+  /// Query field for the [listOfRequiredBoolean] field.
+  @Deprecated(r'Use $listOfRequiredBoolean instead')
+  QueryField<String, ScalarListNonModel, List<bool>?>
+      get LIST_OF_REQUIRED_BOOLEAN => $listOfRequiredBoolean;
   @override
   List<bool?> get requiredListOfBoolean;
+
+  /// Query field for the [requiredListOfBoolean] field.
+  QueryField<String, ScalarListNonModel, List<bool?>>
+      get $requiredListOfBoolean => _queryFields.$requiredListOfBoolean;
+
+  /// Query field for the [requiredListOfBoolean] field.
+  @Deprecated(r'Use $requiredListOfBoolean instead')
+  QueryField<String, ScalarListNonModel, List<bool?>>
+      get REQUIRED_LIST_OF_BOOLEAN => $requiredListOfBoolean;
   @override
   List<bool> get requiredListOfRequiredBoolean;
+
+  /// Query field for the [requiredListOfRequiredBoolean] field.
+  QueryField<String, ScalarListNonModel, List<bool>>
+      get $requiredListOfRequiredBoolean =>
+          _queryFields.$requiredListOfRequiredBoolean;
+
+  /// Query field for the [requiredListOfRequiredBoolean] field.
+  @Deprecated(r'Use $requiredListOfRequiredBoolean instead')
+  QueryField<String, ScalarListNonModel, List<bool>>
+      get REQUIRED_LIST_OF_REQUIRED_BOOLEAN => $requiredListOfRequiredBoolean;
   @override
   List<TemporalDate?>? get listOfAwsDate;
+
+  /// Query field for the [listOfAwsDate] field.
+  QueryField<String, ScalarListNonModel, List<TemporalDate?>?>
+      get $listOfAwsDate => _queryFields.$listOfAwsDate;
+
+  /// Query field for the [listOfAwsDate] field.
+  @Deprecated(r'Use $listOfAwsDate instead')
+  QueryField<String, ScalarListNonModel, List<TemporalDate?>?>
+      get LIST_OF_AWS_DATE => $listOfAwsDate;
   @override
   List<TemporalDate>? get listOfRequiredAwsDate;
+
+  /// Query field for the [listOfRequiredAwsDate] field.
+  QueryField<String, ScalarListNonModel, List<TemporalDate>?>
+      get $listOfRequiredAwsDate => _queryFields.$listOfRequiredAwsDate;
+
+  /// Query field for the [listOfRequiredAwsDate] field.
+  @Deprecated(r'Use $listOfRequiredAwsDate instead')
+  QueryField<String, ScalarListNonModel, List<TemporalDate>?>
+      get LIST_OF_REQUIRED_AWS_DATE => $listOfRequiredAwsDate;
   @override
   List<TemporalDate?> get requiredListOfAwsDate;
+
+  /// Query field for the [requiredListOfAwsDate] field.
+  QueryField<String, ScalarListNonModel, List<TemporalDate?>>
+      get $requiredListOfAwsDate => _queryFields.$requiredListOfAwsDate;
+
+  /// Query field for the [requiredListOfAwsDate] field.
+  @Deprecated(r'Use $requiredListOfAwsDate instead')
+  QueryField<String, ScalarListNonModel, List<TemporalDate?>>
+      get REQUIRED_LIST_OF_AWS_DATE => $requiredListOfAwsDate;
   @override
   List<TemporalDate> get requiredListOfRequiredAwsDate;
+
+  /// Query field for the [requiredListOfRequiredAwsDate] field.
+  QueryField<String, ScalarListNonModel, List<TemporalDate>>
+      get $requiredListOfRequiredAwsDate =>
+          _queryFields.$requiredListOfRequiredAwsDate;
+
+  /// Query field for the [requiredListOfRequiredAwsDate] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsDate instead')
+  QueryField<String, ScalarListNonModel, List<TemporalDate>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_DATE => $requiredListOfRequiredAwsDate;
   @override
   List<TemporalDateTime?>? get listOfAwsDateTime;
+
+  /// Query field for the [listOfAwsDateTime] field.
+  QueryField<String, ScalarListNonModel, List<TemporalDateTime?>?>
+      get $listOfAwsDateTime => _queryFields.$listOfAwsDateTime;
+
+  /// Query field for the [listOfAwsDateTime] field.
+  @Deprecated(r'Use $listOfAwsDateTime instead')
+  QueryField<String, ScalarListNonModel, List<TemporalDateTime?>?>
+      get LIST_OF_AWS_DATE_TIME => $listOfAwsDateTime;
   @override
   List<TemporalDateTime>? get listOfRequiredAwsDateTime;
+
+  /// Query field for the [listOfRequiredAwsDateTime] field.
+  QueryField<String, ScalarListNonModel, List<TemporalDateTime>?>
+      get $listOfRequiredAwsDateTime => _queryFields.$listOfRequiredAwsDateTime;
+
+  /// Query field for the [listOfRequiredAwsDateTime] field.
+  @Deprecated(r'Use $listOfRequiredAwsDateTime instead')
+  QueryField<String, ScalarListNonModel, List<TemporalDateTime>?>
+      get LIST_OF_REQUIRED_AWS_DATE_TIME => $listOfRequiredAwsDateTime;
   @override
   List<TemporalDateTime?> get requiredListOfAwsDateTime;
+
+  /// Query field for the [requiredListOfAwsDateTime] field.
+  QueryField<String, ScalarListNonModel, List<TemporalDateTime?>>
+      get $requiredListOfAwsDateTime => _queryFields.$requiredListOfAwsDateTime;
+
+  /// Query field for the [requiredListOfAwsDateTime] field.
+  @Deprecated(r'Use $requiredListOfAwsDateTime instead')
+  QueryField<String, ScalarListNonModel, List<TemporalDateTime?>>
+      get REQUIRED_LIST_OF_AWS_DATE_TIME => $requiredListOfAwsDateTime;
   @override
   List<TemporalDateTime> get requiredListOfRequiredAwsDateTime;
+
+  /// Query field for the [requiredListOfRequiredAwsDateTime] field.
+  QueryField<String, ScalarListNonModel, List<TemporalDateTime>>
+      get $requiredListOfRequiredAwsDateTime =>
+          _queryFields.$requiredListOfRequiredAwsDateTime;
+
+  /// Query field for the [requiredListOfRequiredAwsDateTime] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsDateTime instead')
+  QueryField<String, ScalarListNonModel, List<TemporalDateTime>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_DATE_TIME =>
+          $requiredListOfRequiredAwsDateTime;
   @override
   List<TemporalTime?>? get listOfAwsTime;
+
+  /// Query field for the [listOfAwsTime] field.
+  QueryField<String, ScalarListNonModel, List<TemporalTime?>?>
+      get $listOfAwsTime => _queryFields.$listOfAwsTime;
+
+  /// Query field for the [listOfAwsTime] field.
+  @Deprecated(r'Use $listOfAwsTime instead')
+  QueryField<String, ScalarListNonModel, List<TemporalTime?>?>
+      get LIST_OF_AWS_TIME => $listOfAwsTime;
   @override
   List<TemporalTime>? get listOfRequiredAwsTime;
+
+  /// Query field for the [listOfRequiredAwsTime] field.
+  QueryField<String, ScalarListNonModel, List<TemporalTime>?>
+      get $listOfRequiredAwsTime => _queryFields.$listOfRequiredAwsTime;
+
+  /// Query field for the [listOfRequiredAwsTime] field.
+  @Deprecated(r'Use $listOfRequiredAwsTime instead')
+  QueryField<String, ScalarListNonModel, List<TemporalTime>?>
+      get LIST_OF_REQUIRED_AWS_TIME => $listOfRequiredAwsTime;
   @override
   List<TemporalTime?> get requiredListOfAwsTime;
+
+  /// Query field for the [requiredListOfAwsTime] field.
+  QueryField<String, ScalarListNonModel, List<TemporalTime?>>
+      get $requiredListOfAwsTime => _queryFields.$requiredListOfAwsTime;
+
+  /// Query field for the [requiredListOfAwsTime] field.
+  @Deprecated(r'Use $requiredListOfAwsTime instead')
+  QueryField<String, ScalarListNonModel, List<TemporalTime?>>
+      get REQUIRED_LIST_OF_AWS_TIME => $requiredListOfAwsTime;
   @override
   List<TemporalTime> get requiredListOfRequiredAwsTime;
+
+  /// Query field for the [requiredListOfRequiredAwsTime] field.
+  QueryField<String, ScalarListNonModel, List<TemporalTime>>
+      get $requiredListOfRequiredAwsTime =>
+          _queryFields.$requiredListOfRequiredAwsTime;
+
+  /// Query field for the [requiredListOfRequiredAwsTime] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsTime instead')
+  QueryField<String, ScalarListNonModel, List<TemporalTime>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_TIME => $requiredListOfRequiredAwsTime;
   @override
   List<TemporalTimestamp?>? get listOfAwsTimestamp;
+
+  /// Query field for the [listOfAwsTimestamp] field.
+  QueryField<String, ScalarListNonModel, List<TemporalTimestamp?>?>
+      get $listOfAwsTimestamp => _queryFields.$listOfAwsTimestamp;
+
+  /// Query field for the [listOfAwsTimestamp] field.
+  @Deprecated(r'Use $listOfAwsTimestamp instead')
+  QueryField<String, ScalarListNonModel, List<TemporalTimestamp?>?>
+      get LIST_OF_AWS_TIMESTAMP => $listOfAwsTimestamp;
   @override
   List<TemporalTimestamp>? get listOfRequiredAwsTimestamp;
+
+  /// Query field for the [listOfRequiredAwsTimestamp] field.
+  QueryField<String, ScalarListNonModel, List<TemporalTimestamp>?>
+      get $listOfRequiredAwsTimestamp =>
+          _queryFields.$listOfRequiredAwsTimestamp;
+
+  /// Query field for the [listOfRequiredAwsTimestamp] field.
+  @Deprecated(r'Use $listOfRequiredAwsTimestamp instead')
+  QueryField<String, ScalarListNonModel, List<TemporalTimestamp>?>
+      get LIST_OF_REQUIRED_AWS_TIMESTAMP => $listOfRequiredAwsTimestamp;
   @override
   List<TemporalTimestamp?> get requiredListOfAwsTimestamp;
+
+  /// Query field for the [requiredListOfAwsTimestamp] field.
+  QueryField<String, ScalarListNonModel, List<TemporalTimestamp?>>
+      get $requiredListOfAwsTimestamp =>
+          _queryFields.$requiredListOfAwsTimestamp;
+
+  /// Query field for the [requiredListOfAwsTimestamp] field.
+  @Deprecated(r'Use $requiredListOfAwsTimestamp instead')
+  QueryField<String, ScalarListNonModel, List<TemporalTimestamp?>>
+      get REQUIRED_LIST_OF_AWS_TIMESTAMP => $requiredListOfAwsTimestamp;
   @override
   List<TemporalTimestamp> get requiredListOfRequiredAwsTimestamp;
+
+  /// Query field for the [requiredListOfRequiredAwsTimestamp] field.
+  QueryField<String, ScalarListNonModel, List<TemporalTimestamp>>
+      get $requiredListOfRequiredAwsTimestamp =>
+          _queryFields.$requiredListOfRequiredAwsTimestamp;
+
+  /// Query field for the [requiredListOfRequiredAwsTimestamp] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsTimestamp instead')
+  QueryField<String, ScalarListNonModel, List<TemporalTimestamp>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_TIMESTAMP =>
+          $requiredListOfRequiredAwsTimestamp;
   @override
   List<String?>? get listOfAwsEmail;
+
+  /// Query field for the [listOfAwsEmail] field.
+  QueryField<String, ScalarListNonModel, List<String?>?> get $listOfAwsEmail =>
+      _queryFields.$listOfAwsEmail;
+
+  /// Query field for the [listOfAwsEmail] field.
+  @Deprecated(r'Use $listOfAwsEmail instead')
+  QueryField<String, ScalarListNonModel, List<String?>?>
+      get LIST_OF_AWS_EMAIL => $listOfAwsEmail;
   @override
   List<String>? get listOfRequiredAwsEmail;
+
+  /// Query field for the [listOfRequiredAwsEmail] field.
+  QueryField<String, ScalarListNonModel, List<String>?>
+      get $listOfRequiredAwsEmail => _queryFields.$listOfRequiredAwsEmail;
+
+  /// Query field for the [listOfRequiredAwsEmail] field.
+  @Deprecated(r'Use $listOfRequiredAwsEmail instead')
+  QueryField<String, ScalarListNonModel, List<String>?>
+      get LIST_OF_REQUIRED_AWS_EMAIL => $listOfRequiredAwsEmail;
   @override
   List<String?> get requiredListOfAwsEmail;
+
+  /// Query field for the [requiredListOfAwsEmail] field.
+  QueryField<String, ScalarListNonModel, List<String?>>
+      get $requiredListOfAwsEmail => _queryFields.$requiredListOfAwsEmail;
+
+  /// Query field for the [requiredListOfAwsEmail] field.
+  @Deprecated(r'Use $requiredListOfAwsEmail instead')
+  QueryField<String, ScalarListNonModel, List<String?>>
+      get REQUIRED_LIST_OF_AWS_EMAIL => $requiredListOfAwsEmail;
   @override
   List<String> get requiredListOfRequiredAwsEmail;
+
+  /// Query field for the [requiredListOfRequiredAwsEmail] field.
+  QueryField<String, ScalarListNonModel, List<String>>
+      get $requiredListOfRequiredAwsEmail =>
+          _queryFields.$requiredListOfRequiredAwsEmail;
+
+  /// Query field for the [requiredListOfRequiredAwsEmail] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsEmail instead')
+  QueryField<String, ScalarListNonModel, List<String>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_EMAIL =>
+          $requiredListOfRequiredAwsEmail;
   @override
   List<Object?>? get listOfAwsjson;
+
+  /// Query field for the [listOfAwsjson] field.
+  QueryField<String, ScalarListNonModel, List<Object?>?> get $listOfAwsjson =>
+      _queryFields.$listOfAwsjson;
+
+  /// Query field for the [listOfAwsjson] field.
+  @Deprecated(r'Use $listOfAwsjson instead')
+  QueryField<String, ScalarListNonModel, List<Object?>?> get LIST_OF_AWSJSON =>
+      $listOfAwsjson;
   @override
   List<Object>? get listOfRequiredAwsjson;
+
+  /// Query field for the [listOfRequiredAwsjson] field.
+  QueryField<String, ScalarListNonModel, List<Object>?>
+      get $listOfRequiredAwsjson => _queryFields.$listOfRequiredAwsjson;
+
+  /// Query field for the [listOfRequiredAwsjson] field.
+  @Deprecated(r'Use $listOfRequiredAwsjson instead')
+  QueryField<String, ScalarListNonModel, List<Object>?>
+      get LIST_OF_REQUIRED_AWSJSON => $listOfRequiredAwsjson;
   @override
   List<Object?> get requiredListOfAwsjson;
+
+  /// Query field for the [requiredListOfAwsjson] field.
+  QueryField<String, ScalarListNonModel, List<Object?>>
+      get $requiredListOfAwsjson => _queryFields.$requiredListOfAwsjson;
+
+  /// Query field for the [requiredListOfAwsjson] field.
+  @Deprecated(r'Use $requiredListOfAwsjson instead')
+  QueryField<String, ScalarListNonModel, List<Object?>>
+      get REQUIRED_LIST_OF_AWSJSON => $requiredListOfAwsjson;
   @override
   List<Object> get requiredListOfRequiredAwsjson;
+
+  /// Query field for the [requiredListOfRequiredAwsjson] field.
+  QueryField<String, ScalarListNonModel, List<Object>>
+      get $requiredListOfRequiredAwsjson =>
+          _queryFields.$requiredListOfRequiredAwsjson;
+
+  /// Query field for the [requiredListOfRequiredAwsjson] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsjson instead')
+  QueryField<String, ScalarListNonModel, List<Object>>
+      get REQUIRED_LIST_OF_REQUIRED_AWSJSON => $requiredListOfRequiredAwsjson;
   @override
   List<String?>? get listOfAwsPhone;
+
+  /// Query field for the [listOfAwsPhone] field.
+  QueryField<String, ScalarListNonModel, List<String?>?> get $listOfAwsPhone =>
+      _queryFields.$listOfAwsPhone;
+
+  /// Query field for the [listOfAwsPhone] field.
+  @Deprecated(r'Use $listOfAwsPhone instead')
+  QueryField<String, ScalarListNonModel, List<String?>?>
+      get LIST_OF_AWS_PHONE => $listOfAwsPhone;
   @override
   List<String>? get listOfRequiredAwsPhone;
+
+  /// Query field for the [listOfRequiredAwsPhone] field.
+  QueryField<String, ScalarListNonModel, List<String>?>
+      get $listOfRequiredAwsPhone => _queryFields.$listOfRequiredAwsPhone;
+
+  /// Query field for the [listOfRequiredAwsPhone] field.
+  @Deprecated(r'Use $listOfRequiredAwsPhone instead')
+  QueryField<String, ScalarListNonModel, List<String>?>
+      get LIST_OF_REQUIRED_AWS_PHONE => $listOfRequiredAwsPhone;
   @override
   List<String?> get requiredListOfAwsPhone;
+
+  /// Query field for the [requiredListOfAwsPhone] field.
+  QueryField<String, ScalarListNonModel, List<String?>>
+      get $requiredListOfAwsPhone => _queryFields.$requiredListOfAwsPhone;
+
+  /// Query field for the [requiredListOfAwsPhone] field.
+  @Deprecated(r'Use $requiredListOfAwsPhone instead')
+  QueryField<String, ScalarListNonModel, List<String?>>
+      get REQUIRED_LIST_OF_AWS_PHONE => $requiredListOfAwsPhone;
   @override
   List<String> get requiredListOfRequiredAwsPhone;
+
+  /// Query field for the [requiredListOfRequiredAwsPhone] field.
+  QueryField<String, ScalarListNonModel, List<String>>
+      get $requiredListOfRequiredAwsPhone =>
+          _queryFields.$requiredListOfRequiredAwsPhone;
+
+  /// Query field for the [requiredListOfRequiredAwsPhone] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsPhone instead')
+  QueryField<String, ScalarListNonModel, List<String>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_PHONE =>
+          $requiredListOfRequiredAwsPhone;
   @override
   List<Uri?>? get listOfAwsUrl;
+
+  /// Query field for the [listOfAwsUrl] field.
+  QueryField<String, ScalarListNonModel, List<Uri?>?> get $listOfAwsUrl =>
+      _queryFields.$listOfAwsUrl;
+
+  /// Query field for the [listOfAwsUrl] field.
+  @Deprecated(r'Use $listOfAwsUrl instead')
+  QueryField<String, ScalarListNonModel, List<Uri?>?> get LIST_OF_AWS_URL =>
+      $listOfAwsUrl;
   @override
   List<Uri>? get listOfRequiredAwsUrl;
+
+  /// Query field for the [listOfRequiredAwsUrl] field.
+  QueryField<String, ScalarListNonModel, List<Uri>?>
+      get $listOfRequiredAwsUrl => _queryFields.$listOfRequiredAwsUrl;
+
+  /// Query field for the [listOfRequiredAwsUrl] field.
+  @Deprecated(r'Use $listOfRequiredAwsUrl instead')
+  QueryField<String, ScalarListNonModel, List<Uri>?>
+      get LIST_OF_REQUIRED_AWS_URL => $listOfRequiredAwsUrl;
   @override
   List<Uri?> get requiredListOfAwsUrl;
+
+  /// Query field for the [requiredListOfAwsUrl] field.
+  QueryField<String, ScalarListNonModel, List<Uri?>>
+      get $requiredListOfAwsUrl => _queryFields.$requiredListOfAwsUrl;
+
+  /// Query field for the [requiredListOfAwsUrl] field.
+  @Deprecated(r'Use $requiredListOfAwsUrl instead')
+  QueryField<String, ScalarListNonModel, List<Uri?>>
+      get REQUIRED_LIST_OF_AWS_URL => $requiredListOfAwsUrl;
   @override
   List<Uri> get requiredListOfRequiredAwsUrl;
+
+  /// Query field for the [requiredListOfRequiredAwsUrl] field.
+  QueryField<String, ScalarListNonModel, List<Uri>>
+      get $requiredListOfRequiredAwsUrl =>
+          _queryFields.$requiredListOfRequiredAwsUrl;
+
+  /// Query field for the [requiredListOfRequiredAwsUrl] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsUrl instead')
+  QueryField<String, ScalarListNonModel, List<Uri>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_URL => $requiredListOfRequiredAwsUrl;
   @override
   List<String?>? get listOfAwsIpAddress;
+
+  /// Query field for the [listOfAwsIpAddress] field.
+  QueryField<String, ScalarListNonModel, List<String?>?>
+      get $listOfAwsIpAddress => _queryFields.$listOfAwsIpAddress;
+
+  /// Query field for the [listOfAwsIpAddress] field.
+  @Deprecated(r'Use $listOfAwsIpAddress instead')
+  QueryField<String, ScalarListNonModel, List<String?>?>
+      get LIST_OF_AWS_IP_ADDRESS => $listOfAwsIpAddress;
   @override
   List<String>? get listOfRequiredAwsIpAddress;
+
+  /// Query field for the [listOfRequiredAwsIpAddress] field.
+  QueryField<String, ScalarListNonModel, List<String>?>
+      get $listOfRequiredAwsIpAddress =>
+          _queryFields.$listOfRequiredAwsIpAddress;
+
+  /// Query field for the [listOfRequiredAwsIpAddress] field.
+  @Deprecated(r'Use $listOfRequiredAwsIpAddress instead')
+  QueryField<String, ScalarListNonModel, List<String>?>
+      get LIST_OF_REQUIRED_AWS_IP_ADDRESS => $listOfRequiredAwsIpAddress;
   @override
   List<String?> get requiredListOfAwsIpAddress;
+
+  /// Query field for the [requiredListOfAwsIpAddress] field.
+  QueryField<String, ScalarListNonModel, List<String?>>
+      get $requiredListOfAwsIpAddress =>
+          _queryFields.$requiredListOfAwsIpAddress;
+
+  /// Query field for the [requiredListOfAwsIpAddress] field.
+  @Deprecated(r'Use $requiredListOfAwsIpAddress instead')
+  QueryField<String, ScalarListNonModel, List<String?>>
+      get REQUIRED_LIST_OF_AWS_IP_ADDRESS => $requiredListOfAwsIpAddress;
   @override
   List<String> get requiredListOfRequiredAwsIpAddress;
+
+  /// Query field for the [requiredListOfRequiredAwsIpAddress] field.
+  QueryField<String, ScalarListNonModel, List<String>>
+      get $requiredListOfRequiredAwsIpAddress =>
+          _queryFields.$requiredListOfRequiredAwsIpAddress;
+
+  /// Query field for the [requiredListOfRequiredAwsIpAddress] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsIpAddress instead')
+  QueryField<String, ScalarListNonModel, List<String>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_IP_ADDRESS =>
+          $requiredListOfRequiredAwsIpAddress;
   @override
   TemporalDateTime? get createdAt;
+
+  /// Query field for the [createdAt] field.
+  QueryField<String, ScalarListNonModel, TemporalDateTime?> get $createdAt =>
+      _queryFields.$createdAt;
+
+  /// Query field for the [createdAt] field.
+  @Deprecated(r'Use $createdAt instead')
+  QueryField<String, ScalarListNonModel, TemporalDateTime?> get CREATED_AT =>
+      $createdAt;
   @override
   TemporalDateTime? get updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  QueryField<String, ScalarListNonModel, TemporalDateTime?> get $updatedAt =>
+      _queryFields.$updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  @Deprecated(r'Use $updatedAt instead')
+  QueryField<String, ScalarListNonModel, TemporalDateTime?> get UPDATED_AT =>
+      $updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, ScalarListNonModel, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, ScalarListNonModel, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
 }
 
 class _ScalarListNonModel extends ScalarListNonModel {

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
@@ -1,0 +1,2975 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+library models.scalar_list_non_model;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class ScalarListNonModelType
+    extends ModelType<String, ScalarListNonModel, PartialScalarListNonModel> {
+  const ScalarListNonModelType();
+
+  @override
+  T fromJson<T extends PartialModel<String, ScalarListNonModel>>(
+      Map<String, Object?> json) {
+    if (T == ScalarListNonModel || T == Model<String, ScalarListNonModel>) {
+      return ScalarListNonModel.fromJson(json) as T;
+    }
+    if (T == RemoteScalarListNonModel ||
+        T == RemoteModel<String, ScalarListNonModel>) {
+      return _RemoteScalarListNonModel.fromJson(json) as T;
+    }
+    return _PartialScalarListNonModel.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'ScalarListNonModel';
+}
+
+abstract class PartialScalarListNonModel
+    extends PartialModel<String, ScalarListNonModel>
+    with AWSEquatable<PartialScalarListNonModel> {
+  const PartialScalarListNonModel._();
+
+  String get id;
+  List<String?>? get listOfString;
+  List<String>? get listOfRequiredString;
+  List<String?>? get requiredListOfString;
+  List<String>? get requiredListOfRequiredString;
+  List<int?>? get listOfInteger;
+  List<int>? get listOfRequiredInteger;
+  List<int?>? get requiredListOfInteger;
+  List<int>? get requiredListOfRequiredInteger;
+  List<double?>? get listOfFloat;
+  List<double>? get listOfRequiredFloat;
+  List<double?>? get requiredListOfFloat;
+  List<double>? get requiredListOfRequiredFloat;
+  List<bool?>? get listOfBoolean;
+  List<bool>? get listOfRequiredBoolean;
+  List<bool?>? get requiredListOfBoolean;
+  List<bool>? get requiredListOfRequiredBoolean;
+  List<TemporalDate?>? get listOfAwsDate;
+  List<TemporalDate>? get listOfRequiredAwsDate;
+  List<TemporalDate?>? get requiredListOfAwsDate;
+  List<TemporalDate>? get requiredListOfRequiredAwsDate;
+  List<TemporalDateTime?>? get listOfAwsDateTime;
+  List<TemporalDateTime>? get listOfRequiredAwsDateTime;
+  List<TemporalDateTime?>? get requiredListOfAwsDateTime;
+  List<TemporalDateTime>? get requiredListOfRequiredAwsDateTime;
+  List<TemporalTime?>? get listOfAwsTime;
+  List<TemporalTime>? get listOfRequiredAwsTime;
+  List<TemporalTime?>? get requiredListOfAwsTime;
+  List<TemporalTime>? get requiredListOfRequiredAwsTime;
+  List<TemporalTimestamp?>? get listOfAwsTimestamp;
+  List<TemporalTimestamp>? get listOfRequiredAwsTimestamp;
+  List<TemporalTimestamp?>? get requiredListOfAwsTimestamp;
+  List<TemporalTimestamp>? get requiredListOfRequiredAwsTimestamp;
+  List<String?>? get listOfAwsEmail;
+  List<String>? get listOfRequiredAwsEmail;
+  List<String?>? get requiredListOfAwsEmail;
+  List<String>? get requiredListOfRequiredAwsEmail;
+  List<Object?>? get listOfAwsjson;
+  List<Object>? get listOfRequiredAwsjson;
+  List<Object?>? get requiredListOfAwsjson;
+  List<Object>? get requiredListOfRequiredAwsjson;
+  List<String?>? get listOfAwsPhone;
+  List<String>? get listOfRequiredAwsPhone;
+  List<String?>? get requiredListOfAwsPhone;
+  List<String>? get requiredListOfRequiredAwsPhone;
+  List<Uri?>? get listOfAwsUrl;
+  List<Uri>? get listOfRequiredAwsUrl;
+  List<Uri?>? get requiredListOfAwsUrl;
+  List<Uri>? get requiredListOfRequiredAwsUrl;
+  List<String?>? get listOfAwsIpAddress;
+  List<String>? get listOfRequiredAwsIpAddress;
+  List<String?>? get requiredListOfAwsIpAddress;
+  List<String>? get requiredListOfRequiredAwsIpAddress;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  ScalarListNonModelType get modelType => ScalarListNonModel.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        listOfString,
+        listOfRequiredString,
+        requiredListOfString,
+        requiredListOfRequiredString,
+        listOfInteger,
+        listOfRequiredInteger,
+        requiredListOfInteger,
+        requiredListOfRequiredInteger,
+        listOfFloat,
+        listOfRequiredFloat,
+        requiredListOfFloat,
+        requiredListOfRequiredFloat,
+        listOfBoolean,
+        listOfRequiredBoolean,
+        requiredListOfBoolean,
+        requiredListOfRequiredBoolean,
+        listOfAwsDate,
+        listOfRequiredAwsDate,
+        requiredListOfAwsDate,
+        requiredListOfRequiredAwsDate,
+        listOfAwsDateTime,
+        listOfRequiredAwsDateTime,
+        requiredListOfAwsDateTime,
+        requiredListOfRequiredAwsDateTime,
+        listOfAwsTime,
+        listOfRequiredAwsTime,
+        requiredListOfAwsTime,
+        requiredListOfRequiredAwsTime,
+        listOfAwsTimestamp,
+        listOfRequiredAwsTimestamp,
+        requiredListOfAwsTimestamp,
+        requiredListOfRequiredAwsTimestamp,
+        listOfAwsEmail,
+        listOfRequiredAwsEmail,
+        requiredListOfAwsEmail,
+        requiredListOfRequiredAwsEmail,
+        listOfAwsjson,
+        listOfRequiredAwsjson,
+        requiredListOfAwsjson,
+        requiredListOfRequiredAwsjson,
+        listOfAwsPhone,
+        listOfRequiredAwsPhone,
+        requiredListOfAwsPhone,
+        requiredListOfRequiredAwsPhone,
+        listOfAwsUrl,
+        listOfRequiredAwsUrl,
+        requiredListOfAwsUrl,
+        requiredListOfRequiredAwsUrl,
+        listOfAwsIpAddress,
+        listOfRequiredAwsIpAddress,
+        requiredListOfAwsIpAddress,
+        requiredListOfRequiredAwsIpAddress,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'listOfString': listOfString,
+        'listOfRequiredString': listOfRequiredString,
+        'requiredListOfString': requiredListOfString,
+        'requiredListOfRequiredString': requiredListOfRequiredString,
+        'listOfInteger': listOfInteger,
+        'listOfRequiredInteger': listOfRequiredInteger,
+        'requiredListOfInteger': requiredListOfInteger,
+        'requiredListOfRequiredInteger': requiredListOfRequiredInteger,
+        'listOfFloat': listOfFloat,
+        'listOfRequiredFloat': listOfRequiredFloat,
+        'requiredListOfFloat': requiredListOfFloat,
+        'requiredListOfRequiredFloat': requiredListOfRequiredFloat,
+        'listOfBoolean': listOfBoolean,
+        'listOfRequiredBoolean': listOfRequiredBoolean,
+        'requiredListOfBoolean': requiredListOfBoolean,
+        'requiredListOfRequiredBoolean': requiredListOfRequiredBoolean,
+        'listOfAWSDate': listOfAwsDate?.map((el) => el?.format()).toList(),
+        'listOfRequiredAWSDate':
+            listOfRequiredAwsDate?.map((el) => el.format()).toList(),
+        'requiredListOfAWSDate':
+            requiredListOfAwsDate?.map((el) => el?.format()).toList(),
+        'requiredListOfRequiredAWSDate':
+            requiredListOfRequiredAwsDate?.map((el) => el.format()).toList(),
+        'listOfAWSDateTime':
+            listOfAwsDateTime?.map((el) => el?.format()).toList(),
+        'listOfRequiredAWSDateTime':
+            listOfRequiredAwsDateTime?.map((el) => el.format()).toList(),
+        'requiredListOfAWSDateTime':
+            requiredListOfAwsDateTime?.map((el) => el?.format()).toList(),
+        'requiredListOfRequiredAWSDateTime': requiredListOfRequiredAwsDateTime
+            ?.map((el) => el.format())
+            .toList(),
+        'listOfAWSTime': listOfAwsTime?.map((el) => el?.format()).toList(),
+        'listOfRequiredAWSTime':
+            listOfRequiredAwsTime?.map((el) => el.format()).toList(),
+        'requiredListOfAWSTime':
+            requiredListOfAwsTime?.map((el) => el?.format()).toList(),
+        'requiredListOfRequiredAWSTime':
+            requiredListOfRequiredAwsTime?.map((el) => el.format()).toList(),
+        'listOfAWSTimestamp':
+            listOfAwsTimestamp?.map((el) => el?.toSeconds()).toList(),
+        'listOfRequiredAWSTimestamp':
+            listOfRequiredAwsTimestamp?.map((el) => el.toSeconds()).toList(),
+        'requiredListOfAWSTimestamp':
+            requiredListOfAwsTimestamp?.map((el) => el?.toSeconds()).toList(),
+        'requiredListOfRequiredAWSTimestamp': requiredListOfRequiredAwsTimestamp
+            ?.map((el) => el.toSeconds())
+            .toList(),
+        'listOfAWSEmail': listOfAwsEmail,
+        'listOfRequiredAWSEmail': listOfRequiredAwsEmail,
+        'requiredListOfAWSEmail': requiredListOfAwsEmail,
+        'requiredListOfRequiredAWSEmail': requiredListOfRequiredAwsEmail,
+        'listOfAWSJSON': listOfAwsjson,
+        'listOfRequiredAWSJSON': listOfRequiredAwsjson,
+        'requiredListOfAWSJSON': requiredListOfAwsjson,
+        'requiredListOfRequiredAWSJSON': requiredListOfRequiredAwsjson,
+        'listOfAWSPhone': listOfAwsPhone,
+        'listOfRequiredAWSPhone': listOfRequiredAwsPhone,
+        'requiredListOfAWSPhone': requiredListOfAwsPhone,
+        'requiredListOfRequiredAWSPhone': requiredListOfRequiredAwsPhone,
+        'listOfAWSUrl': listOfAwsUrl?.map((el) => el?.toString()).toList(),
+        'listOfRequiredAWSUrl':
+            listOfRequiredAwsUrl?.map((el) => el.toString()).toList(),
+        'requiredListOfAWSUrl':
+            requiredListOfAwsUrl?.map((el) => el?.toString()).toList(),
+        'requiredListOfRequiredAWSUrl':
+            requiredListOfRequiredAwsUrl?.map((el) => el.toString()).toList(),
+        'listOfAWSIpAddress': listOfAwsIpAddress,
+        'listOfRequiredAWSIpAddress': listOfRequiredAwsIpAddress,
+        'requiredListOfAWSIpAddress': requiredListOfAwsIpAddress,
+        'requiredListOfRequiredAWSIpAddress':
+            requiredListOfRequiredAwsIpAddress,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'ScalarListNonModel';
+  @override
+  T valueFor<T extends Object?>(
+      QueryField<String, ScalarListNonModel, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'listOfString':
+        value = listOfString;
+        break;
+      case r'listOfRequiredString':
+        value = listOfRequiredString;
+        break;
+      case r'requiredListOfString':
+        value = requiredListOfString;
+        break;
+      case r'requiredListOfRequiredString':
+        value = requiredListOfRequiredString;
+        break;
+      case r'listOfInteger':
+        value = listOfInteger;
+        break;
+      case r'listOfRequiredInteger':
+        value = listOfRequiredInteger;
+        break;
+      case r'requiredListOfInteger':
+        value = requiredListOfInteger;
+        break;
+      case r'requiredListOfRequiredInteger':
+        value = requiredListOfRequiredInteger;
+        break;
+      case r'listOfFloat':
+        value = listOfFloat;
+        break;
+      case r'listOfRequiredFloat':
+        value = listOfRequiredFloat;
+        break;
+      case r'requiredListOfFloat':
+        value = requiredListOfFloat;
+        break;
+      case r'requiredListOfRequiredFloat':
+        value = requiredListOfRequiredFloat;
+        break;
+      case r'listOfBoolean':
+        value = listOfBoolean;
+        break;
+      case r'listOfRequiredBoolean':
+        value = listOfRequiredBoolean;
+        break;
+      case r'requiredListOfBoolean':
+        value = requiredListOfBoolean;
+        break;
+      case r'requiredListOfRequiredBoolean':
+        value = requiredListOfRequiredBoolean;
+        break;
+      case r'listOfAWSDate':
+        value = listOfAwsDate;
+        break;
+      case r'listOfRequiredAWSDate':
+        value = listOfRequiredAwsDate;
+        break;
+      case r'requiredListOfAWSDate':
+        value = requiredListOfAwsDate;
+        break;
+      case r'requiredListOfRequiredAWSDate':
+        value = requiredListOfRequiredAwsDate;
+        break;
+      case r'listOfAWSDateTime':
+        value = listOfAwsDateTime;
+        break;
+      case r'listOfRequiredAWSDateTime':
+        value = listOfRequiredAwsDateTime;
+        break;
+      case r'requiredListOfAWSDateTime':
+        value = requiredListOfAwsDateTime;
+        break;
+      case r'requiredListOfRequiredAWSDateTime':
+        value = requiredListOfRequiredAwsDateTime;
+        break;
+      case r'listOfAWSTime':
+        value = listOfAwsTime;
+        break;
+      case r'listOfRequiredAWSTime':
+        value = listOfRequiredAwsTime;
+        break;
+      case r'requiredListOfAWSTime':
+        value = requiredListOfAwsTime;
+        break;
+      case r'requiredListOfRequiredAWSTime':
+        value = requiredListOfRequiredAwsTime;
+        break;
+      case r'listOfAWSTimestamp':
+        value = listOfAwsTimestamp;
+        break;
+      case r'listOfRequiredAWSTimestamp':
+        value = listOfRequiredAwsTimestamp;
+        break;
+      case r'requiredListOfAWSTimestamp':
+        value = requiredListOfAwsTimestamp;
+        break;
+      case r'requiredListOfRequiredAWSTimestamp':
+        value = requiredListOfRequiredAwsTimestamp;
+        break;
+      case r'listOfAWSEmail':
+        value = listOfAwsEmail;
+        break;
+      case r'listOfRequiredAWSEmail':
+        value = listOfRequiredAwsEmail;
+        break;
+      case r'requiredListOfAWSEmail':
+        value = requiredListOfAwsEmail;
+        break;
+      case r'requiredListOfRequiredAWSEmail':
+        value = requiredListOfRequiredAwsEmail;
+        break;
+      case r'listOfAWSJSON':
+        value = listOfAwsjson;
+        break;
+      case r'listOfRequiredAWSJSON':
+        value = listOfRequiredAwsjson;
+        break;
+      case r'requiredListOfAWSJSON':
+        value = requiredListOfAwsjson;
+        break;
+      case r'requiredListOfRequiredAWSJSON':
+        value = requiredListOfRequiredAwsjson;
+        break;
+      case r'listOfAWSPhone':
+        value = listOfAwsPhone;
+        break;
+      case r'listOfRequiredAWSPhone':
+        value = listOfRequiredAwsPhone;
+        break;
+      case r'requiredListOfAWSPhone':
+        value = requiredListOfAwsPhone;
+        break;
+      case r'requiredListOfRequiredAWSPhone':
+        value = requiredListOfRequiredAwsPhone;
+        break;
+      case r'listOfAWSUrl':
+        value = listOfAwsUrl;
+        break;
+      case r'listOfRequiredAWSUrl':
+        value = listOfRequiredAwsUrl;
+        break;
+      case r'requiredListOfAWSUrl':
+        value = requiredListOfAwsUrl;
+        break;
+      case r'requiredListOfRequiredAWSUrl':
+        value = requiredListOfRequiredAwsUrl;
+        break;
+      case r'listOfAWSIpAddress':
+        value = listOfAwsIpAddress;
+        break;
+      case r'listOfRequiredAWSIpAddress':
+        value = listOfRequiredAwsIpAddress;
+        break;
+      case r'requiredListOfAWSIpAddress':
+        value = requiredListOfAwsIpAddress;
+        break;
+      case r'requiredListOfRequiredAWSIpAddress':
+        value = requiredListOfRequiredAwsIpAddress;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _PartialScalarListNonModel extends PartialScalarListNonModel {
+  _PartialScalarListNonModel({
+    required this.id,
+    this.listOfString,
+    this.listOfRequiredString,
+    this.requiredListOfString,
+    this.requiredListOfRequiredString,
+    this.listOfInteger,
+    this.listOfRequiredInteger,
+    this.requiredListOfInteger,
+    this.requiredListOfRequiredInteger,
+    this.listOfFloat,
+    this.listOfRequiredFloat,
+    this.requiredListOfFloat,
+    this.requiredListOfRequiredFloat,
+    this.listOfBoolean,
+    this.listOfRequiredBoolean,
+    this.requiredListOfBoolean,
+    this.requiredListOfRequiredBoolean,
+    this.listOfAwsDate,
+    this.listOfRequiredAwsDate,
+    this.requiredListOfAwsDate,
+    this.requiredListOfRequiredAwsDate,
+    this.listOfAwsDateTime,
+    this.listOfRequiredAwsDateTime,
+    this.requiredListOfAwsDateTime,
+    this.requiredListOfRequiredAwsDateTime,
+    this.listOfAwsTime,
+    this.listOfRequiredAwsTime,
+    this.requiredListOfAwsTime,
+    this.requiredListOfRequiredAwsTime,
+    this.listOfAwsTimestamp,
+    this.listOfRequiredAwsTimestamp,
+    this.requiredListOfAwsTimestamp,
+    this.requiredListOfRequiredAwsTimestamp,
+    this.listOfAwsEmail,
+    this.listOfRequiredAwsEmail,
+    this.requiredListOfAwsEmail,
+    this.requiredListOfRequiredAwsEmail,
+    this.listOfAwsjson,
+    this.listOfRequiredAwsjson,
+    this.requiredListOfAwsjson,
+    this.requiredListOfRequiredAwsjson,
+    this.listOfAwsPhone,
+    this.listOfRequiredAwsPhone,
+    this.requiredListOfAwsPhone,
+    this.requiredListOfRequiredAwsPhone,
+    this.listOfAwsUrl,
+    this.listOfRequiredAwsUrl,
+    this.requiredListOfAwsUrl,
+    this.requiredListOfRequiredAwsUrl,
+    this.listOfAwsIpAddress,
+    this.listOfRequiredAwsIpAddress,
+    this.requiredListOfAwsIpAddress,
+    this.requiredListOfRequiredAwsIpAddress,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialScalarListNonModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final listOfString = json['listOfString'] == null
+        ? null
+        : (json['listOfString'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredString = json['listOfRequiredString'] == null
+        ? null
+        : (json['listOfRequiredString'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredString',
+                )))
+            .toList();
+    final requiredListOfString = json['requiredListOfString'] == null
+        ? null
+        : (json['requiredListOfString'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredString =
+        json['requiredListOfRequiredString'] == null
+            ? null
+            : (json['requiredListOfRequiredString'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredString',
+                    )))
+                .toList();
+    final listOfInteger = json['listOfInteger'] == null
+        ? null
+        : (json['listOfInteger'] as List<Object?>).cast<int?>().toList();
+    final listOfRequiredInteger = json['listOfRequiredInteger'] == null
+        ? null
+        : (json['listOfRequiredInteger'] as List<Object?>)
+            .cast<int?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredInteger',
+                )))
+            .toList();
+    final requiredListOfInteger = json['requiredListOfInteger'] == null
+        ? null
+        : (json['requiredListOfInteger'] as List<Object?>)
+            .cast<int?>()
+            .toList();
+    final requiredListOfRequiredInteger =
+        json['requiredListOfRequiredInteger'] == null
+            ? null
+            : (json['requiredListOfRequiredInteger'] as List<Object?>)
+                .cast<int?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredInteger',
+                    )))
+                .toList();
+    final listOfFloat = json['listOfFloat'] == null
+        ? null
+        : (json['listOfFloat'] as List<Object?>).cast<double?>().toList();
+    final listOfRequiredFloat = json['listOfRequiredFloat'] == null
+        ? null
+        : (json['listOfRequiredFloat'] as List<Object?>)
+            .cast<double?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredFloat',
+                )))
+            .toList();
+    final requiredListOfFloat = json['requiredListOfFloat'] == null
+        ? null
+        : (json['requiredListOfFloat'] as List<Object?>)
+            .cast<double?>()
+            .toList();
+    final requiredListOfRequiredFloat =
+        json['requiredListOfRequiredFloat'] == null
+            ? null
+            : (json['requiredListOfRequiredFloat'] as List<Object?>)
+                .cast<double?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredFloat',
+                    )))
+                .toList();
+    final listOfBoolean = json['listOfBoolean'] == null
+        ? null
+        : (json['listOfBoolean'] as List<Object?>).cast<bool?>().toList();
+    final listOfRequiredBoolean = json['listOfRequiredBoolean'] == null
+        ? null
+        : (json['listOfRequiredBoolean'] as List<Object?>)
+            .cast<bool?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredBoolean',
+                )))
+            .toList();
+    final requiredListOfBoolean = json['requiredListOfBoolean'] == null
+        ? null
+        : (json['requiredListOfBoolean'] as List<Object?>)
+            .cast<bool?>()
+            .toList();
+    final requiredListOfRequiredBoolean =
+        json['requiredListOfRequiredBoolean'] == null
+            ? null
+            : (json['requiredListOfRequiredBoolean'] as List<Object?>)
+                .cast<bool?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredBoolean',
+                    )))
+                .toList();
+    final listOfAwsDate = json['listOfAWSDate'] == null
+        ? null
+        : (json['listOfAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final listOfRequiredAwsDate = json['listOfRequiredAWSDate'] == null
+        ? null
+        : (json['listOfRequiredAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsDate',
+                  ))
+                : TemporalDate.fromString(el))
+            .toList();
+    final requiredListOfAwsDate = json['requiredListOfAWSDate'] == null
+        ? null
+        : (json['requiredListOfAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsDate =
+        json['requiredListOfRequiredAWSDate'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSDate'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsDate',
+                      ))
+                    : TemporalDate.fromString(el))
+                .toList();
+    final listOfAwsDateTime = json['listOfAWSDateTime'] == null
+        ? null
+        : (json['listOfAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final listOfRequiredAwsDateTime = json['listOfRequiredAWSDateTime'] == null
+        ? null
+        : (json['listOfRequiredAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsDateTime',
+                  ))
+                : TemporalDateTime.fromString(el))
+            .toList();
+    final requiredListOfAwsDateTime = json['requiredListOfAWSDateTime'] == null
+        ? null
+        : (json['requiredListOfAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsDateTime =
+        json['requiredListOfRequiredAWSDateTime'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSDateTime'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsDateTime',
+                      ))
+                    : TemporalDateTime.fromString(el))
+                .toList();
+    final listOfAwsTime = json['listOfAWSTime'] == null
+        ? null
+        : (json['listOfAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final listOfRequiredAwsTime = json['listOfRequiredAWSTime'] == null
+        ? null
+        : (json['listOfRequiredAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsTime',
+                  ))
+                : TemporalTime.fromString(el))
+            .toList();
+    final requiredListOfAwsTime = json['requiredListOfAWSTime'] == null
+        ? null
+        : (json['requiredListOfAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsTime =
+        json['requiredListOfRequiredAWSTime'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSTime'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsTime',
+                      ))
+                    : TemporalTime.fromString(el))
+                .toList();
+    final listOfAwsTimestamp = json['listOfAWSTimestamp'] == null
+        ? null
+        : (json['listOfAWSTimestamp'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final listOfRequiredAwsTimestamp =
+        json['listOfRequiredAWSTimestamp'] == null
+            ? null
+            : (json['listOfRequiredAWSTimestamp'] as List<Object?>)
+                .cast<int?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'listOfRequiredAwsTimestamp',
+                      ))
+                    : TemporalTimestamp.fromSeconds(el))
+                .toList();
+    final requiredListOfAwsTimestamp = json['requiredListOfAWSTimestamp'] ==
+            null
+        ? null
+        : (json['requiredListOfAWSTimestamp'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final requiredListOfRequiredAwsTimestamp =
+        json['requiredListOfRequiredAWSTimestamp'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSTimestamp'] as List<Object?>)
+                .cast<int?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsTimestamp',
+                      ))
+                    : TemporalTimestamp.fromSeconds(el))
+                .toList();
+    final listOfAwsEmail = json['listOfAWSEmail'] == null
+        ? null
+        : (json['listOfAWSEmail'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredAwsEmail = json['listOfRequiredAWSEmail'] == null
+        ? null
+        : (json['listOfRequiredAWSEmail'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredAwsEmail',
+                )))
+            .toList();
+    final requiredListOfAwsEmail = json['requiredListOfAWSEmail'] == null
+        ? null
+        : (json['requiredListOfAWSEmail'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredAwsEmail =
+        json['requiredListOfRequiredAWSEmail'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSEmail'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredAwsEmail',
+                    )))
+                .toList();
+    final listOfAwsjson = json['listOfAWSJSON'] == null
+        ? null
+        : (json['listOfAWSJSON'] as List<Object?>).cast<Object?>().toList();
+    final listOfRequiredAwsjson = json['listOfRequiredAWSJSON'] == null
+        ? null
+        : (json['listOfRequiredAWSJSON'] as List<Object?>)
+            .cast<Object?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredAwsjson',
+                )))
+            .toList();
+    final requiredListOfAwsjson = json['requiredListOfAWSJSON'] == null
+        ? null
+        : (json['requiredListOfAWSJSON'] as List<Object?>)
+            .cast<Object?>()
+            .toList();
+    final requiredListOfRequiredAwsjson =
+        json['requiredListOfRequiredAWSJSON'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSJSON'] as List<Object?>)
+                .cast<Object?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredAwsjson',
+                    )))
+                .toList();
+    final listOfAwsPhone = json['listOfAWSPhone'] == null
+        ? null
+        : (json['listOfAWSPhone'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredAwsPhone = json['listOfRequiredAWSPhone'] == null
+        ? null
+        : (json['listOfRequiredAWSPhone'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredAwsPhone',
+                )))
+            .toList();
+    final requiredListOfAwsPhone = json['requiredListOfAWSPhone'] == null
+        ? null
+        : (json['requiredListOfAWSPhone'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredAwsPhone =
+        json['requiredListOfRequiredAWSPhone'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSPhone'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredAwsPhone',
+                    )))
+                .toList();
+    final listOfAwsUrl = json['listOfAWSUrl'] == null
+        ? null
+        : (json['listOfAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : Uri.parse(el))
+            .toList();
+    final listOfRequiredAwsUrl = json['listOfRequiredAWSUrl'] == null
+        ? null
+        : (json['listOfRequiredAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsUrl',
+                  ))
+                : Uri.parse(el))
+            .toList();
+    final requiredListOfAwsUrl = json['requiredListOfAWSUrl'] == null
+        ? null
+        : (json['requiredListOfAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : Uri.parse(el))
+            .toList();
+    final requiredListOfRequiredAwsUrl =
+        json['requiredListOfRequiredAWSUrl'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSUrl'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsUrl',
+                      ))
+                    : Uri.parse(el))
+                .toList();
+    final listOfAwsIpAddress = json['listOfAWSIpAddress'] == null
+        ? null
+        : (json['listOfAWSIpAddress'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final listOfRequiredAwsIpAddress =
+        json['listOfRequiredAWSIpAddress'] == null
+            ? null
+            : (json['listOfRequiredAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsIpAddress',
+                    )))
+                .toList();
+    final requiredListOfAwsIpAddress =
+        json['requiredListOfAWSIpAddress'] == null
+            ? null
+            : (json['requiredListOfAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .toList();
+    final requiredListOfRequiredAwsIpAddress =
+        json['requiredListOfRequiredAWSIpAddress'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredAwsIpAddress',
+                    )))
+                .toList();
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialScalarListNonModel(
+      id: id,
+      listOfString: listOfString,
+      listOfRequiredString: listOfRequiredString,
+      requiredListOfString: requiredListOfString,
+      requiredListOfRequiredString: requiredListOfRequiredString,
+      listOfInteger: listOfInteger,
+      listOfRequiredInteger: listOfRequiredInteger,
+      requiredListOfInteger: requiredListOfInteger,
+      requiredListOfRequiredInteger: requiredListOfRequiredInteger,
+      listOfFloat: listOfFloat,
+      listOfRequiredFloat: listOfRequiredFloat,
+      requiredListOfFloat: requiredListOfFloat,
+      requiredListOfRequiredFloat: requiredListOfRequiredFloat,
+      listOfBoolean: listOfBoolean,
+      listOfRequiredBoolean: listOfRequiredBoolean,
+      requiredListOfBoolean: requiredListOfBoolean,
+      requiredListOfRequiredBoolean: requiredListOfRequiredBoolean,
+      listOfAwsDate: listOfAwsDate,
+      listOfRequiredAwsDate: listOfRequiredAwsDate,
+      requiredListOfAwsDate: requiredListOfAwsDate,
+      requiredListOfRequiredAwsDate: requiredListOfRequiredAwsDate,
+      listOfAwsDateTime: listOfAwsDateTime,
+      listOfRequiredAwsDateTime: listOfRequiredAwsDateTime,
+      requiredListOfAwsDateTime: requiredListOfAwsDateTime,
+      requiredListOfRequiredAwsDateTime: requiredListOfRequiredAwsDateTime,
+      listOfAwsTime: listOfAwsTime,
+      listOfRequiredAwsTime: listOfRequiredAwsTime,
+      requiredListOfAwsTime: requiredListOfAwsTime,
+      requiredListOfRequiredAwsTime: requiredListOfRequiredAwsTime,
+      listOfAwsTimestamp: listOfAwsTimestamp,
+      listOfRequiredAwsTimestamp: listOfRequiredAwsTimestamp,
+      requiredListOfAwsTimestamp: requiredListOfAwsTimestamp,
+      requiredListOfRequiredAwsTimestamp: requiredListOfRequiredAwsTimestamp,
+      listOfAwsEmail: listOfAwsEmail,
+      listOfRequiredAwsEmail: listOfRequiredAwsEmail,
+      requiredListOfAwsEmail: requiredListOfAwsEmail,
+      requiredListOfRequiredAwsEmail: requiredListOfRequiredAwsEmail,
+      listOfAwsjson: listOfAwsjson,
+      listOfRequiredAwsjson: listOfRequiredAwsjson,
+      requiredListOfAwsjson: requiredListOfAwsjson,
+      requiredListOfRequiredAwsjson: requiredListOfRequiredAwsjson,
+      listOfAwsPhone: listOfAwsPhone,
+      listOfRequiredAwsPhone: listOfRequiredAwsPhone,
+      requiredListOfAwsPhone: requiredListOfAwsPhone,
+      requiredListOfRequiredAwsPhone: requiredListOfRequiredAwsPhone,
+      listOfAwsUrl: listOfAwsUrl,
+      listOfRequiredAwsUrl: listOfRequiredAwsUrl,
+      requiredListOfAwsUrl: requiredListOfAwsUrl,
+      requiredListOfRequiredAwsUrl: requiredListOfRequiredAwsUrl,
+      listOfAwsIpAddress: listOfAwsIpAddress,
+      listOfRequiredAwsIpAddress: listOfRequiredAwsIpAddress,
+      requiredListOfAwsIpAddress: requiredListOfAwsIpAddress,
+      requiredListOfRequiredAwsIpAddress: requiredListOfRequiredAwsIpAddress,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final List<String?>? listOfString;
+
+  @override
+  final List<String>? listOfRequiredString;
+
+  @override
+  final List<String?>? requiredListOfString;
+
+  @override
+  final List<String>? requiredListOfRequiredString;
+
+  @override
+  final List<int?>? listOfInteger;
+
+  @override
+  final List<int>? listOfRequiredInteger;
+
+  @override
+  final List<int?>? requiredListOfInteger;
+
+  @override
+  final List<int>? requiredListOfRequiredInteger;
+
+  @override
+  final List<double?>? listOfFloat;
+
+  @override
+  final List<double>? listOfRequiredFloat;
+
+  @override
+  final List<double?>? requiredListOfFloat;
+
+  @override
+  final List<double>? requiredListOfRequiredFloat;
+
+  @override
+  final List<bool?>? listOfBoolean;
+
+  @override
+  final List<bool>? listOfRequiredBoolean;
+
+  @override
+  final List<bool?>? requiredListOfBoolean;
+
+  @override
+  final List<bool>? requiredListOfRequiredBoolean;
+
+  @override
+  final List<TemporalDate?>? listOfAwsDate;
+
+  @override
+  final List<TemporalDate>? listOfRequiredAwsDate;
+
+  @override
+  final List<TemporalDate?>? requiredListOfAwsDate;
+
+  @override
+  final List<TemporalDate>? requiredListOfRequiredAwsDate;
+
+  @override
+  final List<TemporalDateTime?>? listOfAwsDateTime;
+
+  @override
+  final List<TemporalDateTime>? listOfRequiredAwsDateTime;
+
+  @override
+  final List<TemporalDateTime?>? requiredListOfAwsDateTime;
+
+  @override
+  final List<TemporalDateTime>? requiredListOfRequiredAwsDateTime;
+
+  @override
+  final List<TemporalTime?>? listOfAwsTime;
+
+  @override
+  final List<TemporalTime>? listOfRequiredAwsTime;
+
+  @override
+  final List<TemporalTime?>? requiredListOfAwsTime;
+
+  @override
+  final List<TemporalTime>? requiredListOfRequiredAwsTime;
+
+  @override
+  final List<TemporalTimestamp?>? listOfAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp>? listOfRequiredAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp?>? requiredListOfAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp>? requiredListOfRequiredAwsTimestamp;
+
+  @override
+  final List<String?>? listOfAwsEmail;
+
+  @override
+  final List<String>? listOfRequiredAwsEmail;
+
+  @override
+  final List<String?>? requiredListOfAwsEmail;
+
+  @override
+  final List<String>? requiredListOfRequiredAwsEmail;
+
+  @override
+  final List<Object?>? listOfAwsjson;
+
+  @override
+  final List<Object>? listOfRequiredAwsjson;
+
+  @override
+  final List<Object?>? requiredListOfAwsjson;
+
+  @override
+  final List<Object>? requiredListOfRequiredAwsjson;
+
+  @override
+  final List<String?>? listOfAwsPhone;
+
+  @override
+  final List<String>? listOfRequiredAwsPhone;
+
+  @override
+  final List<String?>? requiredListOfAwsPhone;
+
+  @override
+  final List<String>? requiredListOfRequiredAwsPhone;
+
+  @override
+  final List<Uri?>? listOfAwsUrl;
+
+  @override
+  final List<Uri>? listOfRequiredAwsUrl;
+
+  @override
+  final List<Uri?>? requiredListOfAwsUrl;
+
+  @override
+  final List<Uri>? requiredListOfRequiredAwsUrl;
+
+  @override
+  final List<String?>? listOfAwsIpAddress;
+
+  @override
+  final List<String>? listOfRequiredAwsIpAddress;
+
+  @override
+  final List<String?>? requiredListOfAwsIpAddress;
+
+  @override
+  final List<String>? requiredListOfRequiredAwsIpAddress;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class ScalarListNonModel extends PartialScalarListNonModel
+    implements Model<String, ScalarListNonModel> {
+  factory ScalarListNonModel({
+    String? id,
+    List<String?>? listOfString,
+    List<String>? listOfRequiredString,
+    required List<String?> requiredListOfString,
+    required List<String> requiredListOfRequiredString,
+    List<int?>? listOfInteger,
+    List<int>? listOfRequiredInteger,
+    required List<int?> requiredListOfInteger,
+    required List<int> requiredListOfRequiredInteger,
+    List<double?>? listOfFloat,
+    List<double>? listOfRequiredFloat,
+    required List<double?> requiredListOfFloat,
+    required List<double> requiredListOfRequiredFloat,
+    List<bool?>? listOfBoolean,
+    List<bool>? listOfRequiredBoolean,
+    required List<bool?> requiredListOfBoolean,
+    required List<bool> requiredListOfRequiredBoolean,
+    List<TemporalDate?>? listOfAwsDate,
+    List<TemporalDate>? listOfRequiredAwsDate,
+    required List<TemporalDate?> requiredListOfAwsDate,
+    required List<TemporalDate> requiredListOfRequiredAwsDate,
+    List<TemporalDateTime?>? listOfAwsDateTime,
+    List<TemporalDateTime>? listOfRequiredAwsDateTime,
+    required List<TemporalDateTime?> requiredListOfAwsDateTime,
+    required List<TemporalDateTime> requiredListOfRequiredAwsDateTime,
+    List<TemporalTime?>? listOfAwsTime,
+    List<TemporalTime>? listOfRequiredAwsTime,
+    required List<TemporalTime?> requiredListOfAwsTime,
+    required List<TemporalTime> requiredListOfRequiredAwsTime,
+    List<TemporalTimestamp?>? listOfAwsTimestamp,
+    List<TemporalTimestamp>? listOfRequiredAwsTimestamp,
+    required List<TemporalTimestamp?> requiredListOfAwsTimestamp,
+    required List<TemporalTimestamp> requiredListOfRequiredAwsTimestamp,
+    List<String?>? listOfAwsEmail,
+    List<String>? listOfRequiredAwsEmail,
+    required List<String?> requiredListOfAwsEmail,
+    required List<String> requiredListOfRequiredAwsEmail,
+    List<Object?>? listOfAwsjson,
+    List<Object>? listOfRequiredAwsjson,
+    required List<Object?> requiredListOfAwsjson,
+    required List<Object> requiredListOfRequiredAwsjson,
+    List<String?>? listOfAwsPhone,
+    List<String>? listOfRequiredAwsPhone,
+    required List<String?> requiredListOfAwsPhone,
+    required List<String> requiredListOfRequiredAwsPhone,
+    List<Uri?>? listOfAwsUrl,
+    List<Uri>? listOfRequiredAwsUrl,
+    required List<Uri?> requiredListOfAwsUrl,
+    required List<Uri> requiredListOfRequiredAwsUrl,
+    List<String?>? listOfAwsIpAddress,
+    List<String>? listOfRequiredAwsIpAddress,
+    required List<String?> requiredListOfAwsIpAddress,
+    required List<String> requiredListOfRequiredAwsIpAddress,
+    TemporalDateTime? createdAt,
+    TemporalDateTime? updatedAt,
+  }) = _ScalarListNonModel;
+
+  const ScalarListNonModel._() : super._();
+
+  factory ScalarListNonModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final listOfString = json['listOfString'] == null
+        ? null
+        : (json['listOfString'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredString = json['listOfRequiredString'] == null
+        ? null
+        : (json['listOfRequiredString'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredString',
+                )))
+            .toList();
+    final requiredListOfString = json['requiredListOfString'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfString',
+          ))
+        : (json['requiredListOfString'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredString =
+        json['requiredListOfRequiredString'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredString',
+              ))
+            : (json['requiredListOfRequiredString'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredString',
+                    )))
+                .toList();
+    final listOfInteger = json['listOfInteger'] == null
+        ? null
+        : (json['listOfInteger'] as List<Object?>).cast<int?>().toList();
+    final listOfRequiredInteger = json['listOfRequiredInteger'] == null
+        ? null
+        : (json['listOfRequiredInteger'] as List<Object?>)
+            .cast<int?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredInteger',
+                )))
+            .toList();
+    final requiredListOfInteger = json['requiredListOfInteger'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfInteger',
+          ))
+        : (json['requiredListOfInteger'] as List<Object?>)
+            .cast<int?>()
+            .toList();
+    final requiredListOfRequiredInteger =
+        json['requiredListOfRequiredInteger'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredInteger',
+              ))
+            : (json['requiredListOfRequiredInteger'] as List<Object?>)
+                .cast<int?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredInteger',
+                    )))
+                .toList();
+    final listOfFloat = json['listOfFloat'] == null
+        ? null
+        : (json['listOfFloat'] as List<Object?>).cast<double?>().toList();
+    final listOfRequiredFloat = json['listOfRequiredFloat'] == null
+        ? null
+        : (json['listOfRequiredFloat'] as List<Object?>)
+            .cast<double?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredFloat',
+                )))
+            .toList();
+    final requiredListOfFloat = json['requiredListOfFloat'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfFloat',
+          ))
+        : (json['requiredListOfFloat'] as List<Object?>)
+            .cast<double?>()
+            .toList();
+    final requiredListOfRequiredFloat =
+        json['requiredListOfRequiredFloat'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredFloat',
+              ))
+            : (json['requiredListOfRequiredFloat'] as List<Object?>)
+                .cast<double?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredFloat',
+                    )))
+                .toList();
+    final listOfBoolean = json['listOfBoolean'] == null
+        ? null
+        : (json['listOfBoolean'] as List<Object?>).cast<bool?>().toList();
+    final listOfRequiredBoolean = json['listOfRequiredBoolean'] == null
+        ? null
+        : (json['listOfRequiredBoolean'] as List<Object?>)
+            .cast<bool?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredBoolean',
+                )))
+            .toList();
+    final requiredListOfBoolean = json['requiredListOfBoolean'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfBoolean',
+          ))
+        : (json['requiredListOfBoolean'] as List<Object?>)
+            .cast<bool?>()
+            .toList();
+    final requiredListOfRequiredBoolean =
+        json['requiredListOfRequiredBoolean'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredBoolean',
+              ))
+            : (json['requiredListOfRequiredBoolean'] as List<Object?>)
+                .cast<bool?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredBoolean',
+                    )))
+                .toList();
+    final listOfAwsDate = json['listOfAWSDate'] == null
+        ? null
+        : (json['listOfAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final listOfRequiredAwsDate = json['listOfRequiredAWSDate'] == null
+        ? null
+        : (json['listOfRequiredAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsDate',
+                  ))
+                : TemporalDate.fromString(el))
+            .toList();
+    final requiredListOfAwsDate = json['requiredListOfAWSDate'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsDate',
+          ))
+        : (json['requiredListOfAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsDate =
+        json['requiredListOfRequiredAWSDate'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsDate',
+              ))
+            : (json['requiredListOfRequiredAWSDate'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsDate',
+                      ))
+                    : TemporalDate.fromString(el))
+                .toList();
+    final listOfAwsDateTime = json['listOfAWSDateTime'] == null
+        ? null
+        : (json['listOfAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final listOfRequiredAwsDateTime = json['listOfRequiredAWSDateTime'] == null
+        ? null
+        : (json['listOfRequiredAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsDateTime',
+                  ))
+                : TemporalDateTime.fromString(el))
+            .toList();
+    final requiredListOfAwsDateTime = json['requiredListOfAWSDateTime'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsDateTime',
+          ))
+        : (json['requiredListOfAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsDateTime =
+        json['requiredListOfRequiredAWSDateTime'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsDateTime',
+              ))
+            : (json['requiredListOfRequiredAWSDateTime'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsDateTime',
+                      ))
+                    : TemporalDateTime.fromString(el))
+                .toList();
+    final listOfAwsTime = json['listOfAWSTime'] == null
+        ? null
+        : (json['listOfAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final listOfRequiredAwsTime = json['listOfRequiredAWSTime'] == null
+        ? null
+        : (json['listOfRequiredAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsTime',
+                  ))
+                : TemporalTime.fromString(el))
+            .toList();
+    final requiredListOfAwsTime = json['requiredListOfAWSTime'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsTime',
+          ))
+        : (json['requiredListOfAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsTime =
+        json['requiredListOfRequiredAWSTime'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsTime',
+              ))
+            : (json['requiredListOfRequiredAWSTime'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsTime',
+                      ))
+                    : TemporalTime.fromString(el))
+                .toList();
+    final listOfAwsTimestamp = json['listOfAWSTimestamp'] == null
+        ? null
+        : (json['listOfAWSTimestamp'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final listOfRequiredAwsTimestamp =
+        json['listOfRequiredAWSTimestamp'] == null
+            ? null
+            : (json['listOfRequiredAWSTimestamp'] as List<Object?>)
+                .cast<int?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'listOfRequiredAwsTimestamp',
+                      ))
+                    : TemporalTimestamp.fromSeconds(el))
+                .toList();
+    final requiredListOfAwsTimestamp = json['requiredListOfAWSTimestamp'] ==
+            null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsTimestamp',
+          ))
+        : (json['requiredListOfAWSTimestamp'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final requiredListOfRequiredAwsTimestamp =
+        json['requiredListOfRequiredAWSTimestamp'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsTimestamp',
+              ))
+            : (json['requiredListOfRequiredAWSTimestamp'] as List<Object?>)
+                .cast<int?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsTimestamp',
+                      ))
+                    : TemporalTimestamp.fromSeconds(el))
+                .toList();
+    final listOfAwsEmail = json['listOfAWSEmail'] == null
+        ? null
+        : (json['listOfAWSEmail'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredAwsEmail = json['listOfRequiredAWSEmail'] == null
+        ? null
+        : (json['listOfRequiredAWSEmail'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredAwsEmail',
+                )))
+            .toList();
+    final requiredListOfAwsEmail = json['requiredListOfAWSEmail'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsEmail',
+          ))
+        : (json['requiredListOfAWSEmail'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredAwsEmail =
+        json['requiredListOfRequiredAWSEmail'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsEmail',
+              ))
+            : (json['requiredListOfRequiredAWSEmail'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredAwsEmail',
+                    )))
+                .toList();
+    final listOfAwsjson = json['listOfAWSJSON'] == null
+        ? null
+        : (json['listOfAWSJSON'] as List<Object?>).cast<Object?>().toList();
+    final listOfRequiredAwsjson = json['listOfRequiredAWSJSON'] == null
+        ? null
+        : (json['listOfRequiredAWSJSON'] as List<Object?>)
+            .cast<Object?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredAwsjson',
+                )))
+            .toList();
+    final requiredListOfAwsjson = json['requiredListOfAWSJSON'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsjson',
+          ))
+        : (json['requiredListOfAWSJSON'] as List<Object?>)
+            .cast<Object?>()
+            .toList();
+    final requiredListOfRequiredAwsjson =
+        json['requiredListOfRequiredAWSJSON'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsjson',
+              ))
+            : (json['requiredListOfRequiredAWSJSON'] as List<Object?>)
+                .cast<Object?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredAwsjson',
+                    )))
+                .toList();
+    final listOfAwsPhone = json['listOfAWSPhone'] == null
+        ? null
+        : (json['listOfAWSPhone'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredAwsPhone = json['listOfRequiredAWSPhone'] == null
+        ? null
+        : (json['listOfRequiredAWSPhone'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredAwsPhone',
+                )))
+            .toList();
+    final requiredListOfAwsPhone = json['requiredListOfAWSPhone'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsPhone',
+          ))
+        : (json['requiredListOfAWSPhone'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredAwsPhone =
+        json['requiredListOfRequiredAWSPhone'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsPhone',
+              ))
+            : (json['requiredListOfRequiredAWSPhone'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredAwsPhone',
+                    )))
+                .toList();
+    final listOfAwsUrl = json['listOfAWSUrl'] == null
+        ? null
+        : (json['listOfAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : Uri.parse(el))
+            .toList();
+    final listOfRequiredAwsUrl = json['listOfRequiredAWSUrl'] == null
+        ? null
+        : (json['listOfRequiredAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsUrl',
+                  ))
+                : Uri.parse(el))
+            .toList();
+    final requiredListOfAwsUrl = json['requiredListOfAWSUrl'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsUrl',
+          ))
+        : (json['requiredListOfAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : Uri.parse(el))
+            .toList();
+    final requiredListOfRequiredAwsUrl =
+        json['requiredListOfRequiredAWSUrl'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsUrl',
+              ))
+            : (json['requiredListOfRequiredAWSUrl'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsUrl',
+                      ))
+                    : Uri.parse(el))
+                .toList();
+    final listOfAwsIpAddress = json['listOfAWSIpAddress'] == null
+        ? null
+        : (json['listOfAWSIpAddress'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final listOfRequiredAwsIpAddress =
+        json['listOfRequiredAWSIpAddress'] == null
+            ? null
+            : (json['listOfRequiredAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsIpAddress',
+                    )))
+                .toList();
+    final requiredListOfAwsIpAddress =
+        json['requiredListOfAWSIpAddress'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfAwsIpAddress',
+              ))
+            : (json['requiredListOfAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .toList();
+    final requiredListOfRequiredAwsIpAddress =
+        json['requiredListOfRequiredAWSIpAddress'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsIpAddress',
+              ))
+            : (json['requiredListOfRequiredAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredAwsIpAddress',
+                    )))
+                .toList();
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return ScalarListNonModel(
+      id: id,
+      listOfString: listOfString,
+      listOfRequiredString: listOfRequiredString,
+      requiredListOfString: requiredListOfString,
+      requiredListOfRequiredString: requiredListOfRequiredString,
+      listOfInteger: listOfInteger,
+      listOfRequiredInteger: listOfRequiredInteger,
+      requiredListOfInteger: requiredListOfInteger,
+      requiredListOfRequiredInteger: requiredListOfRequiredInteger,
+      listOfFloat: listOfFloat,
+      listOfRequiredFloat: listOfRequiredFloat,
+      requiredListOfFloat: requiredListOfFloat,
+      requiredListOfRequiredFloat: requiredListOfRequiredFloat,
+      listOfBoolean: listOfBoolean,
+      listOfRequiredBoolean: listOfRequiredBoolean,
+      requiredListOfBoolean: requiredListOfBoolean,
+      requiredListOfRequiredBoolean: requiredListOfRequiredBoolean,
+      listOfAwsDate: listOfAwsDate,
+      listOfRequiredAwsDate: listOfRequiredAwsDate,
+      requiredListOfAwsDate: requiredListOfAwsDate,
+      requiredListOfRequiredAwsDate: requiredListOfRequiredAwsDate,
+      listOfAwsDateTime: listOfAwsDateTime,
+      listOfRequiredAwsDateTime: listOfRequiredAwsDateTime,
+      requiredListOfAwsDateTime: requiredListOfAwsDateTime,
+      requiredListOfRequiredAwsDateTime: requiredListOfRequiredAwsDateTime,
+      listOfAwsTime: listOfAwsTime,
+      listOfRequiredAwsTime: listOfRequiredAwsTime,
+      requiredListOfAwsTime: requiredListOfAwsTime,
+      requiredListOfRequiredAwsTime: requiredListOfRequiredAwsTime,
+      listOfAwsTimestamp: listOfAwsTimestamp,
+      listOfRequiredAwsTimestamp: listOfRequiredAwsTimestamp,
+      requiredListOfAwsTimestamp: requiredListOfAwsTimestamp,
+      requiredListOfRequiredAwsTimestamp: requiredListOfRequiredAwsTimestamp,
+      listOfAwsEmail: listOfAwsEmail,
+      listOfRequiredAwsEmail: listOfRequiredAwsEmail,
+      requiredListOfAwsEmail: requiredListOfAwsEmail,
+      requiredListOfRequiredAwsEmail: requiredListOfRequiredAwsEmail,
+      listOfAwsjson: listOfAwsjson,
+      listOfRequiredAwsjson: listOfRequiredAwsjson,
+      requiredListOfAwsjson: requiredListOfAwsjson,
+      requiredListOfRequiredAwsjson: requiredListOfRequiredAwsjson,
+      listOfAwsPhone: listOfAwsPhone,
+      listOfRequiredAwsPhone: listOfRequiredAwsPhone,
+      requiredListOfAwsPhone: requiredListOfAwsPhone,
+      requiredListOfRequiredAwsPhone: requiredListOfRequiredAwsPhone,
+      listOfAwsUrl: listOfAwsUrl,
+      listOfRequiredAwsUrl: listOfRequiredAwsUrl,
+      requiredListOfAwsUrl: requiredListOfAwsUrl,
+      requiredListOfRequiredAwsUrl: requiredListOfRequiredAwsUrl,
+      listOfAwsIpAddress: listOfAwsIpAddress,
+      listOfRequiredAwsIpAddress: listOfRequiredAwsIpAddress,
+      requiredListOfAwsIpAddress: requiredListOfAwsIpAddress,
+      requiredListOfRequiredAwsIpAddress: requiredListOfRequiredAwsIpAddress,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const ScalarListNonModelType classType = ScalarListNonModelType();
+
+  @override
+  String get id;
+  @override
+  List<String?>? get listOfString;
+  @override
+  List<String>? get listOfRequiredString;
+  @override
+  List<String?> get requiredListOfString;
+  @override
+  List<String> get requiredListOfRequiredString;
+  @override
+  List<int?>? get listOfInteger;
+  @override
+  List<int>? get listOfRequiredInteger;
+  @override
+  List<int?> get requiredListOfInteger;
+  @override
+  List<int> get requiredListOfRequiredInteger;
+  @override
+  List<double?>? get listOfFloat;
+  @override
+  List<double>? get listOfRequiredFloat;
+  @override
+  List<double?> get requiredListOfFloat;
+  @override
+  List<double> get requiredListOfRequiredFloat;
+  @override
+  List<bool?>? get listOfBoolean;
+  @override
+  List<bool>? get listOfRequiredBoolean;
+  @override
+  List<bool?> get requiredListOfBoolean;
+  @override
+  List<bool> get requiredListOfRequiredBoolean;
+  @override
+  List<TemporalDate?>? get listOfAwsDate;
+  @override
+  List<TemporalDate>? get listOfRequiredAwsDate;
+  @override
+  List<TemporalDate?> get requiredListOfAwsDate;
+  @override
+  List<TemporalDate> get requiredListOfRequiredAwsDate;
+  @override
+  List<TemporalDateTime?>? get listOfAwsDateTime;
+  @override
+  List<TemporalDateTime>? get listOfRequiredAwsDateTime;
+  @override
+  List<TemporalDateTime?> get requiredListOfAwsDateTime;
+  @override
+  List<TemporalDateTime> get requiredListOfRequiredAwsDateTime;
+  @override
+  List<TemporalTime?>? get listOfAwsTime;
+  @override
+  List<TemporalTime>? get listOfRequiredAwsTime;
+  @override
+  List<TemporalTime?> get requiredListOfAwsTime;
+  @override
+  List<TemporalTime> get requiredListOfRequiredAwsTime;
+  @override
+  List<TemporalTimestamp?>? get listOfAwsTimestamp;
+  @override
+  List<TemporalTimestamp>? get listOfRequiredAwsTimestamp;
+  @override
+  List<TemporalTimestamp?> get requiredListOfAwsTimestamp;
+  @override
+  List<TemporalTimestamp> get requiredListOfRequiredAwsTimestamp;
+  @override
+  List<String?>? get listOfAwsEmail;
+  @override
+  List<String>? get listOfRequiredAwsEmail;
+  @override
+  List<String?> get requiredListOfAwsEmail;
+  @override
+  List<String> get requiredListOfRequiredAwsEmail;
+  @override
+  List<Object?>? get listOfAwsjson;
+  @override
+  List<Object>? get listOfRequiredAwsjson;
+  @override
+  List<Object?> get requiredListOfAwsjson;
+  @override
+  List<Object> get requiredListOfRequiredAwsjson;
+  @override
+  List<String?>? get listOfAwsPhone;
+  @override
+  List<String>? get listOfRequiredAwsPhone;
+  @override
+  List<String?> get requiredListOfAwsPhone;
+  @override
+  List<String> get requiredListOfRequiredAwsPhone;
+  @override
+  List<Uri?>? get listOfAwsUrl;
+  @override
+  List<Uri>? get listOfRequiredAwsUrl;
+  @override
+  List<Uri?> get requiredListOfAwsUrl;
+  @override
+  List<Uri> get requiredListOfRequiredAwsUrl;
+  @override
+  List<String?>? get listOfAwsIpAddress;
+  @override
+  List<String>? get listOfRequiredAwsIpAddress;
+  @override
+  List<String?> get requiredListOfAwsIpAddress;
+  @override
+  List<String> get requiredListOfRequiredAwsIpAddress;
+  @override
+  TemporalDateTime? get createdAt;
+  @override
+  TemporalDateTime? get updatedAt;
+}
+
+class _ScalarListNonModel extends ScalarListNonModel {
+  _ScalarListNonModel({
+    String? id,
+    this.listOfString,
+    this.listOfRequiredString,
+    required this.requiredListOfString,
+    required this.requiredListOfRequiredString,
+    this.listOfInteger,
+    this.listOfRequiredInteger,
+    required this.requiredListOfInteger,
+    required this.requiredListOfRequiredInteger,
+    this.listOfFloat,
+    this.listOfRequiredFloat,
+    required this.requiredListOfFloat,
+    required this.requiredListOfRequiredFloat,
+    this.listOfBoolean,
+    this.listOfRequiredBoolean,
+    required this.requiredListOfBoolean,
+    required this.requiredListOfRequiredBoolean,
+    this.listOfAwsDate,
+    this.listOfRequiredAwsDate,
+    required this.requiredListOfAwsDate,
+    required this.requiredListOfRequiredAwsDate,
+    this.listOfAwsDateTime,
+    this.listOfRequiredAwsDateTime,
+    required this.requiredListOfAwsDateTime,
+    required this.requiredListOfRequiredAwsDateTime,
+    this.listOfAwsTime,
+    this.listOfRequiredAwsTime,
+    required this.requiredListOfAwsTime,
+    required this.requiredListOfRequiredAwsTime,
+    this.listOfAwsTimestamp,
+    this.listOfRequiredAwsTimestamp,
+    required this.requiredListOfAwsTimestamp,
+    required this.requiredListOfRequiredAwsTimestamp,
+    this.listOfAwsEmail,
+    this.listOfRequiredAwsEmail,
+    required this.requiredListOfAwsEmail,
+    required this.requiredListOfRequiredAwsEmail,
+    this.listOfAwsjson,
+    this.listOfRequiredAwsjson,
+    required this.requiredListOfAwsjson,
+    required this.requiredListOfRequiredAwsjson,
+    this.listOfAwsPhone,
+    this.listOfRequiredAwsPhone,
+    required this.requiredListOfAwsPhone,
+    required this.requiredListOfRequiredAwsPhone,
+    this.listOfAwsUrl,
+    this.listOfRequiredAwsUrl,
+    required this.requiredListOfAwsUrl,
+    required this.requiredListOfRequiredAwsUrl,
+    this.listOfAwsIpAddress,
+    this.listOfRequiredAwsIpAddress,
+    required this.requiredListOfAwsIpAddress,
+    required this.requiredListOfRequiredAwsIpAddress,
+    this.createdAt,
+    this.updatedAt,
+  })  : id = id ?? uuid(),
+        super._();
+
+  @override
+  final String id;
+
+  @override
+  final List<String?>? listOfString;
+
+  @override
+  final List<String>? listOfRequiredString;
+
+  @override
+  final List<String?> requiredListOfString;
+
+  @override
+  final List<String> requiredListOfRequiredString;
+
+  @override
+  final List<int?>? listOfInteger;
+
+  @override
+  final List<int>? listOfRequiredInteger;
+
+  @override
+  final List<int?> requiredListOfInteger;
+
+  @override
+  final List<int> requiredListOfRequiredInteger;
+
+  @override
+  final List<double?>? listOfFloat;
+
+  @override
+  final List<double>? listOfRequiredFloat;
+
+  @override
+  final List<double?> requiredListOfFloat;
+
+  @override
+  final List<double> requiredListOfRequiredFloat;
+
+  @override
+  final List<bool?>? listOfBoolean;
+
+  @override
+  final List<bool>? listOfRequiredBoolean;
+
+  @override
+  final List<bool?> requiredListOfBoolean;
+
+  @override
+  final List<bool> requiredListOfRequiredBoolean;
+
+  @override
+  final List<TemporalDate?>? listOfAwsDate;
+
+  @override
+  final List<TemporalDate>? listOfRequiredAwsDate;
+
+  @override
+  final List<TemporalDate?> requiredListOfAwsDate;
+
+  @override
+  final List<TemporalDate> requiredListOfRequiredAwsDate;
+
+  @override
+  final List<TemporalDateTime?>? listOfAwsDateTime;
+
+  @override
+  final List<TemporalDateTime>? listOfRequiredAwsDateTime;
+
+  @override
+  final List<TemporalDateTime?> requiredListOfAwsDateTime;
+
+  @override
+  final List<TemporalDateTime> requiredListOfRequiredAwsDateTime;
+
+  @override
+  final List<TemporalTime?>? listOfAwsTime;
+
+  @override
+  final List<TemporalTime>? listOfRequiredAwsTime;
+
+  @override
+  final List<TemporalTime?> requiredListOfAwsTime;
+
+  @override
+  final List<TemporalTime> requiredListOfRequiredAwsTime;
+
+  @override
+  final List<TemporalTimestamp?>? listOfAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp>? listOfRequiredAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp?> requiredListOfAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp> requiredListOfRequiredAwsTimestamp;
+
+  @override
+  final List<String?>? listOfAwsEmail;
+
+  @override
+  final List<String>? listOfRequiredAwsEmail;
+
+  @override
+  final List<String?> requiredListOfAwsEmail;
+
+  @override
+  final List<String> requiredListOfRequiredAwsEmail;
+
+  @override
+  final List<Object?>? listOfAwsjson;
+
+  @override
+  final List<Object>? listOfRequiredAwsjson;
+
+  @override
+  final List<Object?> requiredListOfAwsjson;
+
+  @override
+  final List<Object> requiredListOfRequiredAwsjson;
+
+  @override
+  final List<String?>? listOfAwsPhone;
+
+  @override
+  final List<String>? listOfRequiredAwsPhone;
+
+  @override
+  final List<String?> requiredListOfAwsPhone;
+
+  @override
+  final List<String> requiredListOfRequiredAwsPhone;
+
+  @override
+  final List<Uri?>? listOfAwsUrl;
+
+  @override
+  final List<Uri>? listOfRequiredAwsUrl;
+
+  @override
+  final List<Uri?> requiredListOfAwsUrl;
+
+  @override
+  final List<Uri> requiredListOfRequiredAwsUrl;
+
+  @override
+  final List<String?>? listOfAwsIpAddress;
+
+  @override
+  final List<String>? listOfRequiredAwsIpAddress;
+
+  @override
+  final List<String?> requiredListOfAwsIpAddress;
+
+  @override
+  final List<String> requiredListOfRequiredAwsIpAddress;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class RemoteScalarListNonModel extends ScalarListNonModel
+    implements RemoteModel<String, ScalarListNonModel> {
+  const RemoteScalarListNonModel._() : super._();
+}
+
+class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
+  _RemoteScalarListNonModel({
+    required this.id,
+    this.listOfString,
+    this.listOfRequiredString,
+    required this.requiredListOfString,
+    required this.requiredListOfRequiredString,
+    this.listOfInteger,
+    this.listOfRequiredInteger,
+    required this.requiredListOfInteger,
+    required this.requiredListOfRequiredInteger,
+    this.listOfFloat,
+    this.listOfRequiredFloat,
+    required this.requiredListOfFloat,
+    required this.requiredListOfRequiredFloat,
+    this.listOfBoolean,
+    this.listOfRequiredBoolean,
+    required this.requiredListOfBoolean,
+    required this.requiredListOfRequiredBoolean,
+    this.listOfAwsDate,
+    this.listOfRequiredAwsDate,
+    required this.requiredListOfAwsDate,
+    required this.requiredListOfRequiredAwsDate,
+    this.listOfAwsDateTime,
+    this.listOfRequiredAwsDateTime,
+    required this.requiredListOfAwsDateTime,
+    required this.requiredListOfRequiredAwsDateTime,
+    this.listOfAwsTime,
+    this.listOfRequiredAwsTime,
+    required this.requiredListOfAwsTime,
+    required this.requiredListOfRequiredAwsTime,
+    this.listOfAwsTimestamp,
+    this.listOfRequiredAwsTimestamp,
+    required this.requiredListOfAwsTimestamp,
+    required this.requiredListOfRequiredAwsTimestamp,
+    this.listOfAwsEmail,
+    this.listOfRequiredAwsEmail,
+    required this.requiredListOfAwsEmail,
+    required this.requiredListOfRequiredAwsEmail,
+    this.listOfAwsjson,
+    this.listOfRequiredAwsjson,
+    required this.requiredListOfAwsjson,
+    required this.requiredListOfRequiredAwsjson,
+    this.listOfAwsPhone,
+    this.listOfRequiredAwsPhone,
+    required this.requiredListOfAwsPhone,
+    required this.requiredListOfRequiredAwsPhone,
+    this.listOfAwsUrl,
+    this.listOfRequiredAwsUrl,
+    required this.requiredListOfAwsUrl,
+    required this.requiredListOfRequiredAwsUrl,
+    this.listOfAwsIpAddress,
+    this.listOfRequiredAwsIpAddress,
+    required this.requiredListOfAwsIpAddress,
+    required this.requiredListOfRequiredAwsIpAddress,
+    this.createdAt,
+    this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteScalarListNonModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final listOfString = json['listOfString'] == null
+        ? null
+        : (json['listOfString'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredString = json['listOfRequiredString'] == null
+        ? null
+        : (json['listOfRequiredString'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredString',
+                )))
+            .toList();
+    final requiredListOfString = json['requiredListOfString'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfString',
+          ))
+        : (json['requiredListOfString'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredString =
+        json['requiredListOfRequiredString'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredString',
+              ))
+            : (json['requiredListOfRequiredString'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredString',
+                    )))
+                .toList();
+    final listOfInteger = json['listOfInteger'] == null
+        ? null
+        : (json['listOfInteger'] as List<Object?>).cast<int?>().toList();
+    final listOfRequiredInteger = json['listOfRequiredInteger'] == null
+        ? null
+        : (json['listOfRequiredInteger'] as List<Object?>)
+            .cast<int?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredInteger',
+                )))
+            .toList();
+    final requiredListOfInteger = json['requiredListOfInteger'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfInteger',
+          ))
+        : (json['requiredListOfInteger'] as List<Object?>)
+            .cast<int?>()
+            .toList();
+    final requiredListOfRequiredInteger =
+        json['requiredListOfRequiredInteger'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredInteger',
+              ))
+            : (json['requiredListOfRequiredInteger'] as List<Object?>)
+                .cast<int?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredInteger',
+                    )))
+                .toList();
+    final listOfFloat = json['listOfFloat'] == null
+        ? null
+        : (json['listOfFloat'] as List<Object?>).cast<double?>().toList();
+    final listOfRequiredFloat = json['listOfRequiredFloat'] == null
+        ? null
+        : (json['listOfRequiredFloat'] as List<Object?>)
+            .cast<double?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredFloat',
+                )))
+            .toList();
+    final requiredListOfFloat = json['requiredListOfFloat'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfFloat',
+          ))
+        : (json['requiredListOfFloat'] as List<Object?>)
+            .cast<double?>()
+            .toList();
+    final requiredListOfRequiredFloat =
+        json['requiredListOfRequiredFloat'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredFloat',
+              ))
+            : (json['requiredListOfRequiredFloat'] as List<Object?>)
+                .cast<double?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredFloat',
+                    )))
+                .toList();
+    final listOfBoolean = json['listOfBoolean'] == null
+        ? null
+        : (json['listOfBoolean'] as List<Object?>).cast<bool?>().toList();
+    final listOfRequiredBoolean = json['listOfRequiredBoolean'] == null
+        ? null
+        : (json['listOfRequiredBoolean'] as List<Object?>)
+            .cast<bool?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredBoolean',
+                )))
+            .toList();
+    final requiredListOfBoolean = json['requiredListOfBoolean'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfBoolean',
+          ))
+        : (json['requiredListOfBoolean'] as List<Object?>)
+            .cast<bool?>()
+            .toList();
+    final requiredListOfRequiredBoolean =
+        json['requiredListOfRequiredBoolean'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredBoolean',
+              ))
+            : (json['requiredListOfRequiredBoolean'] as List<Object?>)
+                .cast<bool?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredBoolean',
+                    )))
+                .toList();
+    final listOfAwsDate = json['listOfAWSDate'] == null
+        ? null
+        : (json['listOfAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final listOfRequiredAwsDate = json['listOfRequiredAWSDate'] == null
+        ? null
+        : (json['listOfRequiredAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsDate',
+                  ))
+                : TemporalDate.fromString(el))
+            .toList();
+    final requiredListOfAwsDate = json['requiredListOfAWSDate'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsDate',
+          ))
+        : (json['requiredListOfAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsDate =
+        json['requiredListOfRequiredAWSDate'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsDate',
+              ))
+            : (json['requiredListOfRequiredAWSDate'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsDate',
+                      ))
+                    : TemporalDate.fromString(el))
+                .toList();
+    final listOfAwsDateTime = json['listOfAWSDateTime'] == null
+        ? null
+        : (json['listOfAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final listOfRequiredAwsDateTime = json['listOfRequiredAWSDateTime'] == null
+        ? null
+        : (json['listOfRequiredAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsDateTime',
+                  ))
+                : TemporalDateTime.fromString(el))
+            .toList();
+    final requiredListOfAwsDateTime = json['requiredListOfAWSDateTime'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsDateTime',
+          ))
+        : (json['requiredListOfAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsDateTime =
+        json['requiredListOfRequiredAWSDateTime'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsDateTime',
+              ))
+            : (json['requiredListOfRequiredAWSDateTime'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsDateTime',
+                      ))
+                    : TemporalDateTime.fromString(el))
+                .toList();
+    final listOfAwsTime = json['listOfAWSTime'] == null
+        ? null
+        : (json['listOfAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final listOfRequiredAwsTime = json['listOfRequiredAWSTime'] == null
+        ? null
+        : (json['listOfRequiredAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsTime',
+                  ))
+                : TemporalTime.fromString(el))
+            .toList();
+    final requiredListOfAwsTime = json['requiredListOfAWSTime'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsTime',
+          ))
+        : (json['requiredListOfAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsTime =
+        json['requiredListOfRequiredAWSTime'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsTime',
+              ))
+            : (json['requiredListOfRequiredAWSTime'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsTime',
+                      ))
+                    : TemporalTime.fromString(el))
+                .toList();
+    final listOfAwsTimestamp = json['listOfAWSTimestamp'] == null
+        ? null
+        : (json['listOfAWSTimestamp'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final listOfRequiredAwsTimestamp =
+        json['listOfRequiredAWSTimestamp'] == null
+            ? null
+            : (json['listOfRequiredAWSTimestamp'] as List<Object?>)
+                .cast<int?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'listOfRequiredAwsTimestamp',
+                      ))
+                    : TemporalTimestamp.fromSeconds(el))
+                .toList();
+    final requiredListOfAwsTimestamp = json['requiredListOfAWSTimestamp'] ==
+            null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsTimestamp',
+          ))
+        : (json['requiredListOfAWSTimestamp'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final requiredListOfRequiredAwsTimestamp =
+        json['requiredListOfRequiredAWSTimestamp'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsTimestamp',
+              ))
+            : (json['requiredListOfRequiredAWSTimestamp'] as List<Object?>)
+                .cast<int?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsTimestamp',
+                      ))
+                    : TemporalTimestamp.fromSeconds(el))
+                .toList();
+    final listOfAwsEmail = json['listOfAWSEmail'] == null
+        ? null
+        : (json['listOfAWSEmail'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredAwsEmail = json['listOfRequiredAWSEmail'] == null
+        ? null
+        : (json['listOfRequiredAWSEmail'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredAwsEmail',
+                )))
+            .toList();
+    final requiredListOfAwsEmail = json['requiredListOfAWSEmail'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsEmail',
+          ))
+        : (json['requiredListOfAWSEmail'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredAwsEmail =
+        json['requiredListOfRequiredAWSEmail'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsEmail',
+              ))
+            : (json['requiredListOfRequiredAWSEmail'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredAwsEmail',
+                    )))
+                .toList();
+    final listOfAwsjson = json['listOfAWSJSON'] == null
+        ? null
+        : (json['listOfAWSJSON'] as List<Object?>).cast<Object?>().toList();
+    final listOfRequiredAwsjson = json['listOfRequiredAWSJSON'] == null
+        ? null
+        : (json['listOfRequiredAWSJSON'] as List<Object?>)
+            .cast<Object?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredAwsjson',
+                )))
+            .toList();
+    final requiredListOfAwsjson = json['requiredListOfAWSJSON'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsjson',
+          ))
+        : (json['requiredListOfAWSJSON'] as List<Object?>)
+            .cast<Object?>()
+            .toList();
+    final requiredListOfRequiredAwsjson =
+        json['requiredListOfRequiredAWSJSON'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsjson',
+              ))
+            : (json['requiredListOfRequiredAWSJSON'] as List<Object?>)
+                .cast<Object?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredAwsjson',
+                    )))
+                .toList();
+    final listOfAwsPhone = json['listOfAWSPhone'] == null
+        ? null
+        : (json['listOfAWSPhone'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredAwsPhone = json['listOfRequiredAWSPhone'] == null
+        ? null
+        : (json['listOfRequiredAWSPhone'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListNonModel',
+                  'listOfRequiredAwsPhone',
+                )))
+            .toList();
+    final requiredListOfAwsPhone = json['requiredListOfAWSPhone'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsPhone',
+          ))
+        : (json['requiredListOfAWSPhone'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredAwsPhone =
+        json['requiredListOfRequiredAWSPhone'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsPhone',
+              ))
+            : (json['requiredListOfRequiredAWSPhone'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredAwsPhone',
+                    )))
+                .toList();
+    final listOfAwsUrl = json['listOfAWSUrl'] == null
+        ? null
+        : (json['listOfAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : Uri.parse(el))
+            .toList();
+    final listOfRequiredAwsUrl = json['listOfRequiredAWSUrl'] == null
+        ? null
+        : (json['listOfRequiredAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsUrl',
+                  ))
+                : Uri.parse(el))
+            .toList();
+    final requiredListOfAwsUrl = json['requiredListOfAWSUrl'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'requiredListOfAwsUrl',
+          ))
+        : (json['requiredListOfAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : Uri.parse(el))
+            .toList();
+    final requiredListOfRequiredAwsUrl =
+        json['requiredListOfRequiredAWSUrl'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsUrl',
+              ))
+            : (json['requiredListOfRequiredAWSUrl'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsUrl',
+                      ))
+                    : Uri.parse(el))
+                .toList();
+    final listOfAwsIpAddress = json['listOfAWSIpAddress'] == null
+        ? null
+        : (json['listOfAWSIpAddress'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final listOfRequiredAwsIpAddress =
+        json['listOfRequiredAWSIpAddress'] == null
+            ? null
+            : (json['listOfRequiredAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsIpAddress',
+                    )))
+                .toList();
+    final requiredListOfAwsIpAddress =
+        json['requiredListOfAWSIpAddress'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfAwsIpAddress',
+              ))
+            : (json['requiredListOfAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .toList();
+    final requiredListOfRequiredAwsIpAddress =
+        json['requiredListOfRequiredAWSIpAddress'] == null
+            ? (throw ModelFieldError(
+                'ScalarListNonModel',
+                'requiredListOfRequiredAwsIpAddress',
+              ))
+            : (json['requiredListOfRequiredAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'requiredListOfRequiredAwsIpAddress',
+                    )))
+                .toList();
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'ScalarListNonModel',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteScalarListNonModel(
+      id: id,
+      listOfString: listOfString,
+      listOfRequiredString: listOfRequiredString,
+      requiredListOfString: requiredListOfString,
+      requiredListOfRequiredString: requiredListOfRequiredString,
+      listOfInteger: listOfInteger,
+      listOfRequiredInteger: listOfRequiredInteger,
+      requiredListOfInteger: requiredListOfInteger,
+      requiredListOfRequiredInteger: requiredListOfRequiredInteger,
+      listOfFloat: listOfFloat,
+      listOfRequiredFloat: listOfRequiredFloat,
+      requiredListOfFloat: requiredListOfFloat,
+      requiredListOfRequiredFloat: requiredListOfRequiredFloat,
+      listOfBoolean: listOfBoolean,
+      listOfRequiredBoolean: listOfRequiredBoolean,
+      requiredListOfBoolean: requiredListOfBoolean,
+      requiredListOfRequiredBoolean: requiredListOfRequiredBoolean,
+      listOfAwsDate: listOfAwsDate,
+      listOfRequiredAwsDate: listOfRequiredAwsDate,
+      requiredListOfAwsDate: requiredListOfAwsDate,
+      requiredListOfRequiredAwsDate: requiredListOfRequiredAwsDate,
+      listOfAwsDateTime: listOfAwsDateTime,
+      listOfRequiredAwsDateTime: listOfRequiredAwsDateTime,
+      requiredListOfAwsDateTime: requiredListOfAwsDateTime,
+      requiredListOfRequiredAwsDateTime: requiredListOfRequiredAwsDateTime,
+      listOfAwsTime: listOfAwsTime,
+      listOfRequiredAwsTime: listOfRequiredAwsTime,
+      requiredListOfAwsTime: requiredListOfAwsTime,
+      requiredListOfRequiredAwsTime: requiredListOfRequiredAwsTime,
+      listOfAwsTimestamp: listOfAwsTimestamp,
+      listOfRequiredAwsTimestamp: listOfRequiredAwsTimestamp,
+      requiredListOfAwsTimestamp: requiredListOfAwsTimestamp,
+      requiredListOfRequiredAwsTimestamp: requiredListOfRequiredAwsTimestamp,
+      listOfAwsEmail: listOfAwsEmail,
+      listOfRequiredAwsEmail: listOfRequiredAwsEmail,
+      requiredListOfAwsEmail: requiredListOfAwsEmail,
+      requiredListOfRequiredAwsEmail: requiredListOfRequiredAwsEmail,
+      listOfAwsjson: listOfAwsjson,
+      listOfRequiredAwsjson: listOfRequiredAwsjson,
+      requiredListOfAwsjson: requiredListOfAwsjson,
+      requiredListOfRequiredAwsjson: requiredListOfRequiredAwsjson,
+      listOfAwsPhone: listOfAwsPhone,
+      listOfRequiredAwsPhone: listOfRequiredAwsPhone,
+      requiredListOfAwsPhone: requiredListOfAwsPhone,
+      requiredListOfRequiredAwsPhone: requiredListOfRequiredAwsPhone,
+      listOfAwsUrl: listOfAwsUrl,
+      listOfRequiredAwsUrl: listOfRequiredAwsUrl,
+      requiredListOfAwsUrl: requiredListOfAwsUrl,
+      requiredListOfRequiredAwsUrl: requiredListOfRequiredAwsUrl,
+      listOfAwsIpAddress: listOfAwsIpAddress,
+      listOfRequiredAwsIpAddress: listOfRequiredAwsIpAddress,
+      requiredListOfAwsIpAddress: requiredListOfAwsIpAddress,
+      requiredListOfRequiredAwsIpAddress: requiredListOfRequiredAwsIpAddress,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final List<String?>? listOfString;
+
+  @override
+  final List<String>? listOfRequiredString;
+
+  @override
+  final List<String?> requiredListOfString;
+
+  @override
+  final List<String> requiredListOfRequiredString;
+
+  @override
+  final List<int?>? listOfInteger;
+
+  @override
+  final List<int>? listOfRequiredInteger;
+
+  @override
+  final List<int?> requiredListOfInteger;
+
+  @override
+  final List<int> requiredListOfRequiredInteger;
+
+  @override
+  final List<double?>? listOfFloat;
+
+  @override
+  final List<double>? listOfRequiredFloat;
+
+  @override
+  final List<double?> requiredListOfFloat;
+
+  @override
+  final List<double> requiredListOfRequiredFloat;
+
+  @override
+  final List<bool?>? listOfBoolean;
+
+  @override
+  final List<bool>? listOfRequiredBoolean;
+
+  @override
+  final List<bool?> requiredListOfBoolean;
+
+  @override
+  final List<bool> requiredListOfRequiredBoolean;
+
+  @override
+  final List<TemporalDate?>? listOfAwsDate;
+
+  @override
+  final List<TemporalDate>? listOfRequiredAwsDate;
+
+  @override
+  final List<TemporalDate?> requiredListOfAwsDate;
+
+  @override
+  final List<TemporalDate> requiredListOfRequiredAwsDate;
+
+  @override
+  final List<TemporalDateTime?>? listOfAwsDateTime;
+
+  @override
+  final List<TemporalDateTime>? listOfRequiredAwsDateTime;
+
+  @override
+  final List<TemporalDateTime?> requiredListOfAwsDateTime;
+
+  @override
+  final List<TemporalDateTime> requiredListOfRequiredAwsDateTime;
+
+  @override
+  final List<TemporalTime?>? listOfAwsTime;
+
+  @override
+  final List<TemporalTime>? listOfRequiredAwsTime;
+
+  @override
+  final List<TemporalTime?> requiredListOfAwsTime;
+
+  @override
+  final List<TemporalTime> requiredListOfRequiredAwsTime;
+
+  @override
+  final List<TemporalTimestamp?>? listOfAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp>? listOfRequiredAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp?> requiredListOfAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp> requiredListOfRequiredAwsTimestamp;
+
+  @override
+  final List<String?>? listOfAwsEmail;
+
+  @override
+  final List<String>? listOfRequiredAwsEmail;
+
+  @override
+  final List<String?> requiredListOfAwsEmail;
+
+  @override
+  final List<String> requiredListOfRequiredAwsEmail;
+
+  @override
+  final List<Object?>? listOfAwsjson;
+
+  @override
+  final List<Object>? listOfRequiredAwsjson;
+
+  @override
+  final List<Object?> requiredListOfAwsjson;
+
+  @override
+  final List<Object> requiredListOfRequiredAwsjson;
+
+  @override
+  final List<String?>? listOfAwsPhone;
+
+  @override
+  final List<String>? listOfRequiredAwsPhone;
+
+  @override
+  final List<String?> requiredListOfAwsPhone;
+
+  @override
+  final List<String> requiredListOfRequiredAwsPhone;
+
+  @override
+  final List<Uri?>? listOfAwsUrl;
+
+  @override
+  final List<Uri>? listOfRequiredAwsUrl;
+
+  @override
+  final List<Uri?> requiredListOfAwsUrl;
+
+  @override
+  final List<Uri> requiredListOfRequiredAwsUrl;
+
+  @override
+  final List<String?>? listOfAwsIpAddress;
+
+  @override
+  final List<String>? listOfRequiredAwsIpAddress;
+
+  @override
+  final List<String?> requiredListOfAwsIpAddress;
+
+  @override
+  final List<String> requiredListOfRequiredAwsIpAddress;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_non_model.dart
@@ -62,28 +62,28 @@ class ScalarNonModel
             'id',
           ))
         : (json['id'] as String);
-    final str = json['str'] == null ? null : (json['str'] as String?);
+    final str = json['str'] == null ? null : (json['str'] as String);
     final requiredStr = json['requiredStr'] == null
         ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredStr',
           ))
         : (json['requiredStr'] as String);
-    final integer = json['integer'] == null ? null : (json['integer'] as int?);
+    final integer = json['integer'] == null ? null : (json['integer'] as int);
     final requiredInteger = json['requiredInteger'] == null
         ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredInteger',
           ))
         : (json['requiredInteger'] as int);
-    final float = json['float'] == null ? null : (json['float'] as double?);
+    final float = json['float'] == null ? null : (json['float'] as double);
     final requiredFloat = json['requiredFloat'] == null
         ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredFloat',
           ))
         : (json['requiredFloat'] as double);
-    final boolean = json['boolean'] == null ? null : (json['boolean'] as bool?);
+    final boolean = json['boolean'] == null ? null : (json['boolean'] as bool);
     final requiredBoolean = json['requiredBoolean'] == null
         ? (throw ModelFieldError(
             'ScalarNonModel',
@@ -127,7 +127,7 @@ class ScalarNonModel
           ))
         : TemporalTimestamp.fromSeconds((json['requiredAwsTimestamp'] as int));
     final awsEmail =
-        json['awsEmail'] == null ? null : (json['awsEmail'] as String?);
+        json['awsEmail'] == null ? null : (json['awsEmail'] as String);
     final requiredAwsEmail = json['requiredAwsEmail'] == null
         ? (throw ModelFieldError(
             'ScalarNonModel',
@@ -142,7 +142,7 @@ class ScalarNonModel
           ))
         : (json['requiredAwsJson'] as Object);
     final awsPhone =
-        json['awsPhone'] == null ? null : (json['awsPhone'] as String?);
+        json['awsPhone'] == null ? null : (json['awsPhone'] as String);
     final requiredAwsPhone = json['requiredAwsPhone'] == null
         ? (throw ModelFieldError(
             'ScalarNonModel',
@@ -158,7 +158,7 @@ class ScalarNonModel
           ))
         : Uri.parse((json['requiredAwsUrl'] as String));
     final awsIpAddress =
-        json['awsIpAddress'] == null ? null : (json['awsIpAddress'] as String?);
+        json['awsIpAddress'] == null ? null : (json['awsIpAddress'] as String);
     final requiredAwsIpAddress = json['requiredAwsIpAddress'] == null
         ? (throw ModelFieldError(
             'ScalarNonModel',

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_non_model.dart
@@ -19,7 +19,6 @@
 library models.scalar_non_model;
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:aws_common/aws_common.dart';
 
 class ScalarNonModel
     with

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_non_model.dart
@@ -58,113 +58,113 @@ class ScalarNonModel
 
   factory ScalarNonModel.fromJson(Map<String, Object?> json) {
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     final str = json['str'] == null ? null : (json['str'] as String?);
     final requiredStr = json['requiredStr'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredStr',
-          )
+          ))
         : (json['requiredStr'] as String);
     final integer = json['integer'] == null ? null : (json['integer'] as int?);
     final requiredInteger = json['requiredInteger'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredInteger',
-          )
+          ))
         : (json['requiredInteger'] as int);
     final float = json['float'] == null ? null : (json['float'] as double?);
     final requiredFloat = json['requiredFloat'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredFloat',
-          )
+          ))
         : (json['requiredFloat'] as double);
     final boolean = json['boolean'] == null ? null : (json['boolean'] as bool?);
     final requiredBoolean = json['requiredBoolean'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredBoolean',
-          )
+          ))
         : (json['requiredBoolean'] as bool);
     final awsDate = json['awsDate'] == null
         ? null
         : TemporalDate.fromString((json['awsDate'] as String));
     final requiredAwsDate = json['requiredAwsDate'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredAwsDate',
-          )
+          ))
         : TemporalDate.fromString((json['requiredAwsDate'] as String));
     final awsDateTime = json['awsDateTime'] == null
         ? null
         : TemporalDateTime.fromString((json['awsDateTime'] as String));
     final requiredAwsDateTime = json['requiredAwsDateTime'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredAwsDateTime',
-          )
+          ))
         : TemporalDateTime.fromString((json['requiredAwsDateTime'] as String));
     final awsTime = json['awsTime'] == null
         ? null
         : TemporalTime.fromString((json['awsTime'] as String));
     final requiredAwsTime = json['requiredAwsTime'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredAwsTime',
-          )
+          ))
         : TemporalTime.fromString((json['requiredAwsTime'] as String));
     final awsTimestamp = json['awsTimestamp'] == null
         ? null
         : TemporalTimestamp.fromSeconds((json['awsTimestamp'] as int));
     final requiredAwsTimestamp = json['requiredAwsTimestamp'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredAwsTimestamp',
-          )
+          ))
         : TemporalTimestamp.fromSeconds((json['requiredAwsTimestamp'] as int));
     final awsEmail =
         json['awsEmail'] == null ? null : (json['awsEmail'] as String?);
     final requiredAwsEmail = json['requiredAwsEmail'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredAwsEmail',
-          )
+          ))
         : (json['requiredAwsEmail'] as String);
     final awsJson = json['awsJson'];
     final requiredAwsJson = json['requiredAwsJson'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredAwsJson',
-          )
+          ))
         : (json['requiredAwsJson'] as Object);
     final awsPhone =
         json['awsPhone'] == null ? null : (json['awsPhone'] as String?);
     final requiredAwsPhone = json['requiredAwsPhone'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredAwsPhone',
-          )
+          ))
         : (json['requiredAwsPhone'] as String);
     final awsUrl =
         json['awsUrl'] == null ? null : Uri.parse((json['awsUrl'] as String));
     final requiredAwsUrl = json['requiredAwsUrl'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredAwsUrl',
-          )
+          ))
         : Uri.parse((json['requiredAwsUrl'] as String));
     final awsIpAddress =
         json['awsIpAddress'] == null ? null : (json['awsIpAddress'] as String?);
     final requiredAwsIpAddress = json['requiredAwsIpAddress'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarNonModel',
             'requiredAwsIpAddress',
-          )
+          ))
         : (json['requiredAwsIpAddress'] as String);
     return ScalarNonModel(
       id: id,

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_non_model.dart
@@ -16,6 +16,8 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
+// ignore_for_file: non_constant_identifier_names
+
 library models.scalar_non_model;
 
 import 'package:amplify_core/amplify_core.dart';

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
@@ -179,9 +179,13 @@ abstract class MyModel extends PartialMyModel
 
   static const MyModelType classType = MyModelType();
 
+  @override
   String get enum_;
+  @override
   TemporalDateTime? get createdAt;
+  @override
   TemporalDateTime? get updatedAt;
+  @override
   String get id;
 }
 

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
@@ -16,6 +16,8 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
+// ignore_for_file: non_constant_identifier_names
+
 library models.my_model;
 
 import 'package:amplify_core/amplify_core.dart';
@@ -37,6 +39,41 @@ class MyModelType extends ModelType<String, MyModel, PartialMyModel> {
 
   @override
   String get modelName => 'MyModel';
+}
+
+class MyModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const MyModelQueryFields([this.root]);
+
+  final QueryField<ModelIdentifier, M, MyModel>? root;
+
+  /// Query field for the [MyModel.enum_] field.
+  QueryField<ModelIdentifier, M, String> get $enum_ =>
+      NestedQueryField<ModelIdentifier, M, String, MyModel, String>(
+          const QueryField<String, MyModel, String>(fieldName: 'enum'));
+
+  /// Query field for the [MyModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, MyModel, TemporalDateTime?>(
+          const QueryField<String, MyModel, TemporalDateTime?>(
+              fieldName: 'createdAt'));
+
+  /// Query field for the [MyModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, MyModel, TemporalDateTime?>(
+          const QueryField<String, MyModel, TemporalDateTime?>(
+              fieldName: 'updatedAt'));
+
+  /// Query field for the [MyModel.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, MyModel, String>(
+          const QueryField<String, MyModel, String>(fieldName: 'id'));
+
+  /// Query field for the `modelIdentifier` field.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, MyModel, String>(
+          const QueryField<String, MyModel, String>(
+              fieldName: 'modelIdentifier'));
 }
 
 abstract class PartialMyModel extends PartialModel<String, MyModel>
@@ -178,14 +215,55 @@ abstract class MyModel extends PartialMyModel
 
   static const MyModelType classType = MyModelType();
 
+  static const MyModelQueryFields<String, MyModel> _queryFields =
+      MyModelQueryFields();
+
   @override
   String get enum_;
+
+  /// Query field for the [enum_] field.
+  QueryField<String, MyModel, String> get $enum_ => _queryFields.$enum_;
+
+  /// Query field for the [enum_] field.
+  @Deprecated(r'Use $enum_ instead')
+  QueryField<String, MyModel, String> get ENUM => $enum_;
   @override
   TemporalDateTime? get createdAt;
+
+  /// Query field for the [createdAt] field.
+  QueryField<String, MyModel, TemporalDateTime?> get $createdAt =>
+      _queryFields.$createdAt;
+
+  /// Query field for the [createdAt] field.
+  @Deprecated(r'Use $createdAt instead')
+  QueryField<String, MyModel, TemporalDateTime?> get CREATED_AT => $createdAt;
   @override
   TemporalDateTime? get updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  QueryField<String, MyModel, TemporalDateTime?> get $updatedAt =>
+      _queryFields.$updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  @Deprecated(r'Use $updatedAt instead')
+  QueryField<String, MyModel, TemporalDateTime?> get UPDATED_AT => $updatedAt;
   @override
   String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, MyModel, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, MyModel, String> get ID => $id;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, MyModel, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, MyModel, String> get MODEL_IDENTIFIER => $modelIdentifier;
 }
 
 class _MyModel extends MyModel {

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
@@ -19,7 +19,6 @@
 library models.my_model;
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:aws_common/aws_common.dart';
 
 class MyModelType extends ModelType<String, MyModel, PartialMyModel> {
   const MyModelType();

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
@@ -113,10 +113,10 @@ class _PartialMyModel extends PartialMyModel {
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     return _PartialMyModel(
       enum_: enum_,
@@ -152,10 +152,10 @@ abstract class MyModel extends PartialMyModel
 
   factory MyModel.fromJson(Map<String, Object?> json) {
     final enum_ = json['enum'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'enum_',
-          )
+          ))
         : (json['enum'] as String);
     final createdAt = json['createdAt'] == null
         ? null
@@ -164,10 +164,10 @@ abstract class MyModel extends PartialMyModel
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     return MyModel(
       enum_: enum_,
@@ -229,10 +229,10 @@ class _RemoteMyModel extends RemoteMyModel {
 
   factory _RemoteMyModel.fromJson(Map<String, Object?> json) {
     final enum_ = json['enum'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'enum_',
-          )
+          ))
         : (json['enum'] as String);
     final createdAt = json['createdAt'] == null
         ? null
@@ -241,28 +241,28 @@ class _RemoteMyModel extends RemoteMyModel {
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     final version = json['version'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'version',
-          )
+          ))
         : (json['version'] as int);
     final deleted = json['deleted'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'deleted',
-          )
+          ))
         : (json['deleted'] as bool);
     final lastChangedAt = json['lastChangedAt'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyModel',
             'lastChangedAt',
-          )
+          ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
     return _RemoteMyModel(
       enum_: enum_,

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
@@ -96,7 +96,7 @@ abstract class PartialMyModel extends PartialModel<String, MyModel>
 }
 
 class _PartialMyModel extends PartialMyModel {
-  _PartialMyModel({
+  const _PartialMyModel({
     this.enum_,
     this.createdAt,
     this.updatedAt,
@@ -104,7 +104,7 @@ class _PartialMyModel extends PartialMyModel {
   }) : super._();
 
   factory _PartialMyModel.fromJson(Map<String, Object?> json) {
-    final enum_ = json['enum'] == null ? null : (json['enum'] as String?);
+    final enum_ = json['enum'] == null ? null : (json['enum'] as String);
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
@@ -216,7 +216,7 @@ abstract class RemoteMyModel extends MyModel
 }
 
 class _RemoteMyModel extends RemoteMyModel {
-  _RemoteMyModel({
+  const _RemoteMyModel({
     required this.enum_,
     this.createdAt,
     this.updatedAt,

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_non_model.dart
@@ -19,7 +19,6 @@
 library models.my_non_model;
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:aws_common/aws_common.dart';
 
 class MyNonModel
     with

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_non_model.dart
@@ -16,6 +16,8 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
+// ignore_for_file: non_constant_identifier_names
+
 library models.my_non_model;
 
 import 'package:amplify_core/amplify_core.dart';

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_non_model.dart
@@ -30,10 +30,10 @@ class MyNonModel
 
   factory MyNonModel.fromJson(Map<String, Object?> json) {
     final enum_ = json['enum'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'MyNonModel',
             'enum_',
-          )
+          ))
         : (json['enum'] as String);
     return MyNonModel(enum_: enum_);
   }

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
@@ -16,6 +16,8 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
+// ignore_for_file: non_constant_identifier_names
+
 library models.cpk_model;
 
 import 'package:amplify_core/amplify_core.dart';
@@ -68,6 +70,46 @@ class CpkModelType
 
   @override
   String get modelName => 'CPKModel';
+}
+
+class CpkModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const CpkModelQueryFields([this.root]);
+
+  final QueryField<ModelIdentifier, M, CpkModel>? root;
+
+  /// Query field for the [CpkModel.firstName] field.
+  QueryField<ModelIdentifier, M, String> get $firstName => NestedQueryField<
+          ModelIdentifier, M, CpkModelIdentifier, CpkModel, String>(
+      const QueryField<CpkModelIdentifier, CpkModel, String>(
+          fieldName: 'firstName'));
+
+  /// Query field for the [CpkModel.lastName] field.
+  QueryField<ModelIdentifier, M, String> get $lastName => NestedQueryField<
+          ModelIdentifier, M, CpkModelIdentifier, CpkModel, String>(
+      const QueryField<CpkModelIdentifier, CpkModel, String>(
+          fieldName: 'lastName'));
+
+  /// Query field for the [CpkModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, CpkModelIdentifier, CpkModel,
+              TemporalDateTime?>(
+          const QueryField<CpkModelIdentifier, CpkModel, TemporalDateTime?>(
+              fieldName: 'createdAt'));
+
+  /// Query field for the [CpkModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, CpkModelIdentifier, CpkModel,
+              TemporalDateTime?>(
+          const QueryField<CpkModelIdentifier, CpkModel, TemporalDateTime?>(
+              fieldName: 'updatedAt'));
+
+  /// Query field for the `modelIdentifier` field.
+  QueryField<ModelIdentifier, M, CpkModelIdentifier> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, CpkModelIdentifier, CpkModel,
+              CpkModelIdentifier>(
+          const QueryField<CpkModelIdentifier, CpkModel, CpkModelIdentifier>(
+              fieldName: 'modelIdentifier'));
 }
 
 abstract class PartialCpkModel
@@ -219,14 +261,60 @@ abstract class CpkModel extends PartialCpkModel
 
   static const CpkModelType classType = CpkModelType();
 
+  static const CpkModelQueryFields<CpkModelIdentifier, CpkModel> _queryFields =
+      CpkModelQueryFields();
+
   @override
   String get firstName;
+
+  /// Query field for the [firstName] field.
+  QueryField<CpkModelIdentifier, CpkModel, String> get $firstName =>
+      _queryFields.$firstName;
+
+  /// Query field for the [firstName] field.
+  @Deprecated(r'Use $firstName instead')
+  QueryField<CpkModelIdentifier, CpkModel, String> get FIRST_NAME => $firstName;
   @override
   String get lastName;
+
+  /// Query field for the [lastName] field.
+  QueryField<CpkModelIdentifier, CpkModel, String> get $lastName =>
+      _queryFields.$lastName;
+
+  /// Query field for the [lastName] field.
+  @Deprecated(r'Use $lastName instead')
+  QueryField<CpkModelIdentifier, CpkModel, String> get LAST_NAME => $lastName;
   @override
   TemporalDateTime? get createdAt;
+
+  /// Query field for the [createdAt] field.
+  QueryField<CpkModelIdentifier, CpkModel, TemporalDateTime?> get $createdAt =>
+      _queryFields.$createdAt;
+
+  /// Query field for the [createdAt] field.
+  @Deprecated(r'Use $createdAt instead')
+  QueryField<CpkModelIdentifier, CpkModel, TemporalDateTime?> get CREATED_AT =>
+      $createdAt;
   @override
   TemporalDateTime? get updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  QueryField<CpkModelIdentifier, CpkModel, TemporalDateTime?> get $updatedAt =>
+      _queryFields.$updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  @Deprecated(r'Use $updatedAt instead')
+  QueryField<CpkModelIdentifier, CpkModel, TemporalDateTime?> get UPDATED_AT =>
+      $updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<CpkModelIdentifier, CpkModel, CpkModelIdentifier>
+      get $modelIdentifier => _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<CpkModelIdentifier, CpkModel, CpkModelIdentifier>
+      get MODEL_IDENTIFIER => $modelIdentifier;
 }
 
 class _CpkModel extends CpkModel {

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
@@ -132,7 +132,7 @@ abstract class PartialCpkModel
 }
 
 class _PartialCpkModel extends PartialCpkModel {
-  _PartialCpkModel({
+  const _PartialCpkModel({
     required this.firstName,
     required this.lastName,
     this.createdAt,
@@ -256,7 +256,7 @@ abstract class RemoteCpkModel extends CpkModel
 }
 
 class _RemoteCpkModel extends RemoteCpkModel {
-  _RemoteCpkModel({
+  const _RemoteCpkModel({
     required this.firstName,
     required this.lastName,
     this.createdAt,

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
@@ -19,7 +19,6 @@
 library models.cpk_model;
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:aws_common/aws_common.dart';
 import 'package:meta/meta.dart';
 
 @immutable

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
@@ -142,16 +142,16 @@ class _PartialCpkModel extends PartialCpkModel {
 
   factory _PartialCpkModel.fromJson(Map<String, Object?> json) {
     final firstName = json['firstName'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'CpkModel',
             'firstName',
-          )
+          ))
         : (json['firstName'] as String);
     final lastName = json['lastName'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'CpkModel',
             'lastName',
-          )
+          ))
         : (json['lastName'] as String);
     final createdAt = json['createdAt'] == null
         ? null
@@ -193,16 +193,16 @@ abstract class CpkModel extends PartialCpkModel
 
   factory CpkModel.fromJson(Map<String, Object?> json) {
     final firstName = json['firstName'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'CpkModel',
             'firstName',
-          )
+          ))
         : (json['firstName'] as String);
     final lastName = json['lastName'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'CpkModel',
             'lastName',
-          )
+          ))
         : (json['lastName'] as String);
     final createdAt = json['createdAt'] == null
         ? null
@@ -269,16 +269,16 @@ class _RemoteCpkModel extends RemoteCpkModel {
 
   factory _RemoteCpkModel.fromJson(Map<String, Object?> json) {
     final firstName = json['firstName'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'CpkModel',
             'firstName',
-          )
+          ))
         : (json['firstName'] as String);
     final lastName = json['lastName'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'CpkModel',
             'lastName',
-          )
+          ))
         : (json['lastName'] as String);
     final createdAt = json['createdAt'] == null
         ? null
@@ -287,22 +287,22 @@ class _RemoteCpkModel extends RemoteCpkModel {
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
     final version = json['version'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'CpkModel',
             'version',
-          )
+          ))
         : (json['version'] as int);
     final deleted = json['deleted'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'CpkModel',
             'deleted',
-          )
+          ))
         : (json['deleted'] as bool);
     final lastChangedAt = json['lastChangedAt'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'CpkModel',
             'lastChangedAt',
-          )
+          ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
     return _RemoteCpkModel(
       firstName: firstName,

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
@@ -220,9 +220,13 @@ abstract class CpkModel extends PartialCpkModel
 
   static const CpkModelType classType = CpkModelType();
 
+  @override
   String get firstName;
+  @override
   String get lastName;
+  @override
   TemporalDateTime? get createdAt;
+  @override
   TemporalDateTime? get updatedAt;
 }
 

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
@@ -19,7 +19,6 @@
 library models.scalar_list_model;
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:aws_common/aws_common.dart';
 
 class ScalarListModelType
     extends ModelType<String, ScalarListModel, PartialScalarListModel> {

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
@@ -425,7 +425,7 @@ abstract class PartialScalarListModel
 }
 
 class _PartialScalarListModel extends PartialScalarListModel {
-  _PartialScalarListModel({
+  const _PartialScalarListModel({
     required this.id,
     this.listOfString,
     this.listOfRequiredString,
@@ -2137,7 +2137,7 @@ abstract class RemoteScalarListModel extends ScalarListModel
 }
 
 class _RemoteScalarListModel extends RemoteScalarListModel {
-  _RemoteScalarListModel({
+  const _RemoteScalarListModel({
     required this.id,
     this.listOfString,
     this.listOfRequiredString,

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
@@ -16,6 +16,8 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
+// ignore_for_file: non_constant_identifier_names
+
 library models.scalar_list_model;
 
 import 'package:amplify_core/amplify_core.dart';
@@ -39,6 +41,405 @@ class ScalarListModelType
 
   @override
   String get modelName => 'ScalarListModel';
+}
+
+class ScalarListModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ScalarListModelQueryFields([this.root]);
+
+  final QueryField<ModelIdentifier, M, ScalarListModel>? root;
+
+  /// Query field for the [ScalarListModel.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String>(
+          const QueryField<String, ScalarListModel, String>(fieldName: 'id'));
+
+  /// Query field for the [ScalarListModel.listOfString] field.
+  QueryField<ModelIdentifier, M, List<String?>?> get $listOfString =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<String?>?>(
+          const QueryField<String, ScalarListModel, List<String?>?>(
+              fieldName: 'listOfString'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredString] field.
+  QueryField<ModelIdentifier, M, List<String>?> get $listOfRequiredString =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<String>?>(
+          const QueryField<String, ScalarListModel, List<String>?>(
+              fieldName: 'listOfRequiredString'));
+
+  /// Query field for the [ScalarListModel.requiredListOfString] field.
+  QueryField<ModelIdentifier, M, List<String?>> get $requiredListOfString =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<String?>>(
+          const QueryField<String, ScalarListModel, List<String?>>(
+              fieldName: 'requiredListOfString'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredString] field.
+  QueryField<ModelIdentifier, M, List<String>>
+      get $requiredListOfRequiredString => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<String>>(
+          const QueryField<String, ScalarListModel, List<String>>(
+              fieldName: 'requiredListOfRequiredString'));
+
+  /// Query field for the [ScalarListModel.listOfInteger] field.
+  QueryField<ModelIdentifier, M, List<int?>?> get $listOfInteger =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<int?>?>(
+          const QueryField<String, ScalarListModel, List<int?>?>(
+              fieldName: 'listOfInteger'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredInteger] field.
+  QueryField<ModelIdentifier, M, List<int>?> get $listOfRequiredInteger =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel, List<int>?>(
+          const QueryField<String, ScalarListModel, List<int>?>(
+              fieldName: 'listOfRequiredInteger'));
+
+  /// Query field for the [ScalarListModel.requiredListOfInteger] field.
+  QueryField<ModelIdentifier, M, List<int?>> get $requiredListOfInteger =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel, List<int?>>(
+          const QueryField<String, ScalarListModel, List<int?>>(
+              fieldName: 'requiredListOfInteger'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredInteger] field.
+  QueryField<ModelIdentifier, M, List<int>>
+      get $requiredListOfRequiredInteger => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<int>>(
+          const QueryField<String, ScalarListModel, List<int>>(
+              fieldName: 'requiredListOfRequiredInteger'));
+
+  /// Query field for the [ScalarListModel.listOfFloat] field.
+  QueryField<ModelIdentifier, M, List<double?>?> get $listOfFloat =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<double?>?>(
+          const QueryField<String, ScalarListModel, List<double?>?>(
+              fieldName: 'listOfFloat'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredFloat] field.
+  QueryField<ModelIdentifier, M, List<double>?> get $listOfRequiredFloat =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<double>?>(
+          const QueryField<String, ScalarListModel, List<double>?>(
+              fieldName: 'listOfRequiredFloat'));
+
+  /// Query field for the [ScalarListModel.requiredListOfFloat] field.
+  QueryField<ModelIdentifier, M, List<double?>> get $requiredListOfFloat =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<double?>>(
+          const QueryField<String, ScalarListModel, List<double?>>(
+              fieldName: 'requiredListOfFloat'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredFloat] field.
+  QueryField<ModelIdentifier, M, List<double>>
+      get $requiredListOfRequiredFloat => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<double>>(
+          const QueryField<String, ScalarListModel, List<double>>(
+              fieldName: 'requiredListOfRequiredFloat'));
+
+  /// Query field for the [ScalarListModel.listOfBoolean] field.
+  QueryField<ModelIdentifier, M, List<bool?>?> get $listOfBoolean =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<bool?>?>(
+          const QueryField<String, ScalarListModel, List<bool?>?>(
+              fieldName: 'listOfBoolean'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredBoolean] field.
+  QueryField<ModelIdentifier, M, List<bool>?> get $listOfRequiredBoolean =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<bool>?>(
+          const QueryField<String, ScalarListModel, List<bool>?>(
+              fieldName: 'listOfRequiredBoolean'));
+
+  /// Query field for the [ScalarListModel.requiredListOfBoolean] field.
+  QueryField<ModelIdentifier, M, List<bool?>> get $requiredListOfBoolean =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<bool?>>(
+          const QueryField<String, ScalarListModel, List<bool?>>(
+              fieldName: 'requiredListOfBoolean'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredBoolean] field.
+  QueryField<ModelIdentifier, M, List<bool>>
+      get $requiredListOfRequiredBoolean => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<bool>>(
+          const QueryField<String, ScalarListModel, List<bool>>(
+              fieldName: 'requiredListOfRequiredBoolean'));
+
+  /// Query field for the [ScalarListModel.listOfAwsDate] field.
+  QueryField<ModelIdentifier, M, List<TemporalDate?>?> get $listOfAwsDate =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<TemporalDate?>?>(
+          const QueryField<String, ScalarListModel, List<TemporalDate?>?>(
+              fieldName: 'listOfAWSDate'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredAwsDate] field.
+  QueryField<ModelIdentifier, M, List<TemporalDate>?>
+      get $listOfRequiredAwsDate => NestedQueryField<ModelIdentifier, M, String,
+              ScalarListModel, List<TemporalDate>?>(
+          const QueryField<String, ScalarListModel, List<TemporalDate>?>(
+              fieldName: 'listOfRequiredAWSDate'));
+
+  /// Query field for the [ScalarListModel.requiredListOfAwsDate] field.
+  QueryField<ModelIdentifier, M, List<TemporalDate?>>
+      get $requiredListOfAwsDate => NestedQueryField<ModelIdentifier, M, String,
+              ScalarListModel, List<TemporalDate?>>(
+          const QueryField<String, ScalarListModel, List<TemporalDate?>>(
+              fieldName: 'requiredListOfAWSDate'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredAwsDate] field.
+  QueryField<ModelIdentifier, M, List<TemporalDate>>
+      get $requiredListOfRequiredAwsDate => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<TemporalDate>>(
+          const QueryField<String, ScalarListModel, List<TemporalDate>>(
+              fieldName: 'requiredListOfRequiredAWSDate'));
+
+  /// Query field for the [ScalarListModel.listOfAwsDateTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalDateTime?>?>
+      get $listOfAwsDateTime => NestedQueryField<ModelIdentifier, M, String,
+              ScalarListModel, List<TemporalDateTime?>?>(
+          const QueryField<String, ScalarListModel, List<TemporalDateTime?>?>(
+              fieldName: 'listOfAWSDateTime'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredAwsDateTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalDateTime>?>
+      get $listOfRequiredAwsDateTime => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<TemporalDateTime>?>(
+          const QueryField<String, ScalarListModel, List<TemporalDateTime>?>(
+              fieldName: 'listOfRequiredAWSDateTime'));
+
+  /// Query field for the [ScalarListModel.requiredListOfAwsDateTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalDateTime?>>
+      get $requiredListOfAwsDateTime => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<TemporalDateTime?>>(
+          const QueryField<String, ScalarListModel, List<TemporalDateTime?>>(
+              fieldName: 'requiredListOfAWSDateTime'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredAwsDateTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalDateTime>>
+      get $requiredListOfRequiredAwsDateTime => NestedQueryField<
+              ModelIdentifier,
+              M,
+              String,
+              ScalarListModel,
+              List<TemporalDateTime>>(
+          const QueryField<String, ScalarListModel, List<TemporalDateTime>>(
+              fieldName: 'requiredListOfRequiredAWSDateTime'));
+
+  /// Query field for the [ScalarListModel.listOfAwsTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalTime?>?> get $listOfAwsTime =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<TemporalTime?>?>(
+          const QueryField<String, ScalarListModel, List<TemporalTime?>?>(
+              fieldName: 'listOfAWSTime'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredAwsTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalTime>?>
+      get $listOfRequiredAwsTime => NestedQueryField<ModelIdentifier, M, String,
+              ScalarListModel, List<TemporalTime>?>(
+          const QueryField<String, ScalarListModel, List<TemporalTime>?>(
+              fieldName: 'listOfRequiredAWSTime'));
+
+  /// Query field for the [ScalarListModel.requiredListOfAwsTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalTime?>>
+      get $requiredListOfAwsTime => NestedQueryField<ModelIdentifier, M, String,
+              ScalarListModel, List<TemporalTime?>>(
+          const QueryField<String, ScalarListModel, List<TemporalTime?>>(
+              fieldName: 'requiredListOfAWSTime'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredAwsTime] field.
+  QueryField<ModelIdentifier, M, List<TemporalTime>>
+      get $requiredListOfRequiredAwsTime => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<TemporalTime>>(
+          const QueryField<String, ScalarListModel, List<TemporalTime>>(
+              fieldName: 'requiredListOfRequiredAWSTime'));
+
+  /// Query field for the [ScalarListModel.listOfAwsTimestamp] field.
+  QueryField<ModelIdentifier, M, List<TemporalTimestamp?>?>
+      get $listOfAwsTimestamp => NestedQueryField<ModelIdentifier, M, String,
+              ScalarListModel, List<TemporalTimestamp?>?>(
+          const QueryField<String, ScalarListModel, List<TemporalTimestamp?>?>(
+              fieldName: 'listOfAWSTimestamp'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredAwsTimestamp] field.
+  QueryField<ModelIdentifier, M, List<TemporalTimestamp>?>
+      get $listOfRequiredAwsTimestamp => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<TemporalTimestamp>?>(
+          const QueryField<String, ScalarListModel, List<TemporalTimestamp>?>(
+              fieldName: 'listOfRequiredAWSTimestamp'));
+
+  /// Query field for the [ScalarListModel.requiredListOfAwsTimestamp] field.
+  QueryField<ModelIdentifier, M, List<TemporalTimestamp?>>
+      get $requiredListOfAwsTimestamp => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<TemporalTimestamp?>>(
+          const QueryField<String, ScalarListModel, List<TemporalTimestamp?>>(
+              fieldName: 'requiredListOfAWSTimestamp'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredAwsTimestamp] field.
+  QueryField<ModelIdentifier, M, List<TemporalTimestamp>>
+      get $requiredListOfRequiredAwsTimestamp => NestedQueryField<
+              ModelIdentifier,
+              M,
+              String,
+              ScalarListModel,
+              List<TemporalTimestamp>>(
+          const QueryField<String, ScalarListModel, List<TemporalTimestamp>>(
+              fieldName: 'requiredListOfRequiredAWSTimestamp'));
+
+  /// Query field for the [ScalarListModel.listOfAwsEmail] field.
+  QueryField<ModelIdentifier, M, List<String?>?> get $listOfAwsEmail =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<String?>?>(
+          const QueryField<String, ScalarListModel, List<String?>?>(
+              fieldName: 'listOfAWSEmail'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredAwsEmail] field.
+  QueryField<ModelIdentifier, M, List<String>?> get $listOfRequiredAwsEmail =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<String>?>(
+          const QueryField<String, ScalarListModel, List<String>?>(
+              fieldName: 'listOfRequiredAWSEmail'));
+
+  /// Query field for the [ScalarListModel.requiredListOfAwsEmail] field.
+  QueryField<ModelIdentifier, M, List<String?>> get $requiredListOfAwsEmail =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<String?>>(
+          const QueryField<String, ScalarListModel, List<String?>>(
+              fieldName: 'requiredListOfAWSEmail'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredAwsEmail] field.
+  QueryField<ModelIdentifier, M, List<String>>
+      get $requiredListOfRequiredAwsEmail => NestedQueryField<ModelIdentifier,
+              M, String, ScalarListModel, List<String>>(
+          const QueryField<String, ScalarListModel, List<String>>(
+              fieldName: 'requiredListOfRequiredAWSEmail'));
+
+  /// Query field for the [ScalarListModel.listOfAwsjson] field.
+  QueryField<ModelIdentifier, M, List<Object?>?> get $listOfAwsjson =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<Object?>?>(
+          const QueryField<String, ScalarListModel, List<Object?>?>(
+              fieldName: 'listOfAWSJSON'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredAwsjson] field.
+  QueryField<ModelIdentifier, M, List<Object>?> get $listOfRequiredAwsjson =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<Object>?>(
+          const QueryField<String, ScalarListModel, List<Object>?>(
+              fieldName: 'listOfRequiredAWSJSON'));
+
+  /// Query field for the [ScalarListModel.requiredListOfAwsjson] field.
+  QueryField<ModelIdentifier, M, List<Object?>> get $requiredListOfAwsjson =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<Object?>>(
+          const QueryField<String, ScalarListModel, List<Object?>>(
+              fieldName: 'requiredListOfAWSJSON'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredAwsjson] field.
+  QueryField<ModelIdentifier, M, List<Object>>
+      get $requiredListOfRequiredAwsjson => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<Object>>(
+          const QueryField<String, ScalarListModel, List<Object>>(
+              fieldName: 'requiredListOfRequiredAWSJSON'));
+
+  /// Query field for the [ScalarListModel.listOfAwsPhone] field.
+  QueryField<ModelIdentifier, M, List<String?>?> get $listOfAwsPhone =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<String?>?>(
+          const QueryField<String, ScalarListModel, List<String?>?>(
+              fieldName: 'listOfAWSPhone'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredAwsPhone] field.
+  QueryField<ModelIdentifier, M, List<String>?> get $listOfRequiredAwsPhone =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<String>?>(
+          const QueryField<String, ScalarListModel, List<String>?>(
+              fieldName: 'listOfRequiredAWSPhone'));
+
+  /// Query field for the [ScalarListModel.requiredListOfAwsPhone] field.
+  QueryField<ModelIdentifier, M, List<String?>> get $requiredListOfAwsPhone =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<String?>>(
+          const QueryField<String, ScalarListModel, List<String?>>(
+              fieldName: 'requiredListOfAWSPhone'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredAwsPhone] field.
+  QueryField<ModelIdentifier, M, List<String>>
+      get $requiredListOfRequiredAwsPhone => NestedQueryField<ModelIdentifier,
+              M, String, ScalarListModel, List<String>>(
+          const QueryField<String, ScalarListModel, List<String>>(
+              fieldName: 'requiredListOfRequiredAWSPhone'));
+
+  /// Query field for the [ScalarListModel.listOfAwsUrl] field.
+  QueryField<ModelIdentifier, M, List<Uri?>?>
+      get $listOfAwsUrl => NestedQueryField<ModelIdentifier, M, String,
+              ScalarListModel, List<Uri?>?>(
+          const QueryField<String, ScalarListModel, List<Uri?>?>(
+              fieldName: 'listOfAWSUrl'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredAwsUrl] field.
+  QueryField<ModelIdentifier, M, List<Uri>?> get $listOfRequiredAwsUrl =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel, List<Uri>?>(
+          const QueryField<String, ScalarListModel, List<Uri>?>(
+              fieldName: 'listOfRequiredAWSUrl'));
+
+  /// Query field for the [ScalarListModel.requiredListOfAwsUrl] field.
+  QueryField<ModelIdentifier, M, List<Uri?>> get $requiredListOfAwsUrl =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel, List<Uri?>>(
+          const QueryField<String, ScalarListModel, List<Uri?>>(
+              fieldName: 'requiredListOfAWSUrl'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredAwsUrl] field.
+  QueryField<ModelIdentifier, M, List<Uri>> get $requiredListOfRequiredAwsUrl =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel, List<Uri>>(
+          const QueryField<String, ScalarListModel, List<Uri>>(
+              fieldName: 'requiredListOfRequiredAWSUrl'));
+
+  /// Query field for the [ScalarListModel.listOfAwsIpAddress] field.
+  QueryField<ModelIdentifier, M, List<String?>?> get $listOfAwsIpAddress =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              List<String?>?>(
+          const QueryField<String, ScalarListModel, List<String?>?>(
+              fieldName: 'listOfAWSIpAddress'));
+
+  /// Query field for the [ScalarListModel.listOfRequiredAwsIpAddress] field.
+  QueryField<ModelIdentifier, M, List<String>?>
+      get $listOfRequiredAwsIpAddress => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<String>?>(
+          const QueryField<String, ScalarListModel, List<String>?>(
+              fieldName: 'listOfRequiredAWSIpAddress'));
+
+  /// Query field for the [ScalarListModel.requiredListOfAwsIpAddress] field.
+  QueryField<ModelIdentifier, M, List<String?>>
+      get $requiredListOfAwsIpAddress => NestedQueryField<ModelIdentifier, M,
+              String, ScalarListModel, List<String?>>(
+          const QueryField<String, ScalarListModel, List<String?>>(
+              fieldName: 'requiredListOfAWSIpAddress'));
+
+  /// Query field for the [ScalarListModel.requiredListOfRequiredAwsIpAddress] field.
+  QueryField<ModelIdentifier, M, List<String>>
+      get $requiredListOfRequiredAwsIpAddress => NestedQueryField<
+              ModelIdentifier, M, String, ScalarListModel, List<String>>(
+          const QueryField<String, ScalarListModel, List<String>>(
+              fieldName: 'requiredListOfRequiredAWSIpAddress'));
+
+  /// Query field for the [ScalarListModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              TemporalDateTime?>(
+          const QueryField<String, ScalarListModel, TemporalDateTime?>(
+              fieldName: 'createdAt'));
+
+  /// Query field for the [ScalarListModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
+              TemporalDateTime?>(
+          const QueryField<String, ScalarListModel, TemporalDateTime?>(
+              fieldName: 'updatedAt'));
+
+  /// Query field for the `modelIdentifier` field.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String>(
+          const QueryField<String, ScalarListModel, String>(
+              fieldName: 'modelIdentifier'));
 }
 
 abstract class PartialScalarListModel
@@ -1793,116 +2194,643 @@ abstract class ScalarListModel extends PartialScalarListModel
 
   static const ScalarListModelType classType = ScalarListModelType();
 
+  static const ScalarListModelQueryFields<String, ScalarListModel>
+      _queryFields = ScalarListModelQueryFields();
+
   @override
   String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, ScalarListModel, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, ScalarListModel, String> get ID => $id;
   @override
   List<String?>? get listOfString;
+
+  /// Query field for the [listOfString] field.
+  QueryField<String, ScalarListModel, List<String?>?> get $listOfString =>
+      _queryFields.$listOfString;
+
+  /// Query field for the [listOfString] field.
+  @Deprecated(r'Use $listOfString instead')
+  QueryField<String, ScalarListModel, List<String?>?> get LIST_OF_STRING =>
+      $listOfString;
   @override
   List<String>? get listOfRequiredString;
+
+  /// Query field for the [listOfRequiredString] field.
+  QueryField<String, ScalarListModel, List<String>?>
+      get $listOfRequiredString => _queryFields.$listOfRequiredString;
+
+  /// Query field for the [listOfRequiredString] field.
+  @Deprecated(r'Use $listOfRequiredString instead')
+  QueryField<String, ScalarListModel, List<String>?>
+      get LIST_OF_REQUIRED_STRING => $listOfRequiredString;
   @override
   List<String?> get requiredListOfString;
+
+  /// Query field for the [requiredListOfString] field.
+  QueryField<String, ScalarListModel, List<String?>>
+      get $requiredListOfString => _queryFields.$requiredListOfString;
+
+  /// Query field for the [requiredListOfString] field.
+  @Deprecated(r'Use $requiredListOfString instead')
+  QueryField<String, ScalarListModel, List<String?>>
+      get REQUIRED_LIST_OF_STRING => $requiredListOfString;
   @override
   List<String> get requiredListOfRequiredString;
+
+  /// Query field for the [requiredListOfRequiredString] field.
+  QueryField<String, ScalarListModel, List<String>>
+      get $requiredListOfRequiredString =>
+          _queryFields.$requiredListOfRequiredString;
+
+  /// Query field for the [requiredListOfRequiredString] field.
+  @Deprecated(r'Use $requiredListOfRequiredString instead')
+  QueryField<String, ScalarListModel, List<String>>
+      get REQUIRED_LIST_OF_REQUIRED_STRING => $requiredListOfRequiredString;
   @override
   List<int?>? get listOfInteger;
+
+  /// Query field for the [listOfInteger] field.
+  QueryField<String, ScalarListModel, List<int?>?> get $listOfInteger =>
+      _queryFields.$listOfInteger;
+
+  /// Query field for the [listOfInteger] field.
+  @Deprecated(r'Use $listOfInteger instead')
+  QueryField<String, ScalarListModel, List<int?>?> get LIST_OF_INTEGER =>
+      $listOfInteger;
   @override
   List<int>? get listOfRequiredInteger;
+
+  /// Query field for the [listOfRequiredInteger] field.
+  QueryField<String, ScalarListModel, List<int>?> get $listOfRequiredInteger =>
+      _queryFields.$listOfRequiredInteger;
+
+  /// Query field for the [listOfRequiredInteger] field.
+  @Deprecated(r'Use $listOfRequiredInteger instead')
+  QueryField<String, ScalarListModel, List<int>?>
+      get LIST_OF_REQUIRED_INTEGER => $listOfRequiredInteger;
   @override
   List<int?> get requiredListOfInteger;
+
+  /// Query field for the [requiredListOfInteger] field.
+  QueryField<String, ScalarListModel, List<int?>> get $requiredListOfInteger =>
+      _queryFields.$requiredListOfInteger;
+
+  /// Query field for the [requiredListOfInteger] field.
+  @Deprecated(r'Use $requiredListOfInteger instead')
+  QueryField<String, ScalarListModel, List<int?>>
+      get REQUIRED_LIST_OF_INTEGER => $requiredListOfInteger;
   @override
   List<int> get requiredListOfRequiredInteger;
+
+  /// Query field for the [requiredListOfRequiredInteger] field.
+  QueryField<String, ScalarListModel, List<int>>
+      get $requiredListOfRequiredInteger =>
+          _queryFields.$requiredListOfRequiredInteger;
+
+  /// Query field for the [requiredListOfRequiredInteger] field.
+  @Deprecated(r'Use $requiredListOfRequiredInteger instead')
+  QueryField<String, ScalarListModel, List<int>>
+      get REQUIRED_LIST_OF_REQUIRED_INTEGER => $requiredListOfRequiredInteger;
   @override
   List<double?>? get listOfFloat;
+
+  /// Query field for the [listOfFloat] field.
+  QueryField<String, ScalarListModel, List<double?>?> get $listOfFloat =>
+      _queryFields.$listOfFloat;
+
+  /// Query field for the [listOfFloat] field.
+  @Deprecated(r'Use $listOfFloat instead')
+  QueryField<String, ScalarListModel, List<double?>?> get LIST_OF_FLOAT =>
+      $listOfFloat;
   @override
   List<double>? get listOfRequiredFloat;
+
+  /// Query field for the [listOfRequiredFloat] field.
+  QueryField<String, ScalarListModel, List<double>?> get $listOfRequiredFloat =>
+      _queryFields.$listOfRequiredFloat;
+
+  /// Query field for the [listOfRequiredFloat] field.
+  @Deprecated(r'Use $listOfRequiredFloat instead')
+  QueryField<String, ScalarListModel, List<double>?>
+      get LIST_OF_REQUIRED_FLOAT => $listOfRequiredFloat;
   @override
   List<double?> get requiredListOfFloat;
+
+  /// Query field for the [requiredListOfFloat] field.
+  QueryField<String, ScalarListModel, List<double?>> get $requiredListOfFloat =>
+      _queryFields.$requiredListOfFloat;
+
+  /// Query field for the [requiredListOfFloat] field.
+  @Deprecated(r'Use $requiredListOfFloat instead')
+  QueryField<String, ScalarListModel, List<double?>>
+      get REQUIRED_LIST_OF_FLOAT => $requiredListOfFloat;
   @override
   List<double> get requiredListOfRequiredFloat;
+
+  /// Query field for the [requiredListOfRequiredFloat] field.
+  QueryField<String, ScalarListModel, List<double>>
+      get $requiredListOfRequiredFloat =>
+          _queryFields.$requiredListOfRequiredFloat;
+
+  /// Query field for the [requiredListOfRequiredFloat] field.
+  @Deprecated(r'Use $requiredListOfRequiredFloat instead')
+  QueryField<String, ScalarListModel, List<double>>
+      get REQUIRED_LIST_OF_REQUIRED_FLOAT => $requiredListOfRequiredFloat;
   @override
   List<bool?>? get listOfBoolean;
+
+  /// Query field for the [listOfBoolean] field.
+  QueryField<String, ScalarListModel, List<bool?>?> get $listOfBoolean =>
+      _queryFields.$listOfBoolean;
+
+  /// Query field for the [listOfBoolean] field.
+  @Deprecated(r'Use $listOfBoolean instead')
+  QueryField<String, ScalarListModel, List<bool?>?> get LIST_OF_BOOLEAN =>
+      $listOfBoolean;
   @override
   List<bool>? get listOfRequiredBoolean;
+
+  /// Query field for the [listOfRequiredBoolean] field.
+  QueryField<String, ScalarListModel, List<bool>?> get $listOfRequiredBoolean =>
+      _queryFields.$listOfRequiredBoolean;
+
+  /// Query field for the [listOfRequiredBoolean] field.
+  @Deprecated(r'Use $listOfRequiredBoolean instead')
+  QueryField<String, ScalarListModel, List<bool>?>
+      get LIST_OF_REQUIRED_BOOLEAN => $listOfRequiredBoolean;
   @override
   List<bool?> get requiredListOfBoolean;
+
+  /// Query field for the [requiredListOfBoolean] field.
+  QueryField<String, ScalarListModel, List<bool?>> get $requiredListOfBoolean =>
+      _queryFields.$requiredListOfBoolean;
+
+  /// Query field for the [requiredListOfBoolean] field.
+  @Deprecated(r'Use $requiredListOfBoolean instead')
+  QueryField<String, ScalarListModel, List<bool?>>
+      get REQUIRED_LIST_OF_BOOLEAN => $requiredListOfBoolean;
   @override
   List<bool> get requiredListOfRequiredBoolean;
+
+  /// Query field for the [requiredListOfRequiredBoolean] field.
+  QueryField<String, ScalarListModel, List<bool>>
+      get $requiredListOfRequiredBoolean =>
+          _queryFields.$requiredListOfRequiredBoolean;
+
+  /// Query field for the [requiredListOfRequiredBoolean] field.
+  @Deprecated(r'Use $requiredListOfRequiredBoolean instead')
+  QueryField<String, ScalarListModel, List<bool>>
+      get REQUIRED_LIST_OF_REQUIRED_BOOLEAN => $requiredListOfRequiredBoolean;
   @override
   List<TemporalDate?>? get listOfAwsDate;
+
+  /// Query field for the [listOfAwsDate] field.
+  QueryField<String, ScalarListModel, List<TemporalDate?>?>
+      get $listOfAwsDate => _queryFields.$listOfAwsDate;
+
+  /// Query field for the [listOfAwsDate] field.
+  @Deprecated(r'Use $listOfAwsDate instead')
+  QueryField<String, ScalarListModel, List<TemporalDate?>?>
+      get LIST_OF_AWS_DATE => $listOfAwsDate;
   @override
   List<TemporalDate>? get listOfRequiredAwsDate;
+
+  /// Query field for the [listOfRequiredAwsDate] field.
+  QueryField<String, ScalarListModel, List<TemporalDate>?>
+      get $listOfRequiredAwsDate => _queryFields.$listOfRequiredAwsDate;
+
+  /// Query field for the [listOfRequiredAwsDate] field.
+  @Deprecated(r'Use $listOfRequiredAwsDate instead')
+  QueryField<String, ScalarListModel, List<TemporalDate>?>
+      get LIST_OF_REQUIRED_AWS_DATE => $listOfRequiredAwsDate;
   @override
   List<TemporalDate?> get requiredListOfAwsDate;
+
+  /// Query field for the [requiredListOfAwsDate] field.
+  QueryField<String, ScalarListModel, List<TemporalDate?>>
+      get $requiredListOfAwsDate => _queryFields.$requiredListOfAwsDate;
+
+  /// Query field for the [requiredListOfAwsDate] field.
+  @Deprecated(r'Use $requiredListOfAwsDate instead')
+  QueryField<String, ScalarListModel, List<TemporalDate?>>
+      get REQUIRED_LIST_OF_AWS_DATE => $requiredListOfAwsDate;
   @override
   List<TemporalDate> get requiredListOfRequiredAwsDate;
+
+  /// Query field for the [requiredListOfRequiredAwsDate] field.
+  QueryField<String, ScalarListModel, List<TemporalDate>>
+      get $requiredListOfRequiredAwsDate =>
+          _queryFields.$requiredListOfRequiredAwsDate;
+
+  /// Query field for the [requiredListOfRequiredAwsDate] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsDate instead')
+  QueryField<String, ScalarListModel, List<TemporalDate>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_DATE => $requiredListOfRequiredAwsDate;
   @override
   List<TemporalDateTime?>? get listOfAwsDateTime;
+
+  /// Query field for the [listOfAwsDateTime] field.
+  QueryField<String, ScalarListModel, List<TemporalDateTime?>?>
+      get $listOfAwsDateTime => _queryFields.$listOfAwsDateTime;
+
+  /// Query field for the [listOfAwsDateTime] field.
+  @Deprecated(r'Use $listOfAwsDateTime instead')
+  QueryField<String, ScalarListModel, List<TemporalDateTime?>?>
+      get LIST_OF_AWS_DATE_TIME => $listOfAwsDateTime;
   @override
   List<TemporalDateTime>? get listOfRequiredAwsDateTime;
+
+  /// Query field for the [listOfRequiredAwsDateTime] field.
+  QueryField<String, ScalarListModel, List<TemporalDateTime>?>
+      get $listOfRequiredAwsDateTime => _queryFields.$listOfRequiredAwsDateTime;
+
+  /// Query field for the [listOfRequiredAwsDateTime] field.
+  @Deprecated(r'Use $listOfRequiredAwsDateTime instead')
+  QueryField<String, ScalarListModel, List<TemporalDateTime>?>
+      get LIST_OF_REQUIRED_AWS_DATE_TIME => $listOfRequiredAwsDateTime;
   @override
   List<TemporalDateTime?> get requiredListOfAwsDateTime;
+
+  /// Query field for the [requiredListOfAwsDateTime] field.
+  QueryField<String, ScalarListModel, List<TemporalDateTime?>>
+      get $requiredListOfAwsDateTime => _queryFields.$requiredListOfAwsDateTime;
+
+  /// Query field for the [requiredListOfAwsDateTime] field.
+  @Deprecated(r'Use $requiredListOfAwsDateTime instead')
+  QueryField<String, ScalarListModel, List<TemporalDateTime?>>
+      get REQUIRED_LIST_OF_AWS_DATE_TIME => $requiredListOfAwsDateTime;
   @override
   List<TemporalDateTime> get requiredListOfRequiredAwsDateTime;
+
+  /// Query field for the [requiredListOfRequiredAwsDateTime] field.
+  QueryField<String, ScalarListModel, List<TemporalDateTime>>
+      get $requiredListOfRequiredAwsDateTime =>
+          _queryFields.$requiredListOfRequiredAwsDateTime;
+
+  /// Query field for the [requiredListOfRequiredAwsDateTime] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsDateTime instead')
+  QueryField<String, ScalarListModel, List<TemporalDateTime>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_DATE_TIME =>
+          $requiredListOfRequiredAwsDateTime;
   @override
   List<TemporalTime?>? get listOfAwsTime;
+
+  /// Query field for the [listOfAwsTime] field.
+  QueryField<String, ScalarListModel, List<TemporalTime?>?>
+      get $listOfAwsTime => _queryFields.$listOfAwsTime;
+
+  /// Query field for the [listOfAwsTime] field.
+  @Deprecated(r'Use $listOfAwsTime instead')
+  QueryField<String, ScalarListModel, List<TemporalTime?>?>
+      get LIST_OF_AWS_TIME => $listOfAwsTime;
   @override
   List<TemporalTime>? get listOfRequiredAwsTime;
+
+  /// Query field for the [listOfRequiredAwsTime] field.
+  QueryField<String, ScalarListModel, List<TemporalTime>?>
+      get $listOfRequiredAwsTime => _queryFields.$listOfRequiredAwsTime;
+
+  /// Query field for the [listOfRequiredAwsTime] field.
+  @Deprecated(r'Use $listOfRequiredAwsTime instead')
+  QueryField<String, ScalarListModel, List<TemporalTime>?>
+      get LIST_OF_REQUIRED_AWS_TIME => $listOfRequiredAwsTime;
   @override
   List<TemporalTime?> get requiredListOfAwsTime;
+
+  /// Query field for the [requiredListOfAwsTime] field.
+  QueryField<String, ScalarListModel, List<TemporalTime?>>
+      get $requiredListOfAwsTime => _queryFields.$requiredListOfAwsTime;
+
+  /// Query field for the [requiredListOfAwsTime] field.
+  @Deprecated(r'Use $requiredListOfAwsTime instead')
+  QueryField<String, ScalarListModel, List<TemporalTime?>>
+      get REQUIRED_LIST_OF_AWS_TIME => $requiredListOfAwsTime;
   @override
   List<TemporalTime> get requiredListOfRequiredAwsTime;
+
+  /// Query field for the [requiredListOfRequiredAwsTime] field.
+  QueryField<String, ScalarListModel, List<TemporalTime>>
+      get $requiredListOfRequiredAwsTime =>
+          _queryFields.$requiredListOfRequiredAwsTime;
+
+  /// Query field for the [requiredListOfRequiredAwsTime] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsTime instead')
+  QueryField<String, ScalarListModel, List<TemporalTime>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_TIME => $requiredListOfRequiredAwsTime;
   @override
   List<TemporalTimestamp?>? get listOfAwsTimestamp;
+
+  /// Query field for the [listOfAwsTimestamp] field.
+  QueryField<String, ScalarListModel, List<TemporalTimestamp?>?>
+      get $listOfAwsTimestamp => _queryFields.$listOfAwsTimestamp;
+
+  /// Query field for the [listOfAwsTimestamp] field.
+  @Deprecated(r'Use $listOfAwsTimestamp instead')
+  QueryField<String, ScalarListModel, List<TemporalTimestamp?>?>
+      get LIST_OF_AWS_TIMESTAMP => $listOfAwsTimestamp;
   @override
   List<TemporalTimestamp>? get listOfRequiredAwsTimestamp;
+
+  /// Query field for the [listOfRequiredAwsTimestamp] field.
+  QueryField<String, ScalarListModel, List<TemporalTimestamp>?>
+      get $listOfRequiredAwsTimestamp =>
+          _queryFields.$listOfRequiredAwsTimestamp;
+
+  /// Query field for the [listOfRequiredAwsTimestamp] field.
+  @Deprecated(r'Use $listOfRequiredAwsTimestamp instead')
+  QueryField<String, ScalarListModel, List<TemporalTimestamp>?>
+      get LIST_OF_REQUIRED_AWS_TIMESTAMP => $listOfRequiredAwsTimestamp;
   @override
   List<TemporalTimestamp?> get requiredListOfAwsTimestamp;
+
+  /// Query field for the [requiredListOfAwsTimestamp] field.
+  QueryField<String, ScalarListModel, List<TemporalTimestamp?>>
+      get $requiredListOfAwsTimestamp =>
+          _queryFields.$requiredListOfAwsTimestamp;
+
+  /// Query field for the [requiredListOfAwsTimestamp] field.
+  @Deprecated(r'Use $requiredListOfAwsTimestamp instead')
+  QueryField<String, ScalarListModel, List<TemporalTimestamp?>>
+      get REQUIRED_LIST_OF_AWS_TIMESTAMP => $requiredListOfAwsTimestamp;
   @override
   List<TemporalTimestamp> get requiredListOfRequiredAwsTimestamp;
+
+  /// Query field for the [requiredListOfRequiredAwsTimestamp] field.
+  QueryField<String, ScalarListModel, List<TemporalTimestamp>>
+      get $requiredListOfRequiredAwsTimestamp =>
+          _queryFields.$requiredListOfRequiredAwsTimestamp;
+
+  /// Query field for the [requiredListOfRequiredAwsTimestamp] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsTimestamp instead')
+  QueryField<String, ScalarListModel, List<TemporalTimestamp>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_TIMESTAMP =>
+          $requiredListOfRequiredAwsTimestamp;
   @override
   List<String?>? get listOfAwsEmail;
+
+  /// Query field for the [listOfAwsEmail] field.
+  QueryField<String, ScalarListModel, List<String?>?> get $listOfAwsEmail =>
+      _queryFields.$listOfAwsEmail;
+
+  /// Query field for the [listOfAwsEmail] field.
+  @Deprecated(r'Use $listOfAwsEmail instead')
+  QueryField<String, ScalarListModel, List<String?>?> get LIST_OF_AWS_EMAIL =>
+      $listOfAwsEmail;
   @override
   List<String>? get listOfRequiredAwsEmail;
+
+  /// Query field for the [listOfRequiredAwsEmail] field.
+  QueryField<String, ScalarListModel, List<String>?>
+      get $listOfRequiredAwsEmail => _queryFields.$listOfRequiredAwsEmail;
+
+  /// Query field for the [listOfRequiredAwsEmail] field.
+  @Deprecated(r'Use $listOfRequiredAwsEmail instead')
+  QueryField<String, ScalarListModel, List<String>?>
+      get LIST_OF_REQUIRED_AWS_EMAIL => $listOfRequiredAwsEmail;
   @override
   List<String?> get requiredListOfAwsEmail;
+
+  /// Query field for the [requiredListOfAwsEmail] field.
+  QueryField<String, ScalarListModel, List<String?>>
+      get $requiredListOfAwsEmail => _queryFields.$requiredListOfAwsEmail;
+
+  /// Query field for the [requiredListOfAwsEmail] field.
+  @Deprecated(r'Use $requiredListOfAwsEmail instead')
+  QueryField<String, ScalarListModel, List<String?>>
+      get REQUIRED_LIST_OF_AWS_EMAIL => $requiredListOfAwsEmail;
   @override
   List<String> get requiredListOfRequiredAwsEmail;
+
+  /// Query field for the [requiredListOfRequiredAwsEmail] field.
+  QueryField<String, ScalarListModel, List<String>>
+      get $requiredListOfRequiredAwsEmail =>
+          _queryFields.$requiredListOfRequiredAwsEmail;
+
+  /// Query field for the [requiredListOfRequiredAwsEmail] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsEmail instead')
+  QueryField<String, ScalarListModel, List<String>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_EMAIL =>
+          $requiredListOfRequiredAwsEmail;
   @override
   List<Object?>? get listOfAwsjson;
+
+  /// Query field for the [listOfAwsjson] field.
+  QueryField<String, ScalarListModel, List<Object?>?> get $listOfAwsjson =>
+      _queryFields.$listOfAwsjson;
+
+  /// Query field for the [listOfAwsjson] field.
+  @Deprecated(r'Use $listOfAwsjson instead')
+  QueryField<String, ScalarListModel, List<Object?>?> get LIST_OF_AWSJSON =>
+      $listOfAwsjson;
   @override
   List<Object>? get listOfRequiredAwsjson;
+
+  /// Query field for the [listOfRequiredAwsjson] field.
+  QueryField<String, ScalarListModel, List<Object>?>
+      get $listOfRequiredAwsjson => _queryFields.$listOfRequiredAwsjson;
+
+  /// Query field for the [listOfRequiredAwsjson] field.
+  @Deprecated(r'Use $listOfRequiredAwsjson instead')
+  QueryField<String, ScalarListModel, List<Object>?>
+      get LIST_OF_REQUIRED_AWSJSON => $listOfRequiredAwsjson;
   @override
   List<Object?> get requiredListOfAwsjson;
+
+  /// Query field for the [requiredListOfAwsjson] field.
+  QueryField<String, ScalarListModel, List<Object?>>
+      get $requiredListOfAwsjson => _queryFields.$requiredListOfAwsjson;
+
+  /// Query field for the [requiredListOfAwsjson] field.
+  @Deprecated(r'Use $requiredListOfAwsjson instead')
+  QueryField<String, ScalarListModel, List<Object?>>
+      get REQUIRED_LIST_OF_AWSJSON => $requiredListOfAwsjson;
   @override
   List<Object> get requiredListOfRequiredAwsjson;
+
+  /// Query field for the [requiredListOfRequiredAwsjson] field.
+  QueryField<String, ScalarListModel, List<Object>>
+      get $requiredListOfRequiredAwsjson =>
+          _queryFields.$requiredListOfRequiredAwsjson;
+
+  /// Query field for the [requiredListOfRequiredAwsjson] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsjson instead')
+  QueryField<String, ScalarListModel, List<Object>>
+      get REQUIRED_LIST_OF_REQUIRED_AWSJSON => $requiredListOfRequiredAwsjson;
   @override
   List<String?>? get listOfAwsPhone;
+
+  /// Query field for the [listOfAwsPhone] field.
+  QueryField<String, ScalarListModel, List<String?>?> get $listOfAwsPhone =>
+      _queryFields.$listOfAwsPhone;
+
+  /// Query field for the [listOfAwsPhone] field.
+  @Deprecated(r'Use $listOfAwsPhone instead')
+  QueryField<String, ScalarListModel, List<String?>?> get LIST_OF_AWS_PHONE =>
+      $listOfAwsPhone;
   @override
   List<String>? get listOfRequiredAwsPhone;
+
+  /// Query field for the [listOfRequiredAwsPhone] field.
+  QueryField<String, ScalarListModel, List<String>?>
+      get $listOfRequiredAwsPhone => _queryFields.$listOfRequiredAwsPhone;
+
+  /// Query field for the [listOfRequiredAwsPhone] field.
+  @Deprecated(r'Use $listOfRequiredAwsPhone instead')
+  QueryField<String, ScalarListModel, List<String>?>
+      get LIST_OF_REQUIRED_AWS_PHONE => $listOfRequiredAwsPhone;
   @override
   List<String?> get requiredListOfAwsPhone;
+
+  /// Query field for the [requiredListOfAwsPhone] field.
+  QueryField<String, ScalarListModel, List<String?>>
+      get $requiredListOfAwsPhone => _queryFields.$requiredListOfAwsPhone;
+
+  /// Query field for the [requiredListOfAwsPhone] field.
+  @Deprecated(r'Use $requiredListOfAwsPhone instead')
+  QueryField<String, ScalarListModel, List<String?>>
+      get REQUIRED_LIST_OF_AWS_PHONE => $requiredListOfAwsPhone;
   @override
   List<String> get requiredListOfRequiredAwsPhone;
+
+  /// Query field for the [requiredListOfRequiredAwsPhone] field.
+  QueryField<String, ScalarListModel, List<String>>
+      get $requiredListOfRequiredAwsPhone =>
+          _queryFields.$requiredListOfRequiredAwsPhone;
+
+  /// Query field for the [requiredListOfRequiredAwsPhone] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsPhone instead')
+  QueryField<String, ScalarListModel, List<String>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_PHONE =>
+          $requiredListOfRequiredAwsPhone;
   @override
   List<Uri?>? get listOfAwsUrl;
+
+  /// Query field for the [listOfAwsUrl] field.
+  QueryField<String, ScalarListModel, List<Uri?>?> get $listOfAwsUrl =>
+      _queryFields.$listOfAwsUrl;
+
+  /// Query field for the [listOfAwsUrl] field.
+  @Deprecated(r'Use $listOfAwsUrl instead')
+  QueryField<String, ScalarListModel, List<Uri?>?> get LIST_OF_AWS_URL =>
+      $listOfAwsUrl;
   @override
   List<Uri>? get listOfRequiredAwsUrl;
+
+  /// Query field for the [listOfRequiredAwsUrl] field.
+  QueryField<String, ScalarListModel, List<Uri>?> get $listOfRequiredAwsUrl =>
+      _queryFields.$listOfRequiredAwsUrl;
+
+  /// Query field for the [listOfRequiredAwsUrl] field.
+  @Deprecated(r'Use $listOfRequiredAwsUrl instead')
+  QueryField<String, ScalarListModel, List<Uri>?>
+      get LIST_OF_REQUIRED_AWS_URL => $listOfRequiredAwsUrl;
   @override
   List<Uri?> get requiredListOfAwsUrl;
+
+  /// Query field for the [requiredListOfAwsUrl] field.
+  QueryField<String, ScalarListModel, List<Uri?>> get $requiredListOfAwsUrl =>
+      _queryFields.$requiredListOfAwsUrl;
+
+  /// Query field for the [requiredListOfAwsUrl] field.
+  @Deprecated(r'Use $requiredListOfAwsUrl instead')
+  QueryField<String, ScalarListModel, List<Uri?>>
+      get REQUIRED_LIST_OF_AWS_URL => $requiredListOfAwsUrl;
   @override
   List<Uri> get requiredListOfRequiredAwsUrl;
+
+  /// Query field for the [requiredListOfRequiredAwsUrl] field.
+  QueryField<String, ScalarListModel, List<Uri>>
+      get $requiredListOfRequiredAwsUrl =>
+          _queryFields.$requiredListOfRequiredAwsUrl;
+
+  /// Query field for the [requiredListOfRequiredAwsUrl] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsUrl instead')
+  QueryField<String, ScalarListModel, List<Uri>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_URL => $requiredListOfRequiredAwsUrl;
   @override
   List<String?>? get listOfAwsIpAddress;
+
+  /// Query field for the [listOfAwsIpAddress] field.
+  QueryField<String, ScalarListModel, List<String?>?> get $listOfAwsIpAddress =>
+      _queryFields.$listOfAwsIpAddress;
+
+  /// Query field for the [listOfAwsIpAddress] field.
+  @Deprecated(r'Use $listOfAwsIpAddress instead')
+  QueryField<String, ScalarListModel, List<String?>?>
+      get LIST_OF_AWS_IP_ADDRESS => $listOfAwsIpAddress;
   @override
   List<String>? get listOfRequiredAwsIpAddress;
+
+  /// Query field for the [listOfRequiredAwsIpAddress] field.
+  QueryField<String, ScalarListModel, List<String>?>
+      get $listOfRequiredAwsIpAddress =>
+          _queryFields.$listOfRequiredAwsIpAddress;
+
+  /// Query field for the [listOfRequiredAwsIpAddress] field.
+  @Deprecated(r'Use $listOfRequiredAwsIpAddress instead')
+  QueryField<String, ScalarListModel, List<String>?>
+      get LIST_OF_REQUIRED_AWS_IP_ADDRESS => $listOfRequiredAwsIpAddress;
   @override
   List<String?> get requiredListOfAwsIpAddress;
+
+  /// Query field for the [requiredListOfAwsIpAddress] field.
+  QueryField<String, ScalarListModel, List<String?>>
+      get $requiredListOfAwsIpAddress =>
+          _queryFields.$requiredListOfAwsIpAddress;
+
+  /// Query field for the [requiredListOfAwsIpAddress] field.
+  @Deprecated(r'Use $requiredListOfAwsIpAddress instead')
+  QueryField<String, ScalarListModel, List<String?>>
+      get REQUIRED_LIST_OF_AWS_IP_ADDRESS => $requiredListOfAwsIpAddress;
   @override
   List<String> get requiredListOfRequiredAwsIpAddress;
+
+  /// Query field for the [requiredListOfRequiredAwsIpAddress] field.
+  QueryField<String, ScalarListModel, List<String>>
+      get $requiredListOfRequiredAwsIpAddress =>
+          _queryFields.$requiredListOfRequiredAwsIpAddress;
+
+  /// Query field for the [requiredListOfRequiredAwsIpAddress] field.
+  @Deprecated(r'Use $requiredListOfRequiredAwsIpAddress instead')
+  QueryField<String, ScalarListModel, List<String>>
+      get REQUIRED_LIST_OF_REQUIRED_AWS_IP_ADDRESS =>
+          $requiredListOfRequiredAwsIpAddress;
   @override
   TemporalDateTime? get createdAt;
+
+  /// Query field for the [createdAt] field.
+  QueryField<String, ScalarListModel, TemporalDateTime?> get $createdAt =>
+      _queryFields.$createdAt;
+
+  /// Query field for the [createdAt] field.
+  @Deprecated(r'Use $createdAt instead')
+  QueryField<String, ScalarListModel, TemporalDateTime?> get CREATED_AT =>
+      $createdAt;
   @override
   TemporalDateTime? get updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  QueryField<String, ScalarListModel, TemporalDateTime?> get $updatedAt =>
+      _queryFields.$updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  @Deprecated(r'Use $updatedAt instead')
+  QueryField<String, ScalarListModel, TemporalDateTime?> get UPDATED_AT =>
+      $updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, ScalarListModel, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, ScalarListModel, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
 }
 
 class _ScalarListModel extends ScalarListModel {

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
@@ -1,0 +1,2975 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+library models.scalar_list_model;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:aws_common/aws_common.dart';
+
+class ScalarListModelType
+    extends ModelType<String, ScalarListModel, PartialScalarListModel> {
+  const ScalarListModelType();
+
+  @override
+  T fromJson<T extends PartialModel<String, ScalarListModel>>(
+      Map<String, Object?> json) {
+    if (T == ScalarListModel || T == Model<String, ScalarListModel>) {
+      return ScalarListModel.fromJson(json) as T;
+    }
+    if (T == RemoteScalarListModel ||
+        T == RemoteModel<String, ScalarListModel>) {
+      return _RemoteScalarListModel.fromJson(json) as T;
+    }
+    return _PartialScalarListModel.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'ScalarListModel';
+}
+
+abstract class PartialScalarListModel
+    extends PartialModel<String, ScalarListModel>
+    with AWSEquatable<PartialScalarListModel> {
+  const PartialScalarListModel._();
+
+  String get id;
+  List<String?>? get listOfString;
+  List<String>? get listOfRequiredString;
+  List<String?>? get requiredListOfString;
+  List<String>? get requiredListOfRequiredString;
+  List<int?>? get listOfInteger;
+  List<int>? get listOfRequiredInteger;
+  List<int?>? get requiredListOfInteger;
+  List<int>? get requiredListOfRequiredInteger;
+  List<double?>? get listOfFloat;
+  List<double>? get listOfRequiredFloat;
+  List<double?>? get requiredListOfFloat;
+  List<double>? get requiredListOfRequiredFloat;
+  List<bool?>? get listOfBoolean;
+  List<bool>? get listOfRequiredBoolean;
+  List<bool?>? get requiredListOfBoolean;
+  List<bool>? get requiredListOfRequiredBoolean;
+  List<TemporalDate?>? get listOfAwsDate;
+  List<TemporalDate>? get listOfRequiredAwsDate;
+  List<TemporalDate?>? get requiredListOfAwsDate;
+  List<TemporalDate>? get requiredListOfRequiredAwsDate;
+  List<TemporalDateTime?>? get listOfAwsDateTime;
+  List<TemporalDateTime>? get listOfRequiredAwsDateTime;
+  List<TemporalDateTime?>? get requiredListOfAwsDateTime;
+  List<TemporalDateTime>? get requiredListOfRequiredAwsDateTime;
+  List<TemporalTime?>? get listOfAwsTime;
+  List<TemporalTime>? get listOfRequiredAwsTime;
+  List<TemporalTime?>? get requiredListOfAwsTime;
+  List<TemporalTime>? get requiredListOfRequiredAwsTime;
+  List<TemporalTimestamp?>? get listOfAwsTimestamp;
+  List<TemporalTimestamp>? get listOfRequiredAwsTimestamp;
+  List<TemporalTimestamp?>? get requiredListOfAwsTimestamp;
+  List<TemporalTimestamp>? get requiredListOfRequiredAwsTimestamp;
+  List<String?>? get listOfAwsEmail;
+  List<String>? get listOfRequiredAwsEmail;
+  List<String?>? get requiredListOfAwsEmail;
+  List<String>? get requiredListOfRequiredAwsEmail;
+  List<Object?>? get listOfAwsjson;
+  List<Object>? get listOfRequiredAwsjson;
+  List<Object?>? get requiredListOfAwsjson;
+  List<Object>? get requiredListOfRequiredAwsjson;
+  List<String?>? get listOfAwsPhone;
+  List<String>? get listOfRequiredAwsPhone;
+  List<String?>? get requiredListOfAwsPhone;
+  List<String>? get requiredListOfRequiredAwsPhone;
+  List<Uri?>? get listOfAwsUrl;
+  List<Uri>? get listOfRequiredAwsUrl;
+  List<Uri?>? get requiredListOfAwsUrl;
+  List<Uri>? get requiredListOfRequiredAwsUrl;
+  List<String?>? get listOfAwsIpAddress;
+  List<String>? get listOfRequiredAwsIpAddress;
+  List<String?>? get requiredListOfAwsIpAddress;
+  List<String>? get requiredListOfRequiredAwsIpAddress;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  ScalarListModelType get modelType => ScalarListModel.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        listOfString,
+        listOfRequiredString,
+        requiredListOfString,
+        requiredListOfRequiredString,
+        listOfInteger,
+        listOfRequiredInteger,
+        requiredListOfInteger,
+        requiredListOfRequiredInteger,
+        listOfFloat,
+        listOfRequiredFloat,
+        requiredListOfFloat,
+        requiredListOfRequiredFloat,
+        listOfBoolean,
+        listOfRequiredBoolean,
+        requiredListOfBoolean,
+        requiredListOfRequiredBoolean,
+        listOfAwsDate,
+        listOfRequiredAwsDate,
+        requiredListOfAwsDate,
+        requiredListOfRequiredAwsDate,
+        listOfAwsDateTime,
+        listOfRequiredAwsDateTime,
+        requiredListOfAwsDateTime,
+        requiredListOfRequiredAwsDateTime,
+        listOfAwsTime,
+        listOfRequiredAwsTime,
+        requiredListOfAwsTime,
+        requiredListOfRequiredAwsTime,
+        listOfAwsTimestamp,
+        listOfRequiredAwsTimestamp,
+        requiredListOfAwsTimestamp,
+        requiredListOfRequiredAwsTimestamp,
+        listOfAwsEmail,
+        listOfRequiredAwsEmail,
+        requiredListOfAwsEmail,
+        requiredListOfRequiredAwsEmail,
+        listOfAwsjson,
+        listOfRequiredAwsjson,
+        requiredListOfAwsjson,
+        requiredListOfRequiredAwsjson,
+        listOfAwsPhone,
+        listOfRequiredAwsPhone,
+        requiredListOfAwsPhone,
+        requiredListOfRequiredAwsPhone,
+        listOfAwsUrl,
+        listOfRequiredAwsUrl,
+        requiredListOfAwsUrl,
+        requiredListOfRequiredAwsUrl,
+        listOfAwsIpAddress,
+        listOfRequiredAwsIpAddress,
+        requiredListOfAwsIpAddress,
+        requiredListOfRequiredAwsIpAddress,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'listOfString': listOfString,
+        'listOfRequiredString': listOfRequiredString,
+        'requiredListOfString': requiredListOfString,
+        'requiredListOfRequiredString': requiredListOfRequiredString,
+        'listOfInteger': listOfInteger,
+        'listOfRequiredInteger': listOfRequiredInteger,
+        'requiredListOfInteger': requiredListOfInteger,
+        'requiredListOfRequiredInteger': requiredListOfRequiredInteger,
+        'listOfFloat': listOfFloat,
+        'listOfRequiredFloat': listOfRequiredFloat,
+        'requiredListOfFloat': requiredListOfFloat,
+        'requiredListOfRequiredFloat': requiredListOfRequiredFloat,
+        'listOfBoolean': listOfBoolean,
+        'listOfRequiredBoolean': listOfRequiredBoolean,
+        'requiredListOfBoolean': requiredListOfBoolean,
+        'requiredListOfRequiredBoolean': requiredListOfRequiredBoolean,
+        'listOfAWSDate': listOfAwsDate?.map((el) => el?.format()).toList(),
+        'listOfRequiredAWSDate':
+            listOfRequiredAwsDate?.map((el) => el.format()).toList(),
+        'requiredListOfAWSDate':
+            requiredListOfAwsDate?.map((el) => el?.format()).toList(),
+        'requiredListOfRequiredAWSDate':
+            requiredListOfRequiredAwsDate?.map((el) => el.format()).toList(),
+        'listOfAWSDateTime':
+            listOfAwsDateTime?.map((el) => el?.format()).toList(),
+        'listOfRequiredAWSDateTime':
+            listOfRequiredAwsDateTime?.map((el) => el.format()).toList(),
+        'requiredListOfAWSDateTime':
+            requiredListOfAwsDateTime?.map((el) => el?.format()).toList(),
+        'requiredListOfRequiredAWSDateTime': requiredListOfRequiredAwsDateTime
+            ?.map((el) => el.format())
+            .toList(),
+        'listOfAWSTime': listOfAwsTime?.map((el) => el?.format()).toList(),
+        'listOfRequiredAWSTime':
+            listOfRequiredAwsTime?.map((el) => el.format()).toList(),
+        'requiredListOfAWSTime':
+            requiredListOfAwsTime?.map((el) => el?.format()).toList(),
+        'requiredListOfRequiredAWSTime':
+            requiredListOfRequiredAwsTime?.map((el) => el.format()).toList(),
+        'listOfAWSTimestamp':
+            listOfAwsTimestamp?.map((el) => el?.toSeconds()).toList(),
+        'listOfRequiredAWSTimestamp':
+            listOfRequiredAwsTimestamp?.map((el) => el.toSeconds()).toList(),
+        'requiredListOfAWSTimestamp':
+            requiredListOfAwsTimestamp?.map((el) => el?.toSeconds()).toList(),
+        'requiredListOfRequiredAWSTimestamp': requiredListOfRequiredAwsTimestamp
+            ?.map((el) => el.toSeconds())
+            .toList(),
+        'listOfAWSEmail': listOfAwsEmail,
+        'listOfRequiredAWSEmail': listOfRequiredAwsEmail,
+        'requiredListOfAWSEmail': requiredListOfAwsEmail,
+        'requiredListOfRequiredAWSEmail': requiredListOfRequiredAwsEmail,
+        'listOfAWSJSON': listOfAwsjson,
+        'listOfRequiredAWSJSON': listOfRequiredAwsjson,
+        'requiredListOfAWSJSON': requiredListOfAwsjson,
+        'requiredListOfRequiredAWSJSON': requiredListOfRequiredAwsjson,
+        'listOfAWSPhone': listOfAwsPhone,
+        'listOfRequiredAWSPhone': listOfRequiredAwsPhone,
+        'requiredListOfAWSPhone': requiredListOfAwsPhone,
+        'requiredListOfRequiredAWSPhone': requiredListOfRequiredAwsPhone,
+        'listOfAWSUrl': listOfAwsUrl?.map((el) => el?.toString()).toList(),
+        'listOfRequiredAWSUrl':
+            listOfRequiredAwsUrl?.map((el) => el.toString()).toList(),
+        'requiredListOfAWSUrl':
+            requiredListOfAwsUrl?.map((el) => el?.toString()).toList(),
+        'requiredListOfRequiredAWSUrl':
+            requiredListOfRequiredAwsUrl?.map((el) => el.toString()).toList(),
+        'listOfAWSIpAddress': listOfAwsIpAddress,
+        'listOfRequiredAWSIpAddress': listOfRequiredAwsIpAddress,
+        'requiredListOfAWSIpAddress': requiredListOfAwsIpAddress,
+        'requiredListOfRequiredAWSIpAddress':
+            requiredListOfRequiredAwsIpAddress,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'ScalarListModel';
+  @override
+  T valueFor<T extends Object?>(QueryField<String, ScalarListModel, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'listOfString':
+        value = listOfString;
+        break;
+      case r'listOfRequiredString':
+        value = listOfRequiredString;
+        break;
+      case r'requiredListOfString':
+        value = requiredListOfString;
+        break;
+      case r'requiredListOfRequiredString':
+        value = requiredListOfRequiredString;
+        break;
+      case r'listOfInteger':
+        value = listOfInteger;
+        break;
+      case r'listOfRequiredInteger':
+        value = listOfRequiredInteger;
+        break;
+      case r'requiredListOfInteger':
+        value = requiredListOfInteger;
+        break;
+      case r'requiredListOfRequiredInteger':
+        value = requiredListOfRequiredInteger;
+        break;
+      case r'listOfFloat':
+        value = listOfFloat;
+        break;
+      case r'listOfRequiredFloat':
+        value = listOfRequiredFloat;
+        break;
+      case r'requiredListOfFloat':
+        value = requiredListOfFloat;
+        break;
+      case r'requiredListOfRequiredFloat':
+        value = requiredListOfRequiredFloat;
+        break;
+      case r'listOfBoolean':
+        value = listOfBoolean;
+        break;
+      case r'listOfRequiredBoolean':
+        value = listOfRequiredBoolean;
+        break;
+      case r'requiredListOfBoolean':
+        value = requiredListOfBoolean;
+        break;
+      case r'requiredListOfRequiredBoolean':
+        value = requiredListOfRequiredBoolean;
+        break;
+      case r'listOfAWSDate':
+        value = listOfAwsDate;
+        break;
+      case r'listOfRequiredAWSDate':
+        value = listOfRequiredAwsDate;
+        break;
+      case r'requiredListOfAWSDate':
+        value = requiredListOfAwsDate;
+        break;
+      case r'requiredListOfRequiredAWSDate':
+        value = requiredListOfRequiredAwsDate;
+        break;
+      case r'listOfAWSDateTime':
+        value = listOfAwsDateTime;
+        break;
+      case r'listOfRequiredAWSDateTime':
+        value = listOfRequiredAwsDateTime;
+        break;
+      case r'requiredListOfAWSDateTime':
+        value = requiredListOfAwsDateTime;
+        break;
+      case r'requiredListOfRequiredAWSDateTime':
+        value = requiredListOfRequiredAwsDateTime;
+        break;
+      case r'listOfAWSTime':
+        value = listOfAwsTime;
+        break;
+      case r'listOfRequiredAWSTime':
+        value = listOfRequiredAwsTime;
+        break;
+      case r'requiredListOfAWSTime':
+        value = requiredListOfAwsTime;
+        break;
+      case r'requiredListOfRequiredAWSTime':
+        value = requiredListOfRequiredAwsTime;
+        break;
+      case r'listOfAWSTimestamp':
+        value = listOfAwsTimestamp;
+        break;
+      case r'listOfRequiredAWSTimestamp':
+        value = listOfRequiredAwsTimestamp;
+        break;
+      case r'requiredListOfAWSTimestamp':
+        value = requiredListOfAwsTimestamp;
+        break;
+      case r'requiredListOfRequiredAWSTimestamp':
+        value = requiredListOfRequiredAwsTimestamp;
+        break;
+      case r'listOfAWSEmail':
+        value = listOfAwsEmail;
+        break;
+      case r'listOfRequiredAWSEmail':
+        value = listOfRequiredAwsEmail;
+        break;
+      case r'requiredListOfAWSEmail':
+        value = requiredListOfAwsEmail;
+        break;
+      case r'requiredListOfRequiredAWSEmail':
+        value = requiredListOfRequiredAwsEmail;
+        break;
+      case r'listOfAWSJSON':
+        value = listOfAwsjson;
+        break;
+      case r'listOfRequiredAWSJSON':
+        value = listOfRequiredAwsjson;
+        break;
+      case r'requiredListOfAWSJSON':
+        value = requiredListOfAwsjson;
+        break;
+      case r'requiredListOfRequiredAWSJSON':
+        value = requiredListOfRequiredAwsjson;
+        break;
+      case r'listOfAWSPhone':
+        value = listOfAwsPhone;
+        break;
+      case r'listOfRequiredAWSPhone':
+        value = listOfRequiredAwsPhone;
+        break;
+      case r'requiredListOfAWSPhone':
+        value = requiredListOfAwsPhone;
+        break;
+      case r'requiredListOfRequiredAWSPhone':
+        value = requiredListOfRequiredAwsPhone;
+        break;
+      case r'listOfAWSUrl':
+        value = listOfAwsUrl;
+        break;
+      case r'listOfRequiredAWSUrl':
+        value = listOfRequiredAwsUrl;
+        break;
+      case r'requiredListOfAWSUrl':
+        value = requiredListOfAwsUrl;
+        break;
+      case r'requiredListOfRequiredAWSUrl':
+        value = requiredListOfRequiredAwsUrl;
+        break;
+      case r'listOfAWSIpAddress':
+        value = listOfAwsIpAddress;
+        break;
+      case r'listOfRequiredAWSIpAddress':
+        value = listOfRequiredAwsIpAddress;
+        break;
+      case r'requiredListOfAWSIpAddress':
+        value = requiredListOfAwsIpAddress;
+        break;
+      case r'requiredListOfRequiredAWSIpAddress':
+        value = requiredListOfRequiredAwsIpAddress;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _PartialScalarListModel extends PartialScalarListModel {
+  _PartialScalarListModel({
+    required this.id,
+    this.listOfString,
+    this.listOfRequiredString,
+    this.requiredListOfString,
+    this.requiredListOfRequiredString,
+    this.listOfInteger,
+    this.listOfRequiredInteger,
+    this.requiredListOfInteger,
+    this.requiredListOfRequiredInteger,
+    this.listOfFloat,
+    this.listOfRequiredFloat,
+    this.requiredListOfFloat,
+    this.requiredListOfRequiredFloat,
+    this.listOfBoolean,
+    this.listOfRequiredBoolean,
+    this.requiredListOfBoolean,
+    this.requiredListOfRequiredBoolean,
+    this.listOfAwsDate,
+    this.listOfRequiredAwsDate,
+    this.requiredListOfAwsDate,
+    this.requiredListOfRequiredAwsDate,
+    this.listOfAwsDateTime,
+    this.listOfRequiredAwsDateTime,
+    this.requiredListOfAwsDateTime,
+    this.requiredListOfRequiredAwsDateTime,
+    this.listOfAwsTime,
+    this.listOfRequiredAwsTime,
+    this.requiredListOfAwsTime,
+    this.requiredListOfRequiredAwsTime,
+    this.listOfAwsTimestamp,
+    this.listOfRequiredAwsTimestamp,
+    this.requiredListOfAwsTimestamp,
+    this.requiredListOfRequiredAwsTimestamp,
+    this.listOfAwsEmail,
+    this.listOfRequiredAwsEmail,
+    this.requiredListOfAwsEmail,
+    this.requiredListOfRequiredAwsEmail,
+    this.listOfAwsjson,
+    this.listOfRequiredAwsjson,
+    this.requiredListOfAwsjson,
+    this.requiredListOfRequiredAwsjson,
+    this.listOfAwsPhone,
+    this.listOfRequiredAwsPhone,
+    this.requiredListOfAwsPhone,
+    this.requiredListOfRequiredAwsPhone,
+    this.listOfAwsUrl,
+    this.listOfRequiredAwsUrl,
+    this.requiredListOfAwsUrl,
+    this.requiredListOfRequiredAwsUrl,
+    this.listOfAwsIpAddress,
+    this.listOfRequiredAwsIpAddress,
+    this.requiredListOfAwsIpAddress,
+    this.requiredListOfRequiredAwsIpAddress,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialScalarListModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final listOfString = json['listOfString'] == null
+        ? null
+        : (json['listOfString'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredString = json['listOfRequiredString'] == null
+        ? null
+        : (json['listOfRequiredString'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredString',
+                )))
+            .toList();
+    final requiredListOfString = json['requiredListOfString'] == null
+        ? null
+        : (json['requiredListOfString'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredString =
+        json['requiredListOfRequiredString'] == null
+            ? null
+            : (json['requiredListOfRequiredString'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredString',
+                    )))
+                .toList();
+    final listOfInteger = json['listOfInteger'] == null
+        ? null
+        : (json['listOfInteger'] as List<Object?>).cast<int?>().toList();
+    final listOfRequiredInteger = json['listOfRequiredInteger'] == null
+        ? null
+        : (json['listOfRequiredInteger'] as List<Object?>)
+            .cast<int?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredInteger',
+                )))
+            .toList();
+    final requiredListOfInteger = json['requiredListOfInteger'] == null
+        ? null
+        : (json['requiredListOfInteger'] as List<Object?>)
+            .cast<int?>()
+            .toList();
+    final requiredListOfRequiredInteger =
+        json['requiredListOfRequiredInteger'] == null
+            ? null
+            : (json['requiredListOfRequiredInteger'] as List<Object?>)
+                .cast<int?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredInteger',
+                    )))
+                .toList();
+    final listOfFloat = json['listOfFloat'] == null
+        ? null
+        : (json['listOfFloat'] as List<Object?>).cast<double?>().toList();
+    final listOfRequiredFloat = json['listOfRequiredFloat'] == null
+        ? null
+        : (json['listOfRequiredFloat'] as List<Object?>)
+            .cast<double?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredFloat',
+                )))
+            .toList();
+    final requiredListOfFloat = json['requiredListOfFloat'] == null
+        ? null
+        : (json['requiredListOfFloat'] as List<Object?>)
+            .cast<double?>()
+            .toList();
+    final requiredListOfRequiredFloat =
+        json['requiredListOfRequiredFloat'] == null
+            ? null
+            : (json['requiredListOfRequiredFloat'] as List<Object?>)
+                .cast<double?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredFloat',
+                    )))
+                .toList();
+    final listOfBoolean = json['listOfBoolean'] == null
+        ? null
+        : (json['listOfBoolean'] as List<Object?>).cast<bool?>().toList();
+    final listOfRequiredBoolean = json['listOfRequiredBoolean'] == null
+        ? null
+        : (json['listOfRequiredBoolean'] as List<Object?>)
+            .cast<bool?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredBoolean',
+                )))
+            .toList();
+    final requiredListOfBoolean = json['requiredListOfBoolean'] == null
+        ? null
+        : (json['requiredListOfBoolean'] as List<Object?>)
+            .cast<bool?>()
+            .toList();
+    final requiredListOfRequiredBoolean =
+        json['requiredListOfRequiredBoolean'] == null
+            ? null
+            : (json['requiredListOfRequiredBoolean'] as List<Object?>)
+                .cast<bool?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredBoolean',
+                    )))
+                .toList();
+    final listOfAwsDate = json['listOfAWSDate'] == null
+        ? null
+        : (json['listOfAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final listOfRequiredAwsDate = json['listOfRequiredAWSDate'] == null
+        ? null
+        : (json['listOfRequiredAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsDate',
+                  ))
+                : TemporalDate.fromString(el))
+            .toList();
+    final requiredListOfAwsDate = json['requiredListOfAWSDate'] == null
+        ? null
+        : (json['requiredListOfAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsDate =
+        json['requiredListOfRequiredAWSDate'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSDate'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsDate',
+                      ))
+                    : TemporalDate.fromString(el))
+                .toList();
+    final listOfAwsDateTime = json['listOfAWSDateTime'] == null
+        ? null
+        : (json['listOfAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final listOfRequiredAwsDateTime = json['listOfRequiredAWSDateTime'] == null
+        ? null
+        : (json['listOfRequiredAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsDateTime',
+                  ))
+                : TemporalDateTime.fromString(el))
+            .toList();
+    final requiredListOfAwsDateTime = json['requiredListOfAWSDateTime'] == null
+        ? null
+        : (json['requiredListOfAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsDateTime =
+        json['requiredListOfRequiredAWSDateTime'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSDateTime'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsDateTime',
+                      ))
+                    : TemporalDateTime.fromString(el))
+                .toList();
+    final listOfAwsTime = json['listOfAWSTime'] == null
+        ? null
+        : (json['listOfAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final listOfRequiredAwsTime = json['listOfRequiredAWSTime'] == null
+        ? null
+        : (json['listOfRequiredAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsTime',
+                  ))
+                : TemporalTime.fromString(el))
+            .toList();
+    final requiredListOfAwsTime = json['requiredListOfAWSTime'] == null
+        ? null
+        : (json['requiredListOfAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsTime =
+        json['requiredListOfRequiredAWSTime'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSTime'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsTime',
+                      ))
+                    : TemporalTime.fromString(el))
+                .toList();
+    final listOfAwsTimestamp = json['listOfAWSTimestamp'] == null
+        ? null
+        : (json['listOfAWSTimestamp'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final listOfRequiredAwsTimestamp =
+        json['listOfRequiredAWSTimestamp'] == null
+            ? null
+            : (json['listOfRequiredAWSTimestamp'] as List<Object?>)
+                .cast<int?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'listOfRequiredAwsTimestamp',
+                      ))
+                    : TemporalTimestamp.fromSeconds(el))
+                .toList();
+    final requiredListOfAwsTimestamp = json['requiredListOfAWSTimestamp'] ==
+            null
+        ? null
+        : (json['requiredListOfAWSTimestamp'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final requiredListOfRequiredAwsTimestamp =
+        json['requiredListOfRequiredAWSTimestamp'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSTimestamp'] as List<Object?>)
+                .cast<int?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsTimestamp',
+                      ))
+                    : TemporalTimestamp.fromSeconds(el))
+                .toList();
+    final listOfAwsEmail = json['listOfAWSEmail'] == null
+        ? null
+        : (json['listOfAWSEmail'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredAwsEmail = json['listOfRequiredAWSEmail'] == null
+        ? null
+        : (json['listOfRequiredAWSEmail'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredAwsEmail',
+                )))
+            .toList();
+    final requiredListOfAwsEmail = json['requiredListOfAWSEmail'] == null
+        ? null
+        : (json['requiredListOfAWSEmail'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredAwsEmail =
+        json['requiredListOfRequiredAWSEmail'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSEmail'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredAwsEmail',
+                    )))
+                .toList();
+    final listOfAwsjson = json['listOfAWSJSON'] == null
+        ? null
+        : (json['listOfAWSJSON'] as List<Object?>).cast<Object?>().toList();
+    final listOfRequiredAwsjson = json['listOfRequiredAWSJSON'] == null
+        ? null
+        : (json['listOfRequiredAWSJSON'] as List<Object?>)
+            .cast<Object?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredAwsjson',
+                )))
+            .toList();
+    final requiredListOfAwsjson = json['requiredListOfAWSJSON'] == null
+        ? null
+        : (json['requiredListOfAWSJSON'] as List<Object?>)
+            .cast<Object?>()
+            .toList();
+    final requiredListOfRequiredAwsjson =
+        json['requiredListOfRequiredAWSJSON'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSJSON'] as List<Object?>)
+                .cast<Object?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredAwsjson',
+                    )))
+                .toList();
+    final listOfAwsPhone = json['listOfAWSPhone'] == null
+        ? null
+        : (json['listOfAWSPhone'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredAwsPhone = json['listOfRequiredAWSPhone'] == null
+        ? null
+        : (json['listOfRequiredAWSPhone'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredAwsPhone',
+                )))
+            .toList();
+    final requiredListOfAwsPhone = json['requiredListOfAWSPhone'] == null
+        ? null
+        : (json['requiredListOfAWSPhone'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredAwsPhone =
+        json['requiredListOfRequiredAWSPhone'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSPhone'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredAwsPhone',
+                    )))
+                .toList();
+    final listOfAwsUrl = json['listOfAWSUrl'] == null
+        ? null
+        : (json['listOfAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : Uri.parse(el))
+            .toList();
+    final listOfRequiredAwsUrl = json['listOfRequiredAWSUrl'] == null
+        ? null
+        : (json['listOfRequiredAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsUrl',
+                  ))
+                : Uri.parse(el))
+            .toList();
+    final requiredListOfAwsUrl = json['requiredListOfAWSUrl'] == null
+        ? null
+        : (json['requiredListOfAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : Uri.parse(el))
+            .toList();
+    final requiredListOfRequiredAwsUrl =
+        json['requiredListOfRequiredAWSUrl'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSUrl'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsUrl',
+                      ))
+                    : Uri.parse(el))
+                .toList();
+    final listOfAwsIpAddress = json['listOfAWSIpAddress'] == null
+        ? null
+        : (json['listOfAWSIpAddress'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final listOfRequiredAwsIpAddress =
+        json['listOfRequiredAWSIpAddress'] == null
+            ? null
+            : (json['listOfRequiredAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsIpAddress',
+                    )))
+                .toList();
+    final requiredListOfAwsIpAddress =
+        json['requiredListOfAWSIpAddress'] == null
+            ? null
+            : (json['requiredListOfAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .toList();
+    final requiredListOfRequiredAwsIpAddress =
+        json['requiredListOfRequiredAWSIpAddress'] == null
+            ? null
+            : (json['requiredListOfRequiredAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredAwsIpAddress',
+                    )))
+                .toList();
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialScalarListModel(
+      id: id,
+      listOfString: listOfString,
+      listOfRequiredString: listOfRequiredString,
+      requiredListOfString: requiredListOfString,
+      requiredListOfRequiredString: requiredListOfRequiredString,
+      listOfInteger: listOfInteger,
+      listOfRequiredInteger: listOfRequiredInteger,
+      requiredListOfInteger: requiredListOfInteger,
+      requiredListOfRequiredInteger: requiredListOfRequiredInteger,
+      listOfFloat: listOfFloat,
+      listOfRequiredFloat: listOfRequiredFloat,
+      requiredListOfFloat: requiredListOfFloat,
+      requiredListOfRequiredFloat: requiredListOfRequiredFloat,
+      listOfBoolean: listOfBoolean,
+      listOfRequiredBoolean: listOfRequiredBoolean,
+      requiredListOfBoolean: requiredListOfBoolean,
+      requiredListOfRequiredBoolean: requiredListOfRequiredBoolean,
+      listOfAwsDate: listOfAwsDate,
+      listOfRequiredAwsDate: listOfRequiredAwsDate,
+      requiredListOfAwsDate: requiredListOfAwsDate,
+      requiredListOfRequiredAwsDate: requiredListOfRequiredAwsDate,
+      listOfAwsDateTime: listOfAwsDateTime,
+      listOfRequiredAwsDateTime: listOfRequiredAwsDateTime,
+      requiredListOfAwsDateTime: requiredListOfAwsDateTime,
+      requiredListOfRequiredAwsDateTime: requiredListOfRequiredAwsDateTime,
+      listOfAwsTime: listOfAwsTime,
+      listOfRequiredAwsTime: listOfRequiredAwsTime,
+      requiredListOfAwsTime: requiredListOfAwsTime,
+      requiredListOfRequiredAwsTime: requiredListOfRequiredAwsTime,
+      listOfAwsTimestamp: listOfAwsTimestamp,
+      listOfRequiredAwsTimestamp: listOfRequiredAwsTimestamp,
+      requiredListOfAwsTimestamp: requiredListOfAwsTimestamp,
+      requiredListOfRequiredAwsTimestamp: requiredListOfRequiredAwsTimestamp,
+      listOfAwsEmail: listOfAwsEmail,
+      listOfRequiredAwsEmail: listOfRequiredAwsEmail,
+      requiredListOfAwsEmail: requiredListOfAwsEmail,
+      requiredListOfRequiredAwsEmail: requiredListOfRequiredAwsEmail,
+      listOfAwsjson: listOfAwsjson,
+      listOfRequiredAwsjson: listOfRequiredAwsjson,
+      requiredListOfAwsjson: requiredListOfAwsjson,
+      requiredListOfRequiredAwsjson: requiredListOfRequiredAwsjson,
+      listOfAwsPhone: listOfAwsPhone,
+      listOfRequiredAwsPhone: listOfRequiredAwsPhone,
+      requiredListOfAwsPhone: requiredListOfAwsPhone,
+      requiredListOfRequiredAwsPhone: requiredListOfRequiredAwsPhone,
+      listOfAwsUrl: listOfAwsUrl,
+      listOfRequiredAwsUrl: listOfRequiredAwsUrl,
+      requiredListOfAwsUrl: requiredListOfAwsUrl,
+      requiredListOfRequiredAwsUrl: requiredListOfRequiredAwsUrl,
+      listOfAwsIpAddress: listOfAwsIpAddress,
+      listOfRequiredAwsIpAddress: listOfRequiredAwsIpAddress,
+      requiredListOfAwsIpAddress: requiredListOfAwsIpAddress,
+      requiredListOfRequiredAwsIpAddress: requiredListOfRequiredAwsIpAddress,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final List<String?>? listOfString;
+
+  @override
+  final List<String>? listOfRequiredString;
+
+  @override
+  final List<String?>? requiredListOfString;
+
+  @override
+  final List<String>? requiredListOfRequiredString;
+
+  @override
+  final List<int?>? listOfInteger;
+
+  @override
+  final List<int>? listOfRequiredInteger;
+
+  @override
+  final List<int?>? requiredListOfInteger;
+
+  @override
+  final List<int>? requiredListOfRequiredInteger;
+
+  @override
+  final List<double?>? listOfFloat;
+
+  @override
+  final List<double>? listOfRequiredFloat;
+
+  @override
+  final List<double?>? requiredListOfFloat;
+
+  @override
+  final List<double>? requiredListOfRequiredFloat;
+
+  @override
+  final List<bool?>? listOfBoolean;
+
+  @override
+  final List<bool>? listOfRequiredBoolean;
+
+  @override
+  final List<bool?>? requiredListOfBoolean;
+
+  @override
+  final List<bool>? requiredListOfRequiredBoolean;
+
+  @override
+  final List<TemporalDate?>? listOfAwsDate;
+
+  @override
+  final List<TemporalDate>? listOfRequiredAwsDate;
+
+  @override
+  final List<TemporalDate?>? requiredListOfAwsDate;
+
+  @override
+  final List<TemporalDate>? requiredListOfRequiredAwsDate;
+
+  @override
+  final List<TemporalDateTime?>? listOfAwsDateTime;
+
+  @override
+  final List<TemporalDateTime>? listOfRequiredAwsDateTime;
+
+  @override
+  final List<TemporalDateTime?>? requiredListOfAwsDateTime;
+
+  @override
+  final List<TemporalDateTime>? requiredListOfRequiredAwsDateTime;
+
+  @override
+  final List<TemporalTime?>? listOfAwsTime;
+
+  @override
+  final List<TemporalTime>? listOfRequiredAwsTime;
+
+  @override
+  final List<TemporalTime?>? requiredListOfAwsTime;
+
+  @override
+  final List<TemporalTime>? requiredListOfRequiredAwsTime;
+
+  @override
+  final List<TemporalTimestamp?>? listOfAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp>? listOfRequiredAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp?>? requiredListOfAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp>? requiredListOfRequiredAwsTimestamp;
+
+  @override
+  final List<String?>? listOfAwsEmail;
+
+  @override
+  final List<String>? listOfRequiredAwsEmail;
+
+  @override
+  final List<String?>? requiredListOfAwsEmail;
+
+  @override
+  final List<String>? requiredListOfRequiredAwsEmail;
+
+  @override
+  final List<Object?>? listOfAwsjson;
+
+  @override
+  final List<Object>? listOfRequiredAwsjson;
+
+  @override
+  final List<Object?>? requiredListOfAwsjson;
+
+  @override
+  final List<Object>? requiredListOfRequiredAwsjson;
+
+  @override
+  final List<String?>? listOfAwsPhone;
+
+  @override
+  final List<String>? listOfRequiredAwsPhone;
+
+  @override
+  final List<String?>? requiredListOfAwsPhone;
+
+  @override
+  final List<String>? requiredListOfRequiredAwsPhone;
+
+  @override
+  final List<Uri?>? listOfAwsUrl;
+
+  @override
+  final List<Uri>? listOfRequiredAwsUrl;
+
+  @override
+  final List<Uri?>? requiredListOfAwsUrl;
+
+  @override
+  final List<Uri>? requiredListOfRequiredAwsUrl;
+
+  @override
+  final List<String?>? listOfAwsIpAddress;
+
+  @override
+  final List<String>? listOfRequiredAwsIpAddress;
+
+  @override
+  final List<String?>? requiredListOfAwsIpAddress;
+
+  @override
+  final List<String>? requiredListOfRequiredAwsIpAddress;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class ScalarListModel extends PartialScalarListModel
+    implements Model<String, ScalarListModel> {
+  factory ScalarListModel({
+    String? id,
+    List<String?>? listOfString,
+    List<String>? listOfRequiredString,
+    required List<String?> requiredListOfString,
+    required List<String> requiredListOfRequiredString,
+    List<int?>? listOfInteger,
+    List<int>? listOfRequiredInteger,
+    required List<int?> requiredListOfInteger,
+    required List<int> requiredListOfRequiredInteger,
+    List<double?>? listOfFloat,
+    List<double>? listOfRequiredFloat,
+    required List<double?> requiredListOfFloat,
+    required List<double> requiredListOfRequiredFloat,
+    List<bool?>? listOfBoolean,
+    List<bool>? listOfRequiredBoolean,
+    required List<bool?> requiredListOfBoolean,
+    required List<bool> requiredListOfRequiredBoolean,
+    List<TemporalDate?>? listOfAwsDate,
+    List<TemporalDate>? listOfRequiredAwsDate,
+    required List<TemporalDate?> requiredListOfAwsDate,
+    required List<TemporalDate> requiredListOfRequiredAwsDate,
+    List<TemporalDateTime?>? listOfAwsDateTime,
+    List<TemporalDateTime>? listOfRequiredAwsDateTime,
+    required List<TemporalDateTime?> requiredListOfAwsDateTime,
+    required List<TemporalDateTime> requiredListOfRequiredAwsDateTime,
+    List<TemporalTime?>? listOfAwsTime,
+    List<TemporalTime>? listOfRequiredAwsTime,
+    required List<TemporalTime?> requiredListOfAwsTime,
+    required List<TemporalTime> requiredListOfRequiredAwsTime,
+    List<TemporalTimestamp?>? listOfAwsTimestamp,
+    List<TemporalTimestamp>? listOfRequiredAwsTimestamp,
+    required List<TemporalTimestamp?> requiredListOfAwsTimestamp,
+    required List<TemporalTimestamp> requiredListOfRequiredAwsTimestamp,
+    List<String?>? listOfAwsEmail,
+    List<String>? listOfRequiredAwsEmail,
+    required List<String?> requiredListOfAwsEmail,
+    required List<String> requiredListOfRequiredAwsEmail,
+    List<Object?>? listOfAwsjson,
+    List<Object>? listOfRequiredAwsjson,
+    required List<Object?> requiredListOfAwsjson,
+    required List<Object> requiredListOfRequiredAwsjson,
+    List<String?>? listOfAwsPhone,
+    List<String>? listOfRequiredAwsPhone,
+    required List<String?> requiredListOfAwsPhone,
+    required List<String> requiredListOfRequiredAwsPhone,
+    List<Uri?>? listOfAwsUrl,
+    List<Uri>? listOfRequiredAwsUrl,
+    required List<Uri?> requiredListOfAwsUrl,
+    required List<Uri> requiredListOfRequiredAwsUrl,
+    List<String?>? listOfAwsIpAddress,
+    List<String>? listOfRequiredAwsIpAddress,
+    required List<String?> requiredListOfAwsIpAddress,
+    required List<String> requiredListOfRequiredAwsIpAddress,
+    TemporalDateTime? createdAt,
+    TemporalDateTime? updatedAt,
+  }) = _ScalarListModel;
+
+  const ScalarListModel._() : super._();
+
+  factory ScalarListModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final listOfString = json['listOfString'] == null
+        ? null
+        : (json['listOfString'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredString = json['listOfRequiredString'] == null
+        ? null
+        : (json['listOfRequiredString'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredString',
+                )))
+            .toList();
+    final requiredListOfString = json['requiredListOfString'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfString',
+          ))
+        : (json['requiredListOfString'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredString =
+        json['requiredListOfRequiredString'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredString',
+              ))
+            : (json['requiredListOfRequiredString'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredString',
+                    )))
+                .toList();
+    final listOfInteger = json['listOfInteger'] == null
+        ? null
+        : (json['listOfInteger'] as List<Object?>).cast<int?>().toList();
+    final listOfRequiredInteger = json['listOfRequiredInteger'] == null
+        ? null
+        : (json['listOfRequiredInteger'] as List<Object?>)
+            .cast<int?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredInteger',
+                )))
+            .toList();
+    final requiredListOfInteger = json['requiredListOfInteger'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfInteger',
+          ))
+        : (json['requiredListOfInteger'] as List<Object?>)
+            .cast<int?>()
+            .toList();
+    final requiredListOfRequiredInteger =
+        json['requiredListOfRequiredInteger'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredInteger',
+              ))
+            : (json['requiredListOfRequiredInteger'] as List<Object?>)
+                .cast<int?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredInteger',
+                    )))
+                .toList();
+    final listOfFloat = json['listOfFloat'] == null
+        ? null
+        : (json['listOfFloat'] as List<Object?>).cast<double?>().toList();
+    final listOfRequiredFloat = json['listOfRequiredFloat'] == null
+        ? null
+        : (json['listOfRequiredFloat'] as List<Object?>)
+            .cast<double?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredFloat',
+                )))
+            .toList();
+    final requiredListOfFloat = json['requiredListOfFloat'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfFloat',
+          ))
+        : (json['requiredListOfFloat'] as List<Object?>)
+            .cast<double?>()
+            .toList();
+    final requiredListOfRequiredFloat =
+        json['requiredListOfRequiredFloat'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredFloat',
+              ))
+            : (json['requiredListOfRequiredFloat'] as List<Object?>)
+                .cast<double?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredFloat',
+                    )))
+                .toList();
+    final listOfBoolean = json['listOfBoolean'] == null
+        ? null
+        : (json['listOfBoolean'] as List<Object?>).cast<bool?>().toList();
+    final listOfRequiredBoolean = json['listOfRequiredBoolean'] == null
+        ? null
+        : (json['listOfRequiredBoolean'] as List<Object?>)
+            .cast<bool?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredBoolean',
+                )))
+            .toList();
+    final requiredListOfBoolean = json['requiredListOfBoolean'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfBoolean',
+          ))
+        : (json['requiredListOfBoolean'] as List<Object?>)
+            .cast<bool?>()
+            .toList();
+    final requiredListOfRequiredBoolean =
+        json['requiredListOfRequiredBoolean'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredBoolean',
+              ))
+            : (json['requiredListOfRequiredBoolean'] as List<Object?>)
+                .cast<bool?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredBoolean',
+                    )))
+                .toList();
+    final listOfAwsDate = json['listOfAWSDate'] == null
+        ? null
+        : (json['listOfAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final listOfRequiredAwsDate = json['listOfRequiredAWSDate'] == null
+        ? null
+        : (json['listOfRequiredAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsDate',
+                  ))
+                : TemporalDate.fromString(el))
+            .toList();
+    final requiredListOfAwsDate = json['requiredListOfAWSDate'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsDate',
+          ))
+        : (json['requiredListOfAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsDate =
+        json['requiredListOfRequiredAWSDate'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsDate',
+              ))
+            : (json['requiredListOfRequiredAWSDate'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsDate',
+                      ))
+                    : TemporalDate.fromString(el))
+                .toList();
+    final listOfAwsDateTime = json['listOfAWSDateTime'] == null
+        ? null
+        : (json['listOfAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final listOfRequiredAwsDateTime = json['listOfRequiredAWSDateTime'] == null
+        ? null
+        : (json['listOfRequiredAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsDateTime',
+                  ))
+                : TemporalDateTime.fromString(el))
+            .toList();
+    final requiredListOfAwsDateTime = json['requiredListOfAWSDateTime'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsDateTime',
+          ))
+        : (json['requiredListOfAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsDateTime =
+        json['requiredListOfRequiredAWSDateTime'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsDateTime',
+              ))
+            : (json['requiredListOfRequiredAWSDateTime'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsDateTime',
+                      ))
+                    : TemporalDateTime.fromString(el))
+                .toList();
+    final listOfAwsTime = json['listOfAWSTime'] == null
+        ? null
+        : (json['listOfAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final listOfRequiredAwsTime = json['listOfRequiredAWSTime'] == null
+        ? null
+        : (json['listOfRequiredAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsTime',
+                  ))
+                : TemporalTime.fromString(el))
+            .toList();
+    final requiredListOfAwsTime = json['requiredListOfAWSTime'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsTime',
+          ))
+        : (json['requiredListOfAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsTime =
+        json['requiredListOfRequiredAWSTime'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsTime',
+              ))
+            : (json['requiredListOfRequiredAWSTime'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsTime',
+                      ))
+                    : TemporalTime.fromString(el))
+                .toList();
+    final listOfAwsTimestamp = json['listOfAWSTimestamp'] == null
+        ? null
+        : (json['listOfAWSTimestamp'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final listOfRequiredAwsTimestamp =
+        json['listOfRequiredAWSTimestamp'] == null
+            ? null
+            : (json['listOfRequiredAWSTimestamp'] as List<Object?>)
+                .cast<int?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'listOfRequiredAwsTimestamp',
+                      ))
+                    : TemporalTimestamp.fromSeconds(el))
+                .toList();
+    final requiredListOfAwsTimestamp = json['requiredListOfAWSTimestamp'] ==
+            null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsTimestamp',
+          ))
+        : (json['requiredListOfAWSTimestamp'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final requiredListOfRequiredAwsTimestamp =
+        json['requiredListOfRequiredAWSTimestamp'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsTimestamp',
+              ))
+            : (json['requiredListOfRequiredAWSTimestamp'] as List<Object?>)
+                .cast<int?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsTimestamp',
+                      ))
+                    : TemporalTimestamp.fromSeconds(el))
+                .toList();
+    final listOfAwsEmail = json['listOfAWSEmail'] == null
+        ? null
+        : (json['listOfAWSEmail'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredAwsEmail = json['listOfRequiredAWSEmail'] == null
+        ? null
+        : (json['listOfRequiredAWSEmail'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredAwsEmail',
+                )))
+            .toList();
+    final requiredListOfAwsEmail = json['requiredListOfAWSEmail'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsEmail',
+          ))
+        : (json['requiredListOfAWSEmail'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredAwsEmail =
+        json['requiredListOfRequiredAWSEmail'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsEmail',
+              ))
+            : (json['requiredListOfRequiredAWSEmail'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredAwsEmail',
+                    )))
+                .toList();
+    final listOfAwsjson = json['listOfAWSJSON'] == null
+        ? null
+        : (json['listOfAWSJSON'] as List<Object?>).cast<Object?>().toList();
+    final listOfRequiredAwsjson = json['listOfRequiredAWSJSON'] == null
+        ? null
+        : (json['listOfRequiredAWSJSON'] as List<Object?>)
+            .cast<Object?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredAwsjson',
+                )))
+            .toList();
+    final requiredListOfAwsjson = json['requiredListOfAWSJSON'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsjson',
+          ))
+        : (json['requiredListOfAWSJSON'] as List<Object?>)
+            .cast<Object?>()
+            .toList();
+    final requiredListOfRequiredAwsjson =
+        json['requiredListOfRequiredAWSJSON'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsjson',
+              ))
+            : (json['requiredListOfRequiredAWSJSON'] as List<Object?>)
+                .cast<Object?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredAwsjson',
+                    )))
+                .toList();
+    final listOfAwsPhone = json['listOfAWSPhone'] == null
+        ? null
+        : (json['listOfAWSPhone'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredAwsPhone = json['listOfRequiredAWSPhone'] == null
+        ? null
+        : (json['listOfRequiredAWSPhone'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredAwsPhone',
+                )))
+            .toList();
+    final requiredListOfAwsPhone = json['requiredListOfAWSPhone'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsPhone',
+          ))
+        : (json['requiredListOfAWSPhone'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredAwsPhone =
+        json['requiredListOfRequiredAWSPhone'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsPhone',
+              ))
+            : (json['requiredListOfRequiredAWSPhone'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredAwsPhone',
+                    )))
+                .toList();
+    final listOfAwsUrl = json['listOfAWSUrl'] == null
+        ? null
+        : (json['listOfAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : Uri.parse(el))
+            .toList();
+    final listOfRequiredAwsUrl = json['listOfRequiredAWSUrl'] == null
+        ? null
+        : (json['listOfRequiredAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsUrl',
+                  ))
+                : Uri.parse(el))
+            .toList();
+    final requiredListOfAwsUrl = json['requiredListOfAWSUrl'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsUrl',
+          ))
+        : (json['requiredListOfAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : Uri.parse(el))
+            .toList();
+    final requiredListOfRequiredAwsUrl =
+        json['requiredListOfRequiredAWSUrl'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsUrl',
+              ))
+            : (json['requiredListOfRequiredAWSUrl'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsUrl',
+                      ))
+                    : Uri.parse(el))
+                .toList();
+    final listOfAwsIpAddress = json['listOfAWSIpAddress'] == null
+        ? null
+        : (json['listOfAWSIpAddress'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final listOfRequiredAwsIpAddress =
+        json['listOfRequiredAWSIpAddress'] == null
+            ? null
+            : (json['listOfRequiredAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsIpAddress',
+                    )))
+                .toList();
+    final requiredListOfAwsIpAddress =
+        json['requiredListOfAWSIpAddress'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfAwsIpAddress',
+              ))
+            : (json['requiredListOfAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .toList();
+    final requiredListOfRequiredAwsIpAddress =
+        json['requiredListOfRequiredAWSIpAddress'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsIpAddress',
+              ))
+            : (json['requiredListOfRequiredAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredAwsIpAddress',
+                    )))
+                .toList();
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return ScalarListModel(
+      id: id,
+      listOfString: listOfString,
+      listOfRequiredString: listOfRequiredString,
+      requiredListOfString: requiredListOfString,
+      requiredListOfRequiredString: requiredListOfRequiredString,
+      listOfInteger: listOfInteger,
+      listOfRequiredInteger: listOfRequiredInteger,
+      requiredListOfInteger: requiredListOfInteger,
+      requiredListOfRequiredInteger: requiredListOfRequiredInteger,
+      listOfFloat: listOfFloat,
+      listOfRequiredFloat: listOfRequiredFloat,
+      requiredListOfFloat: requiredListOfFloat,
+      requiredListOfRequiredFloat: requiredListOfRequiredFloat,
+      listOfBoolean: listOfBoolean,
+      listOfRequiredBoolean: listOfRequiredBoolean,
+      requiredListOfBoolean: requiredListOfBoolean,
+      requiredListOfRequiredBoolean: requiredListOfRequiredBoolean,
+      listOfAwsDate: listOfAwsDate,
+      listOfRequiredAwsDate: listOfRequiredAwsDate,
+      requiredListOfAwsDate: requiredListOfAwsDate,
+      requiredListOfRequiredAwsDate: requiredListOfRequiredAwsDate,
+      listOfAwsDateTime: listOfAwsDateTime,
+      listOfRequiredAwsDateTime: listOfRequiredAwsDateTime,
+      requiredListOfAwsDateTime: requiredListOfAwsDateTime,
+      requiredListOfRequiredAwsDateTime: requiredListOfRequiredAwsDateTime,
+      listOfAwsTime: listOfAwsTime,
+      listOfRequiredAwsTime: listOfRequiredAwsTime,
+      requiredListOfAwsTime: requiredListOfAwsTime,
+      requiredListOfRequiredAwsTime: requiredListOfRequiredAwsTime,
+      listOfAwsTimestamp: listOfAwsTimestamp,
+      listOfRequiredAwsTimestamp: listOfRequiredAwsTimestamp,
+      requiredListOfAwsTimestamp: requiredListOfAwsTimestamp,
+      requiredListOfRequiredAwsTimestamp: requiredListOfRequiredAwsTimestamp,
+      listOfAwsEmail: listOfAwsEmail,
+      listOfRequiredAwsEmail: listOfRequiredAwsEmail,
+      requiredListOfAwsEmail: requiredListOfAwsEmail,
+      requiredListOfRequiredAwsEmail: requiredListOfRequiredAwsEmail,
+      listOfAwsjson: listOfAwsjson,
+      listOfRequiredAwsjson: listOfRequiredAwsjson,
+      requiredListOfAwsjson: requiredListOfAwsjson,
+      requiredListOfRequiredAwsjson: requiredListOfRequiredAwsjson,
+      listOfAwsPhone: listOfAwsPhone,
+      listOfRequiredAwsPhone: listOfRequiredAwsPhone,
+      requiredListOfAwsPhone: requiredListOfAwsPhone,
+      requiredListOfRequiredAwsPhone: requiredListOfRequiredAwsPhone,
+      listOfAwsUrl: listOfAwsUrl,
+      listOfRequiredAwsUrl: listOfRequiredAwsUrl,
+      requiredListOfAwsUrl: requiredListOfAwsUrl,
+      requiredListOfRequiredAwsUrl: requiredListOfRequiredAwsUrl,
+      listOfAwsIpAddress: listOfAwsIpAddress,
+      listOfRequiredAwsIpAddress: listOfRequiredAwsIpAddress,
+      requiredListOfAwsIpAddress: requiredListOfAwsIpAddress,
+      requiredListOfRequiredAwsIpAddress: requiredListOfRequiredAwsIpAddress,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const ScalarListModelType classType = ScalarListModelType();
+
+  @override
+  String get id;
+  @override
+  List<String?>? get listOfString;
+  @override
+  List<String>? get listOfRequiredString;
+  @override
+  List<String?> get requiredListOfString;
+  @override
+  List<String> get requiredListOfRequiredString;
+  @override
+  List<int?>? get listOfInteger;
+  @override
+  List<int>? get listOfRequiredInteger;
+  @override
+  List<int?> get requiredListOfInteger;
+  @override
+  List<int> get requiredListOfRequiredInteger;
+  @override
+  List<double?>? get listOfFloat;
+  @override
+  List<double>? get listOfRequiredFloat;
+  @override
+  List<double?> get requiredListOfFloat;
+  @override
+  List<double> get requiredListOfRequiredFloat;
+  @override
+  List<bool?>? get listOfBoolean;
+  @override
+  List<bool>? get listOfRequiredBoolean;
+  @override
+  List<bool?> get requiredListOfBoolean;
+  @override
+  List<bool> get requiredListOfRequiredBoolean;
+  @override
+  List<TemporalDate?>? get listOfAwsDate;
+  @override
+  List<TemporalDate>? get listOfRequiredAwsDate;
+  @override
+  List<TemporalDate?> get requiredListOfAwsDate;
+  @override
+  List<TemporalDate> get requiredListOfRequiredAwsDate;
+  @override
+  List<TemporalDateTime?>? get listOfAwsDateTime;
+  @override
+  List<TemporalDateTime>? get listOfRequiredAwsDateTime;
+  @override
+  List<TemporalDateTime?> get requiredListOfAwsDateTime;
+  @override
+  List<TemporalDateTime> get requiredListOfRequiredAwsDateTime;
+  @override
+  List<TemporalTime?>? get listOfAwsTime;
+  @override
+  List<TemporalTime>? get listOfRequiredAwsTime;
+  @override
+  List<TemporalTime?> get requiredListOfAwsTime;
+  @override
+  List<TemporalTime> get requiredListOfRequiredAwsTime;
+  @override
+  List<TemporalTimestamp?>? get listOfAwsTimestamp;
+  @override
+  List<TemporalTimestamp>? get listOfRequiredAwsTimestamp;
+  @override
+  List<TemporalTimestamp?> get requiredListOfAwsTimestamp;
+  @override
+  List<TemporalTimestamp> get requiredListOfRequiredAwsTimestamp;
+  @override
+  List<String?>? get listOfAwsEmail;
+  @override
+  List<String>? get listOfRequiredAwsEmail;
+  @override
+  List<String?> get requiredListOfAwsEmail;
+  @override
+  List<String> get requiredListOfRequiredAwsEmail;
+  @override
+  List<Object?>? get listOfAwsjson;
+  @override
+  List<Object>? get listOfRequiredAwsjson;
+  @override
+  List<Object?> get requiredListOfAwsjson;
+  @override
+  List<Object> get requiredListOfRequiredAwsjson;
+  @override
+  List<String?>? get listOfAwsPhone;
+  @override
+  List<String>? get listOfRequiredAwsPhone;
+  @override
+  List<String?> get requiredListOfAwsPhone;
+  @override
+  List<String> get requiredListOfRequiredAwsPhone;
+  @override
+  List<Uri?>? get listOfAwsUrl;
+  @override
+  List<Uri>? get listOfRequiredAwsUrl;
+  @override
+  List<Uri?> get requiredListOfAwsUrl;
+  @override
+  List<Uri> get requiredListOfRequiredAwsUrl;
+  @override
+  List<String?>? get listOfAwsIpAddress;
+  @override
+  List<String>? get listOfRequiredAwsIpAddress;
+  @override
+  List<String?> get requiredListOfAwsIpAddress;
+  @override
+  List<String> get requiredListOfRequiredAwsIpAddress;
+  @override
+  TemporalDateTime? get createdAt;
+  @override
+  TemporalDateTime? get updatedAt;
+}
+
+class _ScalarListModel extends ScalarListModel {
+  _ScalarListModel({
+    String? id,
+    this.listOfString,
+    this.listOfRequiredString,
+    required this.requiredListOfString,
+    required this.requiredListOfRequiredString,
+    this.listOfInteger,
+    this.listOfRequiredInteger,
+    required this.requiredListOfInteger,
+    required this.requiredListOfRequiredInteger,
+    this.listOfFloat,
+    this.listOfRequiredFloat,
+    required this.requiredListOfFloat,
+    required this.requiredListOfRequiredFloat,
+    this.listOfBoolean,
+    this.listOfRequiredBoolean,
+    required this.requiredListOfBoolean,
+    required this.requiredListOfRequiredBoolean,
+    this.listOfAwsDate,
+    this.listOfRequiredAwsDate,
+    required this.requiredListOfAwsDate,
+    required this.requiredListOfRequiredAwsDate,
+    this.listOfAwsDateTime,
+    this.listOfRequiredAwsDateTime,
+    required this.requiredListOfAwsDateTime,
+    required this.requiredListOfRequiredAwsDateTime,
+    this.listOfAwsTime,
+    this.listOfRequiredAwsTime,
+    required this.requiredListOfAwsTime,
+    required this.requiredListOfRequiredAwsTime,
+    this.listOfAwsTimestamp,
+    this.listOfRequiredAwsTimestamp,
+    required this.requiredListOfAwsTimestamp,
+    required this.requiredListOfRequiredAwsTimestamp,
+    this.listOfAwsEmail,
+    this.listOfRequiredAwsEmail,
+    required this.requiredListOfAwsEmail,
+    required this.requiredListOfRequiredAwsEmail,
+    this.listOfAwsjson,
+    this.listOfRequiredAwsjson,
+    required this.requiredListOfAwsjson,
+    required this.requiredListOfRequiredAwsjson,
+    this.listOfAwsPhone,
+    this.listOfRequiredAwsPhone,
+    required this.requiredListOfAwsPhone,
+    required this.requiredListOfRequiredAwsPhone,
+    this.listOfAwsUrl,
+    this.listOfRequiredAwsUrl,
+    required this.requiredListOfAwsUrl,
+    required this.requiredListOfRequiredAwsUrl,
+    this.listOfAwsIpAddress,
+    this.listOfRequiredAwsIpAddress,
+    required this.requiredListOfAwsIpAddress,
+    required this.requiredListOfRequiredAwsIpAddress,
+    this.createdAt,
+    this.updatedAt,
+  })  : id = id ?? uuid(),
+        super._();
+
+  @override
+  final String id;
+
+  @override
+  final List<String?>? listOfString;
+
+  @override
+  final List<String>? listOfRequiredString;
+
+  @override
+  final List<String?> requiredListOfString;
+
+  @override
+  final List<String> requiredListOfRequiredString;
+
+  @override
+  final List<int?>? listOfInteger;
+
+  @override
+  final List<int>? listOfRequiredInteger;
+
+  @override
+  final List<int?> requiredListOfInteger;
+
+  @override
+  final List<int> requiredListOfRequiredInteger;
+
+  @override
+  final List<double?>? listOfFloat;
+
+  @override
+  final List<double>? listOfRequiredFloat;
+
+  @override
+  final List<double?> requiredListOfFloat;
+
+  @override
+  final List<double> requiredListOfRequiredFloat;
+
+  @override
+  final List<bool?>? listOfBoolean;
+
+  @override
+  final List<bool>? listOfRequiredBoolean;
+
+  @override
+  final List<bool?> requiredListOfBoolean;
+
+  @override
+  final List<bool> requiredListOfRequiredBoolean;
+
+  @override
+  final List<TemporalDate?>? listOfAwsDate;
+
+  @override
+  final List<TemporalDate>? listOfRequiredAwsDate;
+
+  @override
+  final List<TemporalDate?> requiredListOfAwsDate;
+
+  @override
+  final List<TemporalDate> requiredListOfRequiredAwsDate;
+
+  @override
+  final List<TemporalDateTime?>? listOfAwsDateTime;
+
+  @override
+  final List<TemporalDateTime>? listOfRequiredAwsDateTime;
+
+  @override
+  final List<TemporalDateTime?> requiredListOfAwsDateTime;
+
+  @override
+  final List<TemporalDateTime> requiredListOfRequiredAwsDateTime;
+
+  @override
+  final List<TemporalTime?>? listOfAwsTime;
+
+  @override
+  final List<TemporalTime>? listOfRequiredAwsTime;
+
+  @override
+  final List<TemporalTime?> requiredListOfAwsTime;
+
+  @override
+  final List<TemporalTime> requiredListOfRequiredAwsTime;
+
+  @override
+  final List<TemporalTimestamp?>? listOfAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp>? listOfRequiredAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp?> requiredListOfAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp> requiredListOfRequiredAwsTimestamp;
+
+  @override
+  final List<String?>? listOfAwsEmail;
+
+  @override
+  final List<String>? listOfRequiredAwsEmail;
+
+  @override
+  final List<String?> requiredListOfAwsEmail;
+
+  @override
+  final List<String> requiredListOfRequiredAwsEmail;
+
+  @override
+  final List<Object?>? listOfAwsjson;
+
+  @override
+  final List<Object>? listOfRequiredAwsjson;
+
+  @override
+  final List<Object?> requiredListOfAwsjson;
+
+  @override
+  final List<Object> requiredListOfRequiredAwsjson;
+
+  @override
+  final List<String?>? listOfAwsPhone;
+
+  @override
+  final List<String>? listOfRequiredAwsPhone;
+
+  @override
+  final List<String?> requiredListOfAwsPhone;
+
+  @override
+  final List<String> requiredListOfRequiredAwsPhone;
+
+  @override
+  final List<Uri?>? listOfAwsUrl;
+
+  @override
+  final List<Uri>? listOfRequiredAwsUrl;
+
+  @override
+  final List<Uri?> requiredListOfAwsUrl;
+
+  @override
+  final List<Uri> requiredListOfRequiredAwsUrl;
+
+  @override
+  final List<String?>? listOfAwsIpAddress;
+
+  @override
+  final List<String>? listOfRequiredAwsIpAddress;
+
+  @override
+  final List<String?> requiredListOfAwsIpAddress;
+
+  @override
+  final List<String> requiredListOfRequiredAwsIpAddress;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class RemoteScalarListModel extends ScalarListModel
+    implements RemoteModel<String, ScalarListModel> {
+  const RemoteScalarListModel._() : super._();
+}
+
+class _RemoteScalarListModel extends RemoteScalarListModel {
+  _RemoteScalarListModel({
+    required this.id,
+    this.listOfString,
+    this.listOfRequiredString,
+    required this.requiredListOfString,
+    required this.requiredListOfRequiredString,
+    this.listOfInteger,
+    this.listOfRequiredInteger,
+    required this.requiredListOfInteger,
+    required this.requiredListOfRequiredInteger,
+    this.listOfFloat,
+    this.listOfRequiredFloat,
+    required this.requiredListOfFloat,
+    required this.requiredListOfRequiredFloat,
+    this.listOfBoolean,
+    this.listOfRequiredBoolean,
+    required this.requiredListOfBoolean,
+    required this.requiredListOfRequiredBoolean,
+    this.listOfAwsDate,
+    this.listOfRequiredAwsDate,
+    required this.requiredListOfAwsDate,
+    required this.requiredListOfRequiredAwsDate,
+    this.listOfAwsDateTime,
+    this.listOfRequiredAwsDateTime,
+    required this.requiredListOfAwsDateTime,
+    required this.requiredListOfRequiredAwsDateTime,
+    this.listOfAwsTime,
+    this.listOfRequiredAwsTime,
+    required this.requiredListOfAwsTime,
+    required this.requiredListOfRequiredAwsTime,
+    this.listOfAwsTimestamp,
+    this.listOfRequiredAwsTimestamp,
+    required this.requiredListOfAwsTimestamp,
+    required this.requiredListOfRequiredAwsTimestamp,
+    this.listOfAwsEmail,
+    this.listOfRequiredAwsEmail,
+    required this.requiredListOfAwsEmail,
+    required this.requiredListOfRequiredAwsEmail,
+    this.listOfAwsjson,
+    this.listOfRequiredAwsjson,
+    required this.requiredListOfAwsjson,
+    required this.requiredListOfRequiredAwsjson,
+    this.listOfAwsPhone,
+    this.listOfRequiredAwsPhone,
+    required this.requiredListOfAwsPhone,
+    required this.requiredListOfRequiredAwsPhone,
+    this.listOfAwsUrl,
+    this.listOfRequiredAwsUrl,
+    required this.requiredListOfAwsUrl,
+    required this.requiredListOfRequiredAwsUrl,
+    this.listOfAwsIpAddress,
+    this.listOfRequiredAwsIpAddress,
+    required this.requiredListOfAwsIpAddress,
+    required this.requiredListOfRequiredAwsIpAddress,
+    this.createdAt,
+    this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteScalarListModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final listOfString = json['listOfString'] == null
+        ? null
+        : (json['listOfString'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredString = json['listOfRequiredString'] == null
+        ? null
+        : (json['listOfRequiredString'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredString',
+                )))
+            .toList();
+    final requiredListOfString = json['requiredListOfString'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfString',
+          ))
+        : (json['requiredListOfString'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredString =
+        json['requiredListOfRequiredString'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredString',
+              ))
+            : (json['requiredListOfRequiredString'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredString',
+                    )))
+                .toList();
+    final listOfInteger = json['listOfInteger'] == null
+        ? null
+        : (json['listOfInteger'] as List<Object?>).cast<int?>().toList();
+    final listOfRequiredInteger = json['listOfRequiredInteger'] == null
+        ? null
+        : (json['listOfRequiredInteger'] as List<Object?>)
+            .cast<int?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredInteger',
+                )))
+            .toList();
+    final requiredListOfInteger = json['requiredListOfInteger'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfInteger',
+          ))
+        : (json['requiredListOfInteger'] as List<Object?>)
+            .cast<int?>()
+            .toList();
+    final requiredListOfRequiredInteger =
+        json['requiredListOfRequiredInteger'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredInteger',
+              ))
+            : (json['requiredListOfRequiredInteger'] as List<Object?>)
+                .cast<int?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredInteger',
+                    )))
+                .toList();
+    final listOfFloat = json['listOfFloat'] == null
+        ? null
+        : (json['listOfFloat'] as List<Object?>).cast<double?>().toList();
+    final listOfRequiredFloat = json['listOfRequiredFloat'] == null
+        ? null
+        : (json['listOfRequiredFloat'] as List<Object?>)
+            .cast<double?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredFloat',
+                )))
+            .toList();
+    final requiredListOfFloat = json['requiredListOfFloat'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfFloat',
+          ))
+        : (json['requiredListOfFloat'] as List<Object?>)
+            .cast<double?>()
+            .toList();
+    final requiredListOfRequiredFloat =
+        json['requiredListOfRequiredFloat'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredFloat',
+              ))
+            : (json['requiredListOfRequiredFloat'] as List<Object?>)
+                .cast<double?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredFloat',
+                    )))
+                .toList();
+    final listOfBoolean = json['listOfBoolean'] == null
+        ? null
+        : (json['listOfBoolean'] as List<Object?>).cast<bool?>().toList();
+    final listOfRequiredBoolean = json['listOfRequiredBoolean'] == null
+        ? null
+        : (json['listOfRequiredBoolean'] as List<Object?>)
+            .cast<bool?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredBoolean',
+                )))
+            .toList();
+    final requiredListOfBoolean = json['requiredListOfBoolean'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfBoolean',
+          ))
+        : (json['requiredListOfBoolean'] as List<Object?>)
+            .cast<bool?>()
+            .toList();
+    final requiredListOfRequiredBoolean =
+        json['requiredListOfRequiredBoolean'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredBoolean',
+              ))
+            : (json['requiredListOfRequiredBoolean'] as List<Object?>)
+                .cast<bool?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredBoolean',
+                    )))
+                .toList();
+    final listOfAwsDate = json['listOfAWSDate'] == null
+        ? null
+        : (json['listOfAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final listOfRequiredAwsDate = json['listOfRequiredAWSDate'] == null
+        ? null
+        : (json['listOfRequiredAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsDate',
+                  ))
+                : TemporalDate.fromString(el))
+            .toList();
+    final requiredListOfAwsDate = json['requiredListOfAWSDate'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsDate',
+          ))
+        : (json['requiredListOfAWSDate'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsDate =
+        json['requiredListOfRequiredAWSDate'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsDate',
+              ))
+            : (json['requiredListOfRequiredAWSDate'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsDate',
+                      ))
+                    : TemporalDate.fromString(el))
+                .toList();
+    final listOfAwsDateTime = json['listOfAWSDateTime'] == null
+        ? null
+        : (json['listOfAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final listOfRequiredAwsDateTime = json['listOfRequiredAWSDateTime'] == null
+        ? null
+        : (json['listOfRequiredAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsDateTime',
+                  ))
+                : TemporalDateTime.fromString(el))
+            .toList();
+    final requiredListOfAwsDateTime = json['requiredListOfAWSDateTime'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsDateTime',
+          ))
+        : (json['requiredListOfAWSDateTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsDateTime =
+        json['requiredListOfRequiredAWSDateTime'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsDateTime',
+              ))
+            : (json['requiredListOfRequiredAWSDateTime'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsDateTime',
+                      ))
+                    : TemporalDateTime.fromString(el))
+                .toList();
+    final listOfAwsTime = json['listOfAWSTime'] == null
+        ? null
+        : (json['listOfAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final listOfRequiredAwsTime = json['listOfRequiredAWSTime'] == null
+        ? null
+        : (json['listOfRequiredAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsTime',
+                  ))
+                : TemporalTime.fromString(el))
+            .toList();
+    final requiredListOfAwsTime = json['requiredListOfAWSTime'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsTime',
+          ))
+        : (json['requiredListOfAWSTime'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final requiredListOfRequiredAwsTime =
+        json['requiredListOfRequiredAWSTime'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsTime',
+              ))
+            : (json['requiredListOfRequiredAWSTime'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsTime',
+                      ))
+                    : TemporalTime.fromString(el))
+                .toList();
+    final listOfAwsTimestamp = json['listOfAWSTimestamp'] == null
+        ? null
+        : (json['listOfAWSTimestamp'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final listOfRequiredAwsTimestamp =
+        json['listOfRequiredAWSTimestamp'] == null
+            ? null
+            : (json['listOfRequiredAWSTimestamp'] as List<Object?>)
+                .cast<int?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'listOfRequiredAwsTimestamp',
+                      ))
+                    : TemporalTimestamp.fromSeconds(el))
+                .toList();
+    final requiredListOfAwsTimestamp = json['requiredListOfAWSTimestamp'] ==
+            null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsTimestamp',
+          ))
+        : (json['requiredListOfAWSTimestamp'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final requiredListOfRequiredAwsTimestamp =
+        json['requiredListOfRequiredAWSTimestamp'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsTimestamp',
+              ))
+            : (json['requiredListOfRequiredAWSTimestamp'] as List<Object?>)
+                .cast<int?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsTimestamp',
+                      ))
+                    : TemporalTimestamp.fromSeconds(el))
+                .toList();
+    final listOfAwsEmail = json['listOfAWSEmail'] == null
+        ? null
+        : (json['listOfAWSEmail'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredAwsEmail = json['listOfRequiredAWSEmail'] == null
+        ? null
+        : (json['listOfRequiredAWSEmail'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredAwsEmail',
+                )))
+            .toList();
+    final requiredListOfAwsEmail = json['requiredListOfAWSEmail'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsEmail',
+          ))
+        : (json['requiredListOfAWSEmail'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredAwsEmail =
+        json['requiredListOfRequiredAWSEmail'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsEmail',
+              ))
+            : (json['requiredListOfRequiredAWSEmail'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredAwsEmail',
+                    )))
+                .toList();
+    final listOfAwsjson = json['listOfAWSJSON'] == null
+        ? null
+        : (json['listOfAWSJSON'] as List<Object?>).cast<Object?>().toList();
+    final listOfRequiredAwsjson = json['listOfRequiredAWSJSON'] == null
+        ? null
+        : (json['listOfRequiredAWSJSON'] as List<Object?>)
+            .cast<Object?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredAwsjson',
+                )))
+            .toList();
+    final requiredListOfAwsjson = json['requiredListOfAWSJSON'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsjson',
+          ))
+        : (json['requiredListOfAWSJSON'] as List<Object?>)
+            .cast<Object?>()
+            .toList();
+    final requiredListOfRequiredAwsjson =
+        json['requiredListOfRequiredAWSJSON'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsjson',
+              ))
+            : (json['requiredListOfRequiredAWSJSON'] as List<Object?>)
+                .cast<Object?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredAwsjson',
+                    )))
+                .toList();
+    final listOfAwsPhone = json['listOfAWSPhone'] == null
+        ? null
+        : (json['listOfAWSPhone'] as List<Object?>).cast<String?>().toList();
+    final listOfRequiredAwsPhone = json['listOfRequiredAWSPhone'] == null
+        ? null
+        : (json['listOfRequiredAWSPhone'] as List<Object?>)
+            .cast<String?>()
+            .map((el) =>
+                el ??
+                (throw ModelFieldError(
+                  'ScalarListModel',
+                  'listOfRequiredAwsPhone',
+                )))
+            .toList();
+    final requiredListOfAwsPhone = json['requiredListOfAWSPhone'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsPhone',
+          ))
+        : (json['requiredListOfAWSPhone'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final requiredListOfRequiredAwsPhone =
+        json['requiredListOfRequiredAWSPhone'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsPhone',
+              ))
+            : (json['requiredListOfRequiredAWSPhone'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredAwsPhone',
+                    )))
+                .toList();
+    final listOfAwsUrl = json['listOfAWSUrl'] == null
+        ? null
+        : (json['listOfAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : Uri.parse(el))
+            .toList();
+    final listOfRequiredAwsUrl = json['listOfRequiredAWSUrl'] == null
+        ? null
+        : (json['listOfRequiredAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null
+                ? (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsUrl',
+                  ))
+                : Uri.parse(el))
+            .toList();
+    final requiredListOfAwsUrl = json['requiredListOfAWSUrl'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'requiredListOfAwsUrl',
+          ))
+        : (json['requiredListOfAWSUrl'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : Uri.parse(el))
+            .toList();
+    final requiredListOfRequiredAwsUrl =
+        json['requiredListOfRequiredAWSUrl'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsUrl',
+              ))
+            : (json['requiredListOfRequiredAWSUrl'] as List<Object?>)
+                .cast<String?>()
+                .map((el) => el == null
+                    ? (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsUrl',
+                      ))
+                    : Uri.parse(el))
+                .toList();
+    final listOfAwsIpAddress = json['listOfAWSIpAddress'] == null
+        ? null
+        : (json['listOfAWSIpAddress'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final listOfRequiredAwsIpAddress =
+        json['listOfRequiredAWSIpAddress'] == null
+            ? null
+            : (json['listOfRequiredAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsIpAddress',
+                    )))
+                .toList();
+    final requiredListOfAwsIpAddress =
+        json['requiredListOfAWSIpAddress'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfAwsIpAddress',
+              ))
+            : (json['requiredListOfAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .toList();
+    final requiredListOfRequiredAwsIpAddress =
+        json['requiredListOfRequiredAWSIpAddress'] == null
+            ? (throw ModelFieldError(
+                'ScalarListModel',
+                'requiredListOfRequiredAwsIpAddress',
+              ))
+            : (json['requiredListOfRequiredAWSIpAddress'] as List<Object?>)
+                .cast<String?>()
+                .map((el) =>
+                    el ??
+                    (throw ModelFieldError(
+                      'ScalarListModel',
+                      'requiredListOfRequiredAwsIpAddress',
+                    )))
+                .toList();
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'ScalarListModel',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteScalarListModel(
+      id: id,
+      listOfString: listOfString,
+      listOfRequiredString: listOfRequiredString,
+      requiredListOfString: requiredListOfString,
+      requiredListOfRequiredString: requiredListOfRequiredString,
+      listOfInteger: listOfInteger,
+      listOfRequiredInteger: listOfRequiredInteger,
+      requiredListOfInteger: requiredListOfInteger,
+      requiredListOfRequiredInteger: requiredListOfRequiredInteger,
+      listOfFloat: listOfFloat,
+      listOfRequiredFloat: listOfRequiredFloat,
+      requiredListOfFloat: requiredListOfFloat,
+      requiredListOfRequiredFloat: requiredListOfRequiredFloat,
+      listOfBoolean: listOfBoolean,
+      listOfRequiredBoolean: listOfRequiredBoolean,
+      requiredListOfBoolean: requiredListOfBoolean,
+      requiredListOfRequiredBoolean: requiredListOfRequiredBoolean,
+      listOfAwsDate: listOfAwsDate,
+      listOfRequiredAwsDate: listOfRequiredAwsDate,
+      requiredListOfAwsDate: requiredListOfAwsDate,
+      requiredListOfRequiredAwsDate: requiredListOfRequiredAwsDate,
+      listOfAwsDateTime: listOfAwsDateTime,
+      listOfRequiredAwsDateTime: listOfRequiredAwsDateTime,
+      requiredListOfAwsDateTime: requiredListOfAwsDateTime,
+      requiredListOfRequiredAwsDateTime: requiredListOfRequiredAwsDateTime,
+      listOfAwsTime: listOfAwsTime,
+      listOfRequiredAwsTime: listOfRequiredAwsTime,
+      requiredListOfAwsTime: requiredListOfAwsTime,
+      requiredListOfRequiredAwsTime: requiredListOfRequiredAwsTime,
+      listOfAwsTimestamp: listOfAwsTimestamp,
+      listOfRequiredAwsTimestamp: listOfRequiredAwsTimestamp,
+      requiredListOfAwsTimestamp: requiredListOfAwsTimestamp,
+      requiredListOfRequiredAwsTimestamp: requiredListOfRequiredAwsTimestamp,
+      listOfAwsEmail: listOfAwsEmail,
+      listOfRequiredAwsEmail: listOfRequiredAwsEmail,
+      requiredListOfAwsEmail: requiredListOfAwsEmail,
+      requiredListOfRequiredAwsEmail: requiredListOfRequiredAwsEmail,
+      listOfAwsjson: listOfAwsjson,
+      listOfRequiredAwsjson: listOfRequiredAwsjson,
+      requiredListOfAwsjson: requiredListOfAwsjson,
+      requiredListOfRequiredAwsjson: requiredListOfRequiredAwsjson,
+      listOfAwsPhone: listOfAwsPhone,
+      listOfRequiredAwsPhone: listOfRequiredAwsPhone,
+      requiredListOfAwsPhone: requiredListOfAwsPhone,
+      requiredListOfRequiredAwsPhone: requiredListOfRequiredAwsPhone,
+      listOfAwsUrl: listOfAwsUrl,
+      listOfRequiredAwsUrl: listOfRequiredAwsUrl,
+      requiredListOfAwsUrl: requiredListOfAwsUrl,
+      requiredListOfRequiredAwsUrl: requiredListOfRequiredAwsUrl,
+      listOfAwsIpAddress: listOfAwsIpAddress,
+      listOfRequiredAwsIpAddress: listOfRequiredAwsIpAddress,
+      requiredListOfAwsIpAddress: requiredListOfAwsIpAddress,
+      requiredListOfRequiredAwsIpAddress: requiredListOfRequiredAwsIpAddress,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final List<String?>? listOfString;
+
+  @override
+  final List<String>? listOfRequiredString;
+
+  @override
+  final List<String?> requiredListOfString;
+
+  @override
+  final List<String> requiredListOfRequiredString;
+
+  @override
+  final List<int?>? listOfInteger;
+
+  @override
+  final List<int>? listOfRequiredInteger;
+
+  @override
+  final List<int?> requiredListOfInteger;
+
+  @override
+  final List<int> requiredListOfRequiredInteger;
+
+  @override
+  final List<double?>? listOfFloat;
+
+  @override
+  final List<double>? listOfRequiredFloat;
+
+  @override
+  final List<double?> requiredListOfFloat;
+
+  @override
+  final List<double> requiredListOfRequiredFloat;
+
+  @override
+  final List<bool?>? listOfBoolean;
+
+  @override
+  final List<bool>? listOfRequiredBoolean;
+
+  @override
+  final List<bool?> requiredListOfBoolean;
+
+  @override
+  final List<bool> requiredListOfRequiredBoolean;
+
+  @override
+  final List<TemporalDate?>? listOfAwsDate;
+
+  @override
+  final List<TemporalDate>? listOfRequiredAwsDate;
+
+  @override
+  final List<TemporalDate?> requiredListOfAwsDate;
+
+  @override
+  final List<TemporalDate> requiredListOfRequiredAwsDate;
+
+  @override
+  final List<TemporalDateTime?>? listOfAwsDateTime;
+
+  @override
+  final List<TemporalDateTime>? listOfRequiredAwsDateTime;
+
+  @override
+  final List<TemporalDateTime?> requiredListOfAwsDateTime;
+
+  @override
+  final List<TemporalDateTime> requiredListOfRequiredAwsDateTime;
+
+  @override
+  final List<TemporalTime?>? listOfAwsTime;
+
+  @override
+  final List<TemporalTime>? listOfRequiredAwsTime;
+
+  @override
+  final List<TemporalTime?> requiredListOfAwsTime;
+
+  @override
+  final List<TemporalTime> requiredListOfRequiredAwsTime;
+
+  @override
+  final List<TemporalTimestamp?>? listOfAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp>? listOfRequiredAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp?> requiredListOfAwsTimestamp;
+
+  @override
+  final List<TemporalTimestamp> requiredListOfRequiredAwsTimestamp;
+
+  @override
+  final List<String?>? listOfAwsEmail;
+
+  @override
+  final List<String>? listOfRequiredAwsEmail;
+
+  @override
+  final List<String?> requiredListOfAwsEmail;
+
+  @override
+  final List<String> requiredListOfRequiredAwsEmail;
+
+  @override
+  final List<Object?>? listOfAwsjson;
+
+  @override
+  final List<Object>? listOfRequiredAwsjson;
+
+  @override
+  final List<Object?> requiredListOfAwsjson;
+
+  @override
+  final List<Object> requiredListOfRequiredAwsjson;
+
+  @override
+  final List<String?>? listOfAwsPhone;
+
+  @override
+  final List<String>? listOfRequiredAwsPhone;
+
+  @override
+  final List<String?> requiredListOfAwsPhone;
+
+  @override
+  final List<String> requiredListOfRequiredAwsPhone;
+
+  @override
+  final List<Uri?>? listOfAwsUrl;
+
+  @override
+  final List<Uri>? listOfRequiredAwsUrl;
+
+  @override
+  final List<Uri?> requiredListOfAwsUrl;
+
+  @override
+  final List<Uri> requiredListOfRequiredAwsUrl;
+
+  @override
+  final List<String?>? listOfAwsIpAddress;
+
+  @override
+  final List<String>? listOfRequiredAwsIpAddress;
+
+  @override
+  final List<String?> requiredListOfAwsIpAddress;
+
+  @override
+  final List<String> requiredListOfRequiredAwsIpAddress;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
@@ -282,10 +282,10 @@ class _PartialScalarModel extends PartialScalarModel {
 
   factory _PartialScalarModel.fromJson(Map<String, Object?> json) {
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     final str = json['str'] == null ? null : (json['str'] as String?);
     final requiredStr =
@@ -513,113 +513,113 @@ abstract class ScalarModel extends PartialScalarModel
 
   factory ScalarModel.fromJson(Map<String, Object?> json) {
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     final str = json['str'] == null ? null : (json['str'] as String?);
     final requiredStr = json['requiredStr'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredStr',
-          )
+          ))
         : (json['requiredStr'] as String);
     final integer = json['integer'] == null ? null : (json['integer'] as int?);
     final requiredInteger = json['requiredInteger'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredInteger',
-          )
+          ))
         : (json['requiredInteger'] as int);
     final float = json['float'] == null ? null : (json['float'] as double?);
     final requiredFloat = json['requiredFloat'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredFloat',
-          )
+          ))
         : (json['requiredFloat'] as double);
     final boolean = json['boolean'] == null ? null : (json['boolean'] as bool?);
     final requiredBoolean = json['requiredBoolean'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredBoolean',
-          )
+          ))
         : (json['requiredBoolean'] as bool);
     final awsDate = json['awsDate'] == null
         ? null
         : TemporalDate.fromString((json['awsDate'] as String));
     final requiredAwsDate = json['requiredAwsDate'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsDate',
-          )
+          ))
         : TemporalDate.fromString((json['requiredAwsDate'] as String));
     final awsDateTime = json['awsDateTime'] == null
         ? null
         : TemporalDateTime.fromString((json['awsDateTime'] as String));
     final requiredAwsDateTime = json['requiredAwsDateTime'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsDateTime',
-          )
+          ))
         : TemporalDateTime.fromString((json['requiredAwsDateTime'] as String));
     final awsTime = json['awsTime'] == null
         ? null
         : TemporalTime.fromString((json['awsTime'] as String));
     final requiredAwsTime = json['requiredAwsTime'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsTime',
-          )
+          ))
         : TemporalTime.fromString((json['requiredAwsTime'] as String));
     final awsTimestamp = json['awsTimestamp'] == null
         ? null
         : TemporalTimestamp.fromSeconds((json['awsTimestamp'] as int));
     final requiredAwsTimestamp = json['requiredAwsTimestamp'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsTimestamp',
-          )
+          ))
         : TemporalTimestamp.fromSeconds((json['requiredAwsTimestamp'] as int));
     final awsEmail =
         json['awsEmail'] == null ? null : (json['awsEmail'] as String?);
     final requiredAwsEmail = json['requiredAwsEmail'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsEmail',
-          )
+          ))
         : (json['requiredAwsEmail'] as String);
     final awsJson = json['awsJson'];
     final requiredAwsJson = json['requiredAwsJson'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsJson',
-          )
+          ))
         : (json['requiredAwsJson'] as Object);
     final awsPhone =
         json['awsPhone'] == null ? null : (json['awsPhone'] as String?);
     final requiredAwsPhone = json['requiredAwsPhone'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsPhone',
-          )
+          ))
         : (json['requiredAwsPhone'] as String);
     final awsUrl =
         json['awsUrl'] == null ? null : Uri.parse((json['awsUrl'] as String));
     final requiredAwsUrl = json['requiredAwsUrl'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsUrl',
-          )
+          ))
         : Uri.parse((json['requiredAwsUrl'] as String));
     final awsIpAddress =
         json['awsIpAddress'] == null ? null : (json['awsIpAddress'] as String?);
     final requiredAwsIpAddress = json['requiredAwsIpAddress'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsIpAddress',
-          )
+          ))
         : (json['requiredAwsIpAddress'] as String);
     final createdAt = json['createdAt'] == null
         ? null
@@ -887,113 +887,113 @@ class _RemoteScalarModel extends RemoteScalarModel {
 
   factory _RemoteScalarModel.fromJson(Map<String, Object?> json) {
     final id = json['id'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'id',
-          )
+          ))
         : (json['id'] as String);
     final str = json['str'] == null ? null : (json['str'] as String?);
     final requiredStr = json['requiredStr'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredStr',
-          )
+          ))
         : (json['requiredStr'] as String);
     final integer = json['integer'] == null ? null : (json['integer'] as int?);
     final requiredInteger = json['requiredInteger'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredInteger',
-          )
+          ))
         : (json['requiredInteger'] as int);
     final float = json['float'] == null ? null : (json['float'] as double?);
     final requiredFloat = json['requiredFloat'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredFloat',
-          )
+          ))
         : (json['requiredFloat'] as double);
     final boolean = json['boolean'] == null ? null : (json['boolean'] as bool?);
     final requiredBoolean = json['requiredBoolean'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredBoolean',
-          )
+          ))
         : (json['requiredBoolean'] as bool);
     final awsDate = json['awsDate'] == null
         ? null
         : TemporalDate.fromString((json['awsDate'] as String));
     final requiredAwsDate = json['requiredAwsDate'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsDate',
-          )
+          ))
         : TemporalDate.fromString((json['requiredAwsDate'] as String));
     final awsDateTime = json['awsDateTime'] == null
         ? null
         : TemporalDateTime.fromString((json['awsDateTime'] as String));
     final requiredAwsDateTime = json['requiredAwsDateTime'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsDateTime',
-          )
+          ))
         : TemporalDateTime.fromString((json['requiredAwsDateTime'] as String));
     final awsTime = json['awsTime'] == null
         ? null
         : TemporalTime.fromString((json['awsTime'] as String));
     final requiredAwsTime = json['requiredAwsTime'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsTime',
-          )
+          ))
         : TemporalTime.fromString((json['requiredAwsTime'] as String));
     final awsTimestamp = json['awsTimestamp'] == null
         ? null
         : TemporalTimestamp.fromSeconds((json['awsTimestamp'] as int));
     final requiredAwsTimestamp = json['requiredAwsTimestamp'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsTimestamp',
-          )
+          ))
         : TemporalTimestamp.fromSeconds((json['requiredAwsTimestamp'] as int));
     final awsEmail =
         json['awsEmail'] == null ? null : (json['awsEmail'] as String?);
     final requiredAwsEmail = json['requiredAwsEmail'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsEmail',
-          )
+          ))
         : (json['requiredAwsEmail'] as String);
     final awsJson = json['awsJson'];
     final requiredAwsJson = json['requiredAwsJson'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsJson',
-          )
+          ))
         : (json['requiredAwsJson'] as Object);
     final awsPhone =
         json['awsPhone'] == null ? null : (json['awsPhone'] as String?);
     final requiredAwsPhone = json['requiredAwsPhone'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsPhone',
-          )
+          ))
         : (json['requiredAwsPhone'] as String);
     final awsUrl =
         json['awsUrl'] == null ? null : Uri.parse((json['awsUrl'] as String));
     final requiredAwsUrl = json['requiredAwsUrl'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsUrl',
-          )
+          ))
         : Uri.parse((json['requiredAwsUrl'] as String));
     final awsIpAddress =
         json['awsIpAddress'] == null ? null : (json['awsIpAddress'] as String?);
     final requiredAwsIpAddress = json['requiredAwsIpAddress'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'requiredAwsIpAddress',
-          )
+          ))
         : (json['requiredAwsIpAddress'] as String);
     final createdAt = json['createdAt'] == null
         ? null
@@ -1002,22 +1002,22 @@ class _RemoteScalarModel extends RemoteScalarModel {
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
     final version = json['version'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'version',
-          )
+          ))
         : (json['version'] as int);
     final deleted = json['deleted'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'deleted',
-          )
+          ))
         : (json['deleted'] as bool);
     final lastChangedAt = json['lastChangedAt'] == null
-        ? throw ModelFieldError(
+        ? (throw ModelFieldError(
             'ScalarModel',
             'lastChangedAt',
-          )
+          ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
     return _RemoteScalarModel(
       id: id,

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
@@ -662,34 +662,63 @@ abstract class ScalarModel extends PartialScalarModel
 
   static const ScalarModelType classType = ScalarModelType();
 
+  @override
   String get id;
+  @override
   String? get str;
+  @override
   String get requiredStr;
+  @override
   int? get integer;
+  @override
   int get requiredInteger;
+  @override
   double? get float;
+  @override
   double get requiredFloat;
+  @override
   bool? get boolean;
+  @override
   bool get requiredBoolean;
+  @override
   TemporalDate? get awsDate;
+  @override
   TemporalDate get requiredAwsDate;
+  @override
   TemporalDateTime? get awsDateTime;
+  @override
   TemporalDateTime get requiredAwsDateTime;
+  @override
   TemporalTime? get awsTime;
+  @override
   TemporalTime get requiredAwsTime;
+  @override
   TemporalTimestamp? get awsTimestamp;
+  @override
   TemporalTimestamp get requiredAwsTimestamp;
+  @override
   String? get awsEmail;
+  @override
   String get requiredAwsEmail;
+  @override
   Object? get awsJson;
+  @override
   Object get requiredAwsJson;
+  @override
   String? get awsPhone;
+  @override
   String get requiredAwsPhone;
+  @override
   Uri? get awsUrl;
+  @override
   Uri get requiredAwsUrl;
+  @override
   String? get awsIpAddress;
+  @override
   String get requiredAwsIpAddress;
+  @override
   TemporalDateTime? get createdAt;
+  @override
   TemporalDateTime? get updatedAt;
 }
 

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
@@ -16,6 +16,8 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
+// ignore_for_file: non_constant_identifier_names
+
 library models.scalar_model;
 
 import 'package:amplify_core/amplify_core.dart';
@@ -38,6 +40,187 @@ class ScalarModelType
 
   @override
   String get modelName => 'ScalarModel';
+}
+
+class ScalarModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ScalarModelQueryFields([this.root]);
+
+  final QueryField<ModelIdentifier, M, ScalarModel>? root;
+
+  /// Query field for the [ScalarModel.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, String>(
+          const QueryField<String, ScalarModel, String>(fieldName: 'id'));
+
+  /// Query field for the [ScalarModel.str] field.
+  QueryField<ModelIdentifier, M, String?> get $str =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, String?>(
+          const QueryField<String, ScalarModel, String?>(fieldName: 'str'));
+
+  /// Query field for the [ScalarModel.requiredStr] field.
+  QueryField<ModelIdentifier, M, String> get $requiredStr => NestedQueryField<
+          ModelIdentifier, M, String, ScalarModel, String>(
+      const QueryField<String, ScalarModel, String>(fieldName: 'requiredStr'));
+
+  /// Query field for the [ScalarModel.integer] field.
+  QueryField<ModelIdentifier, M, int?> get $integer =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, int?>(
+          const QueryField<String, ScalarModel, int?>(fieldName: 'integer'));
+
+  /// Query field for the [ScalarModel.requiredInteger] field.
+  QueryField<ModelIdentifier, M, int> get $requiredInteger => NestedQueryField<
+          ModelIdentifier, M, String, ScalarModel, int>(
+      const QueryField<String, ScalarModel, int>(fieldName: 'requiredInteger'));
+
+  /// Query field for the [ScalarModel.float] field.
+  QueryField<ModelIdentifier, M, double?> get $float =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, double?>(
+          const QueryField<String, ScalarModel, double?>(fieldName: 'float'));
+
+  /// Query field for the [ScalarModel.requiredFloat] field.
+  QueryField<ModelIdentifier, M, double> get $requiredFloat =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, double>(
+          const QueryField<String, ScalarModel, double>(
+              fieldName: 'requiredFloat'));
+
+  /// Query field for the [ScalarModel.boolean] field.
+  QueryField<ModelIdentifier, M, bool?> get $boolean =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, bool?>(
+          const QueryField<String, ScalarModel, bool?>(fieldName: 'boolean'));
+
+  /// Query field for the [ScalarModel.requiredBoolean] field.
+  QueryField<ModelIdentifier, M, bool> get $requiredBoolean =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, bool>(
+          const QueryField<String, ScalarModel, bool>(
+              fieldName: 'requiredBoolean'));
+
+  /// Query field for the [ScalarModel.awsDate] field.
+  QueryField<ModelIdentifier, M, TemporalDate?> get $awsDate =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, TemporalDate?>(
+          const QueryField<String, ScalarModel, TemporalDate?>(
+              fieldName: 'awsDate'));
+
+  /// Query field for the [ScalarModel.requiredAwsDate] field.
+  QueryField<ModelIdentifier, M, TemporalDate> get $requiredAwsDate =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, TemporalDate>(
+          const QueryField<String, ScalarModel, TemporalDate>(
+              fieldName: 'requiredAwsDate'));
+
+  /// Query field for the [ScalarModel.awsDateTime] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $awsDateTime =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel,
+              TemporalDateTime?>(
+          const QueryField<String, ScalarModel, TemporalDateTime?>(
+              fieldName: 'awsDateTime'));
+
+  /// Query field for the [ScalarModel.requiredAwsDateTime] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $requiredAwsDateTime =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel,
+              TemporalDateTime>(
+          const QueryField<String, ScalarModel, TemporalDateTime>(
+              fieldName: 'requiredAwsDateTime'));
+
+  /// Query field for the [ScalarModel.awsTime] field.
+  QueryField<ModelIdentifier, M, TemporalTime?> get $awsTime =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, TemporalTime?>(
+          const QueryField<String, ScalarModel, TemporalTime?>(
+              fieldName: 'awsTime'));
+
+  /// Query field for the [ScalarModel.requiredAwsTime] field.
+  QueryField<ModelIdentifier, M, TemporalTime> get $requiredAwsTime =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, TemporalTime>(
+          const QueryField<String, ScalarModel, TemporalTime>(
+              fieldName: 'requiredAwsTime'));
+
+  /// Query field for the [ScalarModel.awsTimestamp] field.
+  QueryField<ModelIdentifier, M, TemporalTimestamp?> get $awsTimestamp =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel,
+              TemporalTimestamp?>(
+          const QueryField<String, ScalarModel, TemporalTimestamp?>(
+              fieldName: 'awsTimestamp'));
+
+  /// Query field for the [ScalarModel.requiredAwsTimestamp] field.
+  QueryField<ModelIdentifier, M, TemporalTimestamp> get $requiredAwsTimestamp =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel,
+              TemporalTimestamp>(
+          const QueryField<String, ScalarModel, TemporalTimestamp>(
+              fieldName: 'requiredAwsTimestamp'));
+
+  /// Query field for the [ScalarModel.awsEmail] field.
+  QueryField<ModelIdentifier, M, String?> get $awsEmail => NestedQueryField<
+          ModelIdentifier, M, String, ScalarModel, String?>(
+      const QueryField<String, ScalarModel, String?>(fieldName: 'awsEmail'));
+
+  /// Query field for the [ScalarModel.requiredAwsEmail] field.
+  QueryField<ModelIdentifier, M, String> get $requiredAwsEmail =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, String>(
+          const QueryField<String, ScalarModel, String>(
+              fieldName: 'requiredAwsEmail'));
+
+  /// Query field for the [ScalarModel.awsJson] field.
+  QueryField<ModelIdentifier, M, Object?> get $awsJson =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, Object?>(
+          const QueryField<String, ScalarModel, Object?>(fieldName: 'awsJson'));
+
+  /// Query field for the [ScalarModel.requiredAwsJson] field.
+  QueryField<ModelIdentifier, M, Object> get $requiredAwsJson =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, Object>(
+          const QueryField<String, ScalarModel, Object>(
+              fieldName: 'requiredAwsJson'));
+
+  /// Query field for the [ScalarModel.awsPhone] field.
+  QueryField<ModelIdentifier, M, String?> get $awsPhone => NestedQueryField<
+          ModelIdentifier, M, String, ScalarModel, String?>(
+      const QueryField<String, ScalarModel, String?>(fieldName: 'awsPhone'));
+
+  /// Query field for the [ScalarModel.requiredAwsPhone] field.
+  QueryField<ModelIdentifier, M, String> get $requiredAwsPhone =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, String>(
+          const QueryField<String, ScalarModel, String>(
+              fieldName: 'requiredAwsPhone'));
+
+  /// Query field for the [ScalarModel.awsUrl] field.
+  QueryField<ModelIdentifier, M, Uri?> get $awsUrl =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, Uri?>(
+          const QueryField<String, ScalarModel, Uri?>(fieldName: 'awsUrl'));
+
+  /// Query field for the [ScalarModel.requiredAwsUrl] field.
+  QueryField<ModelIdentifier, M, Uri> get $requiredAwsUrl => NestedQueryField<
+          ModelIdentifier, M, String, ScalarModel, Uri>(
+      const QueryField<String, ScalarModel, Uri>(fieldName: 'requiredAwsUrl'));
+
+  /// Query field for the [ScalarModel.awsIpAddress] field.
+  QueryField<ModelIdentifier, M, String?> get $awsIpAddress =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, String?>(
+          const QueryField<String, ScalarModel, String?>(
+              fieldName: 'awsIpAddress'));
+
+  /// Query field for the [ScalarModel.requiredAwsIpAddress] field.
+  QueryField<ModelIdentifier, M, String> get $requiredAwsIpAddress =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, String>(
+          const QueryField<String, ScalarModel, String>(
+              fieldName: 'requiredAwsIpAddress'));
+
+  /// Query field for the [ScalarModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel,
+              TemporalDateTime?>(
+          const QueryField<String, ScalarModel, TemporalDateTime?>(
+              fieldName: 'createdAt'));
+
+  /// Query field for the [ScalarModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel,
+              TemporalDateTime?>(
+          const QueryField<String, ScalarModel, TemporalDateTime?>(
+              fieldName: 'updatedAt'));
+
+  /// Query field for the `modelIdentifier` field.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, ScalarModel, String>(
+          const QueryField<String, ScalarModel, String>(
+              fieldName: 'modelIdentifier'));
 }
 
 abstract class PartialScalarModel extends PartialModel<String, ScalarModel>
@@ -661,64 +844,315 @@ abstract class ScalarModel extends PartialScalarModel
 
   static const ScalarModelType classType = ScalarModelType();
 
+  static const ScalarModelQueryFields<String, ScalarModel> _queryFields =
+      ScalarModelQueryFields();
+
   @override
   String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, ScalarModel, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, ScalarModel, String> get ID => $id;
   @override
   String? get str;
+
+  /// Query field for the [str] field.
+  QueryField<String, ScalarModel, String?> get $str => _queryFields.$str;
+
+  /// Query field for the [str] field.
+  @Deprecated(r'Use $str instead')
+  QueryField<String, ScalarModel, String?> get STR => $str;
   @override
   String get requiredStr;
+
+  /// Query field for the [requiredStr] field.
+  QueryField<String, ScalarModel, String> get $requiredStr =>
+      _queryFields.$requiredStr;
+
+  /// Query field for the [requiredStr] field.
+  @Deprecated(r'Use $requiredStr instead')
+  QueryField<String, ScalarModel, String> get REQUIRED_STR => $requiredStr;
   @override
   int? get integer;
+
+  /// Query field for the [integer] field.
+  QueryField<String, ScalarModel, int?> get $integer => _queryFields.$integer;
+
+  /// Query field for the [integer] field.
+  @Deprecated(r'Use $integer instead')
+  QueryField<String, ScalarModel, int?> get INTEGER => $integer;
   @override
   int get requiredInteger;
+
+  /// Query field for the [requiredInteger] field.
+  QueryField<String, ScalarModel, int> get $requiredInteger =>
+      _queryFields.$requiredInteger;
+
+  /// Query field for the [requiredInteger] field.
+  @Deprecated(r'Use $requiredInteger instead')
+  QueryField<String, ScalarModel, int> get REQUIRED_INTEGER => $requiredInteger;
   @override
   double? get float;
+
+  /// Query field for the [float] field.
+  QueryField<String, ScalarModel, double?> get $float => _queryFields.$float;
+
+  /// Query field for the [float] field.
+  @Deprecated(r'Use $float instead')
+  QueryField<String, ScalarModel, double?> get FLOAT => $float;
   @override
   double get requiredFloat;
+
+  /// Query field for the [requiredFloat] field.
+  QueryField<String, ScalarModel, double> get $requiredFloat =>
+      _queryFields.$requiredFloat;
+
+  /// Query field for the [requiredFloat] field.
+  @Deprecated(r'Use $requiredFloat instead')
+  QueryField<String, ScalarModel, double> get REQUIRED_FLOAT => $requiredFloat;
   @override
   bool? get boolean;
+
+  /// Query field for the [boolean] field.
+  QueryField<String, ScalarModel, bool?> get $boolean => _queryFields.$boolean;
+
+  /// Query field for the [boolean] field.
+  @Deprecated(r'Use $boolean instead')
+  QueryField<String, ScalarModel, bool?> get BOOLEAN => $boolean;
   @override
   bool get requiredBoolean;
+
+  /// Query field for the [requiredBoolean] field.
+  QueryField<String, ScalarModel, bool> get $requiredBoolean =>
+      _queryFields.$requiredBoolean;
+
+  /// Query field for the [requiredBoolean] field.
+  @Deprecated(r'Use $requiredBoolean instead')
+  QueryField<String, ScalarModel, bool> get REQUIRED_BOOLEAN =>
+      $requiredBoolean;
   @override
   TemporalDate? get awsDate;
+
+  /// Query field for the [awsDate] field.
+  QueryField<String, ScalarModel, TemporalDate?> get $awsDate =>
+      _queryFields.$awsDate;
+
+  /// Query field for the [awsDate] field.
+  @Deprecated(r'Use $awsDate instead')
+  QueryField<String, ScalarModel, TemporalDate?> get AWS_DATE => $awsDate;
   @override
   TemporalDate get requiredAwsDate;
+
+  /// Query field for the [requiredAwsDate] field.
+  QueryField<String, ScalarModel, TemporalDate> get $requiredAwsDate =>
+      _queryFields.$requiredAwsDate;
+
+  /// Query field for the [requiredAwsDate] field.
+  @Deprecated(r'Use $requiredAwsDate instead')
+  QueryField<String, ScalarModel, TemporalDate> get REQUIRED_AWS_DATE =>
+      $requiredAwsDate;
   @override
   TemporalDateTime? get awsDateTime;
+
+  /// Query field for the [awsDateTime] field.
+  QueryField<String, ScalarModel, TemporalDateTime?> get $awsDateTime =>
+      _queryFields.$awsDateTime;
+
+  /// Query field for the [awsDateTime] field.
+  @Deprecated(r'Use $awsDateTime instead')
+  QueryField<String, ScalarModel, TemporalDateTime?> get AWS_DATE_TIME =>
+      $awsDateTime;
   @override
   TemporalDateTime get requiredAwsDateTime;
+
+  /// Query field for the [requiredAwsDateTime] field.
+  QueryField<String, ScalarModel, TemporalDateTime> get $requiredAwsDateTime =>
+      _queryFields.$requiredAwsDateTime;
+
+  /// Query field for the [requiredAwsDateTime] field.
+  @Deprecated(r'Use $requiredAwsDateTime instead')
+  QueryField<String, ScalarModel, TemporalDateTime>
+      get REQUIRED_AWS_DATE_TIME => $requiredAwsDateTime;
   @override
   TemporalTime? get awsTime;
+
+  /// Query field for the [awsTime] field.
+  QueryField<String, ScalarModel, TemporalTime?> get $awsTime =>
+      _queryFields.$awsTime;
+
+  /// Query field for the [awsTime] field.
+  @Deprecated(r'Use $awsTime instead')
+  QueryField<String, ScalarModel, TemporalTime?> get AWS_TIME => $awsTime;
   @override
   TemporalTime get requiredAwsTime;
+
+  /// Query field for the [requiredAwsTime] field.
+  QueryField<String, ScalarModel, TemporalTime> get $requiredAwsTime =>
+      _queryFields.$requiredAwsTime;
+
+  /// Query field for the [requiredAwsTime] field.
+  @Deprecated(r'Use $requiredAwsTime instead')
+  QueryField<String, ScalarModel, TemporalTime> get REQUIRED_AWS_TIME =>
+      $requiredAwsTime;
   @override
   TemporalTimestamp? get awsTimestamp;
+
+  /// Query field for the [awsTimestamp] field.
+  QueryField<String, ScalarModel, TemporalTimestamp?> get $awsTimestamp =>
+      _queryFields.$awsTimestamp;
+
+  /// Query field for the [awsTimestamp] field.
+  @Deprecated(r'Use $awsTimestamp instead')
+  QueryField<String, ScalarModel, TemporalTimestamp?> get AWS_TIMESTAMP =>
+      $awsTimestamp;
   @override
   TemporalTimestamp get requiredAwsTimestamp;
+
+  /// Query field for the [requiredAwsTimestamp] field.
+  QueryField<String, ScalarModel, TemporalTimestamp>
+      get $requiredAwsTimestamp => _queryFields.$requiredAwsTimestamp;
+
+  /// Query field for the [requiredAwsTimestamp] field.
+  @Deprecated(r'Use $requiredAwsTimestamp instead')
+  QueryField<String, ScalarModel, TemporalTimestamp>
+      get REQUIRED_AWS_TIMESTAMP => $requiredAwsTimestamp;
   @override
   String? get awsEmail;
+
+  /// Query field for the [awsEmail] field.
+  QueryField<String, ScalarModel, String?> get $awsEmail =>
+      _queryFields.$awsEmail;
+
+  /// Query field for the [awsEmail] field.
+  @Deprecated(r'Use $awsEmail instead')
+  QueryField<String, ScalarModel, String?> get AWS_EMAIL => $awsEmail;
   @override
   String get requiredAwsEmail;
+
+  /// Query field for the [requiredAwsEmail] field.
+  QueryField<String, ScalarModel, String> get $requiredAwsEmail =>
+      _queryFields.$requiredAwsEmail;
+
+  /// Query field for the [requiredAwsEmail] field.
+  @Deprecated(r'Use $requiredAwsEmail instead')
+  QueryField<String, ScalarModel, String> get REQUIRED_AWS_EMAIL =>
+      $requiredAwsEmail;
   @override
   Object? get awsJson;
+
+  /// Query field for the [awsJson] field.
+  QueryField<String, ScalarModel, Object?> get $awsJson =>
+      _queryFields.$awsJson;
+
+  /// Query field for the [awsJson] field.
+  @Deprecated(r'Use $awsJson instead')
+  QueryField<String, ScalarModel, Object?> get AWS_JSON => $awsJson;
   @override
   Object get requiredAwsJson;
+
+  /// Query field for the [requiredAwsJson] field.
+  QueryField<String, ScalarModel, Object> get $requiredAwsJson =>
+      _queryFields.$requiredAwsJson;
+
+  /// Query field for the [requiredAwsJson] field.
+  @Deprecated(r'Use $requiredAwsJson instead')
+  QueryField<String, ScalarModel, Object> get REQUIRED_AWS_JSON =>
+      $requiredAwsJson;
   @override
   String? get awsPhone;
+
+  /// Query field for the [awsPhone] field.
+  QueryField<String, ScalarModel, String?> get $awsPhone =>
+      _queryFields.$awsPhone;
+
+  /// Query field for the [awsPhone] field.
+  @Deprecated(r'Use $awsPhone instead')
+  QueryField<String, ScalarModel, String?> get AWS_PHONE => $awsPhone;
   @override
   String get requiredAwsPhone;
+
+  /// Query field for the [requiredAwsPhone] field.
+  QueryField<String, ScalarModel, String> get $requiredAwsPhone =>
+      _queryFields.$requiredAwsPhone;
+
+  /// Query field for the [requiredAwsPhone] field.
+  @Deprecated(r'Use $requiredAwsPhone instead')
+  QueryField<String, ScalarModel, String> get REQUIRED_AWS_PHONE =>
+      $requiredAwsPhone;
   @override
   Uri? get awsUrl;
+
+  /// Query field for the [awsUrl] field.
+  QueryField<String, ScalarModel, Uri?> get $awsUrl => _queryFields.$awsUrl;
+
+  /// Query field for the [awsUrl] field.
+  @Deprecated(r'Use $awsUrl instead')
+  QueryField<String, ScalarModel, Uri?> get AWS_URL => $awsUrl;
   @override
   Uri get requiredAwsUrl;
+
+  /// Query field for the [requiredAwsUrl] field.
+  QueryField<String, ScalarModel, Uri> get $requiredAwsUrl =>
+      _queryFields.$requiredAwsUrl;
+
+  /// Query field for the [requiredAwsUrl] field.
+  @Deprecated(r'Use $requiredAwsUrl instead')
+  QueryField<String, ScalarModel, Uri> get REQUIRED_AWS_URL => $requiredAwsUrl;
   @override
   String? get awsIpAddress;
+
+  /// Query field for the [awsIpAddress] field.
+  QueryField<String, ScalarModel, String?> get $awsIpAddress =>
+      _queryFields.$awsIpAddress;
+
+  /// Query field for the [awsIpAddress] field.
+  @Deprecated(r'Use $awsIpAddress instead')
+  QueryField<String, ScalarModel, String?> get AWS_IP_ADDRESS => $awsIpAddress;
   @override
   String get requiredAwsIpAddress;
+
+  /// Query field for the [requiredAwsIpAddress] field.
+  QueryField<String, ScalarModel, String> get $requiredAwsIpAddress =>
+      _queryFields.$requiredAwsIpAddress;
+
+  /// Query field for the [requiredAwsIpAddress] field.
+  @Deprecated(r'Use $requiredAwsIpAddress instead')
+  QueryField<String, ScalarModel, String> get REQUIRED_AWS_IP_ADDRESS =>
+      $requiredAwsIpAddress;
   @override
   TemporalDateTime? get createdAt;
+
+  /// Query field for the [createdAt] field.
+  QueryField<String, ScalarModel, TemporalDateTime?> get $createdAt =>
+      _queryFields.$createdAt;
+
+  /// Query field for the [createdAt] field.
+  @Deprecated(r'Use $createdAt instead')
+  QueryField<String, ScalarModel, TemporalDateTime?> get CREATED_AT =>
+      $createdAt;
   @override
   TemporalDateTime? get updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  QueryField<String, ScalarModel, TemporalDateTime?> get $updatedAt =>
+      _queryFields.$updatedAt;
+
+  /// Query field for the [updatedAt] field.
+  @Deprecated(r'Use $updatedAt instead')
+  QueryField<String, ScalarModel, TemporalDateTime?> get UPDATED_AT =>
+      $updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, ScalarModel, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, ScalarModel, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
 }
 
 class _ScalarModel extends ScalarModel {

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
@@ -19,7 +19,6 @@
 library models.scalar_model;
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:aws_common/aws_common.dart';
 
 class ScalarModelType
     extends ModelType<String, ScalarModel, PartialScalarModel> {

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
@@ -247,7 +247,7 @@ abstract class PartialScalarModel extends PartialModel<String, ScalarModel>
 }
 
 class _PartialScalarModel extends PartialScalarModel {
-  _PartialScalarModel({
+  const _PartialScalarModel({
     required this.id,
     this.str,
     this.requiredStr,
@@ -286,21 +286,21 @@ class _PartialScalarModel extends PartialScalarModel {
             'id',
           ))
         : (json['id'] as String);
-    final str = json['str'] == null ? null : (json['str'] as String?);
+    final str = json['str'] == null ? null : (json['str'] as String);
     final requiredStr =
-        json['requiredStr'] == null ? null : (json['requiredStr'] as String?);
-    final integer = json['integer'] == null ? null : (json['integer'] as int?);
+        json['requiredStr'] == null ? null : (json['requiredStr'] as String);
+    final integer = json['integer'] == null ? null : (json['integer'] as int);
     final requiredInteger = json['requiredInteger'] == null
         ? null
-        : (json['requiredInteger'] as int?);
-    final float = json['float'] == null ? null : (json['float'] as double?);
+        : (json['requiredInteger'] as int);
+    final float = json['float'] == null ? null : (json['float'] as double);
     final requiredFloat = json['requiredFloat'] == null
         ? null
-        : (json['requiredFloat'] as double?);
-    final boolean = json['boolean'] == null ? null : (json['boolean'] as bool?);
+        : (json['requiredFloat'] as double);
+    final boolean = json['boolean'] == null ? null : (json['boolean'] as bool);
     final requiredBoolean = json['requiredBoolean'] == null
         ? null
-        : (json['requiredBoolean'] as bool?);
+        : (json['requiredBoolean'] as bool);
     final awsDate = json['awsDate'] == null
         ? null
         : TemporalDate.fromString((json['awsDate'] as String));
@@ -326,27 +326,27 @@ class _PartialScalarModel extends PartialScalarModel {
         ? null
         : TemporalTimestamp.fromSeconds((json['requiredAwsTimestamp'] as int));
     final awsEmail =
-        json['awsEmail'] == null ? null : (json['awsEmail'] as String?);
+        json['awsEmail'] == null ? null : (json['awsEmail'] as String);
     final requiredAwsEmail = json['requiredAwsEmail'] == null
         ? null
-        : (json['requiredAwsEmail'] as String?);
+        : (json['requiredAwsEmail'] as String);
     final awsJson = json['awsJson'];
     final requiredAwsJson = json['requiredAwsJson'];
     final awsPhone =
-        json['awsPhone'] == null ? null : (json['awsPhone'] as String?);
+        json['awsPhone'] == null ? null : (json['awsPhone'] as String);
     final requiredAwsPhone = json['requiredAwsPhone'] == null
         ? null
-        : (json['requiredAwsPhone'] as String?);
+        : (json['requiredAwsPhone'] as String);
     final awsUrl =
         json['awsUrl'] == null ? null : Uri.parse((json['awsUrl'] as String));
     final requiredAwsUrl = json['requiredAwsUrl'] == null
         ? null
         : Uri.parse((json['requiredAwsUrl'] as String));
     final awsIpAddress =
-        json['awsIpAddress'] == null ? null : (json['awsIpAddress'] as String?);
+        json['awsIpAddress'] == null ? null : (json['awsIpAddress'] as String);
     final requiredAwsIpAddress = json['requiredAwsIpAddress'] == null
         ? null
-        : (json['requiredAwsIpAddress'] as String?);
+        : (json['requiredAwsIpAddress'] as String);
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
@@ -517,28 +517,28 @@ abstract class ScalarModel extends PartialScalarModel
             'id',
           ))
         : (json['id'] as String);
-    final str = json['str'] == null ? null : (json['str'] as String?);
+    final str = json['str'] == null ? null : (json['str'] as String);
     final requiredStr = json['requiredStr'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
             'requiredStr',
           ))
         : (json['requiredStr'] as String);
-    final integer = json['integer'] == null ? null : (json['integer'] as int?);
+    final integer = json['integer'] == null ? null : (json['integer'] as int);
     final requiredInteger = json['requiredInteger'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
             'requiredInteger',
           ))
         : (json['requiredInteger'] as int);
-    final float = json['float'] == null ? null : (json['float'] as double?);
+    final float = json['float'] == null ? null : (json['float'] as double);
     final requiredFloat = json['requiredFloat'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
             'requiredFloat',
           ))
         : (json['requiredFloat'] as double);
-    final boolean = json['boolean'] == null ? null : (json['boolean'] as bool?);
+    final boolean = json['boolean'] == null ? null : (json['boolean'] as bool);
     final requiredBoolean = json['requiredBoolean'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
@@ -582,7 +582,7 @@ abstract class ScalarModel extends PartialScalarModel
           ))
         : TemporalTimestamp.fromSeconds((json['requiredAwsTimestamp'] as int));
     final awsEmail =
-        json['awsEmail'] == null ? null : (json['awsEmail'] as String?);
+        json['awsEmail'] == null ? null : (json['awsEmail'] as String);
     final requiredAwsEmail = json['requiredAwsEmail'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
@@ -597,7 +597,7 @@ abstract class ScalarModel extends PartialScalarModel
           ))
         : (json['requiredAwsJson'] as Object);
     final awsPhone =
-        json['awsPhone'] == null ? null : (json['awsPhone'] as String?);
+        json['awsPhone'] == null ? null : (json['awsPhone'] as String);
     final requiredAwsPhone = json['requiredAwsPhone'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
@@ -613,7 +613,7 @@ abstract class ScalarModel extends PartialScalarModel
           ))
         : Uri.parse((json['requiredAwsUrl'] as String));
     final awsIpAddress =
-        json['awsIpAddress'] == null ? null : (json['awsIpAddress'] as String?);
+        json['awsIpAddress'] == null ? null : (json['awsIpAddress'] as String);
     final requiredAwsIpAddress = json['requiredAwsIpAddress'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
@@ -849,7 +849,7 @@ abstract class RemoteScalarModel extends ScalarModel
 }
 
 class _RemoteScalarModel extends RemoteScalarModel {
-  _RemoteScalarModel({
+  const _RemoteScalarModel({
     required this.id,
     this.str,
     required this.requiredStr,
@@ -891,28 +891,28 @@ class _RemoteScalarModel extends RemoteScalarModel {
             'id',
           ))
         : (json['id'] as String);
-    final str = json['str'] == null ? null : (json['str'] as String?);
+    final str = json['str'] == null ? null : (json['str'] as String);
     final requiredStr = json['requiredStr'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
             'requiredStr',
           ))
         : (json['requiredStr'] as String);
-    final integer = json['integer'] == null ? null : (json['integer'] as int?);
+    final integer = json['integer'] == null ? null : (json['integer'] as int);
     final requiredInteger = json['requiredInteger'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
             'requiredInteger',
           ))
         : (json['requiredInteger'] as int);
-    final float = json['float'] == null ? null : (json['float'] as double?);
+    final float = json['float'] == null ? null : (json['float'] as double);
     final requiredFloat = json['requiredFloat'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
             'requiredFloat',
           ))
         : (json['requiredFloat'] as double);
-    final boolean = json['boolean'] == null ? null : (json['boolean'] as bool?);
+    final boolean = json['boolean'] == null ? null : (json['boolean'] as bool);
     final requiredBoolean = json['requiredBoolean'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
@@ -956,7 +956,7 @@ class _RemoteScalarModel extends RemoteScalarModel {
           ))
         : TemporalTimestamp.fromSeconds((json['requiredAwsTimestamp'] as int));
     final awsEmail =
-        json['awsEmail'] == null ? null : (json['awsEmail'] as String?);
+        json['awsEmail'] == null ? null : (json['awsEmail'] as String);
     final requiredAwsEmail = json['requiredAwsEmail'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
@@ -971,7 +971,7 @@ class _RemoteScalarModel extends RemoteScalarModel {
           ))
         : (json['requiredAwsJson'] as Object);
     final awsPhone =
-        json['awsPhone'] == null ? null : (json['awsPhone'] as String?);
+        json['awsPhone'] == null ? null : (json['awsPhone'] as String);
     final requiredAwsPhone = json['requiredAwsPhone'] == null
         ? (throw ModelFieldError(
             'ScalarModel',
@@ -987,7 +987,7 @@ class _RemoteScalarModel extends RemoteScalarModel {
           ))
         : Uri.parse((json['requiredAwsUrl'] as String));
     final awsIpAddress =
-        json['awsIpAddress'] == null ? null : (json['awsIpAddress'] as String?);
+        json['awsIpAddress'] == null ? null : (json['awsIpAddress'] as String);
     final requiredAwsIpAddress = json['requiredAwsIpAddress'] == null
         ? (throw ModelFieldError(
             'ScalarModel',

--- a/packages/datastore/amplify_codegen/test/parser/common.dart
+++ b/packages/datastore/amplify_codegen/test/parser/common.dart
@@ -1,0 +1,26 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_codegen/amplify_codegen.dart';
+import 'package:amplify_core/amplify_core.dart';
+
+Map<String, ModelTypeDefinition> parseModels(String schema) {
+  return {
+    for (final definition in parseSchema(schema)
+        .typeDefinitions
+        .values
+        .whereType<ModelTypeDefinition>())
+      definition.name: definition,
+  };
+}

--- a/packages/datastore/amplify_codegen/test/parser/has_many_test.dart
+++ b/packages/datastore/amplify_codegen/test/parser/has_many_test.dart
@@ -1,0 +1,122 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:test/test.dart';
+
+import 'common.dart';
+
+// Follows the tests found in amplify-codegen:
+// https://github.com/aws-amplify/amplify-codegen/blob/main/packages/appsync-modelgen-plugin/src/__tests__/utils/process-has-many.test.ts
+void main() {
+  group('hasMany', () {
+    test('adds implict index when there is no belongsTo', () {
+      const schema = '''
+      type Foo @model {
+        id: ID!
+        bar: [Bar] @hasMany
+      }
+
+      type Bar @model {
+        id: ID!
+      }
+      ''';
+      final models = parseModels(schema);
+      expect(
+        models['Bar']!.indexes,
+        unorderedEquals([
+          isA<ModelIndex>().having((i) => i.name, 'name', isNull), // primaryKey
+          isA<ModelIndex>().having((i) => i.name, 'name', 'gsi-Foo.bar'),
+        ]),
+        reason: 'primary index + foreign key for Foo',
+      );
+    });
+
+    test('does not add implict index when there is a belongsTo', () {
+      const schema = '''
+      type Foo @model {
+        id: ID!
+        bar: [Bar] @hasMany
+      }
+
+      type Bar @model {
+        id: ID!
+        foo: Foo @belongsTo
+      }
+      ''';
+      final models = parseModels(schema);
+      expect(
+        models['Bar']!.indexes,
+        unorderedEquals([
+          isA<ModelIndex>().having((i) => i.name, 'name', isNull), // primaryKey
+          isA<ModelIndex>().having((i) => i.name, 'name', 'gsi-Foo.bar'),
+        ]),
+        reason: 'primary index + foreign key for Foo',
+      );
+    });
+
+    test('uses index when specified', () {
+      const schema = '''
+      type Foo @model {
+        id: ID!
+        bar: [Bar] @hasMany(indexName: "byFoo", fields: ["id"])
+      }
+
+      type Bar @model {
+        id: ID!
+        fooId: ID @index(name: "byFoo")
+      }
+      ''';
+      final models = parseModels(schema);
+      expect(
+        models['Bar']!.indexes,
+        unorderedEquals([
+          isA<ModelIndex>().having((i) => i.name, 'name', isNull), // primaryKey
+          isA<ModelIndex>().having((i) => i.name, 'name', 'byFoo'),
+        ]),
+        reason: 'primary index + foreign key for Foo',
+      );
+    });
+
+    test('creates a composite foreign key', () {
+      const schema = '''
+      type Foo @model {
+        id: ID! @primaryKey(sortKeyFields: ["warehouseId"])
+        warehouseId: String!
+        bar: [Bar] @hasMany
+      }
+
+      type Bar @model {
+        id: ID!
+      }
+      ''';
+      final models = parseModels(schema);
+      expect(
+        models['Bar']!.indexes,
+        unorderedEquals([
+          isA<ModelIndex>()
+              .having((idx) => idx.name, 'name', isNull), // primary key
+          isA<ModelIndex>()
+              .having((idx) => idx.name, 'name', 'gsi-Foo.bar')
+              .having(
+                (idx) => idx.fields,
+                'fields',
+                equals(['fooBarId', 'fooBarWarehouseId']),
+              ),
+        ]),
+        reason: 'primary index + foreign key for Foo',
+      );
+    });
+  });
+}

--- a/packages/datastore/amplify_codegen/test/parser/parser_test.dart
+++ b/packages/datastore/amplify_codegen/test/parser/parser_test.dart
@@ -13,23 +13,14 @@
 // limitations under the License.
 
 import 'package:amplify_codegen/src/helpers/model.dart';
-import 'package:amplify_codegen/src/parser/parser.dart';
 import 'package:amplify_core/src/types/models/mipr.dart';
 import 'package:test/test.dart';
+
+import 'common.dart';
 
 // Follows the tests found in amplify-codegen:
 // https://github.com/aws-amplify/amplify-codegen/blob/main/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections-v2.test.ts
 void main() {
-  Map<String, ModelTypeDefinition> parseModels(String schema) {
-    return {
-      for (final definition in parseSchema(schema)
-          .typeDefinitions
-          .values
-          .whereType<ModelTypeDefinition>())
-        definition.name: definition,
-    };
-  }
-
   group('Parser', () {
     group('hasMany', () {
       late Map<String, ModelTypeDefinition> v2Models;
@@ -244,7 +235,7 @@ void main() {
           postsField.association,
           ModelAssociation.hasMany(
             associatedType: 'Post',
-            associatedFields: ['blogPostsId'],
+            associatedFields: ['blog'],
           ),
         );
       });
@@ -256,7 +247,7 @@ void main() {
           commentsField.association,
           ModelAssociation.hasMany(
             associatedType: 'Comment',
-            associatedFields: ['postCommentsId'],
+            associatedFields: ['post'],
           ),
         );
       });
@@ -424,7 +415,7 @@ void main() {
             postCommentsField.association,
             ModelAssociation.hasMany(
               associatedType: 'Comment',
-              associatedFields: ['postCommentsPostId', 'postCommentsTitle'],
+              associatedFields: ['post'],
             ),
           );
 

--- a/packages/datastore/amplify_codegen/test/schemas/non_models.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/non_models.graphql
@@ -28,6 +28,62 @@ type ScalarNonModel {
     requiredAwsIpAddress: AWSIPAddress!
 }
 
+type ScalarListNonModel @model {
+    id: ID!
+    listOfString: [String]
+    listOfRequiredString: [String!]
+    requiredListOfString: [String]!
+    requiredListOfRequiredString: [String!]!
+    listOfInteger: [Int]
+    listOfRequiredInteger: [Int!]
+    requiredListOfInteger: [Int]!
+    requiredListOfRequiredInteger: [Int!]!
+    listOfFloat: [Float]
+    listOfRequiredFloat: [Float!]
+    requiredListOfFloat: [Float]!
+    requiredListOfRequiredFloat: [Float!]!
+    listOfBoolean: [Boolean]
+    listOfRequiredBoolean: [Boolean!]
+    requiredListOfBoolean: [Boolean]!
+    requiredListOfRequiredBoolean: [Boolean!]!
+    listOfAWSDate: [AWSDate]
+    listOfRequiredAWSDate: [AWSDate!]
+    requiredListOfAWSDate: [AWSDate]!
+    requiredListOfRequiredAWSDate: [AWSDate!]!
+    listOfAWSDateTime: [AWSDateTime]
+    listOfRequiredAWSDateTime: [AWSDateTime!]
+    requiredListOfAWSDateTime: [AWSDateTime]!
+    requiredListOfRequiredAWSDateTime: [AWSDateTime!]!
+    listOfAWSTime: [AWSTime]
+    listOfRequiredAWSTime: [AWSTime!]
+    requiredListOfAWSTime: [AWSTime]!
+    requiredListOfRequiredAWSTime: [AWSTime!]!
+    listOfAWSTimestamp: [AWSTimestamp]
+    listOfRequiredAWSTimestamp: [AWSTimestamp!]
+    requiredListOfAWSTimestamp: [AWSTimestamp]!
+    requiredListOfRequiredAWSTimestamp: [AWSTimestamp!]!
+    listOfAWSEmail: [AWSEmail]
+    listOfRequiredAWSEmail: [AWSEmail!]
+    requiredListOfAWSEmail: [AWSEmail]!
+    requiredListOfRequiredAWSEmail: [AWSEmail!]!
+    listOfAWSJSON: [AWSJSON]
+    listOfRequiredAWSJSON: [AWSJSON!]
+    requiredListOfAWSJSON: [AWSJSON]!
+    requiredListOfRequiredAWSJSON: [AWSJSON!]!
+    listOfAWSPhone: [AWSPhone]
+    listOfRequiredAWSPhone: [AWSPhone!]
+    requiredListOfAWSPhone: [AWSPhone]!
+    requiredListOfRequiredAWSPhone: [AWSPhone!]!
+    listOfAWSUrl: [AWSURL]
+    listOfRequiredAWSUrl: [AWSURL!]
+    requiredListOfAWSUrl: [AWSURL]!
+    requiredListOfRequiredAWSUrl: [AWSURL!]!
+    listOfAWSIpAddress: [AWSIPAddress]
+    listOfRequiredAWSIpAddress: [AWSIPAddress!]
+    requiredListOfAWSIpAddress: [AWSIPAddress]!
+    requiredListOfRequiredAWSIpAddress: [AWSIPAddress!]!
+}
+
 type MyModel @model {
     embeddedNonModel: ScalarNonModel
     requiredEmbeddedNonModel: ScalarNonModel!

--- a/packages/datastore/amplify_codegen/test/schemas/simple_models.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/simple_models.graphql
@@ -28,6 +28,62 @@ type ScalarModel @model {
     requiredAwsIpAddress: AWSIPAddress!
 }
 
+type ScalarListModel @model {
+    id: ID!
+    listOfString: [String]
+    listOfRequiredString: [String!]
+    requiredListOfString: [String]!
+    requiredListOfRequiredString: [String!]!
+    listOfInteger: [Int]
+    listOfRequiredInteger: [Int!]
+    requiredListOfInteger: [Int]!
+    requiredListOfRequiredInteger: [Int!]!
+    listOfFloat: [Float]
+    listOfRequiredFloat: [Float!]
+    requiredListOfFloat: [Float]!
+    requiredListOfRequiredFloat: [Float!]!
+    listOfBoolean: [Boolean]
+    listOfRequiredBoolean: [Boolean!]
+    requiredListOfBoolean: [Boolean]!
+    requiredListOfRequiredBoolean: [Boolean!]!
+    listOfAWSDate: [AWSDate]
+    listOfRequiredAWSDate: [AWSDate!]
+    requiredListOfAWSDate: [AWSDate]!
+    requiredListOfRequiredAWSDate: [AWSDate!]!
+    listOfAWSDateTime: [AWSDateTime]
+    listOfRequiredAWSDateTime: [AWSDateTime!]
+    requiredListOfAWSDateTime: [AWSDateTime]!
+    requiredListOfRequiredAWSDateTime: [AWSDateTime!]!
+    listOfAWSTime: [AWSTime]
+    listOfRequiredAWSTime: [AWSTime!]
+    requiredListOfAWSTime: [AWSTime]!
+    requiredListOfRequiredAWSTime: [AWSTime!]!
+    listOfAWSTimestamp: [AWSTimestamp]
+    listOfRequiredAWSTimestamp: [AWSTimestamp!]
+    requiredListOfAWSTimestamp: [AWSTimestamp]!
+    requiredListOfRequiredAWSTimestamp: [AWSTimestamp!]!
+    listOfAWSEmail: [AWSEmail]
+    listOfRequiredAWSEmail: [AWSEmail!]
+    requiredListOfAWSEmail: [AWSEmail]!
+    requiredListOfRequiredAWSEmail: [AWSEmail!]!
+    listOfAWSJSON: [AWSJSON]
+    listOfRequiredAWSJSON: [AWSJSON!]
+    requiredListOfAWSJSON: [AWSJSON]!
+    requiredListOfRequiredAWSJSON: [AWSJSON!]!
+    listOfAWSPhone: [AWSPhone]
+    listOfRequiredAWSPhone: [AWSPhone!]
+    requiredListOfAWSPhone: [AWSPhone]!
+    requiredListOfRequiredAWSPhone: [AWSPhone!]!
+    listOfAWSUrl: [AWSURL]
+    listOfRequiredAWSUrl: [AWSURL!]
+    requiredListOfAWSUrl: [AWSURL]!
+    requiredListOfRequiredAWSUrl: [AWSURL!]!
+    listOfAWSIpAddress: [AWSIPAddress]
+    listOfRequiredAWSIpAddress: [AWSIPAddress!]
+    requiredListOfAWSIpAddress: [AWSIPAddress]!
+    requiredListOfRequiredAWSIpAddress: [AWSIPAddress!]!
+}
+
 type CPKModel @model {
     firstName: String! @primaryKey(sortKeyFields: ["lastName"])
     lastName: String!


### PR DESCRIPTION
Adds support for List types and QueryFields in simple models (no nested models yet). Fixes some parsing/codegen logic, refactors bits, and adds more tests.