### PR TITLE
fix(auth): Refresh tokens when either access or ID token expires

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_user_pool_tokens.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_user_pool_tokens.dart
@@ -79,12 +79,6 @@ abstract class CognitoUserPoolTokens
   /// The Cognito ID token.
   JsonWebToken get idToken;
 
-  /// The expiration of time of [accessToken].
-  DateTime? get expirationTime => accessToken.claims.expiration;
-
-  /// The issued at time of [accessToken].
-  DateTime? get issuedTime => accessToken.claims.issuedAt;
-
   /// The Cognito user's ID.
   String get userId => idToken.userId;
 


### PR DESCRIPTION
Since access and ID tokens can have different expiration times, refresh all tokens when either token expires.
