### PR TITLE
fix(api): fix subscription race condition from previous connection close

### DIFF
--- a/packages/api/amplify_api/lib/src/graphql/ws/web_socket_connection.dart
+++ b/packages/api/amplify_api/lib/src/graphql/ws/web_socket_connection.dart
@@ -445,7 +445,6 @@ class WebSocketConnection implements Closeable {
   Future<void> _sendSubscriptionRegistrationMessage<T>(
     GraphQLRequest<T> request,
   ) async {
-    await init(); // no-op if already connected
     final subscriptionRegistrationMessage =
         await generateSubscriptionRegistrationMessage(
       _config,
@@ -453,6 +452,12 @@ class WebSocketConnection implements Closeable {
       authRepo: _authProviderRepo,
       request: request,
     );
+
+    // No-op if already connected.
+    // Run after generating the connection message to account for connection
+    // closed while generating message.
+    await init();
+
     send(subscriptionRegistrationMessage);
     _subscriptionRequests.add(request);
   }

--- a/packages/api/amplify_api/lib/src/graphql/ws/web_socket_connection.dart
+++ b/packages/api/amplify_api/lib/src/graphql/ws/web_socket_connection.dart
@@ -457,6 +457,9 @@ class WebSocketConnection implements Closeable {
     // Run after generating the connection message to account for connection
     // closed while generating message.
     await init();
+    if (_channel == null) {
+      return _sendSubscriptionRegistrationMessage(request);
+    }
 
     send(subscriptionRegistrationMessage);
     _subscriptionRequests.add(request);


### PR DESCRIPTION
This PR fixes a race condition in API GraphQL subscriptions that is causing auth integ tests to fail. The issue arises when establishing a subscription on a connection that is in the process of being closed, causing an error from trying to send over a closed socket. This PR fixes it by moving some async logic so that the check of connection open/closed while establishing a subscription happens later and will open a new connection.

This fix is a little hacky and would usually have some more unit tests. I didn't do that here because 1) all this will be replaced by subscription state machine 2) the auth integ tests are already serving a sort of check here.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
