### PR TITLE
fix(authenticator)!: use `isSignedIn` to determine auth state on launch

### DIFF
--- a/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -175,10 +175,8 @@ class AmplifyAuthService implements AuthService {
   @override
   Future<bool> isValidSession() async {
     try {
-      var res = await Amplify.Auth.fetchAuthSession(
-              options: CognitoSessionOptions(getAWSCredentials: true))
-          as CognitoAuthSession;
-      return res.userPoolTokens != null;
+      final res = await Amplify.Auth.fetchAuthSession();
+      return res.isSignedIn;
     } on SignedOutException {
       return false;
     } on Exception {


### PR DESCRIPTION
DO NOT MERGE. SEE BELOW FOR DETAILS.

*Issue #, if available:* #2398

*Description of changes:*
Use is `isSignedIn` to determine auth state on launch, rather than the presence of Cognito User Pool Tokens.

This is a breaking change since it changes the behavior on app launch for an end user that had authenticated and then went into an offline state for a period longer than the token expiration.

Do not merge until the change is behavior is confirmed to be desired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
