### PR TITLE
chore(analytics): integ tests in CI

### DIFF
--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         scope:
+          - "amplify_analytics_pinpoint_example"
           - "amplify_api_example"
           - "amplify_auth_cognito_example"
           - "amplify_datastore_example"
@@ -65,6 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         scope:
+          - "amplify_analytics_pinpoint_example"
           - "amplify_api_example"
           - "amplify_auth_cognito_example"
           - "amplify_datastore_example"

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -105,6 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         scope:
+          - "amplify_analytics_pinpoint_example"
           - "amplify_api_example"
           - "amplify_auth_cognito_example"
           - "amplify_storage_s3_example"
@@ -141,6 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         scope: 
+          - "amplify_analytics_pinpoint_example"
           - "amplify_api_example"
           - "amplify_auth_cognito_example"
           - "amplify_storage_s3_example"
@@ -174,7 +176,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scope: 
+        scope:
+          - "amplify_analytics_pinpoint_example"
           - "amplify_api_example"
           - "amplify_auth_cognito_example"
           - "amplify_storage_s3_example"

--- a/packages/analytics/amplify_analytics_pinpoint/example/integration_test/events_test.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/example/integration_test/events_test.dart
@@ -42,8 +42,22 @@ void main() {
 
     setUpAll(() async {
       await Amplify.addPlugins([
-        AmplifyAuthCognito(),
-        AmplifyAnalyticsPinpoint(),
+        AmplifyAuthCognito(
+          credentialStorage: AmplifySecureStorage(
+            config: AmplifySecureStorageConfig(
+              scope: 'analyticsAuth',
+              macOSOptions: MacOSSecureStorageOptions(useDataProtection: false),
+            ),
+          ),
+        ),
+        AmplifyAnalyticsPinpoint(
+          keyValueStore: AmplifySecureStorage(
+            config: AmplifySecureStorageConfig(
+              scope: 'analytics',
+              macOSOptions: MacOSSecureStorageOptions(useDataProtection: false),
+            ),
+          ),
+        ),
         AmplifyAPI(),
       ]);
       await Amplify.configure(amplifyconfig);

--- a/packages/analytics/amplify_analytics_pinpoint/example/test_driver/integration_test.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/example/test_driver/integration_test.dart
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:integration_test/integration_test_driver.dart';
+
+// Required for running integration tests in the browser
+// https://docs.flutter.dev/cookbook/testing/integration/introduction#5b-web
+Future<void> main() => integrationDriver();

--- a/packages/analytics/amplify_analytics_pinpoint/example/tool/pull_test_backend.sh
+++ b/packages/analytics/amplify_analytics_pinpoint/example/tool/pull_test_backend.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+aws s3 cp s3://$AFS_ANALYTICS_BUCKET_NAME/amplifyconfiguration.dart lib/amplifyconfiguration.dart

--- a/packages/analytics/amplify_analytics_pinpoint/lib/src/analytics_plugin_impl.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/src/analytics_plugin_impl.dart
@@ -18,19 +18,23 @@ import 'package:amplify_analytics_pinpoint/src/flutter_path_provider/flutter_pat
 import 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.dart';
 import 'package:amplify_db_common/amplify_db_common.dart' as db_common;
 import 'package:amplify_secure_storage/amplify_secure_storage.dart';
+import 'package:meta/meta.dart';
 
 /// {@template amplify_analytics_pinpoint.analytics_plugin_impl}
 /// The AWS Pinpoint implementation of the Amplify Analytics category.
 /// {@endtemplate}
 class AmplifyAnalyticsPinpoint extends AmplifyAnalyticsPinpointDart {
   /// {@macro amplify_analytics_pinpoint.analytics_plugin_impl}
-  AmplifyAnalyticsPinpoint()
-      : super(
-          keyValueStore: AmplifySecureStorage(
-            config: AmplifySecureStorageConfig(
-              scope: 'analyticsPinpoint',
-            ),
-          ),
+  AmplifyAnalyticsPinpoint({
+    // TODO(fjnoyp): Rename to reflect the data that is stored.
+    @visibleForTesting SecureStorageInterface? keyValueStore,
+  }) : super(
+          keyValueStore: keyValueStore ??
+              AmplifySecureStorage(
+                config: AmplifySecureStorageConfig(
+                  scope: 'analyticsPinpoint',
+                ),
+              ),
           pathProvider: FlutterPathProvider(),
           appLifecycleProvider: FlutterAppLifecycleProvider(),
           deviceContextInfoProvider: const FlutterDeviceContextInfoProvider(),


### PR DESCRIPTION
Cherry picks 026cc9daa4582a4ecc9fc1d0117e9beddde83a07 from main to enable analytics tests in CI for Android/iOS and then adds another commit to enable in mac/web/linux.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
