### PR TITLE
feat(datastore): Temporary codegen (part 6)

### DIFF
--- a/packages/amplify_core/lib/src/types/models/model.dart
+++ b/packages/amplify_core/lib/src/types/models/model.dart
@@ -127,6 +127,19 @@ abstract class Model<ModelIdentifier extends Object,
   T valueFor<T extends Object?>(QueryField<ModelIdentifier, M, T> field);
 }
 
+mixin LegacyModelFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> on Model<ModelIdentifier, M> {
+  @Deprecated('Use modelType instead')
+  ModelType<ModelIdentifier, M, PartialModel<ModelIdentifier, M>>
+      getInstanceType() => modelType;
+
+  @Deprecated('Use modelIdentifier instead')
+  String getId();
+
+  @Deprecated('Use == instead')
+  bool equals(Object other) => this == other;
+}
+
 /// {@template amplify_core.models.remote_model}
 /// An extension to [Model] which adds [RemoteModelMetadata].
 ///

--- a/packages/amplify_core/lib/src/types/models/model.dart
+++ b/packages/amplify_core/lib/src/types/models/model.dart
@@ -108,9 +108,6 @@ abstract class PartialModel<ModelIdentifier extends Object,
 
   /// The model's type, typically used for deserialization.
   ModelType<ModelIdentifier, M, PartialModel<ModelIdentifier, M>> get modelType;
-
-  /// Returns the value of [field].
-  T valueFor<T extends Object?>(QueryField<ModelIdentifier, M, T> field);
 }
 
 /// {@template amplify_core.models.model}
@@ -125,6 +122,9 @@ abstract class Model<ModelIdentifier extends Object,
     extends PartialModel<ModelIdentifier, M> {
   /// {@macro amplify_core.models.model}
   const Model();
+
+  /// Returns the value of [field].
+  T valueFor<T extends Object?>(QueryField<ModelIdentifier, M, T> field);
 }
 
 /// {@template amplify_core.models.remote_model}

--- a/packages/amplify_core/lib/src/types/models/model_provider.dart
+++ b/packages/amplify_core/lib/src/types/models/model_provider.dart
@@ -26,4 +26,10 @@ abstract class ModelProviderInterface {
       ModelIdentifier extends Object,
       M extends Model<ModelIdentifier, M>,
       P extends PartialModel<ModelIdentifier, M>>(String modelName);
+
+  @Deprecated('Use getModelType instead')
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName);
 }

--- a/packages/datastore/amplify_codegen/lib/src/generate.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generate.dart
@@ -14,9 +14,9 @@
 
 import 'package:amplify_codegen/src/generator/context.dart';
 import 'package:amplify_codegen/src/generator/generated_library.dart';
+import 'package:amplify_codegen/src/generator/model_provider.dart';
 import 'package:amplify_codegen/src/generator/visitors.dart';
 import 'package:amplify_codegen/src/parser/parser.dart';
-import 'package:code_builder/code_builder.dart';
 import 'package:gql/language.dart';
 
 /// Generates a Dart file for each model type and enum in [schema].
@@ -30,19 +30,18 @@ Map<String, GeneratedLibrary> generateForSchema(String schema) {
   // Generate libraries for model types and enums
   final libraries = runWithContext(
     context,
-    () => parseString(schema)
-        .definitions
-        .map((definition) {
-          return definition.accept(LibraryVisitor(schemaDefinition));
-        })
-        .whereType<Library>()
-        .toList(),
+    () => <GeneratedLibrary>[
+      ...parseString(schema).definitions.map((definition) {
+        return definition.accept(LibraryVisitor(schemaDefinition));
+      }).whereType(),
+      ModelProviderGenerator(schemaDefinition).generate(),
+    ],
   );
 
   // Emit Dart code and format
   return Map.fromEntries(
     libraries.map((library) {
-      return MapEntry(library.name!, GeneratedLibrary(library));
+      return MapEntry(library.filename, library);
     }),
   );
 }

--- a/packages/datastore/amplify_codegen/lib/src/generator/allocator.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/allocator.dart
@@ -20,8 +20,7 @@ import 'package:code_builder/code_builder.dart';
 /// {@endtemplate}
 class AmplifyAllocator implements Allocator {
   /// {@macro amplify_codegen.amplify_allocator}
-  AmplifyAllocator(String libraryName)
-      : _thisFile = '${libraryName.split('.')[1]}.dart';
+  AmplifyAllocator(String filename) : _thisFile = filename;
 
   final String _thisFile;
 

--- a/packages/datastore/amplify_codegen/lib/src/generator/allocator.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/allocator.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:amplify_codegen/src/generator/types.dart';
 import 'package:code_builder/code_builder.dart';
 
 /// {@template amplify_codegen.amplify_allocator}
@@ -29,6 +30,9 @@ class AmplifyAllocator implements Allocator {
   static const _doNotImport = [
     'dart:core',
   ];
+  static const _prefixes = {
+    Mipr.url: 'mipr',
+  };
 
   @override
   String allocate(Reference reference) {
@@ -38,9 +42,16 @@ class AmplifyAllocator implements Allocator {
         !_doNotImport.contains(url)) {
       _imports.add(url);
     }
-    return reference.symbol!;
+    final symbol = reference.symbol!;
+    final prefix = _prefixes[url];
+    if (prefix != null) {
+      return '$prefix.$symbol';
+    }
+    return symbol;
   }
 
   @override
-  Iterable<Directive> get imports => _imports.map(Directive.import);
+  Iterable<Directive> get imports => _imports.map(
+        (import) => Directive.import(import, as: _prefixes[import]),
+      );
 }

--- a/packages/datastore/amplify_codegen/lib/src/generator/enum.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/enum.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:amplify_codegen/src/generator/generated_library.dart';
 import 'package:amplify_codegen/src/generator/generator.dart';
 import 'package:amplify_codegen/src/generator/types.dart';
 import 'package:amplify_codegen/src/helpers/enum.dart';
@@ -34,7 +35,7 @@ class EnumGenerator
   String get enumName => schemaName.pascalCase;
 
   @override
-  Library generate() {
+  GeneratedLibrary generate() {
     builder.body.add(
       Enum((e) {
         e.mixins.add(
@@ -129,6 +130,6 @@ class EnumGenerator
         ]);
       }),
     );
-    return builder.build();
+    return GeneratedLibrary(builder.build(), definition);
   }
 }

--- a/packages/datastore/amplify_codegen/lib/src/generator/generated_library.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/generated_library.dart
@@ -20,6 +20,10 @@ import 'package:dart_style/dart_style.dart';
 const ignores = [
   // TODO(dnys1): Remove when deprecated fields are removed.
   'non_constant_identifier_names',
+
+  // TODO(dnys1): Add recursive visitor with types or serialize schema
+  // differently
+  'inference_failure_on_collection_literal',
 ];
 
 /// Header for generated output.

--- a/packages/datastore/amplify_codegen/lib/src/generator/generated_library.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/generated_library.dart
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import 'package:amplify_codegen/src/generator/allocator.dart';
+import 'package:amplify_codegen/src/helpers/types.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 
@@ -55,7 +57,10 @@ final header = '''
 /// {@endtemplate}
 class GeneratedLibrary {
   /// {@macro amplify_codegen.generated_library}
-  const GeneratedLibrary(this.library);
+  GeneratedLibrary(
+    this.library, [
+    this.definition,
+  ]) : filename = definition?.filename ?? '${library.name!.split('.')[1]}.dart';
 
   /// The [DartFormatter] instance used to format Amplify codegen output.
   static final formatter = DartFormatter(fixes: StyleFix.all);
@@ -63,13 +68,19 @@ class GeneratedLibrary {
   /// Constructs a single-use [DartEmitter] using [AmplifyAllocator] for
   /// reference allocation.
   DartEmitter buildEmitter() => DartEmitter(
-        allocator: AmplifyAllocator(library.name!),
+        allocator: AmplifyAllocator(filename),
         orderDirectives: true,
         useNullSafetySyntax: true,
       );
 
+  /// The source definition.
+  final SchemaTypeDefinition? definition;
+
   /// The generated `code_builder` [Library].
   final Library library;
+
+  /// The file name of the generated output.
+  final String filename;
 
   /// Emits [library] as Dart source.
   String emit() {

--- a/packages/datastore/amplify_codegen/lib/src/generator/generator.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/generator.dart
@@ -26,7 +26,7 @@ abstract class LibraryGenerator<Node extends TypeDefinitionNode,
   LibraryGenerator({
     required this.node,
     required this.definition,
-  }) : builder = LibraryBuilder()..name = 'models.${node.libraryName}';
+  }) : builder = LibraryBuilder()..name = 'models.${definition.libraryName}';
 
   /// The pre-configured builder for [generate]'s output.
   final LibraryBuilder builder;

--- a/packages/datastore/amplify_codegen/lib/src/generator/generator.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/generator.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:amplify_codegen/src/generator/generated_library.dart';
 import 'package:amplify_codegen/src/helpers/types.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:code_builder/code_builder.dart';
@@ -41,5 +42,5 @@ abstract class LibraryGenerator<Node extends TypeDefinitionNode,
   String get schemaName => node.name.value;
 
   /// Generates a [Library] for [node] and [definition].
-  Library generate();
+  GeneratedLibrary generate();
 }

--- a/packages/datastore/amplify_codegen/lib/src/generator/model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/model.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:amplify_codegen/src/generator/context.dart';
+import 'package:amplify_codegen/src/generator/generated_library.dart';
 import 'package:amplify_codegen/src/generator/structure.dart';
 import 'package:amplify_codegen/src/generator/types.dart';
 import 'package:amplify_codegen/src/helpers/field.dart';
@@ -20,7 +21,6 @@ import 'package:amplify_codegen/src/helpers/model.dart';
 import 'package:amplify_codegen/src/helpers/types.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
-import 'package:built_value/serializer.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
 import 'package:smithy_codegen/src/util/symbol_ext.dart';
@@ -131,7 +131,7 @@ class ModelGenerator extends StructureGenerator<ModelTypeDefinition> {
   }();
 
   @override
-  Library generate() {
+  GeneratedLibrary generate() {
     builder.body.addAll([
       if (modelIdentifierType != null) modelIdentifierType!,
       modelTypeImpl,
@@ -140,8 +140,7 @@ class ModelGenerator extends StructureGenerator<ModelTypeDefinition> {
       ...modelImpl,
       ...remoteModelImpl,
     ]);
-
-    return builder.build();
+    return GeneratedLibrary(builder.build(), definition);
   }
 
   /// The implementation of the model's `ModelType`.

--- a/packages/datastore/amplify_codegen/lib/src/generator/model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/model.dart
@@ -20,6 +20,7 @@ import 'package:amplify_codegen/src/helpers/model.dart';
 import 'package:amplify_codegen/src/helpers/types.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+import 'package:built_value/serializer.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
 import 'package:smithy_codegen/src/util/symbol_ext.dart';
@@ -698,6 +699,31 @@ return value as T;
                   .toList(),
               hierarchyType: ModelHierarchyType.model,
             ),
+        ),
+      );
+
+      // The static `schema` getter
+      c.fields.add(
+        Field(
+          (f) => f
+            ..modifier = FieldModifier.final$
+            ..static = true
+            ..type = DartTypes.amplifyCore.mipr.modelTypeDefinition
+            ..name = 'schema'
+            ..assignment = DartTypes.amplifyCore.mipr.serializers
+                .property('deserializeWith')
+                .call([
+                  DartTypes.amplifyCore.mipr.modelTypeDefinition
+                      .property('serializer'),
+                  literalConstMap(
+                    mipr.serializers.serializeWith(
+                      mipr.ModelTypeDefinition.serializer,
+                      definition,
+                    ) as Map,
+                  ),
+                ])
+                .nullChecked
+                .code,
         ),
       );
     });

--- a/packages/datastore/amplify_codegen/lib/src/generator/model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/model.dart
@@ -339,66 +339,6 @@ return ${allocate(_references.partialModelImpl)}.fromJson(json) as T;
             ..body = literalString(_names.model).code,
         ),
       );
-
-      // `valueFor` to satisfy `PartialModel`
-      c.methods.add(
-        Method(
-          (m) => m
-            ..annotations.add(DartTypes.core.override)
-            ..returns = refer('T')
-            ..name = 'valueFor'
-            ..types.add(
-              TypeReference(
-                (t) => t
-                  ..symbol = 'T'
-                  ..bound = DartTypes.core.object.nullable,
-              ),
-            )
-            ..requiredParameters.add(
-              Parameter(
-                (p) => p
-                  ..type = DartTypes.amplifyCore.queryField(
-                    _references.modelIdentifier,
-                    _references.model,
-                    refer('T'),
-                  )
-                  ..name = 'field',
-              ),
-            )
-            ..body = Block((b) {
-              b.statements.add(
-                const Code(
-                  '''
-Object? value;
-switch (field.fieldName) {
-  ''',
-                ),
-              );
-              for (final field in definition.fields.values) {
-                b.statements.add(
-                  Code(
-                    '''
-  case r'${field.name}':
-    value = ${field.dartName};
-    break;''',
-                  ),
-                );
-              }
-              b.statements.add(
-                const Code(
-                  r'''
-}
-assert(
-  value is T,
-  'Invalid field ${field.fieldName}: $value (expected $T)',
-);
-return value as T;
-''',
-                ),
-              );
-            }),
-        ),
-      );
     });
 
     // Create the private implementation
@@ -617,6 +557,66 @@ return value as T;
           _references.modelIdentifier,
           _references.model,
           _references.modelIdentifier,
+        ),
+      );
+
+      // `valueFor` to satisfy `Model`
+      c.methods.add(
+        Method(
+          (m) => m
+            ..annotations.add(DartTypes.core.override)
+            ..returns = refer('T')
+            ..name = 'valueFor'
+            ..types.add(
+              TypeReference(
+                (t) => t
+                  ..symbol = 'T'
+                  ..bound = DartTypes.core.object.nullable,
+              ),
+            )
+            ..requiredParameters.add(
+              Parameter(
+                (p) => p
+                  ..type = DartTypes.amplifyCore.queryField(
+                    _references.modelIdentifier,
+                    _references.model,
+                    refer('T'),
+                  )
+                  ..name = 'field',
+              ),
+            )
+            ..body = Block((b) {
+              b.statements.add(
+                const Code(
+                  '''
+Object? value;
+switch (field.fieldName) {
+  ''',
+                ),
+              );
+              for (final field in definition.fields.values) {
+                b.statements.add(
+                  Code(
+                    '''
+  case r'${field.name}':
+    value = ${field.dartName};
+    break;''',
+                  ),
+                );
+              }
+              b.statements.add(
+                const Code(
+                  r'''
+}
+assert(
+  value is T,
+  'Invalid field ${field.fieldName}: $value (expected $T)',
+);
+return value as T;
+''',
+                ),
+              );
+            }),
         ),
       );
 

--- a/packages/datastore/amplify_codegen/lib/src/generator/model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/model.dart
@@ -95,7 +95,7 @@ class ModelGenerator extends StructureGenerator<ModelTypeDefinition> {
             ..returns = DartTypes.core.list(DartTypes.core.object.nullable)
             ..type = MethodType.getter
             ..name = 'props'
-            ..body = literalList(fields.map((f) => refer(f.name))).code,
+            ..body = literalList(fields.map((f) => refer(f.dartName))).code,
         ),
       );
 

--- a/packages/datastore/amplify_codegen/lib/src/generator/model_provider.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/model_provider.dart
@@ -1,0 +1,212 @@
+import 'package:amplify_codegen/src/generator/generated_library.dart';
+import 'package:amplify_codegen/src/generator/types.dart';
+import 'package:amplify_codegen/src/helpers/model.dart';
+import 'package:amplify_codegen/src/helpers/types.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+import 'package:code_builder/code_builder.dart';
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+
+/// {@template amplify_codegen.model_provider_generator}
+/// Generates libraries for model providers.
+/// {@endtemplate}
+class ModelProviderGenerator {
+  /// {@macro amplify_codegen.model_provider_generator}
+  ModelProviderGenerator(this._schema);
+
+  final mipr.SchemaDefinition _schema;
+
+  late final List<mipr.ModelTypeDefinition> _models = _schema
+      .typeDefinitions.values
+      .whereType<mipr.ModelTypeDefinition>()
+      .toList();
+  late final List<mipr.NonModelTypeDefinition> _nonModels = _schema
+      .typeDefinitions.values
+      .whereType<mipr.NonModelTypeDefinition>()
+      .toList();
+
+  /// Generates the library for the model provider.
+  GeneratedLibrary generate() {
+    final exportFilenames = [
+      for (final type in _schema.typeDefinitions.values) type.filename
+    ]..sort();
+    return GeneratedLibrary(
+      Library(
+        (l) => l
+          ..name = 'models.model_provider'
+          ..directives.addAll([
+            ...exportFilenames.map(Directive.export),
+          ])
+          ..body.add(_class),
+      ),
+    );
+  }
+
+  Class get _class {
+    return Class(
+      (c) => c
+        ..name = 'ModelProvider'
+        ..extend = DartTypes.amplifyCore.modelProviderInterface
+        ..constructors.add(
+          Constructor((c) => c..name = '_'),
+        )
+        ..fields.addAll(_fields)
+        ..methods.addAll(_methods),
+    );
+  }
+
+  Iterable<Field> get _fields sync* {
+    yield Field(
+      (f) => f
+        ..static = true
+        ..modifier = FieldModifier.final$
+        ..name = 'instance'
+        ..assignment = refer('ModelProvider').newInstanceNamed('_', []).code,
+    );
+  }
+
+  /// Generate a consistent hash for [_schema]. This will be consistent across
+  /// transformer version changes as well as semantic-only schema updates.
+  List<int> get _schemaHash {
+    return md5
+        .convert(
+          mipr.serializers
+              .toJson(mipr.SchemaDefinition.serializer, _schema)
+              .codeUnits,
+        )
+        .bytes;
+  }
+
+  Iterable<Method> get _methods sync* {
+    // version
+    final version = hex.encode(_schemaHash);
+    yield Method(
+      (m) => m
+        ..annotations.add(DartTypes.core.override)
+        ..name = 'version'
+        ..returns = DartTypes.core.string
+        ..type = MethodType.getter
+        ..lambda = true
+        ..body = literalString(version).code,
+    );
+
+    // modelSchemas
+    yield Method(
+      (m) => m
+        ..annotations.add(DartTypes.core.override)
+        ..name = 'modelSchemas'
+        ..returns = DartTypes.core.list(
+          DartTypes.amplifyCore.mipr.modelTypeDefinition,
+        )
+        ..type = MethodType.getter
+        ..lambda = true
+        ..body = literalList([
+          for (final model in _models)
+            ModelReferences(model).model.property('schema')
+        ]).code,
+    );
+
+    // customTypeSchemas
+    yield Method(
+      (m) => m
+        ..annotations.add(DartTypes.core.override)
+        ..name = 'customTypeSchemas'
+        ..returns = DartTypes.core.list(
+          DartTypes.amplifyCore.mipr.nonModelTypeDefinition,
+        )
+        ..type = MethodType.getter
+        ..lambda = true
+        ..body = literalList([
+          for (final nonModel in _nonModels)
+            NonModelReferences(nonModel).classType.property('schema'),
+        ]).code,
+    );
+
+    // getModelType
+    final returnType = DartTypes.amplifyCore.modelType(
+      refer('ModelIdentifier'),
+      refer('M'),
+      refer('P'),
+    );
+    final bounds = [
+      TypeReference(
+        (t) => t
+          ..symbol = 'ModelIdentifier'
+          ..bound = DartTypes.core.object,
+      ),
+      TypeReference(
+        (t) => t
+          ..symbol = 'M'
+          ..bound = DartTypes.amplifyCore.model(
+            refer('ModelIdentifier'),
+            refer('M'),
+          ),
+      ),
+      TypeReference(
+        (t) => t
+          ..symbol = 'P'
+          ..bound = DartTypes.amplifyCore.partialModel(
+            refer('ModelIdentifier'),
+            refer('M'),
+          ),
+      ),
+    ];
+    yield Method((m) {
+      m
+        ..annotations.add(refer('override'))
+        ..returns = returnType
+        ..name = 'getModelType'
+        ..requiredParameters.add(
+          Parameter(
+            (p) => p
+              ..type = DartTypes.core.string
+              ..name = 'modelName',
+          ),
+        )
+        ..types.addAll(bounds)
+        ..body = Block.of([
+          const Code('switch (modelName) {'),
+          for (final model in _models) ...[
+            Code("case '${model.name}':"),
+            if (model.name != ModelNames(model.name).className)
+              Code("case '${ModelNames(model.name).className}':"),
+            ModelReferences(model)
+                .model
+                .property('classType')
+                .asA(returnType)
+                .returned
+                .statement,
+          ],
+          const Code('default:'),
+          refer('ArgumentError')
+              .newInstance([
+                literalString(
+                  'Failed to find model in model provider for model name: '
+                  r'$modelName',
+                )
+              ])
+              .thrown
+              .statement,
+          const Code('}'),
+        ]);
+    });
+
+    // getModelTypeByModelName
+    yield Method((m) {
+      m
+        ..annotations.add(refer('override'))
+        ..returns = returnType
+        ..name = 'getModelTypeByModelName'
+        ..requiredParameters.add(
+          Parameter(
+            (p) => p
+              ..type = DartTypes.core.string
+              ..name = 'modelName',
+          ),
+        )
+        ..types.addAll(bounds)
+        ..lambda = true
+        ..body = refer('getModelType').call([refer('modelName')]).code;
+    });
+  }
+}

--- a/packages/datastore/amplify_codegen/lib/src/generator/non_model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/non_model.dart
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:amplify_codegen/src/generator/generated_library.dart';
 import 'package:amplify_codegen/src/generator/structure.dart';
 import 'package:amplify_codegen/src/generator/types.dart';
 import 'package:amplify_codegen/src/helpers/field.dart';
 import 'package:amplify_codegen/src/helpers/types.dart';
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:code_builder/code_builder.dart';
 
 /// {@template amplify_codegen.non_model_generator}
@@ -30,9 +32,9 @@ class NonModelGenerator extends StructureGenerator<NonModelTypeDefinition> {
   });
 
   @override
-  Library generate() {
+  GeneratedLibrary generate() {
     builder.body.add(nonModelImpl);
-    return builder.build();
+    return GeneratedLibrary(builder.build(), definition);
   }
 
   /// The implementation of the non-model type.
@@ -94,6 +96,31 @@ class NonModelGenerator extends StructureGenerator<NonModelTypeDefinition> {
               modelType: refer(className),
               fields: definition.fields.values.toList(),
             ),
+        ),
+      );
+
+      // The static `schema` getter
+      c.fields.add(
+        Field(
+          (f) => f
+            ..modifier = FieldModifier.final$
+            ..static = true
+            ..type = DartTypes.amplifyCore.mipr.nonModelTypeDefinition
+            ..name = 'schema'
+            ..assignment = DartTypes.amplifyCore.mipr.serializers
+                .property('deserializeWith')
+                .call([
+                  DartTypes.amplifyCore.mipr.nonModelTypeDefinition
+                      .property('serializer'),
+                  literalConstMap(
+                    mipr.serializers.serializeWith(
+                      mipr.NonModelTypeDefinition.serializer,
+                      definition,
+                    ) as Map,
+                  ),
+                ])
+                .nullChecked
+                .code,
         ),
       );
 

--- a/packages/datastore/amplify_codegen/lib/src/generator/types.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/types.dart
@@ -130,6 +130,10 @@ class _AmplifyCore {
   /// Creates an [amplify_core.ModelFieldError] reference.
   Reference get modelFieldError => const Reference('ModelFieldError', _url);
 
+  /// Creates an [amplify_core.ModelProviderInterface] reference.
+  Reference get modelProviderInterface =>
+      const Reference('ModelProviderInterface', _url);
+
   /// Creates an [amplify_core.ModelType] reference.
   TypeReference modelType(
     Reference modelIdentifierType,
@@ -224,6 +228,10 @@ class Mipr {
   /// Creates an [mipr.ModelTypeDefinition] reference.
   Reference get modelTypeDefinition =>
       const Reference('ModelTypeDefinition', url);
+
+  /// Creates an [mipr.NonModelTypeDefinition] reference.
+  Reference get nonModelTypeDefinition =>
+      const Reference('NonModelTypeDefinition', url);
 
   /// Creates an [mipr.serializers] reference.
   Reference get serializers => const Reference('serializers', url);

--- a/packages/datastore/amplify_codegen/lib/src/generator/types.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/types.dart
@@ -113,7 +113,7 @@ class _AmplifyCore {
           ]),
       );
 
-  _AmplifyCoreMipr get mipr => const _AmplifyCoreMipr();
+  Mipr get mipr => const Mipr._();
 
   /// Creates an [amplify_core.Model] reference.
   TypeReference model(
@@ -214,10 +214,19 @@ class _AmplifyCore {
   Reference get temporalDate => const Reference('TemporalDate', _url);
 }
 
-class _AmplifyCoreMipr {
-  const _AmplifyCoreMipr();
+/// Model Intermediate Platform Representation (MIPR) types.
+class Mipr {
+  const Mipr._();
 
-  static const _url = 'package:amplify_core/src/types/models/mipr.dart';
+  /// URL for MIPR types.
+  static const url = 'package:amplify_core/src/types/models/mipr.dart';
+
+  /// Creates an [mipr.ModelTypeDefinition] reference.
+  Reference get modelTypeDefinition =>
+      const Reference('ModelTypeDefinition', url);
+
+  /// Creates an [mipr.serializers] reference.
+  Reference get serializers => const Reference('serializers', url);
 }
 
 /// `package:aws_common` types.

--- a/packages/datastore/amplify_codegen/lib/src/generator/visitors.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/visitors.dart
@@ -103,7 +103,8 @@ class LibraryVisitor extends SimpleVisitor<GeneratedLibrary> {
 
   @override
   GeneratedLibrary visitObjectTypeDefinitionNode(
-      ObjectTypeDefinitionNode node) {
+    ObjectTypeDefinitionNode node,
+  ) {
     final definition =
         schema.typeDefinitions[node.name.value] as StructureTypeDefinition;
     if (definition is ModelTypeDefinition) {

--- a/packages/datastore/amplify_codegen/lib/src/generator/visitors.dart
+++ b/packages/datastore/amplify_codegen/lib/src/generator/visitors.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:amplify_codegen/src/generator/enum.dart';
+import 'package:amplify_codegen/src/generator/generated_library.dart';
 import 'package:amplify_codegen/src/generator/model.dart';
 import 'package:amplify_codegen/src/generator/non_model.dart';
 import 'package:amplify_core/src/types/models/mipr.dart';
@@ -86,7 +87,7 @@ abstract class SchemaVisitor<T> {
 /// each one. Specifically, this targets object `type` definitions and `enum`
 /// definitions.
 /// {@endtemplate}
-class LibraryVisitor extends SimpleVisitor<Library> {
+class LibraryVisitor extends SimpleVisitor<GeneratedLibrary> {
   /// {@macro amplify_codegen.library_visitor}
   LibraryVisitor(this.schema);
 
@@ -94,14 +95,15 @@ class LibraryVisitor extends SimpleVisitor<Library> {
   final SchemaDefinition schema;
 
   @override
-  Library visitEnumTypeDefinitionNode(EnumTypeDefinitionNode node) {
+  GeneratedLibrary visitEnumTypeDefinitionNode(EnumTypeDefinitionNode node) {
     final definition =
         schema.typeDefinitions[node.name.value] as EnumTypeDefinition;
     return EnumGenerator(node: node, definition: definition).generate();
   }
 
   @override
-  Library visitObjectTypeDefinitionNode(ObjectTypeDefinitionNode node) {
+  GeneratedLibrary visitObjectTypeDefinitionNode(
+      ObjectTypeDefinitionNode node) {
     final definition =
         schema.typeDefinitions[node.name.value] as StructureTypeDefinition;
     if (definition is ModelTypeDefinition) {

--- a/packages/datastore/amplify_codegen/lib/src/helpers/field.dart
+++ b/packages/datastore/amplify_codegen/lib/src/helpers/field.dart
@@ -778,6 +778,9 @@ extension AuthRules on List<DirectiveNode> {
           case 'groupsField':
             rule.groupsField = node.stringValue;
             break;
+          // Needed to support legacy cases:
+          // https://github.com/aws-amplify/amplify-codegen/blob/0cdc52777c3e69f2968e72e7534d40645c72e7e5/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts#L199
+          case 'operation':
           case 'operations':
             rule.operations
                 .addAll(node.stringListValue.map(ModelOperation.valueOf));

--- a/packages/datastore/amplify_codegen/lib/src/helpers/field.dart
+++ b/packages/datastore/amplify_codegen/lib/src/helpers/field.dart
@@ -408,12 +408,10 @@ extension ModelFieldHelpers on ModelField {
     );
   }
 
-  /// The Model type factory initializer for `this`.
-  Code? factoryInitializer({required bool isPrimaryKey}) {
+  /// A builder for converting to this field's type from a primitive value.
+  Expression Function(Expression)? get fromPrimitive {
     final type = this.type;
-    var isRequired = type.isRequired;
     Expression Function(Expression)? builder;
-    Expression? defaultValue;
     if (type is ScalarType) {
       switch (type.value) {
         case AppSyncScalar.awsDate:
@@ -421,13 +419,8 @@ extension ModelFieldHelpers on ModelField {
               (ref) => DartTypes.amplifyCore.temporalDate.newInstance([ref]);
           break;
         case AppSyncScalar.awsDateTime:
-          if (isReadOnly) {
-            defaultValue =
-                DartTypes.amplifyCore.temporalDateTime.property('now').call([]);
-          } else {
-            builder = (ref) =>
-                DartTypes.amplifyCore.temporalDateTime.newInstance([ref]);
-          }
+          builder = (ref) =>
+              DartTypes.amplifyCore.temporalDateTime.newInstance([ref]);
           break;
         case AppSyncScalar.awsTime:
           builder =
@@ -438,13 +431,6 @@ extension ModelFieldHelpers on ModelField {
               DartTypes.amplifyCore.temporalTimestamp.newInstance([ref]);
           break;
         case AppSyncScalar.id:
-          // Allow nullable `ID` parameters to the main constructor since these
-          // fields can be auto-generated.
-          if (isPrimaryKey) {
-            isRequired = false;
-            defaultValue = DartTypes.awsCommon.uuid.call([]);
-          }
-          break;
         case AppSyncScalar.awsIpAddress:
         case AppSyncScalar.awsEmail:
         case AppSyncScalar.awsJson:
@@ -472,6 +458,47 @@ extension ModelFieldHelpers on ModelField {
       builder = (ref) => DartTypes.amplifyCore
           .asyncModelCollection()
           .newInstanceNamed('fromList', [ref]);
+    }
+    return builder;
+  }
+
+  /// The Model type factory initializer for `this`.
+  Code? factoryInitializer({required bool isPrimaryKey}) {
+    final type = this.type;
+    var isRequired = type.isRequired;
+    var builder = fromPrimitive;
+    Expression? defaultValue;
+    if (type is ScalarType) {
+      switch (type.value) {
+        case AppSyncScalar.awsDateTime:
+          if (isReadOnly) {
+            defaultValue =
+                DartTypes.amplifyCore.temporalDateTime.property('now').call([]);
+            builder = null;
+          }
+          break;
+        case AppSyncScalar.id:
+          // Allow nullable `ID` parameters to the main constructor since these
+          // fields can be auto-generated.
+          if (isPrimaryKey) {
+            isRequired = false;
+            defaultValue = DartTypes.awsCommon.uuid.call([]);
+          }
+          break;
+        case AppSyncScalar.awsDate:
+        case AppSyncScalar.awsTime:
+        case AppSyncScalar.awsTimestamp:
+        case AppSyncScalar.awsIpAddress:
+        case AppSyncScalar.awsEmail:
+        case AppSyncScalar.awsJson:
+        case AppSyncScalar.awsPhone:
+        case AppSyncScalar.awsUrl:
+        case AppSyncScalar.boolean:
+        case AppSyncScalar.float:
+        case AppSyncScalar.int_:
+        case AppSyncScalar.string:
+          break;
+      }
     }
 
     if (builder == null && defaultValue == null) {

--- a/packages/datastore/amplify_codegen/lib/src/helpers/model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/helpers/model.dart
@@ -211,7 +211,7 @@ class ModelReferences {
   final ModelNames _names;
 
   /// The relative URL of the generated model.
-  String get modelUrl => '${_names.schemaName.snakeCase}.dart';
+  String get modelUrl => '${_definition.libraryName}.dart';
 
   /// The reference for the model type.
   Reference get modelType => refer(_names.modelType, modelUrl);

--- a/packages/datastore/amplify_codegen/lib/src/helpers/model.dart
+++ b/packages/datastore/amplify_codegen/lib/src/helpers/model.dart
@@ -200,6 +200,23 @@ class ModelNames {
   String get queryFields => '${model}QueryFields';
 }
 
+/// {@template amplify_codege.non_model_references}
+/// Reference helpers for [ModelTypeDefinition]s.
+/// {@endtemplate}
+class NonModelReferences {
+  /// {@macro amplify_codege.non_model_references}
+  NonModelReferences(this._definition) : _names = ModelNames(_definition.name);
+
+  final NonModelTypeDefinition _definition;
+  final ModelNames _names;
+
+  /// The relative URL of the generated class.
+  String get url => _definition.filename;
+
+  /// The reference for the class type.
+  Reference get classType => refer(_names.className, url);
+}
+
 /// {@template amplify_codege.model_references}
 /// Reference helpers for [ModelTypeDefinition]s.
 /// {@endtemplate}
@@ -211,7 +228,7 @@ class ModelReferences {
   final ModelNames _names;
 
   /// The relative URL of the generated model.
-  String get modelUrl => '${_definition.libraryName}.dart';
+  String get modelUrl => _definition.filename;
 
   /// The reference for the model type.
   Reference get modelType => refer(_names.modelType, modelUrl);

--- a/packages/datastore/amplify_codegen/lib/src/helpers/types.dart
+++ b/packages/datastore/amplify_codegen/lib/src/helpers/types.dart
@@ -152,8 +152,7 @@ extension SchemaTypeHelpers on SchemaType {
       AppSyncScalar.string,
     ];
     final type = this;
-    return (type is ScalarType && primitiveScalars.contains(type.value)) ||
-        type is EnumType;
+    return type is ScalarType && primitiveScalars.contains(type.value);
   }
 
   /// The Dart name for `this`.

--- a/packages/datastore/amplify_codegen/lib/src/helpers/types.dart
+++ b/packages/datastore/amplify_codegen/lib/src/helpers/types.dart
@@ -178,6 +178,9 @@ extension SchemaTypeHelpers on SchemaType {
 
 /// Helpers for [SchemaTypeDefinition].
 extension SchemaTypeDefinitionHelpers on SchemaTypeDefinition {
+  /// This name of the generated file.
+  String get filename => '${name.snakeCase}.dart';
+
   /// This type's name as a library name.
   String get libraryName {
     final libName = name.snakeCase;

--- a/packages/datastore/amplify_codegen/lib/src/helpers/types.dart
+++ b/packages/datastore/amplify_codegen/lib/src/helpers/types.dart
@@ -176,11 +176,11 @@ extension SchemaTypeHelpers on SchemaType {
   }
 }
 
-/// Helpers for [TypeDefinitionNode].
-extension TypeDefinitionHelpers on TypeDefinitionNode {
+/// Helpers for [SchemaTypeDefinition].
+extension SchemaTypeDefinitionHelpers on SchemaTypeDefinition {
   /// This type's name as a library name.
   String get libraryName {
-    final libName = name.value.snakeCase;
+    final libName = name.snakeCase;
     if (hardReservedWords.contains(libName)) {
       return '${libName}_';
     }

--- a/packages/datastore/amplify_codegen/pubspec.yaml
+++ b/packages/datastore/amplify_codegen/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
   built_value: ">=8.4.0 <8.5.0"
   code_builder: ^4.3.0
   collection: ^1.16.0
+  convert: ^3.1.1
+  crypto: ^3.0.2
   dart_style: ^2.2.4
   gql: ^0.14.0
   graphs: ^2.1.0

--- a/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
@@ -29,7 +29,8 @@ class EnumModelType extends ModelType<String, EnumModel, PartialEnumModel> {
 
   @override
   T fromJson<T extends PartialModel<String, EnumModel>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == EnumModel || T == Model<String, EnumModel>) {
       return EnumModel.fromJson(json) as T;
     }
@@ -74,7 +75,8 @@ class EnumModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, String, EnumModel, TemporalDateTime>(
         const QueryField<String, EnumModel, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -82,7 +84,8 @@ class EnumModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
       NestedQueryField<ModelIdentifier, M, String, EnumModel, TemporalDateTime>(
         const QueryField<String, EnumModel, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -90,7 +93,8 @@ class EnumModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
       NestedQueryField<ModelIdentifier, M, String, EnumModel, String>(
         const QueryField<String, EnumModel, String>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }

--- a/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
@@ -279,6 +279,24 @@ abstract class EnumModel extends PartialEnumModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, EnumModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  EnumModel copyWith({
+    String? id,
+    MyEnum? enum_,
+    MyEnum? requiredEnum,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _EnumModel._(
+      id: id ?? this.id,
+      enum_: enum_ ?? this.enum_,
+      requiredEnum: requiredEnum ?? this.requiredEnum,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, EnumModel, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.enum_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'my_enum.dart';
 
@@ -237,6 +238,55 @@ abstract class EnumModel extends PartialEnumModel
 
   static const EnumModelQueryFields<String, EnumModel> _queryFields =
       EnumModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'EnumModel',
+      'pluralName': 'EnumModels',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'enum': {
+          'name': 'enum',
+          'type': {'enum': 'MY_ENUM'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredEnum': {
+          'name': 'requiredEnum',
+          'type': {'enum': 'MY_ENUM'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/enum_model.dart
@@ -133,32 +133,6 @@ abstract class PartialEnumModel extends PartialModel<String, EnumModel>
       };
   @override
   String get runtimeTypeName => 'EnumModel';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, EnumModel, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'id':
-        value = id;
-        break;
-      case r'enum':
-        value = enum_;
-        break;
-      case r'requiredEnum':
-        value = requiredEnum;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialEnumModel extends PartialEnumModel {
@@ -305,6 +279,32 @@ abstract class EnumModel extends PartialEnumModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, EnumModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, EnumModel, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'enum':
+        value = enum_;
+        break;
+      case r'requiredEnum':
+        value = requiredEnum;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _EnumModel extends EnumModel {

--- a/packages/datastore/amplify_codegen/test/goldens/enums/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/model_provider.dart
@@ -1,0 +1,63 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'enum_model.dart';
+
+export 'enum_model.dart';
+export 'my_enum.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '1587c36ab12c87c5887cf7c8846e3358';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [EnumModel.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'EnumModel':
+        return (EnumModel.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/enums/my_enum.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/enums/my_enum.dart
@@ -16,7 +16,7 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.my_enum;
 

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/comment.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.comment;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'post.dart';
 
@@ -267,6 +268,79 @@ abstract class Comment extends PartialComment
 
   static const CommentQueryFields<String, Comment> _queryFields =
       CommentQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Comment',
+      'pluralName': 'Comments',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'postID': {
+          'name': 'postID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'post': {
+          'name': 'post',
+          'type': {'model': 'Post'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Post',
+            'targetNames': ['postID'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'secondary',
+          'primaryField': 'postID',
+          'sortKeyFields': [],
+          'name': 'byPost',
+          'queryField': 'commentsByPostID',
+        },
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'post',
+          'sortKeyFields': ['postID'],
+          'name': 'post',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/comment.dart
@@ -316,6 +316,26 @@ abstract class Comment extends PartialComment
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Comment, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Comment copyWith({
+    String? id,
+    String? postId,
+    String? content,
+    Post? post,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Comment._(
+      id: id ?? this.id,
+      postId: postId ?? this.postId,
+      content: content ?? this.content,
+      post: post == null ? this.post : AsyncModel.fromModel(post),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Comment, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/comment.dart
@@ -113,7 +113,7 @@ abstract class PartialComment extends PartialModel<String, Comment>
   String get id;
   String? get postId;
   String? get content;
-  AsyncModel<String, Post, PartialPost, PartialPost>? get post;
+  PartialPost? get post;
   TemporalDateTime? get createdAt;
   TemporalDateTime? get updatedAt;
   @override
@@ -165,18 +165,16 @@ class _PartialComment extends PartialComment {
     final postId = json['postID'] == null ? null : (json['postID'] as String);
     final content =
         json['content'] == null ? null : (json['content'] as String);
-    final post = json['post'] == null
-        ? null
-        : AsyncModel<String, Post, PartialPost, PartialPost>.fromModel(
-            Post.classType
-                .fromJson<PartialPost>((json['post'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
     final updatedAt = json['updatedAt'] == null
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final post = json['post'] == null
+        ? null
+        : Post.classType
+            .fromJson<PartialPost>((json['post'] as Map<String, Object?>));
     return _PartialComment(
       id: id,
       postId: postId,
@@ -197,7 +195,7 @@ class _PartialComment extends PartialComment {
   final String? content;
 
   @override
-  final AsyncModel<String, Post, PartialPost, PartialPost>? post;
+  final PartialPost? post;
 
   @override
   final TemporalDateTime? createdAt;
@@ -236,12 +234,6 @@ abstract class Comment extends PartialComment
             'content',
           ))
         : (json['content'] as String);
-    final post = json['post'] == null
-        ? null
-        : AsyncModel<String, Post, PartialPost, Post>.fromModel(
-            Post.classType
-                .fromJson<Post>((json['post'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Comment',
@@ -254,6 +246,9 @@ abstract class Comment extends PartialComment
             'updatedAt',
           ))
         : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final post = json['post'] == null
+        ? null
+        : Post.classType.fromJson<Post>((json['post'] as Map<String, Object?>));
     return _Comment._(
       id: id,
       postId: postId,
@@ -370,7 +365,7 @@ abstract class Comment extends PartialComment
   @Deprecated(r'Use $content instead')
   QueryField<String, Comment, String> get CONTENT => $content;
   @override
-  AsyncModel<String, Post, PartialPost, Post>? get post;
+  Post? get post;
 
   /// Query field for the [post] field.
   PostQueryFields<String, Comment> get $post => _queryFields.$post;
@@ -402,7 +397,7 @@ abstract class Comment extends PartialComment
       id: id ?? this.id,
       postId: postId ?? this.postId,
       content: content ?? this.content,
-      post: post == null ? this.post : AsyncModel.fromModel(post),
+      post: post ?? this.post,
       createdAt:
           createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
       updatedAt:
@@ -446,9 +441,8 @@ class _Comment extends Comment {
     String? id,
     required this.postId,
     required this.content,
-    Post? post,
+    this.post,
   })  : id = id ?? uuid(),
-        post = post == null ? null : AsyncModel.fromModel(post),
         createdAt = TemporalDateTime.now(),
         updatedAt = TemporalDateTime.now(),
         super._();
@@ -472,7 +466,7 @@ class _Comment extends Comment {
   final String content;
 
   @override
-  final AsyncModel<String, Post, PartialPost, Post>? post;
+  final Post? post;
 
   @override
   final TemporalDateTime createdAt;
@@ -518,12 +512,6 @@ class _RemoteComment extends RemoteComment {
             'content',
           ))
         : (json['content'] as String);
-    final post = json['post'] == null
-        ? null
-        : AsyncModel<String, Post, PartialPost, RemotePost>.fromModel(
-            Post.classType
-                .fromJson<RemotePost>((json['post'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Comment',
@@ -554,6 +542,10 @@ class _RemoteComment extends RemoteComment {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final post = json['post'] == null
+        ? null
+        : Post.classType
+            .fromJson<RemotePost>((json['post'] as Map<String, Object?>));
     return _RemoteComment(
       id: id,
       postId: postId,
@@ -577,7 +569,7 @@ class _RemoteComment extends RemoteComment {
   final String content;
 
   @override
-  final AsyncModel<String, Post, PartialPost, RemotePost>? post;
+  final RemotePost? post;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/comment.dart
@@ -1,0 +1,502 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.comment;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'post.dart';
+
+class CommentType extends ModelType<String, Comment, PartialComment> {
+  const CommentType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Comment>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Comment || T == Model<String, Comment>) {
+      return Comment.fromJson(json) as T;
+    }
+    if (T == RemoteComment || T == RemoteModel<String, Comment>) {
+      return _RemoteComment.fromJson(json) as T;
+    }
+    return _PartialComment.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Comment';
+}
+
+class CommentQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const CommentQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Comment>? _root;
+
+  /// Query field for the [Comment.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, String>(
+        const QueryField<String, Comment, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.postId] field.
+  QueryField<ModelIdentifier, M, String> get $postId =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, String>(
+        const QueryField<String, Comment, String>(fieldName: 'postID'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.content] field.
+  QueryField<ModelIdentifier, M, String> get $content =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, String>(
+        const QueryField<String, Comment, String>(fieldName: 'content'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.post] field.
+  PostQueryFields<ModelIdentifier, M> get $post => PostQueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Comment, Post>(
+          const QueryField<String, Comment, Post>(fieldName: 'post'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Comment.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, TemporalDateTime>(
+        const QueryField<String, Comment, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, TemporalDateTime>(
+        const QueryField<String, Comment, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, String>(
+        const QueryField<String, Comment, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialComment extends PartialModel<String, Comment>
+    with AWSEquatable<PartialComment> {
+  const PartialComment._();
+
+  String get id;
+  String? get postId;
+  String? get content;
+  AsyncModel<String, Post, PartialPost, PartialPost>? get post;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  CommentType get modelType => Comment.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        postId,
+        content,
+        post,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'postID': postId,
+        'content': content,
+        'post': post?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Comment';
+}
+
+class _PartialComment extends PartialComment {
+  const _PartialComment({
+    required this.id,
+    this.postId,
+    this.content,
+    this.post,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialComment.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'id',
+          ))
+        : (json['id'] as String);
+    final postId = json['postID'] == null ? null : (json['postID'] as String);
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final post = json['post'] == null
+        ? null
+        : AsyncModel<String, Post, PartialPost, PartialPost>.fromModel(
+            Post.classType
+                .fromJson<PartialPost>((json['post'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialComment(
+      id: id,
+      postId: postId,
+      content: content,
+      post: post,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? postId;
+
+  @override
+  final String? content;
+
+  @override
+  final AsyncModel<String, Post, PartialPost, PartialPost>? post;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Comment extends PartialComment
+    implements Model<String, Comment> {
+  factory Comment({
+    String? id,
+    required String postId,
+    required String content,
+    Post? post,
+  }) = _Comment;
+
+  const Comment._() : super._();
+
+  factory Comment.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'id',
+          ))
+        : (json['id'] as String);
+    final postId = json['postID'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'postId',
+          ))
+        : (json['postID'] as String);
+    final content = json['content'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'content',
+          ))
+        : (json['content'] as String);
+    final post = json['post'] == null
+        ? null
+        : AsyncModel<String, Post, PartialPost, Post>.fromModel(
+            Post.classType
+                .fromJson<Post>((json['post'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Comment._(
+      id: id,
+      postId: postId,
+      content: content,
+      post: post,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const CommentType classType = CommentType();
+
+  static const CommentQueryFields<String, Comment> _queryFields =
+      CommentQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Comment, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Comment, String> get ID => $id;
+  @override
+  String get postId;
+
+  /// Query field for the [postId] field.
+  QueryField<String, Comment, String> get $postId => _queryFields.$postId;
+
+  /// Query field for the [postId] field.
+  @Deprecated(r'Use $postId instead')
+  QueryField<String, Comment, String> get POST_ID => $postId;
+  @override
+  String get content;
+
+  /// Query field for the [content] field.
+  QueryField<String, Comment, String> get $content => _queryFields.$content;
+
+  /// Query field for the [content] field.
+  @Deprecated(r'Use $content instead')
+  QueryField<String, Comment, String> get CONTENT => $content;
+  @override
+  AsyncModel<String, Post, PartialPost, Post>? get post;
+
+  /// Query field for the [post] field.
+  PostQueryFields<String, Comment> get $post => _queryFields.$post;
+
+  /// Query field for the [post] field.
+  @Deprecated(r'Use $post instead')
+  PostQueryFields<String, Comment> get POST => $post;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Comment, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Comment, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Comment, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'postID':
+        value = postId;
+        break;
+      case r'content':
+        value = content;
+        break;
+      case r'post':
+        value = post;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Comment extends Comment {
+  _Comment({
+    String? id,
+    required this.postId,
+    required this.content,
+    Post? post,
+  })  : id = id ?? uuid(),
+        post = post == null ? null : AsyncModel.fromModel(post),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Comment._({
+    required this.id,
+    required this.postId,
+    required this.content,
+    this.post,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String postId;
+
+  @override
+  final String content;
+
+  @override
+  final AsyncModel<String, Post, PartialPost, Post>? post;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteComment extends Comment
+    implements RemoteModel<String, Comment> {
+  const RemoteComment._() : super._();
+}
+
+class _RemoteComment extends RemoteComment {
+  const _RemoteComment({
+    required this.id,
+    required this.postId,
+    required this.content,
+    this.post,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteComment.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'id',
+          ))
+        : (json['id'] as String);
+    final postId = json['postID'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'postId',
+          ))
+        : (json['postID'] as String);
+    final content = json['content'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'content',
+          ))
+        : (json['content'] as String);
+    final post = json['post'] == null
+        ? null
+        : AsyncModel<String, Post, PartialPost, RemotePost>.fromModel(
+            Post.classType
+                .fromJson<RemotePost>((json['post'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteComment(
+      id: id,
+      postId: postId,
+      content: content,
+      post: post,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String postId;
+
+  @override
+  final String content;
+
+  @override
+  final AsyncModel<String, Post, PartialPost, RemotePost>? post;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'comment.dart';
+import 'post.dart';
+
+export 'comment.dart';
+export 'post.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '99921472047b20207640216b406aebe3';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Post.schema,
+        Comment.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Post':
+        return (Post.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Comment':
+        return (Comment.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/post.dart
@@ -296,6 +296,26 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Post, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Post copyWith({
+    String? id,
+    String? title,
+    List<Comment>? comments,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Post._(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      comments: comments == null
+          ? this.comments
+          : AsyncModelCollection.fromList(comments),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/post.dart
@@ -1,0 +1,473 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.post;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'comment.dart';
+
+class PostType extends ModelType<String, Post, PartialPost> {
+  const PostType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Post>>(Map<String, Object?> json) {
+    if (T == Post || T == Model<String, Post>) {
+      return Post.fromJson(json) as T;
+    }
+    if (T == RemotePost || T == RemoteModel<String, Post>) {
+      return _RemotePost.fromJson(json) as T;
+    }
+    return _PartialPost.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Post';
+}
+
+class PostQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const PostQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Post>? _root;
+
+  /// Query field for the [Post.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.title] field.
+  QueryField<ModelIdentifier, M, String> get $title =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'title'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.comments] field.
+  CommentQueryFields<ModelIdentifier, M> get $comments => CommentQueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Post, Comment>(
+          const QueryField<String, Post, Comment>(fieldName: 'comments'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Post.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post, TemporalDateTime>(
+        const QueryField<String, Post, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post, TemporalDateTime>(
+        const QueryField<String, Post, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialPost extends PartialModel<String, Post>
+    with AWSEquatable<PartialPost> {
+  const PartialPost._();
+
+  String get id;
+  String? get title;
+  AsyncModelCollection<String, Comment, PartialComment, PartialComment>?
+      get comments;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  PostType get modelType => Post.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        comments,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'title': title,
+        'comments': comments?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Post';
+}
+
+class _PartialPost extends PartialPost {
+  const _PartialPost({
+    required this.id,
+    this.title,
+    this.comments,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialPost.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null ? null : (json['title'] as String);
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment, PartialComment,
+            PartialComment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<PartialComment>(el),
+                )
+                .whereType<PartialComment>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialPost(
+      id: id,
+      title: title,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? title;
+
+  @override
+  final AsyncModelCollection<String, Comment, PartialComment, PartialComment>?
+      comments;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Post extends PartialPost implements Model<String, Post> {
+  factory Post({
+    String? id,
+    required String title,
+    List<Comment>? comments,
+  }) = _Post;
+
+  const Post._() : super._();
+
+  factory Post.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment, PartialComment,
+            Comment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<Comment>(el),
+                )
+                .whereType<Comment>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Post._(
+      id: id,
+      title: title,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const PostType classType = PostType();
+
+  static const PostQueryFields<String, Post> _queryFields = PostQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Post, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Post, String> get ID => $id;
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<String, Post, String> get $title => _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<String, Post, String> get TITLE => $title;
+  @override
+  AsyncModelCollection<String, Comment, PartialComment, Comment>? get comments;
+
+  /// Query field for the [comments] field.
+  CommentQueryFields<String, Post> get $comments => _queryFields.$comments;
+
+  /// Query field for the [comments] field.
+  @Deprecated(r'Use $comments instead')
+  CommentQueryFields<String, Post> get COMMENTS => $comments;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Post, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Post, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'comments':
+        value = comments;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Post extends Post {
+  _Post({
+    String? id,
+    required this.title,
+    List<Comment>? comments,
+  })  : id = id ?? uuid(),
+        comments =
+            comments == null ? null : AsyncModelCollection.fromList(comments),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Post._({
+    required this.id,
+    required this.title,
+    this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final AsyncModelCollection<String, Comment, PartialComment, Comment>?
+      comments;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemotePost extends Post implements RemoteModel<String, Post> {
+  const RemotePost._() : super._();
+}
+
+class _RemotePost extends RemotePost {
+  const _RemotePost({
+    required this.id,
+    required this.title,
+    this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemotePost.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment, PartialComment,
+            RemoteComment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
+                .whereType<RemoteComment>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemotePost(
+      id: id,
+      title: title,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final AsyncModelCollection<String, Comment, PartialComment, RemoteComment>?
+      comments;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/post.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'comment.dart';
 
@@ -256,6 +257,62 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   static const PostType classType = PostType();
 
   static const PostQueryFields<String, Post> _queryFields = PostQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post',
+      'pluralName': 'Posts',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'comments': {
+          'name': 'comments',
+          'type': {
+            'list': {'model': 'Comment'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Comment',
+            'associatedFields': ['post'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_explicit/post.dart
@@ -151,6 +151,12 @@ class _PartialPost extends PartialPost {
           ))
         : (json['id'] as String);
     final title = json['title'] == null ? null : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<String, Comment, PartialComment,
@@ -165,12 +171,6 @@ class _PartialPost extends PartialPost {
                 .whereType<PartialComment>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
     return _PartialPost(
       id: id,
       title: title,
@@ -219,6 +219,18 @@ abstract class Post extends PartialPost implements Model<String, Post> {
             'title',
           ))
         : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<String, Comment, PartialComment,
@@ -233,18 +245,6 @@ abstract class Post extends PartialPost implements Model<String, Post> {
                 .whereType<Comment>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? (throw ModelFieldError(
-            'Post',
-            'createdAt',
-          ))
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? (throw ModelFieldError(
-            'Post',
-            'updatedAt',
-          ))
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
     return _Post._(
       id: id,
       title: title,
@@ -467,20 +467,6 @@ class _RemotePost extends RemotePost {
             'title',
           ))
         : (json['title'] as String);
-    final comments = json['comments'] == null
-        ? null
-        : AsyncModelCollection<String, Comment, PartialComment,
-            RemoteComment>.fromList(
-            (json['comments'] as List<Object?>)
-                .cast<Map<String, Object?>?>()
-                .map(
-                  (el) => el == null
-                      ? null
-                      : Comment.classType.fromJson<RemoteComment>(el),
-                )
-                .whereType<RemoteComment>()
-                .toList(),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Post',
@@ -511,6 +497,20 @@ class _RemotePost extends RemotePost {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment, PartialComment,
+            RemoteComment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
+                .whereType<RemoteComment>()
+                .toList(),
+          );
     return _RemotePost(
       id: id,
       title: title,
@@ -530,7 +530,7 @@ class _RemotePost extends RemotePost {
   final String title;
 
   @override
-  final AsyncModelCollection<String, Comment, PartialComment, RemoteComment>?
+  final AsyncModelCollection<String, Comment, PartialComment, Comment>?
       comments;
 
   @override

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/blog7_v2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/blog7_v2.dart
@@ -1,0 +1,476 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.blog7_v2;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'post7_v2.dart';
+
+class Blog7V2Type extends ModelType<String, Blog7V2, PartialBlog7V2> {
+  const Blog7V2Type();
+
+  @override
+  T fromJson<T extends PartialModel<String, Blog7V2>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Blog7V2 || T == Model<String, Blog7V2>) {
+      return Blog7V2.fromJson(json) as T;
+    }
+    if (T == RemoteBlog7V2 || T == RemoteModel<String, Blog7V2>) {
+      return _RemoteBlog7V2.fromJson(json) as T;
+    }
+    return _PartialBlog7V2.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Blog7V2';
+}
+
+class Blog7V2QueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const Blog7V2QueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Blog7V2>? _root;
+
+  /// Query field for the [Blog7V2.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Blog7V2, String>(
+        const QueryField<String, Blog7V2, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Blog7V2.name] field.
+  QueryField<ModelIdentifier, M, String> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, Blog7V2, String>(
+        const QueryField<String, Blog7V2, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Blog7V2.posts] field.
+  Post7V2QueryFields<ModelIdentifier, M> get $posts => Post7V2QueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Blog7V2, Post7V2>(
+          const QueryField<String, Blog7V2, Post7V2>(fieldName: 'posts'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Blog7V2.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Blog7V2, TemporalDateTime>(
+        const QueryField<String, Blog7V2, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Blog7V2.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Blog7V2, TemporalDateTime>(
+        const QueryField<String, Blog7V2, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Blog7V2] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Blog7V2, String>(
+        const QueryField<String, Blog7V2, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialBlog7V2 extends PartialModel<String, Blog7V2>
+    with AWSEquatable<PartialBlog7V2> {
+  const PartialBlog7V2._();
+
+  String get id;
+  String? get name;
+  AsyncModelCollection<String, Post7V2, PartialPost7V2, PartialPost7V2>?
+      get posts;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  Blog7V2Type get modelType => Blog7V2.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        posts,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'posts': posts?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Blog7V2';
+}
+
+class _PartialBlog7V2 extends PartialBlog7V2 {
+  const _PartialBlog7V2({
+    required this.id,
+    this.name,
+    this.posts,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialBlog7V2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final posts = json['posts'] == null
+        ? null
+        : AsyncModelCollection<String, Post7V2, PartialPost7V2,
+            PartialPost7V2>.fromList(
+            (json['posts'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Post7V2.classType.fromJson<PartialPost7V2>(el),
+                )
+                .whereType<PartialPost7V2>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialBlog7V2(
+      id: id,
+      name: name,
+      posts: posts,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final AsyncModelCollection<String, Post7V2, PartialPost7V2, PartialPost7V2>?
+      posts;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Blog7V2 extends PartialBlog7V2
+    implements Model<String, Blog7V2> {
+  factory Blog7V2({
+    String? id,
+    required String name,
+    List<Post7V2>? posts,
+  }) = _Blog7V2;
+
+  const Blog7V2._() : super._();
+
+  factory Blog7V2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'name',
+          ))
+        : (json['name'] as String);
+    final posts = json['posts'] == null
+        ? null
+        : AsyncModelCollection<String, Post7V2, PartialPost7V2,
+            Post7V2>.fromList(
+            (json['posts'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Post7V2.classType.fromJson<Post7V2>(el),
+                )
+                .whereType<Post7V2>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Blog7V2._(
+      id: id,
+      name: name,
+      posts: posts,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const Blog7V2Type classType = Blog7V2Type();
+
+  static const Blog7V2QueryFields<String, Blog7V2> _queryFields =
+      Blog7V2QueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Blog7V2, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Blog7V2, String> get ID => $id;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, Blog7V2, String> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, Blog7V2, String> get NAME => $name;
+  @override
+  AsyncModelCollection<String, Post7V2, PartialPost7V2, Post7V2>? get posts;
+
+  /// Query field for the [posts] field.
+  Post7V2QueryFields<String, Blog7V2> get $posts => _queryFields.$posts;
+
+  /// Query field for the [posts] field.
+  @Deprecated(r'Use $posts instead')
+  Post7V2QueryFields<String, Blog7V2> get POSTS => $posts;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Blog7V2, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Blog7V2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Blog7V2, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'posts':
+        value = posts;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Blog7V2 extends Blog7V2 {
+  _Blog7V2({
+    String? id,
+    required this.name,
+    List<Post7V2>? posts,
+  })  : id = id ?? uuid(),
+        posts = posts == null ? null : AsyncModelCollection.fromList(posts),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Blog7V2._({
+    required this.id,
+    required this.name,
+    this.posts,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModelCollection<String, Post7V2, PartialPost7V2, Post7V2>? posts;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteBlog7V2 extends Blog7V2
+    implements RemoteModel<String, Blog7V2> {
+  const RemoteBlog7V2._() : super._();
+}
+
+class _RemoteBlog7V2 extends RemoteBlog7V2 {
+  const _RemoteBlog7V2({
+    required this.id,
+    required this.name,
+    this.posts,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteBlog7V2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'name',
+          ))
+        : (json['name'] as String);
+    final posts = json['posts'] == null
+        ? null
+        : AsyncModelCollection<String, Post7V2, PartialPost7V2,
+            RemotePost7V2>.fromList(
+            (json['posts'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Post7V2.classType.fromJson<RemotePost7V2>(el),
+                )
+                .whereType<RemotePost7V2>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteBlog7V2(
+      id: id,
+      name: name,
+      posts: posts,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModelCollection<String, Post7V2, PartialPost7V2, RemotePost7V2>?
+      posts;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/blog7_v2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/blog7_v2.dart
@@ -153,6 +153,12 @@ class _PartialBlog7V2 extends PartialBlog7V2 {
           ))
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
     final posts = json['posts'] == null
         ? null
         : AsyncModelCollection<String, Post7V2, PartialPost7V2,
@@ -167,12 +173,6 @@ class _PartialBlog7V2 extends PartialBlog7V2 {
                 .whereType<PartialPost7V2>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
     return _PartialBlog7V2(
       id: id,
       name: name,
@@ -222,6 +222,18 @@ abstract class Blog7V2 extends PartialBlog7V2
             'name',
           ))
         : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Blog7V2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
     final posts = json['posts'] == null
         ? null
         : AsyncModelCollection<String, Post7V2, PartialPost7V2,
@@ -236,18 +248,6 @@ abstract class Blog7V2 extends PartialBlog7V2
                 .whereType<Post7V2>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? (throw ModelFieldError(
-            'Blog7V2',
-            'createdAt',
-          ))
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? (throw ModelFieldError(
-            'Blog7V2',
-            'updatedAt',
-          ))
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
     return _Blog7V2._(
       id: id,
       name: name,
@@ -468,20 +468,6 @@ class _RemoteBlog7V2 extends RemoteBlog7V2 {
             'name',
           ))
         : (json['name'] as String);
-    final posts = json['posts'] == null
-        ? null
-        : AsyncModelCollection<String, Post7V2, PartialPost7V2,
-            RemotePost7V2>.fromList(
-            (json['posts'] as List<Object?>)
-                .cast<Map<String, Object?>?>()
-                .map(
-                  (el) => el == null
-                      ? null
-                      : Post7V2.classType.fromJson<RemotePost7V2>(el),
-                )
-                .whereType<RemotePost7V2>()
-                .toList(),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Blog7V2',
@@ -512,6 +498,20 @@ class _RemoteBlog7V2 extends RemoteBlog7V2 {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final posts = json['posts'] == null
+        ? null
+        : AsyncModelCollection<String, Post7V2, PartialPost7V2,
+            RemotePost7V2>.fromList(
+            (json['posts'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Post7V2.classType.fromJson<RemotePost7V2>(el),
+                )
+                .whereType<RemotePost7V2>()
+                .toList(),
+          );
     return _RemoteBlog7V2(
       id: id,
       name: name,
@@ -531,8 +531,7 @@ class _RemoteBlog7V2 extends RemoteBlog7V2 {
   final String name;
 
   @override
-  final AsyncModelCollection<String, Post7V2, PartialPost7V2, RemotePost7V2>?
-      posts;
+  final AsyncModelCollection<String, Post7V2, PartialPost7V2, Post7V2>? posts;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/blog7_v2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/blog7_v2.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.blog7_v2;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'post7_v2.dart';
 
@@ -260,6 +261,62 @@ abstract class Blog7V2 extends PartialBlog7V2
 
   static const Blog7V2QueryFields<String, Blog7V2> _queryFields =
       Blog7V2QueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Blog7V2',
+      'pluralName': 'Blog7V2s',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'posts': {
+          'name': 'posts',
+          'type': {
+            'list': {'model': 'Post7V2'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Post7V2',
+            'associatedFields': ['blog'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/blog7_v2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/blog7_v2.dart
@@ -300,6 +300,24 @@ abstract class Blog7V2 extends PartialBlog7V2
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Blog7V2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Blog7V2 copyWith({
+    String? id,
+    String? name,
+    List<Post7V2>? posts,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Blog7V2._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      posts: posts == null ? this.posts : AsyncModelCollection.fromList(posts),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Blog7V2, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/comment7_v2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/comment7_v2.dart
@@ -1,0 +1,501 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.comment7_v2;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'post7_v2.dart';
+
+class Comment7V2Type extends ModelType<String, Comment7V2, PartialComment7V2> {
+  const Comment7V2Type();
+
+  @override
+  T fromJson<T extends PartialModel<String, Comment7V2>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Comment7V2 || T == Model<String, Comment7V2>) {
+      return Comment7V2.fromJson(json) as T;
+    }
+    if (T == RemoteComment7V2 || T == RemoteModel<String, Comment7V2>) {
+      return _RemoteComment7V2.fromJson(json) as T;
+    }
+    return _PartialComment7V2.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Comment7V2';
+}
+
+class Comment7V2QueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const Comment7V2QueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Comment7V2>? _root;
+
+  /// Query field for the [Comment7V2.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Comment7V2, String>(
+        const QueryField<String, Comment7V2, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment7V2.content] field.
+  QueryField<ModelIdentifier, M, String?> get $content =>
+      NestedQueryField<ModelIdentifier, M, String, Comment7V2, String?>(
+        const QueryField<String, Comment7V2, String?>(fieldName: 'content'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment7V2.post] field.
+  Post7V2QueryFields<ModelIdentifier, M> get $post => Post7V2QueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Comment7V2, Post7V2>(
+          const QueryField<String, Comment7V2, Post7V2>(fieldName: 'post'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Comment7V2.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Comment7V2,
+          TemporalDateTime>(
+        const QueryField<String, Comment7V2, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment7V2.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Comment7V2,
+          TemporalDateTime>(
+        const QueryField<String, Comment7V2, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment7V2.post7V2CommentsId] field.
+  QueryField<ModelIdentifier, M, String?> get $post7V2CommentsId =>
+      NestedQueryField<ModelIdentifier, M, String, Comment7V2, String?>(
+        const QueryField<String, Comment7V2, String?>(
+          fieldName: 'post7V2CommentsId',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment7V2] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Comment7V2, String>(
+        const QueryField<String, Comment7V2, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialComment7V2 extends PartialModel<String, Comment7V2>
+    with AWSEquatable<PartialComment7V2> {
+  const PartialComment7V2._();
+
+  String get id;
+  String? get content;
+  AsyncModel<String, Post7V2, PartialPost7V2, PartialPost7V2>? get post;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String? get post7V2CommentsId;
+  @override
+  String get modelIdentifier => id;
+  @override
+  Comment7V2Type get modelType => Comment7V2.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        content,
+        post,
+        createdAt,
+        updatedAt,
+        post7V2CommentsId,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'content': content,
+        'post': post?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'post7V2CommentsId': post7V2CommentsId,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Comment7V2';
+}
+
+class _PartialComment7V2 extends PartialComment7V2 {
+  const _PartialComment7V2({
+    required this.id,
+    this.content,
+    this.post,
+    this.createdAt,
+    this.updatedAt,
+    this.post7V2CommentsId,
+  }) : super._();
+
+  factory _PartialComment7V2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment7V2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final post = json['post'] == null
+        ? null
+        : AsyncModel<String, Post7V2, PartialPost7V2, PartialPost7V2>.fromModel(
+            Post7V2.classType.fromJson<PartialPost7V2>(
+              (json['post'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final post7V2CommentsId = json['post7V2CommentsId'] == null
+        ? null
+        : (json['post7V2CommentsId'] as String);
+    return _PartialComment7V2(
+      id: id,
+      content: content,
+      post: post,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      post7V2CommentsId: post7V2CommentsId,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? content;
+
+  @override
+  final AsyncModel<String, Post7V2, PartialPost7V2, PartialPost7V2>? post;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String? post7V2CommentsId;
+}
+
+abstract class Comment7V2 extends PartialComment7V2
+    implements Model<String, Comment7V2> {
+  factory Comment7V2({
+    String? id,
+    String? content,
+    Post7V2? post,
+    String? post7V2CommentsId,
+  }) = _Comment7V2;
+
+  const Comment7V2._() : super._();
+
+  factory Comment7V2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment7V2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final post = json['post'] == null
+        ? null
+        : AsyncModel<String, Post7V2, PartialPost7V2, Post7V2>.fromModel(
+            Post7V2.classType
+                .fromJson<Post7V2>((json['post'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Comment7V2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment7V2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final post7V2CommentsId = json['post7V2CommentsId'] == null
+        ? null
+        : (json['post7V2CommentsId'] as String);
+    return _Comment7V2._(
+      id: id,
+      content: content,
+      post: post,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      post7V2CommentsId: post7V2CommentsId,
+    );
+  }
+
+  static const Comment7V2Type classType = Comment7V2Type();
+
+  static const Comment7V2QueryFields<String, Comment7V2> _queryFields =
+      Comment7V2QueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Comment7V2, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Comment7V2, String> get ID => $id;
+  @override
+  String? get content;
+
+  /// Query field for the [content] field.
+  QueryField<String, Comment7V2, String?> get $content => _queryFields.$content;
+
+  /// Query field for the [content] field.
+  @Deprecated(r'Use $content instead')
+  QueryField<String, Comment7V2, String?> get CONTENT => $content;
+  @override
+  AsyncModel<String, Post7V2, PartialPost7V2, Post7V2>? get post;
+
+  /// Query field for the [post] field.
+  Post7V2QueryFields<String, Comment7V2> get $post => _queryFields.$post;
+
+  /// Query field for the [post] field.
+  @Deprecated(r'Use $post instead')
+  Post7V2QueryFields<String, Comment7V2> get POST => $post;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String? get post7V2CommentsId;
+
+  /// Query field for the [post7V2CommentsId] field.
+  QueryField<String, Comment7V2, String?> get $post7V2CommentsId =>
+      _queryFields.$post7V2CommentsId;
+
+  /// Query field for the [post7V2CommentsId] field.
+  @Deprecated(r'Use $post7V2CommentsId instead')
+  QueryField<String, Comment7V2, String?> get POST7_V2_COMMENTS_ID =>
+      $post7V2CommentsId;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Comment7V2, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Comment7V2, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Comment7V2, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'content':
+        value = content;
+        break;
+      case r'post':
+        value = post;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'post7V2CommentsId':
+        value = post7V2CommentsId;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Comment7V2 extends Comment7V2 {
+  _Comment7V2({
+    String? id,
+    this.content,
+    Post7V2? post,
+    this.post7V2CommentsId,
+  })  : id = id ?? uuid(),
+        post = post == null ? null : AsyncModel.fromModel(post),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Comment7V2._({
+    required this.id,
+    this.content,
+    this.post,
+    required this.createdAt,
+    required this.updatedAt,
+    this.post7V2CommentsId,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? content;
+
+  @override
+  final AsyncModel<String, Post7V2, PartialPost7V2, Post7V2>? post;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? post7V2CommentsId;
+}
+
+abstract class RemoteComment7V2 extends Comment7V2
+    implements RemoteModel<String, Comment7V2> {
+  const RemoteComment7V2._() : super._();
+}
+
+class _RemoteComment7V2 extends RemoteComment7V2 {
+  const _RemoteComment7V2({
+    required this.id,
+    this.content,
+    this.post,
+    required this.createdAt,
+    required this.updatedAt,
+    this.post7V2CommentsId,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteComment7V2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment7V2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final post = json['post'] == null
+        ? null
+        : AsyncModel<String, Post7V2, PartialPost7V2, RemotePost7V2>.fromModel(
+            Post7V2.classType.fromJson<RemotePost7V2>(
+              (json['post'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Comment7V2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment7V2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final post7V2CommentsId = json['post7V2CommentsId'] == null
+        ? null
+        : (json['post7V2CommentsId'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Comment7V2',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Comment7V2',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment7V2',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteComment7V2(
+      id: id,
+      content: content,
+      post: post,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      post7V2CommentsId: post7V2CommentsId,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? content;
+
+  @override
+  final AsyncModel<String, Post7V2, PartialPost7V2, RemotePost7V2>? post;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? post7V2CommentsId;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/comment7_v2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/comment7_v2.dart
@@ -321,6 +321,26 @@ abstract class Comment7V2 extends PartialComment7V2
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Comment7V2, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  Comment7V2 copyWith({
+    String? id,
+    String? content,
+    Post7V2? post,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? post7V2CommentsId,
+  }) {
+    return _Comment7V2._(
+      id: id ?? this.id,
+      content: content ?? this.content,
+      post: post == null ? this.post : AsyncModel.fromModel(post),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      post7V2CommentsId: post7V2CommentsId ?? this.post7V2CommentsId,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Comment7V2, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/comment7_v2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/comment7_v2.dart
@@ -118,7 +118,7 @@ abstract class PartialComment7V2 extends PartialModel<String, Comment7V2>
 
   String get id;
   String? get content;
-  AsyncModel<String, Post7V2, PartialPost7V2, PartialPost7V2>? get post;
+  PartialPost7V2? get post;
   TemporalDateTime? get createdAt;
   TemporalDateTime? get updatedAt;
   String? get post7V2CommentsId;
@@ -170,13 +170,6 @@ class _PartialComment7V2 extends PartialComment7V2 {
         : (json['id'] as String);
     final content =
         json['content'] == null ? null : (json['content'] as String);
-    final post = json['post'] == null
-        ? null
-        : AsyncModel<String, Post7V2, PartialPost7V2, PartialPost7V2>.fromModel(
-            Post7V2.classType.fromJson<PartialPost7V2>(
-              (json['post'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
@@ -186,6 +179,10 @@ class _PartialComment7V2 extends PartialComment7V2 {
     final post7V2CommentsId = json['post7V2CommentsId'] == null
         ? null
         : (json['post7V2CommentsId'] as String);
+    final post = json['post'] == null
+        ? null
+        : Post7V2.classType
+            .fromJson<PartialPost7V2>((json['post'] as Map<String, Object?>));
     return _PartialComment7V2(
       id: id,
       content: content,
@@ -203,7 +200,7 @@ class _PartialComment7V2 extends PartialComment7V2 {
   final String? content;
 
   @override
-  final AsyncModel<String, Post7V2, PartialPost7V2, PartialPost7V2>? post;
+  final PartialPost7V2? post;
 
   @override
   final TemporalDateTime? createdAt;
@@ -221,7 +218,6 @@ abstract class Comment7V2 extends PartialComment7V2
     String? id,
     String? content,
     Post7V2? post,
-    String? post7V2CommentsId,
   }) = _Comment7V2;
 
   const Comment7V2._() : super._();
@@ -235,12 +231,6 @@ abstract class Comment7V2 extends PartialComment7V2
         : (json['id'] as String);
     final content =
         json['content'] == null ? null : (json['content'] as String);
-    final post = json['post'] == null
-        ? null
-        : AsyncModel<String, Post7V2, PartialPost7V2, Post7V2>.fromModel(
-            Post7V2.classType
-                .fromJson<Post7V2>((json['post'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Comment7V2',
@@ -256,6 +246,10 @@ abstract class Comment7V2 extends PartialComment7V2
     final post7V2CommentsId = json['post7V2CommentsId'] == null
         ? null
         : (json['post7V2CommentsId'] as String);
+    final post = json['post'] == null
+        ? null
+        : Post7V2.classType
+            .fromJson<Post7V2>((json['post'] as Map<String, Object?>));
     return _Comment7V2._(
       id: id,
       content: content,
@@ -316,7 +310,7 @@ abstract class Comment7V2 extends PartialComment7V2
         'post7V2CommentsId': {
           'name': 'post7V2CommentsId',
           'type': {'scalar': 'ID'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
       },
@@ -356,7 +350,7 @@ abstract class Comment7V2 extends PartialComment7V2
   @Deprecated(r'Use $content instead')
   QueryField<String, Comment7V2, String?> get CONTENT => $content;
   @override
-  AsyncModel<String, Post7V2, PartialPost7V2, Post7V2>? get post;
+  Post7V2? get post;
 
   /// Query field for the [post] field.
   Post7V2QueryFields<String, Comment7V2> get $post => _queryFields.$post;
@@ -370,15 +364,6 @@ abstract class Comment7V2 extends PartialComment7V2
   TemporalDateTime get updatedAt;
   @override
   String? get post7V2CommentsId;
-
-  /// Query field for the [post7V2CommentsId] field.
-  QueryField<String, Comment7V2, String?> get $post7V2CommentsId =>
-      _queryFields.$post7V2CommentsId;
-
-  /// Query field for the [post7V2CommentsId] field.
-  @Deprecated(r'Use $post7V2CommentsId instead')
-  QueryField<String, Comment7V2, String?> get POST7_V2_COMMENTS_ID =>
-      $post7V2CommentsId;
 
   /// Query field for the [modelIdentifier] field.
   QueryField<String, Comment7V2, String> get $modelIdentifier =>
@@ -399,7 +384,7 @@ abstract class Comment7V2 extends PartialComment7V2
     return _Comment7V2._(
       id: id ?? this.id,
       content: content ?? this.content,
-      post: post == null ? this.post : AsyncModel.fromModel(post),
+      post: post ?? this.post,
       createdAt:
           createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
       updatedAt:
@@ -443,12 +428,11 @@ class _Comment7V2 extends Comment7V2 {
   _Comment7V2({
     String? id,
     this.content,
-    Post7V2? post,
-    this.post7V2CommentsId,
+    this.post,
   })  : id = id ?? uuid(),
-        post = post == null ? null : AsyncModel.fromModel(post),
         createdAt = TemporalDateTime.now(),
         updatedAt = TemporalDateTime.now(),
+        post7V2CommentsId = post?.id,
         super._();
 
   const _Comment7V2._({
@@ -467,7 +451,7 @@ class _Comment7V2 extends Comment7V2 {
   final String? content;
 
   @override
-  final AsyncModel<String, Post7V2, PartialPost7V2, Post7V2>? post;
+  final Post7V2? post;
 
   @override
   final TemporalDateTime createdAt;
@@ -506,13 +490,6 @@ class _RemoteComment7V2 extends RemoteComment7V2 {
         : (json['id'] as String);
     final content =
         json['content'] == null ? null : (json['content'] as String);
-    final post = json['post'] == null
-        ? null
-        : AsyncModel<String, Post7V2, PartialPost7V2, RemotePost7V2>.fromModel(
-            Post7V2.classType.fromJson<RemotePost7V2>(
-              (json['post'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Comment7V2',
@@ -546,6 +523,10 @@ class _RemoteComment7V2 extends RemoteComment7V2 {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final post = json['post'] == null
+        ? null
+        : Post7V2.classType
+            .fromJson<RemotePost7V2>((json['post'] as Map<String, Object?>));
     return _RemoteComment7V2(
       id: id,
       content: content,
@@ -566,7 +547,7 @@ class _RemoteComment7V2 extends RemoteComment7V2 {
   final String? content;
 
   @override
-  final AsyncModel<String, Post7V2, PartialPost7V2, RemotePost7V2>? post;
+  final RemotePost7V2? post;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/comment7_v2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/comment7_v2.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.comment7_v2;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'post7_v2.dart';
 
@@ -269,6 +270,72 @@ abstract class Comment7V2 extends PartialComment7V2
 
   static const Comment7V2QueryFields<String, Comment7V2> _queryFields =
       Comment7V2QueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Comment7V2',
+      'pluralName': 'Comment7V2s',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'post': {
+          'name': 'post',
+          'type': {'model': 'Post7V2'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Post7V2',
+            'targetNames': ['post7V2CommentsId'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'post7V2CommentsId': {
+          'name': 'post7V2CommentsId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'post',
+          'sortKeyFields': ['post7V2CommentsId'],
+          'name': 'post',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/model_provider.dart
@@ -1,0 +1,74 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'blog7_v2.dart';
+import 'comment7_v2.dart';
+import 'post7_v2.dart';
+
+export 'blog7_v2.dart';
+export 'comment7_v2.dart';
+export 'post7_v2.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '9292fc891cd5025a461bef6580a0f507';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Blog7V2.schema,
+        Post7V2.schema,
+        Comment7V2.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Blog7V2':
+        return (Blog7V2.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Post7V2':
+        return (Post7V2.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Comment7V2':
+        return (Comment7V2.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/model_provider.dart
@@ -37,7 +37,7 @@ class ModelProvider extends ModelProviderInterface {
   static final instance = ModelProvider._();
 
   @override
-  String get version => '9292fc891cd5025a461bef6580a0f507';
+  String get version => '7ca9f38bee8ec4faf644b2d77c1f29d6';
   @override
   List<mipr.ModelTypeDefinition> get modelSchemas => [
         Blog7V2.schema,

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/post7_v2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/post7_v2.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post7_v2;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'blog7_v2.dart';
 import 'comment7_v2.dart';
@@ -316,6 +317,85 @@ abstract class Post7V2 extends PartialPost7V2
 
   static const Post7V2QueryFields<String, Post7V2> _queryFields =
       Post7V2QueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post7V2',
+      'pluralName': 'Post7V2s',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'blog': {
+          'name': 'blog',
+          'type': {'model': 'Blog7V2'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Blog7V2',
+            'targetNames': ['blog7V2PostsId'],
+          },
+        },
+        'comments': {
+          'name': 'comments',
+          'type': {
+            'list': {'model': 'Comment7V2'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Comment7V2',
+            'associatedFields': ['post'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'blog7V2PostsId': {
+          'name': 'blog7V2PostsId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'blog',
+          'sortKeyFields': ['blog7V2PostsId'],
+          'name': 'blog',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/post7_v2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/post7_v2.dart
@@ -122,7 +122,7 @@ abstract class PartialPost7V2 extends PartialModel<String, Post7V2>
 
   String get id;
   String? get title;
-  AsyncModel<String, Blog7V2, PartialBlog7V2, PartialBlog7V2>? get blog;
+  PartialBlog7V2? get blog;
   AsyncModelCollection<String, Comment7V2, PartialComment7V2,
       PartialComment7V2>? get comments;
   TemporalDateTime? get createdAt;
@@ -178,13 +178,19 @@ class _PartialPost7V2 extends PartialPost7V2 {
           ))
         : (json['id'] as String);
     final title = json['title'] == null ? null : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final blog7V2PostsId = json['blog7V2PostsId'] == null
+        ? null
+        : (json['blog7V2PostsId'] as String);
     final blog = json['blog'] == null
         ? null
-        : AsyncModel<String, Blog7V2, PartialBlog7V2, PartialBlog7V2>.fromModel(
-            Blog7V2.classType.fromJson<PartialBlog7V2>(
-              (json['blog'] as Map<String, Object?>),
-            ),
-          );
+        : Blog7V2.classType
+            .fromJson<PartialBlog7V2>((json['blog'] as Map<String, Object?>));
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<String, Comment7V2, PartialComment7V2,
@@ -199,15 +205,6 @@ class _PartialPost7V2 extends PartialPost7V2 {
                 .whereType<PartialComment7V2>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
-    final blog7V2PostsId = json['blog7V2PostsId'] == null
-        ? null
-        : (json['blog7V2PostsId'] as String);
     return _PartialPost7V2(
       id: id,
       title: title,
@@ -226,7 +223,7 @@ class _PartialPost7V2 extends PartialPost7V2 {
   final String? title;
 
   @override
-  final AsyncModel<String, Blog7V2, PartialBlog7V2, PartialBlog7V2>? blog;
+  final PartialBlog7V2? blog;
 
   @override
   final AsyncModelCollection<String, Comment7V2, PartialComment7V2,
@@ -249,7 +246,6 @@ abstract class Post7V2 extends PartialPost7V2
     required String title,
     Blog7V2? blog,
     List<Comment7V2>? comments,
-    String? blog7V2PostsId,
   }) = _Post7V2;
 
   const Post7V2._() : super._();
@@ -267,26 +263,6 @@ abstract class Post7V2 extends PartialPost7V2
             'title',
           ))
         : (json['title'] as String);
-    final blog = json['blog'] == null
-        ? null
-        : AsyncModel<String, Blog7V2, PartialBlog7V2, Blog7V2>.fromModel(
-            Blog7V2.classType
-                .fromJson<Blog7V2>((json['blog'] as Map<String, Object?>)),
-          );
-    final comments = json['comments'] == null
-        ? null
-        : AsyncModelCollection<String, Comment7V2, PartialComment7V2,
-            Comment7V2>.fromList(
-            (json['comments'] as List<Object?>)
-                .cast<Map<String, Object?>?>()
-                .map(
-                  (el) => el == null
-                      ? null
-                      : Comment7V2.classType.fromJson<Comment7V2>(el),
-                )
-                .whereType<Comment7V2>()
-                .toList(),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Post7V2',
@@ -302,6 +278,24 @@ abstract class Post7V2 extends PartialPost7V2
     final blog7V2PostsId = json['blog7V2PostsId'] == null
         ? null
         : (json['blog7V2PostsId'] as String);
+    final blog = json['blog'] == null
+        ? null
+        : Blog7V2.classType
+            .fromJson<Blog7V2>((json['blog'] as Map<String, Object?>));
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment7V2, PartialComment7V2,
+            Comment7V2>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment7V2.classType.fromJson<Comment7V2>(el),
+                )
+                .whereType<Comment7V2>()
+                .toList(),
+          );
     return _Post7V2._(
       id: id,
       title: title,
@@ -376,7 +370,7 @@ abstract class Post7V2 extends PartialPost7V2
         'blog7V2PostsId': {
           'name': 'blog7V2PostsId',
           'type': {'scalar': 'ID'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
       },
@@ -416,7 +410,7 @@ abstract class Post7V2 extends PartialPost7V2
   @Deprecated(r'Use $title instead')
   QueryField<String, Post7V2, String> get TITLE => $title;
   @override
-  AsyncModel<String, Blog7V2, PartialBlog7V2, Blog7V2>? get blog;
+  Blog7V2? get blog;
 
   /// Query field for the [blog] field.
   Blog7V2QueryFields<String, Post7V2> get $blog => _queryFields.$blog;
@@ -442,14 +436,6 @@ abstract class Post7V2 extends PartialPost7V2
   @override
   String? get blog7V2PostsId;
 
-  /// Query field for the [blog7V2PostsId] field.
-  QueryField<String, Post7V2, String?> get $blog7V2PostsId =>
-      _queryFields.$blog7V2PostsId;
-
-  /// Query field for the [blog7V2PostsId] field.
-  @Deprecated(r'Use $blog7V2PostsId instead')
-  QueryField<String, Post7V2, String?> get BLOG7_V2_POSTS_ID => $blog7V2PostsId;
-
   /// Query field for the [modelIdentifier] field.
   QueryField<String, Post7V2, String> get $modelIdentifier =>
       _queryFields.$modelIdentifier;
@@ -469,7 +455,7 @@ abstract class Post7V2 extends PartialPost7V2
     return _Post7V2._(
       id: id ?? this.id,
       title: title ?? this.title,
-      blog: blog == null ? this.blog : AsyncModel.fromModel(blog),
+      blog: blog ?? this.blog,
       comments: comments == null
           ? this.comments
           : AsyncModelCollection.fromList(comments),
@@ -519,15 +505,14 @@ class _Post7V2 extends Post7V2 {
   _Post7V2({
     String? id,
     required this.title,
-    Blog7V2? blog,
+    this.blog,
     List<Comment7V2>? comments,
-    this.blog7V2PostsId,
   })  : id = id ?? uuid(),
-        blog = blog == null ? null : AsyncModel.fromModel(blog),
         comments =
             comments == null ? null : AsyncModelCollection.fromList(comments),
         createdAt = TemporalDateTime.now(),
         updatedAt = TemporalDateTime.now(),
+        blog7V2PostsId = blog?.id,
         super._();
 
   const _Post7V2._({
@@ -547,7 +532,7 @@ class _Post7V2 extends Post7V2 {
   final String title;
 
   @override
-  final AsyncModel<String, Blog7V2, PartialBlog7V2, Blog7V2>? blog;
+  final Blog7V2? blog;
 
   @override
   final AsyncModelCollection<String, Comment7V2, PartialComment7V2, Comment7V2>?
@@ -595,27 +580,6 @@ class _RemotePost7V2 extends RemotePost7V2 {
             'title',
           ))
         : (json['title'] as String);
-    final blog = json['blog'] == null
-        ? null
-        : AsyncModel<String, Blog7V2, PartialBlog7V2, RemoteBlog7V2>.fromModel(
-            Blog7V2.classType.fromJson<RemoteBlog7V2>(
-              (json['blog'] as Map<String, Object?>),
-            ),
-          );
-    final comments = json['comments'] == null
-        ? null
-        : AsyncModelCollection<String, Comment7V2, PartialComment7V2,
-            RemoteComment7V2>.fromList(
-            (json['comments'] as List<Object?>)
-                .cast<Map<String, Object?>?>()
-                .map(
-                  (el) => el == null
-                      ? null
-                      : Comment7V2.classType.fromJson<RemoteComment7V2>(el),
-                )
-                .whereType<RemoteComment7V2>()
-                .toList(),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Post7V2',
@@ -649,6 +613,24 @@ class _RemotePost7V2 extends RemotePost7V2 {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final blog = json['blog'] == null
+        ? null
+        : Blog7V2.classType
+            .fromJson<RemoteBlog7V2>((json['blog'] as Map<String, Object?>));
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment7V2, PartialComment7V2,
+            RemoteComment7V2>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment7V2.classType.fromJson<RemoteComment7V2>(el),
+                )
+                .whereType<RemoteComment7V2>()
+                .toList(),
+          );
     return _RemotePost7V2(
       id: id,
       title: title,
@@ -670,11 +652,11 @@ class _RemotePost7V2 extends RemotePost7V2 {
   final String title;
 
   @override
-  final AsyncModel<String, Blog7V2, PartialBlog7V2, RemoteBlog7V2>? blog;
+  final RemoteBlog7V2? blog;
 
   @override
-  final AsyncModelCollection<String, Comment7V2, PartialComment7V2,
-      RemoteComment7V2>? comments;
+  final AsyncModelCollection<String, Comment7V2, PartialComment7V2, Comment7V2>?
+      comments;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/post7_v2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/post7_v2.dart
@@ -1,0 +1,592 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.post7_v2;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'blog7_v2.dart';
+import 'comment7_v2.dart';
+
+class Post7V2Type extends ModelType<String, Post7V2, PartialPost7V2> {
+  const Post7V2Type();
+
+  @override
+  T fromJson<T extends PartialModel<String, Post7V2>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Post7V2 || T == Model<String, Post7V2>) {
+      return Post7V2.fromJson(json) as T;
+    }
+    if (T == RemotePost7V2 || T == RemoteModel<String, Post7V2>) {
+      return _RemotePost7V2.fromJson(json) as T;
+    }
+    return _PartialPost7V2.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Post7V2';
+}
+
+class Post7V2QueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const Post7V2QueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Post7V2>? _root;
+
+  /// Query field for the [Post7V2.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Post7V2, String>(
+        const QueryField<String, Post7V2, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Post7V2.title] field.
+  QueryField<ModelIdentifier, M, String> get $title =>
+      NestedQueryField<ModelIdentifier, M, String, Post7V2, String>(
+        const QueryField<String, Post7V2, String>(fieldName: 'title'),
+        root: _root,
+      );
+
+  /// Query field for the [Post7V2.blog] field.
+  Blog7V2QueryFields<ModelIdentifier, M> get $blog => Blog7V2QueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Post7V2, Blog7V2>(
+          const QueryField<String, Post7V2, Blog7V2>(fieldName: 'blog'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Post7V2.comments] field.
+  Comment7V2QueryFields<ModelIdentifier, M> get $comments =>
+      Comment7V2QueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Post7V2, Comment7V2>(
+          const QueryField<String, Post7V2, Comment7V2>(fieldName: 'comments'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Post7V2.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post7V2, TemporalDateTime>(
+        const QueryField<String, Post7V2, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post7V2.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post7V2, TemporalDateTime>(
+        const QueryField<String, Post7V2, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post7V2.blog7V2PostsId] field.
+  QueryField<ModelIdentifier, M, String?> get $blog7V2PostsId =>
+      NestedQueryField<ModelIdentifier, M, String, Post7V2, String?>(
+        const QueryField<String, Post7V2, String?>(fieldName: 'blog7V2PostsId'),
+        root: _root,
+      );
+
+  /// Query field for the [Post7V2] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Post7V2, String>(
+        const QueryField<String, Post7V2, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialPost7V2 extends PartialModel<String, Post7V2>
+    with AWSEquatable<PartialPost7V2> {
+  const PartialPost7V2._();
+
+  String get id;
+  String? get title;
+  AsyncModel<String, Blog7V2, PartialBlog7V2, PartialBlog7V2>? get blog;
+  AsyncModelCollection<String, Comment7V2, PartialComment7V2,
+      PartialComment7V2>? get comments;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String? get blog7V2PostsId;
+  @override
+  String get modelIdentifier => id;
+  @override
+  Post7V2Type get modelType => Post7V2.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        blog,
+        comments,
+        createdAt,
+        updatedAt,
+        blog7V2PostsId,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'title': title,
+        'blog': blog?.toJson(),
+        'comments': comments?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'blog7V2PostsId': blog7V2PostsId,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Post7V2';
+}
+
+class _PartialPost7V2 extends PartialPost7V2 {
+  const _PartialPost7V2({
+    required this.id,
+    this.title,
+    this.blog,
+    this.comments,
+    this.createdAt,
+    this.updatedAt,
+    this.blog7V2PostsId,
+  }) : super._();
+
+  factory _PartialPost7V2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post7V2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null ? null : (json['title'] as String);
+    final blog = json['blog'] == null
+        ? null
+        : AsyncModel<String, Blog7V2, PartialBlog7V2, PartialBlog7V2>.fromModel(
+            Blog7V2.classType.fromJson<PartialBlog7V2>(
+              (json['blog'] as Map<String, Object?>),
+            ),
+          );
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment7V2, PartialComment7V2,
+            PartialComment7V2>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment7V2.classType.fromJson<PartialComment7V2>(el),
+                )
+                .whereType<PartialComment7V2>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final blog7V2PostsId = json['blog7V2PostsId'] == null
+        ? null
+        : (json['blog7V2PostsId'] as String);
+    return _PartialPost7V2(
+      id: id,
+      title: title,
+      blog: blog,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      blog7V2PostsId: blog7V2PostsId,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? title;
+
+  @override
+  final AsyncModel<String, Blog7V2, PartialBlog7V2, PartialBlog7V2>? blog;
+
+  @override
+  final AsyncModelCollection<String, Comment7V2, PartialComment7V2,
+      PartialComment7V2>? comments;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String? blog7V2PostsId;
+}
+
+abstract class Post7V2 extends PartialPost7V2
+    implements Model<String, Post7V2> {
+  factory Post7V2({
+    String? id,
+    required String title,
+    Blog7V2? blog,
+    List<Comment7V2>? comments,
+    String? blog7V2PostsId,
+  }) = _Post7V2;
+
+  const Post7V2._() : super._();
+
+  factory Post7V2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post7V2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post7V2',
+            'title',
+          ))
+        : (json['title'] as String);
+    final blog = json['blog'] == null
+        ? null
+        : AsyncModel<String, Blog7V2, PartialBlog7V2, Blog7V2>.fromModel(
+            Blog7V2.classType
+                .fromJson<Blog7V2>((json['blog'] as Map<String, Object?>)),
+          );
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment7V2, PartialComment7V2,
+            Comment7V2>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment7V2.classType.fromJson<Comment7V2>(el),
+                )
+                .whereType<Comment7V2>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post7V2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post7V2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final blog7V2PostsId = json['blog7V2PostsId'] == null
+        ? null
+        : (json['blog7V2PostsId'] as String);
+    return _Post7V2._(
+      id: id,
+      title: title,
+      blog: blog,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      blog7V2PostsId: blog7V2PostsId,
+    );
+  }
+
+  static const Post7V2Type classType = Post7V2Type();
+
+  static const Post7V2QueryFields<String, Post7V2> _queryFields =
+      Post7V2QueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Post7V2, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Post7V2, String> get ID => $id;
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<String, Post7V2, String> get $title => _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<String, Post7V2, String> get TITLE => $title;
+  @override
+  AsyncModel<String, Blog7V2, PartialBlog7V2, Blog7V2>? get blog;
+
+  /// Query field for the [blog] field.
+  Blog7V2QueryFields<String, Post7V2> get $blog => _queryFields.$blog;
+
+  /// Query field for the [blog] field.
+  @Deprecated(r'Use $blog instead')
+  Blog7V2QueryFields<String, Post7V2> get BLOG => $blog;
+  @override
+  AsyncModelCollection<String, Comment7V2, PartialComment7V2, Comment7V2>?
+      get comments;
+
+  /// Query field for the [comments] field.
+  Comment7V2QueryFields<String, Post7V2> get $comments =>
+      _queryFields.$comments;
+
+  /// Query field for the [comments] field.
+  @Deprecated(r'Use $comments instead')
+  Comment7V2QueryFields<String, Post7V2> get COMMENTS => $comments;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String? get blog7V2PostsId;
+
+  /// Query field for the [blog7V2PostsId] field.
+  QueryField<String, Post7V2, String?> get $blog7V2PostsId =>
+      _queryFields.$blog7V2PostsId;
+
+  /// Query field for the [blog7V2PostsId] field.
+  @Deprecated(r'Use $blog7V2PostsId instead')
+  QueryField<String, Post7V2, String?> get BLOG7_V2_POSTS_ID => $blog7V2PostsId;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Post7V2, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Post7V2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Post7V2, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'blog':
+        value = blog;
+        break;
+      case r'comments':
+        value = comments;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'blog7V2PostsId':
+        value = blog7V2PostsId;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Post7V2 extends Post7V2 {
+  _Post7V2({
+    String? id,
+    required this.title,
+    Blog7V2? blog,
+    List<Comment7V2>? comments,
+    this.blog7V2PostsId,
+  })  : id = id ?? uuid(),
+        blog = blog == null ? null : AsyncModel.fromModel(blog),
+        comments =
+            comments == null ? null : AsyncModelCollection.fromList(comments),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Post7V2._({
+    required this.id,
+    required this.title,
+    this.blog,
+    this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+    this.blog7V2PostsId,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final AsyncModel<String, Blog7V2, PartialBlog7V2, Blog7V2>? blog;
+
+  @override
+  final AsyncModelCollection<String, Comment7V2, PartialComment7V2, Comment7V2>?
+      comments;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? blog7V2PostsId;
+}
+
+abstract class RemotePost7V2 extends Post7V2
+    implements RemoteModel<String, Post7V2> {
+  const RemotePost7V2._() : super._();
+}
+
+class _RemotePost7V2 extends RemotePost7V2 {
+  const _RemotePost7V2({
+    required this.id,
+    required this.title,
+    this.blog,
+    this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+    this.blog7V2PostsId,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemotePost7V2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post7V2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post7V2',
+            'title',
+          ))
+        : (json['title'] as String);
+    final blog = json['blog'] == null
+        ? null
+        : AsyncModel<String, Blog7V2, PartialBlog7V2, RemoteBlog7V2>.fromModel(
+            Blog7V2.classType.fromJson<RemoteBlog7V2>(
+              (json['blog'] as Map<String, Object?>),
+            ),
+          );
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment7V2, PartialComment7V2,
+            RemoteComment7V2>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment7V2.classType.fromJson<RemoteComment7V2>(el),
+                )
+                .whereType<RemoteComment7V2>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post7V2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post7V2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final blog7V2PostsId = json['blog7V2PostsId'] == null
+        ? null
+        : (json['blog7V2PostsId'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Post7V2',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Post7V2',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Post7V2',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemotePost7V2(
+      id: id,
+      title: title,
+      blog: blog,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      blog7V2PostsId: blog7V2PostsId,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final AsyncModel<String, Blog7V2, PartialBlog7V2, RemoteBlog7V2>? blog;
+
+  @override
+  final AsyncModelCollection<String, Comment7V2, PartialComment7V2,
+      RemoteComment7V2>? comments;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? blog7V2PostsId;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/post7_v2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_many_implicit/post7_v2.dart
@@ -377,6 +377,30 @@ abstract class Post7V2 extends PartialPost7V2
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Post7V2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Post7V2 copyWith({
+    String? id,
+    String? title,
+    Blog7V2? blog,
+    List<Comment7V2>? comments,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? blog7V2PostsId,
+  }) {
+    return _Post7V2._(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      blog: blog == null ? this.blog : AsyncModel.fromModel(blog),
+      comments: comments == null
+          ? this.comments
+          : AsyncModelCollection.fromList(comments),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      blog7V2PostsId: blog7V2PostsId ?? this.blog7V2PostsId,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Post7V2, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'project2.dart';
+import 'team2.dart';
+
+export 'project2.dart';
+export 'team2.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'dafb4cb46a8d8cb760d24f2ca261fd2f';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Project2.schema,
+        Team2.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Project2':
+        return (Project2.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Team2':
+        return (Team2.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/project2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/project2.dart
@@ -167,12 +167,6 @@ class _PartialProject2 extends PartialProject2 {
           ))
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<String, Team2, PartialTeam2, PartialTeam2>.fromModel(
-            Team2.classType
-                .fromJson<PartialTeam2>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
@@ -182,6 +176,18 @@ class _PartialProject2 extends PartialProject2 {
     final project2TeamId = json['project2TeamId'] == null
         ? null
         : (json['project2TeamId'] as String);
+    final team = json['team'] == null
+        ? project2TeamId == null
+            ? null
+            : AsyncModel<String, Team2, PartialTeam2,
+                PartialTeam2>.fromModelIdentifier(
+                Team2.classType,
+                project2TeamId,
+              )
+        : AsyncModel<String, Team2, PartialTeam2, PartialTeam2>.fromModel(
+            Team2.classType
+                .fromJson<PartialTeam2>((json['team'] as Map<String, Object?>)),
+          );
     return _PartialProject2(
       id: id,
       name: name,
@@ -230,12 +236,6 @@ abstract class Project2 extends PartialProject2
           ))
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<String, Team2, PartialTeam2, Team2>.fromModel(
-            Team2.classType
-                .fromJson<Team2>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Project2',
@@ -251,6 +251,18 @@ abstract class Project2 extends PartialProject2
     final project2TeamId = json['project2TeamId'] == null
         ? null
         : (json['project2TeamId'] as String);
+    final team = json['team'] == null
+        ? project2TeamId == null
+            ? null
+            : AsyncModel<String, Team2, PartialTeam2,
+                Team2>.fromModelIdentifier(
+                Team2.classType,
+                project2TeamId,
+              )
+        : AsyncModel<String, Team2, PartialTeam2, Team2>.fromModel(
+            Team2.classType
+                .fromJson<Team2>((json['team'] as Map<String, Object?>)),
+          );
     return _Project2._(
       id: id,
       name: name,
@@ -493,12 +505,6 @@ class _RemoteProject2 extends RemoteProject2 {
           ))
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<String, Team2, PartialTeam2, RemoteTeam2>.fromModel(
-            Team2.classType
-                .fromJson<RemoteTeam2>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Project2',
@@ -532,6 +538,18 @@ class _RemoteProject2 extends RemoteProject2 {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final team = json['team'] == null
+        ? project2TeamId == null
+            ? null
+            : AsyncModel<String, Team2, PartialTeam2,
+                RemoteTeam2>.fromModelIdentifier(
+                Team2.classType,
+                project2TeamId,
+              )
+        : AsyncModel<String, Team2, PartialTeam2, RemoteTeam2>.fromModel(
+            Team2.classType
+                .fromJson<RemoteTeam2>((json['team'] as Map<String, Object?>)),
+          );
     return _RemoteProject2(
       id: id,
       name: name,
@@ -552,7 +570,7 @@ class _RemoteProject2 extends RemoteProject2 {
   final String? name;
 
   @override
-  final AsyncModel<String, Team2, PartialTeam2, RemoteTeam2>? team;
+  final AsyncModel<String, Team2, PartialTeam2, Team2>? team;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/project2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/project2.dart
@@ -1,0 +1,492 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.project2;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'team2.dart';
+
+class Project2Type extends ModelType<String, Project2, PartialProject2> {
+  const Project2Type();
+
+  @override
+  T fromJson<T extends PartialModel<String, Project2>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Project2 || T == Model<String, Project2>) {
+      return Project2.fromJson(json) as T;
+    }
+    if (T == RemoteProject2 || T == RemoteModel<String, Project2>) {
+      return _RemoteProject2.fromJson(json) as T;
+    }
+    return _PartialProject2.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Project2';
+}
+
+class Project2QueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const Project2QueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Project2>? _root;
+
+  /// Query field for the [Project2.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Project2, String>(
+        const QueryField<String, Project2, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Project2.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, Project2, String?>(
+        const QueryField<String, Project2, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Project2.team] field.
+  Team2QueryFields<ModelIdentifier, M> get $team => Team2QueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Project2, Team2>(
+          const QueryField<String, Project2, Team2>(fieldName: 'team'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Project2.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Project2, TemporalDateTime>(
+        const QueryField<String, Project2, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project2.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Project2, TemporalDateTime>(
+        const QueryField<String, Project2, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project2.project2TeamId] field.
+  QueryField<ModelIdentifier, M, String?> get $project2TeamId =>
+      NestedQueryField<ModelIdentifier, M, String, Project2, String?>(
+        const QueryField<String, Project2, String?>(
+          fieldName: 'project2TeamId',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project2] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Project2, String>(
+        const QueryField<String, Project2, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialProject2 extends PartialModel<String, Project2>
+    with AWSEquatable<PartialProject2> {
+  const PartialProject2._();
+
+  String get id;
+  String? get name;
+  AsyncModel<String, Team2, PartialTeam2, PartialTeam2>? get team;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String? get project2TeamId;
+  @override
+  String get modelIdentifier => id;
+  @override
+  Project2Type get modelType => Project2.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        team,
+        createdAt,
+        updatedAt,
+        project2TeamId,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'team': team?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'project2TeamId': project2TeamId,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Project2';
+}
+
+class _PartialProject2 extends PartialProject2 {
+  const _PartialProject2({
+    required this.id,
+    this.name,
+    this.team,
+    this.createdAt,
+    this.updatedAt,
+    this.project2TeamId,
+  }) : super._();
+
+  factory _PartialProject2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<String, Team2, PartialTeam2, PartialTeam2>.fromModel(
+            Team2.classType
+                .fromJson<PartialTeam2>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final project2TeamId = json['project2TeamId'] == null
+        ? null
+        : (json['project2TeamId'] as String);
+    return _PartialProject2(
+      id: id,
+      name: name,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      project2TeamId: project2TeamId,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final AsyncModel<String, Team2, PartialTeam2, PartialTeam2>? team;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String? project2TeamId;
+}
+
+abstract class Project2 extends PartialProject2
+    implements Model<String, Project2> {
+  factory Project2({
+    String? id,
+    String? name,
+    Team2? team,
+    String? project2TeamId,
+  }) = _Project2;
+
+  const Project2._() : super._();
+
+  factory Project2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<String, Team2, PartialTeam2, Team2>.fromModel(
+            Team2.classType
+                .fromJson<Team2>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final project2TeamId = json['project2TeamId'] == null
+        ? null
+        : (json['project2TeamId'] as String);
+    return _Project2._(
+      id: id,
+      name: name,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      project2TeamId: project2TeamId,
+    );
+  }
+
+  static const Project2Type classType = Project2Type();
+
+  static const Project2QueryFields<String, Project2> _queryFields =
+      Project2QueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Project2, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Project2, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, Project2, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, Project2, String?> get NAME => $name;
+  @override
+  AsyncModel<String, Team2, PartialTeam2, Team2>? get team;
+
+  /// Query field for the [team] field.
+  Team2QueryFields<String, Project2> get $team => _queryFields.$team;
+
+  /// Query field for the [team] field.
+  @Deprecated(r'Use $team instead')
+  Team2QueryFields<String, Project2> get TEAM => $team;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String? get project2TeamId;
+
+  /// Query field for the [project2TeamId] field.
+  QueryField<String, Project2, String?> get $project2TeamId =>
+      _queryFields.$project2TeamId;
+
+  /// Query field for the [project2TeamId] field.
+  @Deprecated(r'Use $project2TeamId instead')
+  QueryField<String, Project2, String?> get PROJECT2_TEAM_ID => $project2TeamId;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Project2, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Project2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Project2, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'team':
+        value = team;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'project2TeamId':
+        value = project2TeamId;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Project2 extends Project2 {
+  _Project2({
+    String? id,
+    this.name,
+    Team2? team,
+    this.project2TeamId,
+  })  : id = id ?? uuid(),
+        team = team == null ? null : AsyncModel.fromModel(team),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Project2._({
+    required this.id,
+    this.name,
+    this.team,
+    required this.createdAt,
+    required this.updatedAt,
+    this.project2TeamId,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final AsyncModel<String, Team2, PartialTeam2, Team2>? team;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? project2TeamId;
+}
+
+abstract class RemoteProject2 extends Project2
+    implements RemoteModel<String, Project2> {
+  const RemoteProject2._() : super._();
+}
+
+class _RemoteProject2 extends RemoteProject2 {
+  const _RemoteProject2({
+    required this.id,
+    this.name,
+    this.team,
+    required this.createdAt,
+    required this.updatedAt,
+    this.project2TeamId,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteProject2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<String, Team2, PartialTeam2, RemoteTeam2>.fromModel(
+            Team2.classType
+                .fromJson<RemoteTeam2>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final project2TeamId = json['project2TeamId'] == null
+        ? null
+        : (json['project2TeamId'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteProject2(
+      id: id,
+      name: name,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      project2TeamId: project2TeamId,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final AsyncModel<String, Team2, PartialTeam2, RemoteTeam2>? team;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? project2TeamId;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/project2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/project2.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.project2;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'team2.dart';
 
@@ -264,6 +265,67 @@ abstract class Project2 extends PartialProject2
 
   static const Project2QueryFields<String, Project2> _queryFields =
       Project2QueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Project2',
+      'pluralName': 'Project2s',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'team': {
+          'name': 'team',
+          'type': {'model': 'Team2'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'Team2',
+            'associatedFields': ['project'],
+            'targetNames': ['project2TeamId'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'project2TeamId': {
+          'name': 'project2TeamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/project2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/project2.dart
@@ -314,6 +314,26 @@ abstract class Project2 extends PartialProject2
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Project2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Project2 copyWith({
+    String? id,
+    String? name,
+    Team2? team,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? project2TeamId,
+  }) {
+    return _Project2._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      team: team == null ? this.team : AsyncModel.fromModel(team),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      project2TeamId: project2TeamId ?? this.project2TeamId,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Project2, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/team2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/team2.dart
@@ -1,0 +1,494 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.team2;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'project2.dart';
+
+class Team2Type extends ModelType<String, Team2, PartialTeam2> {
+  const Team2Type();
+
+  @override
+  T fromJson<T extends PartialModel<String, Team2>>(Map<String, Object?> json) {
+    if (T == Team2 || T == Model<String, Team2>) {
+      return Team2.fromJson(json) as T;
+    }
+    if (T == RemoteTeam2 || T == RemoteModel<String, Team2>) {
+      return _RemoteTeam2.fromJson(json) as T;
+    }
+    return _PartialTeam2.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Team2';
+}
+
+class Team2QueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const Team2QueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Team2>? _root;
+
+  /// Query field for the [Team2.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Team2, String>(
+        const QueryField<String, Team2, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Team2.name] field.
+  QueryField<ModelIdentifier, M, String> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, Team2, String>(
+        const QueryField<String, Team2, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Team2.projectId] field.
+  QueryField<ModelIdentifier, M, String?> get $projectId =>
+      NestedQueryField<ModelIdentifier, M, String, Team2, String?>(
+        const QueryField<String, Team2, String?>(fieldName: 'projectID'),
+        root: _root,
+      );
+
+  /// Query field for the [Team2.project] field.
+  Project2QueryFields<ModelIdentifier, M> get $project => Project2QueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Team2, Project2>(
+          const QueryField<String, Team2, Project2>(fieldName: 'project'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Team2.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Team2, TemporalDateTime>(
+        const QueryField<String, Team2, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Team2.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Team2, TemporalDateTime>(
+        const QueryField<String, Team2, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Team2] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Team2, String>(
+        const QueryField<String, Team2, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialTeam2 extends PartialModel<String, Team2>
+    with AWSEquatable<PartialTeam2> {
+  const PartialTeam2._();
+
+  String get id;
+  String? get name;
+  String? get projectId;
+  AsyncModel<String, Project2, PartialProject2, PartialProject2>? get project;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  Team2Type get modelType => Team2.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        projectId,
+        project,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'projectID': projectId,
+        'project': project?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Team2';
+}
+
+class _PartialTeam2 extends PartialTeam2 {
+  const _PartialTeam2({
+    required this.id,
+    this.name,
+    this.projectId,
+    this.project,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialTeam2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final projectId =
+        json['projectID'] == null ? null : (json['projectID'] as String);
+    final project = json['project'] == null
+        ? null
+        : AsyncModel<String, Project2, PartialProject2,
+            PartialProject2>.fromModel(
+            Project2.classType.fromJson<PartialProject2>(
+              (json['project'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialTeam2(
+      id: id,
+      name: name,
+      projectId: projectId,
+      project: project,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? projectId;
+
+  @override
+  final AsyncModel<String, Project2, PartialProject2, PartialProject2>? project;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
+  factory Team2({
+    String? id,
+    required String name,
+    String? projectId,
+    Project2? project,
+  }) = _Team2;
+
+  const Team2._() : super._();
+
+  factory Team2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'name',
+          ))
+        : (json['name'] as String);
+    final projectId =
+        json['projectID'] == null ? null : (json['projectID'] as String);
+    final project = json['project'] == null
+        ? null
+        : AsyncModel<String, Project2, PartialProject2, Project2>.fromModel(
+            Project2.classType
+                .fromJson<Project2>((json['project'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Team2._(
+      id: id,
+      name: name,
+      projectId: projectId,
+      project: project,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const Team2Type classType = Team2Type();
+
+  static const Team2QueryFields<String, Team2> _queryFields =
+      Team2QueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Team2, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Team2, String> get ID => $id;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, Team2, String> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, Team2, String> get NAME => $name;
+  @override
+  String? get projectId;
+
+  /// Query field for the [projectId] field.
+  QueryField<String, Team2, String?> get $projectId => _queryFields.$projectId;
+
+  /// Query field for the [projectId] field.
+  @Deprecated(r'Use $projectId instead')
+  QueryField<String, Team2, String?> get PROJECT_ID => $projectId;
+  @override
+  AsyncModel<String, Project2, PartialProject2, Project2>? get project;
+
+  /// Query field for the [project] field.
+  Project2QueryFields<String, Team2> get $project => _queryFields.$project;
+
+  /// Query field for the [project] field.
+  @Deprecated(r'Use $project instead')
+  Project2QueryFields<String, Team2> get PROJECT => $project;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Team2, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Team2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Team2, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'projectID':
+        value = projectId;
+        break;
+      case r'project':
+        value = project;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Team2 extends Team2 {
+  _Team2({
+    String? id,
+    required this.name,
+    this.projectId,
+    Project2? project,
+  })  : id = id ?? uuid(),
+        project = project == null ? null : AsyncModel.fromModel(project),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Team2._({
+    required this.id,
+    required this.name,
+    this.projectId,
+    this.project,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final String? projectId;
+
+  @override
+  final AsyncModel<String, Project2, PartialProject2, Project2>? project;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteTeam2 extends Team2 implements RemoteModel<String, Team2> {
+  const RemoteTeam2._() : super._();
+}
+
+class _RemoteTeam2 extends RemoteTeam2 {
+  const _RemoteTeam2({
+    required this.id,
+    required this.name,
+    this.projectId,
+    this.project,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteTeam2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'name',
+          ))
+        : (json['name'] as String);
+    final projectId =
+        json['projectID'] == null ? null : (json['projectID'] as String);
+    final project = json['project'] == null
+        ? null
+        : AsyncModel<String, Project2, PartialProject2,
+            RemoteProject2>.fromModel(
+            Project2.classType.fromJson<RemoteProject2>(
+              (json['project'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteTeam2(
+      id: id,
+      name: name,
+      projectId: projectId,
+      project: project,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final String? projectId;
+
+  @override
+  final AsyncModel<String, Project2, PartialProject2, RemoteProject2>? project;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/team2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/team2.dart
@@ -111,7 +111,7 @@ abstract class PartialTeam2 extends PartialModel<String, Team2>
   String get id;
   String? get name;
   String? get projectId;
-  AsyncModel<String, Project2, PartialProject2, PartialProject2>? get project;
+  PartialProject2? get project;
   TemporalDateTime? get createdAt;
   TemporalDateTime? get updatedAt;
   @override
@@ -163,20 +163,17 @@ class _PartialTeam2 extends PartialTeam2 {
     final name = json['name'] == null ? null : (json['name'] as String);
     final projectId =
         json['projectID'] == null ? null : (json['projectID'] as String);
-    final project = json['project'] == null
-        ? null
-        : AsyncModel<String, Project2, PartialProject2,
-            PartialProject2>.fromModel(
-            Project2.classType.fromJson<PartialProject2>(
-              (json['project'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
     final updatedAt = json['updatedAt'] == null
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final project = json['project'] == null
+        ? null
+        : Project2.classType.fromJson<PartialProject2>(
+            (json['project'] as Map<String, Object?>),
+          );
     return _PartialTeam2(
       id: id,
       name: name,
@@ -197,7 +194,7 @@ class _PartialTeam2 extends PartialTeam2 {
   final String? projectId;
 
   @override
-  final AsyncModel<String, Project2, PartialProject2, PartialProject2>? project;
+  final PartialProject2? project;
 
   @override
   final TemporalDateTime? createdAt;
@@ -231,12 +228,6 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
         : (json['name'] as String);
     final projectId =
         json['projectID'] == null ? null : (json['projectID'] as String);
-    final project = json['project'] == null
-        ? null
-        : AsyncModel<String, Project2, PartialProject2, Project2>.fromModel(
-            Project2.classType
-                .fromJson<Project2>((json['project'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Team2',
@@ -249,6 +240,10 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
             'updatedAt',
           ))
         : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final project = json['project'] == null
+        ? null
+        : Project2.classType
+            .fromJson<Project2>((json['project'] as Map<String, Object?>));
     return _Team2._(
       id: id,
       name: name,
@@ -358,7 +353,7 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
   @Deprecated(r'Use $projectId instead')
   QueryField<String, Team2, String?> get PROJECT_ID => $projectId;
   @override
-  AsyncModel<String, Project2, PartialProject2, Project2>? get project;
+  Project2? get project;
 
   /// Query field for the [project] field.
   Project2QueryFields<String, Team2> get $project => _queryFields.$project;
@@ -390,7 +385,7 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
       id: id ?? this.id,
       name: name ?? this.name,
       projectId: projectId ?? this.projectId,
-      project: project == null ? this.project : AsyncModel.fromModel(project),
+      project: project ?? this.project,
       createdAt:
           createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
       updatedAt:
@@ -434,9 +429,8 @@ class _Team2 extends Team2 {
     String? id,
     required this.name,
     this.projectId,
-    Project2? project,
+    this.project,
   })  : id = id ?? uuid(),
-        project = project == null ? null : AsyncModel.fromModel(project),
         createdAt = TemporalDateTime.now(),
         updatedAt = TemporalDateTime.now(),
         super._();
@@ -460,7 +454,7 @@ class _Team2 extends Team2 {
   final String? projectId;
 
   @override
-  final AsyncModel<String, Project2, PartialProject2, Project2>? project;
+  final Project2? project;
 
   @override
   final TemporalDateTime createdAt;
@@ -501,14 +495,6 @@ class _RemoteTeam2 extends RemoteTeam2 {
         : (json['name'] as String);
     final projectId =
         json['projectID'] == null ? null : (json['projectID'] as String);
-    final project = json['project'] == null
-        ? null
-        : AsyncModel<String, Project2, PartialProject2,
-            RemoteProject2>.fromModel(
-            Project2.classType.fromJson<RemoteProject2>(
-              (json['project'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Team2',
@@ -539,6 +525,11 @@ class _RemoteTeam2 extends RemoteTeam2 {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final project = json['project'] == null
+        ? null
+        : Project2.classType.fromJson<RemoteProject2>(
+            (json['project'] as Map<String, Object?>),
+          );
     return _RemoteTeam2(
       id: id,
       name: name,
@@ -562,7 +553,7 @@ class _RemoteTeam2 extends RemoteTeam2 {
   final String? projectId;
 
   @override
-  final AsyncModel<String, Project2, PartialProject2, RemoteProject2>? project;
+  final RemoteProject2? project;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/team2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/team2.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.team2;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'project2.dart';
 
@@ -262,6 +263,72 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
 
   static const Team2QueryFields<String, Team2> _queryFields =
       Team2QueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Team2',
+      'pluralName': 'Team2s',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'projectID': {
+          'name': 'projectID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'project': {
+          'name': 'project',
+          'type': {'model': 'Project2'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Project2',
+            'targetNames': ['projectID'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'project',
+          'sortKeyFields': ['projectID'],
+          'name': 'project',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/team2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_explicit/team2.dart
@@ -311,6 +311,26 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Team2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Team2 copyWith({
+    String? id,
+    String? name,
+    String? projectId,
+    Project2? project,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Team2._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      projectId: projectId ?? this.projectId,
+      project: project == null ? this.project : AsyncModel.fromModel(project),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Team2, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'project.dart';
+import 'team.dart';
+
+export 'project.dart';
+export 'team.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '173ab382cb2b7eeb4d69efc225a1960c';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Project.schema,
+        Team.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Project':
+        return (Project.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Team':
+        return (Team.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/model_provider.dart
@@ -35,7 +35,7 @@ class ModelProvider extends ModelProviderInterface {
   static final instance = ModelProvider._();
 
   @override
-  String get version => '173ab382cb2b7eeb4d69efc225a1960c';
+  String get version => 'c58bcf3f6c0a70f6d3380839523dcbc6';
   @override
   List<mipr.ModelTypeDefinition> get modelSchemas => [
         Project.schema,

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/project.dart
@@ -310,6 +310,26 @@ abstract class Project extends PartialProject
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Project, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Project copyWith({
+    String? id,
+    String? name,
+    Team? team,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? projectTeamId,
+  }) {
+    return _Project._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      team: team == null ? this.team : AsyncModel.fromModel(team),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      projectTeamId: projectTeamId ?? this.projectTeamId,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Project, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/project.dart
@@ -163,12 +163,6 @@ class _PartialProject extends PartialProject {
           ))
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<String, Team, PartialTeam, PartialTeam>.fromModel(
-            Team.classType
-                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
@@ -178,6 +172,18 @@ class _PartialProject extends PartialProject {
     final projectTeamId = json['projectTeamId'] == null
         ? null
         : (json['projectTeamId'] as String);
+    final team = json['team'] == null
+        ? projectTeamId == null
+            ? null
+            : AsyncModel<String, Team, PartialTeam,
+                PartialTeam>.fromModelIdentifier(
+                Team.classType,
+                projectTeamId,
+              )
+        : AsyncModel<String, Team, PartialTeam, PartialTeam>.fromModel(
+            Team.classType
+                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)),
+          );
     return _PartialProject(
       id: id,
       name: name,
@@ -226,12 +232,6 @@ abstract class Project extends PartialProject
           ))
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<String, Team, PartialTeam, Team>.fromModel(
-            Team.classType
-                .fromJson<Team>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Project',
@@ -247,6 +247,17 @@ abstract class Project extends PartialProject
     final projectTeamId = json['projectTeamId'] == null
         ? null
         : (json['projectTeamId'] as String);
+    final team = json['team'] == null
+        ? projectTeamId == null
+            ? null
+            : AsyncModel<String, Team, PartialTeam, Team>.fromModelIdentifier(
+                Team.classType,
+                projectTeamId,
+              )
+        : AsyncModel<String, Team, PartialTeam, Team>.fromModel(
+            Team.classType
+                .fromJson<Team>((json['team'] as Map<String, Object?>)),
+          );
     return _Project._(
       id: id,
       name: name,
@@ -489,12 +500,6 @@ class _RemoteProject extends RemoteProject {
           ))
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<String, Team, PartialTeam, RemoteTeam>.fromModel(
-            Team.classType
-                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Project',
@@ -528,6 +533,18 @@ class _RemoteProject extends RemoteProject {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final team = json['team'] == null
+        ? projectTeamId == null
+            ? null
+            : AsyncModel<String, Team, PartialTeam,
+                RemoteTeam>.fromModelIdentifier(
+                Team.classType,
+                projectTeamId,
+              )
+        : AsyncModel<String, Team, PartialTeam, RemoteTeam>.fromModel(
+            Team.classType
+                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)),
+          );
     return _RemoteProject(
       id: id,
       name: name,
@@ -548,7 +565,7 @@ class _RemoteProject extends RemoteProject {
   final String? name;
 
   @override
-  final AsyncModel<String, Team, PartialTeam, RemoteTeam>? team;
+  final AsyncModel<String, Team, PartialTeam, Team>? team;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/project.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.project;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'team.dart';
 
@@ -260,6 +261,67 @@ abstract class Project extends PartialProject
 
   static const ProjectQueryFields<String, Project> _queryFields =
       ProjectQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Project',
+      'pluralName': 'Projects',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'team': {
+          'name': 'team',
+          'type': {'model': 'Team'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'Team',
+            'associatedFields': ['project'],
+            'targetNames': ['projectTeamId'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'projectTeamId': {
+          'name': 'projectTeamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/project.dart
@@ -1,0 +1,488 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.project;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'team.dart';
+
+class ProjectType extends ModelType<String, Project, PartialProject> {
+  const ProjectType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Project>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Project || T == Model<String, Project>) {
+      return Project.fromJson(json) as T;
+    }
+    if (T == RemoteProject || T == RemoteModel<String, Project>) {
+      return _RemoteProject.fromJson(json) as T;
+    }
+    return _PartialProject.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Project';
+}
+
+class ProjectQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ProjectQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Project>? _root;
+
+  /// Query field for the [Project.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Project, String>(
+        const QueryField<String, Project, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Project.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, Project, String?>(
+        const QueryField<String, Project, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Project.team] field.
+  TeamQueryFields<ModelIdentifier, M> get $team => TeamQueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Project, Team>(
+          const QueryField<String, Project, Team>(fieldName: 'team'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Project.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Project, TemporalDateTime>(
+        const QueryField<String, Project, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Project, TemporalDateTime>(
+        const QueryField<String, Project, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project.projectTeamId] field.
+  QueryField<ModelIdentifier, M, String?> get $projectTeamId =>
+      NestedQueryField<ModelIdentifier, M, String, Project, String?>(
+        const QueryField<String, Project, String?>(fieldName: 'projectTeamId'),
+        root: _root,
+      );
+
+  /// Query field for the [Project] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Project, String>(
+        const QueryField<String, Project, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialProject extends PartialModel<String, Project>
+    with AWSEquatable<PartialProject> {
+  const PartialProject._();
+
+  String get id;
+  String? get name;
+  AsyncModel<String, Team, PartialTeam, PartialTeam>? get team;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String? get projectTeamId;
+  @override
+  String get modelIdentifier => id;
+  @override
+  ProjectType get modelType => Project.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        team,
+        createdAt,
+        updatedAt,
+        projectTeamId,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'team': team?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'projectTeamId': projectTeamId,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Project';
+}
+
+class _PartialProject extends PartialProject {
+  const _PartialProject({
+    required this.id,
+    this.name,
+    this.team,
+    this.createdAt,
+    this.updatedAt,
+    this.projectTeamId,
+  }) : super._();
+
+  factory _PartialProject.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<String, Team, PartialTeam, PartialTeam>.fromModel(
+            Team.classType
+                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final projectTeamId = json['projectTeamId'] == null
+        ? null
+        : (json['projectTeamId'] as String);
+    return _PartialProject(
+      id: id,
+      name: name,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      projectTeamId: projectTeamId,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final AsyncModel<String, Team, PartialTeam, PartialTeam>? team;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String? projectTeamId;
+}
+
+abstract class Project extends PartialProject
+    implements Model<String, Project> {
+  factory Project({
+    String? id,
+    String? name,
+    Team? team,
+    String? projectTeamId,
+  }) = _Project;
+
+  const Project._() : super._();
+
+  factory Project.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<String, Team, PartialTeam, Team>.fromModel(
+            Team.classType
+                .fromJson<Team>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final projectTeamId = json['projectTeamId'] == null
+        ? null
+        : (json['projectTeamId'] as String);
+    return _Project._(
+      id: id,
+      name: name,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      projectTeamId: projectTeamId,
+    );
+  }
+
+  static const ProjectType classType = ProjectType();
+
+  static const ProjectQueryFields<String, Project> _queryFields =
+      ProjectQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Project, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Project, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, Project, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, Project, String?> get NAME => $name;
+  @override
+  AsyncModel<String, Team, PartialTeam, Team>? get team;
+
+  /// Query field for the [team] field.
+  TeamQueryFields<String, Project> get $team => _queryFields.$team;
+
+  /// Query field for the [team] field.
+  @Deprecated(r'Use $team instead')
+  TeamQueryFields<String, Project> get TEAM => $team;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String? get projectTeamId;
+
+  /// Query field for the [projectTeamId] field.
+  QueryField<String, Project, String?> get $projectTeamId =>
+      _queryFields.$projectTeamId;
+
+  /// Query field for the [projectTeamId] field.
+  @Deprecated(r'Use $projectTeamId instead')
+  QueryField<String, Project, String?> get PROJECT_TEAM_ID => $projectTeamId;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Project, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Project, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Project, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'team':
+        value = team;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'projectTeamId':
+        value = projectTeamId;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Project extends Project {
+  _Project({
+    String? id,
+    this.name,
+    Team? team,
+    this.projectTeamId,
+  })  : id = id ?? uuid(),
+        team = team == null ? null : AsyncModel.fromModel(team),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Project._({
+    required this.id,
+    this.name,
+    this.team,
+    required this.createdAt,
+    required this.updatedAt,
+    this.projectTeamId,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final AsyncModel<String, Team, PartialTeam, Team>? team;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? projectTeamId;
+}
+
+abstract class RemoteProject extends Project
+    implements RemoteModel<String, Project> {
+  const RemoteProject._() : super._();
+}
+
+class _RemoteProject extends RemoteProject {
+  const _RemoteProject({
+    required this.id,
+    this.name,
+    this.team,
+    required this.createdAt,
+    required this.updatedAt,
+    this.projectTeamId,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteProject.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<String, Team, PartialTeam, RemoteTeam>.fromModel(
+            Team.classType
+                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final projectTeamId = json['projectTeamId'] == null
+        ? null
+        : (json['projectTeamId'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteProject(
+      id: id,
+      name: name,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      projectTeamId: projectTeamId,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final AsyncModel<String, Team, PartialTeam, RemoteTeam>? team;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? projectTeamId;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/team.dart
@@ -1,0 +1,495 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.team;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'project.dart';
+
+class TeamType extends ModelType<String, Team, PartialTeam> {
+  const TeamType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Team>>(Map<String, Object?> json) {
+    if (T == Team || T == Model<String, Team>) {
+      return Team.fromJson(json) as T;
+    }
+    if (T == RemoteTeam || T == RemoteModel<String, Team>) {
+      return _RemoteTeam.fromJson(json) as T;
+    }
+    return _PartialTeam.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Team';
+}
+
+class TeamQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const TeamQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Team>? _root;
+
+  /// Query field for the [Team.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Team, String>(
+        const QueryField<String, Team, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Team.name] field.
+  QueryField<ModelIdentifier, M, String> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, Team, String>(
+        const QueryField<String, Team, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Team.project] field.
+  ProjectQueryFields<ModelIdentifier, M> get $project => ProjectQueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Team, Project>(
+          const QueryField<String, Team, Project>(fieldName: 'project'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Team.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Team, TemporalDateTime>(
+        const QueryField<String, Team, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Team.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Team, TemporalDateTime>(
+        const QueryField<String, Team, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Team.teamProjectId] field.
+  QueryField<ModelIdentifier, M, String?> get $teamProjectId =>
+      NestedQueryField<ModelIdentifier, M, String, Team, String?>(
+        const QueryField<String, Team, String?>(fieldName: 'teamProjectId'),
+        root: _root,
+      );
+
+  /// Query field for the [Team] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Team, String>(
+        const QueryField<String, Team, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialTeam extends PartialModel<String, Team>
+    with AWSEquatable<PartialTeam> {
+  const PartialTeam._();
+
+  String get id;
+  String? get name;
+  AsyncModel<String, Project, PartialProject, PartialProject>? get project;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String? get teamProjectId;
+  @override
+  String get modelIdentifier => id;
+  @override
+  TeamType get modelType => Team.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        project,
+        createdAt,
+        updatedAt,
+        teamProjectId,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'project': project?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'teamProjectId': teamProjectId,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Team';
+}
+
+class _PartialTeam extends PartialTeam {
+  const _PartialTeam({
+    required this.id,
+    this.name,
+    this.project,
+    this.createdAt,
+    this.updatedAt,
+    this.teamProjectId,
+  }) : super._();
+
+  factory _PartialTeam.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final project = json['project'] == null
+        ? null
+        : AsyncModel<String, Project, PartialProject, PartialProject>.fromModel(
+            Project.classType.fromJson<PartialProject>(
+              (json['project'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final teamProjectId = json['teamProjectId'] == null
+        ? null
+        : (json['teamProjectId'] as String);
+    return _PartialTeam(
+      id: id,
+      name: name,
+      project: project,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      teamProjectId: teamProjectId,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final AsyncModel<String, Project, PartialProject, PartialProject>? project;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String? teamProjectId;
+}
+
+abstract class Team extends PartialTeam implements Model<String, Team> {
+  factory Team({
+    String? id,
+    required String name,
+    Project? project,
+    String? teamProjectId,
+  }) = _Team;
+
+  const Team._() : super._();
+
+  factory Team.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'name',
+          ))
+        : (json['name'] as String);
+    final project = json['project'] == null
+        ? null
+        : AsyncModel<String, Project, PartialProject, Project>.fromModel(
+            Project.classType
+                .fromJson<Project>((json['project'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final teamProjectId = json['teamProjectId'] == null
+        ? null
+        : (json['teamProjectId'] as String);
+    return _Team._(
+      id: id,
+      name: name,
+      project: project,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      teamProjectId: teamProjectId,
+    );
+  }
+
+  static const TeamType classType = TeamType();
+
+  static const TeamQueryFields<String, Team> _queryFields = TeamQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Team, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Team, String> get ID => $id;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, Team, String> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, Team, String> get NAME => $name;
+  @override
+  AsyncModel<String, Project, PartialProject, Project>? get project;
+
+  /// Query field for the [project] field.
+  ProjectQueryFields<String, Team> get $project => _queryFields.$project;
+
+  /// Query field for the [project] field.
+  @Deprecated(r'Use $project instead')
+  ProjectQueryFields<String, Team> get PROJECT => $project;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String? get teamProjectId;
+
+  /// Query field for the [teamProjectId] field.
+  QueryField<String, Team, String?> get $teamProjectId =>
+      _queryFields.$teamProjectId;
+
+  /// Query field for the [teamProjectId] field.
+  @Deprecated(r'Use $teamProjectId instead')
+  QueryField<String, Team, String?> get TEAM_PROJECT_ID => $teamProjectId;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Team, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Team, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Team, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'project':
+        value = project;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'teamProjectId':
+        value = teamProjectId;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Team extends Team {
+  _Team({
+    String? id,
+    required this.name,
+    Project? project,
+    this.teamProjectId,
+  })  : id = id ?? uuid(),
+        project = project == null ? null : AsyncModel.fromModel(project),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Team._({
+    required this.id,
+    required this.name,
+    this.project,
+    required this.createdAt,
+    required this.updatedAt,
+    this.teamProjectId,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModel<String, Project, PartialProject, Project>? project;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? teamProjectId;
+}
+
+abstract class RemoteTeam extends Team implements RemoteModel<String, Team> {
+  const RemoteTeam._() : super._();
+}
+
+class _RemoteTeam extends RemoteTeam {
+  const _RemoteTeam({
+    required this.id,
+    required this.name,
+    this.project,
+    required this.createdAt,
+    required this.updatedAt,
+    this.teamProjectId,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteTeam.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'name',
+          ))
+        : (json['name'] as String);
+    final project = json['project'] == null
+        ? null
+        : AsyncModel<String, Project, PartialProject, RemoteProject>.fromModel(
+            Project.classType.fromJson<RemoteProject>(
+              (json['project'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final teamProjectId = json['teamProjectId'] == null
+        ? null
+        : (json['teamProjectId'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteTeam(
+      id: id,
+      name: name,
+      project: project,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      teamProjectId: teamProjectId,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModel<String, Project, PartialProject, RemoteProject>? project;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? teamProjectId;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/team.dart
@@ -312,6 +312,26 @@ abstract class Team extends PartialTeam implements Model<String, Team> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Team, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Team copyWith({
+    String? id,
+    String? name,
+    Project? project,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? teamProjectId,
+  }) {
+    return _Team._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      project: project == null ? this.project : AsyncModel.fromModel(project),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      teamProjectId: teamProjectId ?? this.teamProjectId,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Team, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/team.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.team;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'project.dart';
 
@@ -262,6 +263,72 @@ abstract class Team extends PartialTeam implements Model<String, Team> {
   static const TeamType classType = TeamType();
 
   static const TeamQueryFields<String, Team> _queryFields = TeamQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Team',
+      'pluralName': 'Teams',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'project': {
+          'name': 'project',
+          'type': {'model': 'Project'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Project',
+            'targetNames': ['teamProjectId'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'teamProjectId': {
+          'name': 'teamProjectId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'project',
+          'sortKeyFields': ['teamProjectId'],
+          'name': 'project',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/bidi_has_one_implicit/team.dart
@@ -110,7 +110,7 @@ abstract class PartialTeam extends PartialModel<String, Team>
 
   String get id;
   String? get name;
-  AsyncModel<String, Project, PartialProject, PartialProject>? get project;
+  PartialProject? get project;
   TemporalDateTime? get createdAt;
   TemporalDateTime? get updatedAt;
   String? get teamProjectId;
@@ -161,13 +161,6 @@ class _PartialTeam extends PartialTeam {
           ))
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
-    final project = json['project'] == null
-        ? null
-        : AsyncModel<String, Project, PartialProject, PartialProject>.fromModel(
-            Project.classType.fromJson<PartialProject>(
-              (json['project'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
@@ -177,6 +170,11 @@ class _PartialTeam extends PartialTeam {
     final teamProjectId = json['teamProjectId'] == null
         ? null
         : (json['teamProjectId'] as String);
+    final project = json['project'] == null
+        ? null
+        : Project.classType.fromJson<PartialProject>(
+            (json['project'] as Map<String, Object?>),
+          );
     return _PartialTeam(
       id: id,
       name: name,
@@ -194,7 +192,7 @@ class _PartialTeam extends PartialTeam {
   final String? name;
 
   @override
-  final AsyncModel<String, Project, PartialProject, PartialProject>? project;
+  final PartialProject? project;
 
   @override
   final TemporalDateTime? createdAt;
@@ -211,7 +209,6 @@ abstract class Team extends PartialTeam implements Model<String, Team> {
     String? id,
     required String name,
     Project? project,
-    String? teamProjectId,
   }) = _Team;
 
   const Team._() : super._();
@@ -229,12 +226,6 @@ abstract class Team extends PartialTeam implements Model<String, Team> {
             'name',
           ))
         : (json['name'] as String);
-    final project = json['project'] == null
-        ? null
-        : AsyncModel<String, Project, PartialProject, Project>.fromModel(
-            Project.classType
-                .fromJson<Project>((json['project'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Team',
@@ -250,6 +241,10 @@ abstract class Team extends PartialTeam implements Model<String, Team> {
     final teamProjectId = json['teamProjectId'] == null
         ? null
         : (json['teamProjectId'] as String);
+    final project = json['project'] == null
+        ? null
+        : Project.classType
+            .fromJson<Project>((json['project'] as Map<String, Object?>));
     return _Team._(
       id: id,
       name: name,
@@ -309,7 +304,7 @@ abstract class Team extends PartialTeam implements Model<String, Team> {
         'teamProjectId': {
           'name': 'teamProjectId',
           'type': {'scalar': 'ID'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
       },
@@ -349,7 +344,7 @@ abstract class Team extends PartialTeam implements Model<String, Team> {
   @Deprecated(r'Use $name instead')
   QueryField<String, Team, String> get NAME => $name;
   @override
-  AsyncModel<String, Project, PartialProject, Project>? get project;
+  Project? get project;
 
   /// Query field for the [project] field.
   ProjectQueryFields<String, Team> get $project => _queryFields.$project;
@@ -363,14 +358,6 @@ abstract class Team extends PartialTeam implements Model<String, Team> {
   TemporalDateTime get updatedAt;
   @override
   String? get teamProjectId;
-
-  /// Query field for the [teamProjectId] field.
-  QueryField<String, Team, String?> get $teamProjectId =>
-      _queryFields.$teamProjectId;
-
-  /// Query field for the [teamProjectId] field.
-  @Deprecated(r'Use $teamProjectId instead')
-  QueryField<String, Team, String?> get TEAM_PROJECT_ID => $teamProjectId;
 
   /// Query field for the [modelIdentifier] field.
   QueryField<String, Team, String> get $modelIdentifier =>
@@ -390,7 +377,7 @@ abstract class Team extends PartialTeam implements Model<String, Team> {
     return _Team._(
       id: id ?? this.id,
       name: name ?? this.name,
-      project: project == null ? this.project : AsyncModel.fromModel(project),
+      project: project ?? this.project,
       createdAt:
           createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
       updatedAt:
@@ -434,12 +421,11 @@ class _Team extends Team {
   _Team({
     String? id,
     required this.name,
-    Project? project,
-    this.teamProjectId,
+    this.project,
   })  : id = id ?? uuid(),
-        project = project == null ? null : AsyncModel.fromModel(project),
         createdAt = TemporalDateTime.now(),
         updatedAt = TemporalDateTime.now(),
+        teamProjectId = project?.id,
         super._();
 
   const _Team._({
@@ -458,7 +444,7 @@ class _Team extends Team {
   final String name;
 
   @override
-  final AsyncModel<String, Project, PartialProject, Project>? project;
+  final Project? project;
 
   @override
   final TemporalDateTime createdAt;
@@ -500,13 +486,6 @@ class _RemoteTeam extends RemoteTeam {
             'name',
           ))
         : (json['name'] as String);
-    final project = json['project'] == null
-        ? null
-        : AsyncModel<String, Project, PartialProject, RemoteProject>.fromModel(
-            Project.classType.fromJson<RemoteProject>(
-              (json['project'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Team',
@@ -540,6 +519,10 @@ class _RemoteTeam extends RemoteTeam {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final project = json['project'] == null
+        ? null
+        : Project.classType
+            .fromJson<RemoteProject>((json['project'] as Map<String, Object?>));
     return _RemoteTeam(
       id: id,
       name: name,
@@ -560,7 +543,7 @@ class _RemoteTeam extends RemoteTeam {
   final String name;
 
   @override
-  final AsyncModel<String, Project, PartialProject, RemoteProject>? project;
+  final RemoteProject? project;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/indexes/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/indexes/model_provider.dart
@@ -1,0 +1,64 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'model_with_primary_key.dart';
+
+export 'model_with_primary_key.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '7f4603f51fac0973866e8cb29bb9ea76';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas =>
+      [ModelWithPrimaryKey.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'ModelWithPrimaryKey':
+        return (ModelWithPrimaryKey.classType
+            as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/indexes/model_with_primary_key.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/indexes/model_with_primary_key.dart
@@ -363,6 +363,28 @@ abstract class ModelWithPrimaryKey extends PartialModelWithPrimaryKey
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, ModelWithPrimaryKey, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  ModelWithPrimaryKey copyWith({
+    String? productId,
+    String? name,
+    String? content,
+    String? albumId,
+    String? categoryId,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _ModelWithPrimaryKey._(
+      productId: productId ?? this.productId,
+      name: name ?? this.name,
+      content: content ?? this.content,
+      albumId: albumId ?? this.albumId,
+      categoryId: categoryId ?? this.categoryId,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<String, ModelWithPrimaryKey, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/indexes/model_with_primary_key.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/indexes/model_with_primary_key.dart
@@ -1,0 +1,565 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.model_with_primary_key;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class ModelWithPrimaryKeyType
+    extends ModelType<String, ModelWithPrimaryKey, PartialModelWithPrimaryKey> {
+  const ModelWithPrimaryKeyType();
+
+  @override
+  T fromJson<T extends PartialModel<String, ModelWithPrimaryKey>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == ModelWithPrimaryKey || T == Model<String, ModelWithPrimaryKey>) {
+      return ModelWithPrimaryKey.fromJson(json) as T;
+    }
+    if (T == RemoteModelWithPrimaryKey ||
+        T == RemoteModel<String, ModelWithPrimaryKey>) {
+      return _RemoteModelWithPrimaryKey.fromJson(json) as T;
+    }
+    return _PartialModelWithPrimaryKey.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'ModelWithPrimaryKey';
+}
+
+class ModelWithPrimaryKeyQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ModelWithPrimaryKeyQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, ModelWithPrimaryKey>? _root;
+
+  /// Query field for the [ModelWithPrimaryKey.productId] field.
+  QueryField<ModelIdentifier, M, String> get $productId =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithPrimaryKey, String>(
+        const QueryField<String, ModelWithPrimaryKey, String>(
+          fieldName: 'productID',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithPrimaryKey.name] field.
+  QueryField<ModelIdentifier, M, String> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithPrimaryKey, String>(
+        const QueryField<String, ModelWithPrimaryKey, String>(
+          fieldName: 'name',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithPrimaryKey.content] field.
+  QueryField<ModelIdentifier, M, String?> get $content => NestedQueryField<
+          ModelIdentifier, M, String, ModelWithPrimaryKey, String?>(
+        const QueryField<String, ModelWithPrimaryKey, String?>(
+          fieldName: 'content',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithPrimaryKey.albumId] field.
+  QueryField<ModelIdentifier, M, String> get $albumId =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithPrimaryKey, String>(
+        const QueryField<String, ModelWithPrimaryKey, String>(
+          fieldName: 'albumID',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithPrimaryKey.categoryId] field.
+  QueryField<ModelIdentifier, M, String> get $categoryId =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithPrimaryKey, String>(
+        const QueryField<String, ModelWithPrimaryKey, String>(
+          fieldName: 'categoryID',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithPrimaryKey.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithPrimaryKey,
+          TemporalDateTime>(
+        const QueryField<String, ModelWithPrimaryKey, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithPrimaryKey.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithPrimaryKey,
+          TemporalDateTime>(
+        const QueryField<String, ModelWithPrimaryKey, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithPrimaryKey] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithPrimaryKey, String>(
+        const QueryField<String, ModelWithPrimaryKey, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialModelWithPrimaryKey
+    extends PartialModel<String, ModelWithPrimaryKey>
+    with AWSEquatable<PartialModelWithPrimaryKey> {
+  const PartialModelWithPrimaryKey._();
+
+  String get productId;
+  String? get name;
+  String? get content;
+  String? get albumId;
+  String? get categoryId;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => productId;
+  @override
+  ModelWithPrimaryKeyType get modelType => ModelWithPrimaryKey.classType;
+  @override
+  List<Object?> get props => [
+        productId,
+        name,
+        content,
+        albumId,
+        categoryId,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'productID': productId,
+        'name': name,
+        'content': content,
+        'albumID': albumId,
+        'categoryID': categoryId,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'ModelWithPrimaryKey';
+}
+
+class _PartialModelWithPrimaryKey extends PartialModelWithPrimaryKey {
+  const _PartialModelWithPrimaryKey({
+    required this.productId,
+    this.name,
+    this.content,
+    this.albumId,
+    this.categoryId,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialModelWithPrimaryKey.fromJson(Map<String, Object?> json) {
+    final productId = json['productID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'productId',
+          ))
+        : (json['productID'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final albumId =
+        json['albumID'] == null ? null : (json['albumID'] as String);
+    final categoryId =
+        json['categoryID'] == null ? null : (json['categoryID'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialModelWithPrimaryKey(
+      productId: productId,
+      name: name,
+      content: content,
+      albumId: albumId,
+      categoryId: categoryId,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String productId;
+
+  @override
+  final String? name;
+
+  @override
+  final String? content;
+
+  @override
+  final String? albumId;
+
+  @override
+  final String? categoryId;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class ModelWithPrimaryKey extends PartialModelWithPrimaryKey
+    implements Model<String, ModelWithPrimaryKey> {
+  factory ModelWithPrimaryKey({
+    String? productId,
+    required String name,
+    String? content,
+    required String albumId,
+    required String categoryId,
+  }) = _ModelWithPrimaryKey;
+
+  const ModelWithPrimaryKey._() : super._();
+
+  factory ModelWithPrimaryKey.fromJson(Map<String, Object?> json) {
+    final productId = json['productID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'productId',
+          ))
+        : (json['productID'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'name',
+          ))
+        : (json['name'] as String);
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final albumId = json['albumID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'albumId',
+          ))
+        : (json['albumID'] as String);
+    final categoryId = json['categoryID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'categoryId',
+          ))
+        : (json['categoryID'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _ModelWithPrimaryKey._(
+      productId: productId,
+      name: name,
+      content: content,
+      albumId: albumId,
+      categoryId: categoryId,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const ModelWithPrimaryKeyType classType = ModelWithPrimaryKeyType();
+
+  static const ModelWithPrimaryKeyQueryFields<String, ModelWithPrimaryKey>
+      _queryFields = ModelWithPrimaryKeyQueryFields();
+
+  @override
+  String get productId;
+
+  /// Query field for the [productId] field.
+  QueryField<String, ModelWithPrimaryKey, String> get $productId =>
+      _queryFields.$productId;
+
+  /// Query field for the [productId] field.
+  @Deprecated(r'Use $productId instead')
+  QueryField<String, ModelWithPrimaryKey, String> get PRODUCT_ID => $productId;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, ModelWithPrimaryKey, String> get $name =>
+      _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, ModelWithPrimaryKey, String> get NAME => $name;
+  @override
+  String? get content;
+
+  /// Query field for the [content] field.
+  QueryField<String, ModelWithPrimaryKey, String?> get $content =>
+      _queryFields.$content;
+
+  /// Query field for the [content] field.
+  @Deprecated(r'Use $content instead')
+  QueryField<String, ModelWithPrimaryKey, String?> get CONTENT => $content;
+  @override
+  String get albumId;
+
+  /// Query field for the [albumId] field.
+  QueryField<String, ModelWithPrimaryKey, String> get $albumId =>
+      _queryFields.$albumId;
+
+  /// Query field for the [albumId] field.
+  @Deprecated(r'Use $albumId instead')
+  QueryField<String, ModelWithPrimaryKey, String> get ALBUM_ID => $albumId;
+  @override
+  String get categoryId;
+
+  /// Query field for the [categoryId] field.
+  QueryField<String, ModelWithPrimaryKey, String> get $categoryId =>
+      _queryFields.$categoryId;
+
+  /// Query field for the [categoryId] field.
+  @Deprecated(r'Use $categoryId instead')
+  QueryField<String, ModelWithPrimaryKey, String> get CATEGORY_ID =>
+      $categoryId;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, ModelWithPrimaryKey, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, ModelWithPrimaryKey, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<String, ModelWithPrimaryKey, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'productID':
+        value = productId;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'content':
+        value = content;
+        break;
+      case r'albumID':
+        value = albumId;
+        break;
+      case r'categoryID':
+        value = categoryId;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _ModelWithPrimaryKey extends ModelWithPrimaryKey {
+  _ModelWithPrimaryKey({
+    String? productId,
+    required this.name,
+    this.content,
+    required this.albumId,
+    required this.categoryId,
+  })  : productId = productId ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _ModelWithPrimaryKey._({
+    required this.productId,
+    required this.name,
+    this.content,
+    required this.albumId,
+    required this.categoryId,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String productId;
+
+  @override
+  final String name;
+
+  @override
+  final String? content;
+
+  @override
+  final String albumId;
+
+  @override
+  final String categoryId;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteModelWithPrimaryKey extends ModelWithPrimaryKey
+    implements RemoteModel<String, ModelWithPrimaryKey> {
+  const RemoteModelWithPrimaryKey._() : super._();
+}
+
+class _RemoteModelWithPrimaryKey extends RemoteModelWithPrimaryKey {
+  const _RemoteModelWithPrimaryKey({
+    required this.productId,
+    required this.name,
+    this.content,
+    required this.albumId,
+    required this.categoryId,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteModelWithPrimaryKey.fromJson(Map<String, Object?> json) {
+    final productId = json['productID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'productId',
+          ))
+        : (json['productID'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'name',
+          ))
+        : (json['name'] as String);
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final albumId = json['albumID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'albumId',
+          ))
+        : (json['albumID'] as String);
+    final categoryId = json['categoryID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'categoryId',
+          ))
+        : (json['categoryID'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithPrimaryKey',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteModelWithPrimaryKey(
+      productId: productId,
+      name: name,
+      content: content,
+      albumId: albumId,
+      categoryId: categoryId,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String productId;
+
+  @override
+  final String name;
+
+  @override
+  final String? content;
+
+  @override
+  final String albumId;
+
+  @override
+  final String categoryId;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/indexes/model_with_primary_key.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/indexes/model_with_primary_key.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.model_with_primary_key;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class ModelWithPrimaryKeyType
     extends ModelType<String, ModelWithPrimaryKey, PartialModelWithPrimaryKey> {
@@ -298,6 +299,81 @@ abstract class ModelWithPrimaryKey extends PartialModelWithPrimaryKey
 
   static const ModelWithPrimaryKeyQueryFields<String, ModelWithPrimaryKey>
       _queryFields = ModelWithPrimaryKeyQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'ModelWithPrimaryKey',
+      'pluralName': 'ModelWithPrimaryKeys',
+      'fields': {
+        'productID': {
+          'name': 'productID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'albumID': {
+          'name': 'albumID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'categoryID': {
+          'name': 'categoryID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'secondary',
+          'primaryField': 'albumID',
+          'sortKeyFields': [],
+          'name': 'byAlbum',
+          'queryField': 'modelWithPrimaryKeysByAlbumID',
+        },
+        {
+          'type': 'secondary',
+          'primaryField': 'categoryID',
+          'sortKeyFields': [],
+          'name': 'byCategory',
+          'queryField': 'modelWithPrimaryKeysByCategoryID',
+        },
+        {
+          'type': 'primary',
+          'primaryField': 'productID',
+          'sortKeyFields': [],
+        },
+      ],
+    },
+  )!;
 
   @override
   String get productId;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/secondary_index/customer.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/secondary_index/customer.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.customer;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class CustomerType extends ModelType<String, Customer, PartialCustomer> {
   const CustomerType();
@@ -261,6 +262,68 @@ abstract class Customer extends PartialCustomer
 
   static const CustomerQueryFields<String, Customer> _queryFields =
       CustomerQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Customer',
+      'pluralName': 'Customers',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'phoneNumber': {
+          'name': 'phoneNumber',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'accountRepresentativeID': {
+          'name': 'accountRepresentativeID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'secondary',
+          'primaryField': 'accountRepresentativeID',
+          'sortKeyFields': [],
+          'name': 'byRepresentative',
+          'queryField': 'customerByRepresentative',
+        },
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/secondary_index/customer.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/secondary_index/customer.dart
@@ -1,0 +1,494 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.customer;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class CustomerType extends ModelType<String, Customer, PartialCustomer> {
+  const CustomerType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Customer>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Customer || T == Model<String, Customer>) {
+      return Customer.fromJson(json) as T;
+    }
+    if (T == RemoteCustomer || T == RemoteModel<String, Customer>) {
+      return _RemoteCustomer.fromJson(json) as T;
+    }
+    return _PartialCustomer.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Customer';
+}
+
+class CustomerQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const CustomerQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Customer>? _root;
+
+  /// Query field for the [Customer.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Customer, String>(
+        const QueryField<String, Customer, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Customer.name] field.
+  QueryField<ModelIdentifier, M, String> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, Customer, String>(
+        const QueryField<String, Customer, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Customer.phoneNumber] field.
+  QueryField<ModelIdentifier, M, String?> get $phoneNumber =>
+      NestedQueryField<ModelIdentifier, M, String, Customer, String?>(
+        const QueryField<String, Customer, String?>(fieldName: 'phoneNumber'),
+        root: _root,
+      );
+
+  /// Query field for the [Customer.accountRepresentativeId] field.
+  QueryField<ModelIdentifier, M, String> get $accountRepresentativeId =>
+      NestedQueryField<ModelIdentifier, M, String, Customer, String>(
+        const QueryField<String, Customer, String>(
+          fieldName: 'accountRepresentativeID',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Customer.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Customer, TemporalDateTime>(
+        const QueryField<String, Customer, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Customer.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Customer, TemporalDateTime>(
+        const QueryField<String, Customer, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Customer] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Customer, String>(
+        const QueryField<String, Customer, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialCustomer extends PartialModel<String, Customer>
+    with AWSEquatable<PartialCustomer> {
+  const PartialCustomer._();
+
+  String get id;
+  String? get name;
+  String? get phoneNumber;
+  String? get accountRepresentativeId;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  CustomerType get modelType => Customer.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        phoneNumber,
+        accountRepresentativeId,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'phoneNumber': phoneNumber,
+        'accountRepresentativeID': accountRepresentativeId,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Customer';
+}
+
+class _PartialCustomer extends PartialCustomer {
+  const _PartialCustomer({
+    required this.id,
+    this.name,
+    this.phoneNumber,
+    this.accountRepresentativeId,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialCustomer.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final phoneNumber =
+        json['phoneNumber'] == null ? null : (json['phoneNumber'] as String);
+    final accountRepresentativeId = json['accountRepresentativeID'] == null
+        ? null
+        : (json['accountRepresentativeID'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialCustomer(
+      id: id,
+      name: name,
+      phoneNumber: phoneNumber,
+      accountRepresentativeId: accountRepresentativeId,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? phoneNumber;
+
+  @override
+  final String? accountRepresentativeId;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Customer extends PartialCustomer
+    implements Model<String, Customer> {
+  factory Customer({
+    String? id,
+    required String name,
+    String? phoneNumber,
+    required String accountRepresentativeId,
+  }) = _Customer;
+
+  const Customer._() : super._();
+
+  factory Customer.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'name',
+          ))
+        : (json['name'] as String);
+    final phoneNumber =
+        json['phoneNumber'] == null ? null : (json['phoneNumber'] as String);
+    final accountRepresentativeId = json['accountRepresentativeID'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'accountRepresentativeId',
+          ))
+        : (json['accountRepresentativeID'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Customer._(
+      id: id,
+      name: name,
+      phoneNumber: phoneNumber,
+      accountRepresentativeId: accountRepresentativeId,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const CustomerType classType = CustomerType();
+
+  static const CustomerQueryFields<String, Customer> _queryFields =
+      CustomerQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Customer, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Customer, String> get ID => $id;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, Customer, String> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, Customer, String> get NAME => $name;
+  @override
+  String? get phoneNumber;
+
+  /// Query field for the [phoneNumber] field.
+  QueryField<String, Customer, String?> get $phoneNumber =>
+      _queryFields.$phoneNumber;
+
+  /// Query field for the [phoneNumber] field.
+  @Deprecated(r'Use $phoneNumber instead')
+  QueryField<String, Customer, String?> get PHONE_NUMBER => $phoneNumber;
+  @override
+  String get accountRepresentativeId;
+
+  /// Query field for the [accountRepresentativeId] field.
+  QueryField<String, Customer, String> get $accountRepresentativeId =>
+      _queryFields.$accountRepresentativeId;
+
+  /// Query field for the [accountRepresentativeId] field.
+  @Deprecated(r'Use $accountRepresentativeId instead')
+  QueryField<String, Customer, String> get ACCOUNT_REPRESENTATIVE_ID =>
+      $accountRepresentativeId;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Customer, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Customer, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Customer, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'phoneNumber':
+        value = phoneNumber;
+        break;
+      case r'accountRepresentativeID':
+        value = accountRepresentativeId;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Customer extends Customer {
+  _Customer({
+    String? id,
+    required this.name,
+    this.phoneNumber,
+    required this.accountRepresentativeId,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Customer._({
+    required this.id,
+    required this.name,
+    this.phoneNumber,
+    required this.accountRepresentativeId,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final String? phoneNumber;
+
+  @override
+  final String accountRepresentativeId;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteCustomer extends Customer
+    implements RemoteModel<String, Customer> {
+  const RemoteCustomer._() : super._();
+}
+
+class _RemoteCustomer extends RemoteCustomer {
+  const _RemoteCustomer({
+    required this.id,
+    required this.name,
+    this.phoneNumber,
+    required this.accountRepresentativeId,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteCustomer.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'name',
+          ))
+        : (json['name'] as String);
+    final phoneNumber =
+        json['phoneNumber'] == null ? null : (json['phoneNumber'] as String);
+    final accountRepresentativeId = json['accountRepresentativeID'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'accountRepresentativeId',
+          ))
+        : (json['accountRepresentativeID'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Customer',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteCustomer(
+      id: id,
+      name: name,
+      phoneNumber: phoneNumber,
+      accountRepresentativeId: accountRepresentativeId,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final String? phoneNumber;
+
+  @override
+  final String accountRepresentativeId;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/secondary_index/customer.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/secondary_index/customer.dart
@@ -313,6 +313,27 @@ abstract class Customer extends PartialCustomer
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Customer, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Customer copyWith({
+    String? id,
+    String? name,
+    String? phoneNumber,
+    String? accountRepresentativeId,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Customer._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      phoneNumber: phoneNumber ?? this.phoneNumber,
+      accountRepresentativeId:
+          accountRepresentativeId ?? this.accountRepresentativeId,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Customer, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/secondary_index/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/secondary_index/model_provider.dart
@@ -18,50 +18,45 @@
 
 // ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
-library models.my_non_model;
+library models.model_provider;
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
-class MyNonModel
-    with
-        AWSEquatable<MyNonModel>,
-        AWSSerializable<Map<String, Object?>>,
-        AWSDebuggable {
-  const MyNonModel({required this.enum_});
+import 'customer.dart';
 
-  factory MyNonModel.fromJson(Map<String, Object?> json) {
-    final enum_ = json['enum'] == null
-        ? (throw ModelFieldError(
-            'MyNonModel',
-            'enum_',
-          ))
-        : (json['enum'] as String);
-    return MyNonModel(enum_: enum_);
+export 'customer.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '46daa9e634bd4a2abe307a5be2479d9e';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [Customer.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Customer':
+        return (Customer.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
   }
 
-  final String enum_;
-
-  static final mipr.NonModelTypeDefinition schema =
-      mipr.serializers.deserializeWith(
-    mipr.NonModelTypeDefinition.serializer,
-    const {
-      'name': 'MyNonModel',
-      'fields': {
-        'enum': {
-          'name': 'enum',
-          'type': {'scalar': 'String'},
-          'isReadOnly': false,
-          'authRules': [],
-        }
-      },
-    },
-  )!;
-
   @override
-  List<Object?> get props => [enum_];
-  @override
-  String get runtimeTypeName => 'MyNonModel';
-  @override
-  Map<String, Object?> toJson() => {'enum': enum_};
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
 }

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/timestamp_rename/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/timestamp_rename/model_provider.dart
@@ -18,50 +18,45 @@
 
 // ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
-library models.my_non_model;
+library models.model_provider;
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
-class MyNonModel
-    with
-        AWSEquatable<MyNonModel>,
-        AWSSerializable<Map<String, Object?>>,
-        AWSDebuggable {
-  const MyNonModel({required this.enum_});
+import 'todo.dart';
 
-  factory MyNonModel.fromJson(Map<String, Object?> json) {
-    final enum_ = json['enum'] == null
-        ? (throw ModelFieldError(
-            'MyNonModel',
-            'enum_',
-          ))
-        : (json['enum'] as String);
-    return MyNonModel(enum_: enum_);
+export 'todo.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '89d8e2a097df5b688b91fa12dde8bdac';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [Todo.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Todo':
+        return (Todo.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
   }
 
-  final String enum_;
-
-  static final mipr.NonModelTypeDefinition schema =
-      mipr.serializers.deserializeWith(
-    mipr.NonModelTypeDefinition.serializer,
-    const {
-      'name': 'MyNonModel',
-      'fields': {
-        'enum': {
-          'name': 'enum',
-          'type': {'scalar': 'String'},
-          'isReadOnly': false,
-          'authRules': [],
-        }
-      },
-    },
-  )!;
-
   @override
-  List<Object?> get props => [enum_];
-  @override
-  String get runtimeTypeName => 'MyNonModel';
-  @override
-  Map<String, Object?> toJson() => {'enum': enum_};
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
 }

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/timestamp_rename/todo.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/timestamp_rename/todo.dart
@@ -1,0 +1,376 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.todo;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class TodoType extends ModelType<String, Todo, PartialTodo> {
+  const TodoType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Todo>>(Map<String, Object?> json) {
+    if (T == Todo || T == Model<String, Todo>) {
+      return Todo.fromJson(json) as T;
+    }
+    if (T == RemoteTodo || T == RemoteModel<String, Todo>) {
+      return _RemoteTodo.fromJson(json) as T;
+    }
+    return _PartialTodo.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Todo';
+}
+
+class TodoQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const TodoQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Todo>? _root;
+
+  /// Query field for the [Todo.content] field.
+  QueryField<ModelIdentifier, M, String?> get $content =>
+      NestedQueryField<ModelIdentifier, M, String, Todo, String?>(
+        const QueryField<String, Todo, String?>(fieldName: 'content'),
+        root: _root,
+      );
+
+  /// Query field for the [Todo.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Todo, TemporalDateTime>(
+        const QueryField<String, Todo, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Todo.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Todo, TemporalDateTime>(
+        const QueryField<String, Todo, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Todo.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Todo, String>(
+        const QueryField<String, Todo, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Todo] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Todo, String>(
+        const QueryField<String, Todo, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialTodo extends PartialModel<String, Todo>
+    with AWSEquatable<PartialTodo> {
+  const PartialTodo._();
+
+  String? get content;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String get id;
+  @override
+  String get modelIdentifier => id;
+  @override
+  TodoType get modelType => Todo.classType;
+  @override
+  List<Object?> get props => [
+        content,
+        createdAt,
+        updatedAt,
+        id,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'content': content,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'id': id,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Todo';
+}
+
+class _PartialTodo extends PartialTodo {
+  const _PartialTodo({
+    this.content,
+    this.createdAt,
+    this.updatedAt,
+    required this.id,
+  }) : super._();
+
+  factory _PartialTodo.fromJson(Map<String, Object?> json) {
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Todo',
+            'id',
+          ))
+        : (json['id'] as String);
+    return _PartialTodo(
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      id: id,
+    );
+  }
+
+  @override
+  final String? content;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String id;
+}
+
+abstract class Todo extends PartialTodo implements Model<String, Todo> {
+  factory Todo({
+    String? content,
+    String? id,
+  }) = _Todo;
+
+  const Todo._() : super._();
+
+  factory Todo.fromJson(Map<String, Object?> json) {
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Todo',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Todo',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Todo',
+            'id',
+          ))
+        : (json['id'] as String);
+    return _Todo._(
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      id: id,
+    );
+  }
+
+  static const TodoType classType = TodoType();
+
+  static const TodoQueryFields<String, Todo> _queryFields = TodoQueryFields();
+
+  @override
+  String? get content;
+
+  /// Query field for the [content] field.
+  QueryField<String, Todo, String?> get $content => _queryFields.$content;
+
+  /// Query field for the [content] field.
+  @Deprecated(r'Use $content instead')
+  QueryField<String, Todo, String?> get CONTENT => $content;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Todo, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Todo, String> get ID => $id;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Todo, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Todo, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Todo, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'content':
+        value = content;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'id':
+        value = id;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Todo extends Todo {
+  _Todo({
+    this.content,
+    String? id,
+  })  : createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        id = id ?? uuid(),
+        super._();
+
+  const _Todo._({
+    this.content,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.id,
+  }) : super._();
+
+  @override
+  final String? content;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String id;
+}
+
+abstract class RemoteTodo extends Todo implements RemoteModel<String, Todo> {
+  const RemoteTodo._() : super._();
+}
+
+class _RemoteTodo extends RemoteTodo {
+  const _RemoteTodo({
+    this.content,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.id,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteTodo.fromJson(Map<String, Object?> json) {
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Todo',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Todo',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Todo',
+            'id',
+          ))
+        : (json['id'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Todo',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Todo',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Todo',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteTodo(
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      id: id,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String? content;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String id;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/timestamp_rename/todo.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/timestamp_rename/todo.dart
@@ -234,6 +234,22 @@ abstract class Todo extends PartialTodo implements Model<String, Todo> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Todo, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Todo copyWith({
+    String? content,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? id,
+  }) {
+    return _Todo._(
+      content: content ?? this.content,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      id: id ?? this.id,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Todo, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/timestamp_rename/todo.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/timestamp_rename/todo.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.todo;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class TodoType extends ModelType<String, Todo, PartialTodo> {
   const TodoType();
@@ -203,6 +204,49 @@ abstract class Todo extends PartialTodo implements Model<String, Todo> {
   static const TodoType classType = TodoType();
 
   static const TodoQueryFields<String, Todo> _queryFields = TodoQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Todo',
+      'pluralName': 'Todos',
+      'fields': {
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String? get content;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/comment2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/comment2.dart
@@ -1,0 +1,443 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.comment2;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class Comment2Type extends ModelType<String, Comment2, PartialComment2> {
+  const Comment2Type();
+
+  @override
+  T fromJson<T extends PartialModel<String, Comment2>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Comment2 || T == Model<String, Comment2>) {
+      return Comment2.fromJson(json) as T;
+    }
+    if (T == RemoteComment2 || T == RemoteModel<String, Comment2>) {
+      return _RemoteComment2.fromJson(json) as T;
+    }
+    return _PartialComment2.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Comment2';
+}
+
+class Comment2QueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const Comment2QueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Comment2>? _root;
+
+  /// Query field for the [Comment2.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Comment2, String>(
+        const QueryField<String, Comment2, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment2.postId] field.
+  QueryField<ModelIdentifier, M, String> get $postId =>
+      NestedQueryField<ModelIdentifier, M, String, Comment2, String>(
+        const QueryField<String, Comment2, String>(fieldName: 'postID'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment2.content] field.
+  QueryField<ModelIdentifier, M, String> get $content =>
+      NestedQueryField<ModelIdentifier, M, String, Comment2, String>(
+        const QueryField<String, Comment2, String>(fieldName: 'content'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment2.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Comment2, TemporalDateTime>(
+        const QueryField<String, Comment2, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment2.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Comment2, TemporalDateTime>(
+        const QueryField<String, Comment2, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment2] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Comment2, String>(
+        const QueryField<String, Comment2, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialComment2 extends PartialModel<String, Comment2>
+    with AWSEquatable<PartialComment2> {
+  const PartialComment2._();
+
+  String get id;
+  String? get postId;
+  String? get content;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  Comment2Type get modelType => Comment2.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        postId,
+        content,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'postID': postId,
+        'content': content,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Comment2';
+}
+
+class _PartialComment2 extends PartialComment2 {
+  const _PartialComment2({
+    required this.id,
+    this.postId,
+    this.content,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialComment2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final postId = json['postID'] == null ? null : (json['postID'] as String);
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialComment2(
+      id: id,
+      postId: postId,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? postId;
+
+  @override
+  final String? content;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Comment2 extends PartialComment2
+    implements Model<String, Comment2> {
+  factory Comment2({
+    String? id,
+    required String postId,
+    required String content,
+  }) = _Comment2;
+
+  const Comment2._() : super._();
+
+  factory Comment2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final postId = json['postID'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'postId',
+          ))
+        : (json['postID'] as String);
+    final content = json['content'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'content',
+          ))
+        : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Comment2._(
+      id: id,
+      postId: postId,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const Comment2Type classType = Comment2Type();
+
+  static const Comment2QueryFields<String, Comment2> _queryFields =
+      Comment2QueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Comment2, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Comment2, String> get ID => $id;
+  @override
+  String get postId;
+
+  /// Query field for the [postId] field.
+  QueryField<String, Comment2, String> get $postId => _queryFields.$postId;
+
+  /// Query field for the [postId] field.
+  @Deprecated(r'Use $postId instead')
+  QueryField<String, Comment2, String> get POST_ID => $postId;
+  @override
+  String get content;
+
+  /// Query field for the [content] field.
+  QueryField<String, Comment2, String> get $content => _queryFields.$content;
+
+  /// Query field for the [content] field.
+  @Deprecated(r'Use $content instead')
+  QueryField<String, Comment2, String> get CONTENT => $content;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Comment2, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Comment2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Comment2, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'postID':
+        value = postId;
+        break;
+      case r'content':
+        value = content;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Comment2 extends Comment2 {
+  _Comment2({
+    String? id,
+    required this.postId,
+    required this.content,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Comment2._({
+    required this.id,
+    required this.postId,
+    required this.content,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String postId;
+
+  @override
+  final String content;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteComment2 extends Comment2
+    implements RemoteModel<String, Comment2> {
+  const RemoteComment2._() : super._();
+}
+
+class _RemoteComment2 extends RemoteComment2 {
+  const _RemoteComment2({
+    required this.id,
+    required this.postId,
+    required this.content,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteComment2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final postId = json['postID'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'postId',
+          ))
+        : (json['postID'] as String);
+    final content = json['content'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'content',
+          ))
+        : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment2',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteComment2(
+      id: id,
+      postId: postId,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String postId;
+
+  @override
+  final String content;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/comment2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/comment2.dart
@@ -277,6 +277,24 @@ abstract class Comment2 extends PartialComment2
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Comment2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Comment2 copyWith({
+    String? id,
+    String? postId,
+    String? content,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Comment2._(
+      id: id ?? this.id,
+      postId: postId ?? this.postId,
+      content: content ?? this.content,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Comment2, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/comment2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/comment2.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.comment2;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class Comment2Type extends ModelType<String, Comment2, PartialComment2> {
   const Comment2Type();
@@ -237,6 +238,62 @@ abstract class Comment2 extends PartialComment2
 
   static const Comment2QueryFields<String, Comment2> _queryFields =
       Comment2QueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Comment2',
+      'pluralName': 'Comment2s',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'postID': {
+          'name': 'postID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'secondary',
+          'primaryField': 'postID',
+          'sortKeyFields': [],
+          'name': 'byPost',
+          'queryField': 'comment2sByPostID',
+        },
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'comment2.dart';
+import 'post2.dart';
+
+export 'comment2.dart';
+export 'post2.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '61b82ea49cf0a77e8c549b86baf51a53';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Post2.schema,
+        Comment2.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Post2':
+        return (Post2.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Comment2':
+        return (Comment2.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/post2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/post2.dart
@@ -1,0 +1,475 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.post2;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'comment2.dart';
+
+class Post2Type extends ModelType<String, Post2, PartialPost2> {
+  const Post2Type();
+
+  @override
+  T fromJson<T extends PartialModel<String, Post2>>(Map<String, Object?> json) {
+    if (T == Post2 || T == Model<String, Post2>) {
+      return Post2.fromJson(json) as T;
+    }
+    if (T == RemotePost2 || T == RemoteModel<String, Post2>) {
+      return _RemotePost2.fromJson(json) as T;
+    }
+    return _PartialPost2.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Post2';
+}
+
+class Post2QueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const Post2QueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Post2>? _root;
+
+  /// Query field for the [Post2.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Post2, String>(
+        const QueryField<String, Post2, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Post2.title] field.
+  QueryField<ModelIdentifier, M, String> get $title =>
+      NestedQueryField<ModelIdentifier, M, String, Post2, String>(
+        const QueryField<String, Post2, String>(fieldName: 'title'),
+        root: _root,
+      );
+
+  /// Query field for the [Post2.comments] field.
+  Comment2QueryFields<ModelIdentifier, M> get $comments => Comment2QueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Post2, Comment2>(
+          const QueryField<String, Post2, Comment2>(fieldName: 'comments'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Post2.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post2, TemporalDateTime>(
+        const QueryField<String, Post2, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post2.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post2, TemporalDateTime>(
+        const QueryField<String, Post2, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post2] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Post2, String>(
+        const QueryField<String, Post2, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialPost2 extends PartialModel<String, Post2>
+    with AWSEquatable<PartialPost2> {
+  const PartialPost2._();
+
+  String get id;
+  String? get title;
+  AsyncModelCollection<String, Comment2, PartialComment2, PartialComment2>?
+      get comments;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  Post2Type get modelType => Post2.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        comments,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'title': title,
+        'comments': comments?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Post2';
+}
+
+class _PartialPost2 extends PartialPost2 {
+  const _PartialPost2({
+    required this.id,
+    this.title,
+    this.comments,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialPost2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null ? null : (json['title'] as String);
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment2, PartialComment2,
+            PartialComment2>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment2.classType.fromJson<PartialComment2>(el),
+                )
+                .whereType<PartialComment2>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialPost2(
+      id: id,
+      title: title,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? title;
+
+  @override
+  final AsyncModelCollection<String, Comment2, PartialComment2,
+      PartialComment2>? comments;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Post2 extends PartialPost2 implements Model<String, Post2> {
+  factory Post2({
+    String? id,
+    required String title,
+    List<Comment2>? comments,
+  }) = _Post2;
+
+  const Post2._() : super._();
+
+  factory Post2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'title',
+          ))
+        : (json['title'] as String);
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment2, PartialComment2,
+            Comment2>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment2.classType.fromJson<Comment2>(el),
+                )
+                .whereType<Comment2>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Post2._(
+      id: id,
+      title: title,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const Post2Type classType = Post2Type();
+
+  static const Post2QueryFields<String, Post2> _queryFields =
+      Post2QueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Post2, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Post2, String> get ID => $id;
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<String, Post2, String> get $title => _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<String, Post2, String> get TITLE => $title;
+  @override
+  AsyncModelCollection<String, Comment2, PartialComment2, Comment2>?
+      get comments;
+
+  /// Query field for the [comments] field.
+  Comment2QueryFields<String, Post2> get $comments => _queryFields.$comments;
+
+  /// Query field for the [comments] field.
+  @Deprecated(r'Use $comments instead')
+  Comment2QueryFields<String, Post2> get COMMENTS => $comments;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Post2, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Post2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Post2, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'comments':
+        value = comments;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Post2 extends Post2 {
+  _Post2({
+    String? id,
+    required this.title,
+    List<Comment2>? comments,
+  })  : id = id ?? uuid(),
+        comments =
+            comments == null ? null : AsyncModelCollection.fromList(comments),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Post2._({
+    required this.id,
+    required this.title,
+    this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final AsyncModelCollection<String, Comment2, PartialComment2, Comment2>?
+      comments;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemotePost2 extends Post2 implements RemoteModel<String, Post2> {
+  const RemotePost2._() : super._();
+}
+
+class _RemotePost2 extends RemotePost2 {
+  const _RemotePost2({
+    required this.id,
+    required this.title,
+    this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemotePost2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'title',
+          ))
+        : (json['title'] as String);
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment2, PartialComment2,
+            RemoteComment2>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment2.classType.fromJson<RemoteComment2>(el),
+                )
+                .whereType<RemoteComment2>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemotePost2(
+      id: id,
+      title: title,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final AsyncModelCollection<String, Comment2, PartialComment2, RemoteComment2>?
+      comments;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/post2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/post2.dart
@@ -298,6 +298,26 @@ abstract class Post2 extends PartialPost2 implements Model<String, Post2> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Post2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Post2 copyWith({
+    String? id,
+    String? title,
+    List<Comment2>? comments,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Post2._(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      comments: comments == null
+          ? this.comments
+          : AsyncModelCollection.fromList(comments),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Post2, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/post2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/post2.dart
@@ -151,6 +151,12 @@ class _PartialPost2 extends PartialPost2 {
           ))
         : (json['id'] as String);
     final title = json['title'] == null ? null : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<String, Comment2, PartialComment2,
@@ -165,12 +171,6 @@ class _PartialPost2 extends PartialPost2 {
                 .whereType<PartialComment2>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
     return _PartialPost2(
       id: id,
       title: title,
@@ -219,6 +219,18 @@ abstract class Post2 extends PartialPost2 implements Model<String, Post2> {
             'title',
           ))
         : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<String, Comment2, PartialComment2,
@@ -233,18 +245,6 @@ abstract class Post2 extends PartialPost2 implements Model<String, Post2> {
                 .whereType<Comment2>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? (throw ModelFieldError(
-            'Post2',
-            'createdAt',
-          ))
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? (throw ModelFieldError(
-            'Post2',
-            'updatedAt',
-          ))
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
     return _Post2._(
       id: id,
       title: title,
@@ -469,20 +469,6 @@ class _RemotePost2 extends RemotePost2 {
             'title',
           ))
         : (json['title'] as String);
-    final comments = json['comments'] == null
-        ? null
-        : AsyncModelCollection<String, Comment2, PartialComment2,
-            RemoteComment2>.fromList(
-            (json['comments'] as List<Object?>)
-                .cast<Map<String, Object?>?>()
-                .map(
-                  (el) => el == null
-                      ? null
-                      : Comment2.classType.fromJson<RemoteComment2>(el),
-                )
-                .whereType<RemoteComment2>()
-                .toList(),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Post2',
@@ -513,6 +499,20 @@ class _RemotePost2 extends RemotePost2 {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment2, PartialComment2,
+            RemoteComment2>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment2.classType.fromJson<RemoteComment2>(el),
+                )
+                .whereType<RemoteComment2>()
+                .toList(),
+          );
     return _RemotePost2(
       id: id,
       title: title,
@@ -532,7 +532,7 @@ class _RemotePost2 extends RemotePost2 {
   final String title;
 
   @override
-  final AsyncModelCollection<String, Comment2, PartialComment2, RemoteComment2>?
+  final AsyncModelCollection<String, Comment2, PartialComment2, Comment2>?
       comments;
 
   @override

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/post2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_explicit/post2.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post2;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'comment2.dart';
 
@@ -257,6 +258,62 @@ abstract class Post2 extends PartialPost2 implements Model<String, Post2> {
 
   static const Post2QueryFields<String, Post2> _queryFields =
       Post2QueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post2',
+      'pluralName': 'Post2s',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'comments': {
+          'name': 'comments',
+          'type': {
+            'list': {'model': 'Comment2'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Comment2',
+            'associatedFields': ['postID'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/comment.dart
@@ -275,6 +275,24 @@ abstract class Comment extends PartialComment
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Comment, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Comment copyWith({
+    String? id,
+    String? content,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? postCommentsId,
+  }) {
+    return _Comment._(
+      id: id ?? this.id,
+      content: content ?? this.content,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      postCommentsId: postCommentsId ?? this.postCommentsId,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Comment, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/comment.dart
@@ -1,0 +1,438 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.comment;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class CommentType extends ModelType<String, Comment, PartialComment> {
+  const CommentType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Comment>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Comment || T == Model<String, Comment>) {
+      return Comment.fromJson(json) as T;
+    }
+    if (T == RemoteComment || T == RemoteModel<String, Comment>) {
+      return _RemoteComment.fromJson(json) as T;
+    }
+    return _PartialComment.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Comment';
+}
+
+class CommentQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const CommentQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Comment>? _root;
+
+  /// Query field for the [Comment.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, String>(
+        const QueryField<String, Comment, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.content] field.
+  QueryField<ModelIdentifier, M, String> get $content =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, String>(
+        const QueryField<String, Comment, String>(fieldName: 'content'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, TemporalDateTime>(
+        const QueryField<String, Comment, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, TemporalDateTime>(
+        const QueryField<String, Comment, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.postCommentsId] field.
+  QueryField<ModelIdentifier, M, String?> get $postCommentsId =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, String?>(
+        const QueryField<String, Comment, String?>(fieldName: 'postCommentsId'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, String>(
+        const QueryField<String, Comment, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialComment extends PartialModel<String, Comment>
+    with AWSEquatable<PartialComment> {
+  const PartialComment._();
+
+  String get id;
+  String? get content;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String? get postCommentsId;
+  @override
+  String get modelIdentifier => id;
+  @override
+  CommentType get modelType => Comment.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        content,
+        createdAt,
+        updatedAt,
+        postCommentsId,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'content': content,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'postCommentsId': postCommentsId,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Comment';
+}
+
+class _PartialComment extends PartialComment {
+  const _PartialComment({
+    required this.id,
+    this.content,
+    this.createdAt,
+    this.updatedAt,
+    this.postCommentsId,
+  }) : super._();
+
+  factory _PartialComment.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'id',
+          ))
+        : (json['id'] as String);
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final postCommentsId = json['postCommentsId'] == null
+        ? null
+        : (json['postCommentsId'] as String);
+    return _PartialComment(
+      id: id,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      postCommentsId: postCommentsId,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? content;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String? postCommentsId;
+}
+
+abstract class Comment extends PartialComment
+    implements Model<String, Comment> {
+  factory Comment({
+    String? id,
+    required String content,
+    String? postCommentsId,
+  }) = _Comment;
+
+  const Comment._() : super._();
+
+  factory Comment.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'id',
+          ))
+        : (json['id'] as String);
+    final content = json['content'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'content',
+          ))
+        : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final postCommentsId = json['postCommentsId'] == null
+        ? null
+        : (json['postCommentsId'] as String);
+    return _Comment._(
+      id: id,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      postCommentsId: postCommentsId,
+    );
+  }
+
+  static const CommentType classType = CommentType();
+
+  static const CommentQueryFields<String, Comment> _queryFields =
+      CommentQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Comment, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Comment, String> get ID => $id;
+  @override
+  String get content;
+
+  /// Query field for the [content] field.
+  QueryField<String, Comment, String> get $content => _queryFields.$content;
+
+  /// Query field for the [content] field.
+  @Deprecated(r'Use $content instead')
+  QueryField<String, Comment, String> get CONTENT => $content;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String? get postCommentsId;
+
+  /// Query field for the [postCommentsId] field.
+  QueryField<String, Comment, String?> get $postCommentsId =>
+      _queryFields.$postCommentsId;
+
+  /// Query field for the [postCommentsId] field.
+  @Deprecated(r'Use $postCommentsId instead')
+  QueryField<String, Comment, String?> get POST_COMMENTS_ID => $postCommentsId;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Comment, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Comment, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Comment, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'content':
+        value = content;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'postCommentsId':
+        value = postCommentsId;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Comment extends Comment {
+  _Comment({
+    String? id,
+    required this.content,
+    this.postCommentsId,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Comment._({
+    required this.id,
+    required this.content,
+    required this.createdAt,
+    required this.updatedAt,
+    this.postCommentsId,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String content;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? postCommentsId;
+}
+
+abstract class RemoteComment extends Comment
+    implements RemoteModel<String, Comment> {
+  const RemoteComment._() : super._();
+}
+
+class _RemoteComment extends RemoteComment {
+  const _RemoteComment({
+    required this.id,
+    required this.content,
+    required this.createdAt,
+    required this.updatedAt,
+    this.postCommentsId,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteComment.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'id',
+          ))
+        : (json['id'] as String);
+    final content = json['content'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'content',
+          ))
+        : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final postCommentsId = json['postCommentsId'] == null
+        ? null
+        : (json['postCommentsId'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteComment(
+      id: id,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      postCommentsId: postCommentsId,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String content;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? postCommentsId;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/comment.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.comment;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class CommentType extends ModelType<String, Comment, PartialComment> {
   const CommentType();
@@ -234,6 +235,61 @@ abstract class Comment extends PartialComment
 
   static const CommentQueryFields<String, Comment> _queryFields =
       CommentQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Comment',
+      'pluralName': 'Comments',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'postCommentsId': {
+          'name': 'postCommentsId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'Post.comments',
+          'sortKeyFields': ['postCommentsId'],
+          'name': 'gsi-Post.comments',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'comment.dart';
+import 'post.dart';
+
+export 'comment.dart';
+export 'post.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '5dc446a44178b9f66e6b72ea2387e477';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Post.schema,
+        Comment.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Post':
+        return (Post.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Comment':
+        return (Comment.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/post.dart
@@ -296,6 +296,26 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Post, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Post copyWith({
+    String? id,
+    String? title,
+    List<Comment>? comments,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Post._(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      comments: comments == null
+          ? this.comments
+          : AsyncModelCollection.fromList(comments),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/post.dart
@@ -1,0 +1,473 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.post;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'comment.dart';
+
+class PostType extends ModelType<String, Post, PartialPost> {
+  const PostType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Post>>(Map<String, Object?> json) {
+    if (T == Post || T == Model<String, Post>) {
+      return Post.fromJson(json) as T;
+    }
+    if (T == RemotePost || T == RemoteModel<String, Post>) {
+      return _RemotePost.fromJson(json) as T;
+    }
+    return _PartialPost.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Post';
+}
+
+class PostQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const PostQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Post>? _root;
+
+  /// Query field for the [Post.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.title] field.
+  QueryField<ModelIdentifier, M, String> get $title =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'title'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.comments] field.
+  CommentQueryFields<ModelIdentifier, M> get $comments => CommentQueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Post, Comment>(
+          const QueryField<String, Post, Comment>(fieldName: 'comments'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Post.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post, TemporalDateTime>(
+        const QueryField<String, Post, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post, TemporalDateTime>(
+        const QueryField<String, Post, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialPost extends PartialModel<String, Post>
+    with AWSEquatable<PartialPost> {
+  const PartialPost._();
+
+  String get id;
+  String? get title;
+  AsyncModelCollection<String, Comment, PartialComment, PartialComment>?
+      get comments;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  PostType get modelType => Post.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        comments,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'title': title,
+        'comments': comments?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Post';
+}
+
+class _PartialPost extends PartialPost {
+  const _PartialPost({
+    required this.id,
+    this.title,
+    this.comments,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialPost.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null ? null : (json['title'] as String);
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment, PartialComment,
+            PartialComment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<PartialComment>(el),
+                )
+                .whereType<PartialComment>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialPost(
+      id: id,
+      title: title,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? title;
+
+  @override
+  final AsyncModelCollection<String, Comment, PartialComment, PartialComment>?
+      comments;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Post extends PartialPost implements Model<String, Post> {
+  factory Post({
+    String? id,
+    required String title,
+    List<Comment>? comments,
+  }) = _Post;
+
+  const Post._() : super._();
+
+  factory Post.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment, PartialComment,
+            Comment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<Comment>(el),
+                )
+                .whereType<Comment>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Post._(
+      id: id,
+      title: title,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const PostType classType = PostType();
+
+  static const PostQueryFields<String, Post> _queryFields = PostQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Post, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Post, String> get ID => $id;
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<String, Post, String> get $title => _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<String, Post, String> get TITLE => $title;
+  @override
+  AsyncModelCollection<String, Comment, PartialComment, Comment>? get comments;
+
+  /// Query field for the [comments] field.
+  CommentQueryFields<String, Post> get $comments => _queryFields.$comments;
+
+  /// Query field for the [comments] field.
+  @Deprecated(r'Use $comments instead')
+  CommentQueryFields<String, Post> get COMMENTS => $comments;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Post, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Post, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'comments':
+        value = comments;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Post extends Post {
+  _Post({
+    String? id,
+    required this.title,
+    List<Comment>? comments,
+  })  : id = id ?? uuid(),
+        comments =
+            comments == null ? null : AsyncModelCollection.fromList(comments),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Post._({
+    required this.id,
+    required this.title,
+    this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final AsyncModelCollection<String, Comment, PartialComment, Comment>?
+      comments;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemotePost extends Post implements RemoteModel<String, Post> {
+  const RemotePost._() : super._();
+}
+
+class _RemotePost extends RemotePost {
+  const _RemotePost({
+    required this.id,
+    required this.title,
+    this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemotePost.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment, PartialComment,
+            RemoteComment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
+                .whereType<RemoteComment>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemotePost(
+      id: id,
+      title: title,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final AsyncModelCollection<String, Comment, PartialComment, RemoteComment>?
+      comments;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/post.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'comment.dart';
 
@@ -256,6 +257,62 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   static const PostType classType = PostType();
 
   static const PostQueryFields<String, Post> _queryFields = PostQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post',
+      'pluralName': 'Posts',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'comments': {
+          'name': 'comments',
+          'type': {
+            'list': {'model': 'Comment'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Comment',
+            'associatedFields': ['postCommentsId'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_many_implicit/post.dart
@@ -151,6 +151,12 @@ class _PartialPost extends PartialPost {
           ))
         : (json['id'] as String);
     final title = json['title'] == null ? null : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<String, Comment, PartialComment,
@@ -165,12 +171,6 @@ class _PartialPost extends PartialPost {
                 .whereType<PartialComment>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
     return _PartialPost(
       id: id,
       title: title,
@@ -219,6 +219,18 @@ abstract class Post extends PartialPost implements Model<String, Post> {
             'title',
           ))
         : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<String, Comment, PartialComment,
@@ -233,18 +245,6 @@ abstract class Post extends PartialPost implements Model<String, Post> {
                 .whereType<Comment>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? (throw ModelFieldError(
-            'Post',
-            'createdAt',
-          ))
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? (throw ModelFieldError(
-            'Post',
-            'updatedAt',
-          ))
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
     return _Post._(
       id: id,
       title: title,
@@ -467,20 +467,6 @@ class _RemotePost extends RemotePost {
             'title',
           ))
         : (json['title'] as String);
-    final comments = json['comments'] == null
-        ? null
-        : AsyncModelCollection<String, Comment, PartialComment,
-            RemoteComment>.fromList(
-            (json['comments'] as List<Object?>)
-                .cast<Map<String, Object?>?>()
-                .map(
-                  (el) => el == null
-                      ? null
-                      : Comment.classType.fromJson<RemoteComment>(el),
-                )
-                .whereType<RemoteComment>()
-                .toList(),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Post',
@@ -511,6 +497,20 @@ class _RemotePost extends RemotePost {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment, PartialComment,
+            RemoteComment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
+                .whereType<RemoteComment>()
+                .toList(),
+          );
     return _RemotePost(
       id: id,
       title: title,
@@ -530,7 +530,7 @@ class _RemotePost extends RemotePost {
   final String title;
 
   @override
-  final AsyncModelCollection<String, Comment, PartialComment, RemoteComment>?
+  final AsyncModelCollection<String, Comment, PartialComment, Comment>?
       comments;
 
   @override

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'project2.dart';
+import 'team2.dart';
+
+export 'project2.dart';
+export 'team2.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '474253dd180ddb169b3ef1001b46c8b1';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Project2.schema,
+        Team2.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Project2':
+        return (Project2.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Team2':
+        return (Team2.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/project2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/project2.dart
@@ -1,0 +1,483 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.project2;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'team2.dart';
+
+class Project2Type extends ModelType<String, Project2, PartialProject2> {
+  const Project2Type();
+
+  @override
+  T fromJson<T extends PartialModel<String, Project2>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Project2 || T == Model<String, Project2>) {
+      return Project2.fromJson(json) as T;
+    }
+    if (T == RemoteProject2 || T == RemoteModel<String, Project2>) {
+      return _RemoteProject2.fromJson(json) as T;
+    }
+    return _PartialProject2.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Project2';
+}
+
+class Project2QueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const Project2QueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Project2>? _root;
+
+  /// Query field for the [Project2.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Project2, String>(
+        const QueryField<String, Project2, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Project2.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, Project2, String?>(
+        const QueryField<String, Project2, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Project2.teamId] field.
+  QueryField<ModelIdentifier, M, String?> get $teamId =>
+      NestedQueryField<ModelIdentifier, M, String, Project2, String?>(
+        const QueryField<String, Project2, String?>(fieldName: 'teamID'),
+        root: _root,
+      );
+
+  /// Query field for the [Project2.team] field.
+  Team2QueryFields<ModelIdentifier, M> get $team => Team2QueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Project2, Team2>(
+          const QueryField<String, Project2, Team2>(fieldName: 'team'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Project2.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Project2, TemporalDateTime>(
+        const QueryField<String, Project2, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project2.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Project2, TemporalDateTime>(
+        const QueryField<String, Project2, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project2] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Project2, String>(
+        const QueryField<String, Project2, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialProject2 extends PartialModel<String, Project2>
+    with AWSEquatable<PartialProject2> {
+  const PartialProject2._();
+
+  String get id;
+  String? get name;
+  String? get teamId;
+  AsyncModel<String, Team2, PartialTeam2, PartialTeam2>? get team;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  Project2Type get modelType => Project2.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        teamId,
+        team,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'teamID': teamId,
+        'team': team?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Project2';
+}
+
+class _PartialProject2 extends PartialProject2 {
+  const _PartialProject2({
+    required this.id,
+    this.name,
+    this.teamId,
+    this.team,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialProject2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final teamId = json['teamID'] == null ? null : (json['teamID'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<String, Team2, PartialTeam2, PartialTeam2>.fromModel(
+            Team2.classType
+                .fromJson<PartialTeam2>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialProject2(
+      id: id,
+      name: name,
+      teamId: teamId,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? teamId;
+
+  @override
+  final AsyncModel<String, Team2, PartialTeam2, PartialTeam2>? team;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Project2 extends PartialProject2
+    implements Model<String, Project2> {
+  factory Project2({
+    String? id,
+    String? name,
+    String? teamId,
+    Team2? team,
+  }) = _Project2;
+
+  const Project2._() : super._();
+
+  factory Project2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final teamId = json['teamID'] == null ? null : (json['teamID'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<String, Team2, PartialTeam2, Team2>.fromModel(
+            Team2.classType
+                .fromJson<Team2>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Project2._(
+      id: id,
+      name: name,
+      teamId: teamId,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const Project2Type classType = Project2Type();
+
+  static const Project2QueryFields<String, Project2> _queryFields =
+      Project2QueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Project2, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Project2, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, Project2, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, Project2, String?> get NAME => $name;
+  @override
+  String? get teamId;
+
+  /// Query field for the [teamId] field.
+  QueryField<String, Project2, String?> get $teamId => _queryFields.$teamId;
+
+  /// Query field for the [teamId] field.
+  @Deprecated(r'Use $teamId instead')
+  QueryField<String, Project2, String?> get TEAM_ID => $teamId;
+  @override
+  AsyncModel<String, Team2, PartialTeam2, Team2>? get team;
+
+  /// Query field for the [team] field.
+  Team2QueryFields<String, Project2> get $team => _queryFields.$team;
+
+  /// Query field for the [team] field.
+  @Deprecated(r'Use $team instead')
+  Team2QueryFields<String, Project2> get TEAM => $team;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Project2, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Project2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Project2, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'teamID':
+        value = teamId;
+        break;
+      case r'team':
+        value = team;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Project2 extends Project2 {
+  _Project2({
+    String? id,
+    this.name,
+    this.teamId,
+    Team2? team,
+  })  : id = id ?? uuid(),
+        team = team == null ? null : AsyncModel.fromModel(team),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Project2._({
+    required this.id,
+    this.name,
+    this.teamId,
+    this.team,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? teamId;
+
+  @override
+  final AsyncModel<String, Team2, PartialTeam2, Team2>? team;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteProject2 extends Project2
+    implements RemoteModel<String, Project2> {
+  const RemoteProject2._() : super._();
+}
+
+class _RemoteProject2 extends RemoteProject2 {
+  const _RemoteProject2({
+    required this.id,
+    this.name,
+    this.teamId,
+    this.team,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteProject2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final teamId = json['teamID'] == null ? null : (json['teamID'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<String, Team2, PartialTeam2, RemoteTeam2>.fromModel(
+            Team2.classType
+                .fromJson<RemoteTeam2>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Project2',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteProject2(
+      id: id,
+      name: name,
+      teamId: teamId,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? teamId;
+
+  @override
+  final AsyncModel<String, Team2, PartialTeam2, RemoteTeam2>? team;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/project2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/project2.dart
@@ -307,6 +307,26 @@ abstract class Project2 extends PartialProject2
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Project2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Project2 copyWith({
+    String? id,
+    String? name,
+    String? teamId,
+    Team2? team,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Project2._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      teamId: teamId ?? this.teamId,
+      team: team == null ? this.team : AsyncModel.fromModel(team),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Project2, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/project2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/project2.dart
@@ -166,18 +166,24 @@ class _PartialProject2 extends PartialProject2 {
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
     final teamId = json['teamID'] == null ? null : (json['teamID'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<String, Team2, PartialTeam2, PartialTeam2>.fromModel(
-            Team2.classType
-                .fromJson<PartialTeam2>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
     final updatedAt = json['updatedAt'] == null
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final team = json['team'] == null
+        ? teamId == null
+            ? null
+            : AsyncModel<String, Team2, PartialTeam2,
+                PartialTeam2>.fromModelIdentifier(
+                Team2.classType,
+                teamId,
+              )
+        : AsyncModel<String, Team2, PartialTeam2, PartialTeam2>.fromModel(
+            Team2.classType
+                .fromJson<PartialTeam2>((json['team'] as Map<String, Object?>)),
+          );
     return _PartialProject2(
       id: id,
       name: name,
@@ -227,12 +233,6 @@ abstract class Project2 extends PartialProject2
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
     final teamId = json['teamID'] == null ? null : (json['teamID'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<String, Team2, PartialTeam2, Team2>.fromModel(
-            Team2.classType
-                .fromJson<Team2>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Project2',
@@ -245,6 +245,18 @@ abstract class Project2 extends PartialProject2
             'updatedAt',
           ))
         : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final team = json['team'] == null
+        ? teamId == null
+            ? null
+            : AsyncModel<String, Team2, PartialTeam2,
+                Team2>.fromModelIdentifier(
+                Team2.classType,
+                teamId,
+              )
+        : AsyncModel<String, Team2, PartialTeam2, Team2>.fromModel(
+            Team2.classType
+                .fromJson<Team2>((json['team'] as Map<String, Object?>)),
+          );
     return _Project2._(
       id: id,
       name: name,
@@ -487,12 +499,6 @@ class _RemoteProject2 extends RemoteProject2 {
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
     final teamId = json['teamID'] == null ? null : (json['teamID'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<String, Team2, PartialTeam2, RemoteTeam2>.fromModel(
-            Team2.classType
-                .fromJson<RemoteTeam2>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Project2',
@@ -523,6 +529,18 @@ class _RemoteProject2 extends RemoteProject2 {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final team = json['team'] == null
+        ? teamId == null
+            ? null
+            : AsyncModel<String, Team2, PartialTeam2,
+                RemoteTeam2>.fromModelIdentifier(
+                Team2.classType,
+                teamId,
+              )
+        : AsyncModel<String, Team2, PartialTeam2, RemoteTeam2>.fromModel(
+            Team2.classType
+                .fromJson<RemoteTeam2>((json['team'] as Map<String, Object?>)),
+          );
     return _RemoteProject2(
       id: id,
       name: name,
@@ -546,7 +564,7 @@ class _RemoteProject2 extends RemoteProject2 {
   final String? teamId;
 
   @override
-  final AsyncModel<String, Team2, PartialTeam2, RemoteTeam2>? team;
+  final AsyncModel<String, Team2, PartialTeam2, Team2>? team;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/project2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/project2.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.project2;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'team2.dart';
 
@@ -258,6 +259,67 @@ abstract class Project2 extends PartialProject2
 
   static const Project2QueryFields<String, Project2> _queryFields =
       Project2QueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Project2',
+      'pluralName': 'Project2s',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'teamID': {
+          'name': 'teamID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'team': {
+          'name': 'team',
+          'type': {'model': 'Team2'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'Team2',
+            'associatedFields': ['id'],
+            'targetNames': ['teamID'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/team2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/team2.dart
@@ -1,0 +1,384 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.team2;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class Team2Type extends ModelType<String, Team2, PartialTeam2> {
+  const Team2Type();
+
+  @override
+  T fromJson<T extends PartialModel<String, Team2>>(Map<String, Object?> json) {
+    if (T == Team2 || T == Model<String, Team2>) {
+      return Team2.fromJson(json) as T;
+    }
+    if (T == RemoteTeam2 || T == RemoteModel<String, Team2>) {
+      return _RemoteTeam2.fromJson(json) as T;
+    }
+    return _PartialTeam2.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Team2';
+}
+
+class Team2QueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const Team2QueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Team2>? _root;
+
+  /// Query field for the [Team2.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Team2, String>(
+        const QueryField<String, Team2, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Team2.name] field.
+  QueryField<ModelIdentifier, M, String> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, Team2, String>(
+        const QueryField<String, Team2, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Team2.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Team2, TemporalDateTime>(
+        const QueryField<String, Team2, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Team2.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Team2, TemporalDateTime>(
+        const QueryField<String, Team2, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Team2] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Team2, String>(
+        const QueryField<String, Team2, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialTeam2 extends PartialModel<String, Team2>
+    with AWSEquatable<PartialTeam2> {
+  const PartialTeam2._();
+
+  String get id;
+  String? get name;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  Team2Type get modelType => Team2.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Team2';
+}
+
+class _PartialTeam2 extends PartialTeam2 {
+  const _PartialTeam2({
+    required this.id,
+    this.name,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialTeam2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialTeam2(
+      id: id,
+      name: name,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
+  factory Team2({
+    String? id,
+    required String name,
+  }) = _Team2;
+
+  const Team2._() : super._();
+
+  factory Team2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'name',
+          ))
+        : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Team2._(
+      id: id,
+      name: name,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const Team2Type classType = Team2Type();
+
+  static const Team2QueryFields<String, Team2> _queryFields =
+      Team2QueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Team2, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Team2, String> get ID => $id;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, Team2, String> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, Team2, String> get NAME => $name;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Team2, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Team2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Team2, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Team2 extends Team2 {
+  _Team2({
+    String? id,
+    required this.name,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Team2._({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteTeam2 extends Team2 implements RemoteModel<String, Team2> {
+  const RemoteTeam2._() : super._();
+}
+
+class _RemoteTeam2 extends RemoteTeam2 {
+  const _RemoteTeam2({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteTeam2.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'name',
+          ))
+        : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Team2',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteTeam2(
+      id: id,
+      name: name,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/team2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/team2.dart
@@ -238,6 +238,22 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Team2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Team2 copyWith({
+    String? id,
+    String? name,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Team2._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Team2, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/team2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_explicit/team2.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.team2;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class Team2Type extends ModelType<String, Team2, PartialTeam2> {
   const Team2Type();
@@ -207,6 +208,49 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
 
   static const Team2QueryFields<String, Team2> _queryFields =
       Team2QueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Team2',
+      'pluralName': 'Team2s',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'project.dart';
+import 'team.dart';
+
+export 'project.dart';
+export 'team.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'db56c6e05aec1e5b5ae6a11487623f3e';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Project.schema,
+        Team.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Project':
+        return (Project.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Team':
+        return (Team.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/project.dart
@@ -310,6 +310,26 @@ abstract class Project extends PartialProject
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Project, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Project copyWith({
+    String? id,
+    String? name,
+    Team? team,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? projectTeamId,
+  }) {
+    return _Project._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      team: team == null ? this.team : AsyncModel.fromModel(team),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      projectTeamId: projectTeamId ?? this.projectTeamId,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Project, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/project.dart
@@ -163,12 +163,6 @@ class _PartialProject extends PartialProject {
           ))
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<String, Team, PartialTeam, PartialTeam>.fromModel(
-            Team.classType
-                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
@@ -178,6 +172,18 @@ class _PartialProject extends PartialProject {
     final projectTeamId = json['projectTeamId'] == null
         ? null
         : (json['projectTeamId'] as String);
+    final team = json['team'] == null
+        ? projectTeamId == null
+            ? null
+            : AsyncModel<String, Team, PartialTeam,
+                PartialTeam>.fromModelIdentifier(
+                Team.classType,
+                projectTeamId,
+              )
+        : AsyncModel<String, Team, PartialTeam, PartialTeam>.fromModel(
+            Team.classType
+                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)),
+          );
     return _PartialProject(
       id: id,
       name: name,
@@ -226,12 +232,6 @@ abstract class Project extends PartialProject
           ))
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<String, Team, PartialTeam, Team>.fromModel(
-            Team.classType
-                .fromJson<Team>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Project',
@@ -247,6 +247,17 @@ abstract class Project extends PartialProject
     final projectTeamId = json['projectTeamId'] == null
         ? null
         : (json['projectTeamId'] as String);
+    final team = json['team'] == null
+        ? projectTeamId == null
+            ? null
+            : AsyncModel<String, Team, PartialTeam, Team>.fromModelIdentifier(
+                Team.classType,
+                projectTeamId,
+              )
+        : AsyncModel<String, Team, PartialTeam, Team>.fromModel(
+            Team.classType
+                .fromJson<Team>((json['team'] as Map<String, Object?>)),
+          );
     return _Project._(
       id: id,
       name: name,
@@ -489,12 +500,6 @@ class _RemoteProject extends RemoteProject {
           ))
         : (json['id'] as String);
     final name = json['name'] == null ? null : (json['name'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<String, Team, PartialTeam, RemoteTeam>.fromModel(
-            Team.classType
-                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Project',
@@ -528,6 +533,18 @@ class _RemoteProject extends RemoteProject {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final team = json['team'] == null
+        ? projectTeamId == null
+            ? null
+            : AsyncModel<String, Team, PartialTeam,
+                RemoteTeam>.fromModelIdentifier(
+                Team.classType,
+                projectTeamId,
+              )
+        : AsyncModel<String, Team, PartialTeam, RemoteTeam>.fromModel(
+            Team.classType
+                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)),
+          );
     return _RemoteProject(
       id: id,
       name: name,
@@ -548,7 +565,7 @@ class _RemoteProject extends RemoteProject {
   final String? name;
 
   @override
-  final AsyncModel<String, Team, PartialTeam, RemoteTeam>? team;
+  final AsyncModel<String, Team, PartialTeam, Team>? team;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/project.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.project;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'team.dart';
 
@@ -260,6 +261,67 @@ abstract class Project extends PartialProject
 
   static const ProjectQueryFields<String, Project> _queryFields =
       ProjectQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Project',
+      'pluralName': 'Projects',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'team': {
+          'name': 'team',
+          'type': {'model': 'Team'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'Team',
+            'associatedFields': ['id'],
+            'targetNames': ['projectTeamId'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'projectTeamId': {
+          'name': 'projectTeamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/project.dart
@@ -1,0 +1,488 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.project;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'team.dart';
+
+class ProjectType extends ModelType<String, Project, PartialProject> {
+  const ProjectType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Project>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Project || T == Model<String, Project>) {
+      return Project.fromJson(json) as T;
+    }
+    if (T == RemoteProject || T == RemoteModel<String, Project>) {
+      return _RemoteProject.fromJson(json) as T;
+    }
+    return _PartialProject.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Project';
+}
+
+class ProjectQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ProjectQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Project>? _root;
+
+  /// Query field for the [Project.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Project, String>(
+        const QueryField<String, Project, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Project.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, Project, String?>(
+        const QueryField<String, Project, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Project.team] field.
+  TeamQueryFields<ModelIdentifier, M> get $team => TeamQueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Project, Team>(
+          const QueryField<String, Project, Team>(fieldName: 'team'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Project.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Project, TemporalDateTime>(
+        const QueryField<String, Project, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Project, TemporalDateTime>(
+        const QueryField<String, Project, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project.projectTeamId] field.
+  QueryField<ModelIdentifier, M, String?> get $projectTeamId =>
+      NestedQueryField<ModelIdentifier, M, String, Project, String?>(
+        const QueryField<String, Project, String?>(fieldName: 'projectTeamId'),
+        root: _root,
+      );
+
+  /// Query field for the [Project] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Project, String>(
+        const QueryField<String, Project, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialProject extends PartialModel<String, Project>
+    with AWSEquatable<PartialProject> {
+  const PartialProject._();
+
+  String get id;
+  String? get name;
+  AsyncModel<String, Team, PartialTeam, PartialTeam>? get team;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String? get projectTeamId;
+  @override
+  String get modelIdentifier => id;
+  @override
+  ProjectType get modelType => Project.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        team,
+        createdAt,
+        updatedAt,
+        projectTeamId,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'team': team?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'projectTeamId': projectTeamId,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Project';
+}
+
+class _PartialProject extends PartialProject {
+  const _PartialProject({
+    required this.id,
+    this.name,
+    this.team,
+    this.createdAt,
+    this.updatedAt,
+    this.projectTeamId,
+  }) : super._();
+
+  factory _PartialProject.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<String, Team, PartialTeam, PartialTeam>.fromModel(
+            Team.classType
+                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final projectTeamId = json['projectTeamId'] == null
+        ? null
+        : (json['projectTeamId'] as String);
+    return _PartialProject(
+      id: id,
+      name: name,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      projectTeamId: projectTeamId,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final AsyncModel<String, Team, PartialTeam, PartialTeam>? team;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String? projectTeamId;
+}
+
+abstract class Project extends PartialProject
+    implements Model<String, Project> {
+  factory Project({
+    String? id,
+    String? name,
+    Team? team,
+    String? projectTeamId,
+  }) = _Project;
+
+  const Project._() : super._();
+
+  factory Project.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<String, Team, PartialTeam, Team>.fromModel(
+            Team.classType
+                .fromJson<Team>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final projectTeamId = json['projectTeamId'] == null
+        ? null
+        : (json['projectTeamId'] as String);
+    return _Project._(
+      id: id,
+      name: name,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      projectTeamId: projectTeamId,
+    );
+  }
+
+  static const ProjectType classType = ProjectType();
+
+  static const ProjectQueryFields<String, Project> _queryFields =
+      ProjectQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Project, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Project, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, Project, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, Project, String?> get NAME => $name;
+  @override
+  AsyncModel<String, Team, PartialTeam, Team>? get team;
+
+  /// Query field for the [team] field.
+  TeamQueryFields<String, Project> get $team => _queryFields.$team;
+
+  /// Query field for the [team] field.
+  @Deprecated(r'Use $team instead')
+  TeamQueryFields<String, Project> get TEAM => $team;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String? get projectTeamId;
+
+  /// Query field for the [projectTeamId] field.
+  QueryField<String, Project, String?> get $projectTeamId =>
+      _queryFields.$projectTeamId;
+
+  /// Query field for the [projectTeamId] field.
+  @Deprecated(r'Use $projectTeamId instead')
+  QueryField<String, Project, String?> get PROJECT_TEAM_ID => $projectTeamId;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Project, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Project, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Project, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'team':
+        value = team;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'projectTeamId':
+        value = projectTeamId;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Project extends Project {
+  _Project({
+    String? id,
+    this.name,
+    Team? team,
+    this.projectTeamId,
+  })  : id = id ?? uuid(),
+        team = team == null ? null : AsyncModel.fromModel(team),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Project._({
+    required this.id,
+    this.name,
+    this.team,
+    required this.createdAt,
+    required this.updatedAt,
+    this.projectTeamId,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final AsyncModel<String, Team, PartialTeam, Team>? team;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? projectTeamId;
+}
+
+abstract class RemoteProject extends Project
+    implements RemoteModel<String, Project> {
+  const RemoteProject._() : super._();
+}
+
+class _RemoteProject extends RemoteProject {
+  const _RemoteProject({
+    required this.id,
+    this.name,
+    this.team,
+    required this.createdAt,
+    required this.updatedAt,
+    this.projectTeamId,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteProject.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<String, Team, PartialTeam, RemoteTeam>.fromModel(
+            Team.classType
+                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final projectTeamId = json['projectTeamId'] == null
+        ? null
+        : (json['projectTeamId'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteProject(
+      id: id,
+      name: name,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      projectTeamId: projectTeamId,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final AsyncModel<String, Team, PartialTeam, RemoteTeam>? team;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? projectTeamId;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/team.dart
@@ -237,6 +237,22 @@ abstract class Team extends PartialTeam implements Model<String, Team> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Team, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Team copyWith({
+    String? id,
+    String? name,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Team._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Team, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/team.dart
@@ -1,0 +1,383 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.team;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class TeamType extends ModelType<String, Team, PartialTeam> {
+  const TeamType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Team>>(Map<String, Object?> json) {
+    if (T == Team || T == Model<String, Team>) {
+      return Team.fromJson(json) as T;
+    }
+    if (T == RemoteTeam || T == RemoteModel<String, Team>) {
+      return _RemoteTeam.fromJson(json) as T;
+    }
+    return _PartialTeam.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Team';
+}
+
+class TeamQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const TeamQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Team>? _root;
+
+  /// Query field for the [Team.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Team, String>(
+        const QueryField<String, Team, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Team.name] field.
+  QueryField<ModelIdentifier, M, String> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, Team, String>(
+        const QueryField<String, Team, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Team.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Team, TemporalDateTime>(
+        const QueryField<String, Team, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Team.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Team, TemporalDateTime>(
+        const QueryField<String, Team, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Team] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Team, String>(
+        const QueryField<String, Team, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialTeam extends PartialModel<String, Team>
+    with AWSEquatable<PartialTeam> {
+  const PartialTeam._();
+
+  String get id;
+  String? get name;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  TeamType get modelType => Team.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Team';
+}
+
+class _PartialTeam extends PartialTeam {
+  const _PartialTeam({
+    required this.id,
+    this.name,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialTeam.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialTeam(
+      id: id,
+      name: name,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Team extends PartialTeam implements Model<String, Team> {
+  factory Team({
+    String? id,
+    required String name,
+  }) = _Team;
+
+  const Team._() : super._();
+
+  factory Team.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'name',
+          ))
+        : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Team._(
+      id: id,
+      name: name,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const TeamType classType = TeamType();
+
+  static const TeamQueryFields<String, Team> _queryFields = TeamQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Team, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Team, String> get ID => $id;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, Team, String> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, Team, String> get NAME => $name;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Team, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Team, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Team, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Team extends Team {
+  _Team({
+    String? id,
+    required this.name,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Team._({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteTeam extends Team implements RemoteModel<String, Team> {
+  const RemoteTeam._() : super._();
+}
+
+class _RemoteTeam extends RemoteTeam {
+  const _RemoteTeam({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteTeam.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'name',
+          ))
+        : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteTeam(
+      id: id,
+      name: name,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/gql_v2_regressions/uni_has_one_implicit/team.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.team;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class TeamType extends ModelType<String, Team, PartialTeam> {
   const TeamType();
@@ -206,6 +207,49 @@ abstract class Team extends PartialTeam implements Model<String, Team> {
   static const TeamType classType = TeamType();
 
   static const TeamQueryFields<String, Team> _queryFields = TeamQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Team',
+      'pluralName': 'Teams',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/comment.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.comment;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'post.dart';
@@ -333,6 +334,84 @@ abstract class Comment extends PartialComment
 
   static const CommentQueryFields<CommentIdentifier, Comment> _queryFields =
       CommentQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Comment',
+      'pluralName': 'Comments',
+      'fields': {
+        'commentId': {
+          'name': 'commentId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'post': {
+          'name': 'post',
+          'type': {'model': 'Post'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Post',
+            'targetNames': [
+              'postCommentsPostId',
+              'postCommentsTitle',
+            ],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'postCommentsPostId': {
+          'name': 'postCommentsPostId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'postCommentsTitle': {
+          'name': 'postCommentsTitle',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'commentId',
+          'sortKeyFields': ['content'],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'post',
+          'sortKeyFields': [
+            'postCommentsPostId',
+            'postCommentsTitle',
+          ],
+          'name': 'post',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get commentId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/comment.dart
@@ -380,6 +380,28 @@ abstract class Comment extends PartialComment
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<CommentIdentifier, Comment, CommentIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  Comment copyWith({
+    String? commentId,
+    String? content,
+    Post? post,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? postCommentsPostId,
+    String? postCommentsTitle,
+  }) {
+    return _Comment._(
+      commentId: commentId ?? this.commentId,
+      content: content ?? this.content,
+      post: post == null ? this.post : AsyncModel.fromModel(post),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      postCommentsPostId: postCommentsPostId ?? this.postCommentsPostId,
+      postCommentsTitle: postCommentsTitle ?? this.postCommentsTitle,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<CommentIdentifier, Comment, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/comment.dart
@@ -199,40 +199,6 @@ abstract class PartialComment extends PartialModel<CommentIdentifier, Comment>
       };
   @override
   String get runtimeTypeName => 'Comment';
-  @override
-  T valueFor<T extends Object?>(
-    QueryField<CommentIdentifier, Comment, T> field,
-  ) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'commentId':
-        value = commentId;
-        break;
-      case r'content':
-        value = content;
-        break;
-      case r'post':
-        value = post;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'postCommentsPostId':
-        value = postCommentsPostId;
-        break;
-      case r'postCommentsTitle':
-        value = postCommentsTitle;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialComment extends PartialComment {
@@ -414,6 +380,40 @@ abstract class Comment extends PartialComment
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<CommentIdentifier, Comment, CommentIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<CommentIdentifier, Comment, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'commentId':
+        value = commentId;
+        break;
+      case r'content':
+        value = content;
+        break;
+      case r'post':
+        value = post;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'postCommentsPostId':
+        value = postCommentsPostId;
+        break;
+      case r'postCommentsTitle':
+        value = postCommentsTitle;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Comment extends Comment {

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/comment.dart
@@ -60,7 +60,8 @@ class CommentType
 
   @override
   T fromJson<T extends PartialModel<CommentIdentifier, Comment>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Comment || T == Model<CommentIdentifier, Comment>) {
       return Comment.fromJson(json) as T;
     }
@@ -84,7 +85,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $commentId =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
         const QueryField<CommentIdentifier, Comment, String>(
-            fieldName: 'commentId'),
+          fieldName: 'commentId',
+        ),
         root: _root,
       );
 
@@ -92,24 +94,26 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $content =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
         const QueryField<CommentIdentifier, Comment, String>(
-            fieldName: 'content'),
+          fieldName: 'content',
+        ),
         root: _root,
       );
 
   /// Query field for the [Comment.post] field.
-  PostQueryFields<ModelIdentifier, M> get $post =>
-      PostQueryFields(NestedQueryField<ModelIdentifier, M, CommentIdentifier,
-          Comment, Post>(
-        const QueryField<CommentIdentifier, Comment, Post>(fieldName: 'post'),
-        root: _root,
-      ));
+  PostQueryFields<ModelIdentifier, M> get $post => PostQueryFields(
+        NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, Post>(
+          const QueryField<CommentIdentifier, Comment, Post>(fieldName: 'post'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Comment.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
           TemporalDateTime>(
         const QueryField<CommentIdentifier, Comment, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -118,7 +122,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
           TemporalDateTime>(
         const QueryField<CommentIdentifier, Comment, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -126,7 +131,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $postCommentsPostId =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String?>(
         const QueryField<CommentIdentifier, Comment, String?>(
-            fieldName: 'postCommentsPostId'),
+          fieldName: 'postCommentsPostId',
+        ),
         root: _root,
       );
 
@@ -134,7 +140,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $postCommentsTitle =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String?>(
         const QueryField<CommentIdentifier, Comment, String?>(
-            fieldName: 'postCommentsTitle'),
+          fieldName: 'postCommentsTitle',
+        ),
         root: _root,
       );
 
@@ -143,7 +150,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
           CommentIdentifier>(
         const QueryField<CommentIdentifier, Comment, CommentIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -193,7 +201,8 @@ abstract class PartialComment extends PartialModel<CommentIdentifier, Comment>
   String get runtimeTypeName => 'Comment';
   @override
   T valueFor<T extends Object?>(
-      QueryField<CommentIdentifier, Comment, T> field) {
+    QueryField<CommentIdentifier, Comment, T> field,
+  ) {
     Object? value;
     switch (field.fieldName) {
       case r'commentId':

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/comment.dart
@@ -383,13 +383,13 @@ abstract class Comment extends PartialComment
         'postCommentsPostId': {
           'name': 'postCommentsPostId',
           'type': {'scalar': 'ID'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
         'postCommentsTitle': {
           'name': 'postCommentsTitle',
           'type': {'scalar': 'String'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
       },
@@ -471,7 +471,7 @@ abstract class Comment extends PartialComment
     return _Comment._(
       commentId: commentId ?? this.commentId,
       content: content ?? this.content,
-      post: post == null ? this.post : AsyncModel.fromModel(post),
+      post: post ?? this.post,
       createdAt:
           createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
       updatedAt:

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'comment.dart';
+import 'post.dart';
+
+export 'comment.dart';
+export 'post.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '1ad7d021179ac9174d2c3ab15111a9ce';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Post.schema,
+        Comment.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Post':
+        return (Post.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Comment':
+        return (Comment.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/model_provider.dart
@@ -35,7 +35,7 @@ class ModelProvider extends ModelProviderInterface {
   static final instance = ModelProvider._();
 
   @override
-  String get version => '1ad7d021179ac9174d2c3ab15111a9ce';
+  String get version => 'd3dfb20c48fabd88be38dc0c88d54f26';
   @override
   List<mipr.ModelTypeDefinition> get modelSchemas => [
         Post.schema,

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/post.dart
@@ -346,6 +346,26 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<PostIdentifier, Post, PostIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  Post copyWith({
+    String? postId,
+    String? title,
+    List<Comment>? comments,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Post._(
+      postId: postId ?? this.postId,
+      title: title ?? this.title,
+      comments: comments == null
+          ? this.comments
+          : AsyncModelCollection.fromList(comments),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/post.dart
@@ -172,32 +172,6 @@ abstract class PartialPost extends PartialModel<PostIdentifier, Post>
       };
   @override
   String get runtimeTypeName => 'Post';
-  @override
-  T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'postId':
-        value = postId;
-        break;
-      case r'title':
-        value = title;
-        break;
-      case r'comments':
-        value = comments;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialPost extends PartialPost {
@@ -372,6 +346,32 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<PostIdentifier, Post, PostIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'postId':
+        value = postId;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'comments':
+        value = comments;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Post extends Post {

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/post.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'comment.dart';
@@ -303,6 +304,62 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
 
   static const PostQueryFields<PostIdentifier, Post> _queryFields =
       PostQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post',
+      'pluralName': 'Posts',
+      'fields': {
+        'postId': {
+          'name': 'postId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'comments': {
+          'name': 'comments',
+          'type': {
+            'list': {'model': 'Comment'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Comment',
+            'associatedFields': ['post'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'postId',
+          'sortKeyFields': ['title'],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get postId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi/post.dart
@@ -59,7 +59,8 @@ class PostType extends ModelType<PostIdentifier, Post, PartialPost> {
 
   @override
   T fromJson<T extends PartialModel<PostIdentifier, Post>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Post || T == Model<PostIdentifier, Post>) {
       return Post.fromJson(json) as T;
     }
@@ -95,17 +96,20 @@ class PostQueryFields<ModelIdentifier extends Object,
 
   /// Query field for the [Post.comments] field.
   CommentQueryFields<ModelIdentifier, M> get $comments => CommentQueryFields(
-          NestedQueryField<ModelIdentifier, M, PostIdentifier, Post, Comment>(
-        const QueryField<PostIdentifier, Post, Comment>(fieldName: 'comments'),
-        root: _root,
-      ));
+        NestedQueryField<ModelIdentifier, M, PostIdentifier, Post, Comment>(
+          const QueryField<PostIdentifier, Post, Comment>(
+              fieldName: 'comments'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Post.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
           TemporalDateTime>(
         const QueryField<PostIdentifier, Post, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -114,7 +118,8 @@ class PostQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
           TemporalDateTime>(
         const QueryField<PostIdentifier, Post, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -123,7 +128,8 @@ class PostQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
           PostIdentifier>(
         const QueryField<PostIdentifier, Post, PostIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -225,14 +231,17 @@ class _PartialPost extends PartialPost {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-                PartialComment>.fromList(
+            PartialComment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) => el == null
-                    ? null
-                    : Comment.classType.fromJson<PartialComment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<PartialComment>(el),
+                )
                 .whereType<PartialComment>()
-                .toList());
+                .toList(),
+          );
     return _PartialPost(
       postId: postId,
       title: title,
@@ -296,13 +305,17 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-                Comment>.fromList(
+            Comment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) =>
-                    el == null ? null : Comment.classType.fromJson<Comment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<Comment>(el),
+                )
                 .whereType<Comment>()
-                .toList());
+                .toList(),
+          );
     return _Post._(
       postId: postId,
       title: title,
@@ -461,14 +474,17 @@ class _RemotePost extends RemotePost {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-                RemoteComment>.fromList(
+            RemoteComment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) => el == null
-                    ? null
-                    : Comment.classType.fromJson<RemoteComment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
                 .whereType<RemoteComment>()
-                .toList());
+                .toList(),
+          );
     return _RemotePost(
       postId: postId,
       title: title,

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/comment.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.comment;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'post.dart';
@@ -338,6 +339,91 @@ abstract class Comment extends PartialComment
 
   static const CommentQueryFields<CommentIdentifier, Comment> _queryFields =
       CommentQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Comment',
+      'pluralName': 'Comments',
+      'fields': {
+        'commentId': {
+          'name': 'commentId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'post': {
+          'name': 'post',
+          'type': {'model': 'Post'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Post',
+            'targetNames': [
+              'postId',
+              'postTitle',
+            ],
+          },
+        },
+        'postId': {
+          'name': 'postId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'postTitle': {
+          'name': 'postTitle',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'secondary',
+          'primaryField': 'postId',
+          'sortKeyFields': [],
+          'name': 'byPost',
+          'queryField': 'commentsByPostId',
+        },
+        {
+          'type': 'primary',
+          'primaryField': 'commentId',
+          'sortKeyFields': ['content'],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'post',
+          'sortKeyFields': [
+            'postId',
+            'postTitle',
+          ],
+          'name': 'post',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get commentId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/comment.dart
@@ -499,7 +499,7 @@ abstract class Comment extends PartialComment
     return _Comment._(
       commentId: commentId ?? this.commentId,
       content: content ?? this.content,
-      post: post == null ? this.post : AsyncModel.fromModel(post),
+      post: post ?? this.post,
       postId: postId ?? this.postId,
       postTitle: postTitle ?? this.postTitle,
       createdAt:

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/comment.dart
@@ -401,6 +401,28 @@ abstract class Comment extends PartialComment
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<CommentIdentifier, Comment, CommentIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  Comment copyWith({
+    String? commentId,
+    String? content,
+    Post? post,
+    String? postId,
+    String? postTitle,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Comment._(
+      commentId: commentId ?? this.commentId,
+      content: content ?? this.content,
+      post: post == null ? this.post : AsyncModel.fromModel(post),
+      postId: postId ?? this.postId,
+      postTitle: postTitle ?? this.postTitle,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<CommentIdentifier, Comment, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/comment.dart
@@ -60,7 +60,8 @@ class CommentType
 
   @override
   T fromJson<T extends PartialModel<CommentIdentifier, Comment>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Comment || T == Model<CommentIdentifier, Comment>) {
       return Comment.fromJson(json) as T;
     }
@@ -84,7 +85,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $commentId =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
         const QueryField<CommentIdentifier, Comment, String>(
-            fieldName: 'commentId'),
+          fieldName: 'commentId',
+        ),
         root: _root,
       );
 
@@ -92,23 +94,25 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $content =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
         const QueryField<CommentIdentifier, Comment, String>(
-            fieldName: 'content'),
+          fieldName: 'content',
+        ),
         root: _root,
       );
 
   /// Query field for the [Comment.post] field.
-  PostQueryFields<ModelIdentifier, M> get $post =>
-      PostQueryFields(NestedQueryField<ModelIdentifier, M, CommentIdentifier,
-          Comment, Post>(
-        const QueryField<CommentIdentifier, Comment, Post>(fieldName: 'post'),
-        root: _root,
-      ));
+  PostQueryFields<ModelIdentifier, M> get $post => PostQueryFields(
+        NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, Post>(
+          const QueryField<CommentIdentifier, Comment, Post>(fieldName: 'post'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Comment.postId] field.
   QueryField<ModelIdentifier, M, String> get $postId =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
         const QueryField<CommentIdentifier, Comment, String>(
-            fieldName: 'postId'),
+          fieldName: 'postId',
+        ),
         root: _root,
       );
 
@@ -116,7 +120,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $postTitle =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
         const QueryField<CommentIdentifier, Comment, String>(
-            fieldName: 'postTitle'),
+          fieldName: 'postTitle',
+        ),
         root: _root,
       );
 
@@ -125,7 +130,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
           TemporalDateTime>(
         const QueryField<CommentIdentifier, Comment, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -134,7 +140,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
           TemporalDateTime>(
         const QueryField<CommentIdentifier, Comment, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -143,7 +150,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
           CommentIdentifier>(
         const QueryField<CommentIdentifier, Comment, CommentIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -193,7 +201,8 @@ abstract class PartialComment extends PartialModel<CommentIdentifier, Comment>
   String get runtimeTypeName => 'Comment';
   @override
   T valueFor<T extends Object?>(
-      QueryField<CommentIdentifier, Comment, T> field) {
+    QueryField<CommentIdentifier, Comment, T> field,
+  ) {
     Object? value;
     switch (field.fieldName) {
       case r'commentId':

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/comment.dart
@@ -199,40 +199,6 @@ abstract class PartialComment extends PartialModel<CommentIdentifier, Comment>
       };
   @override
   String get runtimeTypeName => 'Comment';
-  @override
-  T valueFor<T extends Object?>(
-    QueryField<CommentIdentifier, Comment, T> field,
-  ) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'commentId':
-        value = commentId;
-        break;
-      case r'content':
-        value = content;
-        break;
-      case r'post':
-        value = post;
-        break;
-      case r'postId':
-        value = postId;
-        break;
-      case r'postTitle':
-        value = postTitle;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialComment extends PartialComment {
@@ -435,6 +401,40 @@ abstract class Comment extends PartialComment
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<CommentIdentifier, Comment, CommentIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<CommentIdentifier, Comment, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'commentId':
+        value = commentId;
+        break;
+      case r'content':
+        value = content;
+        break;
+      case r'post':
+        value = post;
+        break;
+      case r'postId':
+        value = postId;
+        break;
+      case r'postTitle':
+        value = postTitle;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Comment extends Comment {

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'comment.dart';
+import 'post.dart';
+
+export 'comment.dart';
+export 'post.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'aa9b80cfb8feb7b0d7ec7c11191cd87e';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Post.schema,
+        Comment.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Post':
+        return (Post.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Comment':
+        return (Comment.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/post.dart
@@ -346,6 +346,26 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<PostIdentifier, Post, PostIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  Post copyWith({
+    String? postId,
+    String? title,
+    List<Comment>? comments,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Post._(
+      postId: postId ?? this.postId,
+      title: title ?? this.title,
+      comments: comments == null
+          ? this.comments
+          : AsyncModelCollection.fromList(comments),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/post.dart
@@ -172,32 +172,6 @@ abstract class PartialPost extends PartialModel<PostIdentifier, Post>
       };
   @override
   String get runtimeTypeName => 'Post';
-  @override
-  T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'postId':
-        value = postId;
-        break;
-      case r'title':
-        value = title;
-        break;
-      case r'comments':
-        value = comments;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialPost extends PartialPost {
@@ -372,6 +346,32 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<PostIdentifier, Post, PostIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'postId':
+        value = postId;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'comments':
+        value = comments;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Post extends Post {

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/post.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'comment.dart';
@@ -303,6 +304,62 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
 
   static const PostQueryFields<PostIdentifier, Post> _queryFields =
       PostQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post',
+      'pluralName': 'Posts',
+      'fields': {
+        'postId': {
+          'name': 'postId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'comments': {
+          'name': 'comments',
+          'type': {
+            'list': {'model': 'Comment'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Comment',
+            'associatedFields': ['post'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'postId',
+          'sortKeyFields': ['title'],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get postId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/bidi_with_index/post.dart
@@ -59,7 +59,8 @@ class PostType extends ModelType<PostIdentifier, Post, PartialPost> {
 
   @override
   T fromJson<T extends PartialModel<PostIdentifier, Post>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Post || T == Model<PostIdentifier, Post>) {
       return Post.fromJson(json) as T;
     }
@@ -95,17 +96,20 @@ class PostQueryFields<ModelIdentifier extends Object,
 
   /// Query field for the [Post.comments] field.
   CommentQueryFields<ModelIdentifier, M> get $comments => CommentQueryFields(
-          NestedQueryField<ModelIdentifier, M, PostIdentifier, Post, Comment>(
-        const QueryField<PostIdentifier, Post, Comment>(fieldName: 'comments'),
-        root: _root,
-      ));
+        NestedQueryField<ModelIdentifier, M, PostIdentifier, Post, Comment>(
+          const QueryField<PostIdentifier, Post, Comment>(
+              fieldName: 'comments'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Post.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
           TemporalDateTime>(
         const QueryField<PostIdentifier, Post, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -114,7 +118,8 @@ class PostQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
           TemporalDateTime>(
         const QueryField<PostIdentifier, Post, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -123,7 +128,8 @@ class PostQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
           PostIdentifier>(
         const QueryField<PostIdentifier, Post, PostIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -225,14 +231,17 @@ class _PartialPost extends PartialPost {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-                PartialComment>.fromList(
+            PartialComment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) => el == null
-                    ? null
-                    : Comment.classType.fromJson<PartialComment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<PartialComment>(el),
+                )
                 .whereType<PartialComment>()
-                .toList());
+                .toList(),
+          );
     return _PartialPost(
       postId: postId,
       title: title,
@@ -296,13 +305,17 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-                Comment>.fromList(
+            Comment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) =>
-                    el == null ? null : Comment.classType.fromJson<Comment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<Comment>(el),
+                )
                 .whereType<Comment>()
-                .toList());
+                .toList(),
+          );
     return _Post._(
       postId: postId,
       title: title,
@@ -461,14 +474,17 @@ class _RemotePost extends RemotePost {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-                RemoteComment>.fromList(
+            RemoteComment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) => el == null
-                    ? null
-                    : Comment.classType.fromJson<RemoteComment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
                 .whereType<RemoteComment>()
-                .toList());
+                .toList(),
+          );
     return _RemotePost(
       postId: postId,
       title: title,

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/blog.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/blog.dart
@@ -63,17 +63,19 @@ class BlogQueryFields<ModelIdentifier extends Object,
       );
 
   /// Query field for the [Blog.posts] field.
-  PostQueryFields<ModelIdentifier, M> get $posts =>
-      PostQueryFields(NestedQueryField<ModelIdentifier, M, String, Blog, Post>(
-        const QueryField<String, Blog, Post>(fieldName: 'posts'),
-        root: _root,
-      ));
+  PostQueryFields<ModelIdentifier, M> get $posts => PostQueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Blog, Post>(
+          const QueryField<String, Blog, Post>(fieldName: 'posts'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Blog.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, String, Blog, TemporalDateTime>(
         const QueryField<String, Blog, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -81,7 +83,8 @@ class BlogQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
       NestedQueryField<ModelIdentifier, M, String, Blog, TemporalDateTime>(
         const QueryField<String, Blog, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -183,11 +186,14 @@ class _PartialBlog extends PartialBlog {
         : AsyncModelCollection<String, Post, PartialPost, PartialPost>.fromList(
             (json['posts'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) => el == null
-                    ? null
-                    : Post.classType.fromJson<PartialPost>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Post.classType.fromJson<PartialPost>(el),
+                )
                 .whereType<PartialPost>()
-                .toList());
+                .toList(),
+          );
     return _PartialBlog(
       id: id,
       name: name,
@@ -249,12 +255,14 @@ abstract class Blog extends PartialBlog implements Model<String, Blog> {
         : TemporalDateTime.fromString((json['updatedAt'] as String));
     final posts = json['posts'] == null
         ? null
-        : AsyncModelCollection<String, Post, PartialPost, Post>.fromList((json[
-                'posts'] as List<Object?>)
-            .cast<Map<String, Object?>?>()
-            .map((el) => el == null ? null : Post.classType.fromJson<Post>(el))
-            .whereType<Post>()
-            .toList());
+        : AsyncModelCollection<String, Post, PartialPost, Post>.fromList(
+            (json['posts'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map((el) =>
+                    el == null ? null : Post.classType.fromJson<Post>(el))
+                .whereType<Post>()
+                .toList(),
+          );
     return _Blog._(
       id: id,
       name: name,
@@ -408,10 +416,14 @@ class _RemoteBlog extends RemoteBlog {
         : AsyncModelCollection<String, Post, PartialPost, RemotePost>.fromList(
             (json['posts'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) =>
-                    el == null ? null : Post.classType.fromJson<RemotePost>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Post.classType.fromJson<RemotePost>(el),
+                )
                 .whereType<RemotePost>()
-                .toList());
+                .toList(),
+          );
     return _RemoteBlog(
       id: id,
       name: name,

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/blog.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/blog.dart
@@ -289,6 +289,24 @@ abstract class Blog extends PartialBlog implements Model<String, Blog> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Blog, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Blog copyWith({
+    String? id,
+    String? name,
+    List<Post>? posts,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Blog._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      posts: posts == null ? this.posts : AsyncModelCollection.fromList(posts),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Blog, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/blog.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/blog.dart
@@ -130,32 +130,6 @@ abstract class PartialBlog extends PartialModel<String, Blog>
       };
   @override
   String get runtimeTypeName => 'Blog';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, Blog, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'id':
-        value = id;
-        break;
-      case r'name':
-        value = name;
-        break;
-      case r'posts':
-        value = posts;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialBlog extends PartialBlog {
@@ -315,6 +289,32 @@ abstract class Blog extends PartialBlog implements Model<String, Blog> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Blog, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Blog, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'posts':
+        value = posts;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Blog extends Blog {

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/blog.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/blog.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.blog;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'post.dart';
 
@@ -249,6 +250,62 @@ abstract class Blog extends PartialBlog implements Model<String, Blog> {
   static const BlogType classType = BlogType();
 
   static const BlogQueryFields<String, Blog> _queryFields = BlogQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Blog',
+      'pluralName': 'Blogs',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'posts': {
+          'name': 'posts',
+          'type': {
+            'list': {'model': 'Post'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Post',
+            'associatedFields': ['blog'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/comment.dart
@@ -302,6 +302,26 @@ abstract class Comment extends PartialComment
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Comment, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Comment copyWith({
+    String? id,
+    Post? post,
+    String? content,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? postCommentsId,
+  }) {
+    return _Comment._(
+      id: id ?? this.id,
+      post: post == null ? this.post : AsyncModel.fromModel(post),
+      content: content ?? this.content,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      postCommentsId: postCommentsId ?? this.postCommentsId,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Comment, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/comment.dart
@@ -307,7 +307,7 @@ abstract class Comment extends PartialComment
         'postCommentsId': {
           'name': 'postCommentsId',
           'type': {'scalar': 'ID'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
       },
@@ -379,7 +379,7 @@ abstract class Comment extends PartialComment
   }) {
     return _Comment._(
       id: id ?? this.id,
-      post: post == null ? this.post : AsyncModel.fromModel(post),
+      post: post ?? this.post,
       content: content ?? this.content,
       createdAt:
           createdAt == null ? this.createdAt : TemporalDateTime(createdAt),

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/comment.dart
@@ -29,7 +29,8 @@ class CommentType extends ModelType<String, Comment, PartialComment> {
 
   @override
   T fromJson<T extends PartialModel<String, Comment>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Comment || T == Model<String, Comment>) {
       return Comment.fromJson(json) as T;
     }
@@ -58,10 +59,11 @@ class CommentQueryFields<ModelIdentifier extends Object,
 
   /// Query field for the [Comment.post] field.
   PostQueryFields<ModelIdentifier, M> get $post => PostQueryFields(
-          NestedQueryField<ModelIdentifier, M, String, Comment, Post>(
-        const QueryField<String, Comment, Post>(fieldName: 'post'),
-        root: _root,
-      ));
+        NestedQueryField<ModelIdentifier, M, String, Comment, Post>(
+          const QueryField<String, Comment, Post>(fieldName: 'post'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Comment.content] field.
   QueryField<ModelIdentifier, M, String> get $content =>
@@ -74,7 +76,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, String, Comment, TemporalDateTime>(
         const QueryField<String, Comment, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -82,7 +85,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
       NestedQueryField<ModelIdentifier, M, String, Comment, TemporalDateTime>(
         const QueryField<String, Comment, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/comment.dart
@@ -142,35 +142,6 @@ abstract class PartialComment extends PartialModel<String, Comment>
       };
   @override
   String get runtimeTypeName => 'Comment';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, Comment, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'id':
-        value = id;
-        break;
-      case r'post':
-        value = post;
-        break;
-      case r'content':
-        value = content;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'postCommentsId':
-        value = postCommentsId;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialComment extends PartialComment {
@@ -331,6 +302,35 @@ abstract class Comment extends PartialComment
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Comment, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Comment, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'post':
+        value = post;
+        break;
+      case r'content':
+        value = content;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'postCommentsId':
+        value = postCommentsId;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Comment extends Comment {

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/comment.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.comment;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'post.dart';
 
@@ -260,6 +261,72 @@ abstract class Comment extends PartialComment
 
   static const CommentQueryFields<String, Comment> _queryFields =
       CommentQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Comment',
+      'pluralName': 'Comments',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'post': {
+          'name': 'post',
+          'type': {'model': 'Post'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Post',
+            'targetNames': ['postCommentsId'],
+          },
+        },
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'postCommentsId': {
+          'name': 'postCommentsId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'post',
+          'sortKeyFields': ['postCommentsId'],
+          'name': 'post',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/model_provider.dart
@@ -1,0 +1,74 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'blog.dart';
+import 'comment.dart';
+import 'post.dart';
+
+export 'blog.dart';
+export 'comment.dart';
+export 'post.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '9d857a566835bf4fd9da401eefff789d';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Blog.schema,
+        Post.schema,
+        Comment.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Blog':
+        return (Blog.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Post':
+        return (Post.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Comment':
+        return (Comment.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/model_provider.dart
@@ -37,7 +37,7 @@ class ModelProvider extends ModelProviderInterface {
   static final instance = ModelProvider._();
 
   @override
-  String get version => '9d857a566835bf4fd9da401eefff789d';
+  String get version => 'd93278791d7bc01059d6169007f14f82';
   @override
   List<mipr.ModelTypeDefinition> get modelSchemas => [
         Blog.schema,

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/post.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'blog.dart';
 import 'comment.dart';
@@ -302,6 +303,85 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   static const PostType classType = PostType();
 
   static const PostQueryFields<String, Post> _queryFields = PostQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post',
+      'pluralName': 'Posts',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'blog': {
+          'name': 'blog',
+          'type': {'model': 'Blog'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Blog',
+            'targetNames': ['blogPostsId'],
+          },
+        },
+        'comments': {
+          'name': 'comments',
+          'type': {
+            'list': {'model': 'Comment'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Comment',
+            'associatedFields': ['post'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'blogPostsId': {
+          'name': 'blogPostsId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'blog',
+          'sortKeyFields': ['blogPostsId'],
+          'name': 'blog',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/post.dart
@@ -64,24 +64,27 @@ class PostQueryFields<ModelIdentifier extends Object,
       );
 
   /// Query field for the [Post.blog] field.
-  BlogQueryFields<ModelIdentifier, M> get $blog =>
-      BlogQueryFields(NestedQueryField<ModelIdentifier, M, String, Post, Blog>(
-        const QueryField<String, Post, Blog>(fieldName: 'blog'),
-        root: _root,
-      ));
+  BlogQueryFields<ModelIdentifier, M> get $blog => BlogQueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Post, Blog>(
+          const QueryField<String, Post, Blog>(fieldName: 'blog'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Post.comments] field.
   CommentQueryFields<ModelIdentifier, M> get $comments => CommentQueryFields(
-          NestedQueryField<ModelIdentifier, M, String, Post, Comment>(
-        const QueryField<String, Post, Comment>(fieldName: 'comments'),
-        root: _root,
-      ));
+        NestedQueryField<ModelIdentifier, M, String, Post, Comment>(
+          const QueryField<String, Post, Comment>(fieldName: 'comments'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Post.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, String, Post, TemporalDateTime>(
         const QueryField<String, Post, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -89,7 +92,8 @@ class PostQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
       NestedQueryField<ModelIdentifier, M, String, Post, TemporalDateTime>(
         const QueryField<String, Post, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -217,14 +221,17 @@ class _PartialPost extends PartialPost {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<String, Comment, PartialComment,
-                PartialComment>.fromList(
+            PartialComment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) => el == null
-                    ? null
-                    : Comment.classType.fromJson<PartialComment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<PartialComment>(el),
+                )
                 .whereType<PartialComment>()
-                .toList());
+                .toList(),
+          );
     return _PartialPost(
       id: id,
       title: title,
@@ -302,13 +309,17 @@ abstract class Post extends PartialPost implements Model<String, Post> {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<String, Comment, PartialComment,
-                Comment>.fromList(
+            Comment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) =>
-                    el == null ? null : Comment.classType.fromJson<Comment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<Comment>(el),
+                )
                 .whereType<Comment>()
-                .toList());
+                .toList(),
+          );
     return _Post._(
       id: id,
       title: title,
@@ -493,14 +504,17 @@ class _RemotePost extends RemotePost {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<String, Comment, PartialComment,
-                RemoteComment>.fromList(
+            RemoteComment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) => el == null
-                    ? null
-                    : Comment.classType.fromJson<RemoteComment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
                 .whereType<RemoteComment>()
-                .toList());
+                .toList(),
+          );
     return _RemotePost(
       id: id,
       title: title,

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/post.dart
@@ -362,7 +362,7 @@ abstract class Post extends PartialPost implements Model<String, Post> {
         'blogPostsId': {
           'name': 'blogPostsId',
           'type': {'scalar': 'ID'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
       },
@@ -445,7 +445,7 @@ abstract class Post extends PartialPost implements Model<String, Post> {
     return _Post._(
       id: id ?? this.id,
       title: title ?? this.title,
-      blog: blog == null ? this.blog : AsyncModel.fromModel(blog),
+      blog: blog ?? this.blog,
       comments: comments == null
           ? this.comments
           : AsyncModelCollection.fromList(comments),

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/post.dart
@@ -353,6 +353,30 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Post, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Post copyWith({
+    String? id,
+    String? title,
+    Blog? blog,
+    List<Comment>? comments,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? blogPostsId,
+  }) {
+    return _Post._(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      blog: blog == null ? this.blog : AsyncModel.fromModel(blog),
+      comments: comments == null
+          ? this.comments
+          : AsyncModelCollection.fromList(comments),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      blogPostsId: blogPostsId ?? this.blogPostsId,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/blog/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/blog/post.dart
@@ -153,38 +153,6 @@ abstract class PartialPost extends PartialModel<String, Post>
       };
   @override
   String get runtimeTypeName => 'Post';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'id':
-        value = id;
-        break;
-      case r'title':
-        value = title;
-        break;
-      case r'blog':
-        value = blog;
-        break;
-      case r'comments':
-        value = comments;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'blogPostsId':
-        value = blogPostsId;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialPost extends PartialPost {
@@ -385,6 +353,38 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Post, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'blog':
+        value = blog;
+        break;
+      case r'comments':
+        value = comments;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'blogPostsId':
+        value = blogPostsId;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Post extends Post {

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni/comment.dart
@@ -364,6 +364,26 @@ abstract class Comment extends PartialComment
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<CommentIdentifier, Comment, CommentIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  Comment copyWith({
+    String? commentId,
+    String? content,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? postCommentsPostId,
+    String? postCommentsTitle,
+  }) {
+    return _Comment._(
+      commentId: commentId ?? this.commentId,
+      content: content ?? this.content,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      postCommentsPostId: postCommentsPostId ?? this.postCommentsPostId,
+      postCommentsTitle: postCommentsTitle ?? this.postCommentsTitle,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<CommentIdentifier, Comment, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni/comment.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.comment;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 @immutable
@@ -308,6 +309,70 @@ abstract class Comment extends PartialComment
 
   static const CommentQueryFields<CommentIdentifier, Comment> _queryFields =
       CommentQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Comment',
+      'pluralName': 'Comments',
+      'fields': {
+        'commentId': {
+          'name': 'commentId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'postCommentsPostId': {
+          'name': 'postCommentsPostId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'postCommentsTitle': {
+          'name': 'postCommentsTitle',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'commentId',
+          'sortKeyFields': ['content'],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'Post.comments',
+          'sortKeyFields': [
+            'postCommentsPostId',
+            'postCommentsTitle',
+          ],
+          'name': 'gsi-Post.comments',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get commentId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni/comment.dart
@@ -186,37 +186,6 @@ abstract class PartialComment extends PartialModel<CommentIdentifier, Comment>
       };
   @override
   String get runtimeTypeName => 'Comment';
-  @override
-  T valueFor<T extends Object?>(
-    QueryField<CommentIdentifier, Comment, T> field,
-  ) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'commentId':
-        value = commentId;
-        break;
-      case r'content':
-        value = content;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'postCommentsPostId':
-        value = postCommentsPostId;
-        break;
-      case r'postCommentsTitle':
-        value = postCommentsTitle;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialComment extends PartialComment {
@@ -395,6 +364,37 @@ abstract class Comment extends PartialComment
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<CommentIdentifier, Comment, CommentIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<CommentIdentifier, Comment, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'commentId':
+        value = commentId;
+        break;
+      case r'content':
+        value = content;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'postCommentsPostId':
+        value = postCommentsPostId;
+        break;
+      case r'postCommentsTitle':
+        value = postCommentsTitle;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Comment extends Comment {

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni/comment.dart
@@ -58,7 +58,8 @@ class CommentType
 
   @override
   T fromJson<T extends PartialModel<CommentIdentifier, Comment>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Comment || T == Model<CommentIdentifier, Comment>) {
       return Comment.fromJson(json) as T;
     }
@@ -82,7 +83,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $commentId =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
         const QueryField<CommentIdentifier, Comment, String>(
-            fieldName: 'commentId'),
+          fieldName: 'commentId',
+        ),
         root: _root,
       );
 
@@ -90,7 +92,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $content =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
         const QueryField<CommentIdentifier, Comment, String>(
-            fieldName: 'content'),
+          fieldName: 'content',
+        ),
         root: _root,
       );
 
@@ -99,7 +102,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
           TemporalDateTime>(
         const QueryField<CommentIdentifier, Comment, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -108,7 +112,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
           TemporalDateTime>(
         const QueryField<CommentIdentifier, Comment, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -116,7 +121,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $postCommentsPostId =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String?>(
         const QueryField<CommentIdentifier, Comment, String?>(
-            fieldName: 'postCommentsPostId'),
+          fieldName: 'postCommentsPostId',
+        ),
         root: _root,
       );
 
@@ -124,7 +130,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $postCommentsTitle =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String?>(
         const QueryField<CommentIdentifier, Comment, String?>(
-            fieldName: 'postCommentsTitle'),
+          fieldName: 'postCommentsTitle',
+        ),
         root: _root,
       );
 
@@ -133,7 +140,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
           CommentIdentifier>(
         const QueryField<CommentIdentifier, Comment, CommentIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -180,7 +188,8 @@ abstract class PartialComment extends PartialModel<CommentIdentifier, Comment>
   String get runtimeTypeName => 'Comment';
   @override
   T valueFor<T extends Object?>(
-      QueryField<CommentIdentifier, Comment, T> field) {
+    QueryField<CommentIdentifier, Comment, T> field,
+  ) {
     Object? value;
     switch (field.fieldName) {
       case r'commentId':

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'comment.dart';
+import 'post.dart';
+
+export 'comment.dart';
+export 'post.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'f85a5f8319aae7420b7f0edadb0eef86';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Post.schema,
+        Comment.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Post':
+        return (Post.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Comment':
+        return (Comment.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni/post.dart
@@ -346,6 +346,26 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<PostIdentifier, Post, PostIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  Post copyWith({
+    String? postId,
+    String? title,
+    List<Comment>? comments,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Post._(
+      postId: postId ?? this.postId,
+      title: title ?? this.title,
+      comments: comments == null
+          ? this.comments
+          : AsyncModelCollection.fromList(comments),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni/post.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'comment.dart';
@@ -303,6 +304,65 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
 
   static const PostQueryFields<PostIdentifier, Post> _queryFields =
       PostQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post',
+      'pluralName': 'Posts',
+      'fields': {
+        'postId': {
+          'name': 'postId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'comments': {
+          'name': 'comments',
+          'type': {
+            'list': {'model': 'Comment'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Comment',
+            'associatedFields': [
+              'postCommentsPostId',
+              'postCommentsTitle',
+            ],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'postId',
+          'sortKeyFields': ['title'],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get postId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni/post.dart
@@ -172,32 +172,6 @@ abstract class PartialPost extends PartialModel<PostIdentifier, Post>
       };
   @override
   String get runtimeTypeName => 'Post';
-  @override
-  T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'postId':
-        value = postId;
-        break;
-      case r'title':
-        value = title;
-        break;
-      case r'comments':
-        value = comments;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialPost extends PartialPost {
@@ -372,6 +346,32 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<PostIdentifier, Post, PostIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'postId':
+        value = postId;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'comments':
+        value = comments;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Post extends Post {

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni/post.dart
@@ -59,7 +59,8 @@ class PostType extends ModelType<PostIdentifier, Post, PartialPost> {
 
   @override
   T fromJson<T extends PartialModel<PostIdentifier, Post>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Post || T == Model<PostIdentifier, Post>) {
       return Post.fromJson(json) as T;
     }
@@ -95,17 +96,20 @@ class PostQueryFields<ModelIdentifier extends Object,
 
   /// Query field for the [Post.comments] field.
   CommentQueryFields<ModelIdentifier, M> get $comments => CommentQueryFields(
-          NestedQueryField<ModelIdentifier, M, PostIdentifier, Post, Comment>(
-        const QueryField<PostIdentifier, Post, Comment>(fieldName: 'comments'),
-        root: _root,
-      ));
+        NestedQueryField<ModelIdentifier, M, PostIdentifier, Post, Comment>(
+          const QueryField<PostIdentifier, Post, Comment>(
+              fieldName: 'comments'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Post.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
           TemporalDateTime>(
         const QueryField<PostIdentifier, Post, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -114,7 +118,8 @@ class PostQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
           TemporalDateTime>(
         const QueryField<PostIdentifier, Post, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -123,7 +128,8 @@ class PostQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
           PostIdentifier>(
         const QueryField<PostIdentifier, Post, PostIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -225,14 +231,17 @@ class _PartialPost extends PartialPost {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-                PartialComment>.fromList(
+            PartialComment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) => el == null
-                    ? null
-                    : Comment.classType.fromJson<PartialComment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<PartialComment>(el),
+                )
                 .whereType<PartialComment>()
-                .toList());
+                .toList(),
+          );
     return _PartialPost(
       postId: postId,
       title: title,
@@ -296,13 +305,17 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-                Comment>.fromList(
+            Comment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) =>
-                    el == null ? null : Comment.classType.fromJson<Comment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<Comment>(el),
+                )
                 .whereType<Comment>()
-                .toList());
+                .toList(),
+          );
     return _Post._(
       postId: postId,
       title: title,
@@ -461,14 +474,17 @@ class _RemotePost extends RemotePost {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-                RemoteComment>.fromList(
+            RemoteComment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) => el == null
-                    ? null
-                    : Comment.classType.fromJson<RemoteComment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
                 .whereType<RemoteComment>()
-                .toList());
+                .toList(),
+          );
     return _RemotePost(
       postId: postId,
       title: title,

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/comment.dart
@@ -365,6 +365,26 @@ abstract class Comment extends PartialComment
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<CommentIdentifier, Comment, CommentIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  Comment copyWith({
+    String? commentId,
+    String? content,
+    String? postId,
+    String? postTitle,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Comment._(
+      commentId: commentId ?? this.commentId,
+      content: content ?? this.content,
+      postId: postId ?? this.postId,
+      postTitle: postTitle ?? this.postTitle,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<CommentIdentifier, Comment, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/comment.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.comment;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 @immutable
@@ -311,6 +312,68 @@ abstract class Comment extends PartialComment
 
   static const CommentQueryFields<CommentIdentifier, Comment> _queryFields =
       CommentQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Comment',
+      'pluralName': 'Comments',
+      'fields': {
+        'commentId': {
+          'name': 'commentId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'postId': {
+          'name': 'postId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'postTitle': {
+          'name': 'postTitle',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'secondary',
+          'primaryField': 'postId',
+          'sortKeyFields': [],
+          'name': 'byPost',
+          'queryField': 'commentsByPostId',
+        },
+        {
+          'type': 'primary',
+          'primaryField': 'commentId',
+          'sortKeyFields': ['content'],
+        },
+      ],
+    },
+  )!;
 
   @override
   String get commentId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/comment.dart
@@ -186,37 +186,6 @@ abstract class PartialComment extends PartialModel<CommentIdentifier, Comment>
       };
   @override
   String get runtimeTypeName => 'Comment';
-  @override
-  T valueFor<T extends Object?>(
-    QueryField<CommentIdentifier, Comment, T> field,
-  ) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'commentId':
-        value = commentId;
-        break;
-      case r'content':
-        value = content;
-        break;
-      case r'postId':
-        value = postId;
-        break;
-      case r'postTitle':
-        value = postTitle;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialComment extends PartialComment {
@@ -396,6 +365,37 @@ abstract class Comment extends PartialComment
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<CommentIdentifier, Comment, CommentIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<CommentIdentifier, Comment, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'commentId':
+        value = commentId;
+        break;
+      case r'content':
+        value = content;
+        break;
+      case r'postId':
+        value = postId;
+        break;
+      case r'postTitle':
+        value = postTitle;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Comment extends Comment {

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/comment.dart
@@ -58,7 +58,8 @@ class CommentType
 
   @override
   T fromJson<T extends PartialModel<CommentIdentifier, Comment>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Comment || T == Model<CommentIdentifier, Comment>) {
       return Comment.fromJson(json) as T;
     }
@@ -82,7 +83,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $commentId =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
         const QueryField<CommentIdentifier, Comment, String>(
-            fieldName: 'commentId'),
+          fieldName: 'commentId',
+        ),
         root: _root,
       );
 
@@ -90,7 +92,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $content =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
         const QueryField<CommentIdentifier, Comment, String>(
-            fieldName: 'content'),
+          fieldName: 'content',
+        ),
         root: _root,
       );
 
@@ -98,7 +101,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $postId =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
         const QueryField<CommentIdentifier, Comment, String>(
-            fieldName: 'postId'),
+          fieldName: 'postId',
+        ),
         root: _root,
       );
 
@@ -106,7 +110,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $postTitle =>
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
         const QueryField<CommentIdentifier, Comment, String>(
-            fieldName: 'postTitle'),
+          fieldName: 'postTitle',
+        ),
         root: _root,
       );
 
@@ -115,7 +120,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
           TemporalDateTime>(
         const QueryField<CommentIdentifier, Comment, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -124,7 +130,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
           TemporalDateTime>(
         const QueryField<CommentIdentifier, Comment, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -133,7 +140,8 @@ class CommentQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
           CommentIdentifier>(
         const QueryField<CommentIdentifier, Comment, CommentIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -180,7 +188,8 @@ abstract class PartialComment extends PartialModel<CommentIdentifier, Comment>
   String get runtimeTypeName => 'Comment';
   @override
   T valueFor<T extends Object?>(
-      QueryField<CommentIdentifier, Comment, T> field) {
+    QueryField<CommentIdentifier, Comment, T> field,
+  ) {
     Object? value;
     switch (field.fieldName) {
       case r'commentId':

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'comment.dart';
+import 'post.dart';
+
+export 'comment.dart';
+export 'post.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'b8a14627b7e364694e0c7c1423e6f9a5';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Post.schema,
+        Comment.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Post':
+        return (Post.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Comment':
+        return (Comment.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/post.dart
@@ -346,6 +346,26 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<PostIdentifier, Post, PostIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  Post copyWith({
+    String? postId,
+    String? title,
+    List<Comment>? comments,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Post._(
+      postId: postId ?? this.postId,
+      title: title ?? this.title,
+      comments: comments == null
+          ? this.comments
+          : AsyncModelCollection.fromList(comments),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/post.dart
@@ -172,32 +172,6 @@ abstract class PartialPost extends PartialModel<PostIdentifier, Post>
       };
   @override
   String get runtimeTypeName => 'Post';
-  @override
-  T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'postId':
-        value = postId;
-        break;
-      case r'title':
-        value = title;
-        break;
-      case r'comments':
-        value = comments;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialPost extends PartialPost {
@@ -372,6 +346,32 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<PostIdentifier, Post, PostIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'postId':
+        value = postId;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'comments':
+        value = comments;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Post extends Post {

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/post.dart
@@ -59,7 +59,8 @@ class PostType extends ModelType<PostIdentifier, Post, PartialPost> {
 
   @override
   T fromJson<T extends PartialModel<PostIdentifier, Post>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Post || T == Model<PostIdentifier, Post>) {
       return Post.fromJson(json) as T;
     }
@@ -95,17 +96,20 @@ class PostQueryFields<ModelIdentifier extends Object,
 
   /// Query field for the [Post.comments] field.
   CommentQueryFields<ModelIdentifier, M> get $comments => CommentQueryFields(
-          NestedQueryField<ModelIdentifier, M, PostIdentifier, Post, Comment>(
-        const QueryField<PostIdentifier, Post, Comment>(fieldName: 'comments'),
-        root: _root,
-      ));
+        NestedQueryField<ModelIdentifier, M, PostIdentifier, Post, Comment>(
+          const QueryField<PostIdentifier, Post, Comment>(
+              fieldName: 'comments'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Post.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
           TemporalDateTime>(
         const QueryField<PostIdentifier, Post, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -114,7 +118,8 @@ class PostQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
           TemporalDateTime>(
         const QueryField<PostIdentifier, Post, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -123,7 +128,8 @@ class PostQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
           PostIdentifier>(
         const QueryField<PostIdentifier, Post, PostIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -225,14 +231,17 @@ class _PartialPost extends PartialPost {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-                PartialComment>.fromList(
+            PartialComment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) => el == null
-                    ? null
-                    : Comment.classType.fromJson<PartialComment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<PartialComment>(el),
+                )
                 .whereType<PartialComment>()
-                .toList());
+                .toList(),
+          );
     return _PartialPost(
       postId: postId,
       title: title,
@@ -296,13 +305,17 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-                Comment>.fromList(
+            Comment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) =>
-                    el == null ? null : Comment.classType.fromJson<Comment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<Comment>(el),
+                )
                 .whereType<Comment>()
-                .toList());
+                .toList(),
+          );
     return _Post._(
       postId: postId,
       title: title,
@@ -461,14 +474,17 @@ class _RemotePost extends RemotePost {
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-                RemoteComment>.fromList(
+            RemoteComment>.fromList(
             (json['comments'] as List<Object?>)
                 .cast<Map<String, Object?>?>()
-                .map((el) => el == null
-                    ? null
-                    : Comment.classType.fromJson<RemoteComment>(el))
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
                 .whereType<RemoteComment>()
-                .toList());
+                .toList(),
+          );
     return _RemotePost(
       postId: postId,
       title: title,

--- a/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_many/uni_with_index/post.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'comment.dart';
@@ -303,6 +304,62 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
 
   static const PostQueryFields<PostIdentifier, Post> _queryFields =
       PostQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post',
+      'pluralName': 'Posts',
+      'fields': {
+        'postId': {
+          'name': 'postId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'comments': {
+          'name': 'comments',
+          'type': {
+            'list': {'model': 'Comment'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Comment',
+            'associatedFields': ['postId'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'postId',
+          'sortKeyFields': ['title'],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get postId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/model_provider.dart
@@ -35,7 +35,7 @@ class ModelProvider extends ModelProviderInterface {
   static final instance = ModelProvider._();
 
   @override
-  String get version => '72befcef059b24ff0fb21f93eff0d01d';
+  String get version => 'c39b263c97b84252edd5c9c71ea7e946';
   @override
   List<mipr.ModelTypeDefinition> get modelSchemas => [
         Project2.schema,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'project2.dart';
+import 'team2.dart';
+
+export 'project2.dart';
+export 'team2.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '72befcef059b24ff0fb21f93eff0d01d';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Project2.schema,
+        Team2.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Project2':
+        return (Project2.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Team2':
+        return (Team2.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/project2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/project2.dart
@@ -146,35 +146,6 @@ abstract class PartialProject2 extends PartialModel<String, Project2>
       };
   @override
   String get runtimeTypeName => 'Project2';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, Project2, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'id':
-        value = id;
-        break;
-      case r'name':
-        value = name;
-        break;
-      case r'team':
-        value = team;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'project2TeamId':
-        value = project2TeamId;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialProject2 extends PartialProject2 {
@@ -355,6 +326,35 @@ abstract class Project2 extends PartialProject2
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Project2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Project2, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'team':
+        value = team;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'project2TeamId':
+        value = project2TeamId;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Project2 extends Project2 {

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/project2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/project2.dart
@@ -326,6 +326,26 @@ abstract class Project2 extends PartialProject2
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Project2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Project2 copyWith({
+    String? id,
+    String? name,
+    Team2? team,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? project2TeamId,
+  }) {
+    return _Project2._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      team: team == null ? this.team : AsyncModel.fromModel(team),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      project2TeamId: project2TeamId ?? this.project2TeamId,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Project2, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/project2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/project2.dart
@@ -29,7 +29,8 @@ class Project2Type extends ModelType<String, Project2, PartialProject2> {
 
   @override
   T fromJson<T extends PartialModel<String, Project2>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Project2 || T == Model<String, Project2>) {
       return Project2.fromJson(json) as T;
     }
@@ -65,16 +66,18 @@ class Project2QueryFields<ModelIdentifier extends Object,
 
   /// Query field for the [Project2.team] field.
   Team2QueryFields<ModelIdentifier, M> get $team => Team2QueryFields(
-          NestedQueryField<ModelIdentifier, M, String, Project2, Team2>(
-        const QueryField<String, Project2, Team2>(fieldName: 'team'),
-        root: _root,
-      ));
+        NestedQueryField<ModelIdentifier, M, String, Project2, Team2>(
+          const QueryField<String, Project2, Team2>(fieldName: 'team'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Project2.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, String, Project2, TemporalDateTime>(
         const QueryField<String, Project2, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -82,7 +85,8 @@ class Project2QueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
       NestedQueryField<ModelIdentifier, M, String, Project2, TemporalDateTime>(
         const QueryField<String, Project2, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -90,7 +94,8 @@ class Project2QueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $project2TeamId =>
       NestedQueryField<ModelIdentifier, M, String, Project2, String?>(
         const QueryField<String, Project2, String?>(
-            fieldName: 'project2TeamId'),
+          fieldName: 'project2TeamId',
+        ),
         root: _root,
       );
 
@@ -98,7 +103,8 @@ class Project2QueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
       NestedQueryField<ModelIdentifier, M, String, Project2, String>(
         const QueryField<String, Project2, String>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -206,9 +212,10 @@ class _PartialProject2 extends PartialProject2 {
                 Team2.classType,
                 project2TeamId,
               )
-        : AsyncModel<String, Team2, PartialTeam2, PartialTeam2>.fromModel(Team2
-            .classType
-            .fromJson<PartialTeam2>((json['team'] as Map<String, Object?>)));
+        : AsyncModel<String, Team2, PartialTeam2, PartialTeam2>.fromModel(
+            Team2.classType
+                .fromJson<PartialTeam2>((json['team'] as Map<String, Object?>)),
+          );
     return _PartialProject2(
       id: id,
       name: name,
@@ -280,9 +287,10 @@ abstract class Project2 extends PartialProject2
                 Team2.classType,
                 project2TeamId,
               )
-        : AsyncModel<String, Team2, PartialTeam2, Team2>.fromModel(Team2
-            .classType
-            .fromJson<Team2>((json['team'] as Map<String, Object?>)));
+        : AsyncModel<String, Team2, PartialTeam2, Team2>.fromModel(
+            Team2.classType
+                .fromJson<Team2>((json['team'] as Map<String, Object?>)),
+          );
     return _Project2._(
       id: id,
       name: name,
@@ -456,9 +464,10 @@ class _RemoteProject2 extends RemoteProject2 {
                 Team2.classType,
                 project2TeamId,
               )
-        : AsyncModel<String, Team2, PartialTeam2, RemoteTeam2>.fromModel(Team2
-            .classType
-            .fromJson<RemoteTeam2>((json['team'] as Map<String, Object?>)));
+        : AsyncModel<String, Team2, PartialTeam2, RemoteTeam2>.fromModel(
+            Team2.classType
+                .fromJson<RemoteTeam2>((json['team'] as Map<String, Object?>)),
+          );
     return _RemoteProject2(
       id: id,
       name: name,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/project2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/project2.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.project2;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'team2.dart';
 
@@ -276,6 +277,67 @@ abstract class Project2 extends PartialProject2
 
   static const Project2QueryFields<String, Project2> _queryFields =
       Project2QueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Project2',
+      'pluralName': 'Project2s',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'team': {
+          'name': 'team',
+          'type': {'model': 'Team2'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'Team2',
+            'associatedFields': ['project'],
+            'targetNames': ['project2TeamId'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'project2TeamId': {
+          'name': 'project2TeamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/team2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/team2.dart
@@ -306,6 +306,26 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Team2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Team2 copyWith({
+    String? id,
+    String? name,
+    Project2? project,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? team2ProjectId,
+  }) {
+    return _Team2._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      project: project == null ? this.project : AsyncModel.fromModel(project),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      team2ProjectId: team2ProjectId ?? this.team2ProjectId,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Team2, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/team2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/team2.dart
@@ -311,7 +311,7 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
         'team2ProjectId': {
           'name': 'team2ProjectId',
           'type': {'scalar': 'ID'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
       },
@@ -384,7 +384,7 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
     return _Team2._(
       id: id ?? this.id,
       name: name ?? this.name,
-      project: project == null ? this.project : AsyncModel.fromModel(project),
+      project: project ?? this.project,
       createdAt:
           createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
       updatedAt:

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/team2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/team2.dart
@@ -140,35 +140,6 @@ abstract class PartialTeam2 extends PartialModel<String, Team2>
       };
   @override
   String get runtimeTypeName => 'Team2';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, Team2, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'id':
-        value = id;
-        break;
-      case r'name':
-        value = name;
-        break;
-      case r'project':
-        value = project;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'team2ProjectId':
-        value = team2ProjectId;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialTeam2 extends PartialTeam2 {
@@ -335,6 +306,35 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Team2, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Team2, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'project':
+        value = project;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'team2ProjectId':
+        value = team2ProjectId;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Team2 extends Team2 {

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/team2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/team2.dart
@@ -64,16 +64,18 @@ class Team2QueryFields<ModelIdentifier extends Object,
 
   /// Query field for the [Team2.project] field.
   Project2QueryFields<ModelIdentifier, M> get $project => Project2QueryFields(
-          NestedQueryField<ModelIdentifier, M, String, Team2, Project2>(
-        const QueryField<String, Team2, Project2>(fieldName: 'project'),
-        root: _root,
-      ));
+        NestedQueryField<ModelIdentifier, M, String, Team2, Project2>(
+          const QueryField<String, Team2, Project2>(fieldName: 'project'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Team2.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, String, Team2, TemporalDateTime>(
         const QueryField<String, Team2, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -81,7 +83,8 @@ class Team2QueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
       NestedQueryField<ModelIdentifier, M, String, Team2, TemporalDateTime>(
         const QueryField<String, Team2, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -198,7 +201,8 @@ class _PartialTeam2 extends PartialTeam2 {
     final project = json['project'] == null
         ? null
         : Project2.classType.fromJson<PartialProject2>(
-            (json['project'] as Map<String, Object?>));
+            (json['project'] as Map<String, Object?>),
+          );
     return _PartialTeam2(
       id: id,
       name: name,
@@ -444,7 +448,8 @@ class _RemoteTeam2 extends RemoteTeam2 {
             'project',
           ))
         : Project2.classType.fromJson<RemoteProject2>(
-            (json['project'] as Map<String, Object?>));
+            (json['project'] as Map<String, Object?>),
+          );
     return _RemoteTeam2(
       id: id,
       name: name,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/team2.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/bidi/team2.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.team2;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'project2.dart';
 
@@ -264,6 +265,72 @@ abstract class Team2 extends PartialTeam2 implements Model<String, Team2> {
 
   static const Team2QueryFields<String, Team2> _queryFields =
       Team2QueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Team2',
+      'pluralName': 'Team2s',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'project': {
+          'name': 'project',
+          'type': {'model': 'Project2'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Project2',
+            'targetNames': ['team2ProjectId'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'team2ProjectId': {
+          'name': 'team2ProjectId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'project',
+          'sortKeyFields': ['team2ProjectId'],
+          'name': 'project',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'project.dart';
+import 'team.dart';
+
+export 'project.dart';
+export 'team.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'a1d7010a48d830a7283ea24c1cd81e63';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Project.schema,
+        Team.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Project':
+        return (Project.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Team':
+        return (Team.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/project.dart
@@ -60,7 +60,8 @@ class ProjectType
 
   @override
   T fromJson<T extends PartialModel<ProjectIdentifier, Project>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Project || T == Model<ProjectIdentifier, Project>) {
       return Project.fromJson(json) as T;
     }
@@ -84,7 +85,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $projectId =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String>(
         const QueryField<ProjectIdentifier, Project, String>(
-            fieldName: 'projectId'),
+          fieldName: 'projectId',
+        ),
         root: _root,
       );
 
@@ -96,19 +98,20 @@ class ProjectQueryFields<ModelIdentifier extends Object,
       );
 
   /// Query field for the [Project.team] field.
-  TeamQueryFields<ModelIdentifier, M> get $team =>
-      TeamQueryFields(NestedQueryField<ModelIdentifier, M, ProjectIdentifier,
-          Project, Team>(
-        const QueryField<ProjectIdentifier, Project, Team>(fieldName: 'team'),
-        root: _root,
-      ));
+  TeamQueryFields<ModelIdentifier, M> get $team => TeamQueryFields(
+        NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, Team>(
+          const QueryField<ProjectIdentifier, Project, Team>(fieldName: 'team'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Project.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project,
           TemporalDateTime>(
         const QueryField<ProjectIdentifier, Project, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -117,7 +120,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project,
           TemporalDateTime>(
         const QueryField<ProjectIdentifier, Project, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -125,7 +129,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $projectTeamTeamId =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String?>(
         const QueryField<ProjectIdentifier, Project, String?>(
-            fieldName: 'projectTeamTeamId'),
+          fieldName: 'projectTeamTeamId',
+        ),
         root: _root,
       );
 
@@ -133,7 +138,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $projectTeamName =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String?>(
         const QueryField<ProjectIdentifier, Project, String?>(
-            fieldName: 'projectTeamName'),
+          fieldName: 'projectTeamName',
+        ),
         root: _root,
       );
 
@@ -142,7 +148,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project,
           ProjectIdentifier>(
         const QueryField<ProjectIdentifier, Project, ProjectIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -192,7 +199,8 @@ abstract class PartialProject extends PartialModel<ProjectIdentifier, Project>
   String get runtimeTypeName => 'Project';
   @override
   T valueFor<T extends Object?>(
-      QueryField<ProjectIdentifier, Project, T> field) {
+    QueryField<ProjectIdentifier, Project, T> field,
+  ) {
     Object? value;
     switch (field.fieldName) {
       case r'projectId':
@@ -274,7 +282,8 @@ class _PartialProject extends PartialProject {
               )
         : AsyncModel<TeamIdentifier, Team, PartialTeam, PartialTeam>.fromModel(
             Team.classType
-                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)));
+                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)),
+          );
     return _PartialProject(
       projectId: projectId,
       name: name,
@@ -362,9 +371,10 @@ abstract class Project extends PartialProject
                   name: projectTeamName,
                 ),
               )
-        : AsyncModel<TeamIdentifier, Team, PartialTeam, Team>.fromModel(Team
-            .classType
-            .fromJson<Team>((json['team'] as Map<String, Object?>)));
+        : AsyncModel<TeamIdentifier, Team, PartialTeam, Team>.fromModel(
+            Team.classType
+                .fromJson<Team>((json['team'] as Map<String, Object?>)),
+          );
     return _Project._(
       projectId: projectId,
       name: name,
@@ -573,7 +583,8 @@ class _RemoteProject extends RemoteProject {
               )
         : AsyncModel<TeamIdentifier, Team, PartialTeam, RemoteTeam>.fromModel(
             Team.classType
-                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)));
+                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)),
+          );
     return _RemoteProject(
       projectId: projectId,
       name: name,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/project.dart
@@ -421,6 +421,28 @@ abstract class Project extends PartialProject
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<ProjectIdentifier, Project, ProjectIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  Project copyWith({
+    String? projectId,
+    String? name,
+    Team? team,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? projectTeamTeamId,
+    String? projectTeamName,
+  }) {
+    return _Project._(
+      projectId: projectId ?? this.projectId,
+      name: name ?? this.name,
+      team: team == null ? this.team : AsyncModel.fromModel(team),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      projectTeamTeamId: projectTeamTeamId ?? this.projectTeamTeamId,
+      projectTeamName: projectTeamName ?? this.projectTeamName,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<ProjectIdentifier, Project, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/project.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.project;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'team.dart';
@@ -356,6 +357,79 @@ abstract class Project extends PartialProject
 
   static const ProjectQueryFields<ProjectIdentifier, Project> _queryFields =
       ProjectQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Project',
+      'pluralName': 'Projects',
+      'fields': {
+        'projectId': {
+          'name': 'projectId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'team': {
+          'name': 'team',
+          'type': {'model': 'Team'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'Team',
+            'associatedFields': [
+              'teamId',
+              'name',
+            ],
+            'targetNames': [
+              'projectTeamTeamId',
+              'projectTeamName',
+            ],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'projectTeamTeamId': {
+          'name': 'projectTeamTeamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'projectTeamName': {
+          'name': 'projectTeamName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'projectId',
+          'sortKeyFields': ['name'],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get projectId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/project.dart
@@ -197,40 +197,6 @@ abstract class PartialProject extends PartialModel<ProjectIdentifier, Project>
       };
   @override
   String get runtimeTypeName => 'Project';
-  @override
-  T valueFor<T extends Object?>(
-    QueryField<ProjectIdentifier, Project, T> field,
-  ) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'projectId':
-        value = projectId;
-        break;
-      case r'name':
-        value = name;
-        break;
-      case r'team':
-        value = team;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'projectTeamTeamId':
-        value = projectTeamTeamId;
-        break;
-      case r'projectTeamName':
-        value = projectTeamName;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialProject extends PartialProject {
@@ -455,6 +421,40 @@ abstract class Project extends PartialProject
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<ProjectIdentifier, Project, ProjectIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<ProjectIdentifier, Project, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'projectId':
+        value = projectId;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'team':
+        value = team;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'projectTeamTeamId':
+        value = projectTeamTeamId;
+        break;
+      case r'projectTeamName':
+        value = projectTeamName;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Project extends Project {

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/team.dart
@@ -284,6 +284,22 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<TeamIdentifier, Team, TeamIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  Team copyWith({
+    String? teamId,
+    String? name,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Team._(
+      teamId: teamId ?? this.teamId,
+      name: name ?? this.name,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<TeamIdentifier, Team, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/team.dart
@@ -157,29 +157,6 @@ abstract class PartialTeam extends PartialModel<TeamIdentifier, Team>
       };
   @override
   String get runtimeTypeName => 'Team';
-  @override
-  T valueFor<T extends Object?>(QueryField<TeamIdentifier, Team, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'teamId':
-        value = teamId;
-        break;
-      case r'name':
-        value = name;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialTeam extends PartialTeam {
@@ -307,6 +284,29 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<TeamIdentifier, Team, TeamIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<TeamIdentifier, Team, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'teamId':
+        value = teamId;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Team extends Team {

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/team.dart
@@ -57,7 +57,8 @@ class TeamType extends ModelType<TeamIdentifier, Team, PartialTeam> {
 
   @override
   T fromJson<T extends PartialModel<TeamIdentifier, Team>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Team || T == Model<TeamIdentifier, Team>) {
       return Team.fromJson(json) as T;
     }
@@ -96,7 +97,8 @@ class TeamQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team,
           TemporalDateTime>(
         const QueryField<TeamIdentifier, Team, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -105,7 +107,8 @@ class TeamQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team,
           TemporalDateTime>(
         const QueryField<TeamIdentifier, Team, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -114,7 +117,8 @@ class TeamQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team,
           TeamIdentifier>(
         const QueryField<TeamIdentifier, Team, TeamIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk/team.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.team;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 @immutable
@@ -252,6 +253,49 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
 
   static const TeamQueryFields<TeamIdentifier, Team> _queryFields =
       TeamQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Team',
+      'pluralName': 'Teams',
+      'fields': {
+        'teamId': {
+          'name': 'teamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'teamId',
+          'sortKeyFields': ['name'],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get teamId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'project.dart';
+import 'team.dart';
+
+export 'project.dart';
+export 'team.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '46450b460b680787265b0501deafe8f0';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Project.schema,
+        Team.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Project':
+        return (Project.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Team':
+        return (Team.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/model_provider.dart
@@ -35,7 +35,7 @@ class ModelProvider extends ModelProviderInterface {
   static final instance = ModelProvider._();
 
   @override
-  String get version => '46450b460b680787265b0501deafe8f0';
+  String get version => 'c3bc73436eb6216123f4dea37be553bd';
   @override
   List<mipr.ModelTypeDefinition> get modelSchemas => [
         Project.schema,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/project.dart
@@ -60,7 +60,8 @@ class ProjectType
 
   @override
   T fromJson<T extends PartialModel<ProjectIdentifier, Project>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Project || T == Model<ProjectIdentifier, Project>) {
       return Project.fromJson(json) as T;
     }
@@ -84,7 +85,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $projectId =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String>(
         const QueryField<ProjectIdentifier, Project, String>(
-            fieldName: 'projectId'),
+          fieldName: 'projectId',
+        ),
         root: _root,
       );
 
@@ -96,19 +98,20 @@ class ProjectQueryFields<ModelIdentifier extends Object,
       );
 
   /// Query field for the [Project.team] field.
-  TeamQueryFields<ModelIdentifier, M> get $team =>
-      TeamQueryFields(NestedQueryField<ModelIdentifier, M, ProjectIdentifier,
-          Project, Team>(
-        const QueryField<ProjectIdentifier, Project, Team>(fieldName: 'team'),
-        root: _root,
-      ));
+  TeamQueryFields<ModelIdentifier, M> get $team => TeamQueryFields(
+        NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, Team>(
+          const QueryField<ProjectIdentifier, Project, Team>(fieldName: 'team'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Project.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project,
           TemporalDateTime>(
         const QueryField<ProjectIdentifier, Project, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -117,7 +120,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project,
           TemporalDateTime>(
         const QueryField<ProjectIdentifier, Project, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -125,7 +129,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $projectTeamTeamId =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String?>(
         const QueryField<ProjectIdentifier, Project, String?>(
-            fieldName: 'projectTeamTeamId'),
+          fieldName: 'projectTeamTeamId',
+        ),
         root: _root,
       );
 
@@ -133,7 +138,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $projectTeamName =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String?>(
         const QueryField<ProjectIdentifier, Project, String?>(
-            fieldName: 'projectTeamName'),
+          fieldName: 'projectTeamName',
+        ),
         root: _root,
       );
 
@@ -142,7 +148,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project,
           ProjectIdentifier>(
         const QueryField<ProjectIdentifier, Project, ProjectIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -192,7 +199,8 @@ abstract class PartialProject extends PartialModel<ProjectIdentifier, Project>
   String get runtimeTypeName => 'Project';
   @override
   T valueFor<T extends Object?>(
-      QueryField<ProjectIdentifier, Project, T> field) {
+    QueryField<ProjectIdentifier, Project, T> field,
+  ) {
     Object? value;
     switch (field.fieldName) {
       case r'projectId':
@@ -274,7 +282,8 @@ class _PartialProject extends PartialProject {
               )
         : AsyncModel<TeamIdentifier, Team, PartialTeam, PartialTeam>.fromModel(
             Team.classType
-                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)));
+                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)),
+          );
     return _PartialProject(
       projectId: projectId,
       name: name,
@@ -362,9 +371,10 @@ abstract class Project extends PartialProject
                   name: projectTeamName,
                 ),
               )
-        : AsyncModel<TeamIdentifier, Team, PartialTeam, Team>.fromModel(Team
-            .classType
-            .fromJson<Team>((json['team'] as Map<String, Object?>)));
+        : AsyncModel<TeamIdentifier, Team, PartialTeam, Team>.fromModel(
+            Team.classType
+                .fromJson<Team>((json['team'] as Map<String, Object?>)),
+          );
     return _Project._(
       projectId: projectId,
       name: name,
@@ -573,7 +583,8 @@ class _RemoteProject extends RemoteProject {
               )
         : AsyncModel<TeamIdentifier, Team, PartialTeam, RemoteTeam>.fromModel(
             Team.classType
-                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)));
+                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)),
+          );
     return _RemoteProject(
       projectId: projectId,
       name: name,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/project.dart
@@ -421,6 +421,28 @@ abstract class Project extends PartialProject
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<ProjectIdentifier, Project, ProjectIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  Project copyWith({
+    String? projectId,
+    String? name,
+    Team? team,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? projectTeamTeamId,
+    String? projectTeamName,
+  }) {
+    return _Project._(
+      projectId: projectId ?? this.projectId,
+      name: name ?? this.name,
+      team: team == null ? this.team : AsyncModel.fromModel(team),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      projectTeamTeamId: projectTeamTeamId ?? this.projectTeamTeamId,
+      projectTeamName: projectTeamName ?? this.projectTeamName,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<ProjectIdentifier, Project, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/project.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.project;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'team.dart';
@@ -356,6 +357,76 @@ abstract class Project extends PartialProject
 
   static const ProjectQueryFields<ProjectIdentifier, Project> _queryFields =
       ProjectQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Project',
+      'pluralName': 'Projects',
+      'fields': {
+        'projectId': {
+          'name': 'projectId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'team': {
+          'name': 'team',
+          'type': {'model': 'Team'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'Team',
+            'associatedFields': ['project'],
+            'targetNames': [
+              'projectTeamTeamId',
+              'projectTeamName',
+            ],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'projectTeamTeamId': {
+          'name': 'projectTeamTeamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'projectTeamName': {
+          'name': 'projectTeamName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'projectId',
+          'sortKeyFields': ['name'],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get projectId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/project.dart
@@ -197,40 +197,6 @@ abstract class PartialProject extends PartialModel<ProjectIdentifier, Project>
       };
   @override
   String get runtimeTypeName => 'Project';
-  @override
-  T valueFor<T extends Object?>(
-    QueryField<ProjectIdentifier, Project, T> field,
-  ) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'projectId':
-        value = projectId;
-        break;
-      case r'name':
-        value = name;
-        break;
-      case r'team':
-        value = team;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'projectTeamTeamId':
-        value = projectTeamTeamId;
-        break;
-      case r'projectTeamName':
-        value = projectTeamName;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialProject extends PartialProject {
@@ -455,6 +421,40 @@ abstract class Project extends PartialProject
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<ProjectIdentifier, Project, ProjectIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<ProjectIdentifier, Project, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'projectId':
+        value = projectId;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'team':
+        value = team;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'projectTeamTeamId':
+        value = projectTeamTeamId;
+        break;
+      case r'projectTeamName':
+        value = projectTeamName;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Project extends Project {

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/team.dart
@@ -379,13 +379,13 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
         'teamProjectProjectId': {
           'name': 'teamProjectProjectId',
           'type': {'scalar': 'ID'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
         'teamProjectName': {
           'name': 'teamProjectName',
           'type': {'scalar': 'String'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
       },
@@ -466,7 +466,7 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
     return _Team._(
       teamId: teamId ?? this.teamId,
       name: name ?? this.name,
-      project: project == null ? this.project : AsyncModel.fromModel(project),
+      project: project ?? this.project,
       createdAt:
           createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
       updatedAt:

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/team.dart
@@ -194,38 +194,6 @@ abstract class PartialTeam extends PartialModel<TeamIdentifier, Team>
       };
   @override
   String get runtimeTypeName => 'Team';
-  @override
-  T valueFor<T extends Object?>(QueryField<TeamIdentifier, Team, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'teamId':
-        value = teamId;
-        break;
-      case r'name':
-        value = name;
-        break;
-      case r'project':
-        value = project;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'teamProjectProjectId':
-        value = teamProjectProjectId;
-        break;
-      case r'teamProjectName':
-        value = teamProjectName;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialTeam extends PartialTeam {
@@ -407,6 +375,38 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<TeamIdentifier, Team, TeamIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<TeamIdentifier, Team, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'teamId':
+        value = teamId;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'project':
+        value = project;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'teamProjectProjectId':
+        value = teamProjectProjectId;
+        break;
+      case r'teamProjectName':
+        value = teamProjectName;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Team extends Team {

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/team.dart
@@ -59,7 +59,8 @@ class TeamType extends ModelType<TeamIdentifier, Team, PartialTeam> {
 
   @override
   T fromJson<T extends PartialModel<TeamIdentifier, Team>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Team || T == Model<TeamIdentifier, Team>) {
       return Team.fromJson(json) as T;
     }
@@ -95,17 +96,19 @@ class TeamQueryFields<ModelIdentifier extends Object,
 
   /// Query field for the [Team.project] field.
   ProjectQueryFields<ModelIdentifier, M> get $project => ProjectQueryFields(
-          NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, Project>(
-        const QueryField<TeamIdentifier, Team, Project>(fieldName: 'project'),
-        root: _root,
-      ));
+        NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, Project>(
+          const QueryField<TeamIdentifier, Team, Project>(fieldName: 'project'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Team.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team,
           TemporalDateTime>(
         const QueryField<TeamIdentifier, Team, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -114,7 +117,8 @@ class TeamQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team,
           TemporalDateTime>(
         const QueryField<TeamIdentifier, Team, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -122,7 +126,8 @@ class TeamQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $teamProjectProjectId =>
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, String?>(
         const QueryField<TeamIdentifier, Team, String?>(
-            fieldName: 'teamProjectProjectId'),
+          fieldName: 'teamProjectProjectId',
+        ),
         root: _root,
       );
 
@@ -130,7 +135,8 @@ class TeamQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $teamProjectName =>
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, String?>(
         const QueryField<TeamIdentifier, Team, String?>(
-            fieldName: 'teamProjectName'),
+          fieldName: 'teamProjectName',
+        ),
         root: _root,
       );
 
@@ -139,7 +145,8 @@ class TeamQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team,
           TeamIdentifier>(
         const QueryField<TeamIdentifier, Team, TeamIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -260,7 +267,8 @@ class _PartialTeam extends PartialTeam {
     final project = json['project'] == null
         ? null
         : Project.classType.fromJson<PartialProject>(
-            (json['project'] as Map<String, Object?>));
+            (json['project'] as Map<String, Object?>),
+          );
     return _PartialTeam(
       teamId: teamId,
       name: name,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/team.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.team;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'project.dart';
@@ -329,6 +330,84 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
 
   static const TeamQueryFields<TeamIdentifier, Team> _queryFields =
       TeamQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Team',
+      'pluralName': 'Teams',
+      'fields': {
+        'teamId': {
+          'name': 'teamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'project': {
+          'name': 'project',
+          'type': {'model': 'Project'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Project',
+            'targetNames': [
+              'teamProjectProjectId',
+              'teamProjectName',
+            ],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'teamProjectProjectId': {
+          'name': 'teamProjectProjectId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'teamProjectName': {
+          'name': 'teamProjectName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'teamId',
+          'sortKeyFields': ['name'],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'project',
+          'sortKeyFields': [
+            'teamProjectProjectId',
+            'teamProjectName',
+          ],
+          'name': 'project',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get teamId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/cpk_bidi/team.dart
@@ -375,6 +375,28 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<TeamIdentifier, Team, TeamIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  Team copyWith({
+    String? teamId,
+    String? name,
+    Project? project,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? teamProjectProjectId,
+    String? teamProjectName,
+  }) {
+    return _Team._(
+      teamId: teamId ?? this.teamId,
+      name: name ?? this.name,
+      project: project == null ? this.project : AsyncModel.fromModel(project),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      teamProjectProjectId: teamProjectProjectId ?? this.teamProjectProjectId,
+      teamProjectName: teamProjectName ?? this.teamProjectName,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<TeamIdentifier, Team, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/model_provider.dart
@@ -35,7 +35,7 @@ class ModelProvider extends ModelProviderInterface {
   static final instance = ModelProvider._();
 
   @override
-  String get version => '0f6a0b747e30237e034c84ea17a9105f';
+  String get version => '804e98ee1d02b3f4181609125b3e8fc8';
   @override
   List<mipr.ModelTypeDefinition> get modelSchemas => [
         Project.schema,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'project.dart';
+import 'team.dart';
+
+export 'project.dart';
+export 'team.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '0f6a0b747e30237e034c84ea17a9105f';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Project.schema,
+        Team.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Project':
+        return (Project.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Team':
+        return (Team.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/project.dart
@@ -60,7 +60,8 @@ class ProjectType
 
   @override
   T fromJson<T extends PartialModel<ProjectIdentifier, Project>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Project || T == Model<ProjectIdentifier, Project>) {
       return Project.fromJson(json) as T;
     }
@@ -84,7 +85,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $projectId =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String>(
         const QueryField<ProjectIdentifier, Project, String>(
-            fieldName: 'projectId'),
+          fieldName: 'projectId',
+        ),
         root: _root,
       );
 
@@ -96,29 +98,32 @@ class ProjectQueryFields<ModelIdentifier extends Object,
       );
 
   /// Query field for the [Project.devTeam] field.
-  TeamQueryFields<ModelIdentifier, M> get $devTeam =>
-      TeamQueryFields(NestedQueryField<ModelIdentifier, M, ProjectIdentifier,
-          Project, Team>(
-        const QueryField<ProjectIdentifier, Project, Team>(
-            fieldName: 'devTeam'),
-        root: _root,
-      ));
+  TeamQueryFields<ModelIdentifier, M> get $devTeam => TeamQueryFields(
+        NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, Team>(
+          const QueryField<ProjectIdentifier, Project, Team>(
+            fieldName: 'devTeam',
+          ),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Project.productTeam] field.
-  TeamQueryFields<ModelIdentifier, M> get $productTeam =>
-      TeamQueryFields(NestedQueryField<ModelIdentifier, M, ProjectIdentifier,
-          Project, Team>(
-        const QueryField<ProjectIdentifier, Project, Team>(
-            fieldName: 'productTeam'),
-        root: _root,
-      ));
+  TeamQueryFields<ModelIdentifier, M> get $productTeam => TeamQueryFields(
+        NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, Team>(
+          const QueryField<ProjectIdentifier, Project, Team>(
+            fieldName: 'productTeam',
+          ),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Project.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project,
           TemporalDateTime>(
         const QueryField<ProjectIdentifier, Project, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -127,7 +132,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project,
           TemporalDateTime>(
         const QueryField<ProjectIdentifier, Project, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -135,7 +141,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $projectDevTeamTeamId =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String?>(
         const QueryField<ProjectIdentifier, Project, String?>(
-            fieldName: 'projectDevTeamTeamId'),
+          fieldName: 'projectDevTeamTeamId',
+        ),
         root: _root,
       );
 
@@ -143,7 +150,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $projectDevTeamName =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String?>(
         const QueryField<ProjectIdentifier, Project, String?>(
-            fieldName: 'projectDevTeamName'),
+          fieldName: 'projectDevTeamName',
+        ),
         root: _root,
       );
 
@@ -151,7 +159,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $projectProductTeamTeamId =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String?>(
         const QueryField<ProjectIdentifier, Project, String?>(
-            fieldName: 'projectProductTeamTeamId'),
+          fieldName: 'projectProductTeamTeamId',
+        ),
         root: _root,
       );
 
@@ -159,7 +168,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $projectProductTeamName =>
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String?>(
         const QueryField<ProjectIdentifier, Project, String?>(
-            fieldName: 'projectProductTeamName'),
+          fieldName: 'projectProductTeamName',
+        ),
         root: _root,
       );
 
@@ -168,7 +178,8 @@ class ProjectQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project,
           ProjectIdentifier>(
         const QueryField<ProjectIdentifier, Project, ProjectIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -227,7 +238,8 @@ abstract class PartialProject extends PartialModel<ProjectIdentifier, Project>
   String get runtimeTypeName => 'Project';
   @override
   T valueFor<T extends Object?>(
-      QueryField<ProjectIdentifier, Project, T> field) {
+    QueryField<ProjectIdentifier, Project, T> field,
+  ) {
     Object? value;
     switch (field.fieldName) {
       case r'projectId':
@@ -327,7 +339,9 @@ class _PartialProject extends PartialProject {
               )
         : AsyncModel<TeamIdentifier, Team, PartialTeam, PartialTeam>.fromModel(
             Team.classType.fromJson<PartialTeam>(
-                (json['devTeam'] as Map<String, Object?>)));
+              (json['devTeam'] as Map<String, Object?>),
+            ),
+          );
     final productTeam = json['productTeam'] == null
         ? projectProductTeamTeamId == null || projectProductTeamName == null
             ? null
@@ -341,7 +355,9 @@ class _PartialProject extends PartialProject {
               )
         : AsyncModel<TeamIdentifier, Team, PartialTeam, PartialTeam>.fromModel(
             Team.classType.fromJson<PartialTeam>(
-                (json['productTeam'] as Map<String, Object?>)));
+              (json['productTeam'] as Map<String, Object?>),
+            ),
+          );
     return _PartialProject(
       projectId: projectId,
       name: name,
@@ -450,9 +466,10 @@ abstract class Project extends PartialProject
                   name: projectDevTeamName,
                 ),
               )
-        : AsyncModel<TeamIdentifier, Team, PartialTeam, Team>.fromModel(Team
-            .classType
-            .fromJson<Team>((json['devTeam'] as Map<String, Object?>)));
+        : AsyncModel<TeamIdentifier, Team, PartialTeam, Team>.fromModel(
+            Team.classType
+                .fromJson<Team>((json['devTeam'] as Map<String, Object?>)),
+          );
     final productTeam = json['productTeam'] == null
         ? projectProductTeamTeamId == null || projectProductTeamName == null
             ? null
@@ -464,9 +481,10 @@ abstract class Project extends PartialProject
                   name: projectProductTeamName,
                 ),
               )
-        : AsyncModel<TeamIdentifier, Team, PartialTeam, Team>.fromModel(Team
-            .classType
-            .fromJson<Team>((json['productTeam'] as Map<String, Object?>)));
+        : AsyncModel<TeamIdentifier, Team, PartialTeam, Team>.fromModel(
+            Team.classType
+                .fromJson<Team>((json['productTeam'] as Map<String, Object?>)),
+          );
     return _Project._(
       projectId: projectId,
       name: name,
@@ -737,7 +755,9 @@ class _RemoteProject extends RemoteProject {
               )
         : AsyncModel<TeamIdentifier, Team, PartialTeam, RemoteTeam>.fromModel(
             Team.classType.fromJson<RemoteTeam>(
-                (json['devTeam'] as Map<String, Object?>)));
+              (json['devTeam'] as Map<String, Object?>),
+            ),
+          );
     final productTeam = json['productTeam'] == null
         ? projectProductTeamTeamId == null || projectProductTeamName == null
             ? null
@@ -751,7 +771,9 @@ class _RemoteProject extends RemoteProject {
               )
         : AsyncModel<TeamIdentifier, Team, PartialTeam, RemoteTeam>.fromModel(
             Team.classType.fromJson<RemoteTeam>(
-                (json['productTeam'] as Map<String, Object?>)));
+              (json['productTeam'] as Map<String, Object?>),
+            ),
+          );
     return _RemoteProject(
       projectId: projectId,
       name: name,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/project.dart
@@ -236,49 +236,6 @@ abstract class PartialProject extends PartialModel<ProjectIdentifier, Project>
       };
   @override
   String get runtimeTypeName => 'Project';
-  @override
-  T valueFor<T extends Object?>(
-    QueryField<ProjectIdentifier, Project, T> field,
-  ) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'projectId':
-        value = projectId;
-        break;
-      case r'name':
-        value = name;
-        break;
-      case r'devTeam':
-        value = devTeam;
-        break;
-      case r'productTeam':
-        value = productTeam;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'projectDevTeamTeamId':
-        value = projectDevTeamTeamId;
-        break;
-      case r'projectDevTeamName':
-        value = projectDevTeamName;
-        break;
-      case r'projectProductTeamTeamId':
-        value = projectProductTeamTeamId;
-        break;
-      case r'projectProductTeamName':
-        value = projectProductTeamName;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialProject extends PartialProject {
@@ -601,6 +558,49 @@ abstract class Project extends PartialProject
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<ProjectIdentifier, Project, ProjectIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<ProjectIdentifier, Project, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'projectId':
+        value = projectId;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'devTeam':
+        value = devTeam;
+        break;
+      case r'productTeam':
+        value = productTeam;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'projectDevTeamTeamId':
+        value = projectDevTeamTeamId;
+        break;
+      case r'projectDevTeamName':
+        value = projectDevTeamName;
+        break;
+      case r'projectProductTeamTeamId':
+        value = projectProductTeamTeamId;
+        break;
+      case r'projectProductTeamName':
+        value = projectProductTeamName;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Project extends Project {

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/project.dart
@@ -558,6 +558,38 @@ abstract class Project extends PartialProject
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<ProjectIdentifier, Project, ProjectIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  Project copyWith({
+    String? projectId,
+    String? name,
+    Team? devTeam,
+    Team? productTeam,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? projectDevTeamTeamId,
+    String? projectDevTeamName,
+    String? projectProductTeamTeamId,
+    String? projectProductTeamName,
+  }) {
+    return _Project._(
+      projectId: projectId ?? this.projectId,
+      name: name ?? this.name,
+      devTeam: devTeam == null ? this.devTeam : AsyncModel.fromModel(devTeam),
+      productTeam: productTeam == null
+          ? this.productTeam
+          : AsyncModel.fromModel(productTeam),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      projectDevTeamTeamId: projectDevTeamTeamId ?? this.projectDevTeamTeamId,
+      projectDevTeamName: projectDevTeamName ?? this.projectDevTeamName,
+      projectProductTeamTeamId:
+          projectProductTeamTeamId ?? this.projectProductTeamTeamId,
+      projectProductTeamName:
+          projectProductTeamName ?? this.projectProductTeamName,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<ProjectIdentifier, Project, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/project.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.project;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'team.dart';
@@ -460,6 +461,103 @@ abstract class Project extends PartialProject
 
   static const ProjectQueryFields<ProjectIdentifier, Project> _queryFields =
       ProjectQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Project',
+      'pluralName': 'Projects',
+      'fields': {
+        'projectId': {
+          'name': 'projectId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'devTeam': {
+          'name': 'devTeam',
+          'type': {'model': 'Team'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'Team',
+            'associatedFields': ['project'],
+            'targetNames': [
+              'projectDevTeamTeamId',
+              'projectDevTeamName',
+            ],
+          },
+        },
+        'productTeam': {
+          'name': 'productTeam',
+          'type': {'model': 'Team'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'Team',
+            'associatedFields': ['project'],
+            'targetNames': [
+              'projectProductTeamTeamId',
+              'projectProductTeamName',
+            ],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'projectDevTeamTeamId': {
+          'name': 'projectDevTeamTeamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'projectDevTeamName': {
+          'name': 'projectDevTeamName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'projectProductTeamTeamId': {
+          'name': 'projectProductTeamTeamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'projectProductTeamName': {
+          'name': 'projectProductTeamName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'projectId',
+          'sortKeyFields': ['name'],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get projectId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/team.dart
@@ -379,13 +379,13 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
         'teamProjectProjectId': {
           'name': 'teamProjectProjectId',
           'type': {'scalar': 'ID'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
         'teamProjectName': {
           'name': 'teamProjectName',
           'type': {'scalar': 'String'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
       },
@@ -466,7 +466,7 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
     return _Team._(
       teamId: teamId ?? this.teamId,
       name: name ?? this.name,
-      project: project == null ? this.project : AsyncModel.fromModel(project),
+      project: project ?? this.project,
       createdAt:
           createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
       updatedAt:

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/team.dart
@@ -194,38 +194,6 @@ abstract class PartialTeam extends PartialModel<TeamIdentifier, Team>
       };
   @override
   String get runtimeTypeName => 'Team';
-  @override
-  T valueFor<T extends Object?>(QueryField<TeamIdentifier, Team, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'teamId':
-        value = teamId;
-        break;
-      case r'name':
-        value = name;
-        break;
-      case r'project':
-        value = project;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'teamProjectProjectId':
-        value = teamProjectProjectId;
-        break;
-      case r'teamProjectName':
-        value = teamProjectName;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialTeam extends PartialTeam {
@@ -407,6 +375,38 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<TeamIdentifier, Team, TeamIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<TeamIdentifier, Team, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'teamId':
+        value = teamId;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'project':
+        value = project;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'teamProjectProjectId':
+        value = teamProjectProjectId;
+        break;
+      case r'teamProjectName':
+        value = teamProjectName;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _Team extends Team {

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/team.dart
@@ -59,7 +59,8 @@ class TeamType extends ModelType<TeamIdentifier, Team, PartialTeam> {
 
   @override
   T fromJson<T extends PartialModel<TeamIdentifier, Team>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == Team || T == Model<TeamIdentifier, Team>) {
       return Team.fromJson(json) as T;
     }
@@ -95,17 +96,19 @@ class TeamQueryFields<ModelIdentifier extends Object,
 
   /// Query field for the [Team.project] field.
   ProjectQueryFields<ModelIdentifier, M> get $project => ProjectQueryFields(
-          NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, Project>(
-        const QueryField<TeamIdentifier, Team, Project>(fieldName: 'project'),
-        root: _root,
-      ));
+        NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, Project>(
+          const QueryField<TeamIdentifier, Team, Project>(fieldName: 'project'),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [Team.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team,
           TemporalDateTime>(
         const QueryField<TeamIdentifier, Team, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -114,7 +117,8 @@ class TeamQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team,
           TemporalDateTime>(
         const QueryField<TeamIdentifier, Team, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -122,7 +126,8 @@ class TeamQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $teamProjectProjectId =>
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, String?>(
         const QueryField<TeamIdentifier, Team, String?>(
-            fieldName: 'teamProjectProjectId'),
+          fieldName: 'teamProjectProjectId',
+        ),
         root: _root,
       );
 
@@ -130,7 +135,8 @@ class TeamQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $teamProjectName =>
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, String?>(
         const QueryField<TeamIdentifier, Team, String?>(
-            fieldName: 'teamProjectName'),
+          fieldName: 'teamProjectName',
+        ),
         root: _root,
       );
 
@@ -139,7 +145,8 @@ class TeamQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team,
           TeamIdentifier>(
         const QueryField<TeamIdentifier, Team, TeamIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -260,7 +267,8 @@ class _PartialTeam extends PartialTeam {
     final project = json['project'] == null
         ? null
         : Project.classType.fromJson<PartialProject>(
-            (json['project'] as Map<String, Object?>));
+            (json['project'] as Map<String, Object?>),
+          );
     return _PartialTeam(
       teamId: teamId,
       name: name,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/team.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.team;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'project.dart';
@@ -329,6 +330,84 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
 
   static const TeamQueryFields<TeamIdentifier, Team> _queryFields =
       TeamQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Team',
+      'pluralName': 'Teams',
+      'fields': {
+        'teamId': {
+          'name': 'teamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'project': {
+          'name': 'project',
+          'type': {'model': 'Project'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Project',
+            'targetNames': [
+              'teamProjectProjectId',
+              'teamProjectName',
+            ],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'teamProjectProjectId': {
+          'name': 'teamProjectProjectId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'teamProjectName': {
+          'name': 'teamProjectName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'teamId',
+          'sortKeyFields': ['name'],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'project',
+          'sortKeyFields': [
+            'teamProjectProjectId',
+            'teamProjectName',
+          ],
+          'name': 'project',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get teamId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/multiple_has_one/team.dart
@@ -375,6 +375,28 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<TeamIdentifier, Team, TeamIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  Team copyWith({
+    String? teamId,
+    String? name,
+    Project? project,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? teamProjectProjectId,
+    String? teamProjectName,
+  }) {
+    return _Team._(
+      teamId: teamId ?? this.teamId,
+      name: name ?? this.name,
+      project: project == null ? this.project : AsyncModel.fromModel(project),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      teamProjectProjectId: teamProjectProjectId ?? this.teamProjectProjectId,
+      teamProjectName: teamProjectName ?? this.teamProjectName,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<TeamIdentifier, Team, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/battery_charger.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/battery_charger.dart
@@ -30,7 +30,8 @@ class BatteryChargerType
 
   @override
   T fromJson<T extends PartialModel<String, BatteryCharger>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == BatteryCharger || T == Model<String, BatteryCharger>) {
       return BatteryCharger.fromJson(json) as T;
     }
@@ -52,19 +53,23 @@ class BatteryChargerQueryFields<ModelIdentifier extends Object,
 
   /// Query field for the [BatteryCharger.powerSource] field.
   PowerSourceQueryFields<ModelIdentifier, M> get $powerSource =>
-      PowerSourceQueryFields(NestedQueryField<ModelIdentifier, M, String,
-          BatteryCharger, PowerSource>(
-        const QueryField<String, BatteryCharger, PowerSource>(
-            fieldName: 'powerSource'),
-        root: _root,
-      ));
+      PowerSourceQueryFields(
+        NestedQueryField<ModelIdentifier, M, String, BatteryCharger,
+            PowerSource>(
+          const QueryField<String, BatteryCharger, PowerSource>(
+            fieldName: 'powerSource',
+          ),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [BatteryCharger.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, String, BatteryCharger,
           TemporalDateTime>(
         const QueryField<String, BatteryCharger, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -73,7 +78,8 @@ class BatteryChargerQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, BatteryCharger,
           TemporalDateTime>(
         const QueryField<String, BatteryCharger, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -88,7 +94,8 @@ class BatteryChargerQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $batteryChargerPowerSourceId =>
       NestedQueryField<ModelIdentifier, M, String, BatteryCharger, String?>(
         const QueryField<String, BatteryCharger, String?>(
-            fieldName: 'batteryChargerPowerSourceId'),
+          fieldName: 'batteryChargerPowerSourceId',
+        ),
         root: _root,
       );
 
@@ -96,7 +103,8 @@ class BatteryChargerQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
       NestedQueryField<ModelIdentifier, M, String, BatteryCharger, String>(
         const QueryField<String, BatteryCharger, String>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -200,9 +208,11 @@ class _PartialBatteryCharger extends PartialBatteryCharger {
                 batteryChargerPowerSourceId,
               )
         : AsyncModel<String, PowerSource, PartialPowerSource,
-                PartialPowerSource>.fromModel(
+            PartialPowerSource>.fromModel(
             PowerSource.classType.fromJson<PartialPowerSource>(
-                (json['powerSource'] as Map<String, Object?>)));
+              (json['powerSource'] as Map<String, Object?>),
+            ),
+          );
     return _PartialBatteryCharger(
       powerSource: powerSource,
       createdAt: createdAt,
@@ -271,9 +281,11 @@ abstract class BatteryCharger extends PartialBatteryCharger
                 batteryChargerPowerSourceId,
               )
         : AsyncModel<String, PowerSource, PartialPowerSource,
-                PowerSource>.fromModel(
+            PowerSource>.fromModel(
             PowerSource.classType.fromJson<PowerSource>(
-                (json['powerSource'] as Map<String, Object?>)));
+              (json['powerSource'] as Map<String, Object?>),
+            ),
+          );
     return _BatteryCharger._(
       powerSource: powerSource,
       createdAt: createdAt,
@@ -440,9 +452,11 @@ class _RemoteBatteryCharger extends RemoteBatteryCharger {
                 batteryChargerPowerSourceId,
               )
         : AsyncModel<String, PowerSource, PartialPowerSource,
-                RemotePowerSource>.fromModel(
+            RemotePowerSource>.fromModel(
             PowerSource.classType.fromJson<RemotePowerSource>(
-                (json['powerSource'] as Map<String, Object?>)));
+              (json['powerSource'] as Map<String, Object?>),
+            ),
+          );
     return _RemoteBatteryCharger(
       powerSource: powerSource,
       createdAt: createdAt,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/battery_charger.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/battery_charger.dart
@@ -145,32 +145,6 @@ abstract class PartialBatteryCharger
       };
   @override
   String get runtimeTypeName => 'BatteryCharger';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, BatteryCharger, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'powerSource':
-        value = powerSource;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'id':
-        value = id;
-        break;
-      case r'batteryChargerPowerSourceId':
-        value = batteryChargerPowerSourceId;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialBatteryCharger extends PartialBatteryCharger {
@@ -346,6 +320,32 @@ abstract class BatteryCharger extends PartialBatteryCharger
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, BatteryCharger, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, BatteryCharger, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'powerSource':
+        value = powerSource;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'id':
+        value = id;
+        break;
+      case r'batteryChargerPowerSourceId':
+        value = batteryChargerPowerSourceId;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _BatteryCharger extends BatteryCharger {

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/battery_charger.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/battery_charger.dart
@@ -320,6 +320,27 @@ abstract class BatteryCharger extends PartialBatteryCharger
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, BatteryCharger, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  BatteryCharger copyWith({
+    PowerSource? powerSource,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? id,
+    String? batteryChargerPowerSourceId,
+  }) {
+    return _BatteryCharger._(
+      powerSource: powerSource == null
+          ? this.powerSource
+          : AsyncModel.fromModel(powerSource),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      id: id ?? this.id,
+      batteryChargerPowerSourceId:
+          batteryChargerPowerSourceId ?? this.batteryChargerPowerSourceId,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, BatteryCharger, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/battery_charger.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/battery_charger.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.battery_charger;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'power_source.dart';
 
@@ -273,6 +274,61 @@ abstract class BatteryCharger extends PartialBatteryCharger
 
   static const BatteryChargerQueryFields<String, BatteryCharger> _queryFields =
       BatteryChargerQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'BatteryCharger',
+      'pluralName': 'BatteryChargers',
+      'fields': {
+        'powerSource': {
+          'name': 'powerSource',
+          'type': {'model': 'PowerSource'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'PowerSource',
+            'associatedFields': ['id'],
+            'targetNames': ['batteryChargerPowerSourceId'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'batteryChargerPowerSourceId': {
+          'name': 'batteryChargerPowerSourceId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   AsyncModel<String, PowerSource, PartialPowerSource, PowerSource>?

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'battery_charger.dart';
+import 'power_source.dart';
+
+export 'battery_charger.dart';
+export 'power_source.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '2ffd0441e541f90e2ee4418fb1c433f3';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        BatteryCharger.schema,
+        PowerSource.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'BatteryCharger':
+        return (BatteryCharger.classType as ModelType<ModelIdentifier, M, P>);
+      case 'PowerSource':
+        return (PowerSource.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/power_source.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/power_source.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.power_source;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class PowerSourceType
     extends ModelType<String, PowerSource, PartialPowerSource> {
@@ -239,6 +240,55 @@ abstract class PowerSource extends PartialPowerSource
 
   static const PowerSourceQueryFields<String, PowerSource> _queryFields =
       PowerSourceQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'PowerSource',
+      'pluralName': 'PowerSources',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'amps': {
+          'name': 'amps',
+          'type': {'scalar': 'Float'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'volts': {
+          'name': 'volts',
+          'type': {'scalar': 'Float'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/power_source.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/power_source.dart
@@ -134,32 +134,6 @@ abstract class PartialPowerSource extends PartialModel<String, PowerSource>
       };
   @override
   String get runtimeTypeName => 'PowerSource';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, PowerSource, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'id':
-        value = id;
-        break;
-      case r'amps':
-        value = amps;
-        break;
-      case r'volts':
-        value = volts;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialPowerSource extends PartialPowerSource {
@@ -306,6 +280,32 @@ abstract class PowerSource extends PartialPowerSource
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, PowerSource, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, PowerSource, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'amps':
+        value = amps;
+        break;
+      case r'volts':
+        value = volts;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _PowerSource extends PowerSource {

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/power_source.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/power_source.dart
@@ -280,6 +280,24 @@ abstract class PowerSource extends PartialPowerSource
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, PowerSource, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  PowerSource copyWith({
+    String? id,
+    double? amps,
+    double? volts,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _PowerSource._(
+      id: id ?? this.id,
+      amps: amps ?? this.amps,
+      volts: volts ?? this.volts,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, PowerSource, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/power_source.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/no_fields/power_source.dart
@@ -28,7 +28,8 @@ class PowerSourceType
 
   @override
   T fromJson<T extends PartialModel<String, PowerSource>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == PowerSource || T == Model<String, PowerSource>) {
       return PowerSource.fromJson(json) as T;
     }
@@ -74,7 +75,8 @@ class PowerSourceQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, PowerSource,
           TemporalDateTime>(
         const QueryField<String, PowerSource, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -83,7 +85,8 @@ class PowerSourceQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, PowerSource,
           TemporalDateTime>(
         const QueryField<String, PowerSource, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -91,7 +94,8 @@ class PowerSourceQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
       NestedQueryField<ModelIdentifier, M, String, PowerSource, String>(
         const QueryField<String, PowerSource, String>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/battery_charger.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/battery_charger.dart
@@ -30,7 +30,8 @@ class BatteryChargerType
 
   @override
   T fromJson<T extends PartialModel<String, BatteryCharger>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == BatteryCharger || T == Model<String, BatteryCharger>) {
       return BatteryCharger.fromJson(json) as T;
     }
@@ -54,7 +55,8 @@ class BatteryChargerQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $chargerId =>
       NestedQueryField<ModelIdentifier, M, String, BatteryCharger, String>(
         const QueryField<String, BatteryCharger, String>(
-            fieldName: 'chargerID'),
+          fieldName: 'chargerID',
+        ),
         root: _root,
       );
 
@@ -62,25 +64,30 @@ class BatteryChargerQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $powerSourceId =>
       NestedQueryField<ModelIdentifier, M, String, BatteryCharger, String?>(
         const QueryField<String, BatteryCharger, String?>(
-            fieldName: 'powerSourceID'),
+          fieldName: 'powerSourceID',
+        ),
         root: _root,
       );
 
   /// Query field for the [BatteryCharger.powerSource] field.
   PowerSourceQueryFields<ModelIdentifier, M> get $powerSource =>
-      PowerSourceQueryFields(NestedQueryField<ModelIdentifier, M, String,
-          BatteryCharger, PowerSource>(
-        const QueryField<String, BatteryCharger, PowerSource>(
-            fieldName: 'powerSource'),
-        root: _root,
-      ));
+      PowerSourceQueryFields(
+        NestedQueryField<ModelIdentifier, M, String, BatteryCharger,
+            PowerSource>(
+          const QueryField<String, BatteryCharger, PowerSource>(
+            fieldName: 'powerSource',
+          ),
+          root: _root,
+        ),
+      );
 
   /// Query field for the [BatteryCharger.createdAt] field.
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, String, BatteryCharger,
           TemporalDateTime>(
         const QueryField<String, BatteryCharger, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -89,7 +96,8 @@ class BatteryChargerQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, BatteryCharger,
           TemporalDateTime>(
         const QueryField<String, BatteryCharger, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -104,7 +112,8 @@ class BatteryChargerQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
       NestedQueryField<ModelIdentifier, M, String, BatteryCharger, String>(
         const QueryField<String, BatteryCharger, String>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -216,9 +225,11 @@ class _PartialBatteryCharger extends PartialBatteryCharger {
                 powerSourceId,
               )
         : AsyncModel<String, PowerSource, PartialPowerSource,
-                PartialPowerSource>.fromModel(
+            PartialPowerSource>.fromModel(
             PowerSource.classType.fromJson<PartialPowerSource>(
-                (json['powerSource'] as Map<String, Object?>)));
+              (json['powerSource'] as Map<String, Object?>),
+            ),
+          );
     return _PartialBatteryCharger(
       chargerId: chargerId,
       powerSourceId: powerSourceId,
@@ -297,9 +308,11 @@ abstract class BatteryCharger extends PartialBatteryCharger
                 powerSourceId,
               )
         : AsyncModel<String, PowerSource, PartialPowerSource,
-                PowerSource>.fromModel(
+            PowerSource>.fromModel(
             PowerSource.classType.fromJson<PowerSource>(
-                (json['powerSource'] as Map<String, Object?>)));
+              (json['powerSource'] as Map<String, Object?>),
+            ),
+          );
     return _BatteryCharger._(
       chargerId: chargerId,
       powerSourceId: powerSourceId,
@@ -487,9 +500,11 @@ class _RemoteBatteryCharger extends RemoteBatteryCharger {
                 powerSourceId,
               )
         : AsyncModel<String, PowerSource, PartialPowerSource,
-                RemotePowerSource>.fromModel(
+            RemotePowerSource>.fromModel(
             PowerSource.classType.fromJson<RemotePowerSource>(
-                (json['powerSource'] as Map<String, Object?>)));
+              (json['powerSource'] as Map<String, Object?>),
+            ),
+          );
     return _RemoteBatteryCharger(
       chargerId: chargerId,
       powerSourceId: powerSourceId,

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/battery_charger.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/battery_charger.dart
@@ -354,6 +354,28 @@ abstract class BatteryCharger extends PartialBatteryCharger
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, BatteryCharger, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  BatteryCharger copyWith({
+    String? chargerId,
+    String? powerSourceId,
+    PowerSource? powerSource,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? id,
+  }) {
+    return _BatteryCharger._(
+      chargerId: chargerId ?? this.chargerId,
+      powerSourceId: powerSourceId ?? this.powerSourceId,
+      powerSource: powerSource == null
+          ? this.powerSource
+          : AsyncModel.fromModel(powerSource),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      id: id ?? this.id,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, BatteryCharger, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/battery_charger.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/battery_charger.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.battery_charger;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'power_source.dart';
 
@@ -298,6 +299,67 @@ abstract class BatteryCharger extends PartialBatteryCharger
 
   static const BatteryChargerQueryFields<String, BatteryCharger> _queryFields =
       BatteryChargerQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'BatteryCharger',
+      'pluralName': 'BatteryChargers',
+      'fields': {
+        'chargerID': {
+          'name': 'chargerID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'powerSourceID': {
+          'name': 'powerSourceID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'powerSource': {
+          'name': 'powerSource',
+          'type': {'model': 'PowerSource'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'PowerSource',
+            'associatedFields': ['sourceID'],
+            'targetNames': ['powerSourceID'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get chargerId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/battery_charger.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/battery_charger.dart
@@ -157,35 +157,6 @@ abstract class PartialBatteryCharger
       };
   @override
   String get runtimeTypeName => 'BatteryCharger';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, BatteryCharger, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'chargerID':
-        value = chargerId;
-        break;
-      case r'powerSourceID':
-        value = powerSourceId;
-        break;
-      case r'powerSource':
-        value = powerSource;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'id':
-        value = id;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialBatteryCharger extends PartialBatteryCharger {
@@ -383,6 +354,35 @@ abstract class BatteryCharger extends PartialBatteryCharger
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, BatteryCharger, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, BatteryCharger, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'chargerID':
+        value = chargerId;
+        break;
+      case r'powerSourceID':
+        value = powerSourceId;
+        break;
+      case r'powerSource':
+        value = powerSource;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'id':
+        value = id;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _BatteryCharger extends BatteryCharger {

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'battery_charger.dart';
+import 'power_source.dart';
+
+export 'battery_charger.dart';
+export 'power_source.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '21bac21660f52e85583a27bcf485016f';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        BatteryCharger.schema,
+        PowerSource.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'BatteryCharger':
+        return (BatteryCharger.classType as ModelType<ModelIdentifier, M, P>);
+      case 'PowerSource':
+        return (PowerSource.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/power_source.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/power_source.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.power_source;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class PowerSourceType
     extends ModelType<String, PowerSource, PartialPowerSource> {
@@ -239,6 +240,55 @@ abstract class PowerSource extends PartialPowerSource
 
   static const PowerSourceQueryFields<String, PowerSource> _queryFields =
       PowerSourceQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'PowerSource',
+      'pluralName': 'PowerSources',
+      'fields': {
+        'sourceID': {
+          'name': 'sourceID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'amps': {
+          'name': 'amps',
+          'type': {'scalar': 'Float'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'volts': {
+          'name': 'volts',
+          'type': {'scalar': 'Float'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'sourceID',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get sourceId;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/power_source.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/power_source.dart
@@ -134,32 +134,6 @@ abstract class PartialPowerSource extends PartialModel<String, PowerSource>
       };
   @override
   String get runtimeTypeName => 'PowerSource';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, PowerSource, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'sourceID':
-        value = sourceId;
-        break;
-      case r'amps':
-        value = amps;
-        break;
-      case r'volts':
-        value = volts;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialPowerSource extends PartialPowerSource {
@@ -307,6 +281,32 @@ abstract class PowerSource extends PartialPowerSource
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, PowerSource, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, PowerSource, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'sourceID':
+        value = sourceId;
+        break;
+      case r'amps':
+        value = amps;
+        break;
+      case r'volts':
+        value = volts;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _PowerSource extends PowerSource {

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/power_source.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/power_source.dart
@@ -281,6 +281,24 @@ abstract class PowerSource extends PartialPowerSource
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, PowerSource, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  PowerSource copyWith({
+    String? sourceId,
+    double? amps,
+    double? volts,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _PowerSource._(
+      sourceId: sourceId ?? this.sourceId,
+      amps: amps ?? this.amps,
+      volts: volts ?? this.volts,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, PowerSource, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/power_source.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/has_one_belongs_to/with_fields/power_source.dart
@@ -28,7 +28,8 @@ class PowerSourceType
 
   @override
   T fromJson<T extends PartialModel<String, PowerSource>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == PowerSource || T == Model<String, PowerSource>) {
       return PowerSource.fromJson(json) as T;
     }
@@ -74,7 +75,8 @@ class PowerSourceQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, PowerSource,
           TemporalDateTime>(
         const QueryField<String, PowerSource, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -83,7 +85,8 @@ class PowerSourceQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, PowerSource,
           TemporalDateTime>(
         const QueryField<String, PowerSource, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -91,7 +94,8 @@ class PowerSourceQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
       NestedQueryField<ModelIdentifier, M, String, PowerSource, String>(
         const QueryField<String, PowerSource, String>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/auth_rule_provider/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/auth_rule_provider/model_provider.dart
@@ -1,0 +1,62 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'todo_with_auth.dart';
+
+export 'todo_with_auth.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '7d6b9631e7eb1b068e15a3a92f942c96';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [TodoWithAuth.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'TodoWithAuth':
+        return (TodoWithAuth.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/auth_rule_provider/todo_with_auth.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/auth_rule_provider/todo_with_auth.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.todo_with_auth;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class TodoWithAuthType
     extends ModelType<String, TodoWithAuth, PartialTodoWithAuth> {
@@ -215,6 +216,78 @@ abstract class TodoWithAuth extends PartialTodoWithAuth
 
   static const TodoWithAuthQueryFields<String, TodoWithAuth> _queryFields =
       TodoWithAuthQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'TodoWithAuth',
+      'pluralName': 'TodoWithAuths',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [
+        {
+          'authStrategy': 'GROUPS',
+          'provider': 'USERPOOLS',
+          'operations': [
+            'CREATE',
+            'UPDATE',
+            'DELETE',
+            'READ',
+          ],
+          'groupClaim': 'cognito:groups',
+          'groups': ['admin'],
+          'groupsField': 'groups',
+        },
+        {
+          'authStrategy': 'OWNER',
+          'provider': 'USERPOOLS',
+          'operations': [
+            'CREATE',
+            'UPDATE',
+          ],
+          'ownerField': 'owner',
+          'identityClaim': 'sub::username',
+        },
+        {
+          'authStrategy': 'PUBLIC',
+          'provider': 'APIKEY',
+          'operations': ['READ'],
+        },
+      ],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/auth_rule_provider/todo_with_auth.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/auth_rule_provider/todo_with_auth.dart
@@ -1,0 +1,394 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.todo_with_auth;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class TodoWithAuthType
+    extends ModelType<String, TodoWithAuth, PartialTodoWithAuth> {
+  const TodoWithAuthType();
+
+  @override
+  T fromJson<T extends PartialModel<String, TodoWithAuth>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == TodoWithAuth || T == Model<String, TodoWithAuth>) {
+      return TodoWithAuth.fromJson(json) as T;
+    }
+    if (T == RemoteTodoWithAuth || T == RemoteModel<String, TodoWithAuth>) {
+      return _RemoteTodoWithAuth.fromJson(json) as T;
+    }
+    return _PartialTodoWithAuth.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'TodoWithAuth';
+}
+
+class TodoWithAuthQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const TodoWithAuthQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, TodoWithAuth>? _root;
+
+  /// Query field for the [TodoWithAuth.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, TodoWithAuth, String>(
+        const QueryField<String, TodoWithAuth, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [TodoWithAuth.name] field.
+  QueryField<ModelIdentifier, M, String> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, TodoWithAuth, String>(
+        const QueryField<String, TodoWithAuth, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [TodoWithAuth.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, TodoWithAuth,
+          TemporalDateTime>(
+        const QueryField<String, TodoWithAuth, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TodoWithAuth.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, TodoWithAuth,
+          TemporalDateTime>(
+        const QueryField<String, TodoWithAuth, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TodoWithAuth] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, TodoWithAuth, String>(
+        const QueryField<String, TodoWithAuth, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialTodoWithAuth extends PartialModel<String, TodoWithAuth>
+    with AWSEquatable<PartialTodoWithAuth> {
+  const PartialTodoWithAuth._();
+
+  String get id;
+  String? get name;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  TodoWithAuthType get modelType => TodoWithAuth.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'TodoWithAuth';
+}
+
+class _PartialTodoWithAuth extends PartialTodoWithAuth {
+  const _PartialTodoWithAuth({
+    required this.id,
+    this.name,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialTodoWithAuth.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'TodoWithAuth',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialTodoWithAuth(
+      id: id,
+      name: name,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class TodoWithAuth extends PartialTodoWithAuth
+    implements Model<String, TodoWithAuth> {
+  factory TodoWithAuth({
+    String? id,
+    required String name,
+  }) = _TodoWithAuth;
+
+  const TodoWithAuth._() : super._();
+
+  factory TodoWithAuth.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'TodoWithAuth',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'TodoWithAuth',
+            'name',
+          ))
+        : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'TodoWithAuth',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'TodoWithAuth',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _TodoWithAuth._(
+      id: id,
+      name: name,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const TodoWithAuthType classType = TodoWithAuthType();
+
+  static const TodoWithAuthQueryFields<String, TodoWithAuth> _queryFields =
+      TodoWithAuthQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, TodoWithAuth, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, TodoWithAuth, String> get ID => $id;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, TodoWithAuth, String> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, TodoWithAuth, String> get NAME => $name;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, TodoWithAuth, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, TodoWithAuth, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, TodoWithAuth, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _TodoWithAuth extends TodoWithAuth {
+  _TodoWithAuth({
+    String? id,
+    required this.name,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _TodoWithAuth._({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteTodoWithAuth extends TodoWithAuth
+    implements RemoteModel<String, TodoWithAuth> {
+  const RemoteTodoWithAuth._() : super._();
+}
+
+class _RemoteTodoWithAuth extends RemoteTodoWithAuth {
+  const _RemoteTodoWithAuth({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteTodoWithAuth.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'TodoWithAuth',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'TodoWithAuth',
+            'name',
+          ))
+        : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'TodoWithAuth',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'TodoWithAuth',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'TodoWithAuth',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'TodoWithAuth',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'TodoWithAuth',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteTodoWithAuth(
+      id: id,
+      name: name,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/auth_rule_provider/todo_with_auth.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/auth_rule_provider/todo_with_auth.dart
@@ -247,6 +247,22 @@ abstract class TodoWithAuth extends PartialTodoWithAuth
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, TodoWithAuth, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  TodoWithAuth copyWith({
+    String? id,
+    String? name,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _TodoWithAuth._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, TodoWithAuth, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_provider.dart
@@ -1,0 +1,73 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'model_with_explicitly_defined_pk.dart';
+import 'model_with_explicitly_defined_pk_plus_sort_keys_as_composite_key.dart';
+
+export 'model_with_explicitly_defined_pk.dart';
+export 'model_with_explicitly_defined_pk_plus_sort_keys_as_composite_key.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '1d6e51535d5a0fcdc8e6500a81942708';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        ModelWithExplicitlyDefinedPk.schema,
+        ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'ModelWithExplicitlyDefinedPK':
+      case 'ModelWithExplicitlyDefinedPk':
+        return (ModelWithExplicitlyDefinedPk.classType
+            as ModelType<ModelIdentifier, M, P>);
+      case 'ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKey':
+      case 'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey':
+        return (ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey.classType
+            as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk.dart
@@ -1,0 +1,416 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.model_with_explicitly_defined_pk;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class ModelWithExplicitlyDefinedPkType extends ModelType<String,
+    ModelWithExplicitlyDefinedPk, PartialModelWithExplicitlyDefinedPk> {
+  const ModelWithExplicitlyDefinedPkType();
+
+  @override
+  T fromJson<T extends PartialModel<String, ModelWithExplicitlyDefinedPk>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == ModelWithExplicitlyDefinedPk ||
+        T == Model<String, ModelWithExplicitlyDefinedPk>) {
+      return ModelWithExplicitlyDefinedPk.fromJson(json) as T;
+    }
+    if (T == RemoteModelWithExplicitlyDefinedPk ||
+        T == RemoteModel<String, ModelWithExplicitlyDefinedPk>) {
+      return _RemoteModelWithExplicitlyDefinedPk.fromJson(json) as T;
+    }
+    return _PartialModelWithExplicitlyDefinedPk.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'ModelWithExplicitlyDefinedPK';
+}
+
+class ModelWithExplicitlyDefinedPkQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ModelWithExplicitlyDefinedPkQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, ModelWithExplicitlyDefinedPk>? _root;
+
+  /// Query field for the [ModelWithExplicitlyDefinedPk.modelId] field.
+  QueryField<ModelIdentifier, M, String> get $modelId => NestedQueryField<
+          ModelIdentifier, M, String, ModelWithExplicitlyDefinedPk, String>(
+        const QueryField<String, ModelWithExplicitlyDefinedPk, String>(
+          fieldName: 'modelID',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitlyDefinedPk.title] field.
+  QueryField<ModelIdentifier, M, String> get $title => NestedQueryField<
+          ModelIdentifier, M, String, ModelWithExplicitlyDefinedPk, String>(
+        const QueryField<String, ModelWithExplicitlyDefinedPk, String>(
+          fieldName: 'title',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitlyDefinedPk.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithExplicitlyDefinedPk,
+          TemporalDateTime>(
+        const QueryField<String, ModelWithExplicitlyDefinedPk,
+            TemporalDateTime>(fieldName: 'createdAt'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitlyDefinedPk.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithExplicitlyDefinedPk,
+          TemporalDateTime>(
+        const QueryField<String, ModelWithExplicitlyDefinedPk,
+            TemporalDateTime>(fieldName: 'updatedAt'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitlyDefinedPk] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithExplicitlyDefinedPk,
+          String>(
+        const QueryField<String, ModelWithExplicitlyDefinedPk, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialModelWithExplicitlyDefinedPk
+    extends PartialModel<String, ModelWithExplicitlyDefinedPk>
+    with AWSEquatable<PartialModelWithExplicitlyDefinedPk> {
+  const PartialModelWithExplicitlyDefinedPk._();
+
+  String get modelId;
+  String? get title;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => modelId;
+  @override
+  ModelWithExplicitlyDefinedPkType get modelType =>
+      ModelWithExplicitlyDefinedPk.classType;
+  @override
+  List<Object?> get props => [
+        modelId,
+        title,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'modelID': modelId,
+        'title': title,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'ModelWithExplicitlyDefinedPk';
+}
+
+class _PartialModelWithExplicitlyDefinedPk
+    extends PartialModelWithExplicitlyDefinedPk {
+  const _PartialModelWithExplicitlyDefinedPk({
+    required this.modelId,
+    this.title,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialModelWithExplicitlyDefinedPk.fromJson(
+    Map<String, Object?> json,
+  ) {
+    final modelId = json['modelID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPk',
+            'modelId',
+          ))
+        : (json['modelID'] as String);
+    final title = json['title'] == null ? null : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialModelWithExplicitlyDefinedPk(
+      modelId: modelId,
+      title: title,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String modelId;
+
+  @override
+  final String? title;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class ModelWithExplicitlyDefinedPk
+    extends PartialModelWithExplicitlyDefinedPk
+    implements Model<String, ModelWithExplicitlyDefinedPk> {
+  factory ModelWithExplicitlyDefinedPk({
+    String? modelId,
+    required String title,
+  }) = _ModelWithExplicitlyDefinedPk;
+
+  const ModelWithExplicitlyDefinedPk._() : super._();
+
+  factory ModelWithExplicitlyDefinedPk.fromJson(Map<String, Object?> json) {
+    final modelId = json['modelID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPk',
+            'modelId',
+          ))
+        : (json['modelID'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPk',
+            'title',
+          ))
+        : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPk',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPk',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _ModelWithExplicitlyDefinedPk._(
+      modelId: modelId,
+      title: title,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const ModelWithExplicitlyDefinedPkType classType =
+      ModelWithExplicitlyDefinedPkType();
+
+  static const ModelWithExplicitlyDefinedPkQueryFields<String,
+          ModelWithExplicitlyDefinedPk> _queryFields =
+      ModelWithExplicitlyDefinedPkQueryFields();
+
+  @override
+  String get modelId;
+
+  /// Query field for the [modelId] field.
+  QueryField<String, ModelWithExplicitlyDefinedPk, String> get $modelId =>
+      _queryFields.$modelId;
+
+  /// Query field for the [modelId] field.
+  @Deprecated(r'Use $modelId instead')
+  QueryField<String, ModelWithExplicitlyDefinedPk, String> get MODEL_ID =>
+      $modelId;
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<String, ModelWithExplicitlyDefinedPk, String> get $title =>
+      _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<String, ModelWithExplicitlyDefinedPk, String> get TITLE => $title;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, ModelWithExplicitlyDefinedPk, String>
+      get $modelIdentifier => _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, ModelWithExplicitlyDefinedPk, String>
+      get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<String, ModelWithExplicitlyDefinedPk, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'modelID':
+        value = modelId;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _ModelWithExplicitlyDefinedPk extends ModelWithExplicitlyDefinedPk {
+  _ModelWithExplicitlyDefinedPk({
+    String? modelId,
+    required this.title,
+  })  : modelId = modelId ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _ModelWithExplicitlyDefinedPk._({
+    required this.modelId,
+    required this.title,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String modelId;
+
+  @override
+  final String title;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteModelWithExplicitlyDefinedPk
+    extends ModelWithExplicitlyDefinedPk
+    implements RemoteModel<String, ModelWithExplicitlyDefinedPk> {
+  const RemoteModelWithExplicitlyDefinedPk._() : super._();
+}
+
+class _RemoteModelWithExplicitlyDefinedPk
+    extends RemoteModelWithExplicitlyDefinedPk {
+  const _RemoteModelWithExplicitlyDefinedPk({
+    required this.modelId,
+    required this.title,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteModelWithExplicitlyDefinedPk.fromJson(
+    Map<String, Object?> json,
+  ) {
+    final modelId = json['modelID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPk',
+            'modelId',
+          ))
+        : (json['modelID'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPk',
+            'title',
+          ))
+        : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPk',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPk',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPk',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPk',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPk',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteModelWithExplicitlyDefinedPk(
+      modelId: modelId,
+      title: title,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String modelId;
+
+  @override
+  final String title;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk.dart
@@ -263,6 +263,22 @@ abstract class ModelWithExplicitlyDefinedPk
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, ModelWithExplicitlyDefinedPk, String>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  ModelWithExplicitlyDefinedPk copyWith({
+    String? modelId,
+    String? title,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _ModelWithExplicitlyDefinedPk._(
+      modelId: modelId ?? this.modelId,
+      title: title ?? this.title,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<String, ModelWithExplicitlyDefinedPk, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.model_with_explicitly_defined_pk;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class ModelWithExplicitlyDefinedPkType extends ModelType<String,
     ModelWithExplicitlyDefinedPk, PartialModelWithExplicitlyDefinedPk> {
@@ -228,6 +229,49 @@ abstract class ModelWithExplicitlyDefinedPk
   static const ModelWithExplicitlyDefinedPkQueryFields<String,
           ModelWithExplicitlyDefinedPk> _queryFields =
       ModelWithExplicitlyDefinedPkQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'ModelWithExplicitlyDefinedPK',
+      'pluralName': 'ModelWithExplicitlyDefinedPKs',
+      'fields': {
+        'modelID': {
+          'name': 'modelID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'modelID',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get modelId;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk_plus_sort_keys_as_composite_key.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk_plus_sort_keys_as_composite_key.dart
@@ -437,6 +437,24 @@ abstract class ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey
           ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
           ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey copyWith({
+    String? modelId,
+    String? title,
+    int? rating,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey._(
+      modelId: modelId ?? this.modelId,
+      title: title ?? this.title,
+      rating: rating ?? this.rating,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk_plus_sort_keys_as_composite_key.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk_plus_sort_keys_as_composite_key.dart
@@ -44,7 +44,7 @@ class ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier
 
   @override
   List<Object?> get props => [
-        modelID,
+        modelId,
         title,
         rating,
       ];

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk_plus_sort_keys_as_composite_key.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk_plus_sort_keys_as_composite_key.dart
@@ -1,0 +1,616 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.model_with_explicitly_defined_pk_plus_sort_keys_as_composite_key;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:meta/meta.dart';
+
+@immutable
+class ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier
+    with
+        AWSEquatable<
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  const ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier({
+    required this.modelId,
+    required this.title,
+    required this.rating,
+  });
+
+  final String modelId;
+
+  final String title;
+
+  final int rating;
+
+  @override
+  List<Object?> get props => [
+        modelID,
+        title,
+        rating,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'modelID': modelId,
+        'title': title,
+        'rating': rating,
+      };
+  @override
+  String get runtimeTypeName =>
+      'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier';
+}
+
+class ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyType
+    extends ModelType<
+        ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+        ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+        PartialModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey> {
+  const ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyType();
+
+  @override
+  T fromJson<
+      T extends PartialModel<
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey ||
+        T ==
+            Model<
+                ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+                ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey>) {
+      return ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey.fromJson(
+        json,
+      ) as T;
+    }
+    if (T == RemoteModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey ||
+        T ==
+            RemoteModel<
+                ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+                ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey>) {
+      return _RemoteModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey
+          .fromJson(json) as T;
+    }
+    return _PartialModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey
+        .fromJson(json) as T;
+  }
+
+  @override
+  String get modelName =>
+      'ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKey';
+}
+
+class ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyQueryFields<
+    ModelIdentifier extends Object, M extends Model<ModelIdentifier, M>> {
+  const ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyQueryFields([
+    this._root,
+  ]);
+
+  final QueryField<ModelIdentifier, M,
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey>? _root;
+
+  /// Query field for the [ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey.modelId] field.
+  QueryField<ModelIdentifier, M, String> get $modelId => NestedQueryField<
+          ModelIdentifier,
+          M,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+          String>(
+        const QueryField<
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+            String>(fieldName: 'modelID'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey.title] field.
+  QueryField<ModelIdentifier, M, String> get $title => NestedQueryField<
+          ModelIdentifier,
+          M,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+          String>(
+        const QueryField<
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+            String>(fieldName: 'title'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey.rating] field.
+  QueryField<ModelIdentifier, M, int> get $rating => NestedQueryField<
+          ModelIdentifier,
+          M,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+          int>(
+        const QueryField<
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+            int>(fieldName: 'rating'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<
+          ModelIdentifier,
+          M,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+          TemporalDateTime>(
+        const QueryField<
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+            TemporalDateTime>(fieldName: 'createdAt'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<
+          ModelIdentifier,
+          M,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+          TemporalDateTime>(
+        const QueryField<
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+            TemporalDateTime>(fieldName: 'updatedAt'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey] model identifier.
+  QueryField<ModelIdentifier, M,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier>
+      get $modelIdentifier => NestedQueryField<
+              ModelIdentifier,
+              M,
+              ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+              ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+              ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier>(
+            const QueryField<
+                ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+                ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+                ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier>(
+              fieldName: 'modelIdentifier',
+            ),
+            root: _root,
+          );
+}
+
+abstract class PartialModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey
+    extends PartialModel<
+        ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+        ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey>
+    with
+        AWSEquatable<
+            PartialModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey> {
+  const PartialModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey._();
+
+  String get modelId;
+  String get title;
+  int get rating;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier
+      get modelIdentifier =>
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier(
+            modelId: modelId,
+            title: title,
+            rating: rating,
+          );
+  @override
+  ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyType get modelType =>
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey.classType;
+  @override
+  List<Object?> get props => [
+        modelId,
+        title,
+        rating,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'modelID': modelId,
+        'title': title,
+        'rating': rating,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName =>
+      'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey';
+}
+
+class _PartialModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey
+    extends PartialModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey {
+  const _PartialModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey({
+    required this.modelId,
+    required this.title,
+    required this.rating,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey.fromJson(
+    Map<String, Object?> json,
+  ) {
+    final modelId = json['modelID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'modelId',
+          ))
+        : (json['modelID'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'title',
+          ))
+        : (json['title'] as String);
+    final rating = json['rating'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'rating',
+          ))
+        : (json['rating'] as int);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey(
+      modelId: modelId,
+      title: title,
+      rating: rating,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String modelId;
+
+  @override
+  final String title;
+
+  @override
+  final int rating;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey
+    extends PartialModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey
+    implements
+        Model<ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey> {
+  factory ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey({
+    String? modelId,
+    required String title,
+    required int rating,
+  }) = _ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey;
+
+  const ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey._() : super._();
+
+  factory ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey.fromJson(
+    Map<String, Object?> json,
+  ) {
+    final modelId = json['modelID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'modelId',
+          ))
+        : (json['modelID'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'title',
+          ))
+        : (json['title'] as String);
+    final rating = json['rating'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'rating',
+          ))
+        : (json['rating'] as int);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey._(
+      modelId: modelId,
+      title: title,
+      rating: rating,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyType
+      classType = ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyType();
+
+  static const ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyQueryFields<
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey> _queryFields =
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyQueryFields();
+
+  @override
+  String get modelId;
+
+  /// Query field for the [modelId] field.
+  QueryField<
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+      String> get $modelId => _queryFields.$modelId;
+
+  /// Query field for the [modelId] field.
+  @Deprecated(r'Use $modelId instead')
+  QueryField<
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+      String> get MODEL_ID => $modelId;
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+      String> get $title => _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+      String> get TITLE => $title;
+  @override
+  int get rating;
+
+  /// Query field for the [rating] field.
+  QueryField<
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+      int> get $rating => _queryFields.$rating;
+
+  /// Query field for the [rating] field.
+  @Deprecated(r'Use $rating instead')
+  QueryField<
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+      ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+      int> get RATING => $rating;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier>
+      get $modelIdentifier => _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey,
+          ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier>
+      get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey, T>
+        field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'modelID':
+        value = modelId;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'rating':
+        value = rating;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey
+    extends ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey {
+  _ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey({
+    String? modelId,
+    required this.title,
+    required this.rating,
+  })  : modelId = modelId ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey._({
+    required this.modelId,
+    required this.title,
+    required this.rating,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String modelId;
+
+  @override
+  final String title;
+
+  @override
+  final int rating;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey
+    extends ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey
+    implements
+        RemoteModel<
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
+            ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey> {
+  const RemoteModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey._()
+      : super._();
+}
+
+class _RemoteModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey
+    extends RemoteModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey {
+  const _RemoteModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey({
+    required this.modelId,
+    required this.title,
+    required this.rating,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey.fromJson(
+    Map<String, Object?> json,
+  ) {
+    final modelId = json['modelID'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'modelId',
+          ))
+        : (json['modelID'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'title',
+          ))
+        : (json['title'] as String);
+    final rating = json['rating'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'rating',
+          ))
+        : (json['rating'] as int);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey(
+      modelId: modelId,
+      title: title,
+      rating: rating,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String modelId;
+
+  @override
+  final String title;
+
+  @override
+  final int rating;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk_plus_sort_keys_as_composite_key.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk/model_with_explicitly_defined_pk_plus_sort_keys_as_composite_key.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.model_with_explicitly_defined_pk_plus_sort_keys_as_composite_key;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 @immutable
@@ -372,6 +373,58 @@ abstract class ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey
           ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyIdentifier,
           ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKey> _queryFields =
       ModelWithExplicitlyDefinedPkPlusSortKeysAsCompositeKeyQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKey',
+      'pluralName': 'ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKeys',
+      'fields': {
+        'modelID': {
+          'name': 'modelID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'rating': {
+          'name': 'rating',
+          'type': {'scalar': 'Int'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'modelID',
+          'sortKeyFields': [
+            'title',
+            'rating',
+          ],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get modelId;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_id_field/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_id_field/model_provider.dart
@@ -1,0 +1,65 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'model_with_id_plus_sort_keys.dart';
+
+export 'model_with_id_plus_sort_keys.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '14c742b14ea2d8d7525540b6d3c8c6b5';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas =>
+      [ModelWithIdPlusSortKeys.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'ModelWithIDPlusSortKeys':
+      case 'ModelWithIdPlusSortKeys':
+        return (ModelWithIdPlusSortKeys.classType
+            as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_id_field/model_with_id_plus_sort_keys.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_id_field/model_with_id_plus_sort_keys.dart
@@ -369,6 +369,24 @@ abstract class ModelWithIdPlusSortKeys extends PartialModelWithIdPlusSortKeys
   QueryField<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys,
           ModelWithIdPlusSortKeysIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  ModelWithIdPlusSortKeys copyWith({
+    String? id,
+    String? title,
+    int? rating,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _ModelWithIdPlusSortKeys._(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      rating: rating ?? this.rating,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys, T>

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_id_field/model_with_id_plus_sort_keys.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_id_field/model_with_id_plus_sort_keys.dart
@@ -1,0 +1,540 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.model_with_id_plus_sort_keys;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:meta/meta.dart';
+
+@immutable
+class ModelWithIdPlusSortKeysIdentifier
+    with
+        AWSEquatable<ModelWithIdPlusSortKeysIdentifier>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  const ModelWithIdPlusSortKeysIdentifier({
+    required this.id,
+    required this.title,
+    required this.rating,
+  });
+
+  final String id;
+
+  final String title;
+
+  final int rating;
+
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        rating,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'title': title,
+        'rating': rating,
+      };
+  @override
+  String get runtimeTypeName => 'ModelWithIdPlusSortKeysIdentifier';
+}
+
+class ModelWithIdPlusSortKeysType extends ModelType<
+    ModelWithIdPlusSortKeysIdentifier,
+    ModelWithIdPlusSortKeys,
+    PartialModelWithIdPlusSortKeys> {
+  const ModelWithIdPlusSortKeysType();
+
+  @override
+  T fromJson<
+      T extends PartialModel<ModelWithIdPlusSortKeysIdentifier,
+          ModelWithIdPlusSortKeys>>(Map<String, Object?> json) {
+    if (T == ModelWithIdPlusSortKeys ||
+        T ==
+            Model<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys>) {
+      return ModelWithIdPlusSortKeys.fromJson(json) as T;
+    }
+    if (T == RemoteModelWithIdPlusSortKeys ||
+        T ==
+            RemoteModel<ModelWithIdPlusSortKeysIdentifier,
+                ModelWithIdPlusSortKeys>) {
+      return _RemoteModelWithIdPlusSortKeys.fromJson(json) as T;
+    }
+    return _PartialModelWithIdPlusSortKeys.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'ModelWithIDPlusSortKeys';
+}
+
+class ModelWithIdPlusSortKeysQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ModelWithIdPlusSortKeysQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, ModelWithIdPlusSortKeys>? _root;
+
+  /// Query field for the [ModelWithIdPlusSortKeys.id] field.
+  QueryField<ModelIdentifier, M, String> get $id => NestedQueryField<
+          ModelIdentifier,
+          M,
+          ModelWithIdPlusSortKeysIdentifier,
+          ModelWithIdPlusSortKeys,
+          String>(
+        const QueryField<ModelWithIdPlusSortKeysIdentifier,
+            ModelWithIdPlusSortKeys, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithIdPlusSortKeys.title] field.
+  QueryField<ModelIdentifier, M, String> get $title => NestedQueryField<
+          ModelIdentifier,
+          M,
+          ModelWithIdPlusSortKeysIdentifier,
+          ModelWithIdPlusSortKeys,
+          String>(
+        const QueryField<ModelWithIdPlusSortKeysIdentifier,
+            ModelWithIdPlusSortKeys, String>(fieldName: 'title'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithIdPlusSortKeys.rating] field.
+  QueryField<ModelIdentifier, M, int> get $rating => NestedQueryField<
+          ModelIdentifier,
+          M,
+          ModelWithIdPlusSortKeysIdentifier,
+          ModelWithIdPlusSortKeys,
+          int>(
+        const QueryField<ModelWithIdPlusSortKeysIdentifier,
+            ModelWithIdPlusSortKeys, int>(fieldName: 'rating'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithIdPlusSortKeys.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, ModelWithIdPlusSortKeysIdentifier,
+          ModelWithIdPlusSortKeys, TemporalDateTime>(
+        const QueryField<ModelWithIdPlusSortKeysIdentifier,
+            ModelWithIdPlusSortKeys, TemporalDateTime>(fieldName: 'createdAt'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithIdPlusSortKeys.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, ModelWithIdPlusSortKeysIdentifier,
+          ModelWithIdPlusSortKeys, TemporalDateTime>(
+        const QueryField<ModelWithIdPlusSortKeysIdentifier,
+            ModelWithIdPlusSortKeys, TemporalDateTime>(fieldName: 'updatedAt'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithIdPlusSortKeys] model identifier.
+  QueryField<ModelIdentifier, M, ModelWithIdPlusSortKeysIdentifier>
+      get $modelIdentifier => NestedQueryField<
+              ModelIdentifier,
+              M,
+              ModelWithIdPlusSortKeysIdentifier,
+              ModelWithIdPlusSortKeys,
+              ModelWithIdPlusSortKeysIdentifier>(
+            const QueryField<ModelWithIdPlusSortKeysIdentifier,
+                ModelWithIdPlusSortKeys, ModelWithIdPlusSortKeysIdentifier>(
+              fieldName: 'modelIdentifier',
+            ),
+            root: _root,
+          );
+}
+
+abstract class PartialModelWithIdPlusSortKeys extends PartialModel<
+    ModelWithIdPlusSortKeysIdentifier,
+    ModelWithIdPlusSortKeys> with AWSEquatable<PartialModelWithIdPlusSortKeys> {
+  const PartialModelWithIdPlusSortKeys._();
+
+  String get id;
+  String get title;
+  int get rating;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  ModelWithIdPlusSortKeysIdentifier get modelIdentifier =>
+      ModelWithIdPlusSortKeysIdentifier(
+        id: id,
+        title: title,
+        rating: rating,
+      );
+  @override
+  ModelWithIdPlusSortKeysType get modelType =>
+      ModelWithIdPlusSortKeys.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        rating,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'title': title,
+        'rating': rating,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'ModelWithIdPlusSortKeys';
+}
+
+class _PartialModelWithIdPlusSortKeys extends PartialModelWithIdPlusSortKeys {
+  const _PartialModelWithIdPlusSortKeys({
+    required this.id,
+    required this.title,
+    required this.rating,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialModelWithIdPlusSortKeys.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'title',
+          ))
+        : (json['title'] as String);
+    final rating = json['rating'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'rating',
+          ))
+        : (json['rating'] as int);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialModelWithIdPlusSortKeys(
+      id: id,
+      title: title,
+      rating: rating,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final int rating;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class ModelWithIdPlusSortKeys extends PartialModelWithIdPlusSortKeys
+    implements
+        Model<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys> {
+  factory ModelWithIdPlusSortKeys({
+    String? id,
+    required String title,
+    required int rating,
+  }) = _ModelWithIdPlusSortKeys;
+
+  const ModelWithIdPlusSortKeys._() : super._();
+
+  factory ModelWithIdPlusSortKeys.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'title',
+          ))
+        : (json['title'] as String);
+    final rating = json['rating'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'rating',
+          ))
+        : (json['rating'] as int);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _ModelWithIdPlusSortKeys._(
+      id: id,
+      title: title,
+      rating: rating,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const ModelWithIdPlusSortKeysType classType =
+      ModelWithIdPlusSortKeysType();
+
+  static const ModelWithIdPlusSortKeysQueryFields<
+          ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys>
+      _queryFields = ModelWithIdPlusSortKeysQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys, String>
+      get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys, String>
+      get ID => $id;
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys, String>
+      get $title => _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys, String>
+      get TITLE => $title;
+  @override
+  int get rating;
+
+  /// Query field for the [rating] field.
+  QueryField<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys, int>
+      get $rating => _queryFields.$rating;
+
+  /// Query field for the [rating] field.
+  @Deprecated(r'Use $rating instead')
+  QueryField<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys, int>
+      get RATING => $rating;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys,
+          ModelWithIdPlusSortKeysIdentifier>
+      get $modelIdentifier => _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys,
+          ModelWithIdPlusSortKeysIdentifier>
+      get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys, T>
+        field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'rating':
+        value = rating;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _ModelWithIdPlusSortKeys extends ModelWithIdPlusSortKeys {
+  _ModelWithIdPlusSortKeys({
+    String? id,
+    required this.title,
+    required this.rating,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _ModelWithIdPlusSortKeys._({
+    required this.id,
+    required this.title,
+    required this.rating,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final int rating;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteModelWithIdPlusSortKeys extends ModelWithIdPlusSortKeys
+    implements
+        RemoteModel<ModelWithIdPlusSortKeysIdentifier,
+            ModelWithIdPlusSortKeys> {
+  const RemoteModelWithIdPlusSortKeys._() : super._();
+}
+
+class _RemoteModelWithIdPlusSortKeys extends RemoteModelWithIdPlusSortKeys {
+  const _RemoteModelWithIdPlusSortKeys({
+    required this.id,
+    required this.title,
+    required this.rating,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteModelWithIdPlusSortKeys.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'title',
+          ))
+        : (json['title'] as String);
+    final rating = json['rating'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'rating',
+          ))
+        : (json['rating'] as int);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithIdPlusSortKeys',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteModelWithIdPlusSortKeys(
+      id: id,
+      title: title,
+      rating: rating,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final int rating;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_id_field/model_with_id_plus_sort_keys.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_id_field/model_with_id_plus_sort_keys.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.model_with_id_plus_sort_keys;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 @immutable
@@ -320,6 +321,58 @@ abstract class ModelWithIdPlusSortKeys extends PartialModelWithIdPlusSortKeys
   static const ModelWithIdPlusSortKeysQueryFields<
           ModelWithIdPlusSortKeysIdentifier, ModelWithIdPlusSortKeys>
       _queryFields = ModelWithIdPlusSortKeysQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'ModelWithIDPlusSortKeys',
+      'pluralName': 'ModelWithIDPlusSortKeys',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'rating': {
+          'name': 'rating',
+          'type': {'scalar': 'Int'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [
+            'title',
+            'rating',
+          ],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_child_explicit.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_child_explicit.dart
@@ -1,0 +1,751 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.cpk_one_to_one_bidirectional_child_explicit;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:meta/meta.dart';
+
+import 'cpk_one_to_one_bidirectional_parent.dart';
+
+@immutable
+class CpkOneToOneBidirectionalChildExplicitIdentifier
+    with
+        AWSEquatable<CpkOneToOneBidirectionalChildExplicitIdentifier>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  const CpkOneToOneBidirectionalChildExplicitIdentifier({
+    required this.id,
+    required this.name,
+  });
+
+  final String id;
+
+  final String name;
+
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+      };
+  @override
+  String get runtimeTypeName =>
+      'CpkOneToOneBidirectionalChildExplicitIdentifier';
+}
+
+class CpkOneToOneBidirectionalChildExplicitType extends ModelType<
+    CpkOneToOneBidirectionalChildExplicitIdentifier,
+    CpkOneToOneBidirectionalChildExplicit,
+    PartialCpkOneToOneBidirectionalChildExplicit> {
+  const CpkOneToOneBidirectionalChildExplicitType();
+
+  @override
+  T fromJson<
+      T extends PartialModel<CpkOneToOneBidirectionalChildExplicitIdentifier,
+          CpkOneToOneBidirectionalChildExplicit>>(Map<String, Object?> json) {
+    if (T == CpkOneToOneBidirectionalChildExplicit ||
+        T ==
+            Model<CpkOneToOneBidirectionalChildExplicitIdentifier,
+                CpkOneToOneBidirectionalChildExplicit>) {
+      return CpkOneToOneBidirectionalChildExplicit.fromJson(json) as T;
+    }
+    if (T == RemoteCpkOneToOneBidirectionalChildExplicit ||
+        T ==
+            RemoteModel<CpkOneToOneBidirectionalChildExplicitIdentifier,
+                CpkOneToOneBidirectionalChildExplicit>) {
+      return _RemoteCpkOneToOneBidirectionalChildExplicit.fromJson(json) as T;
+    }
+    return _PartialCpkOneToOneBidirectionalChildExplicit.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'CpkOneToOneBidirectionalChildExplicit';
+}
+
+class CpkOneToOneBidirectionalChildExplicitQueryFields<
+    ModelIdentifier extends Object, M extends Model<ModelIdentifier, M>> {
+  const CpkOneToOneBidirectionalChildExplicitQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, CpkOneToOneBidirectionalChildExplicit>?
+      _root;
+
+  /// Query field for the [CpkOneToOneBidirectionalChildExplicit.id] field.
+  QueryField<ModelIdentifier, M, String> get $id => NestedQueryField<
+          ModelIdentifier,
+          M,
+          CpkOneToOneBidirectionalChildExplicitIdentifier,
+          CpkOneToOneBidirectionalChildExplicit,
+          String>(
+        const QueryField<CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [CpkOneToOneBidirectionalChildExplicit.name] field.
+  QueryField<ModelIdentifier, M, String> get $name => NestedQueryField<
+          ModelIdentifier,
+          M,
+          CpkOneToOneBidirectionalChildExplicitIdentifier,
+          CpkOneToOneBidirectionalChildExplicit,
+          String>(
+        const QueryField<CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [CpkOneToOneBidirectionalChildExplicit.belongsToParentId] field.
+  QueryField<ModelIdentifier, M, String?> get $belongsToParentId =>
+      NestedQueryField<
+          ModelIdentifier,
+          M,
+          CpkOneToOneBidirectionalChildExplicitIdentifier,
+          CpkOneToOneBidirectionalChildExplicit,
+          String?>(
+        const QueryField<
+            CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit,
+            String?>(fieldName: 'belongsToParentID'),
+        root: _root,
+      );
+
+  /// Query field for the [CpkOneToOneBidirectionalChildExplicit.belongsToParentName] field.
+  QueryField<ModelIdentifier, M, String?> get $belongsToParentName =>
+      NestedQueryField<
+          ModelIdentifier,
+          M,
+          CpkOneToOneBidirectionalChildExplicitIdentifier,
+          CpkOneToOneBidirectionalChildExplicit,
+          String?>(
+        const QueryField<
+            CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit,
+            String?>(fieldName: 'belongsToParentName'),
+        root: _root,
+      );
+
+  /// Query field for the [CpkOneToOneBidirectionalChildExplicit.belongsToParent] field.
+  CpkOneToOneBidirectionalParentQueryFields<ModelIdentifier, M>
+      get $belongsToParent => CpkOneToOneBidirectionalParentQueryFields(
+            NestedQueryField<
+                ModelIdentifier,
+                M,
+                CpkOneToOneBidirectionalChildExplicitIdentifier,
+                CpkOneToOneBidirectionalChildExplicit,
+                CpkOneToOneBidirectionalParent>(
+              const QueryField<
+                  CpkOneToOneBidirectionalChildExplicitIdentifier,
+                  CpkOneToOneBidirectionalChildExplicit,
+                  CpkOneToOneBidirectionalParent>(fieldName: 'belongsToParent'),
+              root: _root,
+            ),
+          );
+
+  /// Query field for the [CpkOneToOneBidirectionalChildExplicit.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<
+          ModelIdentifier,
+          M,
+          CpkOneToOneBidirectionalChildExplicitIdentifier,
+          CpkOneToOneBidirectionalChildExplicit,
+          TemporalDateTime>(
+        const QueryField<
+            CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit,
+            TemporalDateTime>(fieldName: 'createdAt'),
+        root: _root,
+      );
+
+  /// Query field for the [CpkOneToOneBidirectionalChildExplicit.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<
+          ModelIdentifier,
+          M,
+          CpkOneToOneBidirectionalChildExplicitIdentifier,
+          CpkOneToOneBidirectionalChildExplicit,
+          TemporalDateTime>(
+        const QueryField<
+            CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit,
+            TemporalDateTime>(fieldName: 'updatedAt'),
+        root: _root,
+      );
+
+  /// Query field for the [CpkOneToOneBidirectionalChildExplicit] model identifier.
+  QueryField<ModelIdentifier, M,
+          CpkOneToOneBidirectionalChildExplicitIdentifier>
+      get $modelIdentifier => NestedQueryField<
+              ModelIdentifier,
+              M,
+              CpkOneToOneBidirectionalChildExplicitIdentifier,
+              CpkOneToOneBidirectionalChildExplicit,
+              CpkOneToOneBidirectionalChildExplicitIdentifier>(
+            const QueryField<
+                CpkOneToOneBidirectionalChildExplicitIdentifier,
+                CpkOneToOneBidirectionalChildExplicit,
+                CpkOneToOneBidirectionalChildExplicitIdentifier>(
+              fieldName: 'modelIdentifier',
+            ),
+            root: _root,
+          );
+}
+
+abstract class PartialCpkOneToOneBidirectionalChildExplicit
+    extends PartialModel<CpkOneToOneBidirectionalChildExplicitIdentifier,
+        CpkOneToOneBidirectionalChildExplicit>
+    with AWSEquatable<PartialCpkOneToOneBidirectionalChildExplicit> {
+  const PartialCpkOneToOneBidirectionalChildExplicit._();
+
+  String get id;
+  String get name;
+  String? get belongsToParentId;
+  String? get belongsToParentName;
+  AsyncModel<
+      CpkOneToOneBidirectionalParentIdentifier,
+      CpkOneToOneBidirectionalParent,
+      PartialCpkOneToOneBidirectionalParent,
+      PartialCpkOneToOneBidirectionalParent>? get belongsToParent;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  CpkOneToOneBidirectionalChildExplicitIdentifier get modelIdentifier =>
+      CpkOneToOneBidirectionalChildExplicitIdentifier(
+        id: id,
+        name: name,
+      );
+  @override
+  CpkOneToOneBidirectionalChildExplicitType get modelType =>
+      CpkOneToOneBidirectionalChildExplicit.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        belongsToParentId,
+        belongsToParentName,
+        belongsToParent,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'belongsToParentID': belongsToParentId,
+        'belongsToParentName': belongsToParentName,
+        'belongsToParent': belongsToParent?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'CpkOneToOneBidirectionalChildExplicit';
+}
+
+class _PartialCpkOneToOneBidirectionalChildExplicit
+    extends PartialCpkOneToOneBidirectionalChildExplicit {
+  const _PartialCpkOneToOneBidirectionalChildExplicit({
+    required this.id,
+    required this.name,
+    this.belongsToParentId,
+    this.belongsToParentName,
+    this.belongsToParent,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialCpkOneToOneBidirectionalChildExplicit.fromJson(
+    Map<String, Object?> json,
+  ) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'name',
+          ))
+        : (json['name'] as String);
+    final belongsToParentId = json['belongsToParentID'] == null
+        ? null
+        : (json['belongsToParentID'] as String);
+    final belongsToParentName = json['belongsToParentName'] == null
+        ? null
+        : (json['belongsToParentName'] as String);
+    final belongsToParent = json['belongsToParent'] == null
+        ? null
+        : AsyncModel<
+            CpkOneToOneBidirectionalParentIdentifier,
+            CpkOneToOneBidirectionalParent,
+            PartialCpkOneToOneBidirectionalParent,
+            PartialCpkOneToOneBidirectionalParent>.fromModel(
+            CpkOneToOneBidirectionalParent.classType
+                .fromJson<PartialCpkOneToOneBidirectionalParent>(
+              (json['belongsToParent'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialCpkOneToOneBidirectionalChildExplicit(
+      id: id,
+      name: name,
+      belongsToParentId: belongsToParentId,
+      belongsToParentName: belongsToParentName,
+      belongsToParent: belongsToParent,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final String? belongsToParentId;
+
+  @override
+  final String? belongsToParentName;
+
+  @override
+  final AsyncModel<
+      CpkOneToOneBidirectionalParentIdentifier,
+      CpkOneToOneBidirectionalParent,
+      PartialCpkOneToOneBidirectionalParent,
+      PartialCpkOneToOneBidirectionalParent>? belongsToParent;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class CpkOneToOneBidirectionalChildExplicit
+    extends PartialCpkOneToOneBidirectionalChildExplicit
+    implements
+        Model<CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit> {
+  factory CpkOneToOneBidirectionalChildExplicit({
+    String? id,
+    required String name,
+    String? belongsToParentId,
+    String? belongsToParentName,
+    CpkOneToOneBidirectionalParent? belongsToParent,
+  }) = _CpkOneToOneBidirectionalChildExplicit;
+
+  const CpkOneToOneBidirectionalChildExplicit._() : super._();
+
+  factory CpkOneToOneBidirectionalChildExplicit.fromJson(
+    Map<String, Object?> json,
+  ) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'name',
+          ))
+        : (json['name'] as String);
+    final belongsToParentId = json['belongsToParentID'] == null
+        ? null
+        : (json['belongsToParentID'] as String);
+    final belongsToParentName = json['belongsToParentName'] == null
+        ? null
+        : (json['belongsToParentName'] as String);
+    final belongsToParent = json['belongsToParent'] == null
+        ? null
+        : AsyncModel<
+            CpkOneToOneBidirectionalParentIdentifier,
+            CpkOneToOneBidirectionalParent,
+            PartialCpkOneToOneBidirectionalParent,
+            CpkOneToOneBidirectionalParent>.fromModel(
+            CpkOneToOneBidirectionalParent.classType
+                .fromJson<CpkOneToOneBidirectionalParent>(
+              (json['belongsToParent'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _CpkOneToOneBidirectionalChildExplicit._(
+      id: id,
+      name: name,
+      belongsToParentId: belongsToParentId,
+      belongsToParentName: belongsToParentName,
+      belongsToParent: belongsToParent,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const CpkOneToOneBidirectionalChildExplicitType classType =
+      CpkOneToOneBidirectionalChildExplicitType();
+
+  static const CpkOneToOneBidirectionalChildExplicitQueryFields<
+          CpkOneToOneBidirectionalChildExplicitIdentifier,
+          CpkOneToOneBidirectionalChildExplicit> _queryFields =
+      CpkOneToOneBidirectionalChildExplicitQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<
+      CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit,
+      String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit, String> get ID => $id;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<
+      CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit,
+      String> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit, String> get NAME => $name;
+  @override
+  String? get belongsToParentId;
+
+  /// Query field for the [belongsToParentId] field.
+  QueryField<
+      CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit,
+      String?> get $belongsToParentId => _queryFields.$belongsToParentId;
+
+  /// Query field for the [belongsToParentId] field.
+  @Deprecated(r'Use $belongsToParentId instead')
+  QueryField<
+      CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit,
+      String?> get BELONGS_TO_PARENT_ID => $belongsToParentId;
+  @override
+  String? get belongsToParentName;
+
+  /// Query field for the [belongsToParentName] field.
+  QueryField<
+      CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit,
+      String?> get $belongsToParentName => _queryFields.$belongsToParentName;
+
+  /// Query field for the [belongsToParentName] field.
+  @Deprecated(r'Use $belongsToParentName instead')
+  QueryField<
+      CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit,
+      String?> get BELONGS_TO_PARENT_NAME => $belongsToParentName;
+  @override
+  AsyncModel<
+      CpkOneToOneBidirectionalParentIdentifier,
+      CpkOneToOneBidirectionalParent,
+      PartialCpkOneToOneBidirectionalParent,
+      CpkOneToOneBidirectionalParent>? get belongsToParent;
+
+  /// Query field for the [belongsToParent] field.
+  CpkOneToOneBidirectionalParentQueryFields<
+          CpkOneToOneBidirectionalChildExplicitIdentifier,
+          CpkOneToOneBidirectionalChildExplicit>
+      get $belongsToParent => _queryFields.$belongsToParent;
+
+  /// Query field for the [belongsToParent] field.
+  @Deprecated(r'Use $belongsToParent instead')
+  CpkOneToOneBidirectionalParentQueryFields<
+          CpkOneToOneBidirectionalChildExplicitIdentifier,
+          CpkOneToOneBidirectionalChildExplicit>
+      get BELONGS_TO_PARENT => $belongsToParent;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<
+          CpkOneToOneBidirectionalChildExplicitIdentifier,
+          CpkOneToOneBidirectionalChildExplicit,
+          CpkOneToOneBidirectionalChildExplicitIdentifier>
+      get $modelIdentifier => _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<
+          CpkOneToOneBidirectionalChildExplicitIdentifier,
+          CpkOneToOneBidirectionalChildExplicit,
+          CpkOneToOneBidirectionalChildExplicitIdentifier>
+      get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit, T>
+        field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'belongsToParentID':
+        value = belongsToParentId;
+        break;
+      case r'belongsToParentName':
+        value = belongsToParentName;
+        break;
+      case r'belongsToParent':
+        value = belongsToParent;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _CpkOneToOneBidirectionalChildExplicit
+    extends CpkOneToOneBidirectionalChildExplicit {
+  _CpkOneToOneBidirectionalChildExplicit({
+    String? id,
+    required this.name,
+    this.belongsToParentId,
+    this.belongsToParentName,
+    CpkOneToOneBidirectionalParent? belongsToParent,
+  })  : id = id ?? uuid(),
+        belongsToParent = belongsToParent == null
+            ? null
+            : AsyncModel.fromModel(belongsToParent),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _CpkOneToOneBidirectionalChildExplicit._({
+    required this.id,
+    required this.name,
+    this.belongsToParentId,
+    this.belongsToParentName,
+    this.belongsToParent,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final String? belongsToParentId;
+
+  @override
+  final String? belongsToParentName;
+
+  @override
+  final AsyncModel<
+      CpkOneToOneBidirectionalParentIdentifier,
+      CpkOneToOneBidirectionalParent,
+      PartialCpkOneToOneBidirectionalParent,
+      CpkOneToOneBidirectionalParent>? belongsToParent;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteCpkOneToOneBidirectionalChildExplicit
+    extends CpkOneToOneBidirectionalChildExplicit
+    implements
+        RemoteModel<CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit> {
+  const RemoteCpkOneToOneBidirectionalChildExplicit._() : super._();
+}
+
+class _RemoteCpkOneToOneBidirectionalChildExplicit
+    extends RemoteCpkOneToOneBidirectionalChildExplicit {
+  const _RemoteCpkOneToOneBidirectionalChildExplicit({
+    required this.id,
+    required this.name,
+    this.belongsToParentId,
+    this.belongsToParentName,
+    this.belongsToParent,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteCpkOneToOneBidirectionalChildExplicit.fromJson(
+    Map<String, Object?> json,
+  ) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'name',
+          ))
+        : (json['name'] as String);
+    final belongsToParentId = json['belongsToParentID'] == null
+        ? null
+        : (json['belongsToParentID'] as String);
+    final belongsToParentName = json['belongsToParentName'] == null
+        ? null
+        : (json['belongsToParentName'] as String);
+    final belongsToParent = json['belongsToParent'] == null
+        ? null
+        : AsyncModel<
+            CpkOneToOneBidirectionalParentIdentifier,
+            CpkOneToOneBidirectionalParent,
+            PartialCpkOneToOneBidirectionalParent,
+            RemoteCpkOneToOneBidirectionalParent>.fromModel(
+            CpkOneToOneBidirectionalParent.classType
+                .fromJson<RemoteCpkOneToOneBidirectionalParent>(
+              (json['belongsToParent'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalChildExplicit',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteCpkOneToOneBidirectionalChildExplicit(
+      id: id,
+      name: name,
+      belongsToParentId: belongsToParentId,
+      belongsToParentName: belongsToParentName,
+      belongsToParent: belongsToParent,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final String? belongsToParentId;
+
+  @override
+  final String? belongsToParentName;
+
+  @override
+  final AsyncModel<
+      CpkOneToOneBidirectionalParentIdentifier,
+      CpkOneToOneBidirectionalParent,
+      PartialCpkOneToOneBidirectionalParent,
+      RemoteCpkOneToOneBidirectionalParent>? belongsToParent;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_child_explicit.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_child_explicit.dart
@@ -525,6 +525,30 @@ abstract class CpkOneToOneBidirectionalChildExplicit
           CpkOneToOneBidirectionalChildExplicit,
           CpkOneToOneBidirectionalChildExplicitIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  CpkOneToOneBidirectionalChildExplicit copyWith({
+    String? id,
+    String? name,
+    String? belongsToParentId,
+    String? belongsToParentName,
+    CpkOneToOneBidirectionalParent? belongsToParent,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _CpkOneToOneBidirectionalChildExplicit._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      belongsToParentId: belongsToParentId ?? this.belongsToParentId,
+      belongsToParentName: belongsToParentName ?? this.belongsToParentName,
+      belongsToParent: belongsToParent == null
+          ? this.belongsToParent
+          : AsyncModel.fromModel(belongsToParent),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<CpkOneToOneBidirectionalChildExplicitIdentifier,

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_child_explicit.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_child_explicit.dart
@@ -222,11 +222,7 @@ abstract class PartialCpkOneToOneBidirectionalChildExplicit
   String get name;
   String? get belongsToParentId;
   String? get belongsToParentName;
-  AsyncModel<
-      CpkOneToOneBidirectionalParentIdentifier,
-      CpkOneToOneBidirectionalParent,
-      PartialCpkOneToOneBidirectionalParent,
-      PartialCpkOneToOneBidirectionalParent>? get belongsToParent;
+  PartialCpkOneToOneBidirectionalParent? get belongsToParent;
   TemporalDateTime? get createdAt;
   TemporalDateTime? get updatedAt;
   @override
@@ -298,24 +294,18 @@ class _PartialCpkOneToOneBidirectionalChildExplicit
     final belongsToParentName = json['belongsToParentName'] == null
         ? null
         : (json['belongsToParentName'] as String);
-    final belongsToParent = json['belongsToParent'] == null
-        ? null
-        : AsyncModel<
-            CpkOneToOneBidirectionalParentIdentifier,
-            CpkOneToOneBidirectionalParent,
-            PartialCpkOneToOneBidirectionalParent,
-            PartialCpkOneToOneBidirectionalParent>.fromModel(
-            CpkOneToOneBidirectionalParent.classType
-                .fromJson<PartialCpkOneToOneBidirectionalParent>(
-              (json['belongsToParent'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
     final updatedAt = json['updatedAt'] == null
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final belongsToParent = json['belongsToParent'] == null
+        ? null
+        : CpkOneToOneBidirectionalParent.classType
+            .fromJson<PartialCpkOneToOneBidirectionalParent>(
+            (json['belongsToParent'] as Map<String, Object?>),
+          );
     return _PartialCpkOneToOneBidirectionalChildExplicit(
       id: id,
       name: name,
@@ -340,11 +330,7 @@ class _PartialCpkOneToOneBidirectionalChildExplicit
   final String? belongsToParentName;
 
   @override
-  final AsyncModel<
-      CpkOneToOneBidirectionalParentIdentifier,
-      CpkOneToOneBidirectionalParent,
-      PartialCpkOneToOneBidirectionalParent,
-      PartialCpkOneToOneBidirectionalParent>? belongsToParent;
+  final PartialCpkOneToOneBidirectionalParent? belongsToParent;
 
   @override
   final TemporalDateTime? createdAt;
@@ -389,18 +375,6 @@ abstract class CpkOneToOneBidirectionalChildExplicit
     final belongsToParentName = json['belongsToParentName'] == null
         ? null
         : (json['belongsToParentName'] as String);
-    final belongsToParent = json['belongsToParent'] == null
-        ? null
-        : AsyncModel<
-            CpkOneToOneBidirectionalParentIdentifier,
-            CpkOneToOneBidirectionalParent,
-            PartialCpkOneToOneBidirectionalParent,
-            CpkOneToOneBidirectionalParent>.fromModel(
-            CpkOneToOneBidirectionalParent.classType
-                .fromJson<CpkOneToOneBidirectionalParent>(
-              (json['belongsToParent'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'CpkOneToOneBidirectionalChildExplicit',
@@ -413,6 +387,12 @@ abstract class CpkOneToOneBidirectionalChildExplicit
             'updatedAt',
           ))
         : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final belongsToParent = json['belongsToParent'] == null
+        ? null
+        : CpkOneToOneBidirectionalParent.classType
+            .fromJson<CpkOneToOneBidirectionalParent>(
+            (json['belongsToParent'] as Map<String, Object?>),
+          );
     return _CpkOneToOneBidirectionalChildExplicit._(
       id: id,
       name: name,
@@ -567,11 +547,7 @@ abstract class CpkOneToOneBidirectionalChildExplicit
       CpkOneToOneBidirectionalChildExplicit,
       String?> get BELONGS_TO_PARENT_NAME => $belongsToParentName;
   @override
-  AsyncModel<
-      CpkOneToOneBidirectionalParentIdentifier,
-      CpkOneToOneBidirectionalParent,
-      PartialCpkOneToOneBidirectionalParent,
-      CpkOneToOneBidirectionalParent>? get belongsToParent;
+  CpkOneToOneBidirectionalParent? get belongsToParent;
 
   /// Query field for the [belongsToParent] field.
   CpkOneToOneBidirectionalParentQueryFields<
@@ -618,9 +594,7 @@ abstract class CpkOneToOneBidirectionalChildExplicit
       name: name ?? this.name,
       belongsToParentId: belongsToParentId ?? this.belongsToParentId,
       belongsToParentName: belongsToParentName ?? this.belongsToParentName,
-      belongsToParent: belongsToParent == null
-          ? this.belongsToParent
-          : AsyncModel.fromModel(belongsToParent),
+      belongsToParent: belongsToParent ?? this.belongsToParent,
       createdAt:
           createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
       updatedAt:
@@ -673,11 +647,8 @@ class _CpkOneToOneBidirectionalChildExplicit
     required this.name,
     this.belongsToParentId,
     this.belongsToParentName,
-    CpkOneToOneBidirectionalParent? belongsToParent,
+    this.belongsToParent,
   })  : id = id ?? uuid(),
-        belongsToParent = belongsToParent == null
-            ? null
-            : AsyncModel.fromModel(belongsToParent),
         createdAt = TemporalDateTime.now(),
         updatedAt = TemporalDateTime.now(),
         super._();
@@ -705,11 +676,7 @@ class _CpkOneToOneBidirectionalChildExplicit
   final String? belongsToParentName;
 
   @override
-  final AsyncModel<
-      CpkOneToOneBidirectionalParentIdentifier,
-      CpkOneToOneBidirectionalParent,
-      PartialCpkOneToOneBidirectionalParent,
-      CpkOneToOneBidirectionalParent>? belongsToParent;
+  final CpkOneToOneBidirectionalParent? belongsToParent;
 
   @override
   final TemporalDateTime createdAt;
@@ -762,18 +729,6 @@ class _RemoteCpkOneToOneBidirectionalChildExplicit
     final belongsToParentName = json['belongsToParentName'] == null
         ? null
         : (json['belongsToParentName'] as String);
-    final belongsToParent = json['belongsToParent'] == null
-        ? null
-        : AsyncModel<
-            CpkOneToOneBidirectionalParentIdentifier,
-            CpkOneToOneBidirectionalParent,
-            PartialCpkOneToOneBidirectionalParent,
-            RemoteCpkOneToOneBidirectionalParent>.fromModel(
-            CpkOneToOneBidirectionalParent.classType
-                .fromJson<RemoteCpkOneToOneBidirectionalParent>(
-              (json['belongsToParent'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'CpkOneToOneBidirectionalChildExplicit',
@@ -804,6 +759,12 @@ class _RemoteCpkOneToOneBidirectionalChildExplicit
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final belongsToParent = json['belongsToParent'] == null
+        ? null
+        : CpkOneToOneBidirectionalParent.classType
+            .fromJson<RemoteCpkOneToOneBidirectionalParent>(
+            (json['belongsToParent'] as Map<String, Object?>),
+          );
     return _RemoteCpkOneToOneBidirectionalChildExplicit(
       id: id,
       name: name,
@@ -831,11 +792,7 @@ class _RemoteCpkOneToOneBidirectionalChildExplicit
   final String? belongsToParentName;
 
   @override
-  final AsyncModel<
-      CpkOneToOneBidirectionalParentIdentifier,
-      CpkOneToOneBidirectionalParent,
-      PartialCpkOneToOneBidirectionalParent,
-      RemoteCpkOneToOneBidirectionalParent>? belongsToParent;
+  final RemoteCpkOneToOneBidirectionalParent? belongsToParent;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_child_explicit.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_child_explicit.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.cpk_one_to_one_bidirectional_child_explicit;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'cpk_one_to_one_bidirectional_parent.dart';
@@ -430,6 +431,84 @@ abstract class CpkOneToOneBidirectionalChildExplicit
           CpkOneToOneBidirectionalChildExplicitIdentifier,
           CpkOneToOneBidirectionalChildExplicit> _queryFields =
       CpkOneToOneBidirectionalChildExplicitQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'CpkOneToOneBidirectionalChildExplicit',
+      'pluralName': 'CpkOneToOneBidirectionalChildExplicits',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'belongsToParentID': {
+          'name': 'belongsToParentID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'belongsToParentName': {
+          'name': 'belongsToParentName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'belongsToParent': {
+          'name': 'belongsToParent',
+          'type': {'model': 'CpkOneToOneBidirectionalParent'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'CpkOneToOneBidirectionalParent',
+            'targetNames': [
+              'belongsToParentID',
+              'belongsToParentName',
+            ],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': ['name'],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'belongsToParent',
+          'sortKeyFields': [
+            'belongsToParentID',
+            'belongsToParentName',
+          ],
+          'name': 'belongsToParent',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_parent.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_parent.dart
@@ -293,18 +293,6 @@ class _PartialCpkOneToOneBidirectionalParent
             'name',
           ))
         : (json['name'] as String);
-    final explicitChild = json['explicitChild'] == null
-        ? null
-        : AsyncModel<
-            CpkOneToOneBidirectionalChildExplicitIdentifier,
-            CpkOneToOneBidirectionalChildExplicit,
-            PartialCpkOneToOneBidirectionalChildExplicit,
-            PartialCpkOneToOneBidirectionalChildExplicit>.fromModel(
-            CpkOneToOneBidirectionalChildExplicit.classType
-                .fromJson<PartialCpkOneToOneBidirectionalChildExplicit>(
-              (json['explicitChild'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
@@ -320,6 +308,31 @@ class _PartialCpkOneToOneBidirectionalParent
             ? null
             : (json['cpkOneToOneBidirectionalParentExplicitChildName']
                 as String);
+    final explicitChild = json['explicitChild'] == null
+        ? cpkOneToOneBidirectionalParentExplicitChildId == null ||
+                cpkOneToOneBidirectionalParentExplicitChildName == null
+            ? null
+            : AsyncModel<
+                CpkOneToOneBidirectionalChildExplicitIdentifier,
+                CpkOneToOneBidirectionalChildExplicit,
+                PartialCpkOneToOneBidirectionalChildExplicit,
+                PartialCpkOneToOneBidirectionalChildExplicit>.fromModelIdentifier(
+                CpkOneToOneBidirectionalChildExplicit.classType,
+                CpkOneToOneBidirectionalChildExplicitIdentifier(
+                  id: cpkOneToOneBidirectionalParentExplicitChildId,
+                  name: cpkOneToOneBidirectionalParentExplicitChildName,
+                ),
+              )
+        : AsyncModel<
+            CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit,
+            PartialCpkOneToOneBidirectionalChildExplicit,
+            PartialCpkOneToOneBidirectionalChildExplicit>.fromModel(
+            CpkOneToOneBidirectionalChildExplicit.classType
+                .fromJson<PartialCpkOneToOneBidirectionalChildExplicit>(
+              (json['explicitChild'] as Map<String, Object?>),
+            ),
+          );
     return _PartialCpkOneToOneBidirectionalParent(
       id: id,
       name: name,
@@ -387,18 +400,6 @@ abstract class CpkOneToOneBidirectionalParent
             'name',
           ))
         : (json['name'] as String);
-    final explicitChild = json['explicitChild'] == null
-        ? null
-        : AsyncModel<
-            CpkOneToOneBidirectionalChildExplicitIdentifier,
-            CpkOneToOneBidirectionalChildExplicit,
-            PartialCpkOneToOneBidirectionalChildExplicit,
-            CpkOneToOneBidirectionalChildExplicit>.fromModel(
-            CpkOneToOneBidirectionalChildExplicit.classType
-                .fromJson<CpkOneToOneBidirectionalChildExplicit>(
-              (json['explicitChild'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'CpkOneToOneBidirectionalParent',
@@ -420,6 +421,31 @@ abstract class CpkOneToOneBidirectionalParent
             ? null
             : (json['cpkOneToOneBidirectionalParentExplicitChildName']
                 as String);
+    final explicitChild = json['explicitChild'] == null
+        ? cpkOneToOneBidirectionalParentExplicitChildId == null ||
+                cpkOneToOneBidirectionalParentExplicitChildName == null
+            ? null
+            : AsyncModel<
+                CpkOneToOneBidirectionalChildExplicitIdentifier,
+                CpkOneToOneBidirectionalChildExplicit,
+                PartialCpkOneToOneBidirectionalChildExplicit,
+                CpkOneToOneBidirectionalChildExplicit>.fromModelIdentifier(
+                CpkOneToOneBidirectionalChildExplicit.classType,
+                CpkOneToOneBidirectionalChildExplicitIdentifier(
+                  id: cpkOneToOneBidirectionalParentExplicitChildId,
+                  name: cpkOneToOneBidirectionalParentExplicitChildName,
+                ),
+              )
+        : AsyncModel<
+            CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit,
+            PartialCpkOneToOneBidirectionalChildExplicit,
+            CpkOneToOneBidirectionalChildExplicit>.fromModel(
+            CpkOneToOneBidirectionalChildExplicit.classType
+                .fromJson<CpkOneToOneBidirectionalChildExplicit>(
+              (json['explicitChild'] as Map<String, Object?>),
+            ),
+          );
     return _CpkOneToOneBidirectionalParent._(
       id: id,
       name: name,
@@ -754,18 +780,6 @@ class _RemoteCpkOneToOneBidirectionalParent
             'name',
           ))
         : (json['name'] as String);
-    final explicitChild = json['explicitChild'] == null
-        ? null
-        : AsyncModel<
-            CpkOneToOneBidirectionalChildExplicitIdentifier,
-            CpkOneToOneBidirectionalChildExplicit,
-            PartialCpkOneToOneBidirectionalChildExplicit,
-            RemoteCpkOneToOneBidirectionalChildExplicit>.fromModel(
-            CpkOneToOneBidirectionalChildExplicit.classType
-                .fromJson<RemoteCpkOneToOneBidirectionalChildExplicit>(
-              (json['explicitChild'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'CpkOneToOneBidirectionalParent',
@@ -805,6 +819,31 @@ class _RemoteCpkOneToOneBidirectionalParent
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final explicitChild = json['explicitChild'] == null
+        ? cpkOneToOneBidirectionalParentExplicitChildId == null ||
+                cpkOneToOneBidirectionalParentExplicitChildName == null
+            ? null
+            : AsyncModel<
+                CpkOneToOneBidirectionalChildExplicitIdentifier,
+                CpkOneToOneBidirectionalChildExplicit,
+                PartialCpkOneToOneBidirectionalChildExplicit,
+                RemoteCpkOneToOneBidirectionalChildExplicit>.fromModelIdentifier(
+                CpkOneToOneBidirectionalChildExplicit.classType,
+                CpkOneToOneBidirectionalChildExplicitIdentifier(
+                  id: cpkOneToOneBidirectionalParentExplicitChildId,
+                  name: cpkOneToOneBidirectionalParentExplicitChildName,
+                ),
+              )
+        : AsyncModel<
+            CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit,
+            PartialCpkOneToOneBidirectionalChildExplicit,
+            RemoteCpkOneToOneBidirectionalChildExplicit>.fromModel(
+            CpkOneToOneBidirectionalChildExplicit.classType
+                .fromJson<RemoteCpkOneToOneBidirectionalChildExplicit>(
+              (json['explicitChild'] as Map<String, Object?>),
+            ),
+          );
     return _RemoteCpkOneToOneBidirectionalParent(
       id: id,
       name: name,
@@ -832,7 +871,7 @@ class _RemoteCpkOneToOneBidirectionalParent
       CpkOneToOneBidirectionalChildExplicitIdentifier,
       CpkOneToOneBidirectionalChildExplicit,
       PartialCpkOneToOneBidirectionalChildExplicit,
-      RemoteCpkOneToOneBidirectionalChildExplicit>? explicitChild;
+      CpkOneToOneBidirectionalChildExplicit>? explicitChild;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_parent.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_parent.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.cpk_one_to_one_bidirectional_parent;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'cpk_one_to_one_bidirectional_child_explicit.dart';
@@ -439,6 +440,76 @@ abstract class CpkOneToOneBidirectionalParent
           CpkOneToOneBidirectionalParentIdentifier,
           CpkOneToOneBidirectionalParent> _queryFields =
       CpkOneToOneBidirectionalParentQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'CpkOneToOneBidirectionalParent',
+      'pluralName': 'CpkOneToOneBidirectionalParents',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'explicitChild': {
+          'name': 'explicitChild',
+          'type': {'model': 'CpkOneToOneBidirectionalChildExplicit'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'CpkOneToOneBidirectionalChildExplicit',
+            'associatedFields': ['belongsToParent'],
+            'targetNames': [
+              'cpkOneToOneBidirectionalParentExplicitChildId',
+              'cpkOneToOneBidirectionalParentExplicitChildName',
+            ],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'cpkOneToOneBidirectionalParentExplicitChildId': {
+          'name': 'cpkOneToOneBidirectionalParentExplicitChildId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'cpkOneToOneBidirectionalParentExplicitChildName': {
+          'name': 'cpkOneToOneBidirectionalParentExplicitChildName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': ['name'],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_parent.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_parent.dart
@@ -1,0 +1,758 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.cpk_one_to_one_bidirectional_parent;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:meta/meta.dart';
+
+import 'cpk_one_to_one_bidirectional_child_explicit.dart';
+
+@immutable
+class CpkOneToOneBidirectionalParentIdentifier
+    with
+        AWSEquatable<CpkOneToOneBidirectionalParentIdentifier>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  const CpkOneToOneBidirectionalParentIdentifier({
+    required this.id,
+    required this.name,
+  });
+
+  final String id;
+
+  final String name;
+
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+      };
+  @override
+  String get runtimeTypeName => 'CpkOneToOneBidirectionalParentIdentifier';
+}
+
+class CpkOneToOneBidirectionalParentType extends ModelType<
+    CpkOneToOneBidirectionalParentIdentifier,
+    CpkOneToOneBidirectionalParent,
+    PartialCpkOneToOneBidirectionalParent> {
+  const CpkOneToOneBidirectionalParentType();
+
+  @override
+  T fromJson<
+      T extends PartialModel<CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent>>(Map<String, Object?> json) {
+    if (T == CpkOneToOneBidirectionalParent ||
+        T ==
+            Model<CpkOneToOneBidirectionalParentIdentifier,
+                CpkOneToOneBidirectionalParent>) {
+      return CpkOneToOneBidirectionalParent.fromJson(json) as T;
+    }
+    if (T == RemoteCpkOneToOneBidirectionalParent ||
+        T ==
+            RemoteModel<CpkOneToOneBidirectionalParentIdentifier,
+                CpkOneToOneBidirectionalParent>) {
+      return _RemoteCpkOneToOneBidirectionalParent.fromJson(json) as T;
+    }
+    return _PartialCpkOneToOneBidirectionalParent.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'CpkOneToOneBidirectionalParent';
+}
+
+class CpkOneToOneBidirectionalParentQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const CpkOneToOneBidirectionalParentQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, CpkOneToOneBidirectionalParent>? _root;
+
+  /// Query field for the [CpkOneToOneBidirectionalParent.id] field.
+  QueryField<ModelIdentifier, M, String> get $id => NestedQueryField<
+          ModelIdentifier,
+          M,
+          CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent,
+          String>(
+        const QueryField<CpkOneToOneBidirectionalParentIdentifier,
+            CpkOneToOneBidirectionalParent, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [CpkOneToOneBidirectionalParent.name] field.
+  QueryField<ModelIdentifier, M, String> get $name => NestedQueryField<
+          ModelIdentifier,
+          M,
+          CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent,
+          String>(
+        const QueryField<CpkOneToOneBidirectionalParentIdentifier,
+            CpkOneToOneBidirectionalParent, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [CpkOneToOneBidirectionalParent.explicitChild] field.
+  CpkOneToOneBidirectionalChildExplicitQueryFields<ModelIdentifier, M>
+      get $explicitChild => CpkOneToOneBidirectionalChildExplicitQueryFields(
+            NestedQueryField<
+                ModelIdentifier,
+                M,
+                CpkOneToOneBidirectionalParentIdentifier,
+                CpkOneToOneBidirectionalParent,
+                CpkOneToOneBidirectionalChildExplicit>(
+              const QueryField<
+                  CpkOneToOneBidirectionalParentIdentifier,
+                  CpkOneToOneBidirectionalParent,
+                  CpkOneToOneBidirectionalChildExplicit>(
+                fieldName: 'explicitChild',
+              ),
+              root: _root,
+            ),
+          );
+
+  /// Query field for the [CpkOneToOneBidirectionalParent.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<
+          ModelIdentifier,
+          M,
+          CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent,
+          TemporalDateTime>(
+        const QueryField<
+            CpkOneToOneBidirectionalParentIdentifier,
+            CpkOneToOneBidirectionalParent,
+            TemporalDateTime>(fieldName: 'createdAt'),
+        root: _root,
+      );
+
+  /// Query field for the [CpkOneToOneBidirectionalParent.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<
+          ModelIdentifier,
+          M,
+          CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent,
+          TemporalDateTime>(
+        const QueryField<
+            CpkOneToOneBidirectionalParentIdentifier,
+            CpkOneToOneBidirectionalParent,
+            TemporalDateTime>(fieldName: 'updatedAt'),
+        root: _root,
+      );
+
+  /// Query field for the [CpkOneToOneBidirectionalParent.cpkOneToOneBidirectionalParentExplicitChildId] field.
+  QueryField<ModelIdentifier, M, String?>
+      get $cpkOneToOneBidirectionalParentExplicitChildId => NestedQueryField<
+              ModelIdentifier,
+              M,
+              CpkOneToOneBidirectionalParentIdentifier,
+              CpkOneToOneBidirectionalParent,
+              String?>(
+            const QueryField<CpkOneToOneBidirectionalParentIdentifier,
+                CpkOneToOneBidirectionalParent, String?>(
+              fieldName: 'cpkOneToOneBidirectionalParentExplicitChildId',
+            ),
+            root: _root,
+          );
+
+  /// Query field for the [CpkOneToOneBidirectionalParent.cpkOneToOneBidirectionalParentExplicitChildName] field.
+  QueryField<ModelIdentifier, M, String?>
+      get $cpkOneToOneBidirectionalParentExplicitChildName => NestedQueryField<
+              ModelIdentifier,
+              M,
+              CpkOneToOneBidirectionalParentIdentifier,
+              CpkOneToOneBidirectionalParent,
+              String?>(
+            const QueryField<CpkOneToOneBidirectionalParentIdentifier,
+                CpkOneToOneBidirectionalParent, String?>(
+              fieldName: 'cpkOneToOneBidirectionalParentExplicitChildName',
+            ),
+            root: _root,
+          );
+
+  /// Query field for the [CpkOneToOneBidirectionalParent] model identifier.
+  QueryField<ModelIdentifier, M, CpkOneToOneBidirectionalParentIdentifier>
+      get $modelIdentifier => NestedQueryField<
+              ModelIdentifier,
+              M,
+              CpkOneToOneBidirectionalParentIdentifier,
+              CpkOneToOneBidirectionalParent,
+              CpkOneToOneBidirectionalParentIdentifier>(
+            const QueryField<
+                CpkOneToOneBidirectionalParentIdentifier,
+                CpkOneToOneBidirectionalParent,
+                CpkOneToOneBidirectionalParentIdentifier>(
+              fieldName: 'modelIdentifier',
+            ),
+            root: _root,
+          );
+}
+
+abstract class PartialCpkOneToOneBidirectionalParent extends PartialModel<
+        CpkOneToOneBidirectionalParentIdentifier,
+        CpkOneToOneBidirectionalParent>
+    with AWSEquatable<PartialCpkOneToOneBidirectionalParent> {
+  const PartialCpkOneToOneBidirectionalParent._();
+
+  String get id;
+  String get name;
+  AsyncModel<
+      CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit,
+      PartialCpkOneToOneBidirectionalChildExplicit,
+      PartialCpkOneToOneBidirectionalChildExplicit>? get explicitChild;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String? get cpkOneToOneBidirectionalParentExplicitChildId;
+  String? get cpkOneToOneBidirectionalParentExplicitChildName;
+  @override
+  CpkOneToOneBidirectionalParentIdentifier get modelIdentifier =>
+      CpkOneToOneBidirectionalParentIdentifier(
+        id: id,
+        name: name,
+      );
+  @override
+  CpkOneToOneBidirectionalParentType get modelType =>
+      CpkOneToOneBidirectionalParent.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        explicitChild,
+        createdAt,
+        updatedAt,
+        cpkOneToOneBidirectionalParentExplicitChildId,
+        cpkOneToOneBidirectionalParentExplicitChildName,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'explicitChild': explicitChild?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'cpkOneToOneBidirectionalParentExplicitChildId':
+            cpkOneToOneBidirectionalParentExplicitChildId,
+        'cpkOneToOneBidirectionalParentExplicitChildName':
+            cpkOneToOneBidirectionalParentExplicitChildName,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'CpkOneToOneBidirectionalParent';
+}
+
+class _PartialCpkOneToOneBidirectionalParent
+    extends PartialCpkOneToOneBidirectionalParent {
+  const _PartialCpkOneToOneBidirectionalParent({
+    required this.id,
+    required this.name,
+    this.explicitChild,
+    this.createdAt,
+    this.updatedAt,
+    this.cpkOneToOneBidirectionalParentExplicitChildId,
+    this.cpkOneToOneBidirectionalParentExplicitChildName,
+  }) : super._();
+
+  factory _PartialCpkOneToOneBidirectionalParent.fromJson(
+    Map<String, Object?> json,
+  ) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'name',
+          ))
+        : (json['name'] as String);
+    final explicitChild = json['explicitChild'] == null
+        ? null
+        : AsyncModel<
+            CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit,
+            PartialCpkOneToOneBidirectionalChildExplicit,
+            PartialCpkOneToOneBidirectionalChildExplicit>.fromModel(
+            CpkOneToOneBidirectionalChildExplicit.classType
+                .fromJson<PartialCpkOneToOneBidirectionalChildExplicit>(
+              (json['explicitChild'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final cpkOneToOneBidirectionalParentExplicitChildId =
+        json['cpkOneToOneBidirectionalParentExplicitChildId'] == null
+            ? null
+            : (json['cpkOneToOneBidirectionalParentExplicitChildId'] as String);
+    final cpkOneToOneBidirectionalParentExplicitChildName =
+        json['cpkOneToOneBidirectionalParentExplicitChildName'] == null
+            ? null
+            : (json['cpkOneToOneBidirectionalParentExplicitChildName']
+                as String);
+    return _PartialCpkOneToOneBidirectionalParent(
+      id: id,
+      name: name,
+      explicitChild: explicitChild,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      cpkOneToOneBidirectionalParentExplicitChildId:
+          cpkOneToOneBidirectionalParentExplicitChildId,
+      cpkOneToOneBidirectionalParentExplicitChildName:
+          cpkOneToOneBidirectionalParentExplicitChildName,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModel<
+      CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit,
+      PartialCpkOneToOneBidirectionalChildExplicit,
+      PartialCpkOneToOneBidirectionalChildExplicit>? explicitChild;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String? cpkOneToOneBidirectionalParentExplicitChildId;
+
+  @override
+  final String? cpkOneToOneBidirectionalParentExplicitChildName;
+}
+
+abstract class CpkOneToOneBidirectionalParent
+    extends PartialCpkOneToOneBidirectionalParent
+    implements
+        Model<CpkOneToOneBidirectionalParentIdentifier,
+            CpkOneToOneBidirectionalParent> {
+  factory CpkOneToOneBidirectionalParent({
+    String? id,
+    required String name,
+    CpkOneToOneBidirectionalChildExplicit? explicitChild,
+    String? cpkOneToOneBidirectionalParentExplicitChildId,
+    String? cpkOneToOneBidirectionalParentExplicitChildName,
+  }) = _CpkOneToOneBidirectionalParent;
+
+  const CpkOneToOneBidirectionalParent._() : super._();
+
+  factory CpkOneToOneBidirectionalParent.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'name',
+          ))
+        : (json['name'] as String);
+    final explicitChild = json['explicitChild'] == null
+        ? null
+        : AsyncModel<
+            CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit,
+            PartialCpkOneToOneBidirectionalChildExplicit,
+            CpkOneToOneBidirectionalChildExplicit>.fromModel(
+            CpkOneToOneBidirectionalChildExplicit.classType
+                .fromJson<CpkOneToOneBidirectionalChildExplicit>(
+              (json['explicitChild'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final cpkOneToOneBidirectionalParentExplicitChildId =
+        json['cpkOneToOneBidirectionalParentExplicitChildId'] == null
+            ? null
+            : (json['cpkOneToOneBidirectionalParentExplicitChildId'] as String);
+    final cpkOneToOneBidirectionalParentExplicitChildName =
+        json['cpkOneToOneBidirectionalParentExplicitChildName'] == null
+            ? null
+            : (json['cpkOneToOneBidirectionalParentExplicitChildName']
+                as String);
+    return _CpkOneToOneBidirectionalParent._(
+      id: id,
+      name: name,
+      explicitChild: explicitChild,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      cpkOneToOneBidirectionalParentExplicitChildId:
+          cpkOneToOneBidirectionalParentExplicitChildId,
+      cpkOneToOneBidirectionalParentExplicitChildName:
+          cpkOneToOneBidirectionalParentExplicitChildName,
+    );
+  }
+
+  static const CpkOneToOneBidirectionalParentType classType =
+      CpkOneToOneBidirectionalParentType();
+
+  static const CpkOneToOneBidirectionalParentQueryFields<
+          CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent> _queryFields =
+      CpkOneToOneBidirectionalParentQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<CpkOneToOneBidirectionalParentIdentifier,
+      CpkOneToOneBidirectionalParent, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<CpkOneToOneBidirectionalParentIdentifier,
+      CpkOneToOneBidirectionalParent, String> get ID => $id;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<CpkOneToOneBidirectionalParentIdentifier,
+      CpkOneToOneBidirectionalParent, String> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<CpkOneToOneBidirectionalParentIdentifier,
+      CpkOneToOneBidirectionalParent, String> get NAME => $name;
+  @override
+  AsyncModel<
+      CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit,
+      PartialCpkOneToOneBidirectionalChildExplicit,
+      CpkOneToOneBidirectionalChildExplicit>? get explicitChild;
+
+  /// Query field for the [explicitChild] field.
+  CpkOneToOneBidirectionalChildExplicitQueryFields<
+          CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent>
+      get $explicitChild => _queryFields.$explicitChild;
+
+  /// Query field for the [explicitChild] field.
+  @Deprecated(r'Use $explicitChild instead')
+  CpkOneToOneBidirectionalChildExplicitQueryFields<
+      CpkOneToOneBidirectionalParentIdentifier,
+      CpkOneToOneBidirectionalParent> get EXPLICIT_CHILD => $explicitChild;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String? get cpkOneToOneBidirectionalParentExplicitChildId;
+
+  /// Query field for the [cpkOneToOneBidirectionalParentExplicitChildId] field.
+  QueryField<CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent, String?>
+      get $cpkOneToOneBidirectionalParentExplicitChildId =>
+          _queryFields.$cpkOneToOneBidirectionalParentExplicitChildId;
+
+  /// Query field for the [cpkOneToOneBidirectionalParentExplicitChildId] field.
+  @Deprecated(r'Use $cpkOneToOneBidirectionalParentExplicitChildId instead')
+  QueryField<CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent, String?>
+      get CPK_ONE_TO_ONE_BIDIRECTIONAL_PARENT_EXPLICIT_CHILD_ID =>
+          $cpkOneToOneBidirectionalParentExplicitChildId;
+  @override
+  String? get cpkOneToOneBidirectionalParentExplicitChildName;
+
+  /// Query field for the [cpkOneToOneBidirectionalParentExplicitChildName] field.
+  QueryField<CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent, String?>
+      get $cpkOneToOneBidirectionalParentExplicitChildName =>
+          _queryFields.$cpkOneToOneBidirectionalParentExplicitChildName;
+
+  /// Query field for the [cpkOneToOneBidirectionalParentExplicitChildName] field.
+  @Deprecated(r'Use $cpkOneToOneBidirectionalParentExplicitChildName instead')
+  QueryField<CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent, String?>
+      get CPK_ONE_TO_ONE_BIDIRECTIONAL_PARENT_EXPLICIT_CHILD_NAME =>
+          $cpkOneToOneBidirectionalParentExplicitChildName;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<
+          CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent,
+          CpkOneToOneBidirectionalParentIdentifier>
+      get $modelIdentifier => _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<
+          CpkOneToOneBidirectionalParentIdentifier,
+          CpkOneToOneBidirectionalParent,
+          CpkOneToOneBidirectionalParentIdentifier>
+      get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<CpkOneToOneBidirectionalParentIdentifier,
+            CpkOneToOneBidirectionalParent, T>
+        field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'explicitChild':
+        value = explicitChild;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'cpkOneToOneBidirectionalParentExplicitChildId':
+        value = cpkOneToOneBidirectionalParentExplicitChildId;
+        break;
+      case r'cpkOneToOneBidirectionalParentExplicitChildName':
+        value = cpkOneToOneBidirectionalParentExplicitChildName;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _CpkOneToOneBidirectionalParent extends CpkOneToOneBidirectionalParent {
+  _CpkOneToOneBidirectionalParent({
+    String? id,
+    required this.name,
+    CpkOneToOneBidirectionalChildExplicit? explicitChild,
+    this.cpkOneToOneBidirectionalParentExplicitChildId,
+    this.cpkOneToOneBidirectionalParentExplicitChildName,
+  })  : id = id ?? uuid(),
+        explicitChild =
+            explicitChild == null ? null : AsyncModel.fromModel(explicitChild),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _CpkOneToOneBidirectionalParent._({
+    required this.id,
+    required this.name,
+    this.explicitChild,
+    required this.createdAt,
+    required this.updatedAt,
+    this.cpkOneToOneBidirectionalParentExplicitChildId,
+    this.cpkOneToOneBidirectionalParentExplicitChildName,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModel<
+      CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit,
+      PartialCpkOneToOneBidirectionalChildExplicit,
+      CpkOneToOneBidirectionalChildExplicit>? explicitChild;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? cpkOneToOneBidirectionalParentExplicitChildId;
+
+  @override
+  final String? cpkOneToOneBidirectionalParentExplicitChildName;
+}
+
+abstract class RemoteCpkOneToOneBidirectionalParent
+    extends CpkOneToOneBidirectionalParent
+    implements
+        RemoteModel<CpkOneToOneBidirectionalParentIdentifier,
+            CpkOneToOneBidirectionalParent> {
+  const RemoteCpkOneToOneBidirectionalParent._() : super._();
+}
+
+class _RemoteCpkOneToOneBidirectionalParent
+    extends RemoteCpkOneToOneBidirectionalParent {
+  const _RemoteCpkOneToOneBidirectionalParent({
+    required this.id,
+    required this.name,
+    this.explicitChild,
+    required this.createdAt,
+    required this.updatedAt,
+    this.cpkOneToOneBidirectionalParentExplicitChildId,
+    this.cpkOneToOneBidirectionalParentExplicitChildName,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteCpkOneToOneBidirectionalParent.fromJson(
+    Map<String, Object?> json,
+  ) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'name',
+          ))
+        : (json['name'] as String);
+    final explicitChild = json['explicitChild'] == null
+        ? null
+        : AsyncModel<
+            CpkOneToOneBidirectionalChildExplicitIdentifier,
+            CpkOneToOneBidirectionalChildExplicit,
+            PartialCpkOneToOneBidirectionalChildExplicit,
+            RemoteCpkOneToOneBidirectionalChildExplicit>.fromModel(
+            CpkOneToOneBidirectionalChildExplicit.classType
+                .fromJson<RemoteCpkOneToOneBidirectionalChildExplicit>(
+              (json['explicitChild'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final cpkOneToOneBidirectionalParentExplicitChildId =
+        json['cpkOneToOneBidirectionalParentExplicitChildId'] == null
+            ? null
+            : (json['cpkOneToOneBidirectionalParentExplicitChildId'] as String);
+    final cpkOneToOneBidirectionalParentExplicitChildName =
+        json['cpkOneToOneBidirectionalParentExplicitChildName'] == null
+            ? null
+            : (json['cpkOneToOneBidirectionalParentExplicitChildName']
+                as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'CpkOneToOneBidirectionalParent',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteCpkOneToOneBidirectionalParent(
+      id: id,
+      name: name,
+      explicitChild: explicitChild,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      cpkOneToOneBidirectionalParentExplicitChildId:
+          cpkOneToOneBidirectionalParentExplicitChildId,
+      cpkOneToOneBidirectionalParentExplicitChildName:
+          cpkOneToOneBidirectionalParentExplicitChildName,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModel<
+      CpkOneToOneBidirectionalChildExplicitIdentifier,
+      CpkOneToOneBidirectionalChildExplicit,
+      PartialCpkOneToOneBidirectionalChildExplicit,
+      RemoteCpkOneToOneBidirectionalChildExplicit>? explicitChild;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? cpkOneToOneBidirectionalParentExplicitChildId;
+
+  @override
+  final String? cpkOneToOneBidirectionalParentExplicitChildName;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_parent.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/cpk_one_to_one_bidirectional_parent.dart
@@ -529,6 +529,34 @@ abstract class CpkOneToOneBidirectionalParent
           CpkOneToOneBidirectionalParent,
           CpkOneToOneBidirectionalParentIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  CpkOneToOneBidirectionalParent copyWith({
+    String? id,
+    String? name,
+    CpkOneToOneBidirectionalChildExplicit? explicitChild,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? cpkOneToOneBidirectionalParentExplicitChildId,
+    String? cpkOneToOneBidirectionalParentExplicitChildName,
+  }) {
+    return _CpkOneToOneBidirectionalParent._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      explicitChild: explicitChild == null
+          ? this.explicitChild
+          : AsyncModel.fromModel(explicitChild),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      cpkOneToOneBidirectionalParentExplicitChildId:
+          cpkOneToOneBidirectionalParentExplicitChildId ??
+              this.cpkOneToOneBidirectionalParentExplicitChildId,
+      cpkOneToOneBidirectionalParentExplicitChildName:
+          cpkOneToOneBidirectionalParentExplicitChildName ??
+              this.cpkOneToOneBidirectionalParentExplicitChildName,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<CpkOneToOneBidirectionalParentIdentifier,

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/model_provider.dart
@@ -39,7 +39,7 @@ class ModelProvider extends ModelProviderInterface {
   static final instance = ModelProvider._();
 
   @override
-  String get version => '8b7fc5ab0f27ea72cddb9793dc5b4c41';
+  String get version => '25fae199e7f0d8f5e550e2cb9fb2a803';
   @override
   List<mipr.ModelTypeDefinition> get modelSchemas => [
         Project.schema,

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/model_provider.dart
@@ -1,0 +1,81 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'cpk_one_to_one_bidirectional_child_explicit.dart';
+import 'cpk_one_to_one_bidirectional_parent.dart';
+import 'project.dart';
+import 'team.dart';
+
+export 'cpk_one_to_one_bidirectional_child_explicit.dart';
+export 'cpk_one_to_one_bidirectional_parent.dart';
+export 'project.dart';
+export 'team.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '8b7fc5ab0f27ea72cddb9793dc5b4c41';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Project.schema,
+        Team.schema,
+        CpkOneToOneBidirectionalParent.schema,
+        CpkOneToOneBidirectionalChildExplicit.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Project':
+        return (Project.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Team':
+        return (Team.classType as ModelType<ModelIdentifier, M, P>);
+      case 'CpkOneToOneBidirectionalParent':
+        return (CpkOneToOneBidirectionalParent.classType
+            as ModelType<ModelIdentifier, M, P>);
+      case 'CpkOneToOneBidirectionalChildExplicit':
+        return (CpkOneToOneBidirectionalChildExplicit.classType
+            as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/project.dart
@@ -403,6 +403,28 @@ abstract class Project extends PartialProject
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<ProjectIdentifier, Project, ProjectIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  Project copyWith({
+    String? projectId,
+    String? name,
+    Team? team,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? projectTeamTeamId,
+    String? projectTeamName,
+  }) {
+    return _Project._(
+      projectId: projectId ?? this.projectId,
+      name: name ?? this.name,
+      team: team == null ? this.team : AsyncModel.fromModel(team),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      projectTeamTeamId: projectTeamTeamId ?? this.projectTeamTeamId,
+      projectTeamName: projectTeamName ?? this.projectTeamName,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<ProjectIdentifier, Project, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/project.dart
@@ -1,0 +1,604 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.project;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:meta/meta.dart';
+
+import 'team.dart';
+
+@immutable
+class ProjectIdentifier
+    with
+        AWSEquatable<ProjectIdentifier>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  const ProjectIdentifier({
+    required this.projectId,
+    required this.name,
+  });
+
+  final String projectId;
+
+  final String name;
+
+  @override
+  List<Object?> get props => [
+        projectId,
+        name,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'projectId': projectId,
+        'name': name,
+      };
+  @override
+  String get runtimeTypeName => 'ProjectIdentifier';
+}
+
+class ProjectType
+    extends ModelType<ProjectIdentifier, Project, PartialProject> {
+  const ProjectType();
+
+  @override
+  T fromJson<T extends PartialModel<ProjectIdentifier, Project>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Project || T == Model<ProjectIdentifier, Project>) {
+      return Project.fromJson(json) as T;
+    }
+    if (T == RemoteProject || T == RemoteModel<ProjectIdentifier, Project>) {
+      return _RemoteProject.fromJson(json) as T;
+    }
+    return _PartialProject.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Project';
+}
+
+class ProjectQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ProjectQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Project>? _root;
+
+  /// Query field for the [Project.projectId] field.
+  QueryField<ModelIdentifier, M, String> get $projectId =>
+      NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String>(
+        const QueryField<ProjectIdentifier, Project, String>(
+          fieldName: 'projectId',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project.name] field.
+  QueryField<ModelIdentifier, M, String> get $name =>
+      NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String>(
+        const QueryField<ProjectIdentifier, Project, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Project.team] field.
+  TeamQueryFields<ModelIdentifier, M> get $team => TeamQueryFields(
+        NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, Team>(
+          const QueryField<ProjectIdentifier, Project, Team>(fieldName: 'team'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Project.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project,
+          TemporalDateTime>(
+        const QueryField<ProjectIdentifier, Project, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project,
+          TemporalDateTime>(
+        const QueryField<ProjectIdentifier, Project, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project.projectTeamTeamId] field.
+  QueryField<ModelIdentifier, M, String?> get $projectTeamTeamId =>
+      NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String?>(
+        const QueryField<ProjectIdentifier, Project, String?>(
+          fieldName: 'projectTeamTeamId',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project.projectTeamName] field.
+  QueryField<ModelIdentifier, M, String?> get $projectTeamName =>
+      NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project, String?>(
+        const QueryField<ProjectIdentifier, Project, String?>(
+          fieldName: 'projectTeamName',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Project] model identifier.
+  QueryField<ModelIdentifier, M, ProjectIdentifier> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, ProjectIdentifier, Project,
+          ProjectIdentifier>(
+        const QueryField<ProjectIdentifier, Project, ProjectIdentifier>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialProject extends PartialModel<ProjectIdentifier, Project>
+    with AWSEquatable<PartialProject> {
+  const PartialProject._();
+
+  String get projectId;
+  String get name;
+  AsyncModel<TeamIdentifier, Team, PartialTeam, PartialTeam>? get team;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String? get projectTeamTeamId;
+  String? get projectTeamName;
+  @override
+  ProjectIdentifier get modelIdentifier => ProjectIdentifier(
+        projectId: projectId,
+        name: name,
+      );
+  @override
+  ProjectType get modelType => Project.classType;
+  @override
+  List<Object?> get props => [
+        projectId,
+        name,
+        team,
+        createdAt,
+        updatedAt,
+        projectTeamTeamId,
+        projectTeamName,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'projectId': projectId,
+        'name': name,
+        'team': team?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'projectTeamTeamId': projectTeamTeamId,
+        'projectTeamName': projectTeamName,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Project';
+}
+
+class _PartialProject extends PartialProject {
+  const _PartialProject({
+    required this.projectId,
+    required this.name,
+    this.team,
+    this.createdAt,
+    this.updatedAt,
+    this.projectTeamTeamId,
+    this.projectTeamName,
+  }) : super._();
+
+  factory _PartialProject.fromJson(Map<String, Object?> json) {
+    final projectId = json['projectId'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'projectId',
+          ))
+        : (json['projectId'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'name',
+          ))
+        : (json['name'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<TeamIdentifier, Team, PartialTeam, PartialTeam>.fromModel(
+            Team.classType
+                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final projectTeamTeamId = json['projectTeamTeamId'] == null
+        ? null
+        : (json['projectTeamTeamId'] as String);
+    final projectTeamName = json['projectTeamName'] == null
+        ? null
+        : (json['projectTeamName'] as String);
+    return _PartialProject(
+      projectId: projectId,
+      name: name,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      projectTeamTeamId: projectTeamTeamId,
+      projectTeamName: projectTeamName,
+    );
+  }
+
+  @override
+  final String projectId;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModel<TeamIdentifier, Team, PartialTeam, PartialTeam>? team;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String? projectTeamTeamId;
+
+  @override
+  final String? projectTeamName;
+}
+
+abstract class Project extends PartialProject
+    implements Model<ProjectIdentifier, Project> {
+  factory Project({
+    String? projectId,
+    required String name,
+    Team? team,
+    String? projectTeamTeamId,
+    String? projectTeamName,
+  }) = _Project;
+
+  const Project._() : super._();
+
+  factory Project.fromJson(Map<String, Object?> json) {
+    final projectId = json['projectId'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'projectId',
+          ))
+        : (json['projectId'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'name',
+          ))
+        : (json['name'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<TeamIdentifier, Team, PartialTeam, Team>.fromModel(
+            Team.classType
+                .fromJson<Team>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final projectTeamTeamId = json['projectTeamTeamId'] == null
+        ? null
+        : (json['projectTeamTeamId'] as String);
+    final projectTeamName = json['projectTeamName'] == null
+        ? null
+        : (json['projectTeamName'] as String);
+    return _Project._(
+      projectId: projectId,
+      name: name,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      projectTeamTeamId: projectTeamTeamId,
+      projectTeamName: projectTeamName,
+    );
+  }
+
+  static const ProjectType classType = ProjectType();
+
+  static const ProjectQueryFields<ProjectIdentifier, Project> _queryFields =
+      ProjectQueryFields();
+
+  @override
+  String get projectId;
+
+  /// Query field for the [projectId] field.
+  QueryField<ProjectIdentifier, Project, String> get $projectId =>
+      _queryFields.$projectId;
+
+  /// Query field for the [projectId] field.
+  @Deprecated(r'Use $projectId instead')
+  QueryField<ProjectIdentifier, Project, String> get PROJECT_ID => $projectId;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<ProjectIdentifier, Project, String> get $name =>
+      _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<ProjectIdentifier, Project, String> get NAME => $name;
+  @override
+  AsyncModel<TeamIdentifier, Team, PartialTeam, Team>? get team;
+
+  /// Query field for the [team] field.
+  TeamQueryFields<ProjectIdentifier, Project> get $team => _queryFields.$team;
+
+  /// Query field for the [team] field.
+  @Deprecated(r'Use $team instead')
+  TeamQueryFields<ProjectIdentifier, Project> get TEAM => $team;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String? get projectTeamTeamId;
+
+  /// Query field for the [projectTeamTeamId] field.
+  QueryField<ProjectIdentifier, Project, String?> get $projectTeamTeamId =>
+      _queryFields.$projectTeamTeamId;
+
+  /// Query field for the [projectTeamTeamId] field.
+  @Deprecated(r'Use $projectTeamTeamId instead')
+  QueryField<ProjectIdentifier, Project, String?> get PROJECT_TEAM_TEAM_ID =>
+      $projectTeamTeamId;
+  @override
+  String? get projectTeamName;
+
+  /// Query field for the [projectTeamName] field.
+  QueryField<ProjectIdentifier, Project, String?> get $projectTeamName =>
+      _queryFields.$projectTeamName;
+
+  /// Query field for the [projectTeamName] field.
+  @Deprecated(r'Use $projectTeamName instead')
+  QueryField<ProjectIdentifier, Project, String?> get PROJECT_TEAM_NAME =>
+      $projectTeamName;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<ProjectIdentifier, Project, ProjectIdentifier>
+      get $modelIdentifier => _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<ProjectIdentifier, Project, ProjectIdentifier>
+      get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<ProjectIdentifier, Project, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'projectId':
+        value = projectId;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'team':
+        value = team;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'projectTeamTeamId':
+        value = projectTeamTeamId;
+        break;
+      case r'projectTeamName':
+        value = projectTeamName;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Project extends Project {
+  _Project({
+    String? projectId,
+    required this.name,
+    Team? team,
+    this.projectTeamTeamId,
+    this.projectTeamName,
+  })  : projectId = projectId ?? uuid(),
+        team = team == null ? null : AsyncModel.fromModel(team),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Project._({
+    required this.projectId,
+    required this.name,
+    this.team,
+    required this.createdAt,
+    required this.updatedAt,
+    this.projectTeamTeamId,
+    this.projectTeamName,
+  }) : super._();
+
+  @override
+  final String projectId;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModel<TeamIdentifier, Team, PartialTeam, Team>? team;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? projectTeamTeamId;
+
+  @override
+  final String? projectTeamName;
+}
+
+abstract class RemoteProject extends Project
+    implements RemoteModel<ProjectIdentifier, Project> {
+  const RemoteProject._() : super._();
+}
+
+class _RemoteProject extends RemoteProject {
+  const _RemoteProject({
+    required this.projectId,
+    required this.name,
+    this.team,
+    required this.createdAt,
+    required this.updatedAt,
+    this.projectTeamTeamId,
+    this.projectTeamName,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteProject.fromJson(Map<String, Object?> json) {
+    final projectId = json['projectId'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'projectId',
+          ))
+        : (json['projectId'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'name',
+          ))
+        : (json['name'] as String);
+    final team = json['team'] == null
+        ? null
+        : AsyncModel<TeamIdentifier, Team, PartialTeam, RemoteTeam>.fromModel(
+            Team.classType
+                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final projectTeamTeamId = json['projectTeamTeamId'] == null
+        ? null
+        : (json['projectTeamTeamId'] as String);
+    final projectTeamName = json['projectTeamName'] == null
+        ? null
+        : (json['projectTeamName'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Project',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteProject(
+      projectId: projectId,
+      name: name,
+      team: team,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      projectTeamTeamId: projectTeamTeamId,
+      projectTeamName: projectTeamName,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String projectId;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModel<TeamIdentifier, Team, PartialTeam, RemoteTeam>? team;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? projectTeamTeamId;
+
+  @override
+  final String? projectTeamName;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/project.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.project;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'team.dart';
@@ -338,6 +339,76 @@ abstract class Project extends PartialProject
 
   static const ProjectQueryFields<ProjectIdentifier, Project> _queryFields =
       ProjectQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Project',
+      'pluralName': 'Projects',
+      'fields': {
+        'projectId': {
+          'name': 'projectId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'team': {
+          'name': 'team',
+          'type': {'model': 'Team'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasOne',
+            'associatedType': 'Team',
+            'associatedFields': ['project'],
+            'targetNames': [
+              'projectTeamTeamId',
+              'projectTeamName',
+            ],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'projectTeamTeamId': {
+          'name': 'projectTeamTeamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'projectTeamName': {
+          'name': 'projectTeamName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'projectId',
+          'sortKeyFields': ['name'],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get projectId;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/project.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/project.dart
@@ -224,12 +224,6 @@ class _PartialProject extends PartialProject {
             'name',
           ))
         : (json['name'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<TeamIdentifier, Team, PartialTeam, PartialTeam>.fromModel(
-            Team.classType
-                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
@@ -242,6 +236,21 @@ class _PartialProject extends PartialProject {
     final projectTeamName = json['projectTeamName'] == null
         ? null
         : (json['projectTeamName'] as String);
+    final team = json['team'] == null
+        ? projectTeamTeamId == null || projectTeamName == null
+            ? null
+            : AsyncModel<TeamIdentifier, Team, PartialTeam,
+                PartialTeam>.fromModelIdentifier(
+                Team.classType,
+                TeamIdentifier(
+                  teamId: projectTeamTeamId,
+                  name: projectTeamName,
+                ),
+              )
+        : AsyncModel<TeamIdentifier, Team, PartialTeam, PartialTeam>.fromModel(
+            Team.classType
+                .fromJson<PartialTeam>((json['team'] as Map<String, Object?>)),
+          );
     return _PartialProject(
       projectId: projectId,
       name: name,
@@ -300,12 +309,6 @@ abstract class Project extends PartialProject
             'name',
           ))
         : (json['name'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<TeamIdentifier, Team, PartialTeam, Team>.fromModel(
-            Team.classType
-                .fromJson<Team>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Project',
@@ -324,6 +327,21 @@ abstract class Project extends PartialProject
     final projectTeamName = json['projectTeamName'] == null
         ? null
         : (json['projectTeamName'] as String);
+    final team = json['team'] == null
+        ? projectTeamTeamId == null || projectTeamName == null
+            ? null
+            : AsyncModel<TeamIdentifier, Team, PartialTeam,
+                Team>.fromModelIdentifier(
+                Team.classType,
+                TeamIdentifier(
+                  teamId: projectTeamTeamId,
+                  name: projectTeamName,
+                ),
+              )
+        : AsyncModel<TeamIdentifier, Team, PartialTeam, Team>.fromModel(
+            Team.classType
+                .fromJson<Team>((json['team'] as Map<String, Object?>)),
+          );
     return _Project._(
       projectId: projectId,
       name: name,
@@ -609,12 +627,6 @@ class _RemoteProject extends RemoteProject {
             'name',
           ))
         : (json['name'] as String);
-    final team = json['team'] == null
-        ? null
-        : AsyncModel<TeamIdentifier, Team, PartialTeam, RemoteTeam>.fromModel(
-            Team.classType
-                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Project',
@@ -651,6 +663,21 @@ class _RemoteProject extends RemoteProject {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final team = json['team'] == null
+        ? projectTeamTeamId == null || projectTeamName == null
+            ? null
+            : AsyncModel<TeamIdentifier, Team, PartialTeam,
+                RemoteTeam>.fromModelIdentifier(
+                Team.classType,
+                TeamIdentifier(
+                  teamId: projectTeamTeamId,
+                  name: projectTeamName,
+                ),
+              )
+        : AsyncModel<TeamIdentifier, Team, PartialTeam, RemoteTeam>.fromModel(
+            Team.classType
+                .fromJson<RemoteTeam>((json['team'] as Map<String, Object?>)),
+          );
     return _RemoteProject(
       projectId: projectId,
       name: name,
@@ -672,7 +699,7 @@ class _RemoteProject extends RemoteProject {
   final String name;
 
   @override
-  final AsyncModel<TeamIdentifier, Team, PartialTeam, RemoteTeam>? team;
+  final AsyncModel<TeamIdentifier, Team, PartialTeam, Team>? team;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/team.dart
@@ -403,6 +403,28 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<TeamIdentifier, Team, TeamIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  Team copyWith({
+    String? teamId,
+    String? name,
+    Project? project,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? teamProjectProjectId,
+    String? teamProjectName,
+  }) {
+    return _Team._(
+      teamId: teamId ?? this.teamId,
+      name: name ?? this.name,
+      project: project == null ? this.project : AsyncModel.fromModel(project),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      teamProjectProjectId: teamProjectProjectId ?? this.teamProjectProjectId,
+      teamProjectName: teamProjectName ?? this.teamProjectName,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<TeamIdentifier, Team, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/team.dart
@@ -1,0 +1,606 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.team;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:meta/meta.dart';
+
+import 'project.dart';
+
+@immutable
+class TeamIdentifier
+    with
+        AWSEquatable<TeamIdentifier>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  const TeamIdentifier({
+    required this.teamId,
+    required this.name,
+  });
+
+  final String teamId;
+
+  final String name;
+
+  @override
+  List<Object?> get props => [
+        teamId,
+        name,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'teamId': teamId,
+        'name': name,
+      };
+  @override
+  String get runtimeTypeName => 'TeamIdentifier';
+}
+
+class TeamType extends ModelType<TeamIdentifier, Team, PartialTeam> {
+  const TeamType();
+
+  @override
+  T fromJson<T extends PartialModel<TeamIdentifier, Team>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Team || T == Model<TeamIdentifier, Team>) {
+      return Team.fromJson(json) as T;
+    }
+    if (T == RemoteTeam || T == RemoteModel<TeamIdentifier, Team>) {
+      return _RemoteTeam.fromJson(json) as T;
+    }
+    return _PartialTeam.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Team';
+}
+
+class TeamQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const TeamQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Team>? _root;
+
+  /// Query field for the [Team.teamId] field.
+  QueryField<ModelIdentifier, M, String> get $teamId =>
+      NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, String>(
+        const QueryField<TeamIdentifier, Team, String>(fieldName: 'teamId'),
+        root: _root,
+      );
+
+  /// Query field for the [Team.name] field.
+  QueryField<ModelIdentifier, M, String> get $name =>
+      NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, String>(
+        const QueryField<TeamIdentifier, Team, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Team.project] field.
+  ProjectQueryFields<ModelIdentifier, M> get $project => ProjectQueryFields(
+        NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, Project>(
+          const QueryField<TeamIdentifier, Team, Project>(fieldName: 'project'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Team.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team,
+          TemporalDateTime>(
+        const QueryField<TeamIdentifier, Team, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Team.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team,
+          TemporalDateTime>(
+        const QueryField<TeamIdentifier, Team, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Team.teamProjectProjectId] field.
+  QueryField<ModelIdentifier, M, String?> get $teamProjectProjectId =>
+      NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, String?>(
+        const QueryField<TeamIdentifier, Team, String?>(
+          fieldName: 'teamProjectProjectId',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Team.teamProjectName] field.
+  QueryField<ModelIdentifier, M, String?> get $teamProjectName =>
+      NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team, String?>(
+        const QueryField<TeamIdentifier, Team, String?>(
+          fieldName: 'teamProjectName',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Team] model identifier.
+  QueryField<ModelIdentifier, M, TeamIdentifier> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, TeamIdentifier, Team,
+          TeamIdentifier>(
+        const QueryField<TeamIdentifier, Team, TeamIdentifier>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialTeam extends PartialModel<TeamIdentifier, Team>
+    with AWSEquatable<PartialTeam> {
+  const PartialTeam._();
+
+  String get teamId;
+  String get name;
+  AsyncModel<ProjectIdentifier, Project, PartialProject, PartialProject>?
+      get project;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String? get teamProjectProjectId;
+  String? get teamProjectName;
+  @override
+  TeamIdentifier get modelIdentifier => TeamIdentifier(
+        teamId: teamId,
+        name: name,
+      );
+  @override
+  TeamType get modelType => Team.classType;
+  @override
+  List<Object?> get props => [
+        teamId,
+        name,
+        project,
+        createdAt,
+        updatedAt,
+        teamProjectProjectId,
+        teamProjectName,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'teamId': teamId,
+        'name': name,
+        'project': project?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'teamProjectProjectId': teamProjectProjectId,
+        'teamProjectName': teamProjectName,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Team';
+}
+
+class _PartialTeam extends PartialTeam {
+  const _PartialTeam({
+    required this.teamId,
+    required this.name,
+    this.project,
+    this.createdAt,
+    this.updatedAt,
+    this.teamProjectProjectId,
+    this.teamProjectName,
+  }) : super._();
+
+  factory _PartialTeam.fromJson(Map<String, Object?> json) {
+    final teamId = json['teamId'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'teamId',
+          ))
+        : (json['teamId'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'name',
+          ))
+        : (json['name'] as String);
+    final project = json['project'] == null
+        ? null
+        : AsyncModel<ProjectIdentifier, Project, PartialProject,
+            PartialProject>.fromModel(
+            Project.classType.fromJson<PartialProject>(
+              (json['project'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final teamProjectProjectId = json['teamProjectProjectId'] == null
+        ? null
+        : (json['teamProjectProjectId'] as String);
+    final teamProjectName = json['teamProjectName'] == null
+        ? null
+        : (json['teamProjectName'] as String);
+    return _PartialTeam(
+      teamId: teamId,
+      name: name,
+      project: project,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      teamProjectProjectId: teamProjectProjectId,
+      teamProjectName: teamProjectName,
+    );
+  }
+
+  @override
+  final String teamId;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModel<ProjectIdentifier, Project, PartialProject, PartialProject>?
+      project;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String? teamProjectProjectId;
+
+  @override
+  final String? teamProjectName;
+}
+
+abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
+  factory Team({
+    String? teamId,
+    required String name,
+    Project? project,
+    String? teamProjectProjectId,
+    String? teamProjectName,
+  }) = _Team;
+
+  const Team._() : super._();
+
+  factory Team.fromJson(Map<String, Object?> json) {
+    final teamId = json['teamId'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'teamId',
+          ))
+        : (json['teamId'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'name',
+          ))
+        : (json['name'] as String);
+    final project = json['project'] == null
+        ? null
+        : AsyncModel<ProjectIdentifier, Project, PartialProject,
+            Project>.fromModel(
+            Project.classType
+                .fromJson<Project>((json['project'] as Map<String, Object?>)),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final teamProjectProjectId = json['teamProjectProjectId'] == null
+        ? null
+        : (json['teamProjectProjectId'] as String);
+    final teamProjectName = json['teamProjectName'] == null
+        ? null
+        : (json['teamProjectName'] as String);
+    return _Team._(
+      teamId: teamId,
+      name: name,
+      project: project,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      teamProjectProjectId: teamProjectProjectId,
+      teamProjectName: teamProjectName,
+    );
+  }
+
+  static const TeamType classType = TeamType();
+
+  static const TeamQueryFields<TeamIdentifier, Team> _queryFields =
+      TeamQueryFields();
+
+  @override
+  String get teamId;
+
+  /// Query field for the [teamId] field.
+  QueryField<TeamIdentifier, Team, String> get $teamId => _queryFields.$teamId;
+
+  /// Query field for the [teamId] field.
+  @Deprecated(r'Use $teamId instead')
+  QueryField<TeamIdentifier, Team, String> get TEAM_ID => $teamId;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<TeamIdentifier, Team, String> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<TeamIdentifier, Team, String> get NAME => $name;
+  @override
+  AsyncModel<ProjectIdentifier, Project, PartialProject, Project>? get project;
+
+  /// Query field for the [project] field.
+  ProjectQueryFields<TeamIdentifier, Team> get $project =>
+      _queryFields.$project;
+
+  /// Query field for the [project] field.
+  @Deprecated(r'Use $project instead')
+  ProjectQueryFields<TeamIdentifier, Team> get PROJECT => $project;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String? get teamProjectProjectId;
+
+  /// Query field for the [teamProjectProjectId] field.
+  QueryField<TeamIdentifier, Team, String?> get $teamProjectProjectId =>
+      _queryFields.$teamProjectProjectId;
+
+  /// Query field for the [teamProjectProjectId] field.
+  @Deprecated(r'Use $teamProjectProjectId instead')
+  QueryField<TeamIdentifier, Team, String?> get TEAM_PROJECT_PROJECT_ID =>
+      $teamProjectProjectId;
+  @override
+  String? get teamProjectName;
+
+  /// Query field for the [teamProjectName] field.
+  QueryField<TeamIdentifier, Team, String?> get $teamProjectName =>
+      _queryFields.$teamProjectName;
+
+  /// Query field for the [teamProjectName] field.
+  @Deprecated(r'Use $teamProjectName instead')
+  QueryField<TeamIdentifier, Team, String?> get TEAM_PROJECT_NAME =>
+      $teamProjectName;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<TeamIdentifier, Team, TeamIdentifier> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<TeamIdentifier, Team, TeamIdentifier> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<TeamIdentifier, Team, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'teamId':
+        value = teamId;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'project':
+        value = project;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'teamProjectProjectId':
+        value = teamProjectProjectId;
+        break;
+      case r'teamProjectName':
+        value = teamProjectName;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Team extends Team {
+  _Team({
+    String? teamId,
+    required this.name,
+    Project? project,
+    this.teamProjectProjectId,
+    this.teamProjectName,
+  })  : teamId = teamId ?? uuid(),
+        project = project == null ? null : AsyncModel.fromModel(project),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Team._({
+    required this.teamId,
+    required this.name,
+    this.project,
+    required this.createdAt,
+    required this.updatedAt,
+    this.teamProjectProjectId,
+    this.teamProjectName,
+  }) : super._();
+
+  @override
+  final String teamId;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModel<ProjectIdentifier, Project, PartialProject, Project>?
+      project;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? teamProjectProjectId;
+
+  @override
+  final String? teamProjectName;
+}
+
+abstract class RemoteTeam extends Team
+    implements RemoteModel<TeamIdentifier, Team> {
+  const RemoteTeam._() : super._();
+}
+
+class _RemoteTeam extends RemoteTeam {
+  const _RemoteTeam({
+    required this.teamId,
+    required this.name,
+    this.project,
+    required this.createdAt,
+    required this.updatedAt,
+    this.teamProjectProjectId,
+    this.teamProjectName,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteTeam.fromJson(Map<String, Object?> json) {
+    final teamId = json['teamId'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'teamId',
+          ))
+        : (json['teamId'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'name',
+          ))
+        : (json['name'] as String);
+    final project = json['project'] == null
+        ? null
+        : AsyncModel<ProjectIdentifier, Project, PartialProject,
+            RemoteProject>.fromModel(
+            Project.classType.fromJson<RemoteProject>(
+              (json['project'] as Map<String, Object?>),
+            ),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final teamProjectProjectId = json['teamProjectProjectId'] == null
+        ? null
+        : (json['teamProjectProjectId'] as String);
+    final teamProjectName = json['teamProjectName'] == null
+        ? null
+        : (json['teamProjectName'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Team',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteTeam(
+      teamId: teamId,
+      name: name,
+      project: project,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      teamProjectProjectId: teamProjectProjectId,
+      teamProjectName: teamProjectName,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String teamId;
+
+  @override
+  final String name;
+
+  @override
+  final AsyncModel<ProjectIdentifier, Project, PartialProject, RemoteProject>?
+      project;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? teamProjectProjectId;
+
+  @override
+  final String? teamProjectName;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/team.dart
@@ -158,8 +158,7 @@ abstract class PartialTeam extends PartialModel<TeamIdentifier, Team>
 
   String get teamId;
   String get name;
-  AsyncModel<ProjectIdentifier, Project, PartialProject, PartialProject>?
-      get project;
+  PartialProject? get project;
   TemporalDateTime? get createdAt;
   TemporalDateTime? get updatedAt;
   String? get teamProjectProjectId;
@@ -222,14 +221,6 @@ class _PartialTeam extends PartialTeam {
             'name',
           ))
         : (json['name'] as String);
-    final project = json['project'] == null
-        ? null
-        : AsyncModel<ProjectIdentifier, Project, PartialProject,
-            PartialProject>.fromModel(
-            Project.classType.fromJson<PartialProject>(
-              (json['project'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
@@ -242,6 +233,11 @@ class _PartialTeam extends PartialTeam {
     final teamProjectName = json['teamProjectName'] == null
         ? null
         : (json['teamProjectName'] as String);
+    final project = json['project'] == null
+        ? null
+        : Project.classType.fromJson<PartialProject>(
+            (json['project'] as Map<String, Object?>),
+          );
     return _PartialTeam(
       teamId: teamId,
       name: name,
@@ -260,8 +256,7 @@ class _PartialTeam extends PartialTeam {
   final String name;
 
   @override
-  final AsyncModel<ProjectIdentifier, Project, PartialProject, PartialProject>?
-      project;
+  final PartialProject? project;
 
   @override
   final TemporalDateTime? createdAt;
@@ -281,8 +276,6 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
     String? teamId,
     required String name,
     Project? project,
-    String? teamProjectProjectId,
-    String? teamProjectName,
   }) = _Team;
 
   const Team._() : super._();
@@ -300,13 +293,6 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
             'name',
           ))
         : (json['name'] as String);
-    final project = json['project'] == null
-        ? null
-        : AsyncModel<ProjectIdentifier, Project, PartialProject,
-            Project>.fromModel(
-            Project.classType
-                .fromJson<Project>((json['project'] as Map<String, Object?>)),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Team',
@@ -325,6 +311,10 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
     final teamProjectName = json['teamProjectName'] == null
         ? null
         : (json['teamProjectName'] as String);
+    final project = json['project'] == null
+        ? null
+        : Project.classType
+            .fromJson<Project>((json['project'] as Map<String, Object?>));
     return _Team._(
       teamId: teamId,
       name: name,
@@ -389,13 +379,13 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
         'teamProjectProjectId': {
           'name': 'teamProjectProjectId',
           'type': {'scalar': 'ID'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
         'teamProjectName': {
           'name': 'teamProjectName',
           'type': {'scalar': 'String'},
-          'isReadOnly': false,
+          'isReadOnly': true,
           'authRules': [],
         },
       },
@@ -438,7 +428,7 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
   @Deprecated(r'Use $name instead')
   QueryField<TeamIdentifier, Team, String> get NAME => $name;
   @override
-  AsyncModel<ProjectIdentifier, Project, PartialProject, Project>? get project;
+  Project? get project;
 
   /// Query field for the [project] field.
   ProjectQueryFields<TeamIdentifier, Team> get $project =>
@@ -453,26 +443,8 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
   TemporalDateTime get updatedAt;
   @override
   String? get teamProjectProjectId;
-
-  /// Query field for the [teamProjectProjectId] field.
-  QueryField<TeamIdentifier, Team, String?> get $teamProjectProjectId =>
-      _queryFields.$teamProjectProjectId;
-
-  /// Query field for the [teamProjectProjectId] field.
-  @Deprecated(r'Use $teamProjectProjectId instead')
-  QueryField<TeamIdentifier, Team, String?> get TEAM_PROJECT_PROJECT_ID =>
-      $teamProjectProjectId;
   @override
   String? get teamProjectName;
-
-  /// Query field for the [teamProjectName] field.
-  QueryField<TeamIdentifier, Team, String?> get $teamProjectName =>
-      _queryFields.$teamProjectName;
-
-  /// Query field for the [teamProjectName] field.
-  @Deprecated(r'Use $teamProjectName instead')
-  QueryField<TeamIdentifier, Team, String?> get TEAM_PROJECT_NAME =>
-      $teamProjectName;
 
   /// Query field for the [modelIdentifier] field.
   QueryField<TeamIdentifier, Team, TeamIdentifier> get $modelIdentifier =>
@@ -494,7 +466,7 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
     return _Team._(
       teamId: teamId ?? this.teamId,
       name: name ?? this.name,
-      project: project == null ? this.project : AsyncModel.fromModel(project),
+      project: project ?? this.project,
       createdAt:
           createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
       updatedAt:
@@ -542,13 +514,12 @@ class _Team extends Team {
   _Team({
     String? teamId,
     required this.name,
-    Project? project,
-    this.teamProjectProjectId,
-    this.teamProjectName,
+    this.project,
   })  : teamId = teamId ?? uuid(),
-        project = project == null ? null : AsyncModel.fromModel(project),
         createdAt = TemporalDateTime.now(),
         updatedAt = TemporalDateTime.now(),
+        teamProjectProjectId = project?.projectId,
+        teamProjectName = project?.name,
         super._();
 
   const _Team._({
@@ -568,8 +539,7 @@ class _Team extends Team {
   final String name;
 
   @override
-  final AsyncModel<ProjectIdentifier, Project, PartialProject, Project>?
-      project;
+  final Project? project;
 
   @override
   final TemporalDateTime createdAt;
@@ -616,14 +586,6 @@ class _RemoteTeam extends RemoteTeam {
             'name',
           ))
         : (json['name'] as String);
-    final project = json['project'] == null
-        ? null
-        : AsyncModel<ProjectIdentifier, Project, PartialProject,
-            RemoteProject>.fromModel(
-            Project.classType.fromJson<RemoteProject>(
-              (json['project'] as Map<String, Object?>),
-            ),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Team',
@@ -660,6 +622,10 @@ class _RemoteTeam extends RemoteTeam {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final project = json['project'] == null
+        ? null
+        : Project.classType
+            .fromJson<RemoteProject>((json['project'] as Map<String, Object?>));
     return _RemoteTeam(
       teamId: teamId,
       name: name,
@@ -681,8 +647,7 @@ class _RemoteTeam extends RemoteTeam {
   final String name;
 
   @override
-  final AsyncModel<ProjectIdentifier, Project, PartialProject, RemoteProject>?
-      project;
+  final RemoteProject? project;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/team.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/cpk_relationships/team.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.team;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'project.dart';
@@ -339,6 +340,84 @@ abstract class Team extends PartialTeam implements Model<TeamIdentifier, Team> {
 
   static const TeamQueryFields<TeamIdentifier, Team> _queryFields =
       TeamQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Team',
+      'pluralName': 'Teams',
+      'fields': {
+        'teamId': {
+          'name': 'teamId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'project': {
+          'name': 'project',
+          'type': {'model': 'Project'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Project',
+            'targetNames': [
+              'teamProjectProjectId',
+              'teamProjectName',
+            ],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'teamProjectProjectId': {
+          'name': 'teamProjectProjectId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'teamProjectName': {
+          'name': 'teamProjectName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'teamId',
+          'sortKeyFields': ['name'],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'project',
+          'sortKeyFields': [
+            'teamProjectProjectId',
+            'teamProjectName',
+          ],
+          'name': 'project',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get teamId;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_groups_claims/custom_claim.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_groups_claims/custom_claim.dart
@@ -1,0 +1,426 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.custom_claim;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class CustomClaimType
+    extends ModelType<String, CustomClaim, PartialCustomClaim> {
+  const CustomClaimType();
+
+  @override
+  T fromJson<T extends PartialModel<String, CustomClaim>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == CustomClaim || T == Model<String, CustomClaim>) {
+      return CustomClaim.fromJson(json) as T;
+    }
+    if (T == RemoteCustomClaim || T == RemoteModel<String, CustomClaim>) {
+      return _RemoteCustomClaim.fromJson(json) as T;
+    }
+    return _PartialCustomClaim.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'customClaim';
+}
+
+class CustomClaimQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const CustomClaimQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, CustomClaim>? _root;
+
+  /// Query field for the [CustomClaim.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, CustomClaim, String>(
+        const QueryField<String, CustomClaim, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [CustomClaim.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, CustomClaim, String?>(
+        const QueryField<String, CustomClaim, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [CustomClaim.bar] field.
+  QueryField<ModelIdentifier, M, String?> get $bar =>
+      NestedQueryField<ModelIdentifier, M, String, CustomClaim, String?>(
+        const QueryField<String, CustomClaim, String?>(fieldName: 'bar'),
+        root: _root,
+      );
+
+  /// Query field for the [CustomClaim.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, CustomClaim,
+          TemporalDateTime>(
+        const QueryField<String, CustomClaim, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [CustomClaim.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, CustomClaim,
+          TemporalDateTime>(
+        const QueryField<String, CustomClaim, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [CustomClaim] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, CustomClaim, String>(
+        const QueryField<String, CustomClaim, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialCustomClaim extends PartialModel<String, CustomClaim>
+    with AWSEquatable<PartialCustomClaim> {
+  const PartialCustomClaim._();
+
+  String get id;
+  String? get name;
+  String? get bar;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  CustomClaimType get modelType => CustomClaim.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        bar,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'CustomClaim';
+}
+
+class _PartialCustomClaim extends PartialCustomClaim {
+  const _PartialCustomClaim({
+    required this.id,
+    this.name,
+    this.bar,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialCustomClaim.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialCustomClaim(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class CustomClaim extends PartialCustomClaim
+    implements Model<String, CustomClaim> {
+  factory CustomClaim({
+    String? id,
+    String? name,
+    String? bar,
+  }) = _CustomClaim;
+
+  const CustomClaim._() : super._();
+
+  factory CustomClaim.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _CustomClaim._(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const CustomClaimType classType = CustomClaimType();
+
+  static const CustomClaimQueryFields<String, CustomClaim> _queryFields =
+      CustomClaimQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, CustomClaim, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, CustomClaim, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, CustomClaim, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, CustomClaim, String?> get NAME => $name;
+  @override
+  String? get bar;
+
+  /// Query field for the [bar] field.
+  QueryField<String, CustomClaim, String?> get $bar => _queryFields.$bar;
+
+  /// Query field for the [bar] field.
+  @Deprecated(r'Use $bar instead')
+  QueryField<String, CustomClaim, String?> get BAR => $bar;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, CustomClaim, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, CustomClaim, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, CustomClaim, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'bar':
+        value = bar;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _CustomClaim extends CustomClaim {
+  _CustomClaim({
+    String? id,
+    this.name,
+    this.bar,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _CustomClaim._({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteCustomClaim extends CustomClaim
+    implements RemoteModel<String, CustomClaim> {
+  const RemoteCustomClaim._() : super._();
+}
+
+class _RemoteCustomClaim extends RemoteCustomClaim {
+  const _RemoteCustomClaim({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteCustomClaim.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteCustomClaim(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_groups_claims/custom_claim.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_groups_claims/custom_claim.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.custom_claim;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class CustomClaimType
     extends ModelType<String, CustomClaim, PartialCustomClaim> {
@@ -229,6 +230,69 @@ abstract class CustomClaim extends PartialCustomClaim
 
   static const CustomClaimQueryFields<String, CustomClaim> _queryFields =
       CustomClaimQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'customClaim',
+      'pluralName': 'customClaims',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'bar': {
+          'name': 'bar',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [
+        {
+          'authStrategy': 'GROUPS',
+          'provider': 'USERPOOLS',
+          'operations': [
+            'CREATE',
+            'UPDATE',
+            'DELETE',
+            'READ',
+          ],
+          'groupClaim': 'user_groups',
+          'groups': ['Moderator'],
+          'groupsField': 'groups',
+        }
+      ],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_groups_claims/custom_claim.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_groups_claims/custom_claim.dart
@@ -270,6 +270,24 @@ abstract class CustomClaim extends PartialCustomClaim
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, CustomClaim, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  CustomClaim copyWith({
+    String? id,
+    String? name,
+    String? bar,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _CustomClaim._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bar: bar ?? this.bar,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, CustomClaim, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_groups_claims/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_groups_claims/model_provider.dart
@@ -1,0 +1,63 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'custom_claim.dart';
+
+export 'custom_claim.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '7a79e32366f94fe61f627f6a1b9aa7bc';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [CustomClaim.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'customClaim':
+      case 'CustomClaim':
+        return (CustomClaim.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_identity_claim/custom_claim.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_identity_claim/custom_claim.dart
@@ -1,0 +1,426 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.custom_claim;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class CustomClaimType
+    extends ModelType<String, CustomClaim, PartialCustomClaim> {
+  const CustomClaimType();
+
+  @override
+  T fromJson<T extends PartialModel<String, CustomClaim>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == CustomClaim || T == Model<String, CustomClaim>) {
+      return CustomClaim.fromJson(json) as T;
+    }
+    if (T == RemoteCustomClaim || T == RemoteModel<String, CustomClaim>) {
+      return _RemoteCustomClaim.fromJson(json) as T;
+    }
+    return _PartialCustomClaim.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'customClaim';
+}
+
+class CustomClaimQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const CustomClaimQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, CustomClaim>? _root;
+
+  /// Query field for the [CustomClaim.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, CustomClaim, String>(
+        const QueryField<String, CustomClaim, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [CustomClaim.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, CustomClaim, String?>(
+        const QueryField<String, CustomClaim, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [CustomClaim.bar] field.
+  QueryField<ModelIdentifier, M, String?> get $bar =>
+      NestedQueryField<ModelIdentifier, M, String, CustomClaim, String?>(
+        const QueryField<String, CustomClaim, String?>(fieldName: 'bar'),
+        root: _root,
+      );
+
+  /// Query field for the [CustomClaim.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, CustomClaim,
+          TemporalDateTime>(
+        const QueryField<String, CustomClaim, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [CustomClaim.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, CustomClaim,
+          TemporalDateTime>(
+        const QueryField<String, CustomClaim, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [CustomClaim] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, CustomClaim, String>(
+        const QueryField<String, CustomClaim, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialCustomClaim extends PartialModel<String, CustomClaim>
+    with AWSEquatable<PartialCustomClaim> {
+  const PartialCustomClaim._();
+
+  String get id;
+  String? get name;
+  String? get bar;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  CustomClaimType get modelType => CustomClaim.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        bar,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'CustomClaim';
+}
+
+class _PartialCustomClaim extends PartialCustomClaim {
+  const _PartialCustomClaim({
+    required this.id,
+    this.name,
+    this.bar,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialCustomClaim.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialCustomClaim(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class CustomClaim extends PartialCustomClaim
+    implements Model<String, CustomClaim> {
+  factory CustomClaim({
+    String? id,
+    String? name,
+    String? bar,
+  }) = _CustomClaim;
+
+  const CustomClaim._() : super._();
+
+  factory CustomClaim.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _CustomClaim._(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const CustomClaimType classType = CustomClaimType();
+
+  static const CustomClaimQueryFields<String, CustomClaim> _queryFields =
+      CustomClaimQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, CustomClaim, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, CustomClaim, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, CustomClaim, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, CustomClaim, String?> get NAME => $name;
+  @override
+  String? get bar;
+
+  /// Query field for the [bar] field.
+  QueryField<String, CustomClaim, String?> get $bar => _queryFields.$bar;
+
+  /// Query field for the [bar] field.
+  @Deprecated(r'Use $bar instead')
+  QueryField<String, CustomClaim, String?> get BAR => $bar;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, CustomClaim, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, CustomClaim, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, CustomClaim, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'bar':
+        value = bar;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _CustomClaim extends CustomClaim {
+  _CustomClaim({
+    String? id,
+    this.name,
+    this.bar,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _CustomClaim._({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteCustomClaim extends CustomClaim
+    implements RemoteModel<String, CustomClaim> {
+  const RemoteCustomClaim._() : super._();
+}
+
+class _RemoteCustomClaim extends RemoteCustomClaim {
+  const _RemoteCustomClaim({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteCustomClaim.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'CustomClaim',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteCustomClaim(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_identity_claim/custom_claim.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_identity_claim/custom_claim.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.custom_claim;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class CustomClaimType
     extends ModelType<String, CustomClaim, PartialCustomClaim> {
@@ -229,6 +230,68 @@ abstract class CustomClaim extends PartialCustomClaim
 
   static const CustomClaimQueryFields<String, CustomClaim> _queryFields =
       CustomClaimQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'customClaim',
+      'pluralName': 'customClaims',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'bar': {
+          'name': 'bar',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [
+        {
+          'authStrategy': 'OWNER',
+          'provider': 'USERPOOLS',
+          'operations': [
+            'CREATE',
+            'UPDATE',
+            'DELETE',
+            'READ',
+          ],
+          'ownerField': 'owner',
+          'identityClaim': 'user_id',
+        }
+      ],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_identity_claim/custom_claim.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_identity_claim/custom_claim.dart
@@ -270,6 +270,24 @@ abstract class CustomClaim extends PartialCustomClaim
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, CustomClaim, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  CustomClaim copyWith({
+    String? id,
+    String? name,
+    String? bar,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _CustomClaim._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bar: bar ?? this.bar,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, CustomClaim, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_identity_claim/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_identity_claim/model_provider.dart
@@ -1,0 +1,63 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'custom_claim.dart';
+
+export 'custom_claim.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '8b6b0f55bce68443df9da1d8c6a0e092';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [CustomClaim.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'customClaim':
+      case 'CustomClaim':
+        return (CustomClaim.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/address.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/address.dart
@@ -21,6 +21,7 @@
 library models.address;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class Address
     with
@@ -79,6 +80,46 @@ class Address
   final String state;
 
   final String postalCode;
+
+  static final mipr.NonModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.NonModelTypeDefinition.serializer,
+    const {
+      'name': 'Address',
+      'fields': {
+        'line1': {
+          'name': 'line1',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'line2': {
+          'name': 'line2',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'city': {
+          'name': 'city',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'state': {
+          'name': 'state',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'postalCode': {
+          'name': 'postalCode',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+    },
+  )!;
 
   @override
   List<Object?> get props => [

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/address.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/address.dart
@@ -1,0 +1,101 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.address;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class Address
+    with
+        AWSEquatable<Address>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  const Address({
+    required this.line1,
+    this.line2,
+    required this.city,
+    required this.state,
+    required this.postalCode,
+  });
+
+  factory Address.fromJson(Map<String, Object?> json) {
+    final line1 = json['line1'] == null
+        ? (throw ModelFieldError(
+            'Address',
+            'line1',
+          ))
+        : (json['line1'] as String);
+    final line2 = json['line2'] == null ? null : (json['line2'] as String);
+    final city = json['city'] == null
+        ? (throw ModelFieldError(
+            'Address',
+            'city',
+          ))
+        : (json['city'] as String);
+    final state = json['state'] == null
+        ? (throw ModelFieldError(
+            'Address',
+            'state',
+          ))
+        : (json['state'] as String);
+    final postalCode = json['postalCode'] == null
+        ? (throw ModelFieldError(
+            'Address',
+            'postalCode',
+          ))
+        : (json['postalCode'] as String);
+    return Address(
+      line1: line1,
+      line2: line2,
+      city: city,
+      state: state,
+      postalCode: postalCode,
+    );
+  }
+
+  final String line1;
+
+  final String? line2;
+
+  final String city;
+
+  final String state;
+
+  final String postalCode;
+
+  @override
+  List<Object?> get props => [
+        line1,
+        line2,
+        city,
+        state,
+        postalCode,
+      ];
+  @override
+  String get runtimeTypeName => 'Address';
+  @override
+  Map<String, Object?> toJson() => {
+        'line1': line1,
+        'line2': line2,
+        'city': city,
+        'state': state,
+        'postalCode': postalCode,
+      };
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/address.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/address.dart
@@ -16,7 +16,7 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.address;
 

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/contact.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/contact.dart
@@ -21,6 +21,7 @@
 library models.contact;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'address.dart';
 import 'phone.dart';
@@ -67,6 +68,36 @@ class Contact
   final Phone phone;
 
   final List<Address?>? mailingAddresses;
+
+  static final mipr.NonModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.NonModelTypeDefinition.serializer,
+    const {
+      'name': 'Contact',
+      'fields': {
+        'contactName': {
+          'name': 'contactName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'phone': {
+          'name': 'phone',
+          'type': {'nonModel': 'Phone'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'mailingAddresses': {
+          'name': 'mailingAddresses',
+          'type': {
+            'list': {'nonModel': 'Address'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+    },
+  )!;
 
   @override
   List<Object?> get props => [

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/contact.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/contact.dart
@@ -1,0 +1,86 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.contact;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'address.dart';
+import 'phone.dart';
+
+class Contact
+    with
+        AWSEquatable<Contact>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  const Contact({
+    required this.contactName,
+    required this.phone,
+    this.mailingAddresses,
+  });
+
+  factory Contact.fromJson(Map<String, Object?> json) {
+    final contactName = json['contactName'] == null
+        ? (throw ModelFieldError(
+            'Contact',
+            'contactName',
+          ))
+        : (json['contactName'] as String);
+    final phone = json['phone'] == null
+        ? (throw ModelFieldError(
+            'Contact',
+            'phone',
+          ))
+        : Phone.fromJson((json['phone'] as Map<String, Object?>));
+    final mailingAddresses = json['mailingAddresses'] == null
+        ? null
+        : (json['mailingAddresses'] as List<Object?>)
+            .cast<Map<String, Object?>?>()
+            .map((el) => el == null ? null : Address.fromJson(el))
+            .toList();
+    return Contact(
+      contactName: contactName,
+      phone: phone,
+      mailingAddresses: mailingAddresses,
+    );
+  }
+
+  final String contactName;
+
+  final Phone phone;
+
+  final List<Address?>? mailingAddresses;
+
+  @override
+  List<Object?> get props => [
+        contactName,
+        phone,
+        mailingAddresses,
+      ];
+  @override
+  String get runtimeTypeName => 'Contact';
+  @override
+  Map<String, Object?> toJson() => {
+        'contactName': contactName,
+        'phone': phone.toJson(),
+        'mailingAddresses':
+            mailingAddresses?.map((el) => el?.toJson()).toList(),
+      };
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/contact.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/contact.dart
@@ -16,7 +16,7 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.contact;
 

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/model_provider.dart
@@ -1,0 +1,72 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'address.dart';
+import 'contact.dart';
+import 'person.dart';
+import 'phone.dart';
+
+export 'address.dart';
+export 'contact.dart';
+export 'person.dart';
+export 'phone.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '76e4dc99d58b0f501619f8a3b0af640d';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [Person.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [
+        Contact.schema,
+        Phone.schema,
+        Address.schema,
+      ];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Person':
+        return (Person.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/person.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/person.dart
@@ -1,0 +1,474 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.person;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'address.dart';
+import 'phone.dart';
+
+class PersonType extends ModelType<String, Person, PartialPerson> {
+  const PersonType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Person>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Person || T == Model<String, Person>) {
+      return Person.fromJson(json) as T;
+    }
+    if (T == RemotePerson || T == RemoteModel<String, Person>) {
+      return _RemotePerson.fromJson(json) as T;
+    }
+    return _PartialPerson.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Person';
+}
+
+class PersonQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const PersonQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Person>? _root;
+
+  /// Query field for the [Person.name] field.
+  QueryField<ModelIdentifier, M, String> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, Person, String>(
+        const QueryField<String, Person, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Person.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Person, TemporalDateTime>(
+        const QueryField<String, Person, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Person.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Person, TemporalDateTime>(
+        const QueryField<String, Person, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Person.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Person, String>(
+        const QueryField<String, Person, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Person] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Person, String>(
+        const QueryField<String, Person, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialPerson extends PartialModel<String, Person>
+    with AWSEquatable<PartialPerson> {
+  const PartialPerson._();
+
+  String? get name;
+  Phone? get phone;
+  List<Address?>? get mailingAddresses;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String get id;
+  @override
+  String get modelIdentifier => id;
+  @override
+  PersonType get modelType => Person.classType;
+  @override
+  List<Object?> get props => [
+        name,
+        phone,
+        mailingAddresses,
+        createdAt,
+        updatedAt,
+        id,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'name': name,
+        'phone': phone?.toJson(),
+        'mailingAddresses':
+            mailingAddresses?.map((el) => el?.toJson()).toList(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'id': id,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Person';
+}
+
+class _PartialPerson extends PartialPerson {
+  const _PartialPerson({
+    this.name,
+    this.phone,
+    this.mailingAddresses,
+    this.createdAt,
+    this.updatedAt,
+    required this.id,
+  }) : super._();
+
+  factory _PartialPerson.fromJson(Map<String, Object?> json) {
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final phone = json['phone'] == null
+        ? null
+        : Phone.fromJson((json['phone'] as Map<String, Object?>));
+    final mailingAddresses = json['mailingAddresses'] == null
+        ? null
+        : (json['mailingAddresses'] as List<Object?>)
+            .cast<Map<String, Object?>?>()
+            .map((el) => el == null ? null : Address.fromJson(el))
+            .toList();
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'id',
+          ))
+        : (json['id'] as String);
+    return _PartialPerson(
+      name: name,
+      phone: phone,
+      mailingAddresses: mailingAddresses,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      id: id,
+    );
+  }
+
+  @override
+  final String? name;
+
+  @override
+  final Phone? phone;
+
+  @override
+  final List<Address?>? mailingAddresses;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String id;
+}
+
+abstract class Person extends PartialPerson implements Model<String, Person> {
+  factory Person({
+    required String name,
+    required Phone phone,
+    List<Address?>? mailingAddresses,
+    String? id,
+  }) = _Person;
+
+  const Person._() : super._();
+
+  factory Person.fromJson(Map<String, Object?> json) {
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'name',
+          ))
+        : (json['name'] as String);
+    final phone = json['phone'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'phone',
+          ))
+        : Phone.fromJson((json['phone'] as Map<String, Object?>));
+    final mailingAddresses = json['mailingAddresses'] == null
+        ? null
+        : (json['mailingAddresses'] as List<Object?>)
+            .cast<Map<String, Object?>?>()
+            .map((el) => el == null ? null : Address.fromJson(el))
+            .toList();
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'id',
+          ))
+        : (json['id'] as String);
+    return _Person._(
+      name: name,
+      phone: phone,
+      mailingAddresses: mailingAddresses,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      id: id,
+    );
+  }
+
+  static const PersonType classType = PersonType();
+
+  static const PersonQueryFields<String, Person> _queryFields =
+      PersonQueryFields();
+
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, Person, String> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, Person, String> get NAME => $name;
+  @override
+  Phone get phone;
+  @override
+  List<Address?>? get mailingAddresses;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Person, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Person, String> get ID => $id;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Person, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Person, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Person, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'name':
+        value = name;
+        break;
+      case r'phone':
+        value = phone;
+        break;
+      case r'mailingAddresses':
+        value = mailingAddresses;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'id':
+        value = id;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Person extends Person {
+  _Person({
+    required this.name,
+    required this.phone,
+    this.mailingAddresses,
+    String? id,
+  })  : createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        id = id ?? uuid(),
+        super._();
+
+  const _Person._({
+    required this.name,
+    required this.phone,
+    this.mailingAddresses,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.id,
+  }) : super._();
+
+  @override
+  final String name;
+
+  @override
+  final Phone phone;
+
+  @override
+  final List<Address?>? mailingAddresses;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String id;
+}
+
+abstract class RemotePerson extends Person
+    implements RemoteModel<String, Person> {
+  const RemotePerson._() : super._();
+}
+
+class _RemotePerson extends RemotePerson {
+  const _RemotePerson({
+    required this.name,
+    required this.phone,
+    this.mailingAddresses,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.id,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemotePerson.fromJson(Map<String, Object?> json) {
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'name',
+          ))
+        : (json['name'] as String);
+    final phone = json['phone'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'phone',
+          ))
+        : Phone.fromJson((json['phone'] as Map<String, Object?>));
+    final mailingAddresses = json['mailingAddresses'] == null
+        ? null
+        : (json['mailingAddresses'] as List<Object?>)
+            .cast<Map<String, Object?>?>()
+            .map((el) => el == null ? null : Address.fromJson(el))
+            .toList();
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'id',
+          ))
+        : (json['id'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Person',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemotePerson(
+      name: name,
+      phone: phone,
+      mailingAddresses: mailingAddresses,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      id: id,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String name;
+
+  @override
+  final Phone phone;
+
+  @override
+  final List<Address?>? mailingAddresses;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String id;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/person.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/person.dart
@@ -289,6 +289,26 @@ abstract class Person extends PartialPerson implements Model<String, Person> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Person, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Person copyWith({
+    String? name,
+    Phone? phone,
+    List<Address?>? mailingAddresses,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? id,
+  }) {
+    return _Person._(
+      name: name ?? this.name,
+      phone: phone ?? this.phone,
+      mailingAddresses: mailingAddresses ?? this.mailingAddresses,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      id: id ?? this.id,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Person, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/person.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/person.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.person;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'address.dart';
 import 'phone.dart';
@@ -254,6 +255,63 @@ abstract class Person extends PartialPerson implements Model<String, Person> {
 
   static const PersonQueryFields<String, Person> _queryFields =
       PersonQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Person',
+      'pluralName': 'Persons',
+      'fields': {
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'phone': {
+          'name': 'phone',
+          'type': {'nonModel': 'Phone'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'mailingAddresses': {
+          'name': 'mailingAddresses',
+          'type': {
+            'list': {'nonModel': 'Address'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get name;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/phone.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/phone.dart
@@ -16,7 +16,7 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.phone;
 

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/phone.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/phone.dart
@@ -1,0 +1,82 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.phone;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class Phone
+    with
+        AWSEquatable<Phone>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  const Phone({
+    required this.countryCode,
+    required this.areaCode,
+    required this.number,
+  });
+
+  factory Phone.fromJson(Map<String, Object?> json) {
+    final countryCode = json['countryCode'] == null
+        ? (throw ModelFieldError(
+            'Phone',
+            'countryCode',
+          ))
+        : (json['countryCode'] as String);
+    final areaCode = json['areaCode'] == null
+        ? (throw ModelFieldError(
+            'Phone',
+            'areaCode',
+          ))
+        : (json['areaCode'] as String);
+    final number = json['number'] == null
+        ? (throw ModelFieldError(
+            'Phone',
+            'number',
+          ))
+        : (json['number'] as String);
+    return Phone(
+      countryCode: countryCode,
+      areaCode: areaCode,
+      number: number,
+    );
+  }
+
+  final String countryCode;
+
+  final String areaCode;
+
+  final String number;
+
+  @override
+  List<Object?> get props => [
+        countryCode,
+        areaCode,
+        number,
+      ];
+  @override
+  String get runtimeTypeName => 'Phone';
+  @override
+  Map<String, Object?> toJson() => {
+        'countryCode': countryCode,
+        'areaCode': areaCode,
+        'number': number,
+      };
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/phone.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/custom_non_model_types/phone.dart
@@ -21,6 +21,7 @@
 library models.phone;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class Phone
     with
@@ -64,6 +65,34 @@ class Phone
   final String areaCode;
 
   final String number;
+
+  static final mipr.NonModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.NonModelTypeDefinition.serializer,
+    const {
+      'name': 'Phone',
+      'fields': {
+        'countryCode': {
+          'name': 'countryCode',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'areaCode': {
+          'name': 'areaCode',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'number': {
+          'name': 'number',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+    },
+  )!;
 
   @override
   List<Object?> get props => [

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/dynamic_groups_auth/dynamic_groups.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/dynamic_groups_auth/dynamic_groups.dart
@@ -270,6 +270,24 @@ abstract class DynamicGroups extends PartialDynamicGroups
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, DynamicGroups, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  DynamicGroups copyWith({
+    String? id,
+    String? name,
+    String? bar,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _DynamicGroups._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bar: bar ?? this.bar,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, DynamicGroups, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/dynamic_groups_auth/dynamic_groups.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/dynamic_groups_auth/dynamic_groups.dart
@@ -1,0 +1,426 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.dynamic_groups;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class DynamicGroupsType
+    extends ModelType<String, DynamicGroups, PartialDynamicGroups> {
+  const DynamicGroupsType();
+
+  @override
+  T fromJson<T extends PartialModel<String, DynamicGroups>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == DynamicGroups || T == Model<String, DynamicGroups>) {
+      return DynamicGroups.fromJson(json) as T;
+    }
+    if (T == RemoteDynamicGroups || T == RemoteModel<String, DynamicGroups>) {
+      return _RemoteDynamicGroups.fromJson(json) as T;
+    }
+    return _PartialDynamicGroups.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'dynamicGroups';
+}
+
+class DynamicGroupsQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const DynamicGroupsQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, DynamicGroups>? _root;
+
+  /// Query field for the [DynamicGroups.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, DynamicGroups, String>(
+        const QueryField<String, DynamicGroups, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [DynamicGroups.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, DynamicGroups, String?>(
+        const QueryField<String, DynamicGroups, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [DynamicGroups.bar] field.
+  QueryField<ModelIdentifier, M, String?> get $bar =>
+      NestedQueryField<ModelIdentifier, M, String, DynamicGroups, String?>(
+        const QueryField<String, DynamicGroups, String?>(fieldName: 'bar'),
+        root: _root,
+      );
+
+  /// Query field for the [DynamicGroups.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, DynamicGroups,
+          TemporalDateTime>(
+        const QueryField<String, DynamicGroups, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [DynamicGroups.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, DynamicGroups,
+          TemporalDateTime>(
+        const QueryField<String, DynamicGroups, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [DynamicGroups] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, DynamicGroups, String>(
+        const QueryField<String, DynamicGroups, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialDynamicGroups extends PartialModel<String, DynamicGroups>
+    with AWSEquatable<PartialDynamicGroups> {
+  const PartialDynamicGroups._();
+
+  String get id;
+  String? get name;
+  String? get bar;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  DynamicGroupsType get modelType => DynamicGroups.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        bar,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'DynamicGroups';
+}
+
+class _PartialDynamicGroups extends PartialDynamicGroups {
+  const _PartialDynamicGroups({
+    required this.id,
+    this.name,
+    this.bar,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialDynamicGroups.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'DynamicGroups',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialDynamicGroups(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class DynamicGroups extends PartialDynamicGroups
+    implements Model<String, DynamicGroups> {
+  factory DynamicGroups({
+    String? id,
+    String? name,
+    String? bar,
+  }) = _DynamicGroups;
+
+  const DynamicGroups._() : super._();
+
+  factory DynamicGroups.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'DynamicGroups',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'DynamicGroups',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'DynamicGroups',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _DynamicGroups._(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const DynamicGroupsType classType = DynamicGroupsType();
+
+  static const DynamicGroupsQueryFields<String, DynamicGroups> _queryFields =
+      DynamicGroupsQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, DynamicGroups, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, DynamicGroups, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, DynamicGroups, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, DynamicGroups, String?> get NAME => $name;
+  @override
+  String? get bar;
+
+  /// Query field for the [bar] field.
+  QueryField<String, DynamicGroups, String?> get $bar => _queryFields.$bar;
+
+  /// Query field for the [bar] field.
+  @Deprecated(r'Use $bar instead')
+  QueryField<String, DynamicGroups, String?> get BAR => $bar;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, DynamicGroups, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, DynamicGroups, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, DynamicGroups, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'bar':
+        value = bar;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _DynamicGroups extends DynamicGroups {
+  _DynamicGroups({
+    String? id,
+    this.name,
+    this.bar,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _DynamicGroups._({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteDynamicGroups extends DynamicGroups
+    implements RemoteModel<String, DynamicGroups> {
+  const RemoteDynamicGroups._() : super._();
+}
+
+class _RemoteDynamicGroups extends RemoteDynamicGroups {
+  const _RemoteDynamicGroups({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteDynamicGroups.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'DynamicGroups',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'DynamicGroups',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'DynamicGroups',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'DynamicGroups',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'DynamicGroups',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'DynamicGroups',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteDynamicGroups(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/dynamic_groups_auth/dynamic_groups.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/dynamic_groups_auth/dynamic_groups.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.dynamic_groups;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class DynamicGroupsType
     extends ModelType<String, DynamicGroups, PartialDynamicGroups> {
@@ -229,6 +230,69 @@ abstract class DynamicGroups extends PartialDynamicGroups
 
   static const DynamicGroupsQueryFields<String, DynamicGroups> _queryFields =
       DynamicGroupsQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'dynamicGroups',
+      'pluralName': 'dynamicGroups',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'bar': {
+          'name': 'bar',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [
+        {
+          'authStrategy': 'GROUPS',
+          'provider': 'USERPOOLS',
+          'operations': [
+            'CREATE',
+            'UPDATE',
+            'DELETE',
+            'READ',
+          ],
+          'groupClaim': 'cognito:groups',
+          'groups': [],
+          'groupsField': 'groups',
+        }
+      ],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/dynamic_groups_auth/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/dynamic_groups_auth/model_provider.dart
@@ -1,0 +1,63 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'dynamic_groups.dart';
+
+export 'dynamic_groups.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'c56ccb146e2d93f633d37d6d3ded8d2e';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [DynamicGroups.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'dynamicGroups':
+      case 'DynamicGroups':
+        return (DynamicGroups.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/model_provider.dart
@@ -1,0 +1,63 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'test_enum_model.dart';
+
+export 'test_enum.dart';
+export 'test_enum_model.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '8b69a9648ae48b3e1613b6d284bd3023';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [TestEnumModel.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'TestEnumModel':
+        return (TestEnumModel.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/test_enum.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/test_enum.dart
@@ -16,7 +16,7 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.test_enum;
 

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/test_enum.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/test_enum.dart
@@ -1,0 +1,38 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.test_enum;
+
+import 'package:amplify_core/amplify_core.dart';
+
+enum TestEnum with AWSSerializable<String> {
+  valueOne('VALUE_ONE'),
+  valueTwo('VALUE_TWO');
+
+  const TestEnum(this.value);
+
+  /// The GraphQL value, as defined in the schema.
+  final String value;
+
+  static TestEnum fromJson(String json) =>
+      values.firstWhere((v) => v.value == json);
+  @override
+  String toJson() => value;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/test_enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/test_enum_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.test_enum_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'test_enum.dart';
 
@@ -403,6 +404,87 @@ abstract class TestEnumModel extends PartialTestEnumModel
 
   static const TestEnumModelQueryFields<String, TestEnumModel> _queryFields =
       TestEnumModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'TestEnumModel',
+      'pluralName': 'TestEnumModels',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'enumVal': {
+          'name': 'enumVal',
+          'type': {'enum': 'TestEnum'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'nullableEnumVal': {
+          'name': 'nullableEnumVal',
+          'type': {'enum': 'TestEnum'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'enumList': {
+          'name': 'enumList',
+          'type': {
+            'list': {'enum': 'TestEnum'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'enumNullableList': {
+          'name': 'enumNullableList',
+          'type': {
+            'list': {'enum': 'TestEnum'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'nullableEnumList': {
+          'name': 'nullableEnumList',
+          'type': {
+            'list': {'enum': 'TestEnum'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'nullableEnumNullableList': {
+          'name': 'nullableEnumNullableList',
+          'type': {
+            'list': {'enum': 'TestEnum'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/test_enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/test_enum_model.dart
@@ -1,0 +1,736 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.test_enum_model;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'test_enum.dart';
+
+class TestEnumModelType
+    extends ModelType<String, TestEnumModel, PartialTestEnumModel> {
+  const TestEnumModelType();
+
+  @override
+  T fromJson<T extends PartialModel<String, TestEnumModel>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == TestEnumModel || T == Model<String, TestEnumModel>) {
+      return TestEnumModel.fromJson(json) as T;
+    }
+    if (T == RemoteTestEnumModel || T == RemoteModel<String, TestEnumModel>) {
+      return _RemoteTestEnumModel.fromJson(json) as T;
+    }
+    return _PartialTestEnumModel.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'TestEnumModel';
+}
+
+class TestEnumModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const TestEnumModelQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, TestEnumModel>? _root;
+
+  /// Query field for the [TestEnumModel.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, TestEnumModel, String>(
+        const QueryField<String, TestEnumModel, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [TestEnumModel.enumVal] field.
+  QueryField<ModelIdentifier, M, TestEnum> get $enumVal =>
+      NestedQueryField<ModelIdentifier, M, String, TestEnumModel, TestEnum>(
+        const QueryField<String, TestEnumModel, TestEnum>(fieldName: 'enumVal'),
+        root: _root,
+      );
+
+  /// Query field for the [TestEnumModel.nullableEnumVal] field.
+  QueryField<ModelIdentifier, M, TestEnum?> get $nullableEnumVal =>
+      NestedQueryField<ModelIdentifier, M, String, TestEnumModel, TestEnum?>(
+        const QueryField<String, TestEnumModel, TestEnum?>(
+          fieldName: 'nullableEnumVal',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestEnumModel.enumList] field.
+  QueryField<ModelIdentifier, M, TestEnum> get $enumList =>
+      NestedQueryField<ModelIdentifier, M, String, TestEnumModel, TestEnum>(
+        const QueryField<String, TestEnumModel, TestEnum>(
+          fieldName: 'enumList',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestEnumModel.enumNullableList] field.
+  QueryField<ModelIdentifier, M, TestEnum> get $enumNullableList =>
+      NestedQueryField<ModelIdentifier, M, String, TestEnumModel, TestEnum>(
+        const QueryField<String, TestEnumModel, TestEnum>(
+          fieldName: 'enumNullableList',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestEnumModel.nullableEnumList] field.
+  QueryField<ModelIdentifier, M, TestEnum?> get $nullableEnumList =>
+      NestedQueryField<ModelIdentifier, M, String, TestEnumModel, TestEnum?>(
+        const QueryField<String, TestEnumModel, TestEnum?>(
+          fieldName: 'nullableEnumList',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestEnumModel.nullableEnumNullableList] field.
+  QueryField<ModelIdentifier, M, TestEnum?> get $nullableEnumNullableList =>
+      NestedQueryField<ModelIdentifier, M, String, TestEnumModel, TestEnum?>(
+        const QueryField<String, TestEnumModel, TestEnum?>(
+          fieldName: 'nullableEnumNullableList',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestEnumModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, TestEnumModel,
+          TemporalDateTime>(
+        const QueryField<String, TestEnumModel, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestEnumModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, TestEnumModel,
+          TemporalDateTime>(
+        const QueryField<String, TestEnumModel, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestEnumModel] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, TestEnumModel, String>(
+        const QueryField<String, TestEnumModel, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialTestEnumModel extends PartialModel<String, TestEnumModel>
+    with AWSEquatable<PartialTestEnumModel> {
+  const PartialTestEnumModel._();
+
+  String get id;
+  TestEnum? get enumVal;
+  TestEnum? get nullableEnumVal;
+  List<TestEnum>? get enumList;
+  List<TestEnum>? get enumNullableList;
+  List<TestEnum?>? get nullableEnumList;
+  List<TestEnum?>? get nullableEnumNullableList;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  TestEnumModelType get modelType => TestEnumModel.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        enumVal,
+        nullableEnumVal,
+        enumList,
+        enumNullableList,
+        nullableEnumList,
+        nullableEnumNullableList,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'enumVal': enumVal?.value,
+        'nullableEnumVal': nullableEnumVal?.value,
+        'enumList': enumList,
+        'enumNullableList': enumNullableList,
+        'nullableEnumList': nullableEnumList,
+        'nullableEnumNullableList': nullableEnumNullableList,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'TestEnumModel';
+}
+
+class _PartialTestEnumModel extends PartialTestEnumModel {
+  const _PartialTestEnumModel({
+    required this.id,
+    this.enumVal,
+    this.nullableEnumVal,
+    this.enumList,
+    this.enumNullableList,
+    this.nullableEnumList,
+    this.nullableEnumNullableList,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialTestEnumModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final enumVal = json['enumVal'] == null
+        ? null
+        : TestEnum.fromJson((json['enumVal'] as String));
+    final nullableEnumVal = json['nullableEnumVal'] == null
+        ? null
+        : TestEnum.fromJson((json['nullableEnumVal'] as String));
+    final enumList = json['enumList'] == null
+        ? null
+        : (json['enumList'] as List<Object?>)
+            .cast<String?>()
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'TestEnumModel',
+                      'enumList',
+                    ))
+                  : TestEnum.fromJson(el),
+            )
+            .toList();
+    final enumNullableList = json['enumNullableList'] == null
+        ? null
+        : (json['enumNullableList'] as List<Object?>)
+            .cast<String?>()
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'TestEnumModel',
+                      'enumNullableList',
+                    ))
+                  : TestEnum.fromJson(el),
+            )
+            .toList();
+    final nullableEnumList = json['nullableEnumList'] == null
+        ? null
+        : (json['nullableEnumList'] as List<Object?>).cast<String?>().toList();
+    final nullableEnumNullableList = json['nullableEnumNullableList'] == null
+        ? null
+        : (json['nullableEnumNullableList'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialTestEnumModel(
+      id: id,
+      enumVal: enumVal,
+      nullableEnumVal: nullableEnumVal,
+      enumList: enumList,
+      enumNullableList: enumNullableList,
+      nullableEnumList: nullableEnumList,
+      nullableEnumNullableList: nullableEnumNullableList,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final TestEnum? enumVal;
+
+  @override
+  final TestEnum? nullableEnumVal;
+
+  @override
+  final List<TestEnum>? enumList;
+
+  @override
+  final List<TestEnum>? enumNullableList;
+
+  @override
+  final List<TestEnum?>? nullableEnumList;
+
+  @override
+  final List<TestEnum?>? nullableEnumNullableList;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class TestEnumModel extends PartialTestEnumModel
+    implements Model<String, TestEnumModel> {
+  factory TestEnumModel({
+    String? id,
+    required TestEnum enumVal,
+    TestEnum? nullableEnumVal,
+    required List<TestEnum> enumList,
+    List<TestEnum>? enumNullableList,
+    required List<TestEnum?> nullableEnumList,
+    List<TestEnum?>? nullableEnumNullableList,
+  }) = _TestEnumModel;
+
+  const TestEnumModel._() : super._();
+
+  factory TestEnumModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final enumVal = json['enumVal'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'enumVal',
+          ))
+        : TestEnum.fromJson((json['enumVal'] as String));
+    final nullableEnumVal = json['nullableEnumVal'] == null
+        ? null
+        : TestEnum.fromJson((json['nullableEnumVal'] as String));
+    final enumList = json['enumList'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'enumList',
+          ))
+        : (json['enumList'] as List<Object?>)
+            .cast<String?>()
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'TestEnumModel',
+                      'enumList',
+                    ))
+                  : TestEnum.fromJson(el),
+            )
+            .toList();
+    final enumNullableList = json['enumNullableList'] == null
+        ? null
+        : (json['enumNullableList'] as List<Object?>)
+            .cast<String?>()
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'TestEnumModel',
+                      'enumNullableList',
+                    ))
+                  : TestEnum.fromJson(el),
+            )
+            .toList();
+    final nullableEnumList = json['nullableEnumList'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'nullableEnumList',
+          ))
+        : (json['nullableEnumList'] as List<Object?>).cast<String?>().toList();
+    final nullableEnumNullableList = json['nullableEnumNullableList'] == null
+        ? null
+        : (json['nullableEnumNullableList'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _TestEnumModel._(
+      id: id,
+      enumVal: enumVal,
+      nullableEnumVal: nullableEnumVal,
+      enumList: enumList,
+      enumNullableList: enumNullableList,
+      nullableEnumList: nullableEnumList,
+      nullableEnumNullableList: nullableEnumNullableList,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const TestEnumModelType classType = TestEnumModelType();
+
+  static const TestEnumModelQueryFields<String, TestEnumModel> _queryFields =
+      TestEnumModelQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, TestEnumModel, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, TestEnumModel, String> get ID => $id;
+  @override
+  TestEnum get enumVal;
+
+  /// Query field for the [enumVal] field.
+  QueryField<String, TestEnumModel, TestEnum> get $enumVal =>
+      _queryFields.$enumVal;
+
+  /// Query field for the [enumVal] field.
+  @Deprecated(r'Use $enumVal instead')
+  QueryField<String, TestEnumModel, TestEnum> get ENUM_VAL => $enumVal;
+  @override
+  TestEnum? get nullableEnumVal;
+
+  /// Query field for the [nullableEnumVal] field.
+  QueryField<String, TestEnumModel, TestEnum?> get $nullableEnumVal =>
+      _queryFields.$nullableEnumVal;
+
+  /// Query field for the [nullableEnumVal] field.
+  @Deprecated(r'Use $nullableEnumVal instead')
+  QueryField<String, TestEnumModel, TestEnum?> get NULLABLE_ENUM_VAL =>
+      $nullableEnumVal;
+  @override
+  List<TestEnum> get enumList;
+
+  /// Query field for the [enumList] field.
+  QueryField<String, TestEnumModel, TestEnum> get $enumList =>
+      _queryFields.$enumList;
+
+  /// Query field for the [enumList] field.
+  @Deprecated(r'Use $enumList instead')
+  QueryField<String, TestEnumModel, TestEnum> get ENUM_LIST => $enumList;
+  @override
+  List<TestEnum>? get enumNullableList;
+
+  /// Query field for the [enumNullableList] field.
+  QueryField<String, TestEnumModel, TestEnum> get $enumNullableList =>
+      _queryFields.$enumNullableList;
+
+  /// Query field for the [enumNullableList] field.
+  @Deprecated(r'Use $enumNullableList instead')
+  QueryField<String, TestEnumModel, TestEnum> get ENUM_NULLABLE_LIST =>
+      $enumNullableList;
+  @override
+  List<TestEnum?> get nullableEnumList;
+
+  /// Query field for the [nullableEnumList] field.
+  QueryField<String, TestEnumModel, TestEnum?> get $nullableEnumList =>
+      _queryFields.$nullableEnumList;
+
+  /// Query field for the [nullableEnumList] field.
+  @Deprecated(r'Use $nullableEnumList instead')
+  QueryField<String, TestEnumModel, TestEnum?> get NULLABLE_ENUM_LIST =>
+      $nullableEnumList;
+  @override
+  List<TestEnum?>? get nullableEnumNullableList;
+
+  /// Query field for the [nullableEnumNullableList] field.
+  QueryField<String, TestEnumModel, TestEnum?> get $nullableEnumNullableList =>
+      _queryFields.$nullableEnumNullableList;
+
+  /// Query field for the [nullableEnumNullableList] field.
+  @Deprecated(r'Use $nullableEnumNullableList instead')
+  QueryField<String, TestEnumModel, TestEnum?>
+      get NULLABLE_ENUM_NULLABLE_LIST => $nullableEnumNullableList;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, TestEnumModel, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, TestEnumModel, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, TestEnumModel, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'enumVal':
+        value = enumVal;
+        break;
+      case r'nullableEnumVal':
+        value = nullableEnumVal;
+        break;
+      case r'enumList':
+        value = enumList;
+        break;
+      case r'enumNullableList':
+        value = enumNullableList;
+        break;
+      case r'nullableEnumList':
+        value = nullableEnumList;
+        break;
+      case r'nullableEnumNullableList':
+        value = nullableEnumNullableList;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _TestEnumModel extends TestEnumModel {
+  _TestEnumModel({
+    String? id,
+    required this.enumVal,
+    this.nullableEnumVal,
+    required this.enumList,
+    this.enumNullableList,
+    required this.nullableEnumList,
+    this.nullableEnumNullableList,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _TestEnumModel._({
+    required this.id,
+    required this.enumVal,
+    this.nullableEnumVal,
+    required this.enumList,
+    this.enumNullableList,
+    required this.nullableEnumList,
+    this.nullableEnumNullableList,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final TestEnum enumVal;
+
+  @override
+  final TestEnum? nullableEnumVal;
+
+  @override
+  final List<TestEnum> enumList;
+
+  @override
+  final List<TestEnum>? enumNullableList;
+
+  @override
+  final List<TestEnum?> nullableEnumList;
+
+  @override
+  final List<TestEnum?>? nullableEnumNullableList;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteTestEnumModel extends TestEnumModel
+    implements RemoteModel<String, TestEnumModel> {
+  const RemoteTestEnumModel._() : super._();
+}
+
+class _RemoteTestEnumModel extends RemoteTestEnumModel {
+  const _RemoteTestEnumModel({
+    required this.id,
+    required this.enumVal,
+    this.nullableEnumVal,
+    required this.enumList,
+    this.enumNullableList,
+    required this.nullableEnumList,
+    this.nullableEnumNullableList,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteTestEnumModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final enumVal = json['enumVal'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'enumVal',
+          ))
+        : TestEnum.fromJson((json['enumVal'] as String));
+    final nullableEnumVal = json['nullableEnumVal'] == null
+        ? null
+        : TestEnum.fromJson((json['nullableEnumVal'] as String));
+    final enumList = json['enumList'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'enumList',
+          ))
+        : (json['enumList'] as List<Object?>)
+            .cast<String?>()
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'TestEnumModel',
+                      'enumList',
+                    ))
+                  : TestEnum.fromJson(el),
+            )
+            .toList();
+    final enumNullableList = json['enumNullableList'] == null
+        ? null
+        : (json['enumNullableList'] as List<Object?>)
+            .cast<String?>()
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'TestEnumModel',
+                      'enumNullableList',
+                    ))
+                  : TestEnum.fromJson(el),
+            )
+            .toList();
+    final nullableEnumList = json['nullableEnumList'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'nullableEnumList',
+          ))
+        : (json['nullableEnumList'] as List<Object?>).cast<String?>().toList();
+    final nullableEnumNullableList = json['nullableEnumNullableList'] == null
+        ? null
+        : (json['nullableEnumNullableList'] as List<Object?>)
+            .cast<String?>()
+            .toList();
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'TestEnumModel',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteTestEnumModel(
+      id: id,
+      enumVal: enumVal,
+      nullableEnumVal: nullableEnumVal,
+      enumList: enumList,
+      enumNullableList: enumNullableList,
+      nullableEnumList: nullableEnumList,
+      nullableEnumNullableList: nullableEnumNullableList,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final TestEnum enumVal;
+
+  @override
+  final TestEnum? nullableEnumVal;
+
+  @override
+  final List<TestEnum> enumList;
+
+  @override
+  final List<TestEnum>? enumNullableList;
+
+  @override
+  final List<TestEnum?> nullableEnumList;
+
+  @override
+  final List<TestEnum?>? nullableEnumNullableList;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/test_enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/test_enum_model.dart
@@ -490,6 +490,33 @@ abstract class TestEnumModel extends PartialTestEnumModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, TestEnumModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  TestEnumModel copyWith({
+    String? id,
+    TestEnum? enumVal,
+    TestEnum? nullableEnumVal,
+    List<TestEnum>? enumList,
+    List<TestEnum>? enumNullableList,
+    List<TestEnum?>? nullableEnumList,
+    List<TestEnum?>? nullableEnumNullableList,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _TestEnumModel._(
+      id: id ?? this.id,
+      enumVal: enumVal ?? this.enumVal,
+      nullableEnumVal: nullableEnumVal ?? this.nullableEnumVal,
+      enumList: enumList ?? this.enumList,
+      enumNullableList: enumNullableList ?? this.enumNullableList,
+      nullableEnumList: nullableEnumList ?? this.nullableEnumList,
+      nullableEnumNullableList:
+          nullableEnumNullableList ?? this.nullableEnumNullableList,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, TestEnumModel, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/test_enum_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_nullability/test_enum_model.dart
@@ -174,10 +174,11 @@ abstract class PartialTestEnumModel extends PartialModel<String, TestEnumModel>
         'id': id,
         'enumVal': enumVal?.value,
         'nullableEnumVal': nullableEnumVal?.value,
-        'enumList': enumList,
-        'enumNullableList': enumNullableList,
-        'nullableEnumList': nullableEnumList,
-        'nullableEnumNullableList': nullableEnumNullableList,
+        'enumList': enumList?.map((el) => el.value).toList(),
+        'enumNullableList': enumNullableList?.map((el) => el.value).toList(),
+        'nullableEnumList': nullableEnumList?.map((el) => el?.value).toList(),
+        'nullableEnumNullableList':
+            nullableEnumNullableList?.map((el) => el?.value).toList(),
         'createdAt': createdAt?.format(),
         'updatedAt': updatedAt?.format(),
         'version': version,
@@ -242,11 +243,15 @@ class _PartialTestEnumModel extends PartialTestEnumModel {
             .toList();
     final nullableEnumList = json['nullableEnumList'] == null
         ? null
-        : (json['nullableEnumList'] as List<Object?>).cast<String?>().toList();
+        : (json['nullableEnumList'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TestEnum.fromJson(el))
+            .toList();
     final nullableEnumNullableList = json['nullableEnumNullableList'] == null
         ? null
         : (json['nullableEnumNullableList'] as List<Object?>)
             .cast<String?>()
+            .map((el) => el == null ? null : TestEnum.fromJson(el))
             .toList();
     final createdAt = json['createdAt'] == null
         ? null
@@ -359,11 +364,15 @@ abstract class TestEnumModel extends PartialTestEnumModel
             'TestEnumModel',
             'nullableEnumList',
           ))
-        : (json['nullableEnumList'] as List<Object?>).cast<String?>().toList();
+        : (json['nullableEnumList'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TestEnum.fromJson(el))
+            .toList();
     final nullableEnumNullableList = json['nullableEnumNullableList'] == null
         ? null
         : (json['nullableEnumNullableList'] as List<Object?>)
             .cast<String?>()
+            .map((el) => el == null ? null : TestEnum.fromJson(el))
             .toList();
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
@@ -646,11 +655,15 @@ class _RemoteTestEnumModel extends RemoteTestEnumModel {
             'TestEnumModel',
             'nullableEnumList',
           ))
-        : (json['nullableEnumList'] as List<Object?>).cast<String?>().toList();
+        : (json['nullableEnumList'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TestEnum.fromJson(el))
+            .toList();
     final nullableEnumNullableList = json['nullableEnumNullableList'] == null
         ? null
         : (json['nullableEnumNullableList'] as List<Object?>)
             .cast<String?>()
+            .map((el) => el == null ? null : TestEnum.fromJson(el))
             .toList();
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_type/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_type/model_provider.dart
@@ -1,0 +1,63 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'simple_model.dart';
+
+export 'simple_model.dart';
+export 'status.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '3e9e06e9c1d6b707b3090eb86a1fda02';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [SimpleModel.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'SimpleModel':
+        return (SimpleModel.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_type/simple_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_type/simple_model.dart
@@ -1,0 +1,392 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.simple_model;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'status.dart';
+
+class SimpleModelType
+    extends ModelType<String, SimpleModel, PartialSimpleModel> {
+  const SimpleModelType();
+
+  @override
+  T fromJson<T extends PartialModel<String, SimpleModel>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == SimpleModel || T == Model<String, SimpleModel>) {
+      return SimpleModel.fromJson(json) as T;
+    }
+    if (T == RemoteSimpleModel || T == RemoteModel<String, SimpleModel>) {
+      return _RemoteSimpleModel.fromJson(json) as T;
+    }
+    return _PartialSimpleModel.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'SimpleModel';
+}
+
+class SimpleModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const SimpleModelQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, SimpleModel>? _root;
+
+  /// Query field for the [SimpleModel.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel, String>(
+        const QueryField<String, SimpleModel, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel.status] field.
+  QueryField<ModelIdentifier, M, Status?> get $status =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel, Status?>(
+        const QueryField<String, SimpleModel, Status?>(fieldName: 'status'),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel,
+          TemporalDateTime>(
+        const QueryField<String, SimpleModel, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel,
+          TemporalDateTime>(
+        const QueryField<String, SimpleModel, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel, String>(
+        const QueryField<String, SimpleModel, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialSimpleModel extends PartialModel<String, SimpleModel>
+    with AWSEquatable<PartialSimpleModel> {
+  const PartialSimpleModel._();
+
+  String get id;
+  Status? get status;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  SimpleModelType get modelType => SimpleModel.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        status,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'status': status?.value,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'SimpleModel';
+}
+
+class _PartialSimpleModel extends PartialSimpleModel {
+  const _PartialSimpleModel({
+    required this.id,
+    this.status,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialSimpleModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final status = json['status'] == null
+        ? null
+        : Status.fromJson((json['status'] as String));
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialSimpleModel(
+      id: id,
+      status: status,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final Status? status;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class SimpleModel extends PartialSimpleModel
+    implements Model<String, SimpleModel> {
+  factory SimpleModel({
+    String? id,
+    Status? status,
+  }) = _SimpleModel;
+
+  const SimpleModel._() : super._();
+
+  factory SimpleModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final status = json['status'] == null
+        ? null
+        : Status.fromJson((json['status'] as String));
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _SimpleModel._(
+      id: id,
+      status: status,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const SimpleModelType classType = SimpleModelType();
+
+  static const SimpleModelQueryFields<String, SimpleModel> _queryFields =
+      SimpleModelQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, SimpleModel, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, SimpleModel, String> get ID => $id;
+  @override
+  Status? get status;
+
+  /// Query field for the [status] field.
+  QueryField<String, SimpleModel, Status?> get $status => _queryFields.$status;
+
+  /// Query field for the [status] field.
+  @Deprecated(r'Use $status instead')
+  QueryField<String, SimpleModel, Status?> get STATUS => $status;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, SimpleModel, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, SimpleModel, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, SimpleModel, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'status':
+        value = status;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _SimpleModel extends SimpleModel {
+  _SimpleModel({
+    String? id,
+    this.status,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _SimpleModel._({
+    required this.id,
+    this.status,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final Status? status;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteSimpleModel extends SimpleModel
+    implements RemoteModel<String, SimpleModel> {
+  const RemoteSimpleModel._() : super._();
+}
+
+class _RemoteSimpleModel extends RemoteSimpleModel {
+  const _RemoteSimpleModel({
+    required this.id,
+    this.status,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteSimpleModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final status = json['status'] == null
+        ? null
+        : Status.fromJson((json['status'] as String));
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteSimpleModel(
+      id: id,
+      status: status,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final Status? status;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_type/simple_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_type/simple_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.simple_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'status.dart';
 
@@ -216,6 +217,49 @@ abstract class SimpleModel extends PartialSimpleModel
 
   static const SimpleModelQueryFields<String, SimpleModel> _queryFields =
       SimpleModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'SimpleModel',
+      'pluralName': 'SimpleModels',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'status': {
+          'name': 'status',
+          'type': {'enum': 'Status'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_type/simple_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_type/simple_model.dart
@@ -248,6 +248,22 @@ abstract class SimpleModel extends PartialSimpleModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, SimpleModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  SimpleModel copyWith({
+    String? id,
+    Status? status,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _SimpleModel._(
+      id: id ?? this.id,
+      status: status ?? this.status,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, SimpleModel, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_type/status.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_type/status.dart
@@ -16,7 +16,7 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.status;
 

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_type/status.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/enum_type/status.dart
@@ -1,0 +1,39 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.status;
+
+import 'package:amplify_core/amplify_core.dart';
+
+enum Status with AWSSerializable<String> {
+  yes('yes'),
+  no('no'),
+  maybe('maybe');
+
+  const Status(this.value);
+
+  /// The GraphQL value, as defined in the schema.
+  final String value;
+
+  static Status fromJson(String json) =>
+      values.firstWhere((v) => v.value == json);
+  @override
+  String toJson() => value;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/comment.dart
@@ -319,6 +319,26 @@ abstract class Comment extends PartialComment
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Comment, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Comment copyWith({
+    String? id,
+    String? postId,
+    Post? post,
+    String? content,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Comment._(
+      id: id ?? this.id,
+      postId: postId ?? this.postId,
+      post: post == null ? this.post : AsyncModel.fromModel(post),
+      content: content ?? this.content,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Comment, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/comment.dart
@@ -1,0 +1,508 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.comment;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'post.dart';
+
+class CommentType extends ModelType<String, Comment, PartialComment> {
+  const CommentType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Comment>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Comment || T == Model<String, Comment>) {
+      return Comment.fromJson(json) as T;
+    }
+    if (T == RemoteComment || T == RemoteModel<String, Comment>) {
+      return _RemoteComment.fromJson(json) as T;
+    }
+    return _PartialComment.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Comment';
+}
+
+class CommentQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const CommentQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Comment>? _root;
+
+  /// Query field for the [Comment.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, String>(
+        const QueryField<String, Comment, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.postId] field.
+  QueryField<ModelIdentifier, M, String> get $postId =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, String>(
+        const QueryField<String, Comment, String>(fieldName: 'postID'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.post] field.
+  PostQueryFields<ModelIdentifier, M> get $post => PostQueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Comment, Post>(
+          const QueryField<String, Comment, Post>(fieldName: 'post'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Comment.content] field.
+  QueryField<ModelIdentifier, M, String> get $content =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, String>(
+        const QueryField<String, Comment, String>(fieldName: 'content'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, TemporalDateTime>(
+        const QueryField<String, Comment, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, TemporalDateTime>(
+        const QueryField<String, Comment, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Comment, String>(
+        const QueryField<String, Comment, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialComment extends PartialModel<String, Comment>
+    with AWSEquatable<PartialComment> {
+  const PartialComment._();
+
+  String get id;
+  String? get postId;
+  AsyncModel<String, Post, PartialPost, PartialPost>? get post;
+  String? get content;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  CommentType get modelType => Comment.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        postId,
+        post,
+        content,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'postID': postId,
+        'post': post?.toJson(),
+        'content': content,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Comment';
+}
+
+class _PartialComment extends PartialComment {
+  const _PartialComment({
+    required this.id,
+    this.postId,
+    this.post,
+    this.content,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialComment.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'id',
+          ))
+        : (json['id'] as String);
+    final postId = json['postID'] == null ? null : (json['postID'] as String);
+    final post = json['post'] == null
+        ? null
+        : AsyncModel<String, Post, PartialPost, PartialPost>.fromModel(
+            Post.classType
+                .fromJson<PartialPost>((json['post'] as Map<String, Object?>)),
+          );
+    final content =
+        json['content'] == null ? null : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialComment(
+      id: id,
+      postId: postId,
+      post: post,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? postId;
+
+  @override
+  final AsyncModel<String, Post, PartialPost, PartialPost>? post;
+
+  @override
+  final String? content;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Comment extends PartialComment
+    implements Model<String, Comment> {
+  factory Comment({
+    String? id,
+    required String postId,
+    required Post post,
+    required String content,
+  }) = _Comment;
+
+  const Comment._() : super._();
+
+  factory Comment.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'id',
+          ))
+        : (json['id'] as String);
+    final postId = json['postID'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'postId',
+          ))
+        : (json['postID'] as String);
+    final post = json['post'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'post',
+          ))
+        : AsyncModel<String, Post, PartialPost, Post>.fromModel(
+            Post.classType
+                .fromJson<Post>((json['post'] as Map<String, Object?>)),
+          );
+    final content = json['content'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'content',
+          ))
+        : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Comment._(
+      id: id,
+      postId: postId,
+      post: post,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const CommentType classType = CommentType();
+
+  static const CommentQueryFields<String, Comment> _queryFields =
+      CommentQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Comment, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Comment, String> get ID => $id;
+  @override
+  String get postId;
+
+  /// Query field for the [postId] field.
+  QueryField<String, Comment, String> get $postId => _queryFields.$postId;
+
+  /// Query field for the [postId] field.
+  @Deprecated(r'Use $postId instead')
+  QueryField<String, Comment, String> get POST_ID => $postId;
+  @override
+  AsyncModel<String, Post, PartialPost, Post> get post;
+
+  /// Query field for the [post] field.
+  PostQueryFields<String, Comment> get $post => _queryFields.$post;
+
+  /// Query field for the [post] field.
+  @Deprecated(r'Use $post instead')
+  PostQueryFields<String, Comment> get POST => $post;
+  @override
+  String get content;
+
+  /// Query field for the [content] field.
+  QueryField<String, Comment, String> get $content => _queryFields.$content;
+
+  /// Query field for the [content] field.
+  @Deprecated(r'Use $content instead')
+  QueryField<String, Comment, String> get CONTENT => $content;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Comment, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Comment, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Comment, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'postID':
+        value = postId;
+        break;
+      case r'post':
+        value = post;
+        break;
+      case r'content':
+        value = content;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Comment extends Comment {
+  _Comment({
+    String? id,
+    required this.postId,
+    required Post post,
+    required this.content,
+  })  : id = id ?? uuid(),
+        post = AsyncModel.fromModel(post),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Comment._({
+    required this.id,
+    required this.postId,
+    required this.post,
+    required this.content,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String postId;
+
+  @override
+  final AsyncModel<String, Post, PartialPost, Post> post;
+
+  @override
+  final String content;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteComment extends Comment
+    implements RemoteModel<String, Comment> {
+  const RemoteComment._() : super._();
+}
+
+class _RemoteComment extends RemoteComment {
+  const _RemoteComment({
+    required this.id,
+    required this.postId,
+    required this.post,
+    required this.content,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteComment.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'id',
+          ))
+        : (json['id'] as String);
+    final postId = json['postID'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'postId',
+          ))
+        : (json['postID'] as String);
+    final post = json['post'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'post',
+          ))
+        : AsyncModel<String, Post, PartialPost, RemotePost>.fromModel(
+            Post.classType
+                .fromJson<RemotePost>((json['post'] as Map<String, Object?>)),
+          );
+    final content = json['content'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'content',
+          ))
+        : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteComment(
+      id: id,
+      postId: postId,
+      post: post,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String postId;
+
+  @override
+  final AsyncModel<String, Post, PartialPost, RemotePost> post;
+
+  @override
+  final String content;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/comment.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.comment;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'post.dart';
 
@@ -270,6 +271,79 @@ abstract class Comment extends PartialComment
 
   static const CommentQueryFields<String, Comment> _queryFields =
       CommentQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Comment',
+      'pluralName': 'Comments',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'postID': {
+          'name': 'postID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'post': {
+          'name': 'post',
+          'type': {'model': 'Post'},
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'BelongsTo',
+            'associatedType': 'Post',
+            'targetNames': ['postID'],
+          },
+        },
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'secondary',
+          'primaryField': 'postID',
+          'sortKeyFields': [],
+          'name': 'byPost',
+          'queryField': 'commentsByPostID',
+        },
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'post',
+          'sortKeyFields': ['postID'],
+          'name': 'post',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/comment.dart
@@ -112,7 +112,7 @@ abstract class PartialComment extends PartialModel<String, Comment>
 
   String get id;
   String? get postId;
-  AsyncModel<String, Post, PartialPost, PartialPost>? get post;
+  PartialPost? get post;
   String? get content;
   TemporalDateTime? get createdAt;
   TemporalDateTime? get updatedAt;
@@ -163,12 +163,6 @@ class _PartialComment extends PartialComment {
           ))
         : (json['id'] as String);
     final postId = json['postID'] == null ? null : (json['postID'] as String);
-    final post = json['post'] == null
-        ? null
-        : AsyncModel<String, Post, PartialPost, PartialPost>.fromModel(
-            Post.classType
-                .fromJson<PartialPost>((json['post'] as Map<String, Object?>)),
-          );
     final content =
         json['content'] == null ? null : (json['content'] as String);
     final createdAt = json['createdAt'] == null
@@ -177,6 +171,10 @@ class _PartialComment extends PartialComment {
     final updatedAt = json['updatedAt'] == null
         ? null
         : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final post = json['post'] == null
+        ? null
+        : Post.classType
+            .fromJson<PartialPost>((json['post'] as Map<String, Object?>));
     return _PartialComment(
       id: id,
       postId: postId,
@@ -194,7 +192,7 @@ class _PartialComment extends PartialComment {
   final String? postId;
 
   @override
-  final AsyncModel<String, Post, PartialPost, PartialPost>? post;
+  final PartialPost? post;
 
   @override
   final String? content;
@@ -230,15 +228,6 @@ abstract class Comment extends PartialComment
             'postId',
           ))
         : (json['postID'] as String);
-    final post = json['post'] == null
-        ? (throw ModelFieldError(
-            'Comment',
-            'post',
-          ))
-        : AsyncModel<String, Post, PartialPost, Post>.fromModel(
-            Post.classType
-                .fromJson<Post>((json['post'] as Map<String, Object?>)),
-          );
     final content = json['content'] == null
         ? (throw ModelFieldError(
             'Comment',
@@ -257,6 +246,12 @@ abstract class Comment extends PartialComment
             'updatedAt',
           ))
         : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final post = json['post'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'post',
+          ))
+        : Post.classType.fromJson<Post>((json['post'] as Map<String, Object?>));
     return _Comment._(
       id: id,
       postId: postId,
@@ -364,7 +359,7 @@ abstract class Comment extends PartialComment
   @Deprecated(r'Use $postId instead')
   QueryField<String, Comment, String> get POST_ID => $postId;
   @override
-  AsyncModel<String, Post, PartialPost, Post> get post;
+  Post get post;
 
   /// Query field for the [post] field.
   PostQueryFields<String, Comment> get $post => _queryFields.$post;
@@ -404,7 +399,7 @@ abstract class Comment extends PartialComment
     return _Comment._(
       id: id ?? this.id,
       postId: postId ?? this.postId,
-      post: post == null ? this.post : AsyncModel.fromModel(post),
+      post: post ?? this.post,
       content: content ?? this.content,
       createdAt:
           createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
@@ -448,10 +443,9 @@ class _Comment extends Comment {
   _Comment({
     String? id,
     required this.postId,
-    required Post post,
+    required this.post,
     required this.content,
   })  : id = id ?? uuid(),
-        post = AsyncModel.fromModel(post),
         createdAt = TemporalDateTime.now(),
         updatedAt = TemporalDateTime.now(),
         super._();
@@ -472,7 +466,7 @@ class _Comment extends Comment {
   final String postId;
 
   @override
-  final AsyncModel<String, Post, PartialPost, Post> post;
+  final Post post;
 
   @override
   final String content;
@@ -515,15 +509,6 @@ class _RemoteComment extends RemoteComment {
             'postId',
           ))
         : (json['postID'] as String);
-    final post = json['post'] == null
-        ? (throw ModelFieldError(
-            'Comment',
-            'post',
-          ))
-        : AsyncModel<String, Post, PartialPost, RemotePost>.fromModel(
-            Post.classType
-                .fromJson<RemotePost>((json['post'] as Map<String, Object?>)),
-          );
     final content = json['content'] == null
         ? (throw ModelFieldError(
             'Comment',
@@ -560,6 +545,13 @@ class _RemoteComment extends RemoteComment {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final post = json['post'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'post',
+          ))
+        : Post.classType
+            .fromJson<RemotePost>((json['post'] as Map<String, Object?>));
     return _RemoteComment(
       id: id,
       postId: postId,
@@ -580,7 +572,7 @@ class _RemoteComment extends RemoteComment {
   final String postId;
 
   @override
-  final AsyncModel<String, Post, PartialPost, RemotePost> post;
+  final RemotePost post;
 
   @override
   final String content;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/model_provider.dart
@@ -1,0 +1,70 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'comment.dart';
+import 'post.dart';
+
+export 'comment.dart';
+export 'post.dart';
+export 'post_status.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'c3b90d0e49e68f1e74393d057701301c';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Post.schema,
+        Comment.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Post':
+        return (Post.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Comment':
+        return (Comment.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/post.dart
@@ -1,0 +1,580 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.post;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'comment.dart';
+import 'post_status.dart';
+
+class PostType extends ModelType<String, Post, PartialPost> {
+  const PostType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Post>>(Map<String, Object?> json) {
+    if (T == Post || T == Model<String, Post>) {
+      return Post.fromJson(json) as T;
+    }
+    if (T == RemotePost || T == RemoteModel<String, Post>) {
+      return _RemotePost.fromJson(json) as T;
+    }
+    return _PartialPost.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Post';
+}
+
+class PostQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const PostQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Post>? _root;
+
+  /// Query field for the [Post.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.title] field.
+  QueryField<ModelIdentifier, M, String> get $title =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'title'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.rating] field.
+  QueryField<ModelIdentifier, M, int> get $rating =>
+      NestedQueryField<ModelIdentifier, M, String, Post, int>(
+        const QueryField<String, Post, int>(fieldName: 'rating'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.status] field.
+  QueryField<ModelIdentifier, M, PostStatus> get $status =>
+      NestedQueryField<ModelIdentifier, M, String, Post, PostStatus>(
+        const QueryField<String, Post, PostStatus>(fieldName: 'status'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.comments] field.
+  CommentQueryFields<ModelIdentifier, M> get $comments => CommentQueryFields(
+        NestedQueryField<ModelIdentifier, M, String, Post, Comment>(
+          const QueryField<String, Post, Comment>(fieldName: 'comments'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Post.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post, TemporalDateTime>(
+        const QueryField<String, Post, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post, TemporalDateTime>(
+        const QueryField<String, Post, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialPost extends PartialModel<String, Post>
+    with AWSEquatable<PartialPost> {
+  const PartialPost._();
+
+  String get id;
+  String? get title;
+  int? get rating;
+  PostStatus? get status;
+  AsyncModelCollection<String, Comment, PartialComment, PartialComment>?
+      get comments;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  PostType get modelType => Post.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        rating,
+        status,
+        comments,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'title': title,
+        'rating': rating,
+        'status': status?.value,
+        'comments': comments?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Post';
+}
+
+class _PartialPost extends PartialPost {
+  const _PartialPost({
+    required this.id,
+    this.title,
+    this.rating,
+    this.status,
+    this.comments,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialPost.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null ? null : (json['title'] as String);
+    final rating = json['rating'] == null ? null : (json['rating'] as int);
+    final status = json['status'] == null
+        ? null
+        : PostStatus.fromJson((json['status'] as String));
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment, PartialComment,
+            PartialComment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<PartialComment>(el),
+                )
+                .whereType<PartialComment>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialPost(
+      id: id,
+      title: title,
+      rating: rating,
+      status: status,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? title;
+
+  @override
+  final int? rating;
+
+  @override
+  final PostStatus? status;
+
+  @override
+  final AsyncModelCollection<String, Comment, PartialComment, PartialComment>?
+      comments;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Post extends PartialPost implements Model<String, Post> {
+  factory Post({
+    String? id,
+    required String title,
+    required int rating,
+    required PostStatus status,
+    List<Comment>? comments,
+  }) = _Post;
+
+  const Post._() : super._();
+
+  factory Post.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final rating = json['rating'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'rating',
+          ))
+        : (json['rating'] as int);
+    final status = json['status'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'status',
+          ))
+        : PostStatus.fromJson((json['status'] as String));
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment, PartialComment,
+            Comment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<Comment>(el),
+                )
+                .whereType<Comment>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Post._(
+      id: id,
+      title: title,
+      rating: rating,
+      status: status,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const PostType classType = PostType();
+
+  static const PostQueryFields<String, Post> _queryFields = PostQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Post, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Post, String> get ID => $id;
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<String, Post, String> get $title => _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<String, Post, String> get TITLE => $title;
+  @override
+  int get rating;
+
+  /// Query field for the [rating] field.
+  QueryField<String, Post, int> get $rating => _queryFields.$rating;
+
+  /// Query field for the [rating] field.
+  @Deprecated(r'Use $rating instead')
+  QueryField<String, Post, int> get RATING => $rating;
+  @override
+  PostStatus get status;
+
+  /// Query field for the [status] field.
+  QueryField<String, Post, PostStatus> get $status => _queryFields.$status;
+
+  /// Query field for the [status] field.
+  @Deprecated(r'Use $status instead')
+  QueryField<String, Post, PostStatus> get STATUS => $status;
+  @override
+  AsyncModelCollection<String, Comment, PartialComment, Comment>? get comments;
+
+  /// Query field for the [comments] field.
+  CommentQueryFields<String, Post> get $comments => _queryFields.$comments;
+
+  /// Query field for the [comments] field.
+  @Deprecated(r'Use $comments instead')
+  CommentQueryFields<String, Post> get COMMENTS => $comments;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Post, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Post, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'rating':
+        value = rating;
+        break;
+      case r'status':
+        value = status;
+        break;
+      case r'comments':
+        value = comments;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Post extends Post {
+  _Post({
+    String? id,
+    required this.title,
+    required this.rating,
+    required this.status,
+    List<Comment>? comments,
+  })  : id = id ?? uuid(),
+        comments =
+            comments == null ? null : AsyncModelCollection.fromList(comments),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Post._({
+    required this.id,
+    required this.title,
+    required this.rating,
+    required this.status,
+    this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final int rating;
+
+  @override
+  final PostStatus status;
+
+  @override
+  final AsyncModelCollection<String, Comment, PartialComment, Comment>?
+      comments;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemotePost extends Post implements RemoteModel<String, Post> {
+  const RemotePost._() : super._();
+}
+
+class _RemotePost extends RemotePost {
+  const _RemotePost({
+    required this.id,
+    required this.title,
+    required this.rating,
+    required this.status,
+    this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemotePost.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final rating = json['rating'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'rating',
+          ))
+        : (json['rating'] as int);
+    final status = json['status'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'status',
+          ))
+        : PostStatus.fromJson((json['status'] as String));
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment, PartialComment,
+            RemoteComment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
+                .whereType<RemoteComment>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemotePost(
+      id: id,
+      title: title,
+      rating: rating,
+      status: status,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final int rating;
+
+  @override
+  final PostStatus status;
+
+  @override
+  final AsyncModelCollection<String, Comment, PartialComment, RemoteComment>?
+      comments;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/post.dart
@@ -178,6 +178,12 @@ class _PartialPost extends PartialPost {
     final status = json['status'] == null
         ? null
         : PostStatus.fromJson((json['status'] as String));
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<String, Comment, PartialComment,
@@ -192,12 +198,6 @@ class _PartialPost extends PartialPost {
                 .whereType<PartialComment>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
     return _PartialPost(
       id: id,
       title: title,
@@ -268,6 +268,18 @@ abstract class Post extends PartialPost implements Model<String, Post> {
             'status',
           ))
         : PostStatus.fromJson((json['status'] as String));
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<String, Comment, PartialComment,
@@ -282,18 +294,6 @@ abstract class Post extends PartialPost implements Model<String, Post> {
                 .whereType<Comment>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? (throw ModelFieldError(
-            'Post',
-            'createdAt',
-          ))
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? (throw ModelFieldError(
-            'Post',
-            'updatedAt',
-          ))
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
     return _Post._(
       id: id,
       title: title,
@@ -582,20 +582,6 @@ class _RemotePost extends RemotePost {
             'status',
           ))
         : PostStatus.fromJson((json['status'] as String));
-    final comments = json['comments'] == null
-        ? null
-        : AsyncModelCollection<String, Comment, PartialComment,
-            RemoteComment>.fromList(
-            (json['comments'] as List<Object?>)
-                .cast<Map<String, Object?>?>()
-                .map(
-                  (el) => el == null
-                      ? null
-                      : Comment.classType.fromJson<RemoteComment>(el),
-                )
-                .whereType<RemoteComment>()
-                .toList(),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Post',
@@ -626,6 +612,20 @@ class _RemotePost extends RemotePost {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<String, Comment, PartialComment,
+            RemoteComment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
+                .whereType<RemoteComment>()
+                .toList(),
+          );
     return _RemotePost(
       id: id,
       title: title,
@@ -653,7 +653,7 @@ class _RemotePost extends RemotePost {
   final PostStatus status;
 
   @override
-  final AsyncModelCollection<String, Comment, PartialComment, RemoteComment>?
+  final AsyncModelCollection<String, Comment, PartialComment, Comment>?
       comments;
 
   @override

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/post.dart
@@ -365,6 +365,30 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Post, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Post copyWith({
+    String? id,
+    String? title,
+    int? rating,
+    PostStatus? status,
+    List<Comment>? comments,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Post._(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      rating: rating ?? this.rating,
+      status: status ?? this.status,
+      comments: comments == null
+          ? this.comments
+          : AsyncModelCollection.fromList(comments),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/post.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'comment.dart';
 import 'post_status.dart';
@@ -307,6 +308,74 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   static const PostType classType = PostType();
 
   static const PostQueryFields<String, Post> _queryFields = PostQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post',
+      'pluralName': 'Posts',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'rating': {
+          'name': 'rating',
+          'type': {'scalar': 'Int'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'status': {
+          'name': 'status',
+          'type': {'enum': 'PostStatus'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'comments': {
+          'name': 'comments',
+          'type': {
+            'list': {'model': 'Comment'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Comment',
+            'associatedFields': ['post'],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/post_status.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/post_status.dart
@@ -16,7 +16,7 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post_status;
 

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/post_status.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_index/post_status.dart
@@ -1,0 +1,38 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.post_status;
+
+import 'package:amplify_core/amplify_core.dart';
+
+enum PostStatus with AWSSerializable<String> {
+  active('ACTIVE'),
+  inactive('INACTIVE');
+
+  const PostStatus(this.value);
+
+  /// The GraphQL value, as defined in the schema.
+  final String value;
+
+  static PostStatus fromJson(String json) =>
+      values.firstWhere((v) => v.value == json);
+  @override
+  String toJson() => value;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/comment.dart
@@ -361,6 +361,26 @@ abstract class Comment extends PartialComment
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<CommentIdentifier, Comment, CommentIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  Comment copyWith({
+    String? id,
+    String? content,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? postCommentsId,
+    String? postCommentsTitle,
+  }) {
+    return _Comment._(
+      id: id ?? this.id,
+      content: content ?? this.content,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      postCommentsId: postCommentsId ?? this.postCommentsId,
+      postCommentsTitle: postCommentsTitle ?? this.postCommentsTitle,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<CommentIdentifier, Comment, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/comment.dart
@@ -1,0 +1,542 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.comment;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:meta/meta.dart';
+
+@immutable
+class CommentIdentifier
+    with
+        AWSEquatable<CommentIdentifier>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  const CommentIdentifier({
+    required this.id,
+    required this.content,
+  });
+
+  final String id;
+
+  final String content;
+
+  @override
+  List<Object?> get props => [
+        id,
+        content,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'content': content,
+      };
+  @override
+  String get runtimeTypeName => 'CommentIdentifier';
+}
+
+class CommentType
+    extends ModelType<CommentIdentifier, Comment, PartialComment> {
+  const CommentType();
+
+  @override
+  T fromJson<T extends PartialModel<CommentIdentifier, Comment>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Comment || T == Model<CommentIdentifier, Comment>) {
+      return Comment.fromJson(json) as T;
+    }
+    if (T == RemoteComment || T == RemoteModel<CommentIdentifier, Comment>) {
+      return _RemoteComment.fromJson(json) as T;
+    }
+    return _PartialComment.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Comment';
+}
+
+class CommentQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const CommentQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Comment>? _root;
+
+  /// Query field for the [Comment.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
+        const QueryField<CommentIdentifier, Comment, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.content] field.
+  QueryField<ModelIdentifier, M, String> get $content =>
+      NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String>(
+        const QueryField<CommentIdentifier, Comment, String>(
+          fieldName: 'content',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
+          TemporalDateTime>(
+        const QueryField<CommentIdentifier, Comment, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
+          TemporalDateTime>(
+        const QueryField<CommentIdentifier, Comment, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.postCommentsId] field.
+  QueryField<ModelIdentifier, M, String?> get $postCommentsId =>
+      NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String?>(
+        const QueryField<CommentIdentifier, Comment, String?>(
+          fieldName: 'postCommentsId',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment.postCommentsTitle] field.
+  QueryField<ModelIdentifier, M, String?> get $postCommentsTitle =>
+      NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment, String?>(
+        const QueryField<CommentIdentifier, Comment, String?>(
+          fieldName: 'postCommentsTitle',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Comment] model identifier.
+  QueryField<ModelIdentifier, M, CommentIdentifier> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, CommentIdentifier, Comment,
+          CommentIdentifier>(
+        const QueryField<CommentIdentifier, Comment, CommentIdentifier>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialComment extends PartialModel<CommentIdentifier, Comment>
+    with AWSEquatable<PartialComment> {
+  const PartialComment._();
+
+  String get id;
+  String get content;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String? get postCommentsId;
+  String? get postCommentsTitle;
+  @override
+  CommentIdentifier get modelIdentifier => CommentIdentifier(
+        id: id,
+        content: content,
+      );
+  @override
+  CommentType get modelType => Comment.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        content,
+        createdAt,
+        updatedAt,
+        postCommentsId,
+        postCommentsTitle,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'content': content,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'postCommentsId': postCommentsId,
+        'postCommentsTitle': postCommentsTitle,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Comment';
+}
+
+class _PartialComment extends PartialComment {
+  const _PartialComment({
+    required this.id,
+    required this.content,
+    this.createdAt,
+    this.updatedAt,
+    this.postCommentsId,
+    this.postCommentsTitle,
+  }) : super._();
+
+  factory _PartialComment.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'id',
+          ))
+        : (json['id'] as String);
+    final content = json['content'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'content',
+          ))
+        : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final postCommentsId = json['postCommentsId'] == null
+        ? null
+        : (json['postCommentsId'] as String);
+    final postCommentsTitle = json['postCommentsTitle'] == null
+        ? null
+        : (json['postCommentsTitle'] as String);
+    return _PartialComment(
+      id: id,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      postCommentsId: postCommentsId,
+      postCommentsTitle: postCommentsTitle,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String content;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String? postCommentsId;
+
+  @override
+  final String? postCommentsTitle;
+}
+
+abstract class Comment extends PartialComment
+    implements Model<CommentIdentifier, Comment> {
+  factory Comment({
+    String? id,
+    required String content,
+    String? postCommentsId,
+    String? postCommentsTitle,
+  }) = _Comment;
+
+  const Comment._() : super._();
+
+  factory Comment.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'id',
+          ))
+        : (json['id'] as String);
+    final content = json['content'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'content',
+          ))
+        : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final postCommentsId = json['postCommentsId'] == null
+        ? null
+        : (json['postCommentsId'] as String);
+    final postCommentsTitle = json['postCommentsTitle'] == null
+        ? null
+        : (json['postCommentsTitle'] as String);
+    return _Comment._(
+      id: id,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      postCommentsId: postCommentsId,
+      postCommentsTitle: postCommentsTitle,
+    );
+  }
+
+  static const CommentType classType = CommentType();
+
+  static const CommentQueryFields<CommentIdentifier, Comment> _queryFields =
+      CommentQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<CommentIdentifier, Comment, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<CommentIdentifier, Comment, String> get ID => $id;
+  @override
+  String get content;
+
+  /// Query field for the [content] field.
+  QueryField<CommentIdentifier, Comment, String> get $content =>
+      _queryFields.$content;
+
+  /// Query field for the [content] field.
+  @Deprecated(r'Use $content instead')
+  QueryField<CommentIdentifier, Comment, String> get CONTENT => $content;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String? get postCommentsId;
+
+  /// Query field for the [postCommentsId] field.
+  QueryField<CommentIdentifier, Comment, String?> get $postCommentsId =>
+      _queryFields.$postCommentsId;
+
+  /// Query field for the [postCommentsId] field.
+  @Deprecated(r'Use $postCommentsId instead')
+  QueryField<CommentIdentifier, Comment, String?> get POST_COMMENTS_ID =>
+      $postCommentsId;
+  @override
+  String? get postCommentsTitle;
+
+  /// Query field for the [postCommentsTitle] field.
+  QueryField<CommentIdentifier, Comment, String?> get $postCommentsTitle =>
+      _queryFields.$postCommentsTitle;
+
+  /// Query field for the [postCommentsTitle] field.
+  @Deprecated(r'Use $postCommentsTitle instead')
+  QueryField<CommentIdentifier, Comment, String?> get POST_COMMENTS_TITLE =>
+      $postCommentsTitle;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<CommentIdentifier, Comment, CommentIdentifier>
+      get $modelIdentifier => _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<CommentIdentifier, Comment, CommentIdentifier>
+      get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<CommentIdentifier, Comment, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'content':
+        value = content;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'postCommentsId':
+        value = postCommentsId;
+        break;
+      case r'postCommentsTitle':
+        value = postCommentsTitle;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Comment extends Comment {
+  _Comment({
+    String? id,
+    required this.content,
+    this.postCommentsId,
+    this.postCommentsTitle,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Comment._({
+    required this.id,
+    required this.content,
+    required this.createdAt,
+    required this.updatedAt,
+    this.postCommentsId,
+    this.postCommentsTitle,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String content;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? postCommentsId;
+
+  @override
+  final String? postCommentsTitle;
+}
+
+abstract class RemoteComment extends Comment
+    implements RemoteModel<CommentIdentifier, Comment> {
+  const RemoteComment._() : super._();
+}
+
+class _RemoteComment extends RemoteComment {
+  const _RemoteComment({
+    required this.id,
+    required this.content,
+    required this.createdAt,
+    required this.updatedAt,
+    this.postCommentsId,
+    this.postCommentsTitle,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteComment.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'id',
+          ))
+        : (json['id'] as String);
+    final content = json['content'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'content',
+          ))
+        : (json['content'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final postCommentsId = json['postCommentsId'] == null
+        ? null
+        : (json['postCommentsId'] as String);
+    final postCommentsTitle = json['postCommentsTitle'] == null
+        ? null
+        : (json['postCommentsTitle'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Comment',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteComment(
+      id: id,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      postCommentsId: postCommentsId,
+      postCommentsTitle: postCommentsTitle,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String content;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String? postCommentsId;
+
+  @override
+  final String? postCommentsTitle;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/comment.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/comment.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.comment;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 @immutable
@@ -306,6 +307,70 @@ abstract class Comment extends PartialComment
 
   static const CommentQueryFields<CommentIdentifier, Comment> _queryFields =
       CommentQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Comment',
+      'pluralName': 'Comments',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'content': {
+          'name': 'content',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'postCommentsId': {
+          'name': 'postCommentsId',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'postCommentsTitle': {
+          'name': 'postCommentsTitle',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': ['content'],
+        },
+        {
+          'type': 'foreign',
+          'primaryField': 'Post.comments',
+          'sortKeyFields': [
+            'postCommentsId',
+            'postCommentsTitle',
+          ],
+          'name': 'gsi-Post.comments',
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/model_provider.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'comment.dart';
+import 'post.dart';
+
+export 'comment.dart';
+export 'post.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '778dc5a4d3522530ecfa01448b375146';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        Post.schema,
+        Comment.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Post':
+        return (Post.classType as ModelType<ModelIdentifier, M, P>);
+      case 'Comment':
+        return (Comment.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/post.dart
@@ -197,6 +197,12 @@ class _PartialPost extends PartialPost {
             'title',
           ))
         : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
@@ -211,12 +217,6 @@ class _PartialPost extends PartialPost {
                 .whereType<PartialComment>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? null
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
     return _PartialPost(
       id: id,
       title: title,
@@ -265,6 +265,18 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
             'title',
           ))
         : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
     final comments = json['comments'] == null
         ? null
         : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
@@ -279,18 +291,6 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
                 .whereType<Comment>()
                 .toList(),
           );
-    final createdAt = json['createdAt'] == null
-        ? (throw ModelFieldError(
-            'Post',
-            'createdAt',
-          ))
-        : TemporalDateTime.fromString((json['createdAt'] as String));
-    final updatedAt = json['updatedAt'] == null
-        ? (throw ModelFieldError(
-            'Post',
-            'updatedAt',
-          ))
-        : TemporalDateTime.fromString((json['updatedAt'] as String));
     return _Post._(
       id: id,
       title: title,
@@ -521,20 +521,6 @@ class _RemotePost extends RemotePost {
             'title',
           ))
         : (json['title'] as String);
-    final comments = json['comments'] == null
-        ? null
-        : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-            RemoteComment>.fromList(
-            (json['comments'] as List<Object?>)
-                .cast<Map<String, Object?>?>()
-                .map(
-                  (el) => el == null
-                      ? null
-                      : Comment.classType.fromJson<RemoteComment>(el),
-                )
-                .whereType<RemoteComment>()
-                .toList(),
-          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'Post',
@@ -565,6 +551,20 @@ class _RemotePost extends RemotePost {
             'lastChangedAt',
           ))
         : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
+            RemoteComment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
+                .whereType<RemoteComment>()
+                .toList(),
+          );
     return _RemotePost(
       id: id,
       title: title,
@@ -585,7 +585,7 @@ class _RemotePost extends RemotePost {
 
   @override
   final AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
-      RemoteComment>? comments;
+      Comment>? comments;
 
   @override
   final TemporalDateTime createdAt;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/post.dart
@@ -346,6 +346,26 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<PostIdentifier, Post, PostIdentifier> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  Post copyWith({
+    String? id,
+    String? title,
+    List<Comment>? comments,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Post._(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      comments: comments == null
+          ? this.comments
+          : AsyncModelCollection.fromList(comments),
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/post.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 import 'comment.dart';
@@ -303,6 +304,65 @@ abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
 
   static const PostQueryFields<PostIdentifier, Post> _queryFields =
       PostQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post',
+      'pluralName': 'Posts',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'comments': {
+          'name': 'comments',
+          'type': {
+            'list': {'model': 'Comment'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+          'association': {
+            'associationType': 'HasMany',
+            'associatedType': 'Comment',
+            'associatedFields': [
+              'postCommentsId',
+              'postCommentsTitle',
+            ],
+          },
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': ['title'],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/has_many_uni/post.dart
@@ -1,0 +1,524 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.post;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:meta/meta.dart';
+
+import 'comment.dart';
+
+@immutable
+class PostIdentifier
+    with
+        AWSEquatable<PostIdentifier>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  const PostIdentifier({
+    required this.id,
+    required this.title,
+  });
+
+  final String id;
+
+  final String title;
+
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'title': title,
+      };
+  @override
+  String get runtimeTypeName => 'PostIdentifier';
+}
+
+class PostType extends ModelType<PostIdentifier, Post, PartialPost> {
+  const PostType();
+
+  @override
+  T fromJson<T extends PartialModel<PostIdentifier, Post>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == Post || T == Model<PostIdentifier, Post>) {
+      return Post.fromJson(json) as T;
+    }
+    if (T == RemotePost || T == RemoteModel<PostIdentifier, Post>) {
+      return _RemotePost.fromJson(json) as T;
+    }
+    return _PartialPost.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Post';
+}
+
+class PostQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const PostQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Post>? _root;
+
+  /// Query field for the [Post.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, PostIdentifier, Post, String>(
+        const QueryField<PostIdentifier, Post, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.title] field.
+  QueryField<ModelIdentifier, M, String> get $title =>
+      NestedQueryField<ModelIdentifier, M, PostIdentifier, Post, String>(
+        const QueryField<PostIdentifier, Post, String>(fieldName: 'title'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.comments] field.
+  CommentQueryFields<ModelIdentifier, M> get $comments => CommentQueryFields(
+        NestedQueryField<ModelIdentifier, M, PostIdentifier, Post, Comment>(
+          const QueryField<PostIdentifier, Post, Comment>(
+              fieldName: 'comments'),
+          root: _root,
+        ),
+      );
+
+  /// Query field for the [Post.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
+          TemporalDateTime>(
+        const QueryField<PostIdentifier, Post, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
+          TemporalDateTime>(
+        const QueryField<PostIdentifier, Post, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post] model identifier.
+  QueryField<ModelIdentifier, M, PostIdentifier> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, PostIdentifier, Post,
+          PostIdentifier>(
+        const QueryField<PostIdentifier, Post, PostIdentifier>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialPost extends PartialModel<PostIdentifier, Post>
+    with AWSEquatable<PartialPost> {
+  const PartialPost._();
+
+  String get id;
+  String get title;
+  AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
+      PartialComment>? get comments;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  PostIdentifier get modelIdentifier => PostIdentifier(
+        id: id,
+        title: title,
+      );
+  @override
+  PostType get modelType => Post.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        comments,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'title': title,
+        'comments': comments?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Post';
+}
+
+class _PartialPost extends PartialPost {
+  const _PartialPost({
+    required this.id,
+    required this.title,
+    this.comments,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialPost.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
+            PartialComment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<PartialComment>(el),
+                )
+                .whereType<PartialComment>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialPost(
+      id: id,
+      title: title,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
+      PartialComment>? comments;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Post extends PartialPost implements Model<PostIdentifier, Post> {
+  factory Post({
+    String? id,
+    required String title,
+    List<Comment>? comments,
+  }) = _Post;
+
+  const Post._() : super._();
+
+  factory Post.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
+            Comment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<Comment>(el),
+                )
+                .whereType<Comment>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Post._(
+      id: id,
+      title: title,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const PostType classType = PostType();
+
+  static const PostQueryFields<PostIdentifier, Post> _queryFields =
+      PostQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<PostIdentifier, Post, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<PostIdentifier, Post, String> get ID => $id;
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<PostIdentifier, Post, String> get $title => _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<PostIdentifier, Post, String> get TITLE => $title;
+  @override
+  AsyncModelCollection<CommentIdentifier, Comment, PartialComment, Comment>?
+      get comments;
+
+  /// Query field for the [comments] field.
+  CommentQueryFields<PostIdentifier, Post> get $comments =>
+      _queryFields.$comments;
+
+  /// Query field for the [comments] field.
+  @Deprecated(r'Use $comments instead')
+  CommentQueryFields<PostIdentifier, Post> get COMMENTS => $comments;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<PostIdentifier, Post, PostIdentifier> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<PostIdentifier, Post, PostIdentifier> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<PostIdentifier, Post, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'comments':
+        value = comments;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Post extends Post {
+  _Post({
+    String? id,
+    required this.title,
+    List<Comment>? comments,
+  })  : id = id ?? uuid(),
+        comments =
+            comments == null ? null : AsyncModelCollection.fromList(comments),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Post._({
+    required this.id,
+    required this.title,
+    this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
+      Comment>? comments;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemotePost extends Post
+    implements RemoteModel<PostIdentifier, Post> {
+  const RemotePost._() : super._();
+}
+
+class _RemotePost extends RemotePost {
+  const _RemotePost({
+    required this.id,
+    required this.title,
+    this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemotePost.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final comments = json['comments'] == null
+        ? null
+        : AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
+            RemoteComment>.fromList(
+            (json['comments'] as List<Object?>)
+                .cast<Map<String, Object?>?>()
+                .map(
+                  (el) => el == null
+                      ? null
+                      : Comment.classType.fromJson<RemoteComment>(el),
+                )
+                .whereType<RemoteComment>()
+                .toList(),
+          );
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemotePost(
+      id: id,
+      title: title,
+      comments: comments,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final AsyncModelCollection<CommentIdentifier, Comment, PartialComment,
+      RemoteComment>? comments;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/list_nullability/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/list_nullability/model_provider.dart
@@ -1,0 +1,62 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'test_model.dart';
+
+export 'test_model.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '4ea0bbc3c998b0db630c43660b73dd3c';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [TestModel.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'TestModel':
+        return (TestModel.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/list_nullability/test_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/list_nullability/test_model.dart
@@ -1,0 +1,727 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.test_model;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class TestModelType extends ModelType<String, TestModel, PartialTestModel> {
+  const TestModelType();
+
+  @override
+  T fromJson<T extends PartialModel<String, TestModel>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == TestModel || T == Model<String, TestModel>) {
+      return TestModel.fromJson(json) as T;
+    }
+    if (T == RemoteTestModel || T == RemoteModel<String, TestModel>) {
+      return _RemoteTestModel.fromJson(json) as T;
+    }
+    return _PartialTestModel.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'TestModel';
+}
+
+class TestModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const TestModelQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, TestModel>? _root;
+
+  /// Query field for the [TestModel.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, TestModel, String>(
+        const QueryField<String, TestModel, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [TestModel.floatVal] field.
+  QueryField<ModelIdentifier, M, double> get $floatVal =>
+      NestedQueryField<ModelIdentifier, M, String, TestModel, double>(
+        const QueryField<String, TestModel, double>(fieldName: 'floatVal'),
+        root: _root,
+      );
+
+  /// Query field for the [TestModel.floatNullableVal] field.
+  QueryField<ModelIdentifier, M, double?> get $floatNullableVal =>
+      NestedQueryField<ModelIdentifier, M, String, TestModel, double?>(
+        const QueryField<String, TestModel, double?>(
+          fieldName: 'floatNullableVal',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestModel.floatList] field.
+  QueryField<ModelIdentifier, M, double> get $floatList =>
+      NestedQueryField<ModelIdentifier, M, String, TestModel, double>(
+        const QueryField<String, TestModel, double>(fieldName: 'floatList'),
+        root: _root,
+      );
+
+  /// Query field for the [TestModel.floatNullableList] field.
+  QueryField<ModelIdentifier, M, double> get $floatNullableList =>
+      NestedQueryField<ModelIdentifier, M, String, TestModel, double>(
+        const QueryField<String, TestModel, double>(
+          fieldName: 'floatNullableList',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestModel.nullableFloatList] field.
+  QueryField<ModelIdentifier, M, double?> get $nullableFloatList =>
+      NestedQueryField<ModelIdentifier, M, String, TestModel, double?>(
+        const QueryField<String, TestModel, double?>(
+          fieldName: 'nullableFloatList',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestModel.nullableFloatNullableList] field.
+  QueryField<ModelIdentifier, M, double?> get $nullableFloatNullableList =>
+      NestedQueryField<ModelIdentifier, M, String, TestModel, double?>(
+        const QueryField<String, TestModel, double?>(
+          fieldName: 'nullableFloatNullableList',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, TestModel, TemporalDateTime>(
+        const QueryField<String, TestModel, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, TestModel, TemporalDateTime>(
+        const QueryField<String, TestModel, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TestModel] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, TestModel, String>(
+        const QueryField<String, TestModel, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialTestModel extends PartialModel<String, TestModel>
+    with AWSEquatable<PartialTestModel> {
+  const PartialTestModel._();
+
+  String get id;
+  double? get floatVal;
+  double? get floatNullableVal;
+  List<double>? get floatList;
+  List<double>? get floatNullableList;
+  List<double?>? get nullableFloatList;
+  List<double?>? get nullableFloatNullableList;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  TestModelType get modelType => TestModel.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        floatVal,
+        floatNullableVal,
+        floatList,
+        floatNullableList,
+        nullableFloatList,
+        nullableFloatNullableList,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'floatVal': floatVal,
+        'floatNullableVal': floatNullableVal,
+        'floatList': floatList,
+        'floatNullableList': floatNullableList,
+        'nullableFloatList': nullableFloatList,
+        'nullableFloatNullableList': nullableFloatNullableList,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'TestModel';
+}
+
+class _PartialTestModel extends PartialTestModel {
+  const _PartialTestModel({
+    required this.id,
+    this.floatVal,
+    this.floatNullableVal,
+    this.floatList,
+    this.floatNullableList,
+    this.nullableFloatList,
+    this.nullableFloatNullableList,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialTestModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final floatVal =
+        json['floatVal'] == null ? null : (json['floatVal'] as double);
+    final floatNullableVal = json['floatNullableVal'] == null
+        ? null
+        : (json['floatNullableVal'] as double);
+    final floatList = json['floatList'] == null
+        ? null
+        : (json['floatList'] as List<Object?>)
+            .cast<double?>()
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'TestModel',
+                    'floatList',
+                  )),
+            )
+            .toList();
+    final floatNullableList = json['floatNullableList'] == null
+        ? null
+        : (json['floatNullableList'] as List<Object?>)
+            .cast<double?>()
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'TestModel',
+                    'floatNullableList',
+                  )),
+            )
+            .toList();
+    final nullableFloatList = json['nullableFloatList'] == null
+        ? null
+        : (json['nullableFloatList'] as List<Object?>).cast<double?>().toList();
+    final nullableFloatNullableList = json['nullableFloatNullableList'] == null
+        ? null
+        : (json['nullableFloatNullableList'] as List<Object?>)
+            .cast<double?>()
+            .toList();
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialTestModel(
+      id: id,
+      floatVal: floatVal,
+      floatNullableVal: floatNullableVal,
+      floatList: floatList,
+      floatNullableList: floatNullableList,
+      nullableFloatList: nullableFloatList,
+      nullableFloatNullableList: nullableFloatNullableList,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final double? floatVal;
+
+  @override
+  final double? floatNullableVal;
+
+  @override
+  final List<double>? floatList;
+
+  @override
+  final List<double>? floatNullableList;
+
+  @override
+  final List<double?>? nullableFloatList;
+
+  @override
+  final List<double?>? nullableFloatNullableList;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class TestModel extends PartialTestModel
+    implements Model<String, TestModel> {
+  factory TestModel({
+    String? id,
+    required double floatVal,
+    double? floatNullableVal,
+    required List<double> floatList,
+    List<double>? floatNullableList,
+    required List<double?> nullableFloatList,
+    List<double?>? nullableFloatNullableList,
+  }) = _TestModel;
+
+  const TestModel._() : super._();
+
+  factory TestModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final floatVal = json['floatVal'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'floatVal',
+          ))
+        : (json['floatVal'] as double);
+    final floatNullableVal = json['floatNullableVal'] == null
+        ? null
+        : (json['floatNullableVal'] as double);
+    final floatList = json['floatList'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'floatList',
+          ))
+        : (json['floatList'] as List<Object?>)
+            .cast<double?>()
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'TestModel',
+                    'floatList',
+                  )),
+            )
+            .toList();
+    final floatNullableList = json['floatNullableList'] == null
+        ? null
+        : (json['floatNullableList'] as List<Object?>)
+            .cast<double?>()
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'TestModel',
+                    'floatNullableList',
+                  )),
+            )
+            .toList();
+    final nullableFloatList = json['nullableFloatList'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'nullableFloatList',
+          ))
+        : (json['nullableFloatList'] as List<Object?>).cast<double?>().toList();
+    final nullableFloatNullableList = json['nullableFloatNullableList'] == null
+        ? null
+        : (json['nullableFloatNullableList'] as List<Object?>)
+            .cast<double?>()
+            .toList();
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _TestModel._(
+      id: id,
+      floatVal: floatVal,
+      floatNullableVal: floatNullableVal,
+      floatList: floatList,
+      floatNullableList: floatNullableList,
+      nullableFloatList: nullableFloatList,
+      nullableFloatNullableList: nullableFloatNullableList,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const TestModelType classType = TestModelType();
+
+  static const TestModelQueryFields<String, TestModel> _queryFields =
+      TestModelQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, TestModel, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, TestModel, String> get ID => $id;
+  @override
+  double get floatVal;
+
+  /// Query field for the [floatVal] field.
+  QueryField<String, TestModel, double> get $floatVal => _queryFields.$floatVal;
+
+  /// Query field for the [floatVal] field.
+  @Deprecated(r'Use $floatVal instead')
+  QueryField<String, TestModel, double> get FLOAT_VAL => $floatVal;
+  @override
+  double? get floatNullableVal;
+
+  /// Query field for the [floatNullableVal] field.
+  QueryField<String, TestModel, double?> get $floatNullableVal =>
+      _queryFields.$floatNullableVal;
+
+  /// Query field for the [floatNullableVal] field.
+  @Deprecated(r'Use $floatNullableVal instead')
+  QueryField<String, TestModel, double?> get FLOAT_NULLABLE_VAL =>
+      $floatNullableVal;
+  @override
+  List<double> get floatList;
+
+  /// Query field for the [floatList] field.
+  QueryField<String, TestModel, double> get $floatList =>
+      _queryFields.$floatList;
+
+  /// Query field for the [floatList] field.
+  @Deprecated(r'Use $floatList instead')
+  QueryField<String, TestModel, double> get FLOAT_LIST => $floatList;
+  @override
+  List<double>? get floatNullableList;
+
+  /// Query field for the [floatNullableList] field.
+  QueryField<String, TestModel, double> get $floatNullableList =>
+      _queryFields.$floatNullableList;
+
+  /// Query field for the [floatNullableList] field.
+  @Deprecated(r'Use $floatNullableList instead')
+  QueryField<String, TestModel, double> get FLOAT_NULLABLE_LIST =>
+      $floatNullableList;
+  @override
+  List<double?> get nullableFloatList;
+
+  /// Query field for the [nullableFloatList] field.
+  QueryField<String, TestModel, double?> get $nullableFloatList =>
+      _queryFields.$nullableFloatList;
+
+  /// Query field for the [nullableFloatList] field.
+  @Deprecated(r'Use $nullableFloatList instead')
+  QueryField<String, TestModel, double?> get NULLABLE_FLOAT_LIST =>
+      $nullableFloatList;
+  @override
+  List<double?>? get nullableFloatNullableList;
+
+  /// Query field for the [nullableFloatNullableList] field.
+  QueryField<String, TestModel, double?> get $nullableFloatNullableList =>
+      _queryFields.$nullableFloatNullableList;
+
+  /// Query field for the [nullableFloatNullableList] field.
+  @Deprecated(r'Use $nullableFloatNullableList instead')
+  QueryField<String, TestModel, double?> get NULLABLE_FLOAT_NULLABLE_LIST =>
+      $nullableFloatNullableList;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, TestModel, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, TestModel, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, TestModel, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'floatVal':
+        value = floatVal;
+        break;
+      case r'floatNullableVal':
+        value = floatNullableVal;
+        break;
+      case r'floatList':
+        value = floatList;
+        break;
+      case r'floatNullableList':
+        value = floatNullableList;
+        break;
+      case r'nullableFloatList':
+        value = nullableFloatList;
+        break;
+      case r'nullableFloatNullableList':
+        value = nullableFloatNullableList;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _TestModel extends TestModel {
+  _TestModel({
+    String? id,
+    required this.floatVal,
+    this.floatNullableVal,
+    required this.floatList,
+    this.floatNullableList,
+    required this.nullableFloatList,
+    this.nullableFloatNullableList,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _TestModel._({
+    required this.id,
+    required this.floatVal,
+    this.floatNullableVal,
+    required this.floatList,
+    this.floatNullableList,
+    required this.nullableFloatList,
+    this.nullableFloatNullableList,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final double floatVal;
+
+  @override
+  final double? floatNullableVal;
+
+  @override
+  final List<double> floatList;
+
+  @override
+  final List<double>? floatNullableList;
+
+  @override
+  final List<double?> nullableFloatList;
+
+  @override
+  final List<double?>? nullableFloatNullableList;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteTestModel extends TestModel
+    implements RemoteModel<String, TestModel> {
+  const RemoteTestModel._() : super._();
+}
+
+class _RemoteTestModel extends RemoteTestModel {
+  const _RemoteTestModel({
+    required this.id,
+    required this.floatVal,
+    this.floatNullableVal,
+    required this.floatList,
+    this.floatNullableList,
+    required this.nullableFloatList,
+    this.nullableFloatNullableList,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteTestModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final floatVal = json['floatVal'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'floatVal',
+          ))
+        : (json['floatVal'] as double);
+    final floatNullableVal = json['floatNullableVal'] == null
+        ? null
+        : (json['floatNullableVal'] as double);
+    final floatList = json['floatList'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'floatList',
+          ))
+        : (json['floatList'] as List<Object?>)
+            .cast<double?>()
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'TestModel',
+                    'floatList',
+                  )),
+            )
+            .toList();
+    final floatNullableList = json['floatNullableList'] == null
+        ? null
+        : (json['floatNullableList'] as List<Object?>)
+            .cast<double?>()
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'TestModel',
+                    'floatNullableList',
+                  )),
+            )
+            .toList();
+    final nullableFloatList = json['nullableFloatList'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'nullableFloatList',
+          ))
+        : (json['nullableFloatList'] as List<Object?>).cast<double?>().toList();
+    final nullableFloatNullableList = json['nullableFloatNullableList'] == null
+        ? null
+        : (json['nullableFloatNullableList'] as List<Object?>)
+            .cast<double?>()
+            .toList();
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'TestModel',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteTestModel(
+      id: id,
+      floatVal: floatVal,
+      floatNullableVal: floatNullableVal,
+      floatList: floatList,
+      floatNullableList: floatNullableList,
+      nullableFloatList: nullableFloatList,
+      nullableFloatNullableList: nullableFloatNullableList,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final double floatVal;
+
+  @override
+  final double? floatNullableVal;
+
+  @override
+  final List<double> floatList;
+
+  @override
+  final List<double>? floatNullableList;
+
+  @override
+  final List<double?> nullableFloatList;
+
+  @override
+  final List<double?>? nullableFloatNullableList;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/list_nullability/test_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/list_nullability/test_model.dart
@@ -472,6 +472,33 @@ abstract class TestModel extends PartialTestModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, TestModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  TestModel copyWith({
+    String? id,
+    double? floatVal,
+    double? floatNullableVal,
+    List<double>? floatList,
+    List<double>? floatNullableList,
+    List<double?>? nullableFloatList,
+    List<double?>? nullableFloatNullableList,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _TestModel._(
+      id: id ?? this.id,
+      floatVal: floatVal ?? this.floatVal,
+      floatNullableVal: floatNullableVal ?? this.floatNullableVal,
+      floatList: floatList ?? this.floatList,
+      floatNullableList: floatNullableList ?? this.floatNullableList,
+      nullableFloatList: nullableFloatList ?? this.nullableFloatList,
+      nullableFloatNullableList:
+          nullableFloatNullableList ?? this.nullableFloatNullableList,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, TestModel, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/list_nullability/test_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/list_nullability/test_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.test_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class TestModelType extends ModelType<String, TestModel, PartialTestModel> {
   const TestModelType();
@@ -386,6 +387,87 @@ abstract class TestModel extends PartialTestModel
 
   static const TestModelQueryFields<String, TestModel> _queryFields =
       TestModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'TestModel',
+      'pluralName': 'TestModels',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'floatVal': {
+          'name': 'floatVal',
+          'type': {'scalar': 'Float'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'floatNullableVal': {
+          'name': 'floatNullableVal',
+          'type': {'scalar': 'Float'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'floatList': {
+          'name': 'floatList',
+          'type': {
+            'list': {'scalar': 'Float'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'floatNullableList': {
+          'name': 'floatNullableList',
+          'type': {
+            'list': {'scalar': 'Float'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'nullableFloatList': {
+          'name': 'nullableFloatList',
+          'type': {
+            'list': {'scalar': 'Float'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'nullableFloatNullableList': {
+          'name': 'nullableFloatNullableList',
+          'type': {
+            'list': {'scalar': 'Float'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/multiple_auth_rules/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/multiple_auth_rules/model_provider.dart
@@ -18,50 +18,45 @@
 
 // ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
-library models.my_non_model;
+library models.model_provider;
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
-class MyNonModel
-    with
-        AWSEquatable<MyNonModel>,
-        AWSSerializable<Map<String, Object?>>,
-        AWSDebuggable {
-  const MyNonModel({required this.enum_});
+import 'post.dart';
 
-  factory MyNonModel.fromJson(Map<String, Object?> json) {
-    final enum_ = json['enum'] == null
-        ? (throw ModelFieldError(
-            'MyNonModel',
-            'enum_',
-          ))
-        : (json['enum'] as String);
-    return MyNonModel(enum_: enum_);
+export 'post.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '70fe39d67bd6e2fb0657a38cf965f7ab';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [Post.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Post':
+        return (Post.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
   }
 
-  final String enum_;
-
-  static final mipr.NonModelTypeDefinition schema =
-      mipr.serializers.deserializeWith(
-    mipr.NonModelTypeDefinition.serializer,
-    const {
-      'name': 'MyNonModel',
-      'fields': {
-        'enum': {
-          'name': 'enum',
-          'type': {'scalar': 'String'},
-          'isReadOnly': false,
-          'authRules': [],
-        }
-      },
-    },
-  )!;
-
   @override
-  List<Object?> get props => [enum_];
-  @override
-  String get runtimeTypeName => 'MyNonModel';
-  @override
-  Map<String, Object?> toJson() => {'enum': enum_};
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
 }

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/multiple_auth_rules/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/multiple_auth_rules/post.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class PostType extends ModelType<String, Post, PartialPost> {
   const PostType();
@@ -230,6 +231,84 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   static const PostType classType = PostType();
 
   static const PostQueryFields<String, Post> _queryFields = PostQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post',
+      'pluralName': 'Posts',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'owner': {
+          'name': 'owner',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [
+        {
+          'authStrategy': 'GROUPS',
+          'provider': 'USERPOOLS',
+          'operations': [
+            'CREATE',
+            'UPDATE',
+            'DELETE',
+            'READ',
+          ],
+          'groupClaim': 'cognito:groups',
+          'groups': ['admin'],
+          'groupsField': 'groups',
+        },
+        {
+          'authStrategy': 'OWNER',
+          'provider': 'USERPOOLS',
+          'operations': [
+            'CREATE',
+            'UPDATE',
+          ],
+          'ownerField': 'owner',
+          'identityClaim': 'sub::username',
+        },
+        {
+          'authStrategy': 'PUBLIC',
+          'provider': 'APIKEY',
+          'operations': ['READ'],
+        },
+      ],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/multiple_auth_rules/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/multiple_auth_rules/post.dart
@@ -1,0 +1,435 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.post;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class PostType extends ModelType<String, Post, PartialPost> {
+  const PostType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Post>>(Map<String, Object?> json) {
+    if (T == Post || T == Model<String, Post>) {
+      return Post.fromJson(json) as T;
+    }
+    if (T == RemotePost || T == RemoteModel<String, Post>) {
+      return _RemotePost.fromJson(json) as T;
+    }
+    return _PartialPost.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Post';
+}
+
+class PostQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const PostQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Post>? _root;
+
+  /// Query field for the [Post.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.title] field.
+  QueryField<ModelIdentifier, M, String> get $title =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'title'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.owner] field.
+  QueryField<ModelIdentifier, M, String> get $owner =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'owner'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post, TemporalDateTime>(
+        const QueryField<String, Post, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post, TemporalDateTime>(
+        const QueryField<String, Post, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialPost extends PartialModel<String, Post>
+    with AWSEquatable<PartialPost> {
+  const PartialPost._();
+
+  String get id;
+  String? get title;
+  String? get owner;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  PostType get modelType => Post.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        owner,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'title': title,
+        'owner': owner,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Post';
+}
+
+class _PartialPost extends PartialPost {
+  const _PartialPost({
+    required this.id,
+    this.title,
+    this.owner,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialPost.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null ? null : (json['title'] as String);
+    final owner = json['owner'] == null ? null : (json['owner'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialPost(
+      id: id,
+      title: title,
+      owner: owner,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? title;
+
+  @override
+  final String? owner;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Post extends PartialPost implements Model<String, Post> {
+  factory Post({
+    String? id,
+    required String title,
+    required String owner,
+  }) = _Post;
+
+  const Post._() : super._();
+
+  factory Post.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final owner = json['owner'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'owner',
+          ))
+        : (json['owner'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Post._(
+      id: id,
+      title: title,
+      owner: owner,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const PostType classType = PostType();
+
+  static const PostQueryFields<String, Post> _queryFields = PostQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Post, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Post, String> get ID => $id;
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<String, Post, String> get $title => _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<String, Post, String> get TITLE => $title;
+  @override
+  String get owner;
+
+  /// Query field for the [owner] field.
+  QueryField<String, Post, String> get $owner => _queryFields.$owner;
+
+  /// Query field for the [owner] field.
+  @Deprecated(r'Use $owner instead')
+  QueryField<String, Post, String> get OWNER => $owner;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Post, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Post, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'owner':
+        value = owner;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Post extends Post {
+  _Post({
+    String? id,
+    required this.title,
+    required this.owner,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Post._({
+    required this.id,
+    required this.title,
+    required this.owner,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final String owner;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemotePost extends Post implements RemoteModel<String, Post> {
+  const RemotePost._() : super._();
+}
+
+class _RemotePost extends RemotePost {
+  const _RemotePost({
+    required this.id,
+    required this.title,
+    required this.owner,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemotePost.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final owner = json['owner'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'owner',
+          ))
+        : (json['owner'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemotePost(
+      id: id,
+      title: title,
+      owner: owner,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final String owner;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/multiple_auth_rules/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/multiple_auth_rules/post.dart
@@ -270,6 +270,24 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Post, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Post copyWith({
+    String? id,
+    String? title,
+    String? owner,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Post._(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      owner: owner ?? this.owner,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/optional_fields/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/optional_fields/model_provider.dart
@@ -1,0 +1,62 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'simple_model.dart';
+
+export 'simple_model.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '3095c8ec43e901c662e7238e37a66573';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [SimpleModel.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'SimpleModel':
+        return (SimpleModel.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/optional_fields/simple_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/optional_fields/simple_model.dart
@@ -270,6 +270,24 @@ abstract class SimpleModel extends PartialSimpleModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, SimpleModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  SimpleModel copyWith({
+    String? id,
+    String? name,
+    String? bar,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _SimpleModel._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bar: bar ?? this.bar,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, SimpleModel, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/optional_fields/simple_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/optional_fields/simple_model.dart
@@ -1,0 +1,426 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.simple_model;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class SimpleModelType
+    extends ModelType<String, SimpleModel, PartialSimpleModel> {
+  const SimpleModelType();
+
+  @override
+  T fromJson<T extends PartialModel<String, SimpleModel>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == SimpleModel || T == Model<String, SimpleModel>) {
+      return SimpleModel.fromJson(json) as T;
+    }
+    if (T == RemoteSimpleModel || T == RemoteModel<String, SimpleModel>) {
+      return _RemoteSimpleModel.fromJson(json) as T;
+    }
+    return _PartialSimpleModel.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'SimpleModel';
+}
+
+class SimpleModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const SimpleModelQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, SimpleModel>? _root;
+
+  /// Query field for the [SimpleModel.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel, String>(
+        const QueryField<String, SimpleModel, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel, String?>(
+        const QueryField<String, SimpleModel, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel.bar] field.
+  QueryField<ModelIdentifier, M, String?> get $bar =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel, String?>(
+        const QueryField<String, SimpleModel, String?>(fieldName: 'bar'),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel,
+          TemporalDateTime>(
+        const QueryField<String, SimpleModel, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel,
+          TemporalDateTime>(
+        const QueryField<String, SimpleModel, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel, String>(
+        const QueryField<String, SimpleModel, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialSimpleModel extends PartialModel<String, SimpleModel>
+    with AWSEquatable<PartialSimpleModel> {
+  const PartialSimpleModel._();
+
+  String get id;
+  String? get name;
+  String? get bar;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  SimpleModelType get modelType => SimpleModel.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        bar,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'SimpleModel';
+}
+
+class _PartialSimpleModel extends PartialSimpleModel {
+  const _PartialSimpleModel({
+    required this.id,
+    this.name,
+    this.bar,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialSimpleModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialSimpleModel(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class SimpleModel extends PartialSimpleModel
+    implements Model<String, SimpleModel> {
+  factory SimpleModel({
+    String? id,
+    String? name,
+    String? bar,
+  }) = _SimpleModel;
+
+  const SimpleModel._() : super._();
+
+  factory SimpleModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _SimpleModel._(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const SimpleModelType classType = SimpleModelType();
+
+  static const SimpleModelQueryFields<String, SimpleModel> _queryFields =
+      SimpleModelQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, SimpleModel, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, SimpleModel, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, SimpleModel, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, SimpleModel, String?> get NAME => $name;
+  @override
+  String? get bar;
+
+  /// Query field for the [bar] field.
+  QueryField<String, SimpleModel, String?> get $bar => _queryFields.$bar;
+
+  /// Query field for the [bar] field.
+  @Deprecated(r'Use $bar instead')
+  QueryField<String, SimpleModel, String?> get BAR => $bar;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, SimpleModel, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, SimpleModel, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, SimpleModel, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'bar':
+        value = bar;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _SimpleModel extends SimpleModel {
+  _SimpleModel({
+    String? id,
+    this.name,
+    this.bar,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _SimpleModel._({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteSimpleModel extends SimpleModel
+    implements RemoteModel<String, SimpleModel> {
+  const RemoteSimpleModel._() : super._();
+}
+
+class _RemoteSimpleModel extends RemoteSimpleModel {
+  const _RemoteSimpleModel({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteSimpleModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteSimpleModel(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/optional_fields/simple_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/optional_fields/simple_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.simple_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class SimpleModelType
     extends ModelType<String, SimpleModel, PartialSimpleModel> {
@@ -229,6 +230,55 @@ abstract class SimpleModel extends PartialSimpleModel
 
   static const SimpleModelQueryFields<String, SimpleModel> _queryFields =
       SimpleModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'SimpleModel',
+      'pluralName': 'SimpleModels',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'bar': {
+          'name': 'bar',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_auth/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_auth/model_provider.dart
@@ -1,0 +1,63 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'simple_owner_auth.dart';
+
+export 'simple_owner_auth.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '49290f2cbe6d43f42ded15959b5f12b8';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [SimpleOwnerAuth.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'simpleOwnerAuth':
+      case 'SimpleOwnerAuth':
+        return (SimpleOwnerAuth.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_auth/simple_owner_auth.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_auth/simple_owner_auth.dart
@@ -272,6 +272,24 @@ abstract class SimpleOwnerAuth extends PartialSimpleOwnerAuth
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, SimpleOwnerAuth, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  SimpleOwnerAuth copyWith({
+    String? id,
+    String? name,
+    String? bar,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _SimpleOwnerAuth._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bar: bar ?? this.bar,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, SimpleOwnerAuth, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_auth/simple_owner_auth.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_auth/simple_owner_auth.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.simple_owner_auth;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class SimpleOwnerAuthType
     extends ModelType<String, SimpleOwnerAuth, PartialSimpleOwnerAuth> {
@@ -231,6 +232,68 @@ abstract class SimpleOwnerAuth extends PartialSimpleOwnerAuth
 
   static const SimpleOwnerAuthQueryFields<String, SimpleOwnerAuth>
       _queryFields = SimpleOwnerAuthQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'simpleOwnerAuth',
+      'pluralName': 'simpleOwnerAuths',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'bar': {
+          'name': 'bar',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [
+        {
+          'authStrategy': 'OWNER',
+          'provider': 'USERPOOLS',
+          'operations': [
+            'CREATE',
+            'UPDATE',
+            'DELETE',
+            'READ',
+          ],
+          'ownerField': 'owner',
+          'identityClaim': 'sub::username',
+        }
+      ],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_auth/simple_owner_auth.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_auth/simple_owner_auth.dart
@@ -1,0 +1,428 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.simple_owner_auth;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class SimpleOwnerAuthType
+    extends ModelType<String, SimpleOwnerAuth, PartialSimpleOwnerAuth> {
+  const SimpleOwnerAuthType();
+
+  @override
+  T fromJson<T extends PartialModel<String, SimpleOwnerAuth>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == SimpleOwnerAuth || T == Model<String, SimpleOwnerAuth>) {
+      return SimpleOwnerAuth.fromJson(json) as T;
+    }
+    if (T == RemoteSimpleOwnerAuth ||
+        T == RemoteModel<String, SimpleOwnerAuth>) {
+      return _RemoteSimpleOwnerAuth.fromJson(json) as T;
+    }
+    return _PartialSimpleOwnerAuth.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'simpleOwnerAuth';
+}
+
+class SimpleOwnerAuthQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const SimpleOwnerAuthQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, SimpleOwnerAuth>? _root;
+
+  /// Query field for the [SimpleOwnerAuth.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleOwnerAuth, String>(
+        const QueryField<String, SimpleOwnerAuth, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleOwnerAuth.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleOwnerAuth, String?>(
+        const QueryField<String, SimpleOwnerAuth, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleOwnerAuth.bar] field.
+  QueryField<ModelIdentifier, M, String?> get $bar =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleOwnerAuth, String?>(
+        const QueryField<String, SimpleOwnerAuth, String?>(fieldName: 'bar'),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleOwnerAuth.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleOwnerAuth,
+          TemporalDateTime>(
+        const QueryField<String, SimpleOwnerAuth, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleOwnerAuth.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleOwnerAuth,
+          TemporalDateTime>(
+        const QueryField<String, SimpleOwnerAuth, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleOwnerAuth] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleOwnerAuth, String>(
+        const QueryField<String, SimpleOwnerAuth, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialSimpleOwnerAuth
+    extends PartialModel<String, SimpleOwnerAuth>
+    with AWSEquatable<PartialSimpleOwnerAuth> {
+  const PartialSimpleOwnerAuth._();
+
+  String get id;
+  String? get name;
+  String? get bar;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  SimpleOwnerAuthType get modelType => SimpleOwnerAuth.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        bar,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'SimpleOwnerAuth';
+}
+
+class _PartialSimpleOwnerAuth extends PartialSimpleOwnerAuth {
+  const _PartialSimpleOwnerAuth({
+    required this.id,
+    this.name,
+    this.bar,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialSimpleOwnerAuth.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'SimpleOwnerAuth',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialSimpleOwnerAuth(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class SimpleOwnerAuth extends PartialSimpleOwnerAuth
+    implements Model<String, SimpleOwnerAuth> {
+  factory SimpleOwnerAuth({
+    String? id,
+    String? name,
+    String? bar,
+  }) = _SimpleOwnerAuth;
+
+  const SimpleOwnerAuth._() : super._();
+
+  factory SimpleOwnerAuth.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'SimpleOwnerAuth',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleOwnerAuth',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleOwnerAuth',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _SimpleOwnerAuth._(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const SimpleOwnerAuthType classType = SimpleOwnerAuthType();
+
+  static const SimpleOwnerAuthQueryFields<String, SimpleOwnerAuth>
+      _queryFields = SimpleOwnerAuthQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, SimpleOwnerAuth, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, SimpleOwnerAuth, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, SimpleOwnerAuth, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, SimpleOwnerAuth, String?> get NAME => $name;
+  @override
+  String? get bar;
+
+  /// Query field for the [bar] field.
+  QueryField<String, SimpleOwnerAuth, String?> get $bar => _queryFields.$bar;
+
+  /// Query field for the [bar] field.
+  @Deprecated(r'Use $bar instead')
+  QueryField<String, SimpleOwnerAuth, String?> get BAR => $bar;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, SimpleOwnerAuth, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, SimpleOwnerAuth, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, SimpleOwnerAuth, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'bar':
+        value = bar;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _SimpleOwnerAuth extends SimpleOwnerAuth {
+  _SimpleOwnerAuth({
+    String? id,
+    this.name,
+    this.bar,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _SimpleOwnerAuth._({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteSimpleOwnerAuth extends SimpleOwnerAuth
+    implements RemoteModel<String, SimpleOwnerAuth> {
+  const RemoteSimpleOwnerAuth._() : super._();
+}
+
+class _RemoteSimpleOwnerAuth extends RemoteSimpleOwnerAuth {
+  const _RemoteSimpleOwnerAuth({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteSimpleOwnerAuth.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'SimpleOwnerAuth',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleOwnerAuth',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleOwnerAuth',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'SimpleOwnerAuth',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'SimpleOwnerAuth',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleOwnerAuth',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteSimpleOwnerAuth(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_field_auth/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_field_auth/model_provider.dart
@@ -18,50 +18,45 @@
 
 // ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
-library models.my_non_model;
+library models.model_provider;
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
-class MyNonModel
-    with
-        AWSEquatable<MyNonModel>,
-        AWSSerializable<Map<String, Object?>>,
-        AWSDebuggable {
-  const MyNonModel({required this.enum_});
+import 'post.dart';
 
-  factory MyNonModel.fromJson(Map<String, Object?> json) {
-    final enum_ = json['enum'] == null
-        ? (throw ModelFieldError(
-            'MyNonModel',
-            'enum_',
-          ))
-        : (json['enum'] as String);
-    return MyNonModel(enum_: enum_);
+export 'post.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '42e1970aba600093a07ee6ade8be4cf3';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [Post.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'Post':
+        return (Post.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
   }
 
-  final String enum_;
-
-  static final mipr.NonModelTypeDefinition schema =
-      mipr.serializers.deserializeWith(
-    mipr.NonModelTypeDefinition.serializer,
-    const {
-      'name': 'MyNonModel',
-      'fields': {
-        'enum': {
-          'name': 'enum',
-          'type': {'scalar': 'String'},
-          'isReadOnly': false,
-          'authRules': [],
-        }
-      },
-    },
-  )!;
-
   @override
-  List<Object?> get props => [enum_];
-  @override
-  String get runtimeTypeName => 'MyNonModel';
-  @override
-  Map<String, Object?> toJson() => {'enum': enum_};
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
 }

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_field_auth/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_field_auth/post.dart
@@ -270,6 +270,24 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Post, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Post copyWith({
+    String? id,
+    String? title,
+    String? author,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Post._(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      author: author ?? this.author,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_field_auth/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_field_auth/post.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.post;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class PostType extends ModelType<String, Post, PartialPost> {
   const PostType();
@@ -230,6 +231,68 @@ abstract class Post extends PartialPost implements Model<String, Post> {
   static const PostType classType = PostType();
 
   static const PostQueryFields<String, Post> _queryFields = PostQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'Post',
+      'pluralName': 'Posts',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'author': {
+          'name': 'author',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [
+        {
+          'authStrategy': 'OWNER',
+          'provider': 'USERPOOLS',
+          'operations': [
+            'CREATE',
+            'UPDATE',
+            'DELETE',
+            'READ',
+          ],
+          'ownerField': 'author',
+          'identityClaim': 'sub::username',
+        }
+      ],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_field_auth/post.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_field_auth/post.dart
@@ -1,0 +1,435 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.post;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class PostType extends ModelType<String, Post, PartialPost> {
+  const PostType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Post>>(Map<String, Object?> json) {
+    if (T == Post || T == Model<String, Post>) {
+      return Post.fromJson(json) as T;
+    }
+    if (T == RemotePost || T == RemoteModel<String, Post>) {
+      return _RemotePost.fromJson(json) as T;
+    }
+    return _PartialPost.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'Post';
+}
+
+class PostQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const PostQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Post>? _root;
+
+  /// Query field for the [Post.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.title] field.
+  QueryField<ModelIdentifier, M, String> get $title =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'title'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.author] field.
+  QueryField<ModelIdentifier, M, String> get $author =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'author'),
+        root: _root,
+      );
+
+  /// Query field for the [Post.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post, TemporalDateTime>(
+        const QueryField<String, Post, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Post, TemporalDateTime>(
+        const QueryField<String, Post, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Post] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Post, String>(
+        const QueryField<String, Post, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialPost extends PartialModel<String, Post>
+    with AWSEquatable<PartialPost> {
+  const PartialPost._();
+
+  String get id;
+  String? get title;
+  String? get author;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  PostType get modelType => Post.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        author,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'title': title,
+        'author': author,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Post';
+}
+
+class _PartialPost extends PartialPost {
+  const _PartialPost({
+    required this.id,
+    this.title,
+    this.author,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialPost.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null ? null : (json['title'] as String);
+    final author = json['author'] == null ? null : (json['author'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialPost(
+      id: id,
+      title: title,
+      author: author,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? title;
+
+  @override
+  final String? author;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Post extends PartialPost implements Model<String, Post> {
+  factory Post({
+    String? id,
+    required String title,
+    required String author,
+  }) = _Post;
+
+  const Post._() : super._();
+
+  factory Post.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final author = json['author'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'author',
+          ))
+        : (json['author'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Post._(
+      id: id,
+      title: title,
+      author: author,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const PostType classType = PostType();
+
+  static const PostQueryFields<String, Post> _queryFields = PostQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Post, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Post, String> get ID => $id;
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<String, Post, String> get $title => _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<String, Post, String> get TITLE => $title;
+  @override
+  String get author;
+
+  /// Query field for the [author] field.
+  QueryField<String, Post, String> get $author => _queryFields.$author;
+
+  /// Query field for the [author] field.
+  @Deprecated(r'Use $author instead')
+  QueryField<String, Post, String> get AUTHOR => $author;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Post, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Post, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Post, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'author':
+        value = author;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Post extends Post {
+  _Post({
+    String? id,
+    required this.title,
+    required this.author,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Post._({
+    required this.id,
+    required this.title,
+    required this.author,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final String author;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemotePost extends Post implements RemoteModel<String, Post> {
+  const RemotePost._() : super._();
+}
+
+class _RemotePost extends RemotePost {
+  const _RemotePost({
+    required this.id,
+    required this.title,
+    required this.author,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemotePost.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'title',
+          ))
+        : (json['title'] as String);
+    final author = json['author'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'author',
+          ))
+        : (json['author'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Post',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemotePost(
+      id: id,
+      title: title,
+      author: author,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final String author;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_plus_read_auth/allow_read.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_plus_read_auth/allow_read.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.allow_read;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class AllowReadType extends ModelType<String, AllowRead, PartialAllowRead> {
   const AllowReadType();
@@ -226,6 +227,67 @@ abstract class AllowRead extends PartialAllowRead
 
   static const AllowReadQueryFields<String, AllowRead> _queryFields =
       AllowReadQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'allowRead',
+      'pluralName': 'allowReads',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'bar': {
+          'name': 'bar',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [
+        {
+          'authStrategy': 'OWNER',
+          'provider': 'USERPOOLS',
+          'operations': [
+            'CREATE',
+            'DELETE',
+            'UPDATE',
+          ],
+          'ownerField': 'owner',
+          'identityClaim': 'sub::username',
+        }
+      ],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_plus_read_auth/allow_read.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_plus_read_auth/allow_read.dart
@@ -1,0 +1,423 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.allow_read;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class AllowReadType extends ModelType<String, AllowRead, PartialAllowRead> {
+  const AllowReadType();
+
+  @override
+  T fromJson<T extends PartialModel<String, AllowRead>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == AllowRead || T == Model<String, AllowRead>) {
+      return AllowRead.fromJson(json) as T;
+    }
+    if (T == RemoteAllowRead || T == RemoteModel<String, AllowRead>) {
+      return _RemoteAllowRead.fromJson(json) as T;
+    }
+    return _PartialAllowRead.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'allowRead';
+}
+
+class AllowReadQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const AllowReadQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, AllowRead>? _root;
+
+  /// Query field for the [AllowRead.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, AllowRead, String>(
+        const QueryField<String, AllowRead, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [AllowRead.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, AllowRead, String?>(
+        const QueryField<String, AllowRead, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [AllowRead.bar] field.
+  QueryField<ModelIdentifier, M, String?> get $bar =>
+      NestedQueryField<ModelIdentifier, M, String, AllowRead, String?>(
+        const QueryField<String, AllowRead, String?>(fieldName: 'bar'),
+        root: _root,
+      );
+
+  /// Query field for the [AllowRead.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, AllowRead, TemporalDateTime>(
+        const QueryField<String, AllowRead, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [AllowRead.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, AllowRead, TemporalDateTime>(
+        const QueryField<String, AllowRead, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [AllowRead] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, AllowRead, String>(
+        const QueryField<String, AllowRead, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialAllowRead extends PartialModel<String, AllowRead>
+    with AWSEquatable<PartialAllowRead> {
+  const PartialAllowRead._();
+
+  String get id;
+  String? get name;
+  String? get bar;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  AllowReadType get modelType => AllowRead.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        bar,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'AllowRead';
+}
+
+class _PartialAllowRead extends PartialAllowRead {
+  const _PartialAllowRead({
+    required this.id,
+    this.name,
+    this.bar,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialAllowRead.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'AllowRead',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialAllowRead(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class AllowRead extends PartialAllowRead
+    implements Model<String, AllowRead> {
+  factory AllowRead({
+    String? id,
+    String? name,
+    String? bar,
+  }) = _AllowRead;
+
+  const AllowRead._() : super._();
+
+  factory AllowRead.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'AllowRead',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'AllowRead',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'AllowRead',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _AllowRead._(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const AllowReadType classType = AllowReadType();
+
+  static const AllowReadQueryFields<String, AllowRead> _queryFields =
+      AllowReadQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, AllowRead, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, AllowRead, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, AllowRead, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, AllowRead, String?> get NAME => $name;
+  @override
+  String? get bar;
+
+  /// Query field for the [bar] field.
+  QueryField<String, AllowRead, String?> get $bar => _queryFields.$bar;
+
+  /// Query field for the [bar] field.
+  @Deprecated(r'Use $bar instead')
+  QueryField<String, AllowRead, String?> get BAR => $bar;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, AllowRead, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, AllowRead, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, AllowRead, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'bar':
+        value = bar;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _AllowRead extends AllowRead {
+  _AllowRead({
+    String? id,
+    this.name,
+    this.bar,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _AllowRead._({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteAllowRead extends AllowRead
+    implements RemoteModel<String, AllowRead> {
+  const RemoteAllowRead._() : super._();
+}
+
+class _RemoteAllowRead extends RemoteAllowRead {
+  const _RemoteAllowRead({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteAllowRead.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'AllowRead',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'AllowRead',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'AllowRead',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'AllowRead',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'AllowRead',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'AllowRead',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteAllowRead(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_plus_read_auth/allow_read.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_plus_read_auth/allow_read.dart
@@ -267,6 +267,24 @@ abstract class AllowRead extends PartialAllowRead
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, AllowRead, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  AllowRead copyWith({
+    String? id,
+    String? name,
+    String? bar,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _AllowRead._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bar: bar ?? this.bar,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, AllowRead, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_plus_read_auth/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/owner_plus_read_auth/model_provider.dart
@@ -1,0 +1,63 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'allow_read.dart';
+
+export 'allow_read.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'adfa83586835018e2fc8e274921ab310';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [AllowRead.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'allowRead':
+      case 'AllowRead':
+        return (AllowRead.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_provider.dart
@@ -1,0 +1,80 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'model_with_explicit_id.dart';
+import 'model_with_explicit_id_and_sdi.dart';
+import 'model_with_implicit_id.dart';
+
+export 'model_with_explicit_id.dart';
+export 'model_with_explicit_id_and_sdi.dart';
+export 'model_with_implicit_id.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '9303d3ac6ec1a164fb7e52aeffe6fbb6';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        ModelWithImplicitId.schema,
+        ModelWithExplicitId.schema,
+        ModelWithExplicitIdAndSdi.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'ModelWithImplicitID':
+      case 'ModelWithImplicitId':
+        return (ModelWithImplicitId.classType
+            as ModelType<ModelIdentifier, M, P>);
+      case 'ModelWithExplicitID':
+      case 'ModelWithExplicitId':
+        return (ModelWithExplicitId.classType
+            as ModelType<ModelIdentifier, M, P>);
+      case 'ModelWithExplicitIDAndSDI':
+      case 'ModelWithExplicitIdAndSdi':
+        return (ModelWithExplicitIdAndSdi.classType
+            as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_explicit_id.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_explicit_id.dart
@@ -252,6 +252,22 @@ abstract class ModelWithExplicitId extends PartialModelWithExplicitId
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, ModelWithExplicitId, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  ModelWithExplicitId copyWith({
+    String? id,
+    String? title,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _ModelWithExplicitId._(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<String, ModelWithExplicitId, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_explicit_id.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_explicit_id.dart
@@ -1,0 +1,401 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.model_with_explicit_id;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class ModelWithExplicitIdType
+    extends ModelType<String, ModelWithExplicitId, PartialModelWithExplicitId> {
+  const ModelWithExplicitIdType();
+
+  @override
+  T fromJson<T extends PartialModel<String, ModelWithExplicitId>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == ModelWithExplicitId || T == Model<String, ModelWithExplicitId>) {
+      return ModelWithExplicitId.fromJson(json) as T;
+    }
+    if (T == RemoteModelWithExplicitId ||
+        T == RemoteModel<String, ModelWithExplicitId>) {
+      return _RemoteModelWithExplicitId.fromJson(json) as T;
+    }
+    return _PartialModelWithExplicitId.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'ModelWithExplicitID';
+}
+
+class ModelWithExplicitIdQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ModelWithExplicitIdQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, ModelWithExplicitId>? _root;
+
+  /// Query field for the [ModelWithExplicitId.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithExplicitId, String>(
+        const QueryField<String, ModelWithExplicitId, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitId.title] field.
+  QueryField<ModelIdentifier, M, String> get $title =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithExplicitId, String>(
+        const QueryField<String, ModelWithExplicitId, String>(
+          fieldName: 'title',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitId.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithExplicitId,
+          TemporalDateTime>(
+        const QueryField<String, ModelWithExplicitId, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitId.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithExplicitId,
+          TemporalDateTime>(
+        const QueryField<String, ModelWithExplicitId, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitId] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithExplicitId, String>(
+        const QueryField<String, ModelWithExplicitId, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialModelWithExplicitId
+    extends PartialModel<String, ModelWithExplicitId>
+    with AWSEquatable<PartialModelWithExplicitId> {
+  const PartialModelWithExplicitId._();
+
+  String get id;
+  String? get title;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  ModelWithExplicitIdType get modelType => ModelWithExplicitId.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'title': title,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'ModelWithExplicitId';
+}
+
+class _PartialModelWithExplicitId extends PartialModelWithExplicitId {
+  const _PartialModelWithExplicitId({
+    required this.id,
+    this.title,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialModelWithExplicitId.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitId',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null ? null : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialModelWithExplicitId(
+      id: id,
+      title: title,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? title;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class ModelWithExplicitId extends PartialModelWithExplicitId
+    implements Model<String, ModelWithExplicitId> {
+  factory ModelWithExplicitId({
+    String? id,
+    required String title,
+  }) = _ModelWithExplicitId;
+
+  const ModelWithExplicitId._() : super._();
+
+  factory ModelWithExplicitId.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitId',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitId',
+            'title',
+          ))
+        : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitId',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitId',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _ModelWithExplicitId._(
+      id: id,
+      title: title,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const ModelWithExplicitIdType classType = ModelWithExplicitIdType();
+
+  static const ModelWithExplicitIdQueryFields<String, ModelWithExplicitId>
+      _queryFields = ModelWithExplicitIdQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, ModelWithExplicitId, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, ModelWithExplicitId, String> get ID => $id;
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<String, ModelWithExplicitId, String> get $title =>
+      _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<String, ModelWithExplicitId, String> get TITLE => $title;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, ModelWithExplicitId, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, ModelWithExplicitId, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<String, ModelWithExplicitId, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'title':
+        value = title;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _ModelWithExplicitId extends ModelWithExplicitId {
+  _ModelWithExplicitId({
+    String? id,
+    required this.title,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _ModelWithExplicitId._({
+    required this.id,
+    required this.title,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteModelWithExplicitId extends ModelWithExplicitId
+    implements RemoteModel<String, ModelWithExplicitId> {
+  const RemoteModelWithExplicitId._() : super._();
+}
+
+class _RemoteModelWithExplicitId extends RemoteModelWithExplicitId {
+  const _RemoteModelWithExplicitId({
+    required this.id,
+    required this.title,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteModelWithExplicitId.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitId',
+            'id',
+          ))
+        : (json['id'] as String);
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitId',
+            'title',
+          ))
+        : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitId',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitId',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitId',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitId',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitId',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteModelWithExplicitId(
+      id: id,
+      title: title,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String title;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_explicit_id.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_explicit_id.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.model_with_explicit_id;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class ModelWithExplicitIdType
     extends ModelType<String, ModelWithExplicitId, PartialModelWithExplicitId> {
@@ -219,6 +220,49 @@ abstract class ModelWithExplicitId extends PartialModelWithExplicitId
 
   static const ModelWithExplicitIdQueryFields<String, ModelWithExplicitId>
       _queryFields = ModelWithExplicitIdQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'ModelWithExplicitID',
+      'pluralName': 'ModelWithExplicitIDs',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_explicit_id_and_sdi.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_explicit_id_and_sdi.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.model_with_explicit_id_and_sdi;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class ModelWithExplicitIdAndSdiType extends ModelType<String,
     ModelWithExplicitIdAndSdi, PartialModelWithExplicitIdAndSdi> {
@@ -227,6 +228,56 @@ abstract class ModelWithExplicitIdAndSdi
   static const ModelWithExplicitIdAndSdiQueryFields<String,
           ModelWithExplicitIdAndSdi> _queryFields =
       ModelWithExplicitIdAndSdiQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'ModelWithExplicitIDAndSDI',
+      'pluralName': 'ModelWithExplicitIDAndSDIs',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'parentID': {
+          'name': 'parentID',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'secondary',
+          'primaryField': 'parentID',
+          'sortKeyFields': [],
+          'name': 'byParent',
+          'queryField': 'modelWithExplicitIDAndSDIsByParentID',
+        },
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        },
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_explicit_id_and_sdi.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_explicit_id_and_sdi.dart
@@ -262,6 +262,22 @@ abstract class ModelWithExplicitIdAndSdi
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, ModelWithExplicitIdAndSdi, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  ModelWithExplicitIdAndSdi copyWith({
+    String? id,
+    String? parentId,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _ModelWithExplicitIdAndSdi._(
+      id: id ?? this.id,
+      parentId: parentId ?? this.parentId,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<String, ModelWithExplicitIdAndSdi, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_explicit_id_and_sdi.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_explicit_id_and_sdi.dart
@@ -1,0 +1,407 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.model_with_explicit_id_and_sdi;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class ModelWithExplicitIdAndSdiType extends ModelType<String,
+    ModelWithExplicitIdAndSdi, PartialModelWithExplicitIdAndSdi> {
+  const ModelWithExplicitIdAndSdiType();
+
+  @override
+  T fromJson<T extends PartialModel<String, ModelWithExplicitIdAndSdi>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == ModelWithExplicitIdAndSdi ||
+        T == Model<String, ModelWithExplicitIdAndSdi>) {
+      return ModelWithExplicitIdAndSdi.fromJson(json) as T;
+    }
+    if (T == RemoteModelWithExplicitIdAndSdi ||
+        T == RemoteModel<String, ModelWithExplicitIdAndSdi>) {
+      return _RemoteModelWithExplicitIdAndSdi.fromJson(json) as T;
+    }
+    return _PartialModelWithExplicitIdAndSdi.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'ModelWithExplicitIDAndSDI';
+}
+
+class ModelWithExplicitIdAndSdiQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ModelWithExplicitIdAndSdiQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, ModelWithExplicitIdAndSdi>? _root;
+
+  /// Query field for the [ModelWithExplicitIdAndSdi.id] field.
+  QueryField<ModelIdentifier, M, String> get $id => NestedQueryField<
+          ModelIdentifier, M, String, ModelWithExplicitIdAndSdi, String>(
+        const QueryField<String, ModelWithExplicitIdAndSdi, String>(
+          fieldName: 'id',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitIdAndSdi.parentId] field.
+  QueryField<ModelIdentifier, M, String?> get $parentId => NestedQueryField<
+          ModelIdentifier, M, String, ModelWithExplicitIdAndSdi, String?>(
+        const QueryField<String, ModelWithExplicitIdAndSdi, String?>(
+          fieldName: 'parentID',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitIdAndSdi.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithExplicitIdAndSdi,
+          TemporalDateTime>(
+        const QueryField<String, ModelWithExplicitIdAndSdi, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitIdAndSdi.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithExplicitIdAndSdi,
+          TemporalDateTime>(
+        const QueryField<String, ModelWithExplicitIdAndSdi, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithExplicitIdAndSdi] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithExplicitIdAndSdi,
+          String>(
+        const QueryField<String, ModelWithExplicitIdAndSdi, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialModelWithExplicitIdAndSdi
+    extends PartialModel<String, ModelWithExplicitIdAndSdi>
+    with AWSEquatable<PartialModelWithExplicitIdAndSdi> {
+  const PartialModelWithExplicitIdAndSdi._();
+
+  String get id;
+  String? get parentId;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  ModelWithExplicitIdAndSdiType get modelType =>
+      ModelWithExplicitIdAndSdi.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        parentId,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'parentID': parentId,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'ModelWithExplicitIdAndSdi';
+}
+
+class _PartialModelWithExplicitIdAndSdi
+    extends PartialModelWithExplicitIdAndSdi {
+  const _PartialModelWithExplicitIdAndSdi({
+    required this.id,
+    this.parentId,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialModelWithExplicitIdAndSdi.fromJson(
+    Map<String, Object?> json,
+  ) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitIdAndSdi',
+            'id',
+          ))
+        : (json['id'] as String);
+    final parentId =
+        json['parentID'] == null ? null : (json['parentID'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialModelWithExplicitIdAndSdi(
+      id: id,
+      parentId: parentId,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? parentId;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class ModelWithExplicitIdAndSdi
+    extends PartialModelWithExplicitIdAndSdi
+    implements Model<String, ModelWithExplicitIdAndSdi> {
+  factory ModelWithExplicitIdAndSdi({
+    String? id,
+    String? parentId,
+  }) = _ModelWithExplicitIdAndSdi;
+
+  const ModelWithExplicitIdAndSdi._() : super._();
+
+  factory ModelWithExplicitIdAndSdi.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitIdAndSdi',
+            'id',
+          ))
+        : (json['id'] as String);
+    final parentId =
+        json['parentID'] == null ? null : (json['parentID'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitIdAndSdi',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitIdAndSdi',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _ModelWithExplicitIdAndSdi._(
+      id: id,
+      parentId: parentId,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const ModelWithExplicitIdAndSdiType classType =
+      ModelWithExplicitIdAndSdiType();
+
+  static const ModelWithExplicitIdAndSdiQueryFields<String,
+          ModelWithExplicitIdAndSdi> _queryFields =
+      ModelWithExplicitIdAndSdiQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, ModelWithExplicitIdAndSdi, String> get $id =>
+      _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, ModelWithExplicitIdAndSdi, String> get ID => $id;
+  @override
+  String? get parentId;
+
+  /// Query field for the [parentId] field.
+  QueryField<String, ModelWithExplicitIdAndSdi, String?> get $parentId =>
+      _queryFields.$parentId;
+
+  /// Query field for the [parentId] field.
+  @Deprecated(r'Use $parentId instead')
+  QueryField<String, ModelWithExplicitIdAndSdi, String?> get PARENT_ID =>
+      $parentId;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, ModelWithExplicitIdAndSdi, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, ModelWithExplicitIdAndSdi, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<String, ModelWithExplicitIdAndSdi, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'parentID':
+        value = parentId;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _ModelWithExplicitIdAndSdi extends ModelWithExplicitIdAndSdi {
+  _ModelWithExplicitIdAndSdi({
+    String? id,
+    this.parentId,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _ModelWithExplicitIdAndSdi._({
+    required this.id,
+    this.parentId,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? parentId;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteModelWithExplicitIdAndSdi extends ModelWithExplicitIdAndSdi
+    implements RemoteModel<String, ModelWithExplicitIdAndSdi> {
+  const RemoteModelWithExplicitIdAndSdi._() : super._();
+}
+
+class _RemoteModelWithExplicitIdAndSdi extends RemoteModelWithExplicitIdAndSdi {
+  const _RemoteModelWithExplicitIdAndSdi({
+    required this.id,
+    this.parentId,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteModelWithExplicitIdAndSdi.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitIdAndSdi',
+            'id',
+          ))
+        : (json['id'] as String);
+    final parentId =
+        json['parentID'] == null ? null : (json['parentID'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitIdAndSdi',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitIdAndSdi',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitIdAndSdi',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitIdAndSdi',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithExplicitIdAndSdi',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteModelWithExplicitIdAndSdi(
+      id: id,
+      parentId: parentId,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? parentId;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_implicit_id.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_implicit_id.dart
@@ -252,6 +252,22 @@ abstract class ModelWithImplicitId extends PartialModelWithImplicitId
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, ModelWithImplicitId, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  ModelWithImplicitId copyWith({
+    String? title,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? id,
+  }) {
+    return _ModelWithImplicitId._(
+      title: title ?? this.title,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      id: id ?? this.id,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<String, ModelWithImplicitId, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_implicit_id.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_implicit_id.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.model_with_implicit_id;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class ModelWithImplicitIdType
     extends ModelType<String, ModelWithImplicitId, PartialModelWithImplicitId> {
@@ -219,6 +220,49 @@ abstract class ModelWithImplicitId extends PartialModelWithImplicitId
 
   static const ModelWithImplicitIdQueryFields<String, ModelWithImplicitId>
       _queryFields = ModelWithImplicitIdQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'ModelWithImplicitID',
+      'pluralName': 'ModelWithImplicitIDs',
+      'fields': {
+        'title': {
+          'name': 'title',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get title;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_implicit_id.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/primary_keys/model_with_implicit_id.dart
@@ -1,0 +1,401 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.model_with_implicit_id;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class ModelWithImplicitIdType
+    extends ModelType<String, ModelWithImplicitId, PartialModelWithImplicitId> {
+  const ModelWithImplicitIdType();
+
+  @override
+  T fromJson<T extends PartialModel<String, ModelWithImplicitId>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == ModelWithImplicitId || T == Model<String, ModelWithImplicitId>) {
+      return ModelWithImplicitId.fromJson(json) as T;
+    }
+    if (T == RemoteModelWithImplicitId ||
+        T == RemoteModel<String, ModelWithImplicitId>) {
+      return _RemoteModelWithImplicitId.fromJson(json) as T;
+    }
+    return _PartialModelWithImplicitId.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'ModelWithImplicitID';
+}
+
+class ModelWithImplicitIdQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ModelWithImplicitIdQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, ModelWithImplicitId>? _root;
+
+  /// Query field for the [ModelWithImplicitId.title] field.
+  QueryField<ModelIdentifier, M, String> get $title =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithImplicitId, String>(
+        const QueryField<String, ModelWithImplicitId, String>(
+          fieldName: 'title',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithImplicitId.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithImplicitId,
+          TemporalDateTime>(
+        const QueryField<String, ModelWithImplicitId, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithImplicitId.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithImplicitId,
+          TemporalDateTime>(
+        const QueryField<String, ModelWithImplicitId, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithImplicitId.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithImplicitId, String>(
+        const QueryField<String, ModelWithImplicitId, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [ModelWithImplicitId] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, ModelWithImplicitId, String>(
+        const QueryField<String, ModelWithImplicitId, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialModelWithImplicitId
+    extends PartialModel<String, ModelWithImplicitId>
+    with AWSEquatable<PartialModelWithImplicitId> {
+  const PartialModelWithImplicitId._();
+
+  String? get title;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  String get id;
+  @override
+  String get modelIdentifier => id;
+  @override
+  ModelWithImplicitIdType get modelType => ModelWithImplicitId.classType;
+  @override
+  List<Object?> get props => [
+        title,
+        createdAt,
+        updatedAt,
+        id,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'title': title,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'id': id,
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'ModelWithImplicitId';
+}
+
+class _PartialModelWithImplicitId extends PartialModelWithImplicitId {
+  const _PartialModelWithImplicitId({
+    this.title,
+    this.createdAt,
+    this.updatedAt,
+    required this.id,
+  }) : super._();
+
+  factory _PartialModelWithImplicitId.fromJson(Map<String, Object?> json) {
+    final title = json['title'] == null ? null : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ModelWithImplicitId',
+            'id',
+          ))
+        : (json['id'] as String);
+    return _PartialModelWithImplicitId(
+      title: title,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      id: id,
+    );
+  }
+
+  @override
+  final String? title;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+
+  @override
+  final String id;
+}
+
+abstract class ModelWithImplicitId extends PartialModelWithImplicitId
+    implements Model<String, ModelWithImplicitId> {
+  factory ModelWithImplicitId({
+    required String title,
+    String? id,
+  }) = _ModelWithImplicitId;
+
+  const ModelWithImplicitId._() : super._();
+
+  factory ModelWithImplicitId.fromJson(Map<String, Object?> json) {
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'ModelWithImplicitId',
+            'title',
+          ))
+        : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithImplicitId',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithImplicitId',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ModelWithImplicitId',
+            'id',
+          ))
+        : (json['id'] as String);
+    return _ModelWithImplicitId._(
+      title: title,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      id: id,
+    );
+  }
+
+  static const ModelWithImplicitIdType classType = ModelWithImplicitIdType();
+
+  static const ModelWithImplicitIdQueryFields<String, ModelWithImplicitId>
+      _queryFields = ModelWithImplicitIdQueryFields();
+
+  @override
+  String get title;
+
+  /// Query field for the [title] field.
+  QueryField<String, ModelWithImplicitId, String> get $title =>
+      _queryFields.$title;
+
+  /// Query field for the [title] field.
+  @Deprecated(r'Use $title instead')
+  QueryField<String, ModelWithImplicitId, String> get TITLE => $title;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, ModelWithImplicitId, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, ModelWithImplicitId, String> get ID => $id;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, ModelWithImplicitId, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, ModelWithImplicitId, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<String, ModelWithImplicitId, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'title':
+        value = title;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'id':
+        value = id;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _ModelWithImplicitId extends ModelWithImplicitId {
+  _ModelWithImplicitId({
+    required this.title,
+    String? id,
+  })  : createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        id = id ?? uuid(),
+        super._();
+
+  const _ModelWithImplicitId._({
+    required this.title,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.id,
+  }) : super._();
+
+  @override
+  final String title;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String id;
+}
+
+abstract class RemoteModelWithImplicitId extends ModelWithImplicitId
+    implements RemoteModel<String, ModelWithImplicitId> {
+  const RemoteModelWithImplicitId._() : super._();
+}
+
+class _RemoteModelWithImplicitId extends RemoteModelWithImplicitId {
+  const _RemoteModelWithImplicitId({
+    required this.title,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.id,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteModelWithImplicitId.fromJson(Map<String, Object?> json) {
+    final title = json['title'] == null
+        ? (throw ModelFieldError(
+            'ModelWithImplicitId',
+            'title',
+          ))
+        : (json['title'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithImplicitId',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithImplicitId',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ModelWithImplicitId',
+            'id',
+          ))
+        : (json['id'] as String);
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'ModelWithImplicitId',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'ModelWithImplicitId',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'ModelWithImplicitId',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteModelWithImplicitId(
+      title: title,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      id: id,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String title;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final String id;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/private_auth/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/private_auth/model_provider.dart
@@ -1,0 +1,63 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'private_type.dart';
+
+export 'private_type.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '12ff64588e643446342176ee612d17ab';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [PrivateType.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'privateType':
+      case 'PrivateType':
+        return (PrivateType.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/private_auth/private_type.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/private_auth/private_type.dart
@@ -1,0 +1,426 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.private_type;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class PrivateTypeType
+    extends ModelType<String, PrivateType, PartialPrivateType> {
+  const PrivateTypeType();
+
+  @override
+  T fromJson<T extends PartialModel<String, PrivateType>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == PrivateType || T == Model<String, PrivateType>) {
+      return PrivateType.fromJson(json) as T;
+    }
+    if (T == RemotePrivateType || T == RemoteModel<String, PrivateType>) {
+      return _RemotePrivateType.fromJson(json) as T;
+    }
+    return _PartialPrivateType.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'privateType';
+}
+
+class PrivateTypeQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const PrivateTypeQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, PrivateType>? _root;
+
+  /// Query field for the [PrivateType.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, PrivateType, String>(
+        const QueryField<String, PrivateType, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [PrivateType.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, PrivateType, String?>(
+        const QueryField<String, PrivateType, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [PrivateType.bar] field.
+  QueryField<ModelIdentifier, M, String?> get $bar =>
+      NestedQueryField<ModelIdentifier, M, String, PrivateType, String?>(
+        const QueryField<String, PrivateType, String?>(fieldName: 'bar'),
+        root: _root,
+      );
+
+  /// Query field for the [PrivateType.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, PrivateType,
+          TemporalDateTime>(
+        const QueryField<String, PrivateType, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [PrivateType.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, PrivateType,
+          TemporalDateTime>(
+        const QueryField<String, PrivateType, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [PrivateType] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, PrivateType, String>(
+        const QueryField<String, PrivateType, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialPrivateType extends PartialModel<String, PrivateType>
+    with AWSEquatable<PartialPrivateType> {
+  const PartialPrivateType._();
+
+  String get id;
+  String? get name;
+  String? get bar;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  PrivateTypeType get modelType => PrivateType.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        bar,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'PrivateType';
+}
+
+class _PartialPrivateType extends PartialPrivateType {
+  const _PartialPrivateType({
+    required this.id,
+    this.name,
+    this.bar,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialPrivateType.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'PrivateType',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialPrivateType(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class PrivateType extends PartialPrivateType
+    implements Model<String, PrivateType> {
+  factory PrivateType({
+    String? id,
+    String? name,
+    String? bar,
+  }) = _PrivateType;
+
+  const PrivateType._() : super._();
+
+  factory PrivateType.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'PrivateType',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'PrivateType',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'PrivateType',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PrivateType._(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const PrivateTypeType classType = PrivateTypeType();
+
+  static const PrivateTypeQueryFields<String, PrivateType> _queryFields =
+      PrivateTypeQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, PrivateType, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, PrivateType, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, PrivateType, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, PrivateType, String?> get NAME => $name;
+  @override
+  String? get bar;
+
+  /// Query field for the [bar] field.
+  QueryField<String, PrivateType, String?> get $bar => _queryFields.$bar;
+
+  /// Query field for the [bar] field.
+  @Deprecated(r'Use $bar instead')
+  QueryField<String, PrivateType, String?> get BAR => $bar;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, PrivateType, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, PrivateType, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, PrivateType, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'bar':
+        value = bar;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _PrivateType extends PrivateType {
+  _PrivateType({
+    String? id,
+    this.name,
+    this.bar,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _PrivateType._({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemotePrivateType extends PrivateType
+    implements RemoteModel<String, PrivateType> {
+  const RemotePrivateType._() : super._();
+}
+
+class _RemotePrivateType extends RemotePrivateType {
+  const _RemotePrivateType({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemotePrivateType.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'PrivateType',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'PrivateType',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'PrivateType',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'PrivateType',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'PrivateType',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'PrivateType',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemotePrivateType(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/private_auth/private_type.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/private_auth/private_type.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.private_type;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class PrivateTypeType
     extends ModelType<String, PrivateType, PartialPrivateType> {
@@ -229,6 +230,66 @@ abstract class PrivateType extends PartialPrivateType
 
   static const PrivateTypeQueryFields<String, PrivateType> _queryFields =
       PrivateTypeQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'privateType',
+      'pluralName': 'privateTypes',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'bar': {
+          'name': 'bar',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [
+        {
+          'authStrategy': 'PRIVATE',
+          'provider': 'USERPOOLS',
+          'operations': [
+            'CREATE',
+            'UPDATE',
+            'DELETE',
+            'READ',
+          ],
+        }
+      ],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/private_auth/private_type.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/private_auth/private_type.dart
@@ -270,6 +270,24 @@ abstract class PrivateType extends PartialPrivateType
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, PrivateType, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  PrivateType copyWith({
+    String? id,
+    String? name,
+    String? bar,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _PrivateType._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bar: bar ?? this.bar,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, PrivateType, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/public_auth/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/public_auth/model_provider.dart
@@ -1,0 +1,63 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'public_type.dart';
+
+export 'public_type.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'f6630a897b09328f5393d8f094aa3492';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [PublicType.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'publicType':
+      case 'PublicType':
+        return (PublicType.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/public_auth/public_type.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/public_auth/public_type.dart
@@ -269,6 +269,24 @@ abstract class PublicType extends PartialPublicType
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, PublicType, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  PublicType copyWith({
+    String? id,
+    String? name,
+    String? bar,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _PublicType._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bar: bar ?? this.bar,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, PublicType, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/public_auth/public_type.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/public_auth/public_type.dart
@@ -1,0 +1,425 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.public_type;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class PublicTypeType extends ModelType<String, PublicType, PartialPublicType> {
+  const PublicTypeType();
+
+  @override
+  T fromJson<T extends PartialModel<String, PublicType>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == PublicType || T == Model<String, PublicType>) {
+      return PublicType.fromJson(json) as T;
+    }
+    if (T == RemotePublicType || T == RemoteModel<String, PublicType>) {
+      return _RemotePublicType.fromJson(json) as T;
+    }
+    return _PartialPublicType.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'publicType';
+}
+
+class PublicTypeQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const PublicTypeQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, PublicType>? _root;
+
+  /// Query field for the [PublicType.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, PublicType, String>(
+        const QueryField<String, PublicType, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [PublicType.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, PublicType, String?>(
+        const QueryField<String, PublicType, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [PublicType.bar] field.
+  QueryField<ModelIdentifier, M, String?> get $bar =>
+      NestedQueryField<ModelIdentifier, M, String, PublicType, String?>(
+        const QueryField<String, PublicType, String?>(fieldName: 'bar'),
+        root: _root,
+      );
+
+  /// Query field for the [PublicType.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, PublicType,
+          TemporalDateTime>(
+        const QueryField<String, PublicType, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [PublicType.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, PublicType,
+          TemporalDateTime>(
+        const QueryField<String, PublicType, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [PublicType] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, PublicType, String>(
+        const QueryField<String, PublicType, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialPublicType extends PartialModel<String, PublicType>
+    with AWSEquatable<PartialPublicType> {
+  const PartialPublicType._();
+
+  String get id;
+  String? get name;
+  String? get bar;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  PublicTypeType get modelType => PublicType.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        bar,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'PublicType';
+}
+
+class _PartialPublicType extends PartialPublicType {
+  const _PartialPublicType({
+    required this.id,
+    this.name,
+    this.bar,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialPublicType.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'PublicType',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialPublicType(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class PublicType extends PartialPublicType
+    implements Model<String, PublicType> {
+  factory PublicType({
+    String? id,
+    String? name,
+    String? bar,
+  }) = _PublicType;
+
+  const PublicType._() : super._();
+
+  factory PublicType.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'PublicType',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'PublicType',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'PublicType',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PublicType._(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const PublicTypeType classType = PublicTypeType();
+
+  static const PublicTypeQueryFields<String, PublicType> _queryFields =
+      PublicTypeQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, PublicType, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, PublicType, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, PublicType, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, PublicType, String?> get NAME => $name;
+  @override
+  String? get bar;
+
+  /// Query field for the [bar] field.
+  QueryField<String, PublicType, String?> get $bar => _queryFields.$bar;
+
+  /// Query field for the [bar] field.
+  @Deprecated(r'Use $bar instead')
+  QueryField<String, PublicType, String?> get BAR => $bar;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, PublicType, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, PublicType, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, PublicType, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'bar':
+        value = bar;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _PublicType extends PublicType {
+  _PublicType({
+    String? id,
+    this.name,
+    this.bar,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _PublicType._({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemotePublicType extends PublicType
+    implements RemoteModel<String, PublicType> {
+  const RemotePublicType._() : super._();
+}
+
+class _RemotePublicType extends RemotePublicType {
+  const _RemotePublicType({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemotePublicType.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'PublicType',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'PublicType',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'PublicType',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'PublicType',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'PublicType',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'PublicType',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemotePublicType(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/public_auth/public_type.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/public_auth/public_type.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.public_type;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class PublicTypeType extends ModelType<String, PublicType, PartialPublicType> {
   const PublicTypeType();
@@ -228,6 +229,66 @@ abstract class PublicType extends PartialPublicType
 
   static const PublicTypeQueryFields<String, PublicType> _queryFields =
       PublicTypeQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'publicType',
+      'pluralName': 'publicTypes',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'bar': {
+          'name': 'bar',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [
+        {
+          'authStrategy': 'PUBLIC',
+          'provider': 'APIKEY',
+          'operations': [
+            'CREATE',
+            'UPDATE',
+            'DELETE',
+            'READ',
+          ],
+        }
+      ],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/class.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/class.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.class_;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class ClassType extends ModelType<String, Class, PartialClass> {
   const ClassType();
@@ -207,6 +208,49 @@ abstract class Class extends PartialClass implements Model<String, Class> {
 
   static const ClassQueryFields<String, Class> _queryFields =
       ClassQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'class',
+      'pluralName': 'class',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/class.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/class.dart
@@ -22,8 +22,6 @@ library models.class_;
 
 import 'package:amplify_core/amplify_core.dart';
 
-import 'class.dart';
-
 class ClassType extends ModelType<String, Class, PartialClass> {
   const ClassType();
 

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/class.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/class.dart
@@ -238,6 +238,22 @@ abstract class Class extends PartialClass implements Model<String, Class> {
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, Class, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  Class copyWith({
+    String? id,
+    String? name,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _Class._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, Class, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/class_.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/class_.dart
@@ -1,0 +1,386 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.class_;
+
+import 'package:amplify_core/amplify_core.dart';
+
+import 'class.dart';
+
+class ClassType extends ModelType<String, Class, PartialClass> {
+  const ClassType();
+
+  @override
+  T fromJson<T extends PartialModel<String, Class>>(Map<String, Object?> json) {
+    if (T == Class || T == Model<String, Class>) {
+      return Class.fromJson(json) as T;
+    }
+    if (T == RemoteClass || T == RemoteModel<String, Class>) {
+      return _RemoteClass.fromJson(json) as T;
+    }
+    return _PartialClass.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'class';
+}
+
+class ClassQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ClassQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, Class>? _root;
+
+  /// Query field for the [Class.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, Class, String>(
+        const QueryField<String, Class, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [Class.name] field.
+  QueryField<ModelIdentifier, M, String> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, Class, String>(
+        const QueryField<String, Class, String>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [Class.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, Class, TemporalDateTime>(
+        const QueryField<String, Class, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Class.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, Class, TemporalDateTime>(
+        const QueryField<String, Class, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [Class] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, Class, String>(
+        const QueryField<String, Class, String>(fieldName: 'modelIdentifier'),
+        root: _root,
+      );
+}
+
+abstract class PartialClass extends PartialModel<String, Class>
+    with AWSEquatable<PartialClass> {
+  const PartialClass._();
+
+  String get id;
+  String? get name;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  ClassType get modelType => Class.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'Class';
+}
+
+class _PartialClass extends PartialClass {
+  const _PartialClass({
+    required this.id,
+    this.name,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialClass.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Class',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialClass(
+      id: id,
+      name: name,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class Class extends PartialClass implements Model<String, Class> {
+  factory Class({
+    String? id,
+    required String name,
+  }) = _Class;
+
+  const Class._() : super._();
+
+  factory Class.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Class',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Class',
+            'name',
+          ))
+        : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Class',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Class',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _Class._(
+      id: id,
+      name: name,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const ClassType classType = ClassType();
+
+  static const ClassQueryFields<String, Class> _queryFields =
+      ClassQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, Class, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, Class, String> get ID => $id;
+  @override
+  String get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, Class, String> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, Class, String> get NAME => $name;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, Class, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, Class, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, Class, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _Class extends Class {
+  _Class({
+    String? id,
+    required this.name,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _Class._({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteClass extends Class implements RemoteModel<String, Class> {
+  const RemoteClass._() : super._();
+}
+
+class _RemoteClass extends RemoteClass {
+  const _RemoteClass({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteClass.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'Class',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null
+        ? (throw ModelFieldError(
+            'Class',
+            'name',
+          ))
+        : (json['name'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'Class',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'Class',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'Class',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'Class',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'Class',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteClass(
+      id: id,
+      name: name,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String name;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/model_provider.dart
@@ -1,0 +1,70 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'class.dart';
+import 'reserved_word.dart';
+
+export 'class.dart';
+export 'reserved_word.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'dc061a60da54041c0a2069068a985265';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        ReservedWord.schema,
+        Class.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'ReservedWord':
+        return (ReservedWord.classType as ModelType<ModelIdentifier, M, P>);
+      case 'class':
+      case 'Class':
+        return (Class.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/reserved_word.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/reserved_word.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.reserved_word;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class ReservedWordType
     extends ModelType<String, ReservedWord, PartialReservedWord> {
@@ -215,6 +216,49 @@ abstract class ReservedWord extends PartialReservedWord
 
   static const ReservedWordQueryFields<String, ReservedWord> _queryFields =
       ReservedWordQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'ReservedWord',
+      'pluralName': 'ReservedWords',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'class': {
+          'name': 'class',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/reserved_word.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/reserved_word.dart
@@ -1,0 +1,394 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.reserved_word;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class ReservedWordType
+    extends ModelType<String, ReservedWord, PartialReservedWord> {
+  const ReservedWordType();
+
+  @override
+  T fromJson<T extends PartialModel<String, ReservedWord>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == ReservedWord || T == Model<String, ReservedWord>) {
+      return ReservedWord.fromJson(json) as T;
+    }
+    if (T == RemoteReservedWord || T == RemoteModel<String, ReservedWord>) {
+      return _RemoteReservedWord.fromJson(json) as T;
+    }
+    return _PartialReservedWord.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'ReservedWord';
+}
+
+class ReservedWordQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const ReservedWordQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, ReservedWord>? _root;
+
+  /// Query field for the [ReservedWord.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, ReservedWord, String>(
+        const QueryField<String, ReservedWord, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [ReservedWord.class_] field.
+  QueryField<ModelIdentifier, M, String> get $class_ =>
+      NestedQueryField<ModelIdentifier, M, String, ReservedWord, String>(
+        const QueryField<String, ReservedWord, String>(fieldName: 'class'),
+        root: _root,
+      );
+
+  /// Query field for the [ReservedWord.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, ReservedWord,
+          TemporalDateTime>(
+        const QueryField<String, ReservedWord, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ReservedWord.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, ReservedWord,
+          TemporalDateTime>(
+        const QueryField<String, ReservedWord, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [ReservedWord] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, ReservedWord, String>(
+        const QueryField<String, ReservedWord, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialReservedWord extends PartialModel<String, ReservedWord>
+    with AWSEquatable<PartialReservedWord> {
+  const PartialReservedWord._();
+
+  String get id;
+  String? get class_;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  ReservedWordType get modelType => ReservedWord.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        class_,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'class': class_,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'ReservedWord';
+}
+
+class _PartialReservedWord extends PartialReservedWord {
+  const _PartialReservedWord({
+    required this.id,
+    this.class_,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialReservedWord.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ReservedWord',
+            'id',
+          ))
+        : (json['id'] as String);
+    final class_ = json['class'] == null ? null : (json['class'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialReservedWord(
+      id: id,
+      class_: class_,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? class_;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class ReservedWord extends PartialReservedWord
+    implements Model<String, ReservedWord> {
+  factory ReservedWord({
+    String? id,
+    required String class_,
+  }) = _ReservedWord;
+
+  const ReservedWord._() : super._();
+
+  factory ReservedWord.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ReservedWord',
+            'id',
+          ))
+        : (json['id'] as String);
+    final class_ = json['class'] == null
+        ? (throw ModelFieldError(
+            'ReservedWord',
+            'class_',
+          ))
+        : (json['class'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ReservedWord',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ReservedWord',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _ReservedWord._(
+      id: id,
+      class_: class_,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const ReservedWordType classType = ReservedWordType();
+
+  static const ReservedWordQueryFields<String, ReservedWord> _queryFields =
+      ReservedWordQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, ReservedWord, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, ReservedWord, String> get ID => $id;
+  @override
+  String get class_;
+
+  /// Query field for the [class_] field.
+  QueryField<String, ReservedWord, String> get $class_ => _queryFields.$class_;
+
+  /// Query field for the [class_] field.
+  @Deprecated(r'Use $class_ instead')
+  QueryField<String, ReservedWord, String> get CLASS => $class_;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, ReservedWord, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, ReservedWord, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, ReservedWord, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'class':
+        value = class_;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _ReservedWord extends ReservedWord {
+  _ReservedWord({
+    String? id,
+    required this.class_,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _ReservedWord._({
+    required this.id,
+    required this.class_,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String class_;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteReservedWord extends ReservedWord
+    implements RemoteModel<String, ReservedWord> {
+  const RemoteReservedWord._() : super._();
+}
+
+class _RemoteReservedWord extends RemoteReservedWord {
+  const _RemoteReservedWord({
+    required this.id,
+    required this.class_,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteReservedWord.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'ReservedWord',
+            'id',
+          ))
+        : (json['id'] as String);
+    final class_ = json['class'] == null
+        ? (throw ModelFieldError(
+            'ReservedWord',
+            'class_',
+          ))
+        : (json['class'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'ReservedWord',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'ReservedWord',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'ReservedWord',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'ReservedWord',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'ReservedWord',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteReservedWord(
+      id: id,
+      class_: class_,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String class_;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/reserved_word.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/reserved_words/reserved_word.dart
@@ -247,6 +247,22 @@ abstract class ReservedWord extends PartialReservedWord
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, ReservedWord, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  ReservedWord copyWith({
+    String? id,
+    String? class_,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _ReservedWord._(
+      id: id ?? this.id,
+      class_: class_ ?? this.class_,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, ReservedWord, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/simple_model/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/simple_model/model_provider.dart
@@ -1,0 +1,62 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'simple_model.dart';
+
+export 'simple_model.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '3095c8ec43e901c662e7238e37a66573';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [SimpleModel.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'SimpleModel':
+        return (SimpleModel.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/simple_model/simple_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/simple_model/simple_model.dart
@@ -270,6 +270,24 @@ abstract class SimpleModel extends PartialSimpleModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, SimpleModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  SimpleModel copyWith({
+    String? id,
+    String? name,
+    String? bar,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _SimpleModel._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bar: bar ?? this.bar,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, SimpleModel, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/simple_model/simple_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/simple_model/simple_model.dart
@@ -1,0 +1,426 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.simple_model;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class SimpleModelType
+    extends ModelType<String, SimpleModel, PartialSimpleModel> {
+  const SimpleModelType();
+
+  @override
+  T fromJson<T extends PartialModel<String, SimpleModel>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == SimpleModel || T == Model<String, SimpleModel>) {
+      return SimpleModel.fromJson(json) as T;
+    }
+    if (T == RemoteSimpleModel || T == RemoteModel<String, SimpleModel>) {
+      return _RemoteSimpleModel.fromJson(json) as T;
+    }
+    return _PartialSimpleModel.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'SimpleModel';
+}
+
+class SimpleModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const SimpleModelQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, SimpleModel>? _root;
+
+  /// Query field for the [SimpleModel.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel, String>(
+        const QueryField<String, SimpleModel, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel, String?>(
+        const QueryField<String, SimpleModel, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel.bar] field.
+  QueryField<ModelIdentifier, M, String?> get $bar =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel, String?>(
+        const QueryField<String, SimpleModel, String?>(fieldName: 'bar'),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel,
+          TemporalDateTime>(
+        const QueryField<String, SimpleModel, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel,
+          TemporalDateTime>(
+        const QueryField<String, SimpleModel, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [SimpleModel] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, SimpleModel, String>(
+        const QueryField<String, SimpleModel, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialSimpleModel extends PartialModel<String, SimpleModel>
+    with AWSEquatable<PartialSimpleModel> {
+  const PartialSimpleModel._();
+
+  String get id;
+  String? get name;
+  String? get bar;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  SimpleModelType get modelType => SimpleModel.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        bar,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'SimpleModel';
+}
+
+class _PartialSimpleModel extends PartialSimpleModel {
+  const _PartialSimpleModel({
+    required this.id,
+    this.name,
+    this.bar,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialSimpleModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialSimpleModel(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class SimpleModel extends PartialSimpleModel
+    implements Model<String, SimpleModel> {
+  factory SimpleModel({
+    String? id,
+    String? name,
+    String? bar,
+  }) = _SimpleModel;
+
+  const SimpleModel._() : super._();
+
+  factory SimpleModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _SimpleModel._(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const SimpleModelType classType = SimpleModelType();
+
+  static const SimpleModelQueryFields<String, SimpleModel> _queryFields =
+      SimpleModelQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, SimpleModel, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, SimpleModel, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, SimpleModel, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, SimpleModel, String?> get NAME => $name;
+  @override
+  String? get bar;
+
+  /// Query field for the [bar] field.
+  QueryField<String, SimpleModel, String?> get $bar => _queryFields.$bar;
+
+  /// Query field for the [bar] field.
+  @Deprecated(r'Use $bar instead')
+  QueryField<String, SimpleModel, String?> get BAR => $bar;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, SimpleModel, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, SimpleModel, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, SimpleModel, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'bar':
+        value = bar;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _SimpleModel extends SimpleModel {
+  _SimpleModel({
+    String? id,
+    this.name,
+    this.bar,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _SimpleModel._({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteSimpleModel extends SimpleModel
+    implements RemoteModel<String, SimpleModel> {
+  const RemoteSimpleModel._() : super._();
+}
+
+class _RemoteSimpleModel extends RemoteSimpleModel {
+  const _RemoteSimpleModel({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteSimpleModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'SimpleModel',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteSimpleModel(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/simple_model/simple_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/simple_model/simple_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.simple_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class SimpleModelType
     extends ModelType<String, SimpleModel, PartialSimpleModel> {
@@ -229,6 +230,55 @@ abstract class SimpleModel extends PartialSimpleModel
 
   static const SimpleModelQueryFields<String, SimpleModel> _queryFields =
       SimpleModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'SimpleModel',
+      'pluralName': 'SimpleModels',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'bar': {
+          'name': 'bar',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/static_groups_auth/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/static_groups_auth/model_provider.dart
@@ -1,0 +1,63 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'static_groups.dart';
+
+export 'static_groups.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'e18bccb92d24df3cb9f3e00b381b0fdf';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [StaticGroups.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'staticGroups':
+      case 'StaticGroups':
+        return (StaticGroups.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/static_groups_auth/static_groups.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/static_groups_auth/static_groups.dart
@@ -270,6 +270,24 @@ abstract class StaticGroups extends PartialStaticGroups
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, StaticGroups, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  StaticGroups copyWith({
+    String? id,
+    String? name,
+    String? bar,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _StaticGroups._(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bar: bar ?? this.bar,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, StaticGroups, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/static_groups_auth/static_groups.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/static_groups_auth/static_groups.dart
@@ -1,0 +1,426 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.static_groups;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class StaticGroupsType
+    extends ModelType<String, StaticGroups, PartialStaticGroups> {
+  const StaticGroupsType();
+
+  @override
+  T fromJson<T extends PartialModel<String, StaticGroups>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == StaticGroups || T == Model<String, StaticGroups>) {
+      return StaticGroups.fromJson(json) as T;
+    }
+    if (T == RemoteStaticGroups || T == RemoteModel<String, StaticGroups>) {
+      return _RemoteStaticGroups.fromJson(json) as T;
+    }
+    return _PartialStaticGroups.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'staticGroups';
+}
+
+class StaticGroupsQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const StaticGroupsQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, StaticGroups>? _root;
+
+  /// Query field for the [StaticGroups.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, StaticGroups, String>(
+        const QueryField<String, StaticGroups, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [StaticGroups.name] field.
+  QueryField<ModelIdentifier, M, String?> get $name =>
+      NestedQueryField<ModelIdentifier, M, String, StaticGroups, String?>(
+        const QueryField<String, StaticGroups, String?>(fieldName: 'name'),
+        root: _root,
+      );
+
+  /// Query field for the [StaticGroups.bar] field.
+  QueryField<ModelIdentifier, M, String?> get $bar =>
+      NestedQueryField<ModelIdentifier, M, String, StaticGroups, String?>(
+        const QueryField<String, StaticGroups, String?>(fieldName: 'bar'),
+        root: _root,
+      );
+
+  /// Query field for the [StaticGroups.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, StaticGroups,
+          TemporalDateTime>(
+        const QueryField<String, StaticGroups, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [StaticGroups.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, StaticGroups,
+          TemporalDateTime>(
+        const QueryField<String, StaticGroups, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [StaticGroups] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, StaticGroups, String>(
+        const QueryField<String, StaticGroups, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialStaticGroups extends PartialModel<String, StaticGroups>
+    with AWSEquatable<PartialStaticGroups> {
+  const PartialStaticGroups._();
+
+  String get id;
+  String? get name;
+  String? get bar;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  StaticGroupsType get modelType => StaticGroups.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        bar,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'StaticGroups';
+}
+
+class _PartialStaticGroups extends PartialStaticGroups {
+  const _PartialStaticGroups({
+    required this.id,
+    this.name,
+    this.bar,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialStaticGroups.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'StaticGroups',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialStaticGroups(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class StaticGroups extends PartialStaticGroups
+    implements Model<String, StaticGroups> {
+  factory StaticGroups({
+    String? id,
+    String? name,
+    String? bar,
+  }) = _StaticGroups;
+
+  const StaticGroups._() : super._();
+
+  factory StaticGroups.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'StaticGroups',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'StaticGroups',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'StaticGroups',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _StaticGroups._(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const StaticGroupsType classType = StaticGroupsType();
+
+  static const StaticGroupsQueryFields<String, StaticGroups> _queryFields =
+      StaticGroupsQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, StaticGroups, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, StaticGroups, String> get ID => $id;
+  @override
+  String? get name;
+
+  /// Query field for the [name] field.
+  QueryField<String, StaticGroups, String?> get $name => _queryFields.$name;
+
+  /// Query field for the [name] field.
+  @Deprecated(r'Use $name instead')
+  QueryField<String, StaticGroups, String?> get NAME => $name;
+  @override
+  String? get bar;
+
+  /// Query field for the [bar] field.
+  QueryField<String, StaticGroups, String?> get $bar => _queryFields.$bar;
+
+  /// Query field for the [bar] field.
+  @Deprecated(r'Use $bar instead')
+  QueryField<String, StaticGroups, String?> get BAR => $bar;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, StaticGroups, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, StaticGroups, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, StaticGroups, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'name':
+        value = name;
+        break;
+      case r'bar':
+        value = bar;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _StaticGroups extends StaticGroups {
+  _StaticGroups({
+    String? id,
+    this.name,
+    this.bar,
+  })  : id = id ?? uuid(),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _StaticGroups._({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteStaticGroups extends StaticGroups
+    implements RemoteModel<String, StaticGroups> {
+  const RemoteStaticGroups._() : super._();
+}
+
+class _RemoteStaticGroups extends RemoteStaticGroups {
+  const _RemoteStaticGroups({
+    required this.id,
+    this.name,
+    this.bar,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteStaticGroups.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'StaticGroups',
+            'id',
+          ))
+        : (json['id'] as String);
+    final name = json['name'] == null ? null : (json['name'] as String);
+    final bar = json['bar'] == null ? null : (json['bar'] as String);
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'StaticGroups',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'StaticGroups',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'StaticGroups',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'StaticGroups',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'StaticGroups',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteStaticGroups(
+      id: id,
+      name: name,
+      bar: bar,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final String? name;
+
+  @override
+  final String? bar;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/static_groups_auth/static_groups.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/static_groups_auth/static_groups.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.static_groups;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class StaticGroupsType
     extends ModelType<String, StaticGroups, PartialStaticGroups> {
@@ -229,6 +230,69 @@ abstract class StaticGroups extends PartialStaticGroups
 
   static const StaticGroupsQueryFields<String, StaticGroups> _queryFields =
       StaticGroupsQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'staticGroups',
+      'pluralName': 'staticGroups',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'name': {
+          'name': 'name',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'bar': {
+          'name': 'bar',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [
+        {
+          'authStrategy': 'GROUPS',
+          'provider': 'USERPOOLS',
+          'operations': [
+            'CREATE',
+            'UPDATE',
+            'DELETE',
+            'READ',
+          ],
+          'groupClaim': 'cognito:groups',
+          'groups': ['Admin'],
+          'groupsField': 'groups',
+        }
+      ],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/time_types/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/time_types/model_provider.dart
@@ -1,0 +1,63 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'temporal_time_model.dart';
+
+export 'temporal_time_model.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => 'b18e8345b490e3b2949b0af2e6ad4e80';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [TemporalTimeModel.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'TemporalTimeModel':
+        return (TemporalTimeModel.classType
+            as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/time_types/temporal_time_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/time_types/temporal_time_model.dart
@@ -594,6 +594,41 @@ abstract class TemporalTimeModel extends PartialTemporalTimeModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, TemporalTimeModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  TemporalTimeModel copyWith({
+    String? id,
+    DateTime? date,
+    DateTime? time,
+    DateTime? dateTime,
+    DateTime? timestamp,
+    int? intNum,
+    List<TemporalDate?>? dateList,
+    List<TemporalTime?>? timeList,
+    List<TemporalDateTime?>? dateTimeList,
+    List<TemporalTimestamp?>? timestampList,
+    List<int?>? intList,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _TemporalTimeModel._(
+      id: id ?? this.id,
+      date: date == null ? this.date : TemporalDate(date),
+      time: time == null ? this.time : TemporalTime(time),
+      dateTime: dateTime == null ? this.dateTime : TemporalDateTime(dateTime),
+      timestamp:
+          timestamp == null ? this.timestamp : TemporalTimestamp(timestamp),
+      intNum: intNum ?? this.intNum,
+      dateList: dateList ?? this.dateList,
+      timeList: timeList ?? this.timeList,
+      dateTimeList: dateTimeList ?? this.dateTimeList,
+      timestampList: timestampList ?? this.timestampList,
+      intList: intList ?? this.intList,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<String, TemporalTimeModel, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/time_types/temporal_time_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/time_types/temporal_time_model.dart
@@ -1,0 +1,898 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names
+
+library models.temporal_time_model;
+
+import 'package:amplify_core/amplify_core.dart';
+
+class TemporalTimeModelType
+    extends ModelType<String, TemporalTimeModel, PartialTemporalTimeModel> {
+  const TemporalTimeModelType();
+
+  @override
+  T fromJson<T extends PartialModel<String, TemporalTimeModel>>(
+    Map<String, Object?> json,
+  ) {
+    if (T == TemporalTimeModel || T == Model<String, TemporalTimeModel>) {
+      return TemporalTimeModel.fromJson(json) as T;
+    }
+    if (T == RemoteTemporalTimeModel ||
+        T == RemoteModel<String, TemporalTimeModel>) {
+      return _RemoteTemporalTimeModel.fromJson(json) as T;
+    }
+    return _PartialTemporalTimeModel.fromJson(json) as T;
+  }
+
+  @override
+  String get modelName => 'TemporalTimeModel';
+}
+
+class TemporalTimeModelQueryFields<ModelIdentifier extends Object,
+    M extends Model<ModelIdentifier, M>> {
+  const TemporalTimeModelQueryFields([this._root]);
+
+  final QueryField<ModelIdentifier, M, TemporalTimeModel>? _root;
+
+  /// Query field for the [TemporalTimeModel.id] field.
+  QueryField<ModelIdentifier, M, String> get $id =>
+      NestedQueryField<ModelIdentifier, M, String, TemporalTimeModel, String>(
+        const QueryField<String, TemporalTimeModel, String>(fieldName: 'id'),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel.date] field.
+  QueryField<ModelIdentifier, M, TemporalDate?> get $date => NestedQueryField<
+          ModelIdentifier, M, String, TemporalTimeModel, TemporalDate?>(
+        const QueryField<String, TemporalTimeModel, TemporalDate?>(
+          fieldName: 'date',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel.time] field.
+  QueryField<ModelIdentifier, M, TemporalTime?> get $time => NestedQueryField<
+          ModelIdentifier, M, String, TemporalTimeModel, TemporalTime?>(
+        const QueryField<String, TemporalTimeModel, TemporalTime?>(
+          fieldName: 'time',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel.dateTime] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $dateTime =>
+      NestedQueryField<ModelIdentifier, M, String, TemporalTimeModel,
+          TemporalDateTime?>(
+        const QueryField<String, TemporalTimeModel, TemporalDateTime?>(
+          fieldName: 'dateTime',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel.timestamp] field.
+  QueryField<ModelIdentifier, M, TemporalTimestamp?> get $timestamp =>
+      NestedQueryField<ModelIdentifier, M, String, TemporalTimeModel,
+          TemporalTimestamp?>(
+        const QueryField<String, TemporalTimeModel, TemporalTimestamp?>(
+          fieldName: 'timestamp',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel.intNum] field.
+  QueryField<ModelIdentifier, M, int?> get $intNum =>
+      NestedQueryField<ModelIdentifier, M, String, TemporalTimeModel, int?>(
+        const QueryField<String, TemporalTimeModel, int?>(fieldName: 'intNum'),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel.dateList] field.
+  QueryField<ModelIdentifier, M, TemporalDate?> get $dateList =>
+      NestedQueryField<ModelIdentifier, M, String, TemporalTimeModel,
+          TemporalDate?>(
+        const QueryField<String, TemporalTimeModel, TemporalDate?>(
+          fieldName: 'dateList',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel.timeList] field.
+  QueryField<ModelIdentifier, M, TemporalTime?> get $timeList =>
+      NestedQueryField<ModelIdentifier, M, String, TemporalTimeModel,
+          TemporalTime?>(
+        const QueryField<String, TemporalTimeModel, TemporalTime?>(
+          fieldName: 'timeList',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel.dateTimeList] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime?> get $dateTimeList =>
+      NestedQueryField<ModelIdentifier, M, String, TemporalTimeModel,
+          TemporalDateTime?>(
+        const QueryField<String, TemporalTimeModel, TemporalDateTime?>(
+          fieldName: 'dateTimeList',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel.timestampList] field.
+  QueryField<ModelIdentifier, M, TemporalTimestamp?> get $timestampList =>
+      NestedQueryField<ModelIdentifier, M, String, TemporalTimeModel,
+          TemporalTimestamp?>(
+        const QueryField<String, TemporalTimeModel, TemporalTimestamp?>(
+          fieldName: 'timestampList',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel.intList] field.
+  QueryField<ModelIdentifier, M, int?> get $intList =>
+      NestedQueryField<ModelIdentifier, M, String, TemporalTimeModel, int?>(
+        const QueryField<String, TemporalTimeModel, int?>(fieldName: 'intList'),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel.createdAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
+      NestedQueryField<ModelIdentifier, M, String, TemporalTimeModel,
+          TemporalDateTime>(
+        const QueryField<String, TemporalTimeModel, TemporalDateTime>(
+          fieldName: 'createdAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel.updatedAt] field.
+  QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
+      NestedQueryField<ModelIdentifier, M, String, TemporalTimeModel,
+          TemporalDateTime>(
+        const QueryField<String, TemporalTimeModel, TemporalDateTime>(
+          fieldName: 'updatedAt',
+        ),
+        root: _root,
+      );
+
+  /// Query field for the [TemporalTimeModel] model identifier.
+  QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
+      NestedQueryField<ModelIdentifier, M, String, TemporalTimeModel, String>(
+        const QueryField<String, TemporalTimeModel, String>(
+          fieldName: 'modelIdentifier',
+        ),
+        root: _root,
+      );
+}
+
+abstract class PartialTemporalTimeModel
+    extends PartialModel<String, TemporalTimeModel>
+    with AWSEquatable<PartialTemporalTimeModel> {
+  const PartialTemporalTimeModel._();
+
+  String get id;
+  TemporalDate? get date;
+  TemporalTime? get time;
+  TemporalDateTime? get dateTime;
+  TemporalTimestamp? get timestamp;
+  int? get intNum;
+  List<TemporalDate?>? get dateList;
+  List<TemporalTime?>? get timeList;
+  List<TemporalDateTime?>? get dateTimeList;
+  List<TemporalTimestamp?>? get timestampList;
+  List<int?>? get intList;
+  TemporalDateTime? get createdAt;
+  TemporalDateTime? get updatedAt;
+  @override
+  String get modelIdentifier => id;
+  @override
+  TemporalTimeModelType get modelType => TemporalTimeModel.classType;
+  @override
+  List<Object?> get props => [
+        id,
+        date,
+        time,
+        dateTime,
+        timestamp,
+        intNum,
+        dateList,
+        timeList,
+        dateTimeList,
+        timestampList,
+        intList,
+        createdAt,
+        updatedAt,
+      ];
+  @override
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'date': date?.format(),
+        'time': time?.format(),
+        'dateTime': dateTime?.format(),
+        'timestamp': timestamp?.toSeconds(),
+        'intNum': intNum,
+        'dateList': dateList?.map((el) => el?.format()).toList(),
+        'timeList': timeList?.map((el) => el?.format()).toList(),
+        'dateTimeList': dateTimeList?.map((el) => el?.format()).toList(),
+        'timestampList': timestampList?.map((el) => el?.toSeconds()).toList(),
+        'intList': intList,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format(),
+        'version': version,
+        'deleted': deleted,
+        'lastChangedAt': lastChangedAt?.format(),
+      };
+  @override
+  String get runtimeTypeName => 'TemporalTimeModel';
+}
+
+class _PartialTemporalTimeModel extends PartialTemporalTimeModel {
+  const _PartialTemporalTimeModel({
+    required this.id,
+    this.date,
+    this.time,
+    this.dateTime,
+    this.timestamp,
+    this.intNum,
+    this.dateList,
+    this.timeList,
+    this.dateTimeList,
+    this.timestampList,
+    this.intList,
+    this.createdAt,
+    this.updatedAt,
+  }) : super._();
+
+  factory _PartialTemporalTimeModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'TemporalTimeModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final date = json['date'] == null
+        ? null
+        : TemporalDate.fromString((json['date'] as String));
+    final time = json['time'] == null
+        ? null
+        : TemporalTime.fromString((json['time'] as String));
+    final dateTime = json['dateTime'] == null
+        ? null
+        : TemporalDateTime.fromString((json['dateTime'] as String));
+    final timestamp = json['timestamp'] == null
+        ? null
+        : TemporalTimestamp.fromSeconds((json['timestamp'] as int));
+    final intNum = json['intNum'] == null ? null : (json['intNum'] as int);
+    final dateList = json['dateList'] == null
+        ? null
+        : (json['dateList'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final timeList = json['timeList'] == null
+        ? null
+        : (json['timeList'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final dateTimeList = json['dateTimeList'] == null
+        ? null
+        : (json['dateTimeList'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final timestampList = json['timestampList'] == null
+        ? null
+        : (json['timestampList'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final intList = json['intList'] == null
+        ? null
+        : (json['intList'] as List<Object?>).cast<int?>().toList();
+    final createdAt = json['createdAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? null
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _PartialTemporalTimeModel(
+      id: id,
+      date: date,
+      time: time,
+      dateTime: dateTime,
+      timestamp: timestamp,
+      intNum: intNum,
+      dateList: dateList,
+      timeList: timeList,
+      dateTimeList: dateTimeList,
+      timestampList: timestampList,
+      intList: intList,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final TemporalDate? date;
+
+  @override
+  final TemporalTime? time;
+
+  @override
+  final TemporalDateTime? dateTime;
+
+  @override
+  final TemporalTimestamp? timestamp;
+
+  @override
+  final int? intNum;
+
+  @override
+  final List<TemporalDate?>? dateList;
+
+  @override
+  final List<TemporalTime?>? timeList;
+
+  @override
+  final List<TemporalDateTime?>? dateTimeList;
+
+  @override
+  final List<TemporalTimestamp?>? timestampList;
+
+  @override
+  final List<int?>? intList;
+
+  @override
+  final TemporalDateTime? createdAt;
+
+  @override
+  final TemporalDateTime? updatedAt;
+}
+
+abstract class TemporalTimeModel extends PartialTemporalTimeModel
+    implements Model<String, TemporalTimeModel> {
+  factory TemporalTimeModel({
+    String? id,
+    DateTime? date,
+    DateTime? time,
+    DateTime? dateTime,
+    DateTime? timestamp,
+    int? intNum,
+    List<TemporalDate?>? dateList,
+    List<TemporalTime?>? timeList,
+    List<TemporalDateTime?>? dateTimeList,
+    List<TemporalTimestamp?>? timestampList,
+    List<int?>? intList,
+  }) = _TemporalTimeModel;
+
+  const TemporalTimeModel._() : super._();
+
+  factory TemporalTimeModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'TemporalTimeModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final date = json['date'] == null
+        ? null
+        : TemporalDate.fromString((json['date'] as String));
+    final time = json['time'] == null
+        ? null
+        : TemporalTime.fromString((json['time'] as String));
+    final dateTime = json['dateTime'] == null
+        ? null
+        : TemporalDateTime.fromString((json['dateTime'] as String));
+    final timestamp = json['timestamp'] == null
+        ? null
+        : TemporalTimestamp.fromSeconds((json['timestamp'] as int));
+    final intNum = json['intNum'] == null ? null : (json['intNum'] as int);
+    final dateList = json['dateList'] == null
+        ? null
+        : (json['dateList'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final timeList = json['timeList'] == null
+        ? null
+        : (json['timeList'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final dateTimeList = json['dateTimeList'] == null
+        ? null
+        : (json['dateTimeList'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final timestampList = json['timestampList'] == null
+        ? null
+        : (json['timestampList'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final intList = json['intList'] == null
+        ? null
+        : (json['intList'] as List<Object?>).cast<int?>().toList();
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'TemporalTimeModel',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'TemporalTimeModel',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    return _TemporalTimeModel._(
+      id: id,
+      date: date,
+      time: time,
+      dateTime: dateTime,
+      timestamp: timestamp,
+      intNum: intNum,
+      dateList: dateList,
+      timeList: timeList,
+      dateTimeList: dateTimeList,
+      timestampList: timestampList,
+      intList: intList,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static const TemporalTimeModelType classType = TemporalTimeModelType();
+
+  static const TemporalTimeModelQueryFields<String, TemporalTimeModel>
+      _queryFields = TemporalTimeModelQueryFields();
+
+  @override
+  String get id;
+
+  /// Query field for the [id] field.
+  QueryField<String, TemporalTimeModel, String> get $id => _queryFields.$id;
+
+  /// Query field for the [id] field.
+  @Deprecated(r'Use $id instead')
+  QueryField<String, TemporalTimeModel, String> get ID => $id;
+  @override
+  TemporalDate? get date;
+
+  /// Query field for the [date] field.
+  QueryField<String, TemporalTimeModel, TemporalDate?> get $date =>
+      _queryFields.$date;
+
+  /// Query field for the [date] field.
+  @Deprecated(r'Use $date instead')
+  QueryField<String, TemporalTimeModel, TemporalDate?> get DATE => $date;
+  @override
+  TemporalTime? get time;
+
+  /// Query field for the [time] field.
+  QueryField<String, TemporalTimeModel, TemporalTime?> get $time =>
+      _queryFields.$time;
+
+  /// Query field for the [time] field.
+  @Deprecated(r'Use $time instead')
+  QueryField<String, TemporalTimeModel, TemporalTime?> get TIME => $time;
+  @override
+  TemporalDateTime? get dateTime;
+
+  /// Query field for the [dateTime] field.
+  QueryField<String, TemporalTimeModel, TemporalDateTime?> get $dateTime =>
+      _queryFields.$dateTime;
+
+  /// Query field for the [dateTime] field.
+  @Deprecated(r'Use $dateTime instead')
+  QueryField<String, TemporalTimeModel, TemporalDateTime?> get DATE_TIME =>
+      $dateTime;
+  @override
+  TemporalTimestamp? get timestamp;
+
+  /// Query field for the [timestamp] field.
+  QueryField<String, TemporalTimeModel, TemporalTimestamp?> get $timestamp =>
+      _queryFields.$timestamp;
+
+  /// Query field for the [timestamp] field.
+  @Deprecated(r'Use $timestamp instead')
+  QueryField<String, TemporalTimeModel, TemporalTimestamp?> get TIMESTAMP =>
+      $timestamp;
+  @override
+  int? get intNum;
+
+  /// Query field for the [intNum] field.
+  QueryField<String, TemporalTimeModel, int?> get $intNum =>
+      _queryFields.$intNum;
+
+  /// Query field for the [intNum] field.
+  @Deprecated(r'Use $intNum instead')
+  QueryField<String, TemporalTimeModel, int?> get INT_NUM => $intNum;
+  @override
+  List<TemporalDate?>? get dateList;
+
+  /// Query field for the [dateList] field.
+  QueryField<String, TemporalTimeModel, TemporalDate?> get $dateList =>
+      _queryFields.$dateList;
+
+  /// Query field for the [dateList] field.
+  @Deprecated(r'Use $dateList instead')
+  QueryField<String, TemporalTimeModel, TemporalDate?> get DATE_LIST =>
+      $dateList;
+  @override
+  List<TemporalTime?>? get timeList;
+
+  /// Query field for the [timeList] field.
+  QueryField<String, TemporalTimeModel, TemporalTime?> get $timeList =>
+      _queryFields.$timeList;
+
+  /// Query field for the [timeList] field.
+  @Deprecated(r'Use $timeList instead')
+  QueryField<String, TemporalTimeModel, TemporalTime?> get TIME_LIST =>
+      $timeList;
+  @override
+  List<TemporalDateTime?>? get dateTimeList;
+
+  /// Query field for the [dateTimeList] field.
+  QueryField<String, TemporalTimeModel, TemporalDateTime?> get $dateTimeList =>
+      _queryFields.$dateTimeList;
+
+  /// Query field for the [dateTimeList] field.
+  @Deprecated(r'Use $dateTimeList instead')
+  QueryField<String, TemporalTimeModel, TemporalDateTime?> get DATE_TIME_LIST =>
+      $dateTimeList;
+  @override
+  List<TemporalTimestamp?>? get timestampList;
+
+  /// Query field for the [timestampList] field.
+  QueryField<String, TemporalTimeModel, TemporalTimestamp?>
+      get $timestampList => _queryFields.$timestampList;
+
+  /// Query field for the [timestampList] field.
+  @Deprecated(r'Use $timestampList instead')
+  QueryField<String, TemporalTimeModel, TemporalTimestamp?>
+      get TIMESTAMP_LIST => $timestampList;
+  @override
+  List<int?>? get intList;
+
+  /// Query field for the [intList] field.
+  QueryField<String, TemporalTimeModel, int?> get $intList =>
+      _queryFields.$intList;
+
+  /// Query field for the [intList] field.
+  @Deprecated(r'Use $intList instead')
+  QueryField<String, TemporalTimeModel, int?> get INT_LIST => $intList;
+  @override
+  TemporalDateTime get createdAt;
+  @override
+  TemporalDateTime get updatedAt;
+
+  /// Query field for the [modelIdentifier] field.
+  QueryField<String, TemporalTimeModel, String> get $modelIdentifier =>
+      _queryFields.$modelIdentifier;
+
+  /// Query field for the [modelIdentifier] field.
+  @Deprecated(r'Use $modelIdentifier instead')
+  QueryField<String, TemporalTimeModel, String> get MODEL_IDENTIFIER =>
+      $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<String, TemporalTimeModel, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'date':
+        value = date;
+        break;
+      case r'time':
+        value = time;
+        break;
+      case r'dateTime':
+        value = dateTime;
+        break;
+      case r'timestamp':
+        value = timestamp;
+        break;
+      case r'intNum':
+        value = intNum;
+        break;
+      case r'dateList':
+        value = dateList;
+        break;
+      case r'timeList':
+        value = timeList;
+        break;
+      case r'dateTimeList':
+        value = dateTimeList;
+        break;
+      case r'timestampList':
+        value = timestampList;
+        break;
+      case r'intList':
+        value = intList;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
+}
+
+class _TemporalTimeModel extends TemporalTimeModel {
+  _TemporalTimeModel({
+    String? id,
+    DateTime? date,
+    DateTime? time,
+    DateTime? dateTime,
+    DateTime? timestamp,
+    this.intNum,
+    this.dateList,
+    this.timeList,
+    this.dateTimeList,
+    this.timestampList,
+    this.intList,
+  })  : id = id ?? uuid(),
+        date = date == null ? null : TemporalDate(date),
+        time = time == null ? null : TemporalTime(time),
+        dateTime = dateTime == null ? null : TemporalDateTime(dateTime),
+        timestamp = timestamp == null ? null : TemporalTimestamp(timestamp),
+        createdAt = TemporalDateTime.now(),
+        updatedAt = TemporalDateTime.now(),
+        super._();
+
+  const _TemporalTimeModel._({
+    required this.id,
+    this.date,
+    this.time,
+    this.dateTime,
+    this.timestamp,
+    this.intNum,
+    this.dateList,
+    this.timeList,
+    this.dateTimeList,
+    this.timestampList,
+    this.intList,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : super._();
+
+  @override
+  final String id;
+
+  @override
+  final TemporalDate? date;
+
+  @override
+  final TemporalTime? time;
+
+  @override
+  final TemporalDateTime? dateTime;
+
+  @override
+  final TemporalTimestamp? timestamp;
+
+  @override
+  final int? intNum;
+
+  @override
+  final List<TemporalDate?>? dateList;
+
+  @override
+  final List<TemporalTime?>? timeList;
+
+  @override
+  final List<TemporalDateTime?>? dateTimeList;
+
+  @override
+  final List<TemporalTimestamp?>? timestampList;
+
+  @override
+  final List<int?>? intList;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+}
+
+abstract class RemoteTemporalTimeModel extends TemporalTimeModel
+    implements RemoteModel<String, TemporalTimeModel> {
+  const RemoteTemporalTimeModel._() : super._();
+}
+
+class _RemoteTemporalTimeModel extends RemoteTemporalTimeModel {
+  const _RemoteTemporalTimeModel({
+    required this.id,
+    this.date,
+    this.time,
+    this.dateTime,
+    this.timestamp,
+    this.intNum,
+    this.dateList,
+    this.timeList,
+    this.dateTimeList,
+    this.timestampList,
+    this.intList,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    required this.deleted,
+    required this.lastChangedAt,
+  }) : super._();
+
+  factory _RemoteTemporalTimeModel.fromJson(Map<String, Object?> json) {
+    final id = json['id'] == null
+        ? (throw ModelFieldError(
+            'TemporalTimeModel',
+            'id',
+          ))
+        : (json['id'] as String);
+    final date = json['date'] == null
+        ? null
+        : TemporalDate.fromString((json['date'] as String));
+    final time = json['time'] == null
+        ? null
+        : TemporalTime.fromString((json['time'] as String));
+    final dateTime = json['dateTime'] == null
+        ? null
+        : TemporalDateTime.fromString((json['dateTime'] as String));
+    final timestamp = json['timestamp'] == null
+        ? null
+        : TemporalTimestamp.fromSeconds((json['timestamp'] as int));
+    final intNum = json['intNum'] == null ? null : (json['intNum'] as int);
+    final dateList = json['dateList'] == null
+        ? null
+        : (json['dateList'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDate.fromString(el))
+            .toList();
+    final timeList = json['timeList'] == null
+        ? null
+        : (json['timeList'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalTime.fromString(el))
+            .toList();
+    final dateTimeList = json['dateTimeList'] == null
+        ? null
+        : (json['dateTimeList'] as List<Object?>)
+            .cast<String?>()
+            .map((el) => el == null ? null : TemporalDateTime.fromString(el))
+            .toList();
+    final timestampList = json['timestampList'] == null
+        ? null
+        : (json['timestampList'] as List<Object?>)
+            .cast<int?>()
+            .map((el) => el == null ? null : TemporalTimestamp.fromSeconds(el))
+            .toList();
+    final intList = json['intList'] == null
+        ? null
+        : (json['intList'] as List<Object?>).cast<int?>().toList();
+    final createdAt = json['createdAt'] == null
+        ? (throw ModelFieldError(
+            'TemporalTimeModel',
+            'createdAt',
+          ))
+        : TemporalDateTime.fromString((json['createdAt'] as String));
+    final updatedAt = json['updatedAt'] == null
+        ? (throw ModelFieldError(
+            'TemporalTimeModel',
+            'updatedAt',
+          ))
+        : TemporalDateTime.fromString((json['updatedAt'] as String));
+    final version = json['version'] == null
+        ? (throw ModelFieldError(
+            'TemporalTimeModel',
+            'version',
+          ))
+        : (json['version'] as int);
+    final deleted = json['deleted'] == null
+        ? (throw ModelFieldError(
+            'TemporalTimeModel',
+            'deleted',
+          ))
+        : (json['deleted'] as bool);
+    final lastChangedAt = json['lastChangedAt'] == null
+        ? (throw ModelFieldError(
+            'TemporalTimeModel',
+            'lastChangedAt',
+          ))
+        : TemporalDateTime.fromString((json['lastChangedAt'] as String));
+    return _RemoteTemporalTimeModel(
+      id: id,
+      date: date,
+      time: time,
+      dateTime: dateTime,
+      timestamp: timestamp,
+      intNum: intNum,
+      dateList: dateList,
+      timeList: timeList,
+      dateTimeList: dateTimeList,
+      timestampList: timestampList,
+      intList: intList,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      version: version,
+      deleted: deleted,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  @override
+  final String id;
+
+  @override
+  final TemporalDate? date;
+
+  @override
+  final TemporalTime? time;
+
+  @override
+  final TemporalDateTime? dateTime;
+
+  @override
+  final TemporalTimestamp? timestamp;
+
+  @override
+  final int? intNum;
+
+  @override
+  final List<TemporalDate?>? dateList;
+
+  @override
+  final List<TemporalTime?>? timeList;
+
+  @override
+  final List<TemporalDateTime?>? dateTimeList;
+
+  @override
+  final List<TemporalTimestamp?>? timestampList;
+
+  @override
+  final List<int?>? intList;
+
+  @override
+  final TemporalDateTime createdAt;
+
+  @override
+  final TemporalDateTime updatedAt;
+
+  @override
+  final int version;
+
+  @override
+  final bool deleted;
+
+  @override
+  final TemporalDateTime lastChangedAt;
+}

--- a/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/time_types/temporal_time_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/legacy_visitor/time_types/temporal_time_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.temporal_time_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class TemporalTimeModelType
     extends ModelType<String, TemporalTimeModel, PartialTemporalTimeModel> {
@@ -465,6 +466,113 @@ abstract class TemporalTimeModel extends PartialTemporalTimeModel
 
   static const TemporalTimeModelQueryFields<String, TemporalTimeModel>
       _queryFields = TemporalTimeModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'TemporalTimeModel',
+      'pluralName': 'TemporalTimeModels',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'date': {
+          'name': 'date',
+          'type': {'scalar': 'AWSDate'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'time': {
+          'name': 'time',
+          'type': {'scalar': 'AWSTime'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'dateTime': {
+          'name': 'dateTime',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'timestamp': {
+          'name': 'timestamp',
+          'type': {'scalar': 'AWSTimestamp'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'intNum': {
+          'name': 'intNum',
+          'type': {'scalar': 'Int'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'dateList': {
+          'name': 'dateList',
+          'type': {
+            'list': {'scalar': 'AWSDate'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'timeList': {
+          'name': 'timeList',
+          'type': {
+            'list': {'scalar': 'AWSTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'dateTimeList': {
+          'name': 'dateTimeList',
+          'type': {
+            'list': {'scalar': 'AWSDateTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'timestampList': {
+          'name': 'timestampList',
+          'type': {
+            'list': {'scalar': 'AWSTimestamp'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'intList': {
+          'name': 'intList',
+          'type': {
+            'list': {'scalar': 'Int'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/model_provider.dart
@@ -1,0 +1,73 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'my_model.dart';
+import 'scalar_list_non_model.dart';
+import 'scalar_non_model.dart';
+
+export 'my_model.dart';
+export 'scalar_list_non_model.dart';
+export 'scalar_non_model.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '95573e11f28905ac0bbf0b7636c46fdc';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        ScalarListNonModel.schema,
+        MyModel.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas =>
+      [ScalarNonModel.schema];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'ScalarListNonModel':
+        return (ScalarListNonModel.classType
+            as ModelType<ModelIdentifier, M, P>);
+      case 'MyModel':
+        return (MyModel.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
@@ -257,6 +257,25 @@ abstract class MyModel extends PartialMyModel
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, MyModel, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  MyModel copyWith({
+    ScalarNonModel? embeddedNonModel,
+    ScalarNonModel? requiredEmbeddedNonModel,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? id,
+  }) {
+    return _MyModel._(
+      embeddedNonModel: embeddedNonModel ?? this.embeddedNonModel,
+      requiredEmbeddedNonModel:
+          requiredEmbeddedNonModel ?? this.requiredEmbeddedNonModel,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      id: id ?? this.id,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, MyModel, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.my_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 import 'scalar_non_model.dart';
 
@@ -231,6 +232,55 @@ abstract class MyModel extends PartialMyModel
 
   static const MyModelQueryFields<String, MyModel> _queryFields =
       MyModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'MyModel',
+      'pluralName': 'MyModels',
+      'fields': {
+        'embeddedNonModel': {
+          'name': 'embeddedNonModel',
+          'type': {'nonModel': 'ScalarNonModel'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredEmbeddedNonModel': {
+          'name': 'requiredEmbeddedNonModel',
+          'type': {'nonModel': 'ScalarNonModel'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   ScalarNonModel? get embeddedNonModel;

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
@@ -29,7 +29,8 @@ class MyModelType extends ModelType<String, MyModel, PartialMyModel> {
 
   @override
   T fromJson<T extends PartialModel<String, MyModel>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == MyModel || T == Model<String, MyModel>) {
       return MyModel.fromJson(json) as T;
     }
@@ -53,7 +54,8 @@ class MyModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, String, MyModel, TemporalDateTime>(
         const QueryField<String, MyModel, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -61,7 +63,8 @@ class MyModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
       NestedQueryField<ModelIdentifier, M, String, MyModel, TemporalDateTime>(
         const QueryField<String, MyModel, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -155,11 +158,13 @@ class _PartialMyModel extends PartialMyModel {
     final embeddedNonModel = json['embeddedNonModel'] == null
         ? null
         : ScalarNonModel.fromJson(
-            (json['embeddedNonModel'] as Map<String, Object?>));
+            (json['embeddedNonModel'] as Map<String, Object?>),
+          );
     final requiredEmbeddedNonModel = json['requiredEmbeddedNonModel'] == null
         ? null
         : ScalarNonModel.fromJson(
-            (json['requiredEmbeddedNonModel'] as Map<String, Object?>));
+            (json['requiredEmbeddedNonModel'] as Map<String, Object?>),
+          );
     final createdAt = json['createdAt'] == null
         ? null
         : TemporalDateTime.fromString((json['createdAt'] as String));
@@ -211,14 +216,16 @@ abstract class MyModel extends PartialMyModel
     final embeddedNonModel = json['embeddedNonModel'] == null
         ? null
         : ScalarNonModel.fromJson(
-            (json['embeddedNonModel'] as Map<String, Object?>));
+            (json['embeddedNonModel'] as Map<String, Object?>),
+          );
     final requiredEmbeddedNonModel = json['requiredEmbeddedNonModel'] == null
         ? (throw ModelFieldError(
             'MyModel',
             'requiredEmbeddedNonModel',
           ))
         : ScalarNonModel.fromJson(
-            (json['requiredEmbeddedNonModel'] as Map<String, Object?>));
+            (json['requiredEmbeddedNonModel'] as Map<String, Object?>),
+          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'MyModel',
@@ -333,14 +340,16 @@ class _RemoteMyModel extends RemoteMyModel {
     final embeddedNonModel = json['embeddedNonModel'] == null
         ? null
         : ScalarNonModel.fromJson(
-            (json['embeddedNonModel'] as Map<String, Object?>));
+            (json['embeddedNonModel'] as Map<String, Object?>),
+          );
     final requiredEmbeddedNonModel = json['requiredEmbeddedNonModel'] == null
         ? (throw ModelFieldError(
             'MyModel',
             'requiredEmbeddedNonModel',
           ))
         : ScalarNonModel.fromJson(
-            (json['requiredEmbeddedNonModel'] as Map<String, Object?>));
+            (json['requiredEmbeddedNonModel'] as Map<String, Object?>),
+          );
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
             'MyModel',

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/my_model.dart
@@ -117,32 +117,6 @@ abstract class PartialMyModel extends PartialModel<String, MyModel>
       };
   @override
   String get runtimeTypeName => 'MyModel';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, MyModel, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'embeddedNonModel':
-        value = embeddedNonModel;
-        break;
-      case r'requiredEmbeddedNonModel':
-        value = requiredEmbeddedNonModel;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'id':
-        value = id;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialMyModel extends PartialMyModel {
@@ -283,6 +257,32 @@ abstract class MyModel extends PartialMyModel
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, MyModel, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, MyModel, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'embeddedNonModel':
+        value = embeddedNonModel;
+        break;
+      case r'requiredEmbeddedNonModel':
+        value = requiredEmbeddedNonModel;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'id':
+        value = id;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _MyModel extends MyModel {

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.scalar_list_non_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class ScalarListNonModelType
     extends ModelType<String, ScalarListNonModel, PartialScalarListNonModel> {
@@ -2262,6 +2263,459 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
 
   static const ScalarListNonModelQueryFields<String, ScalarListNonModel>
       _queryFields = ScalarListNonModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'ScalarListNonModel',
+      'pluralName': 'ScalarListNonModels',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfString': {
+          'name': 'listOfString',
+          'type': {
+            'list': {'scalar': 'String'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredString': {
+          'name': 'listOfRequiredString',
+          'type': {
+            'list': {'scalar': 'String'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfString': {
+          'name': 'requiredListOfString',
+          'type': {
+            'list': {'scalar': 'String'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredString': {
+          'name': 'requiredListOfRequiredString',
+          'type': {
+            'list': {'scalar': 'String'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfInteger': {
+          'name': 'listOfInteger',
+          'type': {
+            'list': {'scalar': 'Int'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredInteger': {
+          'name': 'listOfRequiredInteger',
+          'type': {
+            'list': {'scalar': 'Int'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfInteger': {
+          'name': 'requiredListOfInteger',
+          'type': {
+            'list': {'scalar': 'Int'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredInteger': {
+          'name': 'requiredListOfRequiredInteger',
+          'type': {
+            'list': {'scalar': 'Int'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfFloat': {
+          'name': 'listOfFloat',
+          'type': {
+            'list': {'scalar': 'Float'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredFloat': {
+          'name': 'listOfRequiredFloat',
+          'type': {
+            'list': {'scalar': 'Float'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfFloat': {
+          'name': 'requiredListOfFloat',
+          'type': {
+            'list': {'scalar': 'Float'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredFloat': {
+          'name': 'requiredListOfRequiredFloat',
+          'type': {
+            'list': {'scalar': 'Float'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfBoolean': {
+          'name': 'listOfBoolean',
+          'type': {
+            'list': {'scalar': 'Boolean'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredBoolean': {
+          'name': 'listOfRequiredBoolean',
+          'type': {
+            'list': {'scalar': 'Boolean'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfBoolean': {
+          'name': 'requiredListOfBoolean',
+          'type': {
+            'list': {'scalar': 'Boolean'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredBoolean': {
+          'name': 'requiredListOfRequiredBoolean',
+          'type': {
+            'list': {'scalar': 'Boolean'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSDate': {
+          'name': 'listOfAWSDate',
+          'type': {
+            'list': {'scalar': 'AWSDate'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSDate': {
+          'name': 'listOfRequiredAWSDate',
+          'type': {
+            'list': {'scalar': 'AWSDate'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSDate': {
+          'name': 'requiredListOfAWSDate',
+          'type': {
+            'list': {'scalar': 'AWSDate'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSDate': {
+          'name': 'requiredListOfRequiredAWSDate',
+          'type': {
+            'list': {'scalar': 'AWSDate'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSDateTime': {
+          'name': 'listOfAWSDateTime',
+          'type': {
+            'list': {'scalar': 'AWSDateTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSDateTime': {
+          'name': 'listOfRequiredAWSDateTime',
+          'type': {
+            'list': {'scalar': 'AWSDateTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSDateTime': {
+          'name': 'requiredListOfAWSDateTime',
+          'type': {
+            'list': {'scalar': 'AWSDateTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSDateTime': {
+          'name': 'requiredListOfRequiredAWSDateTime',
+          'type': {
+            'list': {'scalar': 'AWSDateTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSTime': {
+          'name': 'listOfAWSTime',
+          'type': {
+            'list': {'scalar': 'AWSTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSTime': {
+          'name': 'listOfRequiredAWSTime',
+          'type': {
+            'list': {'scalar': 'AWSTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSTime': {
+          'name': 'requiredListOfAWSTime',
+          'type': {
+            'list': {'scalar': 'AWSTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSTime': {
+          'name': 'requiredListOfRequiredAWSTime',
+          'type': {
+            'list': {'scalar': 'AWSTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSTimestamp': {
+          'name': 'listOfAWSTimestamp',
+          'type': {
+            'list': {'scalar': 'AWSTimestamp'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSTimestamp': {
+          'name': 'listOfRequiredAWSTimestamp',
+          'type': {
+            'list': {'scalar': 'AWSTimestamp'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSTimestamp': {
+          'name': 'requiredListOfAWSTimestamp',
+          'type': {
+            'list': {'scalar': 'AWSTimestamp'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSTimestamp': {
+          'name': 'requiredListOfRequiredAWSTimestamp',
+          'type': {
+            'list': {'scalar': 'AWSTimestamp'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSEmail': {
+          'name': 'listOfAWSEmail',
+          'type': {
+            'list': {'scalar': 'AWSEmail'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSEmail': {
+          'name': 'listOfRequiredAWSEmail',
+          'type': {
+            'list': {'scalar': 'AWSEmail'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSEmail': {
+          'name': 'requiredListOfAWSEmail',
+          'type': {
+            'list': {'scalar': 'AWSEmail'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSEmail': {
+          'name': 'requiredListOfRequiredAWSEmail',
+          'type': {
+            'list': {'scalar': 'AWSEmail'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSJSON': {
+          'name': 'listOfAWSJSON',
+          'type': {
+            'list': {'scalar': 'AWSJSON'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSJSON': {
+          'name': 'listOfRequiredAWSJSON',
+          'type': {
+            'list': {'scalar': 'AWSJSON'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSJSON': {
+          'name': 'requiredListOfAWSJSON',
+          'type': {
+            'list': {'scalar': 'AWSJSON'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSJSON': {
+          'name': 'requiredListOfRequiredAWSJSON',
+          'type': {
+            'list': {'scalar': 'AWSJSON'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSPhone': {
+          'name': 'listOfAWSPhone',
+          'type': {
+            'list': {'scalar': 'AWSPhone'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSPhone': {
+          'name': 'listOfRequiredAWSPhone',
+          'type': {
+            'list': {'scalar': 'AWSPhone'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSPhone': {
+          'name': 'requiredListOfAWSPhone',
+          'type': {
+            'list': {'scalar': 'AWSPhone'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSPhone': {
+          'name': 'requiredListOfRequiredAWSPhone',
+          'type': {
+            'list': {'scalar': 'AWSPhone'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSUrl': {
+          'name': 'listOfAWSUrl',
+          'type': {
+            'list': {'scalar': 'AWSURL'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSUrl': {
+          'name': 'listOfRequiredAWSUrl',
+          'type': {
+            'list': {'scalar': 'AWSURL'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSUrl': {
+          'name': 'requiredListOfAWSUrl',
+          'type': {
+            'list': {'scalar': 'AWSURL'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSUrl': {
+          'name': 'requiredListOfRequiredAWSUrl',
+          'type': {
+            'list': {'scalar': 'AWSURL'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSIpAddress': {
+          'name': 'listOfAWSIpAddress',
+          'type': {
+            'list': {'scalar': 'AWSIPAddress'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSIpAddress': {
+          'name': 'listOfRequiredAWSIpAddress',
+          'type': {
+            'list': {'scalar': 'AWSIPAddress'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSIpAddress': {
+          'name': 'requiredListOfAWSIpAddress',
+          'type': {
+            'list': {'scalar': 'AWSIPAddress'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSIpAddress': {
+          'name': 'requiredListOfRequiredAWSIpAddress',
+          'type': {
+            'list': {'scalar': 'AWSIPAddress'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
@@ -28,7 +28,8 @@ class ScalarListNonModelType
 
   @override
   T fromJson<T extends PartialModel<String, ScalarListNonModel>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == ScalarListNonModel || T == Model<String, ScalarListNonModel>) {
       return ScalarListNonModel.fromJson(json) as T;
     }
@@ -60,7 +61,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $listOfString =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String?>(
         const QueryField<String, ScalarListNonModel, String?>(
-            fieldName: 'listOfString'),
+          fieldName: 'listOfString',
+        ),
         root: _root,
       );
 
@@ -68,7 +70,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $listOfRequiredString =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String>(
         const QueryField<String, ScalarListNonModel, String>(
-            fieldName: 'listOfRequiredString'),
+          fieldName: 'listOfRequiredString',
+        ),
         root: _root,
       );
 
@@ -76,7 +79,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $requiredListOfString =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String?>(
         const QueryField<String, ScalarListNonModel, String?>(
-            fieldName: 'requiredListOfString'),
+          fieldName: 'requiredListOfString',
+        ),
         root: _root,
       );
 
@@ -84,7 +88,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $requiredListOfRequiredString =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String>(
         const QueryField<String, ScalarListNonModel, String>(
-            fieldName: 'requiredListOfRequiredString'),
+          fieldName: 'requiredListOfRequiredString',
+        ),
         root: _root,
       );
 
@@ -92,7 +97,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, int?> get $listOfInteger =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, int?>(
         const QueryField<String, ScalarListNonModel, int?>(
-            fieldName: 'listOfInteger'),
+          fieldName: 'listOfInteger',
+        ),
         root: _root,
       );
 
@@ -100,7 +106,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, int> get $listOfRequiredInteger =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, int>(
         const QueryField<String, ScalarListNonModel, int>(
-            fieldName: 'listOfRequiredInteger'),
+          fieldName: 'listOfRequiredInteger',
+        ),
         root: _root,
       );
 
@@ -108,7 +115,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, int?> get $requiredListOfInteger =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, int?>(
         const QueryField<String, ScalarListNonModel, int?>(
-            fieldName: 'requiredListOfInteger'),
+          fieldName: 'requiredListOfInteger',
+        ),
         root: _root,
       );
 
@@ -116,7 +124,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, int> get $requiredListOfRequiredInteger =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, int>(
         const QueryField<String, ScalarListNonModel, int>(
-            fieldName: 'requiredListOfRequiredInteger'),
+          fieldName: 'requiredListOfRequiredInteger',
+        ),
         root: _root,
       );
 
@@ -124,7 +133,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, double?> get $listOfFloat =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, double?>(
         const QueryField<String, ScalarListNonModel, double?>(
-            fieldName: 'listOfFloat'),
+          fieldName: 'listOfFloat',
+        ),
         root: _root,
       );
 
@@ -132,7 +142,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, double> get $listOfRequiredFloat =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, double>(
         const QueryField<String, ScalarListNonModel, double>(
-            fieldName: 'listOfRequiredFloat'),
+          fieldName: 'listOfRequiredFloat',
+        ),
         root: _root,
       );
 
@@ -140,7 +151,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, double?> get $requiredListOfFloat =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, double?>(
         const QueryField<String, ScalarListNonModel, double?>(
-            fieldName: 'requiredListOfFloat'),
+          fieldName: 'requiredListOfFloat',
+        ),
         root: _root,
       );
 
@@ -148,7 +160,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, double> get $requiredListOfRequiredFloat =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, double>(
         const QueryField<String, ScalarListNonModel, double>(
-            fieldName: 'requiredListOfRequiredFloat'),
+          fieldName: 'requiredListOfRequiredFloat',
+        ),
         root: _root,
       );
 
@@ -156,7 +169,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, bool?> get $listOfBoolean =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, bool?>(
         const QueryField<String, ScalarListNonModel, bool?>(
-            fieldName: 'listOfBoolean'),
+          fieldName: 'listOfBoolean',
+        ),
         root: _root,
       );
 
@@ -164,7 +178,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, bool> get $listOfRequiredBoolean =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, bool>(
         const QueryField<String, ScalarListNonModel, bool>(
-            fieldName: 'listOfRequiredBoolean'),
+          fieldName: 'listOfRequiredBoolean',
+        ),
         root: _root,
       );
 
@@ -172,7 +187,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, bool?> get $requiredListOfBoolean =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, bool?>(
         const QueryField<String, ScalarListNonModel, bool?>(
-            fieldName: 'requiredListOfBoolean'),
+          fieldName: 'requiredListOfBoolean',
+        ),
         root: _root,
       );
 
@@ -180,7 +196,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, bool> get $requiredListOfRequiredBoolean =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, bool>(
         const QueryField<String, ScalarListNonModel, bool>(
-            fieldName: 'requiredListOfRequiredBoolean'),
+          fieldName: 'requiredListOfRequiredBoolean',
+        ),
         root: _root,
       );
 
@@ -189,7 +206,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
           TemporalDate?>(
         const QueryField<String, ScalarListNonModel, TemporalDate?>(
-            fieldName: 'listOfAWSDate'),
+          fieldName: 'listOfAWSDate',
+        ),
         root: _root,
       );
 
@@ -198,7 +216,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
           TemporalDate>(
         const QueryField<String, ScalarListNonModel, TemporalDate>(
-            fieldName: 'listOfRequiredAWSDate'),
+          fieldName: 'listOfRequiredAWSDate',
+        ),
         root: _root,
       );
 
@@ -207,7 +226,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
           TemporalDate?>(
         const QueryField<String, ScalarListNonModel, TemporalDate?>(
-            fieldName: 'requiredListOfAWSDate'),
+          fieldName: 'requiredListOfAWSDate',
+        ),
         root: _root,
       );
 
@@ -216,7 +236,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfRequiredAwsDate => NestedQueryField<ModelIdentifier, M,
               String, ScalarListNonModel, TemporalDate>(
             const QueryField<String, ScalarListNonModel, TemporalDate>(
-                fieldName: 'requiredListOfRequiredAWSDate'),
+              fieldName: 'requiredListOfRequiredAWSDate',
+            ),
             root: _root,
           );
 
@@ -225,7 +246,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
           TemporalDateTime?>(
         const QueryField<String, ScalarListNonModel, TemporalDateTime?>(
-            fieldName: 'listOfAWSDateTime'),
+          fieldName: 'listOfAWSDateTime',
+        ),
         root: _root,
       );
 
@@ -234,7 +256,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       get $listOfRequiredAwsDateTime => NestedQueryField<ModelIdentifier, M,
               String, ScalarListNonModel, TemporalDateTime>(
             const QueryField<String, ScalarListNonModel, TemporalDateTime>(
-                fieldName: 'listOfRequiredAWSDateTime'),
+              fieldName: 'listOfRequiredAWSDateTime',
+            ),
             root: _root,
           );
 
@@ -243,7 +266,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfAwsDateTime => NestedQueryField<ModelIdentifier, M,
               String, ScalarListNonModel, TemporalDateTime?>(
             const QueryField<String, ScalarListNonModel, TemporalDateTime?>(
-                fieldName: 'requiredListOfAWSDateTime'),
+              fieldName: 'requiredListOfAWSDateTime',
+            ),
             root: _root,
           );
 
@@ -252,7 +276,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfRequiredAwsDateTime => NestedQueryField<
               ModelIdentifier, M, String, ScalarListNonModel, TemporalDateTime>(
             const QueryField<String, ScalarListNonModel, TemporalDateTime>(
-                fieldName: 'requiredListOfRequiredAWSDateTime'),
+              fieldName: 'requiredListOfRequiredAWSDateTime',
+            ),
             root: _root,
           );
 
@@ -261,7 +286,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
           TemporalTime?>(
         const QueryField<String, ScalarListNonModel, TemporalTime?>(
-            fieldName: 'listOfAWSTime'),
+          fieldName: 'listOfAWSTime',
+        ),
         root: _root,
       );
 
@@ -270,7 +296,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
           TemporalTime>(
         const QueryField<String, ScalarListNonModel, TemporalTime>(
-            fieldName: 'listOfRequiredAWSTime'),
+          fieldName: 'listOfRequiredAWSTime',
+        ),
         root: _root,
       );
 
@@ -279,7 +306,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
           TemporalTime?>(
         const QueryField<String, ScalarListNonModel, TemporalTime?>(
-            fieldName: 'requiredListOfAWSTime'),
+          fieldName: 'requiredListOfAWSTime',
+        ),
         root: _root,
       );
 
@@ -288,7 +316,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfRequiredAwsTime => NestedQueryField<ModelIdentifier, M,
               String, ScalarListNonModel, TemporalTime>(
             const QueryField<String, ScalarListNonModel, TemporalTime>(
-                fieldName: 'requiredListOfRequiredAWSTime'),
+              fieldName: 'requiredListOfRequiredAWSTime',
+            ),
             root: _root,
           );
 
@@ -297,7 +326,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
           TemporalTimestamp?>(
         const QueryField<String, ScalarListNonModel, TemporalTimestamp?>(
-            fieldName: 'listOfAWSTimestamp'),
+          fieldName: 'listOfAWSTimestamp',
+        ),
         root: _root,
       );
 
@@ -306,7 +336,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       get $listOfRequiredAwsTimestamp => NestedQueryField<ModelIdentifier, M,
               String, ScalarListNonModel, TemporalTimestamp>(
             const QueryField<String, ScalarListNonModel, TemporalTimestamp>(
-                fieldName: 'listOfRequiredAWSTimestamp'),
+              fieldName: 'listOfRequiredAWSTimestamp',
+            ),
             root: _root,
           );
 
@@ -315,7 +346,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfAwsTimestamp => NestedQueryField<ModelIdentifier, M,
               String, ScalarListNonModel, TemporalTimestamp?>(
             const QueryField<String, ScalarListNonModel, TemporalTimestamp?>(
-                fieldName: 'requiredListOfAWSTimestamp'),
+              fieldName: 'requiredListOfAWSTimestamp',
+            ),
             root: _root,
           );
 
@@ -328,7 +360,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
               ScalarListNonModel,
               TemporalTimestamp>(
             const QueryField<String, ScalarListNonModel, TemporalTimestamp>(
-                fieldName: 'requiredListOfRequiredAWSTimestamp'),
+              fieldName: 'requiredListOfRequiredAWSTimestamp',
+            ),
             root: _root,
           );
 
@@ -336,7 +369,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $listOfAwsEmail =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String?>(
         const QueryField<String, ScalarListNonModel, String?>(
-            fieldName: 'listOfAWSEmail'),
+          fieldName: 'listOfAWSEmail',
+        ),
         root: _root,
       );
 
@@ -344,7 +378,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $listOfRequiredAwsEmail =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String>(
         const QueryField<String, ScalarListNonModel, String>(
-            fieldName: 'listOfRequiredAWSEmail'),
+          fieldName: 'listOfRequiredAWSEmail',
+        ),
         root: _root,
       );
 
@@ -352,7 +387,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $requiredListOfAwsEmail =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String?>(
         const QueryField<String, ScalarListNonModel, String?>(
-            fieldName: 'requiredListOfAWSEmail'),
+          fieldName: 'requiredListOfAWSEmail',
+        ),
         root: _root,
       );
 
@@ -360,7 +396,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $requiredListOfRequiredAwsEmail =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String>(
         const QueryField<String, ScalarListNonModel, String>(
-            fieldName: 'requiredListOfRequiredAWSEmail'),
+          fieldName: 'requiredListOfRequiredAWSEmail',
+        ),
         root: _root,
       );
 
@@ -368,7 +405,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Object?> get $listOfAwsjson =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, Object?>(
         const QueryField<String, ScalarListNonModel, Object?>(
-            fieldName: 'listOfAWSJSON'),
+          fieldName: 'listOfAWSJSON',
+        ),
         root: _root,
       );
 
@@ -376,7 +414,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Object> get $listOfRequiredAwsjson =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, Object>(
         const QueryField<String, ScalarListNonModel, Object>(
-            fieldName: 'listOfRequiredAWSJSON'),
+          fieldName: 'listOfRequiredAWSJSON',
+        ),
         root: _root,
       );
 
@@ -384,7 +423,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Object?> get $requiredListOfAwsjson =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, Object?>(
         const QueryField<String, ScalarListNonModel, Object?>(
-            fieldName: 'requiredListOfAWSJSON'),
+          fieldName: 'requiredListOfAWSJSON',
+        ),
         root: _root,
       );
 
@@ -392,7 +432,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Object> get $requiredListOfRequiredAwsjson =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, Object>(
         const QueryField<String, ScalarListNonModel, Object>(
-            fieldName: 'requiredListOfRequiredAWSJSON'),
+          fieldName: 'requiredListOfRequiredAWSJSON',
+        ),
         root: _root,
       );
 
@@ -400,7 +441,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $listOfAwsPhone =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String?>(
         const QueryField<String, ScalarListNonModel, String?>(
-            fieldName: 'listOfAWSPhone'),
+          fieldName: 'listOfAWSPhone',
+        ),
         root: _root,
       );
 
@@ -408,7 +450,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $listOfRequiredAwsPhone =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String>(
         const QueryField<String, ScalarListNonModel, String>(
-            fieldName: 'listOfRequiredAWSPhone'),
+          fieldName: 'listOfRequiredAWSPhone',
+        ),
         root: _root,
       );
 
@@ -416,7 +459,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $requiredListOfAwsPhone =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String?>(
         const QueryField<String, ScalarListNonModel, String?>(
-            fieldName: 'requiredListOfAWSPhone'),
+          fieldName: 'requiredListOfAWSPhone',
+        ),
         root: _root,
       );
 
@@ -424,7 +468,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $requiredListOfRequiredAwsPhone =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String>(
         const QueryField<String, ScalarListNonModel, String>(
-            fieldName: 'requiredListOfRequiredAWSPhone'),
+          fieldName: 'requiredListOfRequiredAWSPhone',
+        ),
         root: _root,
       );
 
@@ -432,7 +477,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Uri?> get $listOfAwsUrl =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, Uri?>(
         const QueryField<String, ScalarListNonModel, Uri?>(
-            fieldName: 'listOfAWSUrl'),
+          fieldName: 'listOfAWSUrl',
+        ),
         root: _root,
       );
 
@@ -440,7 +486,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Uri> get $listOfRequiredAwsUrl =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, Uri>(
         const QueryField<String, ScalarListNonModel, Uri>(
-            fieldName: 'listOfRequiredAWSUrl'),
+          fieldName: 'listOfRequiredAWSUrl',
+        ),
         root: _root,
       );
 
@@ -448,7 +495,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Uri?> get $requiredListOfAwsUrl =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, Uri?>(
         const QueryField<String, ScalarListNonModel, Uri?>(
-            fieldName: 'requiredListOfAWSUrl'),
+          fieldName: 'requiredListOfAWSUrl',
+        ),
         root: _root,
       );
 
@@ -456,7 +504,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Uri> get $requiredListOfRequiredAwsUrl =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, Uri>(
         const QueryField<String, ScalarListNonModel, Uri>(
-            fieldName: 'requiredListOfRequiredAWSUrl'),
+          fieldName: 'requiredListOfRequiredAWSUrl',
+        ),
         root: _root,
       );
 
@@ -464,7 +513,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $listOfAwsIpAddress =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String?>(
         const QueryField<String, ScalarListNonModel, String?>(
-            fieldName: 'listOfAWSIpAddress'),
+          fieldName: 'listOfAWSIpAddress',
+        ),
         root: _root,
       );
 
@@ -472,7 +522,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $listOfRequiredAwsIpAddress =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String>(
         const QueryField<String, ScalarListNonModel, String>(
-            fieldName: 'listOfRequiredAWSIpAddress'),
+          fieldName: 'listOfRequiredAWSIpAddress',
+        ),
         root: _root,
       );
 
@@ -480,7 +531,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $requiredListOfAwsIpAddress =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String?>(
         const QueryField<String, ScalarListNonModel, String?>(
-            fieldName: 'requiredListOfAWSIpAddress'),
+          fieldName: 'requiredListOfAWSIpAddress',
+        ),
         root: _root,
       );
 
@@ -489,7 +541,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfRequiredAwsIpAddress => NestedQueryField<
               ModelIdentifier, M, String, ScalarListNonModel, String>(
             const QueryField<String, ScalarListNonModel, String>(
-                fieldName: 'requiredListOfRequiredAWSIpAddress'),
+              fieldName: 'requiredListOfRequiredAWSIpAddress',
+            ),
             root: _root,
           );
 
@@ -498,7 +551,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
           TemporalDateTime>(
         const QueryField<String, ScalarListNonModel, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -507,7 +561,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel,
           TemporalDateTime>(
         const QueryField<String, ScalarListNonModel, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -515,7 +570,8 @@ class ScalarListNonModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListNonModel, String>(
         const QueryField<String, ScalarListNonModel, String>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -727,7 +783,8 @@ abstract class PartialScalarListNonModel
   String get runtimeTypeName => 'ScalarListNonModel';
   @override
   T valueFor<T extends Object?>(
-      QueryField<String, ScalarListNonModel, T> field) {
+    QueryField<String, ScalarListNonModel, T> field,
+  ) {
     Object? value;
     switch (field.fieldName) {
       case r'id':
@@ -977,12 +1034,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
         ? null
         : (json['listOfRequiredString'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredString',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredString',
+                  )),
+            )
             .toList();
     final requiredListOfString = json['requiredListOfString'] == null
         ? null
@@ -994,12 +1053,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredString'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredString',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredString',
+                      )),
+                )
                 .toList();
     final listOfInteger = json['listOfInteger'] == null
         ? null
@@ -1008,12 +1069,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
         ? null
         : (json['listOfRequiredInteger'] as List<Object?>)
             .cast<int?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredInteger',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredInteger',
+                  )),
+            )
             .toList();
     final requiredListOfInteger = json['requiredListOfInteger'] == null
         ? null
@@ -1025,12 +1088,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredInteger'] as List<Object?>)
                 .cast<int?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredInteger',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredInteger',
+                      )),
+                )
                 .toList();
     final listOfFloat = json['listOfFloat'] == null
         ? null
@@ -1039,12 +1104,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
         ? null
         : (json['listOfRequiredFloat'] as List<Object?>)
             .cast<double?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredFloat',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredFloat',
+                  )),
+            )
             .toList();
     final requiredListOfFloat = json['requiredListOfFloat'] == null
         ? null
@@ -1056,12 +1123,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredFloat'] as List<Object?>)
                 .cast<double?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredFloat',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredFloat',
+                      )),
+                )
                 .toList();
     final listOfBoolean = json['listOfBoolean'] == null
         ? null
@@ -1070,12 +1139,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
         ? null
         : (json['listOfRequiredBoolean'] as List<Object?>)
             .cast<bool?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredBoolean',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredBoolean',
+                  )),
+            )
             .toList();
     final requiredListOfBoolean = json['requiredListOfBoolean'] == null
         ? null
@@ -1087,12 +1158,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredBoolean'] as List<Object?>)
                 .cast<bool?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredBoolean',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredBoolean',
+                      )),
+                )
                 .toList();
     final listOfAwsDate = json['listOfAWSDate'] == null
         ? null
@@ -1104,12 +1177,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSDate'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListNonModel',
-                    'listOfRequiredAwsDate',
-                  ))
-                : TemporalDate.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsDate',
+                    ))
+                  : TemporalDate.fromString(el),
+            )
             .toList();
     final requiredListOfAwsDate = json['requiredListOfAWSDate'] == null
         ? null
@@ -1122,12 +1197,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredAWSDate'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsDate',
-                      ))
-                    : TemporalDate.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsDate',
+                        ))
+                      : TemporalDate.fromString(el),
+                )
                 .toList();
     final listOfAwsDateTime = json['listOfAWSDateTime'] == null
         ? null
@@ -1139,12 +1216,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSDateTime'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListNonModel',
-                    'listOfRequiredAwsDateTime',
-                  ))
-                : TemporalDateTime.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsDateTime',
+                    ))
+                  : TemporalDateTime.fromString(el),
+            )
             .toList();
     final requiredListOfAwsDateTime = json['requiredListOfAWSDateTime'] == null
         ? null
@@ -1157,12 +1236,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredAWSDateTime'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsDateTime',
-                      ))
-                    : TemporalDateTime.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsDateTime',
+                        ))
+                      : TemporalDateTime.fromString(el),
+                )
                 .toList();
     final listOfAwsTime = json['listOfAWSTime'] == null
         ? null
@@ -1174,12 +1255,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSTime'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListNonModel',
-                    'listOfRequiredAwsTime',
-                  ))
-                : TemporalTime.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsTime',
+                    ))
+                  : TemporalTime.fromString(el),
+            )
             .toList();
     final requiredListOfAwsTime = json['requiredListOfAWSTime'] == null
         ? null
@@ -1192,12 +1275,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredAWSTime'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsTime',
-                      ))
-                    : TemporalTime.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsTime',
+                        ))
+                      : TemporalTime.fromString(el),
+                )
                 .toList();
     final listOfAwsTimestamp = json['listOfAWSTimestamp'] == null
         ? null
@@ -1210,12 +1295,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['listOfRequiredAWSTimestamp'] as List<Object?>)
                 .cast<int?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'listOfRequiredAwsTimestamp',
-                      ))
-                    : TemporalTimestamp.fromSeconds(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'listOfRequiredAwsTimestamp',
+                        ))
+                      : TemporalTimestamp.fromSeconds(el),
+                )
                 .toList();
     final requiredListOfAwsTimestamp = json['requiredListOfAWSTimestamp'] ==
             null
@@ -1229,12 +1316,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredAWSTimestamp'] as List<Object?>)
                 .cast<int?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsTimestamp',
-                      ))
-                    : TemporalTimestamp.fromSeconds(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsTimestamp',
+                        ))
+                      : TemporalTimestamp.fromSeconds(el),
+                )
                 .toList();
     final listOfAwsEmail = json['listOfAWSEmail'] == null
         ? null
@@ -1243,12 +1332,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSEmail'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredAwsEmail',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsEmail',
+                  )),
+            )
             .toList();
     final requiredListOfAwsEmail = json['requiredListOfAWSEmail'] == null
         ? null
@@ -1260,12 +1351,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredAWSEmail'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredAwsEmail',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsEmail',
+                      )),
+                )
                 .toList();
     final listOfAwsjson = json['listOfAWSJSON'] == null
         ? null
@@ -1274,12 +1367,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSJSON'] as List<Object?>)
             .cast<Object?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredAwsjson',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsjson',
+                  )),
+            )
             .toList();
     final requiredListOfAwsjson = json['requiredListOfAWSJSON'] == null
         ? null
@@ -1291,12 +1386,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredAWSJSON'] as List<Object?>)
                 .cast<Object?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredAwsjson',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsjson',
+                      )),
+                )
                 .toList();
     final listOfAwsPhone = json['listOfAWSPhone'] == null
         ? null
@@ -1305,12 +1402,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSPhone'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredAwsPhone',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsPhone',
+                  )),
+            )
             .toList();
     final requiredListOfAwsPhone = json['requiredListOfAWSPhone'] == null
         ? null
@@ -1322,12 +1421,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredAWSPhone'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredAwsPhone',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsPhone',
+                      )),
+                )
                 .toList();
     final listOfAwsUrl = json['listOfAWSUrl'] == null
         ? null
@@ -1339,12 +1440,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSUrl'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListNonModel',
-                    'listOfRequiredAwsUrl',
-                  ))
-                : Uri.parse(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsUrl',
+                    ))
+                  : Uri.parse(el),
+            )
             .toList();
     final requiredListOfAwsUrl = json['requiredListOfAWSUrl'] == null
         ? null
@@ -1357,12 +1460,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredAWSUrl'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsUrl',
-                      ))
-                    : Uri.parse(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsUrl',
+                        ))
+                      : Uri.parse(el),
+                )
                 .toList();
     final listOfAwsIpAddress = json['listOfAWSIpAddress'] == null
         ? null
@@ -1374,12 +1479,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['listOfRequiredAWSIpAddress'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'listOfRequiredAwsIpAddress',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'listOfRequiredAwsIpAddress',
+                      )),
+                )
                 .toList();
     final requiredListOfAwsIpAddress =
         json['requiredListOfAWSIpAddress'] == null
@@ -1392,12 +1499,14 @@ class _PartialScalarListNonModel extends PartialScalarListNonModel {
             ? null
             : (json['requiredListOfRequiredAWSIpAddress'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredAwsIpAddress',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsIpAddress',
+                      )),
+                )
                 .toList();
     final createdAt = json['createdAt'] == null
         ? null
@@ -1704,12 +1813,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
         ? null
         : (json['listOfRequiredString'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredString',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredString',
+                  )),
+            )
             .toList();
     final requiredListOfString = json['requiredListOfString'] == null
         ? (throw ModelFieldError(
@@ -1727,12 +1838,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredString'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredString',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredString',
+                      )),
+                )
                 .toList();
     final listOfInteger = json['listOfInteger'] == null
         ? null
@@ -1741,12 +1854,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
         ? null
         : (json['listOfRequiredInteger'] as List<Object?>)
             .cast<int?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredInteger',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredInteger',
+                  )),
+            )
             .toList();
     final requiredListOfInteger = json['requiredListOfInteger'] == null
         ? (throw ModelFieldError(
@@ -1764,12 +1879,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredInteger'] as List<Object?>)
                 .cast<int?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredInteger',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredInteger',
+                      )),
+                )
                 .toList();
     final listOfFloat = json['listOfFloat'] == null
         ? null
@@ -1778,12 +1895,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
         ? null
         : (json['listOfRequiredFloat'] as List<Object?>)
             .cast<double?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredFloat',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredFloat',
+                  )),
+            )
             .toList();
     final requiredListOfFloat = json['requiredListOfFloat'] == null
         ? (throw ModelFieldError(
@@ -1801,12 +1920,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredFloat'] as List<Object?>)
                 .cast<double?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredFloat',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredFloat',
+                      )),
+                )
                 .toList();
     final listOfBoolean = json['listOfBoolean'] == null
         ? null
@@ -1815,12 +1936,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
         ? null
         : (json['listOfRequiredBoolean'] as List<Object?>)
             .cast<bool?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredBoolean',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredBoolean',
+                  )),
+            )
             .toList();
     final requiredListOfBoolean = json['requiredListOfBoolean'] == null
         ? (throw ModelFieldError(
@@ -1838,12 +1961,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredBoolean'] as List<Object?>)
                 .cast<bool?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredBoolean',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredBoolean',
+                      )),
+                )
                 .toList();
     final listOfAwsDate = json['listOfAWSDate'] == null
         ? null
@@ -1855,12 +1980,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
         ? null
         : (json['listOfRequiredAWSDate'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListNonModel',
-                    'listOfRequiredAwsDate',
-                  ))
-                : TemporalDate.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsDate',
+                    ))
+                  : TemporalDate.fromString(el),
+            )
             .toList();
     final requiredListOfAwsDate = json['requiredListOfAWSDate'] == null
         ? (throw ModelFieldError(
@@ -1879,12 +2006,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredAWSDate'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsDate',
-                      ))
-                    : TemporalDate.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsDate',
+                        ))
+                      : TemporalDate.fromString(el),
+                )
                 .toList();
     final listOfAwsDateTime = json['listOfAWSDateTime'] == null
         ? null
@@ -1896,12 +2025,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
         ? null
         : (json['listOfRequiredAWSDateTime'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListNonModel',
-                    'listOfRequiredAwsDateTime',
-                  ))
-                : TemporalDateTime.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsDateTime',
+                    ))
+                  : TemporalDateTime.fromString(el),
+            )
             .toList();
     final requiredListOfAwsDateTime = json['requiredListOfAWSDateTime'] == null
         ? (throw ModelFieldError(
@@ -1920,12 +2051,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredAWSDateTime'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsDateTime',
-                      ))
-                    : TemporalDateTime.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsDateTime',
+                        ))
+                      : TemporalDateTime.fromString(el),
+                )
                 .toList();
     final listOfAwsTime = json['listOfAWSTime'] == null
         ? null
@@ -1937,12 +2070,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
         ? null
         : (json['listOfRequiredAWSTime'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListNonModel',
-                    'listOfRequiredAwsTime',
-                  ))
-                : TemporalTime.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsTime',
+                    ))
+                  : TemporalTime.fromString(el),
+            )
             .toList();
     final requiredListOfAwsTime = json['requiredListOfAWSTime'] == null
         ? (throw ModelFieldError(
@@ -1961,12 +2096,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredAWSTime'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsTime',
-                      ))
-                    : TemporalTime.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsTime',
+                        ))
+                      : TemporalTime.fromString(el),
+                )
                 .toList();
     final listOfAwsTimestamp = json['listOfAWSTimestamp'] == null
         ? null
@@ -1979,12 +2116,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
             ? null
             : (json['listOfRequiredAWSTimestamp'] as List<Object?>)
                 .cast<int?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'listOfRequiredAwsTimestamp',
-                      ))
-                    : TemporalTimestamp.fromSeconds(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'listOfRequiredAwsTimestamp',
+                        ))
+                      : TemporalTimestamp.fromSeconds(el),
+                )
                 .toList();
     final requiredListOfAwsTimestamp = json['requiredListOfAWSTimestamp'] ==
             null
@@ -2004,12 +2143,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredAWSTimestamp'] as List<Object?>)
                 .cast<int?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsTimestamp',
-                      ))
-                    : TemporalTimestamp.fromSeconds(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsTimestamp',
+                        ))
+                      : TemporalTimestamp.fromSeconds(el),
+                )
                 .toList();
     final listOfAwsEmail = json['listOfAWSEmail'] == null
         ? null
@@ -2018,12 +2159,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
         ? null
         : (json['listOfRequiredAWSEmail'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredAwsEmail',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsEmail',
+                  )),
+            )
             .toList();
     final requiredListOfAwsEmail = json['requiredListOfAWSEmail'] == null
         ? (throw ModelFieldError(
@@ -2041,12 +2184,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredAWSEmail'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredAwsEmail',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsEmail',
+                      )),
+                )
                 .toList();
     final listOfAwsjson = json['listOfAWSJSON'] == null
         ? null
@@ -2055,12 +2200,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
         ? null
         : (json['listOfRequiredAWSJSON'] as List<Object?>)
             .cast<Object?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredAwsjson',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsjson',
+                  )),
+            )
             .toList();
     final requiredListOfAwsjson = json['requiredListOfAWSJSON'] == null
         ? (throw ModelFieldError(
@@ -2078,12 +2225,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredAWSJSON'] as List<Object?>)
                 .cast<Object?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredAwsjson',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsjson',
+                      )),
+                )
                 .toList();
     final listOfAwsPhone = json['listOfAWSPhone'] == null
         ? null
@@ -2092,12 +2241,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
         ? null
         : (json['listOfRequiredAWSPhone'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredAwsPhone',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsPhone',
+                  )),
+            )
             .toList();
     final requiredListOfAwsPhone = json['requiredListOfAWSPhone'] == null
         ? (throw ModelFieldError(
@@ -2115,12 +2266,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredAWSPhone'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredAwsPhone',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsPhone',
+                      )),
+                )
                 .toList();
     final listOfAwsUrl = json['listOfAWSUrl'] == null
         ? null
@@ -2132,12 +2285,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
         ? null
         : (json['listOfRequiredAWSUrl'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListNonModel',
-                    'listOfRequiredAwsUrl',
-                  ))
-                : Uri.parse(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsUrl',
+                    ))
+                  : Uri.parse(el),
+            )
             .toList();
     final requiredListOfAwsUrl = json['requiredListOfAWSUrl'] == null
         ? (throw ModelFieldError(
@@ -2156,12 +2311,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredAWSUrl'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsUrl',
-                      ))
-                    : Uri.parse(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsUrl',
+                        ))
+                      : Uri.parse(el),
+                )
                 .toList();
     final listOfAwsIpAddress = json['listOfAWSIpAddress'] == null
         ? null
@@ -2173,12 +2330,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
             ? null
             : (json['listOfRequiredAWSIpAddress'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'listOfRequiredAwsIpAddress',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'listOfRequiredAwsIpAddress',
+                      )),
+                )
                 .toList();
     final requiredListOfAwsIpAddress =
         json['requiredListOfAWSIpAddress'] == null
@@ -2197,12 +2356,14 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
               ))
             : (json['requiredListOfRequiredAWSIpAddress'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredAwsIpAddress',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsIpAddress',
+                      )),
+                )
                 .toList();
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
@@ -3263,12 +3424,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
         ? null
         : (json['listOfRequiredString'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredString',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredString',
+                  )),
+            )
             .toList();
     final requiredListOfString = json['requiredListOfString'] == null
         ? (throw ModelFieldError(
@@ -3286,12 +3449,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredString'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredString',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredString',
+                      )),
+                )
                 .toList();
     final listOfInteger = json['listOfInteger'] == null
         ? null
@@ -3300,12 +3465,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
         ? null
         : (json['listOfRequiredInteger'] as List<Object?>)
             .cast<int?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredInteger',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredInteger',
+                  )),
+            )
             .toList();
     final requiredListOfInteger = json['requiredListOfInteger'] == null
         ? (throw ModelFieldError(
@@ -3323,12 +3490,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredInteger'] as List<Object?>)
                 .cast<int?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredInteger',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredInteger',
+                      )),
+                )
                 .toList();
     final listOfFloat = json['listOfFloat'] == null
         ? null
@@ -3337,12 +3506,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
         ? null
         : (json['listOfRequiredFloat'] as List<Object?>)
             .cast<double?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredFloat',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredFloat',
+                  )),
+            )
             .toList();
     final requiredListOfFloat = json['requiredListOfFloat'] == null
         ? (throw ModelFieldError(
@@ -3360,12 +3531,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredFloat'] as List<Object?>)
                 .cast<double?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredFloat',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredFloat',
+                      )),
+                )
                 .toList();
     final listOfBoolean = json['listOfBoolean'] == null
         ? null
@@ -3374,12 +3547,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
         ? null
         : (json['listOfRequiredBoolean'] as List<Object?>)
             .cast<bool?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredBoolean',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredBoolean',
+                  )),
+            )
             .toList();
     final requiredListOfBoolean = json['requiredListOfBoolean'] == null
         ? (throw ModelFieldError(
@@ -3397,12 +3572,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredBoolean'] as List<Object?>)
                 .cast<bool?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredBoolean',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredBoolean',
+                      )),
+                )
                 .toList();
     final listOfAwsDate = json['listOfAWSDate'] == null
         ? null
@@ -3414,12 +3591,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSDate'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListNonModel',
-                    'listOfRequiredAwsDate',
-                  ))
-                : TemporalDate.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsDate',
+                    ))
+                  : TemporalDate.fromString(el),
+            )
             .toList();
     final requiredListOfAwsDate = json['requiredListOfAWSDate'] == null
         ? (throw ModelFieldError(
@@ -3438,12 +3617,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredAWSDate'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsDate',
-                      ))
-                    : TemporalDate.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsDate',
+                        ))
+                      : TemporalDate.fromString(el),
+                )
                 .toList();
     final listOfAwsDateTime = json['listOfAWSDateTime'] == null
         ? null
@@ -3455,12 +3636,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSDateTime'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListNonModel',
-                    'listOfRequiredAwsDateTime',
-                  ))
-                : TemporalDateTime.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsDateTime',
+                    ))
+                  : TemporalDateTime.fromString(el),
+            )
             .toList();
     final requiredListOfAwsDateTime = json['requiredListOfAWSDateTime'] == null
         ? (throw ModelFieldError(
@@ -3479,12 +3662,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredAWSDateTime'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsDateTime',
-                      ))
-                    : TemporalDateTime.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsDateTime',
+                        ))
+                      : TemporalDateTime.fromString(el),
+                )
                 .toList();
     final listOfAwsTime = json['listOfAWSTime'] == null
         ? null
@@ -3496,12 +3681,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSTime'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListNonModel',
-                    'listOfRequiredAwsTime',
-                  ))
-                : TemporalTime.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsTime',
+                    ))
+                  : TemporalTime.fromString(el),
+            )
             .toList();
     final requiredListOfAwsTime = json['requiredListOfAWSTime'] == null
         ? (throw ModelFieldError(
@@ -3520,12 +3707,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredAWSTime'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsTime',
-                      ))
-                    : TemporalTime.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsTime',
+                        ))
+                      : TemporalTime.fromString(el),
+                )
                 .toList();
     final listOfAwsTimestamp = json['listOfAWSTimestamp'] == null
         ? null
@@ -3538,12 +3727,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
             ? null
             : (json['listOfRequiredAWSTimestamp'] as List<Object?>)
                 .cast<int?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'listOfRequiredAwsTimestamp',
-                      ))
-                    : TemporalTimestamp.fromSeconds(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'listOfRequiredAwsTimestamp',
+                        ))
+                      : TemporalTimestamp.fromSeconds(el),
+                )
                 .toList();
     final requiredListOfAwsTimestamp = json['requiredListOfAWSTimestamp'] ==
             null
@@ -3563,12 +3754,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredAWSTimestamp'] as List<Object?>)
                 .cast<int?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsTimestamp',
-                      ))
-                    : TemporalTimestamp.fromSeconds(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsTimestamp',
+                        ))
+                      : TemporalTimestamp.fromSeconds(el),
+                )
                 .toList();
     final listOfAwsEmail = json['listOfAWSEmail'] == null
         ? null
@@ -3577,12 +3770,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSEmail'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredAwsEmail',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsEmail',
+                  )),
+            )
             .toList();
     final requiredListOfAwsEmail = json['requiredListOfAWSEmail'] == null
         ? (throw ModelFieldError(
@@ -3600,12 +3795,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredAWSEmail'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredAwsEmail',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsEmail',
+                      )),
+                )
                 .toList();
     final listOfAwsjson = json['listOfAWSJSON'] == null
         ? null
@@ -3614,12 +3811,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSJSON'] as List<Object?>)
             .cast<Object?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredAwsjson',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsjson',
+                  )),
+            )
             .toList();
     final requiredListOfAwsjson = json['requiredListOfAWSJSON'] == null
         ? (throw ModelFieldError(
@@ -3637,12 +3836,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredAWSJSON'] as List<Object?>)
                 .cast<Object?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredAwsjson',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsjson',
+                      )),
+                )
                 .toList();
     final listOfAwsPhone = json['listOfAWSPhone'] == null
         ? null
@@ -3651,12 +3852,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSPhone'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListNonModel',
-                  'listOfRequiredAwsPhone',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListNonModel',
+                    'listOfRequiredAwsPhone',
+                  )),
+            )
             .toList();
     final requiredListOfAwsPhone = json['requiredListOfAWSPhone'] == null
         ? (throw ModelFieldError(
@@ -3674,12 +3877,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredAWSPhone'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredAwsPhone',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsPhone',
+                      )),
+                )
                 .toList();
     final listOfAwsUrl = json['listOfAWSUrl'] == null
         ? null
@@ -3691,12 +3896,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
         ? null
         : (json['listOfRequiredAWSUrl'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListNonModel',
-                    'listOfRequiredAwsUrl',
-                  ))
-                : Uri.parse(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListNonModel',
+                      'listOfRequiredAwsUrl',
+                    ))
+                  : Uri.parse(el),
+            )
             .toList();
     final requiredListOfAwsUrl = json['requiredListOfAWSUrl'] == null
         ? (throw ModelFieldError(
@@ -3715,12 +3922,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredAWSUrl'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListNonModel',
-                        'requiredListOfRequiredAwsUrl',
-                      ))
-                    : Uri.parse(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListNonModel',
+                          'requiredListOfRequiredAwsUrl',
+                        ))
+                      : Uri.parse(el),
+                )
                 .toList();
     final listOfAwsIpAddress = json['listOfAWSIpAddress'] == null
         ? null
@@ -3732,12 +3941,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
             ? null
             : (json['listOfRequiredAWSIpAddress'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'listOfRequiredAwsIpAddress',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'listOfRequiredAwsIpAddress',
+                      )),
+                )
                 .toList();
     final requiredListOfAwsIpAddress =
         json['requiredListOfAWSIpAddress'] == null
@@ -3756,12 +3967,14 @@ class _RemoteScalarListNonModel extends RemoteScalarListNonModel {
               ))
             : (json['requiredListOfRequiredAWSIpAddress'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListNonModel',
-                      'requiredListOfRequiredAwsIpAddress',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListNonModel',
+                        'requiredListOfRequiredAwsIpAddress',
+                      )),
+                )
                 .toList();
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
@@ -781,184 +781,6 @@ abstract class PartialScalarListNonModel
       };
   @override
   String get runtimeTypeName => 'ScalarListNonModel';
-  @override
-  T valueFor<T extends Object?>(
-    QueryField<String, ScalarListNonModel, T> field,
-  ) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'id':
-        value = id;
-        break;
-      case r'listOfString':
-        value = listOfString;
-        break;
-      case r'listOfRequiredString':
-        value = listOfRequiredString;
-        break;
-      case r'requiredListOfString':
-        value = requiredListOfString;
-        break;
-      case r'requiredListOfRequiredString':
-        value = requiredListOfRequiredString;
-        break;
-      case r'listOfInteger':
-        value = listOfInteger;
-        break;
-      case r'listOfRequiredInteger':
-        value = listOfRequiredInteger;
-        break;
-      case r'requiredListOfInteger':
-        value = requiredListOfInteger;
-        break;
-      case r'requiredListOfRequiredInteger':
-        value = requiredListOfRequiredInteger;
-        break;
-      case r'listOfFloat':
-        value = listOfFloat;
-        break;
-      case r'listOfRequiredFloat':
-        value = listOfRequiredFloat;
-        break;
-      case r'requiredListOfFloat':
-        value = requiredListOfFloat;
-        break;
-      case r'requiredListOfRequiredFloat':
-        value = requiredListOfRequiredFloat;
-        break;
-      case r'listOfBoolean':
-        value = listOfBoolean;
-        break;
-      case r'listOfRequiredBoolean':
-        value = listOfRequiredBoolean;
-        break;
-      case r'requiredListOfBoolean':
-        value = requiredListOfBoolean;
-        break;
-      case r'requiredListOfRequiredBoolean':
-        value = requiredListOfRequiredBoolean;
-        break;
-      case r'listOfAWSDate':
-        value = listOfAwsDate;
-        break;
-      case r'listOfRequiredAWSDate':
-        value = listOfRequiredAwsDate;
-        break;
-      case r'requiredListOfAWSDate':
-        value = requiredListOfAwsDate;
-        break;
-      case r'requiredListOfRequiredAWSDate':
-        value = requiredListOfRequiredAwsDate;
-        break;
-      case r'listOfAWSDateTime':
-        value = listOfAwsDateTime;
-        break;
-      case r'listOfRequiredAWSDateTime':
-        value = listOfRequiredAwsDateTime;
-        break;
-      case r'requiredListOfAWSDateTime':
-        value = requiredListOfAwsDateTime;
-        break;
-      case r'requiredListOfRequiredAWSDateTime':
-        value = requiredListOfRequiredAwsDateTime;
-        break;
-      case r'listOfAWSTime':
-        value = listOfAwsTime;
-        break;
-      case r'listOfRequiredAWSTime':
-        value = listOfRequiredAwsTime;
-        break;
-      case r'requiredListOfAWSTime':
-        value = requiredListOfAwsTime;
-        break;
-      case r'requiredListOfRequiredAWSTime':
-        value = requiredListOfRequiredAwsTime;
-        break;
-      case r'listOfAWSTimestamp':
-        value = listOfAwsTimestamp;
-        break;
-      case r'listOfRequiredAWSTimestamp':
-        value = listOfRequiredAwsTimestamp;
-        break;
-      case r'requiredListOfAWSTimestamp':
-        value = requiredListOfAwsTimestamp;
-        break;
-      case r'requiredListOfRequiredAWSTimestamp':
-        value = requiredListOfRequiredAwsTimestamp;
-        break;
-      case r'listOfAWSEmail':
-        value = listOfAwsEmail;
-        break;
-      case r'listOfRequiredAWSEmail':
-        value = listOfRequiredAwsEmail;
-        break;
-      case r'requiredListOfAWSEmail':
-        value = requiredListOfAwsEmail;
-        break;
-      case r'requiredListOfRequiredAWSEmail':
-        value = requiredListOfRequiredAwsEmail;
-        break;
-      case r'listOfAWSJSON':
-        value = listOfAwsjson;
-        break;
-      case r'listOfRequiredAWSJSON':
-        value = listOfRequiredAwsjson;
-        break;
-      case r'requiredListOfAWSJSON':
-        value = requiredListOfAwsjson;
-        break;
-      case r'requiredListOfRequiredAWSJSON':
-        value = requiredListOfRequiredAwsjson;
-        break;
-      case r'listOfAWSPhone':
-        value = listOfAwsPhone;
-        break;
-      case r'listOfRequiredAWSPhone':
-        value = listOfRequiredAwsPhone;
-        break;
-      case r'requiredListOfAWSPhone':
-        value = requiredListOfAwsPhone;
-        break;
-      case r'requiredListOfRequiredAWSPhone':
-        value = requiredListOfRequiredAwsPhone;
-        break;
-      case r'listOfAWSUrl':
-        value = listOfAwsUrl;
-        break;
-      case r'listOfRequiredAWSUrl':
-        value = listOfRequiredAwsUrl;
-        break;
-      case r'requiredListOfAWSUrl':
-        value = requiredListOfAwsUrl;
-        break;
-      case r'requiredListOfRequiredAWSUrl':
-        value = requiredListOfRequiredAwsUrl;
-        break;
-      case r'listOfAWSIpAddress':
-        value = listOfAwsIpAddress;
-        break;
-      case r'listOfRequiredAWSIpAddress':
-        value = listOfRequiredAwsIpAddress;
-        break;
-      case r'requiredListOfAWSIpAddress':
-        value = requiredListOfAwsIpAddress;
-        break;
-      case r'requiredListOfRequiredAWSIpAddress':
-        value = requiredListOfRequiredAwsIpAddress;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialScalarListNonModel extends PartialScalarListNonModel {
@@ -3057,6 +2879,184 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, ScalarListNonModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<String, ScalarListNonModel, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'listOfString':
+        value = listOfString;
+        break;
+      case r'listOfRequiredString':
+        value = listOfRequiredString;
+        break;
+      case r'requiredListOfString':
+        value = requiredListOfString;
+        break;
+      case r'requiredListOfRequiredString':
+        value = requiredListOfRequiredString;
+        break;
+      case r'listOfInteger':
+        value = listOfInteger;
+        break;
+      case r'listOfRequiredInteger':
+        value = listOfRequiredInteger;
+        break;
+      case r'requiredListOfInteger':
+        value = requiredListOfInteger;
+        break;
+      case r'requiredListOfRequiredInteger':
+        value = requiredListOfRequiredInteger;
+        break;
+      case r'listOfFloat':
+        value = listOfFloat;
+        break;
+      case r'listOfRequiredFloat':
+        value = listOfRequiredFloat;
+        break;
+      case r'requiredListOfFloat':
+        value = requiredListOfFloat;
+        break;
+      case r'requiredListOfRequiredFloat':
+        value = requiredListOfRequiredFloat;
+        break;
+      case r'listOfBoolean':
+        value = listOfBoolean;
+        break;
+      case r'listOfRequiredBoolean':
+        value = listOfRequiredBoolean;
+        break;
+      case r'requiredListOfBoolean':
+        value = requiredListOfBoolean;
+        break;
+      case r'requiredListOfRequiredBoolean':
+        value = requiredListOfRequiredBoolean;
+        break;
+      case r'listOfAWSDate':
+        value = listOfAwsDate;
+        break;
+      case r'listOfRequiredAWSDate':
+        value = listOfRequiredAwsDate;
+        break;
+      case r'requiredListOfAWSDate':
+        value = requiredListOfAwsDate;
+        break;
+      case r'requiredListOfRequiredAWSDate':
+        value = requiredListOfRequiredAwsDate;
+        break;
+      case r'listOfAWSDateTime':
+        value = listOfAwsDateTime;
+        break;
+      case r'listOfRequiredAWSDateTime':
+        value = listOfRequiredAwsDateTime;
+        break;
+      case r'requiredListOfAWSDateTime':
+        value = requiredListOfAwsDateTime;
+        break;
+      case r'requiredListOfRequiredAWSDateTime':
+        value = requiredListOfRequiredAwsDateTime;
+        break;
+      case r'listOfAWSTime':
+        value = listOfAwsTime;
+        break;
+      case r'listOfRequiredAWSTime':
+        value = listOfRequiredAwsTime;
+        break;
+      case r'requiredListOfAWSTime':
+        value = requiredListOfAwsTime;
+        break;
+      case r'requiredListOfRequiredAWSTime':
+        value = requiredListOfRequiredAwsTime;
+        break;
+      case r'listOfAWSTimestamp':
+        value = listOfAwsTimestamp;
+        break;
+      case r'listOfRequiredAWSTimestamp':
+        value = listOfRequiredAwsTimestamp;
+        break;
+      case r'requiredListOfAWSTimestamp':
+        value = requiredListOfAwsTimestamp;
+        break;
+      case r'requiredListOfRequiredAWSTimestamp':
+        value = requiredListOfRequiredAwsTimestamp;
+        break;
+      case r'listOfAWSEmail':
+        value = listOfAwsEmail;
+        break;
+      case r'listOfRequiredAWSEmail':
+        value = listOfRequiredAwsEmail;
+        break;
+      case r'requiredListOfAWSEmail':
+        value = requiredListOfAwsEmail;
+        break;
+      case r'requiredListOfRequiredAWSEmail':
+        value = requiredListOfRequiredAwsEmail;
+        break;
+      case r'listOfAWSJSON':
+        value = listOfAwsjson;
+        break;
+      case r'listOfRequiredAWSJSON':
+        value = listOfRequiredAwsjson;
+        break;
+      case r'requiredListOfAWSJSON':
+        value = requiredListOfAwsjson;
+        break;
+      case r'requiredListOfRequiredAWSJSON':
+        value = requiredListOfRequiredAwsjson;
+        break;
+      case r'listOfAWSPhone':
+        value = listOfAwsPhone;
+        break;
+      case r'listOfRequiredAWSPhone':
+        value = listOfRequiredAwsPhone;
+        break;
+      case r'requiredListOfAWSPhone':
+        value = requiredListOfAwsPhone;
+        break;
+      case r'requiredListOfRequiredAWSPhone':
+        value = requiredListOfRequiredAwsPhone;
+        break;
+      case r'listOfAWSUrl':
+        value = listOfAwsUrl;
+        break;
+      case r'listOfRequiredAWSUrl':
+        value = listOfRequiredAwsUrl;
+        break;
+      case r'requiredListOfAWSUrl':
+        value = requiredListOfAwsUrl;
+        break;
+      case r'requiredListOfRequiredAWSUrl':
+        value = requiredListOfRequiredAwsUrl;
+        break;
+      case r'listOfAWSIpAddress':
+        value = listOfAwsIpAddress;
+        break;
+      case r'listOfRequiredAWSIpAddress':
+        value = listOfRequiredAwsIpAddress;
+        break;
+      case r'requiredListOfAWSIpAddress':
+        value = requiredListOfAwsIpAddress;
+        break;
+      case r'requiredListOfRequiredAWSIpAddress':
+        value = requiredListOfRequiredAwsIpAddress;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _ScalarListNonModel extends ScalarListNonModel {

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_list_non_model.dart
@@ -2879,6 +2879,157 @@ abstract class ScalarListNonModel extends PartialScalarListNonModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, ScalarListNonModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  ScalarListNonModel copyWith({
+    String? id,
+    List<String?>? listOfString,
+    List<String>? listOfRequiredString,
+    List<String?>? requiredListOfString,
+    List<String>? requiredListOfRequiredString,
+    List<int?>? listOfInteger,
+    List<int>? listOfRequiredInteger,
+    List<int?>? requiredListOfInteger,
+    List<int>? requiredListOfRequiredInteger,
+    List<double?>? listOfFloat,
+    List<double>? listOfRequiredFloat,
+    List<double?>? requiredListOfFloat,
+    List<double>? requiredListOfRequiredFloat,
+    List<bool?>? listOfBoolean,
+    List<bool>? listOfRequiredBoolean,
+    List<bool?>? requiredListOfBoolean,
+    List<bool>? requiredListOfRequiredBoolean,
+    List<TemporalDate?>? listOfAwsDate,
+    List<TemporalDate>? listOfRequiredAwsDate,
+    List<TemporalDate?>? requiredListOfAwsDate,
+    List<TemporalDate>? requiredListOfRequiredAwsDate,
+    List<TemporalDateTime?>? listOfAwsDateTime,
+    List<TemporalDateTime>? listOfRequiredAwsDateTime,
+    List<TemporalDateTime?>? requiredListOfAwsDateTime,
+    List<TemporalDateTime>? requiredListOfRequiredAwsDateTime,
+    List<TemporalTime?>? listOfAwsTime,
+    List<TemporalTime>? listOfRequiredAwsTime,
+    List<TemporalTime?>? requiredListOfAwsTime,
+    List<TemporalTime>? requiredListOfRequiredAwsTime,
+    List<TemporalTimestamp?>? listOfAwsTimestamp,
+    List<TemporalTimestamp>? listOfRequiredAwsTimestamp,
+    List<TemporalTimestamp?>? requiredListOfAwsTimestamp,
+    List<TemporalTimestamp>? requiredListOfRequiredAwsTimestamp,
+    List<String?>? listOfAwsEmail,
+    List<String>? listOfRequiredAwsEmail,
+    List<String?>? requiredListOfAwsEmail,
+    List<String>? requiredListOfRequiredAwsEmail,
+    List<Object?>? listOfAwsjson,
+    List<Object>? listOfRequiredAwsjson,
+    List<Object?>? requiredListOfAwsjson,
+    List<Object>? requiredListOfRequiredAwsjson,
+    List<String?>? listOfAwsPhone,
+    List<String>? listOfRequiredAwsPhone,
+    List<String?>? requiredListOfAwsPhone,
+    List<String>? requiredListOfRequiredAwsPhone,
+    List<Uri?>? listOfAwsUrl,
+    List<Uri>? listOfRequiredAwsUrl,
+    List<Uri?>? requiredListOfAwsUrl,
+    List<Uri>? requiredListOfRequiredAwsUrl,
+    List<String?>? listOfAwsIpAddress,
+    List<String>? listOfRequiredAwsIpAddress,
+    List<String?>? requiredListOfAwsIpAddress,
+    List<String>? requiredListOfRequiredAwsIpAddress,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _ScalarListNonModel._(
+      id: id ?? this.id,
+      listOfString: listOfString ?? this.listOfString,
+      listOfRequiredString: listOfRequiredString ?? this.listOfRequiredString,
+      requiredListOfString: requiredListOfString ?? this.requiredListOfString,
+      requiredListOfRequiredString:
+          requiredListOfRequiredString ?? this.requiredListOfRequiredString,
+      listOfInteger: listOfInteger ?? this.listOfInteger,
+      listOfRequiredInteger:
+          listOfRequiredInteger ?? this.listOfRequiredInteger,
+      requiredListOfInteger:
+          requiredListOfInteger ?? this.requiredListOfInteger,
+      requiredListOfRequiredInteger:
+          requiredListOfRequiredInteger ?? this.requiredListOfRequiredInteger,
+      listOfFloat: listOfFloat ?? this.listOfFloat,
+      listOfRequiredFloat: listOfRequiredFloat ?? this.listOfRequiredFloat,
+      requiredListOfFloat: requiredListOfFloat ?? this.requiredListOfFloat,
+      requiredListOfRequiredFloat:
+          requiredListOfRequiredFloat ?? this.requiredListOfRequiredFloat,
+      listOfBoolean: listOfBoolean ?? this.listOfBoolean,
+      listOfRequiredBoolean:
+          listOfRequiredBoolean ?? this.listOfRequiredBoolean,
+      requiredListOfBoolean:
+          requiredListOfBoolean ?? this.requiredListOfBoolean,
+      requiredListOfRequiredBoolean:
+          requiredListOfRequiredBoolean ?? this.requiredListOfRequiredBoolean,
+      listOfAwsDate: listOfAwsDate ?? this.listOfAwsDate,
+      listOfRequiredAwsDate:
+          listOfRequiredAwsDate ?? this.listOfRequiredAwsDate,
+      requiredListOfAwsDate:
+          requiredListOfAwsDate ?? this.requiredListOfAwsDate,
+      requiredListOfRequiredAwsDate:
+          requiredListOfRequiredAwsDate ?? this.requiredListOfRequiredAwsDate,
+      listOfAwsDateTime: listOfAwsDateTime ?? this.listOfAwsDateTime,
+      listOfRequiredAwsDateTime:
+          listOfRequiredAwsDateTime ?? this.listOfRequiredAwsDateTime,
+      requiredListOfAwsDateTime:
+          requiredListOfAwsDateTime ?? this.requiredListOfAwsDateTime,
+      requiredListOfRequiredAwsDateTime: requiredListOfRequiredAwsDateTime ??
+          this.requiredListOfRequiredAwsDateTime,
+      listOfAwsTime: listOfAwsTime ?? this.listOfAwsTime,
+      listOfRequiredAwsTime:
+          listOfRequiredAwsTime ?? this.listOfRequiredAwsTime,
+      requiredListOfAwsTime:
+          requiredListOfAwsTime ?? this.requiredListOfAwsTime,
+      requiredListOfRequiredAwsTime:
+          requiredListOfRequiredAwsTime ?? this.requiredListOfRequiredAwsTime,
+      listOfAwsTimestamp: listOfAwsTimestamp ?? this.listOfAwsTimestamp,
+      listOfRequiredAwsTimestamp:
+          listOfRequiredAwsTimestamp ?? this.listOfRequiredAwsTimestamp,
+      requiredListOfAwsTimestamp:
+          requiredListOfAwsTimestamp ?? this.requiredListOfAwsTimestamp,
+      requiredListOfRequiredAwsTimestamp: requiredListOfRequiredAwsTimestamp ??
+          this.requiredListOfRequiredAwsTimestamp,
+      listOfAwsEmail: listOfAwsEmail ?? this.listOfAwsEmail,
+      listOfRequiredAwsEmail:
+          listOfRequiredAwsEmail ?? this.listOfRequiredAwsEmail,
+      requiredListOfAwsEmail:
+          requiredListOfAwsEmail ?? this.requiredListOfAwsEmail,
+      requiredListOfRequiredAwsEmail:
+          requiredListOfRequiredAwsEmail ?? this.requiredListOfRequiredAwsEmail,
+      listOfAwsjson: listOfAwsjson ?? this.listOfAwsjson,
+      listOfRequiredAwsjson:
+          listOfRequiredAwsjson ?? this.listOfRequiredAwsjson,
+      requiredListOfAwsjson:
+          requiredListOfAwsjson ?? this.requiredListOfAwsjson,
+      requiredListOfRequiredAwsjson:
+          requiredListOfRequiredAwsjson ?? this.requiredListOfRequiredAwsjson,
+      listOfAwsPhone: listOfAwsPhone ?? this.listOfAwsPhone,
+      listOfRequiredAwsPhone:
+          listOfRequiredAwsPhone ?? this.listOfRequiredAwsPhone,
+      requiredListOfAwsPhone:
+          requiredListOfAwsPhone ?? this.requiredListOfAwsPhone,
+      requiredListOfRequiredAwsPhone:
+          requiredListOfRequiredAwsPhone ?? this.requiredListOfRequiredAwsPhone,
+      listOfAwsUrl: listOfAwsUrl ?? this.listOfAwsUrl,
+      listOfRequiredAwsUrl: listOfRequiredAwsUrl ?? this.listOfRequiredAwsUrl,
+      requiredListOfAwsUrl: requiredListOfAwsUrl ?? this.requiredListOfAwsUrl,
+      requiredListOfRequiredAwsUrl:
+          requiredListOfRequiredAwsUrl ?? this.requiredListOfRequiredAwsUrl,
+      listOfAwsIpAddress: listOfAwsIpAddress ?? this.listOfAwsIpAddress,
+      listOfRequiredAwsIpAddress:
+          listOfRequiredAwsIpAddress ?? this.listOfRequiredAwsIpAddress,
+      requiredListOfAwsIpAddress:
+          requiredListOfAwsIpAddress ?? this.requiredListOfAwsIpAddress,
+      requiredListOfRequiredAwsIpAddress: requiredListOfRequiredAwsIpAddress ??
+          this.requiredListOfRequiredAwsIpAddress,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<String, ScalarListNonModel, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_non_model.dart
@@ -16,7 +16,7 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.scalar_non_model;
 

--- a/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/non_models/scalar_non_model.dart
@@ -21,6 +21,7 @@
 library models.scalar_non_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class ScalarNonModel
     with
@@ -251,6 +252,178 @@ class ScalarNonModel
   final String? awsIpAddress;
 
   final String requiredAwsIpAddress;
+
+  static final mipr.NonModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.NonModelTypeDefinition.serializer,
+    const {
+      'name': 'ScalarNonModel',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'str': {
+          'name': 'str',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredStr': {
+          'name': 'requiredStr',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'integer': {
+          'name': 'integer',
+          'type': {'scalar': 'Int'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredInteger': {
+          'name': 'requiredInteger',
+          'type': {'scalar': 'Int'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'float': {
+          'name': 'float',
+          'type': {'scalar': 'Float'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredFloat': {
+          'name': 'requiredFloat',
+          'type': {'scalar': 'Float'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'boolean': {
+          'name': 'boolean',
+          'type': {'scalar': 'Boolean'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredBoolean': {
+          'name': 'requiredBoolean',
+          'type': {'scalar': 'Boolean'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsDate': {
+          'name': 'awsDate',
+          'type': {'scalar': 'AWSDate'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsDate': {
+          'name': 'requiredAwsDate',
+          'type': {'scalar': 'AWSDate'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsDateTime': {
+          'name': 'awsDateTime',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsDateTime': {
+          'name': 'requiredAwsDateTime',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsTime': {
+          'name': 'awsTime',
+          'type': {'scalar': 'AWSTime'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsTime': {
+          'name': 'requiredAwsTime',
+          'type': {'scalar': 'AWSTime'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsTimestamp': {
+          'name': 'awsTimestamp',
+          'type': {'scalar': 'AWSTimestamp'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsTimestamp': {
+          'name': 'requiredAwsTimestamp',
+          'type': {'scalar': 'AWSTimestamp'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsEmail': {
+          'name': 'awsEmail',
+          'type': {'scalar': 'AWSEmail'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsEmail': {
+          'name': 'requiredAwsEmail',
+          'type': {'scalar': 'AWSEmail'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsJson': {
+          'name': 'awsJson',
+          'type': {'scalar': 'AWSJSON'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsJson': {
+          'name': 'requiredAwsJson',
+          'type': {'scalar': 'AWSJSON'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsPhone': {
+          'name': 'awsPhone',
+          'type': {'scalar': 'AWSPhone'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsPhone': {
+          'name': 'requiredAwsPhone',
+          'type': {'scalar': 'AWSPhone'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsUrl': {
+          'name': 'awsUrl',
+          'type': {'scalar': 'AWSURL'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsUrl': {
+          'name': 'requiredAwsUrl',
+          'type': {'scalar': 'AWSURL'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsIpAddress': {
+          'name': 'awsIpAddress',
+          'type': {'scalar': 'AWSIPAddress'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsIpAddress': {
+          'name': 'requiredAwsIpAddress',
+          'type': {'scalar': 'AWSIPAddress'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+    },
+  )!;
 
   @override
   List<Object?> get props => [

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/model_provider.dart
@@ -1,0 +1,65 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'my_model.dart';
+import 'my_non_model.dart';
+
+export 'my_model.dart';
+export 'my_non_model.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '992f29674bc85603bb880a04306ea07c';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [MyModel.schema];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas =>
+      [MyNonModel.schema];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'MyModel':
+        return (MyModel.classType as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
@@ -27,7 +27,8 @@ class MyModelType extends ModelType<String, MyModel, PartialMyModel> {
 
   @override
   T fromJson<T extends PartialModel<String, MyModel>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == MyModel || T == Model<String, MyModel>) {
       return MyModel.fromJson(json) as T;
     }
@@ -58,7 +59,8 @@ class MyModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDateTime> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, String, MyModel, TemporalDateTime>(
         const QueryField<String, MyModel, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -66,7 +68,8 @@ class MyModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDateTime> get $updatedAt =>
       NestedQueryField<ModelIdentifier, M, String, MyModel, TemporalDateTime>(
         const QueryField<String, MyModel, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
@@ -241,6 +241,22 @@ abstract class MyModel extends PartialMyModel
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, MyModel, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  MyModel copyWith({
+    String? enum_,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? id,
+  }) {
+    return _MyModel._(
+      enum_: enum_ ?? this.enum_,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+      id: id ?? this.id,
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, MyModel, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
@@ -119,29 +119,6 @@ abstract class PartialMyModel extends PartialModel<String, MyModel>
       };
   @override
   String get runtimeTypeName => 'MyModel';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, MyModel, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'enum':
-        value = enum_;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-      case r'id':
-        value = id;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialMyModel extends PartialMyModel {
@@ -264,6 +241,29 @@ abstract class MyModel extends PartialMyModel
   /// Query field for the [modelIdentifier] field.
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, MyModel, String> get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, MyModel, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'enum':
+        value = enum_;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+      case r'id':
+        value = id;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _MyModel extends MyModel {

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.my_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class MyModelType extends ModelType<String, MyModel, PartialMyModel> {
   const MyModelType();
@@ -210,6 +211,49 @@ abstract class MyModel extends PartialMyModel
 
   static const MyModelQueryFields<String, MyModel> _queryFields =
       MyModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'MyModel',
+      'pluralName': 'MyModels',
+      'fields': {
+        'enum': {
+          'name': 'enum',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get enum_;

--- a/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_non_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/reserved_words/my_non_model.dart
@@ -16,7 +16,7 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.my_non_model;
 

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
@@ -58,7 +58,8 @@ class CpkModelType
 
   @override
   T fromJson<T extends PartialModel<CpkModelIdentifier, CpkModel>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == CpkModel || T == Model<CpkModelIdentifier, CpkModel>) {
       return CpkModel.fromJson(json) as T;
     }
@@ -82,7 +83,8 @@ class CpkModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $firstName => NestedQueryField<
           ModelIdentifier, M, CpkModelIdentifier, CpkModel, String>(
         const QueryField<CpkModelIdentifier, CpkModel, String>(
-            fieldName: 'firstName'),
+          fieldName: 'firstName',
+        ),
         root: _root,
       );
 
@@ -90,7 +92,8 @@ class CpkModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $lastName => NestedQueryField<
           ModelIdentifier, M, CpkModelIdentifier, CpkModel, String>(
         const QueryField<CpkModelIdentifier, CpkModel, String>(
-            fieldName: 'lastName'),
+          fieldName: 'lastName',
+        ),
         root: _root,
       );
 
@@ -99,7 +102,8 @@ class CpkModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CpkModelIdentifier, CpkModel,
           TemporalDateTime>(
         const QueryField<CpkModelIdentifier, CpkModel, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -108,7 +112,8 @@ class CpkModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CpkModelIdentifier, CpkModel,
           TemporalDateTime>(
         const QueryField<CpkModelIdentifier, CpkModel, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -117,7 +122,8 @@ class CpkModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, CpkModelIdentifier, CpkModel,
           CpkModelIdentifier>(
         const QueryField<CpkModelIdentifier, CpkModel, CpkModelIdentifier>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -159,7 +165,8 @@ abstract class PartialCpkModel
   String get runtimeTypeName => 'CpkModel';
   @override
   T valueFor<T extends Object?>(
-      QueryField<CpkModelIdentifier, CpkModel, T> field) {
+    QueryField<CpkModelIdentifier, CpkModel, T> field,
+  ) {
     Object? value;
     switch (field.fieldName) {
       case r'firstName':

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
@@ -163,31 +163,6 @@ abstract class PartialCpkModel
       };
   @override
   String get runtimeTypeName => 'CpkModel';
-  @override
-  T valueFor<T extends Object?>(
-    QueryField<CpkModelIdentifier, CpkModel, T> field,
-  ) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'firstName':
-        value = firstName;
-        break;
-      case r'lastName':
-        value = lastName;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialCpkModel extends PartialCpkModel {
@@ -318,6 +293,31 @@ abstract class CpkModel extends PartialCpkModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<CpkModelIdentifier, CpkModel, CpkModelIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<CpkModelIdentifier, CpkModel, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'firstName':
+        value = firstName;
+        break;
+      case r'lastName':
+        value = lastName;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _CpkModel extends CpkModel {

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
@@ -293,6 +293,22 @@ abstract class CpkModel extends PartialCpkModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<CpkModelIdentifier, CpkModel, CpkModelIdentifier>
       get MODEL_IDENTIFIER => $modelIdentifier;
+  CpkModel copyWith({
+    String? firstName,
+    String? lastName,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _CpkModel._(
+      firstName: firstName ?? this.firstName,
+      lastName: lastName ?? this.lastName,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<CpkModelIdentifier, CpkModel, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/cpk_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.cpk_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 import 'package:meta/meta.dart';
 
 @immutable
@@ -259,6 +260,49 @@ abstract class CpkModel extends PartialCpkModel
 
   static const CpkModelQueryFields<CpkModelIdentifier, CpkModel> _queryFields =
       CpkModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'CPKModel',
+      'pluralName': 'CPKModels',
+      'fields': {
+        'firstName': {
+          'name': 'firstName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'lastName': {
+          'name': 'lastName',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'firstName',
+          'sortKeyFields': ['lastName'],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get firstName;

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/date_time_overrides.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/date_time_overrides.dart
@@ -28,7 +28,8 @@ class DateTimeOverridesType
 
   @override
   T fromJson<T extends PartialModel<String, DateTimeOverrides>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == DateTimeOverrides || T == Model<String, DateTimeOverrides>) {
       return DateTimeOverrides.fromJson(json) as T;
     }
@@ -60,7 +61,8 @@ class DateTimeOverridesQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $createdAt =>
       NestedQueryField<ModelIdentifier, M, String, DateTimeOverrides, String>(
         const QueryField<String, DateTimeOverrides, String>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -69,7 +71,8 @@ class DateTimeOverridesQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, DateTimeOverrides,
           TemporalDateTime>(
         const QueryField<String, DateTimeOverrides, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -77,7 +80,8 @@ class DateTimeOverridesQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
       NestedQueryField<ModelIdentifier, M, String, DateTimeOverrides, String>(
         const QueryField<String, DateTimeOverrides, String>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -113,7 +117,8 @@ abstract class PartialDateTimeOverrides
   String get runtimeTypeName => 'DateTimeOverrides';
   @override
   T valueFor<T extends Object?>(
-      QueryField<String, DateTimeOverrides, T> field) {
+    QueryField<String, DateTimeOverrides, T> field,
+  ) {
     Object? value;
     switch (field.fieldName) {
       case r'id':

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/date_time_overrides.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/date_time_overrides.dart
@@ -233,6 +233,19 @@ abstract class DateTimeOverrides extends PartialDateTimeOverrides
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, DateTimeOverrides, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  DateTimeOverrides copyWith({
+    String? id,
+    String? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _DateTimeOverrides._(
+      id: id ?? this.id,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(
     QueryField<String, DateTimeOverrides, T> field,

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/date_time_overrides.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/date_time_overrides.dart
@@ -115,28 +115,6 @@ abstract class PartialDateTimeOverrides
       };
   @override
   String get runtimeTypeName => 'DateTimeOverrides';
-  @override
-  T valueFor<T extends Object?>(
-    QueryField<String, DateTimeOverrides, T> field,
-  ) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'id':
-        value = id;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialDateTimeOverrides extends PartialDateTimeOverrides {
@@ -255,6 +233,28 @@ abstract class DateTimeOverrides extends PartialDateTimeOverrides
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, DateTimeOverrides, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(
+    QueryField<String, DateTimeOverrides, T> field,
+  ) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _DateTimeOverrides extends DateTimeOverrides {

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/date_time_overrides.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/date_time_overrides.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.date_time_overrides;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class DateTimeOverridesType
     extends ModelType<String, DateTimeOverrides, PartialDateTimeOverrides> {
@@ -193,6 +194,43 @@ abstract class DateTimeOverrides extends PartialDateTimeOverrides
 
   static const DateTimeOverridesQueryFields<String, DateTimeOverrides>
       _queryFields = DateTimeOverridesQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'DateTimeOverrides',
+      'pluralName': 'DateTimeOverrides',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/model_provider.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/model_provider.dart
@@ -1,0 +1,81 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
+
+library models.model_provider;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
+
+import 'cpk_model.dart';
+import 'date_time_overrides.dart';
+import 'scalar_list_model.dart';
+import 'scalar_model.dart';
+
+export 'cpk_model.dart';
+export 'date_time_overrides.dart';
+export 'scalar_list_model.dart';
+export 'scalar_model.dart';
+
+class ModelProvider extends ModelProviderInterface {
+  ModelProvider._();
+
+  static final instance = ModelProvider._();
+
+  @override
+  String get version => '3905450cc8965183869556e67ccae253';
+  @override
+  List<mipr.ModelTypeDefinition> get modelSchemas => [
+        ScalarModel.schema,
+        ScalarListModel.schema,
+        CpkModel.schema,
+        DateTimeOverrides.schema,
+      ];
+  @override
+  List<mipr.NonModelTypeDefinition> get customTypeSchemas => [];
+  @override
+  ModelType<ModelIdentifier, M, P> getModelType<
+      ModelIdentifier extends Object,
+      M extends Model<ModelIdentifier, M>,
+      P extends PartialModel<ModelIdentifier, M>>(String modelName) {
+    switch (modelName) {
+      case 'ScalarModel':
+        return (ScalarModel.classType as ModelType<ModelIdentifier, M, P>);
+      case 'ScalarListModel':
+        return (ScalarListModel.classType as ModelType<ModelIdentifier, M, P>);
+      case 'CPKModel':
+      case 'CpkModel':
+        return (CpkModel.classType as ModelType<ModelIdentifier, M, P>);
+      case 'DateTimeOverrides':
+        return (DateTimeOverrides.classType
+            as ModelType<ModelIdentifier, M, P>);
+      default:
+        throw ArgumentError(
+          'Failed to find model in model provider for model name: $modelName',
+        );
+    }
+  }
+
+  @override
+  ModelType<ModelIdentifier, M, P> getModelTypeByModelName<
+          ModelIdentifier extends Object,
+          M extends Model<ModelIdentifier, M>,
+          P extends PartialModel<ModelIdentifier, M>>(String modelName) =>
+      getModelType(modelName);
+}

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.scalar_list_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class ScalarListModelType
     extends ModelType<String, ScalarListModel, PartialScalarListModel> {
@@ -2258,6 +2259,459 @@ abstract class ScalarListModel extends PartialScalarListModel
 
   static const ScalarListModelQueryFields<String, ScalarListModel>
       _queryFields = ScalarListModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'ScalarListModel',
+      'pluralName': 'ScalarListModels',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfString': {
+          'name': 'listOfString',
+          'type': {
+            'list': {'scalar': 'String'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredString': {
+          'name': 'listOfRequiredString',
+          'type': {
+            'list': {'scalar': 'String'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfString': {
+          'name': 'requiredListOfString',
+          'type': {
+            'list': {'scalar': 'String'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredString': {
+          'name': 'requiredListOfRequiredString',
+          'type': {
+            'list': {'scalar': 'String'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfInteger': {
+          'name': 'listOfInteger',
+          'type': {
+            'list': {'scalar': 'Int'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredInteger': {
+          'name': 'listOfRequiredInteger',
+          'type': {
+            'list': {'scalar': 'Int'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfInteger': {
+          'name': 'requiredListOfInteger',
+          'type': {
+            'list': {'scalar': 'Int'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredInteger': {
+          'name': 'requiredListOfRequiredInteger',
+          'type': {
+            'list': {'scalar': 'Int'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfFloat': {
+          'name': 'listOfFloat',
+          'type': {
+            'list': {'scalar': 'Float'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredFloat': {
+          'name': 'listOfRequiredFloat',
+          'type': {
+            'list': {'scalar': 'Float'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfFloat': {
+          'name': 'requiredListOfFloat',
+          'type': {
+            'list': {'scalar': 'Float'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredFloat': {
+          'name': 'requiredListOfRequiredFloat',
+          'type': {
+            'list': {'scalar': 'Float'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfBoolean': {
+          'name': 'listOfBoolean',
+          'type': {
+            'list': {'scalar': 'Boolean'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredBoolean': {
+          'name': 'listOfRequiredBoolean',
+          'type': {
+            'list': {'scalar': 'Boolean'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfBoolean': {
+          'name': 'requiredListOfBoolean',
+          'type': {
+            'list': {'scalar': 'Boolean'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredBoolean': {
+          'name': 'requiredListOfRequiredBoolean',
+          'type': {
+            'list': {'scalar': 'Boolean'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSDate': {
+          'name': 'listOfAWSDate',
+          'type': {
+            'list': {'scalar': 'AWSDate'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSDate': {
+          'name': 'listOfRequiredAWSDate',
+          'type': {
+            'list': {'scalar': 'AWSDate'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSDate': {
+          'name': 'requiredListOfAWSDate',
+          'type': {
+            'list': {'scalar': 'AWSDate'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSDate': {
+          'name': 'requiredListOfRequiredAWSDate',
+          'type': {
+            'list': {'scalar': 'AWSDate'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSDateTime': {
+          'name': 'listOfAWSDateTime',
+          'type': {
+            'list': {'scalar': 'AWSDateTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSDateTime': {
+          'name': 'listOfRequiredAWSDateTime',
+          'type': {
+            'list': {'scalar': 'AWSDateTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSDateTime': {
+          'name': 'requiredListOfAWSDateTime',
+          'type': {
+            'list': {'scalar': 'AWSDateTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSDateTime': {
+          'name': 'requiredListOfRequiredAWSDateTime',
+          'type': {
+            'list': {'scalar': 'AWSDateTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSTime': {
+          'name': 'listOfAWSTime',
+          'type': {
+            'list': {'scalar': 'AWSTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSTime': {
+          'name': 'listOfRequiredAWSTime',
+          'type': {
+            'list': {'scalar': 'AWSTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSTime': {
+          'name': 'requiredListOfAWSTime',
+          'type': {
+            'list': {'scalar': 'AWSTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSTime': {
+          'name': 'requiredListOfRequiredAWSTime',
+          'type': {
+            'list': {'scalar': 'AWSTime'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSTimestamp': {
+          'name': 'listOfAWSTimestamp',
+          'type': {
+            'list': {'scalar': 'AWSTimestamp'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSTimestamp': {
+          'name': 'listOfRequiredAWSTimestamp',
+          'type': {
+            'list': {'scalar': 'AWSTimestamp'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSTimestamp': {
+          'name': 'requiredListOfAWSTimestamp',
+          'type': {
+            'list': {'scalar': 'AWSTimestamp'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSTimestamp': {
+          'name': 'requiredListOfRequiredAWSTimestamp',
+          'type': {
+            'list': {'scalar': 'AWSTimestamp'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSEmail': {
+          'name': 'listOfAWSEmail',
+          'type': {
+            'list': {'scalar': 'AWSEmail'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSEmail': {
+          'name': 'listOfRequiredAWSEmail',
+          'type': {
+            'list': {'scalar': 'AWSEmail'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSEmail': {
+          'name': 'requiredListOfAWSEmail',
+          'type': {
+            'list': {'scalar': 'AWSEmail'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSEmail': {
+          'name': 'requiredListOfRequiredAWSEmail',
+          'type': {
+            'list': {'scalar': 'AWSEmail'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSJSON': {
+          'name': 'listOfAWSJSON',
+          'type': {
+            'list': {'scalar': 'AWSJSON'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSJSON': {
+          'name': 'listOfRequiredAWSJSON',
+          'type': {
+            'list': {'scalar': 'AWSJSON'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSJSON': {
+          'name': 'requiredListOfAWSJSON',
+          'type': {
+            'list': {'scalar': 'AWSJSON'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSJSON': {
+          'name': 'requiredListOfRequiredAWSJSON',
+          'type': {
+            'list': {'scalar': 'AWSJSON'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSPhone': {
+          'name': 'listOfAWSPhone',
+          'type': {
+            'list': {'scalar': 'AWSPhone'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSPhone': {
+          'name': 'listOfRequiredAWSPhone',
+          'type': {
+            'list': {'scalar': 'AWSPhone'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSPhone': {
+          'name': 'requiredListOfAWSPhone',
+          'type': {
+            'list': {'scalar': 'AWSPhone'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSPhone': {
+          'name': 'requiredListOfRequiredAWSPhone',
+          'type': {
+            'list': {'scalar': 'AWSPhone'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSUrl': {
+          'name': 'listOfAWSUrl',
+          'type': {
+            'list': {'scalar': 'AWSURL'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSUrl': {
+          'name': 'listOfRequiredAWSUrl',
+          'type': {
+            'list': {'scalar': 'AWSURL'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSUrl': {
+          'name': 'requiredListOfAWSUrl',
+          'type': {
+            'list': {'scalar': 'AWSURL'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSUrl': {
+          'name': 'requiredListOfRequiredAWSUrl',
+          'type': {
+            'list': {'scalar': 'AWSURL'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfAWSIpAddress': {
+          'name': 'listOfAWSIpAddress',
+          'type': {
+            'list': {'scalar': 'AWSIPAddress'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'listOfRequiredAWSIpAddress': {
+          'name': 'listOfRequiredAWSIpAddress',
+          'type': {
+            'list': {'scalar': 'AWSIPAddress'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfAWSIpAddress': {
+          'name': 'requiredListOfAWSIpAddress',
+          'type': {
+            'list': {'scalar': 'AWSIPAddress'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredListOfRequiredAWSIpAddress': {
+          'name': 'requiredListOfRequiredAWSIpAddress',
+          'type': {
+            'list': {'scalar': 'AWSIPAddress'}
+          },
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
@@ -2872,6 +2872,157 @@ abstract class ScalarListModel extends PartialScalarListModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, ScalarListModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  ScalarListModel copyWith({
+    String? id,
+    List<String?>? listOfString,
+    List<String>? listOfRequiredString,
+    List<String?>? requiredListOfString,
+    List<String>? requiredListOfRequiredString,
+    List<int?>? listOfInteger,
+    List<int>? listOfRequiredInteger,
+    List<int?>? requiredListOfInteger,
+    List<int>? requiredListOfRequiredInteger,
+    List<double?>? listOfFloat,
+    List<double>? listOfRequiredFloat,
+    List<double?>? requiredListOfFloat,
+    List<double>? requiredListOfRequiredFloat,
+    List<bool?>? listOfBoolean,
+    List<bool>? listOfRequiredBoolean,
+    List<bool?>? requiredListOfBoolean,
+    List<bool>? requiredListOfRequiredBoolean,
+    List<TemporalDate?>? listOfAwsDate,
+    List<TemporalDate>? listOfRequiredAwsDate,
+    List<TemporalDate?>? requiredListOfAwsDate,
+    List<TemporalDate>? requiredListOfRequiredAwsDate,
+    List<TemporalDateTime?>? listOfAwsDateTime,
+    List<TemporalDateTime>? listOfRequiredAwsDateTime,
+    List<TemporalDateTime?>? requiredListOfAwsDateTime,
+    List<TemporalDateTime>? requiredListOfRequiredAwsDateTime,
+    List<TemporalTime?>? listOfAwsTime,
+    List<TemporalTime>? listOfRequiredAwsTime,
+    List<TemporalTime?>? requiredListOfAwsTime,
+    List<TemporalTime>? requiredListOfRequiredAwsTime,
+    List<TemporalTimestamp?>? listOfAwsTimestamp,
+    List<TemporalTimestamp>? listOfRequiredAwsTimestamp,
+    List<TemporalTimestamp?>? requiredListOfAwsTimestamp,
+    List<TemporalTimestamp>? requiredListOfRequiredAwsTimestamp,
+    List<String?>? listOfAwsEmail,
+    List<String>? listOfRequiredAwsEmail,
+    List<String?>? requiredListOfAwsEmail,
+    List<String>? requiredListOfRequiredAwsEmail,
+    List<Object?>? listOfAwsjson,
+    List<Object>? listOfRequiredAwsjson,
+    List<Object?>? requiredListOfAwsjson,
+    List<Object>? requiredListOfRequiredAwsjson,
+    List<String?>? listOfAwsPhone,
+    List<String>? listOfRequiredAwsPhone,
+    List<String?>? requiredListOfAwsPhone,
+    List<String>? requiredListOfRequiredAwsPhone,
+    List<Uri?>? listOfAwsUrl,
+    List<Uri>? listOfRequiredAwsUrl,
+    List<Uri?>? requiredListOfAwsUrl,
+    List<Uri>? requiredListOfRequiredAwsUrl,
+    List<String?>? listOfAwsIpAddress,
+    List<String>? listOfRequiredAwsIpAddress,
+    List<String?>? requiredListOfAwsIpAddress,
+    List<String>? requiredListOfRequiredAwsIpAddress,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _ScalarListModel._(
+      id: id ?? this.id,
+      listOfString: listOfString ?? this.listOfString,
+      listOfRequiredString: listOfRequiredString ?? this.listOfRequiredString,
+      requiredListOfString: requiredListOfString ?? this.requiredListOfString,
+      requiredListOfRequiredString:
+          requiredListOfRequiredString ?? this.requiredListOfRequiredString,
+      listOfInteger: listOfInteger ?? this.listOfInteger,
+      listOfRequiredInteger:
+          listOfRequiredInteger ?? this.listOfRequiredInteger,
+      requiredListOfInteger:
+          requiredListOfInteger ?? this.requiredListOfInteger,
+      requiredListOfRequiredInteger:
+          requiredListOfRequiredInteger ?? this.requiredListOfRequiredInteger,
+      listOfFloat: listOfFloat ?? this.listOfFloat,
+      listOfRequiredFloat: listOfRequiredFloat ?? this.listOfRequiredFloat,
+      requiredListOfFloat: requiredListOfFloat ?? this.requiredListOfFloat,
+      requiredListOfRequiredFloat:
+          requiredListOfRequiredFloat ?? this.requiredListOfRequiredFloat,
+      listOfBoolean: listOfBoolean ?? this.listOfBoolean,
+      listOfRequiredBoolean:
+          listOfRequiredBoolean ?? this.listOfRequiredBoolean,
+      requiredListOfBoolean:
+          requiredListOfBoolean ?? this.requiredListOfBoolean,
+      requiredListOfRequiredBoolean:
+          requiredListOfRequiredBoolean ?? this.requiredListOfRequiredBoolean,
+      listOfAwsDate: listOfAwsDate ?? this.listOfAwsDate,
+      listOfRequiredAwsDate:
+          listOfRequiredAwsDate ?? this.listOfRequiredAwsDate,
+      requiredListOfAwsDate:
+          requiredListOfAwsDate ?? this.requiredListOfAwsDate,
+      requiredListOfRequiredAwsDate:
+          requiredListOfRequiredAwsDate ?? this.requiredListOfRequiredAwsDate,
+      listOfAwsDateTime: listOfAwsDateTime ?? this.listOfAwsDateTime,
+      listOfRequiredAwsDateTime:
+          listOfRequiredAwsDateTime ?? this.listOfRequiredAwsDateTime,
+      requiredListOfAwsDateTime:
+          requiredListOfAwsDateTime ?? this.requiredListOfAwsDateTime,
+      requiredListOfRequiredAwsDateTime: requiredListOfRequiredAwsDateTime ??
+          this.requiredListOfRequiredAwsDateTime,
+      listOfAwsTime: listOfAwsTime ?? this.listOfAwsTime,
+      listOfRequiredAwsTime:
+          listOfRequiredAwsTime ?? this.listOfRequiredAwsTime,
+      requiredListOfAwsTime:
+          requiredListOfAwsTime ?? this.requiredListOfAwsTime,
+      requiredListOfRequiredAwsTime:
+          requiredListOfRequiredAwsTime ?? this.requiredListOfRequiredAwsTime,
+      listOfAwsTimestamp: listOfAwsTimestamp ?? this.listOfAwsTimestamp,
+      listOfRequiredAwsTimestamp:
+          listOfRequiredAwsTimestamp ?? this.listOfRequiredAwsTimestamp,
+      requiredListOfAwsTimestamp:
+          requiredListOfAwsTimestamp ?? this.requiredListOfAwsTimestamp,
+      requiredListOfRequiredAwsTimestamp: requiredListOfRequiredAwsTimestamp ??
+          this.requiredListOfRequiredAwsTimestamp,
+      listOfAwsEmail: listOfAwsEmail ?? this.listOfAwsEmail,
+      listOfRequiredAwsEmail:
+          listOfRequiredAwsEmail ?? this.listOfRequiredAwsEmail,
+      requiredListOfAwsEmail:
+          requiredListOfAwsEmail ?? this.requiredListOfAwsEmail,
+      requiredListOfRequiredAwsEmail:
+          requiredListOfRequiredAwsEmail ?? this.requiredListOfRequiredAwsEmail,
+      listOfAwsjson: listOfAwsjson ?? this.listOfAwsjson,
+      listOfRequiredAwsjson:
+          listOfRequiredAwsjson ?? this.listOfRequiredAwsjson,
+      requiredListOfAwsjson:
+          requiredListOfAwsjson ?? this.requiredListOfAwsjson,
+      requiredListOfRequiredAwsjson:
+          requiredListOfRequiredAwsjson ?? this.requiredListOfRequiredAwsjson,
+      listOfAwsPhone: listOfAwsPhone ?? this.listOfAwsPhone,
+      listOfRequiredAwsPhone:
+          listOfRequiredAwsPhone ?? this.listOfRequiredAwsPhone,
+      requiredListOfAwsPhone:
+          requiredListOfAwsPhone ?? this.requiredListOfAwsPhone,
+      requiredListOfRequiredAwsPhone:
+          requiredListOfRequiredAwsPhone ?? this.requiredListOfRequiredAwsPhone,
+      listOfAwsUrl: listOfAwsUrl ?? this.listOfAwsUrl,
+      listOfRequiredAwsUrl: listOfRequiredAwsUrl ?? this.listOfRequiredAwsUrl,
+      requiredListOfAwsUrl: requiredListOfAwsUrl ?? this.requiredListOfAwsUrl,
+      requiredListOfRequiredAwsUrl:
+          requiredListOfRequiredAwsUrl ?? this.requiredListOfRequiredAwsUrl,
+      listOfAwsIpAddress: listOfAwsIpAddress ?? this.listOfAwsIpAddress,
+      listOfRequiredAwsIpAddress:
+          listOfRequiredAwsIpAddress ?? this.listOfRequiredAwsIpAddress,
+      requiredListOfAwsIpAddress:
+          requiredListOfAwsIpAddress ?? this.requiredListOfAwsIpAddress,
+      requiredListOfRequiredAwsIpAddress: requiredListOfRequiredAwsIpAddress ??
+          this.requiredListOfRequiredAwsIpAddress,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, ScalarListModel, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
@@ -28,7 +28,8 @@ class ScalarListModelType
 
   @override
   T fromJson<T extends PartialModel<String, ScalarListModel>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == ScalarListModel || T == Model<String, ScalarListModel>) {
       return ScalarListModel.fromJson(json) as T;
     }
@@ -60,7 +61,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $listOfString =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String?>(
         const QueryField<String, ScalarListModel, String?>(
-            fieldName: 'listOfString'),
+          fieldName: 'listOfString',
+        ),
         root: _root,
       );
 
@@ -68,7 +70,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $listOfRequiredString =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String>(
         const QueryField<String, ScalarListModel, String>(
-            fieldName: 'listOfRequiredString'),
+          fieldName: 'listOfRequiredString',
+        ),
         root: _root,
       );
 
@@ -76,7 +79,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $requiredListOfString =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String?>(
         const QueryField<String, ScalarListModel, String?>(
-            fieldName: 'requiredListOfString'),
+          fieldName: 'requiredListOfString',
+        ),
         root: _root,
       );
 
@@ -84,7 +88,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $requiredListOfRequiredString =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String>(
         const QueryField<String, ScalarListModel, String>(
-            fieldName: 'requiredListOfRequiredString'),
+          fieldName: 'requiredListOfRequiredString',
+        ),
         root: _root,
       );
 
@@ -92,7 +97,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, int?> get $listOfInteger =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, int?>(
         const QueryField<String, ScalarListModel, int?>(
-            fieldName: 'listOfInteger'),
+          fieldName: 'listOfInteger',
+        ),
         root: _root,
       );
 
@@ -100,7 +106,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, int> get $listOfRequiredInteger =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, int>(
         const QueryField<String, ScalarListModel, int>(
-            fieldName: 'listOfRequiredInteger'),
+          fieldName: 'listOfRequiredInteger',
+        ),
         root: _root,
       );
 
@@ -108,7 +115,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, int?> get $requiredListOfInteger =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, int?>(
         const QueryField<String, ScalarListModel, int?>(
-            fieldName: 'requiredListOfInteger'),
+          fieldName: 'requiredListOfInteger',
+        ),
         root: _root,
       );
 
@@ -116,7 +124,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, int> get $requiredListOfRequiredInteger =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, int>(
         const QueryField<String, ScalarListModel, int>(
-            fieldName: 'requiredListOfRequiredInteger'),
+          fieldName: 'requiredListOfRequiredInteger',
+        ),
         root: _root,
       );
 
@@ -124,7 +133,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, double?> get $listOfFloat =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, double?>(
         const QueryField<String, ScalarListModel, double?>(
-            fieldName: 'listOfFloat'),
+          fieldName: 'listOfFloat',
+        ),
         root: _root,
       );
 
@@ -132,7 +142,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, double> get $listOfRequiredFloat =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, double>(
         const QueryField<String, ScalarListModel, double>(
-            fieldName: 'listOfRequiredFloat'),
+          fieldName: 'listOfRequiredFloat',
+        ),
         root: _root,
       );
 
@@ -140,7 +151,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, double?> get $requiredListOfFloat =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, double?>(
         const QueryField<String, ScalarListModel, double?>(
-            fieldName: 'requiredListOfFloat'),
+          fieldName: 'requiredListOfFloat',
+        ),
         root: _root,
       );
 
@@ -148,7 +160,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, double> get $requiredListOfRequiredFloat =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, double>(
         const QueryField<String, ScalarListModel, double>(
-            fieldName: 'requiredListOfRequiredFloat'),
+          fieldName: 'requiredListOfRequiredFloat',
+        ),
         root: _root,
       );
 
@@ -156,7 +169,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, bool?> get $listOfBoolean =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, bool?>(
         const QueryField<String, ScalarListModel, bool?>(
-            fieldName: 'listOfBoolean'),
+          fieldName: 'listOfBoolean',
+        ),
         root: _root,
       );
 
@@ -164,7 +178,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, bool> get $listOfRequiredBoolean =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, bool>(
         const QueryField<String, ScalarListModel, bool>(
-            fieldName: 'listOfRequiredBoolean'),
+          fieldName: 'listOfRequiredBoolean',
+        ),
         root: _root,
       );
 
@@ -172,7 +187,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, bool?> get $requiredListOfBoolean =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, bool?>(
         const QueryField<String, ScalarListModel, bool?>(
-            fieldName: 'requiredListOfBoolean'),
+          fieldName: 'requiredListOfBoolean',
+        ),
         root: _root,
       );
 
@@ -180,7 +196,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, bool> get $requiredListOfRequiredBoolean =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, bool>(
         const QueryField<String, ScalarListModel, bool>(
-            fieldName: 'requiredListOfRequiredBoolean'),
+          fieldName: 'requiredListOfRequiredBoolean',
+        ),
         root: _root,
       );
 
@@ -189,7 +206,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
           TemporalDate?>(
         const QueryField<String, ScalarListModel, TemporalDate?>(
-            fieldName: 'listOfAWSDate'),
+          fieldName: 'listOfAWSDate',
+        ),
         root: _root,
       );
 
@@ -198,7 +216,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
           TemporalDate>(
         const QueryField<String, ScalarListModel, TemporalDate>(
-            fieldName: 'listOfRequiredAWSDate'),
+          fieldName: 'listOfRequiredAWSDate',
+        ),
         root: _root,
       );
 
@@ -207,7 +226,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
           TemporalDate?>(
         const QueryField<String, ScalarListModel, TemporalDate?>(
-            fieldName: 'requiredListOfAWSDate'),
+          fieldName: 'requiredListOfAWSDate',
+        ),
         root: _root,
       );
 
@@ -216,7 +236,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfRequiredAwsDate => NestedQueryField<ModelIdentifier, M,
               String, ScalarListModel, TemporalDate>(
             const QueryField<String, ScalarListModel, TemporalDate>(
-                fieldName: 'requiredListOfRequiredAWSDate'),
+              fieldName: 'requiredListOfRequiredAWSDate',
+            ),
             root: _root,
           );
 
@@ -225,7 +246,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
           TemporalDateTime?>(
         const QueryField<String, ScalarListModel, TemporalDateTime?>(
-            fieldName: 'listOfAWSDateTime'),
+          fieldName: 'listOfAWSDateTime',
+        ),
         root: _root,
       );
 
@@ -234,7 +256,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       get $listOfRequiredAwsDateTime => NestedQueryField<ModelIdentifier, M,
               String, ScalarListModel, TemporalDateTime>(
             const QueryField<String, ScalarListModel, TemporalDateTime>(
-                fieldName: 'listOfRequiredAWSDateTime'),
+              fieldName: 'listOfRequiredAWSDateTime',
+            ),
             root: _root,
           );
 
@@ -243,7 +266,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfAwsDateTime => NestedQueryField<ModelIdentifier, M,
               String, ScalarListModel, TemporalDateTime?>(
             const QueryField<String, ScalarListModel, TemporalDateTime?>(
-                fieldName: 'requiredListOfAWSDateTime'),
+              fieldName: 'requiredListOfAWSDateTime',
+            ),
             root: _root,
           );
 
@@ -252,7 +276,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfRequiredAwsDateTime => NestedQueryField<
               ModelIdentifier, M, String, ScalarListModel, TemporalDateTime>(
             const QueryField<String, ScalarListModel, TemporalDateTime>(
-                fieldName: 'requiredListOfRequiredAWSDateTime'),
+              fieldName: 'requiredListOfRequiredAWSDateTime',
+            ),
             root: _root,
           );
 
@@ -261,7 +286,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
           TemporalTime?>(
         const QueryField<String, ScalarListModel, TemporalTime?>(
-            fieldName: 'listOfAWSTime'),
+          fieldName: 'listOfAWSTime',
+        ),
         root: _root,
       );
 
@@ -270,7 +296,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
           TemporalTime>(
         const QueryField<String, ScalarListModel, TemporalTime>(
-            fieldName: 'listOfRequiredAWSTime'),
+          fieldName: 'listOfRequiredAWSTime',
+        ),
         root: _root,
       );
 
@@ -279,7 +306,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
           TemporalTime?>(
         const QueryField<String, ScalarListModel, TemporalTime?>(
-            fieldName: 'requiredListOfAWSTime'),
+          fieldName: 'requiredListOfAWSTime',
+        ),
         root: _root,
       );
 
@@ -288,7 +316,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfRequiredAwsTime => NestedQueryField<ModelIdentifier, M,
               String, ScalarListModel, TemporalTime>(
             const QueryField<String, ScalarListModel, TemporalTime>(
-                fieldName: 'requiredListOfRequiredAWSTime'),
+              fieldName: 'requiredListOfRequiredAWSTime',
+            ),
             root: _root,
           );
 
@@ -297,7 +326,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
           TemporalTimestamp?>(
         const QueryField<String, ScalarListModel, TemporalTimestamp?>(
-            fieldName: 'listOfAWSTimestamp'),
+          fieldName: 'listOfAWSTimestamp',
+        ),
         root: _root,
       );
 
@@ -306,7 +336,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       get $listOfRequiredAwsTimestamp => NestedQueryField<ModelIdentifier, M,
               String, ScalarListModel, TemporalTimestamp>(
             const QueryField<String, ScalarListModel, TemporalTimestamp>(
-                fieldName: 'listOfRequiredAWSTimestamp'),
+              fieldName: 'listOfRequiredAWSTimestamp',
+            ),
             root: _root,
           );
 
@@ -315,7 +346,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfAwsTimestamp => NestedQueryField<ModelIdentifier, M,
               String, ScalarListModel, TemporalTimestamp?>(
             const QueryField<String, ScalarListModel, TemporalTimestamp?>(
-                fieldName: 'requiredListOfAWSTimestamp'),
+              fieldName: 'requiredListOfAWSTimestamp',
+            ),
             root: _root,
           );
 
@@ -324,7 +356,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfRequiredAwsTimestamp => NestedQueryField<
               ModelIdentifier, M, String, ScalarListModel, TemporalTimestamp>(
             const QueryField<String, ScalarListModel, TemporalTimestamp>(
-                fieldName: 'requiredListOfRequiredAWSTimestamp'),
+              fieldName: 'requiredListOfRequiredAWSTimestamp',
+            ),
             root: _root,
           );
 
@@ -332,7 +365,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $listOfAwsEmail =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String?>(
         const QueryField<String, ScalarListModel, String?>(
-            fieldName: 'listOfAWSEmail'),
+          fieldName: 'listOfAWSEmail',
+        ),
         root: _root,
       );
 
@@ -340,7 +374,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $listOfRequiredAwsEmail =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String>(
         const QueryField<String, ScalarListModel, String>(
-            fieldName: 'listOfRequiredAWSEmail'),
+          fieldName: 'listOfRequiredAWSEmail',
+        ),
         root: _root,
       );
 
@@ -348,7 +383,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $requiredListOfAwsEmail =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String?>(
         const QueryField<String, ScalarListModel, String?>(
-            fieldName: 'requiredListOfAWSEmail'),
+          fieldName: 'requiredListOfAWSEmail',
+        ),
         root: _root,
       );
 
@@ -356,7 +392,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $requiredListOfRequiredAwsEmail =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String>(
         const QueryField<String, ScalarListModel, String>(
-            fieldName: 'requiredListOfRequiredAWSEmail'),
+          fieldName: 'requiredListOfRequiredAWSEmail',
+        ),
         root: _root,
       );
 
@@ -364,7 +401,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Object?> get $listOfAwsjson =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, Object?>(
         const QueryField<String, ScalarListModel, Object?>(
-            fieldName: 'listOfAWSJSON'),
+          fieldName: 'listOfAWSJSON',
+        ),
         root: _root,
       );
 
@@ -372,7 +410,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Object> get $listOfRequiredAwsjson =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, Object>(
         const QueryField<String, ScalarListModel, Object>(
-            fieldName: 'listOfRequiredAWSJSON'),
+          fieldName: 'listOfRequiredAWSJSON',
+        ),
         root: _root,
       );
 
@@ -380,7 +419,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Object?> get $requiredListOfAwsjson =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, Object?>(
         const QueryField<String, ScalarListModel, Object?>(
-            fieldName: 'requiredListOfAWSJSON'),
+          fieldName: 'requiredListOfAWSJSON',
+        ),
         root: _root,
       );
 
@@ -388,7 +428,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Object> get $requiredListOfRequiredAwsjson =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, Object>(
         const QueryField<String, ScalarListModel, Object>(
-            fieldName: 'requiredListOfRequiredAWSJSON'),
+          fieldName: 'requiredListOfRequiredAWSJSON',
+        ),
         root: _root,
       );
 
@@ -396,7 +437,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $listOfAwsPhone =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String?>(
         const QueryField<String, ScalarListModel, String?>(
-            fieldName: 'listOfAWSPhone'),
+          fieldName: 'listOfAWSPhone',
+        ),
         root: _root,
       );
 
@@ -404,7 +446,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $listOfRequiredAwsPhone =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String>(
         const QueryField<String, ScalarListModel, String>(
-            fieldName: 'listOfRequiredAWSPhone'),
+          fieldName: 'listOfRequiredAWSPhone',
+        ),
         root: _root,
       );
 
@@ -412,7 +455,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $requiredListOfAwsPhone =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String?>(
         const QueryField<String, ScalarListModel, String?>(
-            fieldName: 'requiredListOfAWSPhone'),
+          fieldName: 'requiredListOfAWSPhone',
+        ),
         root: _root,
       );
 
@@ -420,7 +464,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $requiredListOfRequiredAwsPhone =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String>(
         const QueryField<String, ScalarListModel, String>(
-            fieldName: 'requiredListOfRequiredAWSPhone'),
+          fieldName: 'requiredListOfRequiredAWSPhone',
+        ),
         root: _root,
       );
 
@@ -428,7 +473,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Uri?> get $listOfAwsUrl =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, Uri?>(
         const QueryField<String, ScalarListModel, Uri?>(
-            fieldName: 'listOfAWSUrl'),
+          fieldName: 'listOfAWSUrl',
+        ),
         root: _root,
       );
 
@@ -436,7 +482,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Uri> get $listOfRequiredAwsUrl =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, Uri>(
         const QueryField<String, ScalarListModel, Uri>(
-            fieldName: 'listOfRequiredAWSUrl'),
+          fieldName: 'listOfRequiredAWSUrl',
+        ),
         root: _root,
       );
 
@@ -444,7 +491,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Uri?> get $requiredListOfAwsUrl =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, Uri?>(
         const QueryField<String, ScalarListModel, Uri?>(
-            fieldName: 'requiredListOfAWSUrl'),
+          fieldName: 'requiredListOfAWSUrl',
+        ),
         root: _root,
       );
 
@@ -452,7 +500,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Uri> get $requiredListOfRequiredAwsUrl =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, Uri>(
         const QueryField<String, ScalarListModel, Uri>(
-            fieldName: 'requiredListOfRequiredAWSUrl'),
+          fieldName: 'requiredListOfRequiredAWSUrl',
+        ),
         root: _root,
       );
 
@@ -460,7 +509,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $listOfAwsIpAddress =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String?>(
         const QueryField<String, ScalarListModel, String?>(
-            fieldName: 'listOfAWSIpAddress'),
+          fieldName: 'listOfAWSIpAddress',
+        ),
         root: _root,
       );
 
@@ -468,7 +518,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $listOfRequiredAwsIpAddress =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String>(
         const QueryField<String, ScalarListModel, String>(
-            fieldName: 'listOfRequiredAWSIpAddress'),
+          fieldName: 'listOfRequiredAWSIpAddress',
+        ),
         root: _root,
       );
 
@@ -476,7 +527,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $requiredListOfAwsIpAddress =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String?>(
         const QueryField<String, ScalarListModel, String?>(
-            fieldName: 'requiredListOfAWSIpAddress'),
+          fieldName: 'requiredListOfAWSIpAddress',
+        ),
         root: _root,
       );
 
@@ -485,7 +537,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       get $requiredListOfRequiredAwsIpAddress =>
           NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String>(
             const QueryField<String, ScalarListModel, String>(
-                fieldName: 'requiredListOfRequiredAWSIpAddress'),
+              fieldName: 'requiredListOfRequiredAWSIpAddress',
+            ),
             root: _root,
           );
 
@@ -494,7 +547,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
           TemporalDateTime>(
         const QueryField<String, ScalarListModel, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -503,7 +557,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel,
           TemporalDateTime>(
         const QueryField<String, ScalarListModel, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -511,7 +566,8 @@ class ScalarListModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
       NestedQueryField<ModelIdentifier, M, String, ScalarListModel, String>(
         const QueryField<String, ScalarListModel, String>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }
@@ -972,12 +1028,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
         ? null
         : (json['listOfRequiredString'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredString',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredString',
+                  )),
+            )
             .toList();
     final requiredListOfString = json['requiredListOfString'] == null
         ? null
@@ -989,12 +1047,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredString'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredString',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredString',
+                      )),
+                )
                 .toList();
     final listOfInteger = json['listOfInteger'] == null
         ? null
@@ -1003,12 +1063,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
         ? null
         : (json['listOfRequiredInteger'] as List<Object?>)
             .cast<int?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredInteger',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredInteger',
+                  )),
+            )
             .toList();
     final requiredListOfInteger = json['requiredListOfInteger'] == null
         ? null
@@ -1020,12 +1082,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredInteger'] as List<Object?>)
                 .cast<int?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredInteger',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredInteger',
+                      )),
+                )
                 .toList();
     final listOfFloat = json['listOfFloat'] == null
         ? null
@@ -1034,12 +1098,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
         ? null
         : (json['listOfRequiredFloat'] as List<Object?>)
             .cast<double?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredFloat',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredFloat',
+                  )),
+            )
             .toList();
     final requiredListOfFloat = json['requiredListOfFloat'] == null
         ? null
@@ -1051,12 +1117,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredFloat'] as List<Object?>)
                 .cast<double?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredFloat',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredFloat',
+                      )),
+                )
                 .toList();
     final listOfBoolean = json['listOfBoolean'] == null
         ? null
@@ -1065,12 +1133,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
         ? null
         : (json['listOfRequiredBoolean'] as List<Object?>)
             .cast<bool?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredBoolean',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredBoolean',
+                  )),
+            )
             .toList();
     final requiredListOfBoolean = json['requiredListOfBoolean'] == null
         ? null
@@ -1082,12 +1152,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredBoolean'] as List<Object?>)
                 .cast<bool?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredBoolean',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredBoolean',
+                      )),
+                )
                 .toList();
     final listOfAwsDate = json['listOfAWSDate'] == null
         ? null
@@ -1099,12 +1171,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
         ? null
         : (json['listOfRequiredAWSDate'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListModel',
-                    'listOfRequiredAwsDate',
-                  ))
-                : TemporalDate.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsDate',
+                    ))
+                  : TemporalDate.fromString(el),
+            )
             .toList();
     final requiredListOfAwsDate = json['requiredListOfAWSDate'] == null
         ? null
@@ -1117,12 +1191,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredAWSDate'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsDate',
-                      ))
-                    : TemporalDate.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsDate',
+                        ))
+                      : TemporalDate.fromString(el),
+                )
                 .toList();
     final listOfAwsDateTime = json['listOfAWSDateTime'] == null
         ? null
@@ -1134,12 +1210,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
         ? null
         : (json['listOfRequiredAWSDateTime'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListModel',
-                    'listOfRequiredAwsDateTime',
-                  ))
-                : TemporalDateTime.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsDateTime',
+                    ))
+                  : TemporalDateTime.fromString(el),
+            )
             .toList();
     final requiredListOfAwsDateTime = json['requiredListOfAWSDateTime'] == null
         ? null
@@ -1152,12 +1230,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredAWSDateTime'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsDateTime',
-                      ))
-                    : TemporalDateTime.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsDateTime',
+                        ))
+                      : TemporalDateTime.fromString(el),
+                )
                 .toList();
     final listOfAwsTime = json['listOfAWSTime'] == null
         ? null
@@ -1169,12 +1249,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
         ? null
         : (json['listOfRequiredAWSTime'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListModel',
-                    'listOfRequiredAwsTime',
-                  ))
-                : TemporalTime.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsTime',
+                    ))
+                  : TemporalTime.fromString(el),
+            )
             .toList();
     final requiredListOfAwsTime = json['requiredListOfAWSTime'] == null
         ? null
@@ -1187,12 +1269,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredAWSTime'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsTime',
-                      ))
-                    : TemporalTime.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsTime',
+                        ))
+                      : TemporalTime.fromString(el),
+                )
                 .toList();
     final listOfAwsTimestamp = json['listOfAWSTimestamp'] == null
         ? null
@@ -1205,12 +1289,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['listOfRequiredAWSTimestamp'] as List<Object?>)
                 .cast<int?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'listOfRequiredAwsTimestamp',
-                      ))
-                    : TemporalTimestamp.fromSeconds(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'listOfRequiredAwsTimestamp',
+                        ))
+                      : TemporalTimestamp.fromSeconds(el),
+                )
                 .toList();
     final requiredListOfAwsTimestamp = json['requiredListOfAWSTimestamp'] ==
             null
@@ -1224,12 +1310,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredAWSTimestamp'] as List<Object?>)
                 .cast<int?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsTimestamp',
-                      ))
-                    : TemporalTimestamp.fromSeconds(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsTimestamp',
+                        ))
+                      : TemporalTimestamp.fromSeconds(el),
+                )
                 .toList();
     final listOfAwsEmail = json['listOfAWSEmail'] == null
         ? null
@@ -1238,12 +1326,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
         ? null
         : (json['listOfRequiredAWSEmail'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredAwsEmail',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsEmail',
+                  )),
+            )
             .toList();
     final requiredListOfAwsEmail = json['requiredListOfAWSEmail'] == null
         ? null
@@ -1255,12 +1345,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredAWSEmail'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredAwsEmail',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsEmail',
+                      )),
+                )
                 .toList();
     final listOfAwsjson = json['listOfAWSJSON'] == null
         ? null
@@ -1269,12 +1361,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
         ? null
         : (json['listOfRequiredAWSJSON'] as List<Object?>)
             .cast<Object?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredAwsjson',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsjson',
+                  )),
+            )
             .toList();
     final requiredListOfAwsjson = json['requiredListOfAWSJSON'] == null
         ? null
@@ -1286,12 +1380,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredAWSJSON'] as List<Object?>)
                 .cast<Object?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredAwsjson',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsjson',
+                      )),
+                )
                 .toList();
     final listOfAwsPhone = json['listOfAWSPhone'] == null
         ? null
@@ -1300,12 +1396,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
         ? null
         : (json['listOfRequiredAWSPhone'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredAwsPhone',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsPhone',
+                  )),
+            )
             .toList();
     final requiredListOfAwsPhone = json['requiredListOfAWSPhone'] == null
         ? null
@@ -1317,12 +1415,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredAWSPhone'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredAwsPhone',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsPhone',
+                      )),
+                )
                 .toList();
     final listOfAwsUrl = json['listOfAWSUrl'] == null
         ? null
@@ -1334,12 +1434,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
         ? null
         : (json['listOfRequiredAWSUrl'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListModel',
-                    'listOfRequiredAwsUrl',
-                  ))
-                : Uri.parse(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsUrl',
+                    ))
+                  : Uri.parse(el),
+            )
             .toList();
     final requiredListOfAwsUrl = json['requiredListOfAWSUrl'] == null
         ? null
@@ -1352,12 +1454,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredAWSUrl'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsUrl',
-                      ))
-                    : Uri.parse(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsUrl',
+                        ))
+                      : Uri.parse(el),
+                )
                 .toList();
     final listOfAwsIpAddress = json['listOfAWSIpAddress'] == null
         ? null
@@ -1369,12 +1473,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['listOfRequiredAWSIpAddress'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'listOfRequiredAwsIpAddress',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'listOfRequiredAwsIpAddress',
+                      )),
+                )
                 .toList();
     final requiredListOfAwsIpAddress =
         json['requiredListOfAWSIpAddress'] == null
@@ -1387,12 +1493,14 @@ class _PartialScalarListModel extends PartialScalarListModel {
             ? null
             : (json['requiredListOfRequiredAWSIpAddress'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredAwsIpAddress',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsIpAddress',
+                      )),
+                )
                 .toList();
     final createdAt = json['createdAt'] == null
         ? null
@@ -1699,12 +1807,14 @@ abstract class ScalarListModel extends PartialScalarListModel
         ? null
         : (json['listOfRequiredString'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredString',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredString',
+                  )),
+            )
             .toList();
     final requiredListOfString = json['requiredListOfString'] == null
         ? (throw ModelFieldError(
@@ -1722,12 +1832,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredString'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredString',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredString',
+                      )),
+                )
                 .toList();
     final listOfInteger = json['listOfInteger'] == null
         ? null
@@ -1736,12 +1848,14 @@ abstract class ScalarListModel extends PartialScalarListModel
         ? null
         : (json['listOfRequiredInteger'] as List<Object?>)
             .cast<int?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredInteger',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredInteger',
+                  )),
+            )
             .toList();
     final requiredListOfInteger = json['requiredListOfInteger'] == null
         ? (throw ModelFieldError(
@@ -1759,12 +1873,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredInteger'] as List<Object?>)
                 .cast<int?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredInteger',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredInteger',
+                      )),
+                )
                 .toList();
     final listOfFloat = json['listOfFloat'] == null
         ? null
@@ -1773,12 +1889,14 @@ abstract class ScalarListModel extends PartialScalarListModel
         ? null
         : (json['listOfRequiredFloat'] as List<Object?>)
             .cast<double?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredFloat',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredFloat',
+                  )),
+            )
             .toList();
     final requiredListOfFloat = json['requiredListOfFloat'] == null
         ? (throw ModelFieldError(
@@ -1796,12 +1914,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredFloat'] as List<Object?>)
                 .cast<double?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredFloat',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredFloat',
+                      )),
+                )
                 .toList();
     final listOfBoolean = json['listOfBoolean'] == null
         ? null
@@ -1810,12 +1930,14 @@ abstract class ScalarListModel extends PartialScalarListModel
         ? null
         : (json['listOfRequiredBoolean'] as List<Object?>)
             .cast<bool?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredBoolean',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredBoolean',
+                  )),
+            )
             .toList();
     final requiredListOfBoolean = json['requiredListOfBoolean'] == null
         ? (throw ModelFieldError(
@@ -1833,12 +1955,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredBoolean'] as List<Object?>)
                 .cast<bool?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredBoolean',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredBoolean',
+                      )),
+                )
                 .toList();
     final listOfAwsDate = json['listOfAWSDate'] == null
         ? null
@@ -1850,12 +1974,14 @@ abstract class ScalarListModel extends PartialScalarListModel
         ? null
         : (json['listOfRequiredAWSDate'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListModel',
-                    'listOfRequiredAwsDate',
-                  ))
-                : TemporalDate.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsDate',
+                    ))
+                  : TemporalDate.fromString(el),
+            )
             .toList();
     final requiredListOfAwsDate = json['requiredListOfAWSDate'] == null
         ? (throw ModelFieldError(
@@ -1874,12 +2000,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredAWSDate'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsDate',
-                      ))
-                    : TemporalDate.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsDate',
+                        ))
+                      : TemporalDate.fromString(el),
+                )
                 .toList();
     final listOfAwsDateTime = json['listOfAWSDateTime'] == null
         ? null
@@ -1891,12 +2019,14 @@ abstract class ScalarListModel extends PartialScalarListModel
         ? null
         : (json['listOfRequiredAWSDateTime'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListModel',
-                    'listOfRequiredAwsDateTime',
-                  ))
-                : TemporalDateTime.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsDateTime',
+                    ))
+                  : TemporalDateTime.fromString(el),
+            )
             .toList();
     final requiredListOfAwsDateTime = json['requiredListOfAWSDateTime'] == null
         ? (throw ModelFieldError(
@@ -1915,12 +2045,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredAWSDateTime'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsDateTime',
-                      ))
-                    : TemporalDateTime.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsDateTime',
+                        ))
+                      : TemporalDateTime.fromString(el),
+                )
                 .toList();
     final listOfAwsTime = json['listOfAWSTime'] == null
         ? null
@@ -1932,12 +2064,14 @@ abstract class ScalarListModel extends PartialScalarListModel
         ? null
         : (json['listOfRequiredAWSTime'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListModel',
-                    'listOfRequiredAwsTime',
-                  ))
-                : TemporalTime.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsTime',
+                    ))
+                  : TemporalTime.fromString(el),
+            )
             .toList();
     final requiredListOfAwsTime = json['requiredListOfAWSTime'] == null
         ? (throw ModelFieldError(
@@ -1956,12 +2090,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredAWSTime'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsTime',
-                      ))
-                    : TemporalTime.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsTime',
+                        ))
+                      : TemporalTime.fromString(el),
+                )
                 .toList();
     final listOfAwsTimestamp = json['listOfAWSTimestamp'] == null
         ? null
@@ -1974,12 +2110,14 @@ abstract class ScalarListModel extends PartialScalarListModel
             ? null
             : (json['listOfRequiredAWSTimestamp'] as List<Object?>)
                 .cast<int?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'listOfRequiredAwsTimestamp',
-                      ))
-                    : TemporalTimestamp.fromSeconds(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'listOfRequiredAwsTimestamp',
+                        ))
+                      : TemporalTimestamp.fromSeconds(el),
+                )
                 .toList();
     final requiredListOfAwsTimestamp = json['requiredListOfAWSTimestamp'] ==
             null
@@ -1999,12 +2137,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredAWSTimestamp'] as List<Object?>)
                 .cast<int?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsTimestamp',
-                      ))
-                    : TemporalTimestamp.fromSeconds(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsTimestamp',
+                        ))
+                      : TemporalTimestamp.fromSeconds(el),
+                )
                 .toList();
     final listOfAwsEmail = json['listOfAWSEmail'] == null
         ? null
@@ -2013,12 +2153,14 @@ abstract class ScalarListModel extends PartialScalarListModel
         ? null
         : (json['listOfRequiredAWSEmail'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredAwsEmail',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsEmail',
+                  )),
+            )
             .toList();
     final requiredListOfAwsEmail = json['requiredListOfAWSEmail'] == null
         ? (throw ModelFieldError(
@@ -2036,12 +2178,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredAWSEmail'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredAwsEmail',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsEmail',
+                      )),
+                )
                 .toList();
     final listOfAwsjson = json['listOfAWSJSON'] == null
         ? null
@@ -2050,12 +2194,14 @@ abstract class ScalarListModel extends PartialScalarListModel
         ? null
         : (json['listOfRequiredAWSJSON'] as List<Object?>)
             .cast<Object?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredAwsjson',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsjson',
+                  )),
+            )
             .toList();
     final requiredListOfAwsjson = json['requiredListOfAWSJSON'] == null
         ? (throw ModelFieldError(
@@ -2073,12 +2219,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredAWSJSON'] as List<Object?>)
                 .cast<Object?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredAwsjson',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsjson',
+                      )),
+                )
                 .toList();
     final listOfAwsPhone = json['listOfAWSPhone'] == null
         ? null
@@ -2087,12 +2235,14 @@ abstract class ScalarListModel extends PartialScalarListModel
         ? null
         : (json['listOfRequiredAWSPhone'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredAwsPhone',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsPhone',
+                  )),
+            )
             .toList();
     final requiredListOfAwsPhone = json['requiredListOfAWSPhone'] == null
         ? (throw ModelFieldError(
@@ -2110,12 +2260,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredAWSPhone'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredAwsPhone',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsPhone',
+                      )),
+                )
                 .toList();
     final listOfAwsUrl = json['listOfAWSUrl'] == null
         ? null
@@ -2127,12 +2279,14 @@ abstract class ScalarListModel extends PartialScalarListModel
         ? null
         : (json['listOfRequiredAWSUrl'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListModel',
-                    'listOfRequiredAwsUrl',
-                  ))
-                : Uri.parse(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsUrl',
+                    ))
+                  : Uri.parse(el),
+            )
             .toList();
     final requiredListOfAwsUrl = json['requiredListOfAWSUrl'] == null
         ? (throw ModelFieldError(
@@ -2151,12 +2305,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredAWSUrl'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsUrl',
-                      ))
-                    : Uri.parse(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsUrl',
+                        ))
+                      : Uri.parse(el),
+                )
                 .toList();
     final listOfAwsIpAddress = json['listOfAWSIpAddress'] == null
         ? null
@@ -2168,12 +2324,14 @@ abstract class ScalarListModel extends PartialScalarListModel
             ? null
             : (json['listOfRequiredAWSIpAddress'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'listOfRequiredAwsIpAddress',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'listOfRequiredAwsIpAddress',
+                      )),
+                )
                 .toList();
     final requiredListOfAwsIpAddress =
         json['requiredListOfAWSIpAddress'] == null
@@ -2192,12 +2350,14 @@ abstract class ScalarListModel extends PartialScalarListModel
               ))
             : (json['requiredListOfRequiredAWSIpAddress'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredAwsIpAddress',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsIpAddress',
+                      )),
+                )
                 .toList();
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(
@@ -3255,12 +3415,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
         ? null
         : (json['listOfRequiredString'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredString',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredString',
+                  )),
+            )
             .toList();
     final requiredListOfString = json['requiredListOfString'] == null
         ? (throw ModelFieldError(
@@ -3278,12 +3440,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredString'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredString',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredString',
+                      )),
+                )
                 .toList();
     final listOfInteger = json['listOfInteger'] == null
         ? null
@@ -3292,12 +3456,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
         ? null
         : (json['listOfRequiredInteger'] as List<Object?>)
             .cast<int?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredInteger',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredInteger',
+                  )),
+            )
             .toList();
     final requiredListOfInteger = json['requiredListOfInteger'] == null
         ? (throw ModelFieldError(
@@ -3315,12 +3481,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredInteger'] as List<Object?>)
                 .cast<int?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredInteger',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredInteger',
+                      )),
+                )
                 .toList();
     final listOfFloat = json['listOfFloat'] == null
         ? null
@@ -3329,12 +3497,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
         ? null
         : (json['listOfRequiredFloat'] as List<Object?>)
             .cast<double?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredFloat',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredFloat',
+                  )),
+            )
             .toList();
     final requiredListOfFloat = json['requiredListOfFloat'] == null
         ? (throw ModelFieldError(
@@ -3352,12 +3522,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredFloat'] as List<Object?>)
                 .cast<double?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredFloat',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredFloat',
+                      )),
+                )
                 .toList();
     final listOfBoolean = json['listOfBoolean'] == null
         ? null
@@ -3366,12 +3538,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
         ? null
         : (json['listOfRequiredBoolean'] as List<Object?>)
             .cast<bool?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredBoolean',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredBoolean',
+                  )),
+            )
             .toList();
     final requiredListOfBoolean = json['requiredListOfBoolean'] == null
         ? (throw ModelFieldError(
@@ -3389,12 +3563,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredBoolean'] as List<Object?>)
                 .cast<bool?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredBoolean',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredBoolean',
+                      )),
+                )
                 .toList();
     final listOfAwsDate = json['listOfAWSDate'] == null
         ? null
@@ -3406,12 +3582,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
         ? null
         : (json['listOfRequiredAWSDate'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListModel',
-                    'listOfRequiredAwsDate',
-                  ))
-                : TemporalDate.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsDate',
+                    ))
+                  : TemporalDate.fromString(el),
+            )
             .toList();
     final requiredListOfAwsDate = json['requiredListOfAWSDate'] == null
         ? (throw ModelFieldError(
@@ -3430,12 +3608,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredAWSDate'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsDate',
-                      ))
-                    : TemporalDate.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsDate',
+                        ))
+                      : TemporalDate.fromString(el),
+                )
                 .toList();
     final listOfAwsDateTime = json['listOfAWSDateTime'] == null
         ? null
@@ -3447,12 +3627,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
         ? null
         : (json['listOfRequiredAWSDateTime'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListModel',
-                    'listOfRequiredAwsDateTime',
-                  ))
-                : TemporalDateTime.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsDateTime',
+                    ))
+                  : TemporalDateTime.fromString(el),
+            )
             .toList();
     final requiredListOfAwsDateTime = json['requiredListOfAWSDateTime'] == null
         ? (throw ModelFieldError(
@@ -3471,12 +3653,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredAWSDateTime'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsDateTime',
-                      ))
-                    : TemporalDateTime.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsDateTime',
+                        ))
+                      : TemporalDateTime.fromString(el),
+                )
                 .toList();
     final listOfAwsTime = json['listOfAWSTime'] == null
         ? null
@@ -3488,12 +3672,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
         ? null
         : (json['listOfRequiredAWSTime'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListModel',
-                    'listOfRequiredAwsTime',
-                  ))
-                : TemporalTime.fromString(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsTime',
+                    ))
+                  : TemporalTime.fromString(el),
+            )
             .toList();
     final requiredListOfAwsTime = json['requiredListOfAWSTime'] == null
         ? (throw ModelFieldError(
@@ -3512,12 +3698,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredAWSTime'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsTime',
-                      ))
-                    : TemporalTime.fromString(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsTime',
+                        ))
+                      : TemporalTime.fromString(el),
+                )
                 .toList();
     final listOfAwsTimestamp = json['listOfAWSTimestamp'] == null
         ? null
@@ -3530,12 +3718,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
             ? null
             : (json['listOfRequiredAWSTimestamp'] as List<Object?>)
                 .cast<int?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'listOfRequiredAwsTimestamp',
-                      ))
-                    : TemporalTimestamp.fromSeconds(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'listOfRequiredAwsTimestamp',
+                        ))
+                      : TemporalTimestamp.fromSeconds(el),
+                )
                 .toList();
     final requiredListOfAwsTimestamp = json['requiredListOfAWSTimestamp'] ==
             null
@@ -3555,12 +3745,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredAWSTimestamp'] as List<Object?>)
                 .cast<int?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsTimestamp',
-                      ))
-                    : TemporalTimestamp.fromSeconds(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsTimestamp',
+                        ))
+                      : TemporalTimestamp.fromSeconds(el),
+                )
                 .toList();
     final listOfAwsEmail = json['listOfAWSEmail'] == null
         ? null
@@ -3569,12 +3761,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
         ? null
         : (json['listOfRequiredAWSEmail'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredAwsEmail',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsEmail',
+                  )),
+            )
             .toList();
     final requiredListOfAwsEmail = json['requiredListOfAWSEmail'] == null
         ? (throw ModelFieldError(
@@ -3592,12 +3786,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredAWSEmail'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredAwsEmail',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsEmail',
+                      )),
+                )
                 .toList();
     final listOfAwsjson = json['listOfAWSJSON'] == null
         ? null
@@ -3606,12 +3802,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
         ? null
         : (json['listOfRequiredAWSJSON'] as List<Object?>)
             .cast<Object?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredAwsjson',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsjson',
+                  )),
+            )
             .toList();
     final requiredListOfAwsjson = json['requiredListOfAWSJSON'] == null
         ? (throw ModelFieldError(
@@ -3629,12 +3827,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredAWSJSON'] as List<Object?>)
                 .cast<Object?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredAwsjson',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsjson',
+                      )),
+                )
                 .toList();
     final listOfAwsPhone = json['listOfAWSPhone'] == null
         ? null
@@ -3643,12 +3843,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
         ? null
         : (json['listOfRequiredAWSPhone'] as List<Object?>)
             .cast<String?>()
-            .map((el) =>
-                el ??
-                (throw ModelFieldError(
-                  'ScalarListModel',
-                  'listOfRequiredAwsPhone',
-                )))
+            .map(
+              (el) =>
+                  el ??
+                  (throw ModelFieldError(
+                    'ScalarListModel',
+                    'listOfRequiredAwsPhone',
+                  )),
+            )
             .toList();
     final requiredListOfAwsPhone = json['requiredListOfAWSPhone'] == null
         ? (throw ModelFieldError(
@@ -3666,12 +3868,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredAWSPhone'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredAwsPhone',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsPhone',
+                      )),
+                )
                 .toList();
     final listOfAwsUrl = json['listOfAWSUrl'] == null
         ? null
@@ -3683,12 +3887,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
         ? null
         : (json['listOfRequiredAWSUrl'] as List<Object?>)
             .cast<String?>()
-            .map((el) => el == null
-                ? (throw ModelFieldError(
-                    'ScalarListModel',
-                    'listOfRequiredAwsUrl',
-                  ))
-                : Uri.parse(el))
+            .map(
+              (el) => el == null
+                  ? (throw ModelFieldError(
+                      'ScalarListModel',
+                      'listOfRequiredAwsUrl',
+                    ))
+                  : Uri.parse(el),
+            )
             .toList();
     final requiredListOfAwsUrl = json['requiredListOfAWSUrl'] == null
         ? (throw ModelFieldError(
@@ -3707,12 +3913,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredAWSUrl'] as List<Object?>)
                 .cast<String?>()
-                .map((el) => el == null
-                    ? (throw ModelFieldError(
-                        'ScalarListModel',
-                        'requiredListOfRequiredAwsUrl',
-                      ))
-                    : Uri.parse(el))
+                .map(
+                  (el) => el == null
+                      ? (throw ModelFieldError(
+                          'ScalarListModel',
+                          'requiredListOfRequiredAwsUrl',
+                        ))
+                      : Uri.parse(el),
+                )
                 .toList();
     final listOfAwsIpAddress = json['listOfAWSIpAddress'] == null
         ? null
@@ -3724,12 +3932,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
             ? null
             : (json['listOfRequiredAWSIpAddress'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'listOfRequiredAwsIpAddress',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'listOfRequiredAwsIpAddress',
+                      )),
+                )
                 .toList();
     final requiredListOfAwsIpAddress =
         json['requiredListOfAWSIpAddress'] == null
@@ -3748,12 +3958,14 @@ class _RemoteScalarListModel extends RemoteScalarListModel {
               ))
             : (json['requiredListOfRequiredAWSIpAddress'] as List<Object?>)
                 .cast<String?>()
-                .map((el) =>
-                    el ??
-                    (throw ModelFieldError(
-                      'ScalarListModel',
-                      'requiredListOfRequiredAwsIpAddress',
-                    )))
+                .map(
+                  (el) =>
+                      el ??
+                      (throw ModelFieldError(
+                        'ScalarListModel',
+                        'requiredListOfRequiredAwsIpAddress',
+                      )),
+                )
                 .toList();
     final createdAt = json['createdAt'] == null
         ? (throw ModelFieldError(

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_list_model.dart
@@ -777,182 +777,6 @@ abstract class PartialScalarListModel
       };
   @override
   String get runtimeTypeName => 'ScalarListModel';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, ScalarListModel, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'id':
-        value = id;
-        break;
-      case r'listOfString':
-        value = listOfString;
-        break;
-      case r'listOfRequiredString':
-        value = listOfRequiredString;
-        break;
-      case r'requiredListOfString':
-        value = requiredListOfString;
-        break;
-      case r'requiredListOfRequiredString':
-        value = requiredListOfRequiredString;
-        break;
-      case r'listOfInteger':
-        value = listOfInteger;
-        break;
-      case r'listOfRequiredInteger':
-        value = listOfRequiredInteger;
-        break;
-      case r'requiredListOfInteger':
-        value = requiredListOfInteger;
-        break;
-      case r'requiredListOfRequiredInteger':
-        value = requiredListOfRequiredInteger;
-        break;
-      case r'listOfFloat':
-        value = listOfFloat;
-        break;
-      case r'listOfRequiredFloat':
-        value = listOfRequiredFloat;
-        break;
-      case r'requiredListOfFloat':
-        value = requiredListOfFloat;
-        break;
-      case r'requiredListOfRequiredFloat':
-        value = requiredListOfRequiredFloat;
-        break;
-      case r'listOfBoolean':
-        value = listOfBoolean;
-        break;
-      case r'listOfRequiredBoolean':
-        value = listOfRequiredBoolean;
-        break;
-      case r'requiredListOfBoolean':
-        value = requiredListOfBoolean;
-        break;
-      case r'requiredListOfRequiredBoolean':
-        value = requiredListOfRequiredBoolean;
-        break;
-      case r'listOfAWSDate':
-        value = listOfAwsDate;
-        break;
-      case r'listOfRequiredAWSDate':
-        value = listOfRequiredAwsDate;
-        break;
-      case r'requiredListOfAWSDate':
-        value = requiredListOfAwsDate;
-        break;
-      case r'requiredListOfRequiredAWSDate':
-        value = requiredListOfRequiredAwsDate;
-        break;
-      case r'listOfAWSDateTime':
-        value = listOfAwsDateTime;
-        break;
-      case r'listOfRequiredAWSDateTime':
-        value = listOfRequiredAwsDateTime;
-        break;
-      case r'requiredListOfAWSDateTime':
-        value = requiredListOfAwsDateTime;
-        break;
-      case r'requiredListOfRequiredAWSDateTime':
-        value = requiredListOfRequiredAwsDateTime;
-        break;
-      case r'listOfAWSTime':
-        value = listOfAwsTime;
-        break;
-      case r'listOfRequiredAWSTime':
-        value = listOfRequiredAwsTime;
-        break;
-      case r'requiredListOfAWSTime':
-        value = requiredListOfAwsTime;
-        break;
-      case r'requiredListOfRequiredAWSTime':
-        value = requiredListOfRequiredAwsTime;
-        break;
-      case r'listOfAWSTimestamp':
-        value = listOfAwsTimestamp;
-        break;
-      case r'listOfRequiredAWSTimestamp':
-        value = listOfRequiredAwsTimestamp;
-        break;
-      case r'requiredListOfAWSTimestamp':
-        value = requiredListOfAwsTimestamp;
-        break;
-      case r'requiredListOfRequiredAWSTimestamp':
-        value = requiredListOfRequiredAwsTimestamp;
-        break;
-      case r'listOfAWSEmail':
-        value = listOfAwsEmail;
-        break;
-      case r'listOfRequiredAWSEmail':
-        value = listOfRequiredAwsEmail;
-        break;
-      case r'requiredListOfAWSEmail':
-        value = requiredListOfAwsEmail;
-        break;
-      case r'requiredListOfRequiredAWSEmail':
-        value = requiredListOfRequiredAwsEmail;
-        break;
-      case r'listOfAWSJSON':
-        value = listOfAwsjson;
-        break;
-      case r'listOfRequiredAWSJSON':
-        value = listOfRequiredAwsjson;
-        break;
-      case r'requiredListOfAWSJSON':
-        value = requiredListOfAwsjson;
-        break;
-      case r'requiredListOfRequiredAWSJSON':
-        value = requiredListOfRequiredAwsjson;
-        break;
-      case r'listOfAWSPhone':
-        value = listOfAwsPhone;
-        break;
-      case r'listOfRequiredAWSPhone':
-        value = listOfRequiredAwsPhone;
-        break;
-      case r'requiredListOfAWSPhone':
-        value = requiredListOfAwsPhone;
-        break;
-      case r'requiredListOfRequiredAWSPhone':
-        value = requiredListOfRequiredAwsPhone;
-        break;
-      case r'listOfAWSUrl':
-        value = listOfAwsUrl;
-        break;
-      case r'listOfRequiredAWSUrl':
-        value = listOfRequiredAwsUrl;
-        break;
-      case r'requiredListOfAWSUrl':
-        value = requiredListOfAwsUrl;
-        break;
-      case r'requiredListOfRequiredAWSUrl':
-        value = requiredListOfRequiredAwsUrl;
-        break;
-      case r'listOfAWSIpAddress':
-        value = listOfAwsIpAddress;
-        break;
-      case r'listOfRequiredAWSIpAddress':
-        value = listOfRequiredAwsIpAddress;
-        break;
-      case r'requiredListOfAWSIpAddress':
-        value = requiredListOfAwsIpAddress;
-        break;
-      case r'requiredListOfRequiredAWSIpAddress':
-        value = requiredListOfRequiredAwsIpAddress;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialScalarListModel extends PartialScalarListModel {
@@ -3048,6 +2872,182 @@ abstract class ScalarListModel extends PartialScalarListModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, ScalarListModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, ScalarListModel, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'listOfString':
+        value = listOfString;
+        break;
+      case r'listOfRequiredString':
+        value = listOfRequiredString;
+        break;
+      case r'requiredListOfString':
+        value = requiredListOfString;
+        break;
+      case r'requiredListOfRequiredString':
+        value = requiredListOfRequiredString;
+        break;
+      case r'listOfInteger':
+        value = listOfInteger;
+        break;
+      case r'listOfRequiredInteger':
+        value = listOfRequiredInteger;
+        break;
+      case r'requiredListOfInteger':
+        value = requiredListOfInteger;
+        break;
+      case r'requiredListOfRequiredInteger':
+        value = requiredListOfRequiredInteger;
+        break;
+      case r'listOfFloat':
+        value = listOfFloat;
+        break;
+      case r'listOfRequiredFloat':
+        value = listOfRequiredFloat;
+        break;
+      case r'requiredListOfFloat':
+        value = requiredListOfFloat;
+        break;
+      case r'requiredListOfRequiredFloat':
+        value = requiredListOfRequiredFloat;
+        break;
+      case r'listOfBoolean':
+        value = listOfBoolean;
+        break;
+      case r'listOfRequiredBoolean':
+        value = listOfRequiredBoolean;
+        break;
+      case r'requiredListOfBoolean':
+        value = requiredListOfBoolean;
+        break;
+      case r'requiredListOfRequiredBoolean':
+        value = requiredListOfRequiredBoolean;
+        break;
+      case r'listOfAWSDate':
+        value = listOfAwsDate;
+        break;
+      case r'listOfRequiredAWSDate':
+        value = listOfRequiredAwsDate;
+        break;
+      case r'requiredListOfAWSDate':
+        value = requiredListOfAwsDate;
+        break;
+      case r'requiredListOfRequiredAWSDate':
+        value = requiredListOfRequiredAwsDate;
+        break;
+      case r'listOfAWSDateTime':
+        value = listOfAwsDateTime;
+        break;
+      case r'listOfRequiredAWSDateTime':
+        value = listOfRequiredAwsDateTime;
+        break;
+      case r'requiredListOfAWSDateTime':
+        value = requiredListOfAwsDateTime;
+        break;
+      case r'requiredListOfRequiredAWSDateTime':
+        value = requiredListOfRequiredAwsDateTime;
+        break;
+      case r'listOfAWSTime':
+        value = listOfAwsTime;
+        break;
+      case r'listOfRequiredAWSTime':
+        value = listOfRequiredAwsTime;
+        break;
+      case r'requiredListOfAWSTime':
+        value = requiredListOfAwsTime;
+        break;
+      case r'requiredListOfRequiredAWSTime':
+        value = requiredListOfRequiredAwsTime;
+        break;
+      case r'listOfAWSTimestamp':
+        value = listOfAwsTimestamp;
+        break;
+      case r'listOfRequiredAWSTimestamp':
+        value = listOfRequiredAwsTimestamp;
+        break;
+      case r'requiredListOfAWSTimestamp':
+        value = requiredListOfAwsTimestamp;
+        break;
+      case r'requiredListOfRequiredAWSTimestamp':
+        value = requiredListOfRequiredAwsTimestamp;
+        break;
+      case r'listOfAWSEmail':
+        value = listOfAwsEmail;
+        break;
+      case r'listOfRequiredAWSEmail':
+        value = listOfRequiredAwsEmail;
+        break;
+      case r'requiredListOfAWSEmail':
+        value = requiredListOfAwsEmail;
+        break;
+      case r'requiredListOfRequiredAWSEmail':
+        value = requiredListOfRequiredAwsEmail;
+        break;
+      case r'listOfAWSJSON':
+        value = listOfAwsjson;
+        break;
+      case r'listOfRequiredAWSJSON':
+        value = listOfRequiredAwsjson;
+        break;
+      case r'requiredListOfAWSJSON':
+        value = requiredListOfAwsjson;
+        break;
+      case r'requiredListOfRequiredAWSJSON':
+        value = requiredListOfRequiredAwsjson;
+        break;
+      case r'listOfAWSPhone':
+        value = listOfAwsPhone;
+        break;
+      case r'listOfRequiredAWSPhone':
+        value = listOfRequiredAwsPhone;
+        break;
+      case r'requiredListOfAWSPhone':
+        value = requiredListOfAwsPhone;
+        break;
+      case r'requiredListOfRequiredAWSPhone':
+        value = requiredListOfRequiredAwsPhone;
+        break;
+      case r'listOfAWSUrl':
+        value = listOfAwsUrl;
+        break;
+      case r'listOfRequiredAWSUrl':
+        value = listOfRequiredAwsUrl;
+        break;
+      case r'requiredListOfAWSUrl':
+        value = requiredListOfAwsUrl;
+        break;
+      case r'requiredListOfRequiredAWSUrl':
+        value = requiredListOfRequiredAwsUrl;
+        break;
+      case r'listOfAWSIpAddress':
+        value = listOfAwsIpAddress;
+        break;
+      case r'listOfRequiredAWSIpAddress':
+        value = listOfRequiredAwsIpAddress;
+        break;
+      case r'requiredListOfAWSIpAddress':
+        value = requiredListOfAwsIpAddress;
+        break;
+      case r'requiredListOfRequiredAWSIpAddress':
+        value = requiredListOfRequiredAwsIpAddress;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _ScalarListModel extends ScalarListModel {

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
@@ -16,11 +16,12 @@
 // Generated files can be excluded from analysis in analysis_options.yaml
 // For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names,inference_failure_on_collection_literal
 
 library models.scalar_model;
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/models/mipr.dart' as mipr;
 
 class ScalarModelType
     extends ModelType<String, ScalarModel, PartialScalarModel> {
@@ -833,6 +834,199 @@ abstract class ScalarModel extends PartialScalarModel
 
   static const ScalarModelQueryFields<String, ScalarModel> _queryFields =
       ScalarModelQueryFields();
+
+  static final mipr.ModelTypeDefinition schema =
+      mipr.serializers.deserializeWith(
+    mipr.ModelTypeDefinition.serializer,
+    const {
+      'name': 'ScalarModel',
+      'pluralName': 'ScalarModels',
+      'fields': {
+        'id': {
+          'name': 'id',
+          'type': {'scalar': 'ID'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'str': {
+          'name': 'str',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredStr': {
+          'name': 'requiredStr',
+          'type': {'scalar': 'String'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'integer': {
+          'name': 'integer',
+          'type': {'scalar': 'Int'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredInteger': {
+          'name': 'requiredInteger',
+          'type': {'scalar': 'Int'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'float': {
+          'name': 'float',
+          'type': {'scalar': 'Float'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredFloat': {
+          'name': 'requiredFloat',
+          'type': {'scalar': 'Float'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'boolean': {
+          'name': 'boolean',
+          'type': {'scalar': 'Boolean'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredBoolean': {
+          'name': 'requiredBoolean',
+          'type': {'scalar': 'Boolean'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsDate': {
+          'name': 'awsDate',
+          'type': {'scalar': 'AWSDate'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsDate': {
+          'name': 'requiredAwsDate',
+          'type': {'scalar': 'AWSDate'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsDateTime': {
+          'name': 'awsDateTime',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsDateTime': {
+          'name': 'requiredAwsDateTime',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsTime': {
+          'name': 'awsTime',
+          'type': {'scalar': 'AWSTime'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsTime': {
+          'name': 'requiredAwsTime',
+          'type': {'scalar': 'AWSTime'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsTimestamp': {
+          'name': 'awsTimestamp',
+          'type': {'scalar': 'AWSTimestamp'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsTimestamp': {
+          'name': 'requiredAwsTimestamp',
+          'type': {'scalar': 'AWSTimestamp'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsEmail': {
+          'name': 'awsEmail',
+          'type': {'scalar': 'AWSEmail'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsEmail': {
+          'name': 'requiredAwsEmail',
+          'type': {'scalar': 'AWSEmail'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsJson': {
+          'name': 'awsJson',
+          'type': {'scalar': 'AWSJSON'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsJson': {
+          'name': 'requiredAwsJson',
+          'type': {'scalar': 'AWSJSON'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsPhone': {
+          'name': 'awsPhone',
+          'type': {'scalar': 'AWSPhone'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsPhone': {
+          'name': 'requiredAwsPhone',
+          'type': {'scalar': 'AWSPhone'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsUrl': {
+          'name': 'awsUrl',
+          'type': {'scalar': 'AWSURL'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsUrl': {
+          'name': 'requiredAwsUrl',
+          'type': {'scalar': 'AWSURL'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'awsIpAddress': {
+          'name': 'awsIpAddress',
+          'type': {'scalar': 'AWSIPAddress'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'requiredAwsIpAddress': {
+          'name': 'requiredAwsIpAddress',
+          'type': {'scalar': 'AWSIPAddress'},
+          'isReadOnly': false,
+          'authRules': [],
+        },
+        'createdAt': {
+          'name': 'createdAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+        'updatedAt': {
+          'name': 'updatedAt',
+          'type': {'scalar': 'AWSDateTime'},
+          'isReadOnly': true,
+          'authRules': [],
+        },
+      },
+      'authRules': [],
+      'indexes': [
+        {
+          'type': 'primary',
+          'primaryField': 'id',
+          'sortKeyFields': [],
+        }
+      ],
+    },
+  )!;
 
   @override
   String get id;

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
@@ -410,104 +410,6 @@ abstract class PartialScalarModel extends PartialModel<String, ScalarModel>
       };
   @override
   String get runtimeTypeName => 'ScalarModel';
-  @override
-  T valueFor<T extends Object?>(QueryField<String, ScalarModel, T> field) {
-    Object? value;
-    switch (field.fieldName) {
-      case r'id':
-        value = id;
-        break;
-      case r'str':
-        value = str;
-        break;
-      case r'requiredStr':
-        value = requiredStr;
-        break;
-      case r'integer':
-        value = integer;
-        break;
-      case r'requiredInteger':
-        value = requiredInteger;
-        break;
-      case r'float':
-        value = float;
-        break;
-      case r'requiredFloat':
-        value = requiredFloat;
-        break;
-      case r'boolean':
-        value = boolean;
-        break;
-      case r'requiredBoolean':
-        value = requiredBoolean;
-        break;
-      case r'awsDate':
-        value = awsDate;
-        break;
-      case r'requiredAwsDate':
-        value = requiredAwsDate;
-        break;
-      case r'awsDateTime':
-        value = awsDateTime;
-        break;
-      case r'requiredAwsDateTime':
-        value = requiredAwsDateTime;
-        break;
-      case r'awsTime':
-        value = awsTime;
-        break;
-      case r'requiredAwsTime':
-        value = requiredAwsTime;
-        break;
-      case r'awsTimestamp':
-        value = awsTimestamp;
-        break;
-      case r'requiredAwsTimestamp':
-        value = requiredAwsTimestamp;
-        break;
-      case r'awsEmail':
-        value = awsEmail;
-        break;
-      case r'requiredAwsEmail':
-        value = requiredAwsEmail;
-        break;
-      case r'awsJson':
-        value = awsJson;
-        break;
-      case r'requiredAwsJson':
-        value = requiredAwsJson;
-        break;
-      case r'awsPhone':
-        value = awsPhone;
-        break;
-      case r'requiredAwsPhone':
-        value = requiredAwsPhone;
-        break;
-      case r'awsUrl':
-        value = awsUrl;
-        break;
-      case r'requiredAwsUrl':
-        value = requiredAwsUrl;
-        break;
-      case r'awsIpAddress':
-        value = awsIpAddress;
-        break;
-      case r'requiredAwsIpAddress':
-        value = requiredAwsIpAddress;
-        break;
-      case r'createdAt':
-        value = createdAt;
-        break;
-      case r'updatedAt':
-        value = updatedAt;
-        break;
-    }
-    assert(
-      value is T,
-      'Invalid field ${field.fieldName}: $value (expected $T)',
-    );
-    return value as T;
-  }
 }
 
 class _PartialScalarModel extends PartialScalarModel {
@@ -1220,6 +1122,104 @@ abstract class ScalarModel extends PartialScalarModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, ScalarModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  @override
+  T valueFor<T extends Object?>(QueryField<String, ScalarModel, T> field) {
+    Object? value;
+    switch (field.fieldName) {
+      case r'id':
+        value = id;
+        break;
+      case r'str':
+        value = str;
+        break;
+      case r'requiredStr':
+        value = requiredStr;
+        break;
+      case r'integer':
+        value = integer;
+        break;
+      case r'requiredInteger':
+        value = requiredInteger;
+        break;
+      case r'float':
+        value = float;
+        break;
+      case r'requiredFloat':
+        value = requiredFloat;
+        break;
+      case r'boolean':
+        value = boolean;
+        break;
+      case r'requiredBoolean':
+        value = requiredBoolean;
+        break;
+      case r'awsDate':
+        value = awsDate;
+        break;
+      case r'requiredAwsDate':
+        value = requiredAwsDate;
+        break;
+      case r'awsDateTime':
+        value = awsDateTime;
+        break;
+      case r'requiredAwsDateTime':
+        value = requiredAwsDateTime;
+        break;
+      case r'awsTime':
+        value = awsTime;
+        break;
+      case r'requiredAwsTime':
+        value = requiredAwsTime;
+        break;
+      case r'awsTimestamp':
+        value = awsTimestamp;
+        break;
+      case r'requiredAwsTimestamp':
+        value = requiredAwsTimestamp;
+        break;
+      case r'awsEmail':
+        value = awsEmail;
+        break;
+      case r'requiredAwsEmail':
+        value = requiredAwsEmail;
+        break;
+      case r'awsJson':
+        value = awsJson;
+        break;
+      case r'requiredAwsJson':
+        value = requiredAwsJson;
+        break;
+      case r'awsPhone':
+        value = awsPhone;
+        break;
+      case r'requiredAwsPhone':
+        value = requiredAwsPhone;
+        break;
+      case r'awsUrl':
+        value = awsUrl;
+        break;
+      case r'requiredAwsUrl':
+        value = requiredAwsUrl;
+        break;
+      case r'awsIpAddress':
+        value = awsIpAddress;
+        break;
+      case r'requiredAwsIpAddress':
+        value = requiredAwsIpAddress;
+        break;
+      case r'createdAt':
+        value = createdAt;
+        break;
+      case r'updatedAt':
+        value = updatedAt;
+        break;
+    }
+    assert(
+      value is T,
+      'Invalid field ${field.fieldName}: $value (expected $T)',
+    );
+    return value as T;
+  }
 }
 
 class _ScalarModel extends ScalarModel {

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
@@ -28,7 +28,8 @@ class ScalarModelType
 
   @override
   T fromJson<T extends PartialModel<String, ScalarModel>>(
-      Map<String, Object?> json) {
+    Map<String, Object?> json,
+  ) {
     if (T == ScalarModel || T == Model<String, ScalarModel>) {
       return ScalarModel.fromJson(json) as T;
     }
@@ -80,7 +81,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, int> get $requiredInteger =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, int>(
         const QueryField<String, ScalarModel, int>(
-            fieldName: 'requiredInteger'),
+          fieldName: 'requiredInteger',
+        ),
         root: _root,
       );
 
@@ -95,7 +97,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, double> get $requiredFloat =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, double>(
         const QueryField<String, ScalarModel, double>(
-            fieldName: 'requiredFloat'),
+          fieldName: 'requiredFloat',
+        ),
         root: _root,
       );
 
@@ -110,7 +113,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, bool> get $requiredBoolean =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, bool>(
         const QueryField<String, ScalarModel, bool>(
-            fieldName: 'requiredBoolean'),
+          fieldName: 'requiredBoolean',
+        ),
         root: _root,
       );
 
@@ -118,7 +122,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDate?> get $awsDate =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, TemporalDate?>(
         const QueryField<String, ScalarModel, TemporalDate?>(
-            fieldName: 'awsDate'),
+          fieldName: 'awsDate',
+        ),
         root: _root,
       );
 
@@ -126,7 +131,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalDate> get $requiredAwsDate =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, TemporalDate>(
         const QueryField<String, ScalarModel, TemporalDate>(
-            fieldName: 'requiredAwsDate'),
+          fieldName: 'requiredAwsDate',
+        ),
         root: _root,
       );
 
@@ -135,7 +141,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarModel,
           TemporalDateTime?>(
         const QueryField<String, ScalarModel, TemporalDateTime?>(
-            fieldName: 'awsDateTime'),
+          fieldName: 'awsDateTime',
+        ),
         root: _root,
       );
 
@@ -144,7 +151,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarModel,
           TemporalDateTime>(
         const QueryField<String, ScalarModel, TemporalDateTime>(
-            fieldName: 'requiredAwsDateTime'),
+          fieldName: 'requiredAwsDateTime',
+        ),
         root: _root,
       );
 
@@ -152,7 +160,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalTime?> get $awsTime =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, TemporalTime?>(
         const QueryField<String, ScalarModel, TemporalTime?>(
-            fieldName: 'awsTime'),
+          fieldName: 'awsTime',
+        ),
         root: _root,
       );
 
@@ -160,7 +169,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, TemporalTime> get $requiredAwsTime =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, TemporalTime>(
         const QueryField<String, ScalarModel, TemporalTime>(
-            fieldName: 'requiredAwsTime'),
+          fieldName: 'requiredAwsTime',
+        ),
         root: _root,
       );
 
@@ -169,7 +179,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarModel,
           TemporalTimestamp?>(
         const QueryField<String, ScalarModel, TemporalTimestamp?>(
-            fieldName: 'awsTimestamp'),
+          fieldName: 'awsTimestamp',
+        ),
         root: _root,
       );
 
@@ -178,7 +189,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarModel,
           TemporalTimestamp>(
         const QueryField<String, ScalarModel, TemporalTimestamp>(
-            fieldName: 'requiredAwsTimestamp'),
+          fieldName: 'requiredAwsTimestamp',
+        ),
         root: _root,
       );
 
@@ -193,7 +205,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $requiredAwsEmail =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, String>(
         const QueryField<String, ScalarModel, String>(
-            fieldName: 'requiredAwsEmail'),
+          fieldName: 'requiredAwsEmail',
+        ),
         root: _root,
       );
 
@@ -208,7 +221,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, Object> get $requiredAwsJson =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, Object>(
         const QueryField<String, ScalarModel, Object>(
-            fieldName: 'requiredAwsJson'),
+          fieldName: 'requiredAwsJson',
+        ),
         root: _root,
       );
 
@@ -223,7 +237,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $requiredAwsPhone =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, String>(
         const QueryField<String, ScalarModel, String>(
-            fieldName: 'requiredAwsPhone'),
+          fieldName: 'requiredAwsPhone',
+        ),
         root: _root,
       );
 
@@ -245,7 +260,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String?> get $awsIpAddress =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, String?>(
         const QueryField<String, ScalarModel, String?>(
-            fieldName: 'awsIpAddress'),
+          fieldName: 'awsIpAddress',
+        ),
         root: _root,
       );
 
@@ -253,7 +269,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $requiredAwsIpAddress =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, String>(
         const QueryField<String, ScalarModel, String>(
-            fieldName: 'requiredAwsIpAddress'),
+          fieldName: 'requiredAwsIpAddress',
+        ),
         root: _root,
       );
 
@@ -262,7 +279,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarModel,
           TemporalDateTime>(
         const QueryField<String, ScalarModel, TemporalDateTime>(
-            fieldName: 'createdAt'),
+          fieldName: 'createdAt',
+        ),
         root: _root,
       );
 
@@ -271,7 +289,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
       NestedQueryField<ModelIdentifier, M, String, ScalarModel,
           TemporalDateTime>(
         const QueryField<String, ScalarModel, TemporalDateTime>(
-            fieldName: 'updatedAt'),
+          fieldName: 'updatedAt',
+        ),
         root: _root,
       );
 
@@ -279,7 +298,8 @@ class ScalarModelQueryFields<ModelIdentifier extends Object,
   QueryField<ModelIdentifier, M, String> get $modelIdentifier =>
       NestedQueryField<ModelIdentifier, M, String, ScalarModel, String>(
         const QueryField<String, ScalarModel, String>(
-            fieldName: 'modelIdentifier'),
+          fieldName: 'modelIdentifier',
+        ),
         root: _root,
       );
 }

--- a/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
+++ b/packages/datastore/amplify_codegen/test/goldens/simple_models/scalar_model.dart
@@ -1122,6 +1122,84 @@ abstract class ScalarModel extends PartialScalarModel
   @Deprecated(r'Use $modelIdentifier instead')
   QueryField<String, ScalarModel, String> get MODEL_IDENTIFIER =>
       $modelIdentifier;
+  ScalarModel copyWith({
+    String? id,
+    String? str,
+    String? requiredStr,
+    int? integer,
+    int? requiredInteger,
+    double? float,
+    double? requiredFloat,
+    bool? boolean,
+    bool? requiredBoolean,
+    DateTime? awsDate,
+    DateTime? requiredAwsDate,
+    DateTime? awsDateTime,
+    DateTime? requiredAwsDateTime,
+    DateTime? awsTime,
+    DateTime? requiredAwsTime,
+    DateTime? awsTimestamp,
+    DateTime? requiredAwsTimestamp,
+    String? awsEmail,
+    String? requiredAwsEmail,
+    Object? awsJson,
+    Object? requiredAwsJson,
+    String? awsPhone,
+    String? requiredAwsPhone,
+    Uri? awsUrl,
+    Uri? requiredAwsUrl,
+    String? awsIpAddress,
+    String? requiredAwsIpAddress,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return _ScalarModel._(
+      id: id ?? this.id,
+      str: str ?? this.str,
+      requiredStr: requiredStr ?? this.requiredStr,
+      integer: integer ?? this.integer,
+      requiredInteger: requiredInteger ?? this.requiredInteger,
+      float: float ?? this.float,
+      requiredFloat: requiredFloat ?? this.requiredFloat,
+      boolean: boolean ?? this.boolean,
+      requiredBoolean: requiredBoolean ?? this.requiredBoolean,
+      awsDate: awsDate == null ? this.awsDate : TemporalDate(awsDate),
+      requiredAwsDate: requiredAwsDate == null
+          ? this.requiredAwsDate
+          : TemporalDate(requiredAwsDate),
+      awsDateTime: awsDateTime == null
+          ? this.awsDateTime
+          : TemporalDateTime(awsDateTime),
+      requiredAwsDateTime: requiredAwsDateTime == null
+          ? this.requiredAwsDateTime
+          : TemporalDateTime(requiredAwsDateTime),
+      awsTime: awsTime == null ? this.awsTime : TemporalTime(awsTime),
+      requiredAwsTime: requiredAwsTime == null
+          ? this.requiredAwsTime
+          : TemporalTime(requiredAwsTime),
+      awsTimestamp: awsTimestamp == null
+          ? this.awsTimestamp
+          : TemporalTimestamp(awsTimestamp),
+      requiredAwsTimestamp: requiredAwsTimestamp == null
+          ? this.requiredAwsTimestamp
+          : TemporalTimestamp(requiredAwsTimestamp),
+      awsEmail: awsEmail ?? this.awsEmail,
+      requiredAwsEmail: requiredAwsEmail ?? this.requiredAwsEmail,
+      awsJson: awsJson ?? this.awsJson,
+      requiredAwsJson: requiredAwsJson ?? this.requiredAwsJson,
+      awsPhone: awsPhone ?? this.awsPhone,
+      requiredAwsPhone: requiredAwsPhone ?? this.requiredAwsPhone,
+      awsUrl: awsUrl ?? this.awsUrl,
+      requiredAwsUrl: requiredAwsUrl ?? this.requiredAwsUrl,
+      awsIpAddress: awsIpAddress ?? this.awsIpAddress,
+      requiredAwsIpAddress: requiredAwsIpAddress ?? this.requiredAwsIpAddress,
+      createdAt:
+          createdAt == null ? this.createdAt : TemporalDateTime(createdAt),
+      updatedAt:
+          updatedAt == null ? this.updatedAt : TemporalDateTime(updatedAt),
+    );
+  }
+
   @override
   T valueFor<T extends Object?>(QueryField<String, ScalarModel, T> field) {
     Object? value;

--- a/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/bidi_has_many_explicit.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/bidi_has_many_explicit.graphql
@@ -1,0 +1,13 @@
+# Explicit - Bi-directional Has Many
+type Post @model {
+  id: ID!
+  title: String!
+  comments: [Comment] @hasMany(indexName: "byPost", fields: ["id"])
+}
+
+type Comment @model {
+  id: ID!
+  postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+  content: String!
+  post: Post @belongsTo(fields: ["postID"])
+}

--- a/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/bidi_has_many_implicit.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/bidi_has_many_implicit.graphql
@@ -1,0 +1,17 @@
+# 7 - Blog Post Comment
+type Blog7V2 @model {
+  id: ID!
+  name: String!
+  posts: [Post7V2] @hasMany
+}
+type Post7V2 @model {
+  id: ID!
+  title: String!
+  blog: Blog7V2 @belongsTo
+  comments: [Comment7V2] @hasMany
+}
+type Comment7V2 @model {
+  id: ID!
+  content: String
+  post: Post7V2 @belongsTo
+}

--- a/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/bidi_has_one_explicit.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/bidi_has_one_explicit.graphql
@@ -1,0 +1,13 @@
+# Explicit
+type Project2 @model {
+  id: ID!
+  name: String
+  team: Team2 @hasOne
+}
+
+type Team2 @model {
+  id: ID!
+  name: String!
+  projectID: ID
+  project: Project2 @belongsTo(fields: ["projectID"])
+}

--- a/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/bidi_has_one_implicit.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/bidi_has_one_implicit.graphql
@@ -1,0 +1,12 @@
+# Implicit
+type Project @model {
+  id: ID!
+  name: String
+  team: Team @hasOne
+}
+
+type Team @model {
+  id: ID!
+  name: String!
+  project: Project @belongsTo
+}

--- a/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/indexes.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/indexes.graphql
@@ -1,0 +1,7 @@
+type ModelWithPrimaryKey @model {
+  productID: ID! @primaryKey
+  name: String!
+  content: String
+  albumID: ID! @index(name: "byAlbum", sortKeyFields: ["name"])
+  categoryID: ID! @index(name: "byCategory", sortKeyFields: ["name", "content"])
+}

--- a/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/secondary_index.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/secondary_index.graphql
@@ -1,0 +1,7 @@
+type Customer @model {
+  id: ID!
+  name: String!
+  phoneNumber: String
+  accountRepresentativeID: ID!
+    @index(name: "byRepresentative", queryField: "customerByRepresentative")
+}

--- a/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/timestamp_rename.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/timestamp_rename.graphql
@@ -1,0 +1,4 @@
+type Todo
+  @model(timestamps: { createdAt: "createdOn", updatedAt: "updatedOn" }) {
+  content: String
+}

--- a/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/uni_has_many_explicit.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/uni_has_many_explicit.graphql
@@ -1,0 +1,12 @@
+# Explicit
+type Post2 @model {
+  id: ID!
+  title: String!
+  comments: [Comment2] @hasMany(indexName: "byPost", fields: ["id"])
+}
+
+type Comment2 @model {
+  id: ID!
+  postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+  content: String!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/uni_has_many_implicit.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/uni_has_many_implicit.graphql
@@ -1,0 +1,11 @@
+# Implicit
+type Post @model {
+  id: ID!
+  title: String!
+  comments: [Comment] @hasMany
+}
+
+type Comment @model {
+  id: ID!
+  content: String!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/uni_has_one_explicit.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/uni_has_one_explicit.graphql
@@ -1,0 +1,12 @@
+# Explicit field
+type Project2 @model {
+  id: ID!
+  name: String
+  teamID: ID
+  team: Team2 @hasOne(fields: ["teamID"])
+}
+
+type Team2 @model {
+  id: ID!
+  name: String!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/uni_has_one_implicit.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/gql_v2_regressions/uni_has_one_implicit.graphql
@@ -1,0 +1,11 @@
+# Implicit field
+type Project @model {
+  id: ID!
+  name: String
+  team: Team @hasOne
+}
+
+type Team @model {
+  id: ID!
+  name: String!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/auth_rule_provider.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/auth_rule_provider.graphql
@@ -1,0 +1,12 @@
+type TodoWithAuth
+  @model
+  @auth(
+    rules: [
+      { allow: groups, groups: ["admin"] }
+      { allow: owner, operations: ["create", "update"] }
+      { allow: public, operations: ["read"], provider: "apiKey" }
+    ]
+  ) {
+  id: ID!
+  name: String!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/cpk.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/cpk.graphql
@@ -1,0 +1,10 @@
+type ModelWithExplicitlyDefinedPK @model {
+  modelID: ID! @primaryKey
+  title: String!
+}
+
+type ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKey @model {
+  modelID: ID! @primaryKey(sortKeyFields: ["title", "rating"])
+  title: String!
+  rating: Int!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/cpk_id_field.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/cpk_id_field.graphql
@@ -1,0 +1,5 @@
+type ModelWithIDPlusSortKeys @model {
+  id: ID! @primaryKey(sortKeyFields: ["title", "rating"])
+  title: String!
+  rating: Int!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/cpk_relationships.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/cpk_relationships.graphql
@@ -1,0 +1,26 @@
+type Project @model {
+  projectId: ID! @primaryKey(sortKeyFields: ["name"])
+  name: String!
+  team: Team @hasOne
+}
+
+type Team @model {
+  teamId: ID! @primaryKey(sortKeyFields: ["name"])
+  name: String!
+  project: Project @belongsTo
+}
+
+type CpkOneToOneBidirectionalParent @model {
+  id: ID! @primaryKey(sortKeyFields: ["name"])
+  name: String!
+  explicitChild: CpkOneToOneBidirectionalChildExplicit @hasOne
+}
+
+type CpkOneToOneBidirectionalChildExplicit @model {
+  id: ID! @primaryKey(sortKeyFields: ["name"])
+  name: String!
+  belongsToParentID: ID
+  belongsToParentName: String
+  belongsToParent: CpkOneToOneBidirectionalParent
+    @belongsTo(fields: ["belongsToParentID", "belongsToParentName"])
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/custom_groups_claims.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/custom_groups_claims.graphql
@@ -1,0 +1,9 @@
+type customClaim
+  @model
+  @auth(
+    rules: [{ allow: groups, groups: ["Moderator"], groupClaim: "user_groups" }]
+  ) {
+  id: ID!
+  name: String
+  bar: String
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/custom_identity_claim.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/custom_identity_claim.graphql
@@ -1,0 +1,7 @@
+type customClaim
+  @model
+  @auth(rules: [{ allow: owner, identityClaim: "user_id" }]) {
+  id: ID!
+  name: String
+  bar: String
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/custom_non_model_types.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/custom_non_model_types.graphql
@@ -1,0 +1,25 @@
+type Person @model {
+  name: String!
+  phone: Phone!
+  mailingAddresses: [Address]
+}
+
+type Contact {
+  contactName: String!
+  phone: Phone!
+  mailingAddresses: [Address]
+}
+
+type Phone {
+  countryCode: String!
+  areaCode: String!
+  number: String!
+}
+
+type Address {
+  line1: String!
+  line2: String
+  city: String!
+  state: String!
+  postalCode: String!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/dynamic_groups_auth.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/dynamic_groups_auth.graphql
@@ -1,0 +1,7 @@
+type dynamicGroups
+  @model
+  @auth(rules: [{ allow: groups, groupsField: "groups" }]) {
+  id: ID!
+  name: String
+  bar: String
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/enum_nullability.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/enum_nullability.graphql
@@ -1,0 +1,14 @@
+type TestEnumModel @model {
+  id: ID!
+  enumVal: TestEnum!
+  nullableEnumVal: TestEnum
+  enumList: [TestEnum!]!
+  enumNullableList: [TestEnum!]
+  nullableEnumList: [TestEnum]!
+  nullableEnumNullableList: [TestEnum]
+}
+
+enum TestEnum {
+  VALUE_ONE
+  VALUE_TWO
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/enum_type.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/enum_type.graphql
@@ -1,0 +1,10 @@
+type SimpleModel @model {
+  id: ID!
+  status: Status
+}
+
+enum Status {
+  yes
+  no
+  maybe
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/has_many_index.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/has_many_index.graphql
@@ -1,0 +1,21 @@
+enum PostStatus {
+  ACTIVE
+  INACTIVE
+}
+
+type Post @model {
+  id: ID!
+  title: String!
+  rating: Int!
+  status: PostStatus!
+  # New field with @hasMany
+  comments: [Comment] @hasMany(indexName: "byPost", fields: ["id"])
+}
+
+# New model
+type Comment @model {
+  id: ID!
+  postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+  post: Post! @belongsTo(fields: ["postID"])
+  content: String!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/has_many_uni.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/has_many_uni.graphql
@@ -1,0 +1,10 @@
+type Post @model {
+  id: ID! @primaryKey(sortKeyFields: ["title"])
+  title: String!
+  comments: [Comment] @hasMany
+}
+
+type Comment @model {
+  id: ID! @primaryKey(sortKeyFields: ["content"])
+  content: String!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/list_nullability.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/list_nullability.graphql
@@ -1,0 +1,9 @@
+type TestModel @model {
+  id: ID!
+  floatVal: Float!
+  floatNullableVal: Float
+  floatList: [Float!]!
+  floatNullableList: [Float!]
+  nullableFloatList: [Float]!
+  nullableFloatNullableList: [Float]
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/multiple_auth_rules.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/multiple_auth_rules.graphql
@@ -1,0 +1,13 @@
+type Post
+  @model
+  @auth(
+    rules: [
+      { allow: groups, groups: ["admin"] }
+      { allow: owner, operations: ["create", "update"] }
+      { allow: public, operation: ["read"] }
+    ]
+  ) {
+  id: ID!
+  title: String!
+  owner: String!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/optional_fields.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/optional_fields.graphql
@@ -1,0 +1,5 @@
+type SimpleModel @model {
+  id: ID!
+  name: String
+  bar: String
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/owner_auth.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/owner_auth.graphql
@@ -1,0 +1,5 @@
+type simpleOwnerAuth @model @auth(rules: [{ allow: owner }]) {
+  id: ID!
+  name: String
+  bar: String
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/owner_field_auth.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/owner_field_auth.graphql
@@ -1,0 +1,5 @@
+type Post @model @auth(rules: [{ allow: owner, ownerField: "author" }]) {
+  id: ID!
+  title: String!
+  author: String!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/owner_plus_read_auth.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/owner_plus_read_auth.graphql
@@ -1,0 +1,7 @@
+type allowRead
+  @model
+  @auth(rules: [{ allow: owner, operations: [create, delete, update] }]) {
+  id: ID!
+  name: String
+  bar: String
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/primary_keys.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/primary_keys.graphql
@@ -1,0 +1,13 @@
+type ModelWithImplicitID @model {
+  title: String!
+}
+
+type ModelWithExplicitID @model {
+  id: ID!
+  title: String!
+}
+
+type ModelWithExplicitIDAndSDI @model {
+  id: ID!
+  parentID: ID @index(name: "byParent")
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/private_auth.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/private_auth.graphql
@@ -1,0 +1,5 @@
+type privateType @model @auth(rules: [{ allow: private }]) {
+  id: ID!
+  name: String
+  bar: String
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/public_auth.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/public_auth.graphql
@@ -1,0 +1,5 @@
+type publicType @model @auth(rules: [{ allow: public }]) {
+  id: ID!
+  name: String
+  bar: String
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/reserved_words.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/reserved_words.graphql
@@ -1,0 +1,9 @@
+type ReservedWord @model {
+  id: ID!
+  class: String!
+}
+
+type class @model {
+  id: ID!
+  name: String!
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/simple_model.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/simple_model.graphql
@@ -1,0 +1,5 @@
+type SimpleModel @model {
+  id: ID!
+  name: String
+  bar: String
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/static_groups_auth.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/static_groups_auth.graphql
@@ -1,0 +1,5 @@
+type staticGroups @model @auth(rules: [{ allow: groups, groups: ["Admin"] }]) {
+  id: ID!
+  name: String
+  bar: String
+}

--- a/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/time_types.graphql
+++ b/packages/datastore/amplify_codegen/test/schemas/legacy_visitor/time_types.graphql
@@ -1,0 +1,13 @@
+type TemporalTimeModel @model {
+  id: ID!
+  date: AWSDate
+  time: AWSTime
+  dateTime: AWSDateTime
+  timestamp: AWSTimestamp
+  intNum: Int
+  dateList: [AWSDate]
+  timeList: [AWSTime]
+  dateTimeList: [AWSDateTime]
+  timestampList: [AWSTimestamp]
+  intList: [Int]
+}

--- a/packages/datastore/amplify_codegen/tool/update_goldens.dart
+++ b/packages/datastore/amplify_codegen/tool/update_goldens.dart
@@ -41,9 +41,13 @@ void main() {
     );
     final outputDir = Directory(outputPath)..createSync(recursive: true);
     for (final entry in generated.entries) {
-      final filename = '${entry.key.split('.').last}.dart';
-      stdout.writeln('  -- Generated $filename');
-      File.fromUri(outputDir.uri.resolve(filename))
+      // Undo library rename
+      final libraryName = entry.key.split('.').last;
+      final filename = libraryName.endsWith('_')
+          ? libraryName.substring(0, libraryName.length - 1)
+          : libraryName;
+      stdout.writeln('  -- Generated $filename.dart');
+      File.fromUri(outputDir.uri.resolve('$filename.dart'))
           .writeAsStringSync(entry.value.emit());
     }
   }

--- a/packages/datastore/amplify_codegen/tool/update_goldens.dart
+++ b/packages/datastore/amplify_codegen/tool/update_goldens.dart
@@ -47,7 +47,6 @@ void main() {
           .writeAsStringSync(entry.value.emit());
     }
   }
-  // TODO(dnys1): Re-enable when all APIs are implemented
-  // Process.runSync('dart', ['fix', '--apply', goldensDir.path]);
+  Process.runSync('dart', ['fix', '--apply', goldensDir.path]);
   Process.runSync('dart', ['format', '--fix', goldensDir.path]);
 }

--- a/packages/datastore/amplify_codegen/tool/update_goldens.dart
+++ b/packages/datastore/amplify_codegen/tool/update_goldens.dart
@@ -41,13 +41,9 @@ void main() {
     );
     final outputDir = Directory(outputPath)..createSync(recursive: true);
     for (final entry in generated.entries) {
-      // Undo library rename
-      final libraryName = entry.key.split('.').last;
-      final filename = libraryName.endsWith('_')
-          ? libraryName.substring(0, libraryName.length - 1)
-          : libraryName;
-      stdout.writeln('  -- Generated $filename.dart');
-      File.fromUri(outputDir.uri.resolve('$filename.dart'))
+      final filename = entry.key;
+      stdout.writeln('  -- Generated $filename');
+      File.fromUri(outputDir.uri.resolve(filename))
           .writeAsStringSync(entry.value.emit());
     }
   }


### PR DESCRIPTION
- Add goldens for legacy `amplify-codegen` schemas
- Add model providers
- Add `Model.schema` and `NonModel.schema`
- Add `copyWith`
- Refactor and reduce breaking changes