### PR TITLE
chore(repo): Align example app secure storage settings

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint/example/lib/main.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/example/lib/main.dart
@@ -51,7 +51,17 @@ class _MyAppState extends State<MyApp> {
     if (!mounted) return;
 
     // Configure analytics plugin
-    final authPlugin = AmplifyAuthCognito();
+    final secureStorage = AmplifySecureStorage(
+      config: AmplifySecureStorageConfig(
+        scope: 'analytics',
+        // FIXME: In your app, make sure to remove this line and set up
+        /// Keychain Sharing in Xcode as described in the docs:
+        /// https://docs.amplify.aws/lib/project-setup/platform-setup/q/platform/flutter/#enable-keychain
+        // ignore: invalid_use_of_visible_for_testing_member
+        macOSOptions: MacOSSecureStorageOptions(useDataProtection: false),
+      ),
+    );
+    final authPlugin = AmplifyAuthCognito(credentialStorage: secureStorage);
     final analyticsPlugin = AmplifyAnalyticsPinpoint();
 
     await Amplify.addPlugins([authPlugin, analyticsPlugin]);

--- a/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner.xcodeproj/project.pbxproj
@@ -403,7 +403,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -417,12 +417,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;				
+				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.amazonaws.amplify.amplify-analytics-pinpoint-example";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -481,7 +482,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -528,7 +529,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -548,6 +549,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.amazonaws.amplify.amplify-analytics-pinpoint-example";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -567,6 +569,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.amazonaws.amplify.amplify-analytics-pinpoint-example";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/DebugProfile.entitlements
@@ -10,9 +10,5 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)com.amazonaws.amplify.amplify-analytics-pinpoint-example</string>
-	</array>
 </dict>
 </plist>

--- a/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/Release.entitlements
+++ b/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/Release.entitlements
@@ -4,9 +4,9 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)com.amazonaws.amplify.amplify-analytics-pinpoint-example</string>
-	</array>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/api/amplify_api/example/lib/main.dart
+++ b/packages/api/amplify_api/example/lib/main.dart
@@ -45,8 +45,19 @@ class _MyAppState extends State<MyApp> {
   }
 
   void _configureAmplify() async {
+    final secureStorage = AmplifySecureStorage(
+      config: AmplifySecureStorageConfig(
+        scope: 'api',
+        // FIXME: In your app, make sure to remove this line and set up
+        /// Keychain Sharing in Xcode as described in the docs:
+        /// https://docs.amplify.aws/lib/project-setup/platform-setup/q/platform/flutter/#enable-keychain
+        // ignore: invalid_use_of_visible_for_testing_member
+        macOSOptions: MacOSSecureStorageOptions(useDataProtection: false),
+      ),
+    );
+    final authPlugin = AmplifyAuthCognito(credentialStorage: secureStorage);
     await Amplify.addPlugins([
-      AmplifyAuthCognito(),
+      authPlugin,
       AmplifyAPI(),
     ]);
 

--- a/packages/api/amplify_api/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/api/amplify_api/example/macos/Runner.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 /* Begin PBXFileReference section */
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -344,7 +344,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -366,6 +366,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -423,7 +424,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -470,7 +471,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -492,6 +493,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -512,6 +514,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};

--- a/packages/api/amplify_api/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/api/amplify_api/example/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>

--- a/packages/api/amplify_api/example/macos/Runner/Release.entitlements
+++ b/packages/api/amplify_api/example/macos/Runner/Release.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/auth/amplify_auth_cognito/example/lib/main.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/main.dart
@@ -93,7 +93,19 @@ class _MyAppState extends State<MyApp> {
       if (!zIsWeb && (Platform.isAndroid || Platform.isIOS)) {
         await Amplify.addPlugin(AmplifyAPI());
       }
-      await Amplify.addPlugin(AmplifyAuthCognito());
+      final secureStorage = AmplifySecureStorage(
+        config: AmplifySecureStorageConfig(
+          scope: 'auth',
+          // FIXME: In your app, make sure to remove this line and set up
+          /// Keychain Sharing in Xcode as described in the docs:
+          /// https://docs.amplify.aws/lib/project-setup/platform-setup/q/platform/flutter/#enable-keychain
+          // ignore: invalid_use_of_visible_for_testing_member
+          macOSOptions: MacOSSecureStorageOptions(useDataProtection: false),
+        ),
+      );
+      await Amplify.addPlugin(
+        AmplifyAuthCognito(credentialStorage: secureStorage),
+      );
       // Uncomment this block, and comment out the one above to change how
       // credentials are persisted.
       // await Amplify.addPlugin(

--- a/packages/aws_common/lib/src/io/aws_file.dart
+++ b/packages/aws_common/lib/src/io/aws_file.dart
@@ -41,10 +41,10 @@ import 'package:meta/meta.dart';
 /// final awsFile = AWSFile.fromStream(pickedFile.readStream);
 /// ```
 /// ----
-/// 
+///
 /// You can also create an [AWSFile] by providing a file path or file bytes
 /// to [AWSFile.fromPath] or [AWSFile.fromData], respectively.
-/// 
+///
 /// ----
 /// If you are developing a _**Web only**_ App, and want to use the `dart:html`
 /// `File` or `Blob` types, you can import [AWSFilePlatform] directly which provides

--- a/packages/storage/amplify_storage_s3/example/lib/main.dart
+++ b/packages/storage/amplify_storage_s3/example/lib/main.dart
@@ -15,6 +15,7 @@
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_secure_storage/amplify_secure_storage.dart';
 import 'package:amplify_storage_s3/amplify_storage_s3.dart';
 import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
 import 'package:flutter/material.dart';
@@ -69,7 +70,17 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> configureAmplify() async {
-    final auth = AmplifyAuthCognito();
+    final secureStorage = AmplifySecureStorage(
+      config: AmplifySecureStorageConfig(
+        scope: 'storage',
+        // FIXME: In your app, make sure to remove this line and set up
+        /// Keychain Sharing in Xcode as described in the docs:
+        /// https://docs.amplify.aws/lib/project-setup/platform-setup/q/platform/flutter/#enable-keychain
+        // ignore: invalid_use_of_visible_for_testing_member
+        macOSOptions: MacOSSecureStorageOptions(useDataProtection: false),
+      ),
+    );
+    final auth = AmplifyAuthCognito(credentialStorage: secureStorage);
     final storage = AmplifyStorageS3();
 
     try {

--- a/packages/storage/amplify_storage_s3/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/storage/amplify_storage_s3/example/macos/Runner/DebugProfile.entitlements
@@ -12,7 +12,5 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array/>
 </dict>
 </plist>

--- a/packages/storage/amplify_storage_s3/example/macos/Runner/Release.entitlements
+++ b/packages/storage/amplify_storage_s3/example/macos/Runner/Release.entitlements
@@ -10,7 +10,5 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
- Aligns all example apps to share the same secure storage settings and warnings suggesting alternate usage in production cases.
- Aligns macOS Xcode settings to have Keychain Sharing disabled, Network permissions enabled, and deployment target set to 10.15.