### PR TITLE
chore(api): integ tests in CI for mac/linux

### DIFF
--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -139,6 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         scope: 
+          - "amplify_api_example"
           - "amplify_auth_cognito_example"
           - "amplify_storage_s3_example"
     steps:
@@ -172,6 +173,7 @@ jobs:
       fail-fast: false
       matrix:
         scope: 
+          - "amplify_api_example"
           - "amplify_auth_cognito_example"
           - "amplify_storage_s3_example"
     steps:

--- a/build-support/integ_test.sh
+++ b/build-support/integ_test.sh
@@ -38,13 +38,15 @@ small=${small:-$DEFAULT_SMALL}
 
 if [[ "$OSTYPE" == "linux-gnu"* && $deviceId == "linux"* ]]; then
     sudo apt-get update -y
-    sudo apt-get install -y ninja-build libgtk-3-dev libsecret-1-dev libglib2.0-dev gnome-keyring
+    sudo apt-get install -y ninja-build libgtk-3-dev libsecret-1-dev libglib2.0-dev gnome-keyring network-manager
 
     if [ -n $CI ]; then
         # Headless tests require virtual display for the linux tests to run.
         # from https://github.com/fluttercommunity/plus_plugins/blob/main/.github/workflows/scripts/integration-test.sh
         export DISPLAY=:99
         sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+        # Needed for WebSocket connections in API GraphQL subscriptions.
+        sudo systemctl start NetworkManager.service
 
         # Set up keyring.
         echo 'password' | gnome-keyring-daemon --start --replace --daemonize --unlock

--- a/packages/api/amplify_api/example/integration_test/util.dart
+++ b/packages/api/amplify_api/example/integration_test/util.dart
@@ -85,7 +85,14 @@ class TestUser {
 Future<void> configureAmplify() async {
   if (!Amplify.isConfigured) {
     await Amplify.addPlugins([
-      AmplifyAuthCognito(),
+      AmplifyAuthCognito(
+        credentialStorage: AmplifySecureStorage(
+          config: AmplifySecureStorageConfig(
+            scope: 'api',
+            macOSOptions: MacOSSecureStorageOptions(useDataProtection: false),
+          ),
+        ),
+      ),
       AmplifyAPI(modelProvider: ModelProvider.instance)
     ]);
     await Amplify.configure(amplifyconfig);

--- a/packages/api/amplify_api/example/macos/Podfile
+++ b/packages/api/amplify_api/example/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.11'
+platform :osx, '10.15'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'


### PR DESCRIPTION
Enables integ tests in CI for API category on MacOS and linux. There are some config changes to make that work in the API example app as well as a change to a test script from https://github.com/aws-amplify/amplify-flutter/pull/2388.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
