### PR TITLE
chore(auth): Add `validationData` to CognitoSignInOptions

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -584,6 +584,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
             ..password = request.password,
         ),
         clientMetadata: options.clientMetadata,
+        validationData: options.validationData,
       ),
     );
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_options.dart
@@ -24,7 +24,11 @@ part 'cognito_sign_in_options.g.dart';
 class CognitoSignInOptions extends SignInOptions
     with AWSEquatable<CognitoSignInOptions>, AWSDebuggable {
   /// {@macro amplify_auth_cognito.model.cognito_sign_in_options}
-  const CognitoSignInOptions({this.authFlowType, this.clientMetadata});
+  const CognitoSignInOptions({
+    this.authFlowType,
+    this.clientMetadata,
+    this.validationData,
+  });
 
   /// {@macro amplify_auth_cognito.model.cognito_sign_in_options}
   factory CognitoSignInOptions.fromJson(Map<String, Object?> json) =>
@@ -37,8 +41,13 @@ class CognitoSignInOptions extends SignInOptions
   /// custom workflows that this action triggers.
   final Map<String, String>? clientMetadata;
 
+  /// An optional map of arbitrary key-value pairs which will be passed to your
+  /// Lambda triggers as-is, used for implementing additional validations around
+  /// authentication.
+  final Map<String, String>? validationData;
+
   @override
-  List<Object?> get props => [authFlowType, clientMetadata];
+  List<Object?> get props => [authFlowType, clientMetadata, validationData];
 
   @override
   String get runtimeTypeName => 'CognitoSignInOptions';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_options.g.dart
@@ -14,6 +14,9 @@ CognitoSignInOptions _$CognitoSignInOptionsFromJson(
       clientMetadata: (json['clientMetadata'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
+      validationData: (json['validationData'] as Map<String, dynamic>?)?.map(
+        (k, e) => MapEntry(k, e as String),
+      ),
     );
 
 Map<String, dynamic> _$CognitoSignInOptionsToJson(
@@ -29,6 +32,7 @@ Map<String, dynamic> _$CognitoSignInOptionsToJson(
   writeNotNull(
       'authFlowType', _$AuthenticationFlowTypeEnumMap[instance.authFlowType]);
   writeNotNull('clientMetadata', instance.clientMetadata);
+  writeNotNull('validationData', instance.validationData);
   return val;
 }
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_sign_up_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_sign_up_options.dart
@@ -86,15 +86,12 @@ class CognitoSignUpOptions extends SignUpOptions
   Map<String, String> get userAttributes => super.userAttributes;
 
   /// An optional map of arbitrary key-value pairs which will be passed to your
-  /// PreAuthentication Lambda trigger as-is, used for implementing additional
-  /// validations around authentication.
-  ///
-  /// Currently supported on `Android` only.
+  /// Lambda triggers as-is, used for implementing additional validations around
+  /// authentication.
   final Map<String, String>? validationData;
 
   /// Additional custom attributes to be sent to the service such as information
   /// about the client.
-  ///
   final Map<String, String>? clientMetadata;
 
   /// Creates a copy of `this` with the given parameters overridden.

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/sign_in_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/sign_in_event.dart
@@ -52,6 +52,7 @@ abstract class SignInEvent
     AuthFlowType? authFlowType,
     required SignInParameters parameters,
     Map<String, String>? clientMetadata,
+    Map<String, String>? validationData,
   }) = SignInInitiate;
 
   /// {@macro amplify_auth_cognito.sign_in_respond_to_challenge}
@@ -86,7 +87,9 @@ class SignInInitiate extends SignInEvent {
     this.authFlowType,
     required this.parameters,
     Map<String, String>? clientMetadata,
+    Map<String, String>? validationData,
   })  : clientMetadata = clientMetadata ?? const {},
+        validationData = validationData ?? const {},
         super._();
 
   /// Runtime override of the Authentication flow.
@@ -98,11 +101,20 @@ class SignInInitiate extends SignInEvent {
   /// The optional client metadata.
   final Map<String, String> clientMetadata;
 
+  /// The optional validation data.
+  final Map<String, String> validationData;
+
   @override
   SignInEventType get type => SignInEventType.initiate;
 
   @override
-  List<Object?> get props => [type, authFlowType, clientMetadata, parameters];
+  List<Object?> get props => [
+        type,
+        authFlowType,
+        clientMetadata,
+        validationData,
+        parameters,
+      ];
 
   @override
   PreconditionException? checkPrecondition(SignInState currentState) {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -425,7 +425,10 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState> {
           CognitoConstants.challengeParamSrpA:
               _initResult!.publicA.toRadixString(16),
         })
-        ..clientMetadata.addAll(event.clientMetadata);
+        ..clientMetadata.addAll(event.clientMetadata)
+        // `validationData` is passed to clientMetadata for sign-in APIs
+        // https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-sign-up.html#cognito-user-pools-lambda-trigger-syntax-pre-signup-request
+        ..clientMetadata.addAll(event.validationData);
 
       if (config.appClientSecret != null) {
         b.authParameters[CognitoConstants.challengeParamSecretHash] =
@@ -457,7 +460,10 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState> {
           CognitoConstants.challengeParamUsername: parameters.username,
           CognitoConstants.challengeParamPassword: password,
         })
-        ..clientMetadata.addAll(event.clientMetadata);
+        ..clientMetadata.addAll(event.clientMetadata)
+        // `validationData` is passed to clientMetadata for sign-in APIs
+        // https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-sign-up.html#cognito-user-pools-lambda-trigger-syntax-pre-signup-request
+        ..clientMetadata.addAll(event.validationData);
 
       if (config.appClientSecret != null) {
         b.authParameters[CognitoConstants.challengeParamSecretHash] =
@@ -498,7 +504,10 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState> {
           CognitoConstants.challengeParamUsername: parameters.username,
         })
         ..clientId = config.appClientId
-        ..clientMetadata.addAll(event.clientMetadata);
+        ..clientMetadata.addAll(event.clientMetadata)
+        // `validationData` is passed to clientMetadata for sign-in APIs
+        // https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-sign-up.html#cognito-user-pools-lambda-trigger-syntax-pre-signup-request
+        ..clientMetadata.addAll(event.validationData);
 
       if (config.appClientSecret != null) {
         b.authParameters[CognitoConstants.challengeParamSecretHash] =


### PR DESCRIPTION
While this technically does not do anything which `clientMetadata` doesn't already do, it aligns the API with iOS/Android and with Cognito Lambda triggers which call sign-in clientMetadata "validationData": https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-sign-up.html#cognito-user-pools-lambda-trigger-syntax-pre-signup-request

See also iOS: https://github.com/aws-amplify/amplify-swift/blob/f68530431adbc22db45a12f3efd8450a0c94e44e/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift#L122