### PR TITLE
chore(auth): Rename `UserAttributeKey` to `AuthUserAttributeKey`

### DIFF
--- a/packages/amplify_core/lib/src/category/amplify_auth_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_auth_category.dart
@@ -29,7 +29,7 @@ import 'package:meta/meta.dart';
 /// {@endtemplate}
 class AuthCategory<
     PluginAuthUser extends AuthUser,
-    PluginUserAttributeKey extends UserAttributeKey,
+    PluginUserAttributeKey extends AuthUserAttributeKey,
     PluginAuthUserAttribute extends AuthUserAttribute<PluginUserAttributeKey>,
     PluginAuthDevice extends AuthDevice,
     PluginSignUpOptions extends SignUpOptions,
@@ -160,7 +160,7 @@ class AuthCategory<
       GetPluginResendUserAttributeConfirmationCodeResult,
       P> getPlugin<
           GetPluginAuthUser extends AuthUser,
-          GetPluginUserAttributeKey extends UserAttributeKey,
+          GetPluginUserAttributeKey extends AuthUserAttributeKey,
           GetPluginAuthUserAttribute extends AuthUserAttribute<
               GetPluginUserAttributeKey>,
           GetPluginAuthDevice extends AuthDevice,

--- a/packages/amplify_core/lib/src/plugin/amplify_auth_plugin_interface.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_auth_plugin_interface.dart
@@ -23,7 +23,7 @@ import 'package:meta/meta.dart';
 /// {@macro amplify_core.amplify_auth_category}
 abstract class AuthPluginInterface<
         PluginAuthUser extends AuthUser,
-        PluginUserAttributeKey extends UserAttributeKey,
+        PluginUserAttributeKey extends AuthUserAttributeKey,
         PluginAuthUserAttribute extends AuthUserAttribute<PluginUserAttributeKey>,
         PluginAuthDevice extends AuthDevice,
         PluginSignUpOptions extends SignUpOptions,

--- a/packages/amplify_core/lib/src/plugin/amplify_plugin_key.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_plugin_key.dart
@@ -30,7 +30,7 @@ abstract class AmplifyPluginKey<P extends AmplifyPluginInterface>
 /// {@endtemplate}
 abstract class AuthPluginKey<
     PluginAuthUser extends AuthUser,
-    PluginUserAttributeKey extends UserAttributeKey,
+    PluginUserAttributeKey extends AuthUserAttributeKey,
     PluginAuthUserAttribute extends AuthUserAttribute<PluginUserAttributeKey>,
     PluginAuthDevice extends AuthDevice,
     PluginSignUpOptions extends SignUpOptions,

--- a/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute.dart
@@ -21,7 +21,7 @@ part 'auth_user_attribute.g.dart';
 /// The key and value for a user attribute.
 /// {@endtemplate}
 @zAmplifyGenericSerializable
-class AuthUserAttribute<Key extends UserAttributeKey>
+class AuthUserAttribute<Key extends AuthUserAttributeKey>
     with
         // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
         AWSEquatable<AuthUserAttribute<Key>>,

--- a/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute.g.dart
@@ -7,7 +7,7 @@ part of 'auth_user_attribute.dart';
 // **************************************************************************
 
 AuthUserAttribute<Key>
-    _$AuthUserAttributeFromJson<Key extends UserAttributeKey>(
+    _$AuthUserAttributeFromJson<Key extends AuthUserAttributeKey>(
   Map<String, dynamic> json,
   Key Function(Object? json) fromJsonKey,
 ) =>
@@ -16,11 +16,12 @@ AuthUserAttribute<Key>
           value: json['value'] as String,
         );
 
-Map<String, dynamic> _$AuthUserAttributeToJson<Key extends UserAttributeKey>(
+Map<String, dynamic>
+    _$AuthUserAttributeToJson<Key extends AuthUserAttributeKey>(
   AuthUserAttribute<Key> instance,
   Object? Function(Key value) toJsonKey,
 ) =>
-    <String, dynamic>{
-      'userAttributeKey': toJsonKey(instance.userAttributeKey),
-      'value': instance.value,
-    };
+        <String, dynamic>{
+          'userAttributeKey': toJsonKey(instance.userAttributeKey),
+          'value': instance.value,
+        };

--- a/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute_key.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute_key.dart
@@ -16,15 +16,18 @@
 import 'package:amplify_core/amplify_core.dart';
 import 'package:meta/meta.dart';
 
-/// {@template amplify_core.user_attribute_key}
+@Deprecated('Use AuthUserAttributeKey instead')
+typedef UserAttributeKey = AuthUserAttributeKey;
+
+/// {@template amplify_core.auth_user_attribute_key}
 /// A user attribute identifier.
 /// {@endtemplate}
 @immutable
-abstract class UserAttributeKey
+abstract class AuthUserAttributeKey
     with AWSSerializable<String>
-    implements Comparable<UserAttributeKey> {
-  /// {@macro amplify_core.user_attribute_key}
-  const UserAttributeKey();
+    implements Comparable<AuthUserAttributeKey> {
+  /// {@macro amplify_core.auth_user_attribute_key}
+  const AuthUserAttributeKey();
 
   /// The JSON key for this attribute.
   String get key;
@@ -33,14 +36,15 @@ abstract class UserAttributeKey
   String toJson() => key;
 
   @override
-  int compareTo(UserAttributeKey other) => key.compareTo(other.key);
+  int compareTo(AuthUserAttributeKey other) => key.compareTo(other.key);
 
   @override
   String toString() => key;
 
   @override
   bool operator ==(Object other) =>
-      identical(this, other) || other is UserAttributeKey && key == other.key;
+      identical(this, other) ||
+      other is AuthUserAttributeKey && key == other.key;
 
   @override
   int get hashCode => key.hashCode;

--- a/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute_key.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute_key.dart
@@ -16,6 +16,7 @@
 import 'package:amplify_core/amplify_core.dart';
 import 'package:meta/meta.dart';
 
+// TODO(dnys1): Remove at GA
 @Deprecated('Use AuthUserAttributeKey instead')
 typedef UserAttributeKey = AuthUserAttributeKey;
 

--- a/packages/amplify_core/lib/src/types/auth/attribute/cognito_user_attribute_key.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/cognito_user_attribute_key.dart
@@ -24,7 +24,7 @@ import 'package:meta/meta.dart';
 ///
 /// Use [CognitoUserAttributeKey.custom] to create a custom Cognito attribute.
 @immutable
-class CognitoUserAttributeKey extends UserAttributeKey
+class CognitoUserAttributeKey extends AuthUserAttributeKey
     with AWSEquatable<CognitoUserAttributeKey>, AWSDebuggable {
   const CognitoUserAttributeKey._(this._key, {this.readOnly = false})
       : isCustom = false;

--- a/packages/amplify_core/lib/src/types/auth/attribute/confirm_user_attribute_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/confirm_user_attribute_request.dart
@@ -21,7 +21,7 @@ part 'confirm_user_attribute_request.g.dart';
 /// Encapsulates parameters for a request to confirm a user attribute update.
 /// {@endtemplate}
 @zAmplifyGenericSerializable
-class ConfirmUserAttributeRequest<Key extends UserAttributeKey,
+class ConfirmUserAttributeRequest<Key extends AuthUserAttributeKey,
         Options extends ConfirmUserAttributeOptions>
     with
         // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484

--- a/packages/amplify_core/lib/src/types/auth/attribute/confirm_user_attribute_request.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/confirm_user_attribute_request.g.dart
@@ -7,7 +7,7 @@ part of 'confirm_user_attribute_request.dart';
 // **************************************************************************
 
 ConfirmUserAttributeRequest<Key, Options> _$ConfirmUserAttributeRequestFromJson<
-        Key extends UserAttributeKey,
+        Key extends AuthUserAttributeKey,
         Options extends ConfirmUserAttributeOptions>(
   Map<String, dynamic> json,
   Key Function(Object? json) fromJsonKey,
@@ -20,7 +20,8 @@ ConfirmUserAttributeRequest<Key, Options> _$ConfirmUserAttributeRequestFromJson<
     );
 
 Map<String, dynamic> _$ConfirmUserAttributeRequestToJson<
-    Key extends UserAttributeKey, Options extends ConfirmUserAttributeOptions>(
+    Key extends AuthUserAttributeKey,
+    Options extends ConfirmUserAttributeOptions>(
   ConfirmUserAttributeRequest<Key, Options> instance,
   Object? Function(Key value) toJsonKey,
   Object? Function(Options value) toJsonOptions,

--- a/packages/amplify_core/lib/src/types/auth/attribute/resend_user_attribute_confirmation_code_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/resend_user_attribute_confirmation_code_request.dart
@@ -22,7 +22,8 @@ part 'resend_user_attribute_confirmation_code_request.g.dart';
 /// confirmation code.
 /// {@endtemplate}
 @zAmplifyGenericSerializable
-class ResendUserAttributeConfirmationCodeRequest<Key extends UserAttributeKey,
+class ResendUserAttributeConfirmationCodeRequest<
+        Key extends AuthUserAttributeKey,
         Options extends ResendUserAttributeConfirmationCodeOptions>
     with
         // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484

--- a/packages/amplify_core/lib/src/types/auth/attribute/resend_user_attribute_confirmation_code_request.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/resend_user_attribute_confirmation_code_request.g.dart
@@ -8,7 +8,7 @@ part of 'resend_user_attribute_confirmation_code_request.dart';
 
 ResendUserAttributeConfirmationCodeRequest<Key, Options>
     _$ResendUserAttributeConfirmationCodeRequestFromJson<
-            Key extends UserAttributeKey,
+            Key extends AuthUserAttributeKey,
             Options extends ResendUserAttributeConfirmationCodeOptions>(
   Map<String, dynamic> json,
   Key Function(Object? json) fromJsonKey,
@@ -20,7 +20,7 @@ ResendUserAttributeConfirmationCodeRequest<Key, Options>
         );
 
 Map<String, dynamic> _$ResendUserAttributeConfirmationCodeRequestToJson<
-    Key extends UserAttributeKey,
+    Key extends AuthUserAttributeKey,
     Options extends ResendUserAttributeConfirmationCodeOptions>(
   ResendUserAttributeConfirmationCodeRequest<Key, Options> instance,
   Object? Function(Key value) toJsonKey,

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_request.dart
@@ -27,7 +27,7 @@ part 'update_user_attribute_request.g.dart';
   explicitToJson: true,
   constructor: '_',
 )
-class UpdateUserAttributeRequest<Key extends UserAttributeKey,
+class UpdateUserAttributeRequest<Key extends AuthUserAttributeKey,
         Options extends UpdateUserAttributeOptions>
     with
         // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_request.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_request.g.dart
@@ -7,7 +7,7 @@ part of 'update_user_attribute_request.dart';
 // **************************************************************************
 
 UpdateUserAttributeRequest<Key, Options> _$UpdateUserAttributeRequestFromJson<
-        Key extends UserAttributeKey,
+        Key extends AuthUserAttributeKey,
         Options extends UpdateUserAttributeOptions>(
   Map<String, dynamic> json,
   Key Function(Object? json) fromJsonKey,
@@ -21,7 +21,8 @@ UpdateUserAttributeRequest<Key, Options> _$UpdateUserAttributeRequestFromJson<
     );
 
 Map<String, dynamic> _$UpdateUserAttributeRequestToJson<
-    Key extends UserAttributeKey, Options extends UpdateUserAttributeOptions>(
+    Key extends AuthUserAttributeKey,
+    Options extends UpdateUserAttributeOptions>(
   UpdateUserAttributeRequest<Key, Options> instance,
   Object? Function(Key value) toJsonKey,
   Object? Function(Options value) toJsonOptions,

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attributes_request.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attributes_request.dart
@@ -21,7 +21,7 @@ part 'update_user_attributes_request.g.dart';
 /// Encapsulates parameters for a update user attributes operation.
 /// {@endtemplate}
 @zAmplifyGenericSerializable
-class UpdateUserAttributesRequest<Key extends UserAttributeKey,
+class UpdateUserAttributesRequest<Key extends AuthUserAttributeKey,
         Options extends UpdateUserAttributesOptions>
     with
         // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attributes_request.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attributes_request.g.dart
@@ -7,7 +7,7 @@ part of 'update_user_attributes_request.dart';
 // **************************************************************************
 
 UpdateUserAttributesRequest<Key, Options> _$UpdateUserAttributesRequestFromJson<
-        Key extends UserAttributeKey,
+        Key extends AuthUserAttributeKey,
         Options extends UpdateUserAttributesOptions>(
   Map<String, dynamic> json,
   Key Function(Object? json) fromJsonKey,
@@ -22,7 +22,8 @@ UpdateUserAttributesRequest<Key, Options> _$UpdateUserAttributesRequestFromJson<
     );
 
 Map<String, dynamic> _$UpdateUserAttributesRequestToJson<
-    Key extends UserAttributeKey, Options extends UpdateUserAttributesOptions>(
+    Key extends AuthUserAttributeKey,
+    Options extends UpdateUserAttributesOptions>(
   UpdateUserAttributesRequest<Key, Options> instance,
   Object? Function(Key value) toJsonKey,
   Object? Function(Options value) toJsonOptions,

--- a/packages/amplify_core/lib/src/types/auth/auth_types.dart
+++ b/packages/amplify_core/lib/src/types/auth/auth_types.dart
@@ -26,6 +26,7 @@ export '../exception/auth/user_cancelled_exception.dart';
 /// Attributes
 export 'attribute/auth_next_update_attribute_step.dart';
 export 'attribute/auth_user_attribute.dart';
+export 'attribute/auth_user_attribute_key.dart';
 export 'attribute/cognito_user_attribute_key.dart';
 export 'attribute/confirm_user_attribute_options.dart';
 export 'attribute/confirm_user_attribute_request.dart';
@@ -40,14 +41,13 @@ export 'attribute/update_user_attribute_request.dart';
 export 'attribute/update_user_attribute_result.dart';
 export 'attribute/update_user_attributes_options.dart';
 export 'attribute/update_user_attributes_request.dart';
-export 'attribute/user_attribute_key.dart';
 
 /// Common
 export 'auth_code_delivery_details.dart';
 export 'auth_device.dart';
 export 'auth_next_step.dart';
 
-// Hub
+/// Hub
 export 'hub/auth_hub_event.dart';
 
 /// Password

--- a/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.dart
@@ -18,7 +18,7 @@ import 'package:amplify_core/amplify_core.dart';
 part 'auth_next_sign_in_step.g.dart';
 
 @zAmplifyGenericSerializable
-class AuthNextSignInStep<Key extends UserAttributeKey> extends AuthNextStep
+class AuthNextSignInStep<Key extends AuthUserAttributeKey> extends AuthNextStep
     with
         // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
         AWSEquatable<AuthNextSignInStep<Key>>,

--- a/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.g.dart
@@ -7,7 +7,7 @@ part of 'auth_next_sign_in_step.dart';
 // **************************************************************************
 
 AuthNextSignInStep<Key>
-    _$AuthNextSignInStepFromJson<Key extends UserAttributeKey>(
+    _$AuthNextSignInStepFromJson<Key extends AuthUserAttributeKey>(
   Map<String, dynamic> json,
   Key Function(Object? json) fromJsonKey,
 ) =>
@@ -27,7 +27,8 @@ AuthNextSignInStep<Key>
               const [],
         );
 
-Map<String, dynamic> _$AuthNextSignInStepToJson<Key extends UserAttributeKey>(
+Map<String, dynamic>
+    _$AuthNextSignInStepToJson<Key extends AuthUserAttributeKey>(
   AuthNextSignInStep<Key> instance,
   Object? Function(Key value) toJsonKey,
 ) {

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_result.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_result.dart
@@ -25,7 +25,7 @@ part 'sign_in_result.g.dart';
   // TODO(dnys1): Fix generic serialization
   createFactory: false,
 )
-class SignInResult<Key extends UserAttributeKey>
+class SignInResult<Key extends AuthUserAttributeKey>
     with
         // TODO(dnys1): https://github.com/dart-lang/sdk/issues/49484
         AWSEquatable<SignInResult<Key>>,

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_result.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_result.g.dart
@@ -6,7 +6,7 @@ part of 'sign_in_result.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-Map<String, dynamic> _$SignInResultToJson<Key extends UserAttributeKey>(
+Map<String, dynamic> _$SignInResultToJson<Key extends AuthUserAttributeKey>(
   SignInResult<Key> instance,
   Object? Function(Key value) toJsonKey,
 ) {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/user_attributes_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/user_attributes_test.dart
@@ -25,7 +25,7 @@ import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 extension on List<AuthUserAttribute> {
-  String? valueOf(UserAttributeKey key) =>
+  String? valueOf(AuthUserAttributeKey key) =>
       singleWhereOrNull((el) => el.userAttributeKey == key)?.value;
 }
 

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/confirm_user_attribute.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/confirm_user_attribute.dart
@@ -22,7 +22,7 @@ class ConfirmUserAttributeScreen extends StatefulWidget {
     super.key,
   });
 
-  final UserAttributeKey userAttributeKey;
+  final AuthUserAttributeKey userAttributeKey;
 
   @override
   State<ConfirmUserAttributeScreen> createState() =>

--- a/packages/auth/amplify_auth_cognito_dart/example/lib/common.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/lib/common.dart
@@ -111,7 +111,7 @@ Future<void> forgetDevice() async {
 }
 
 Future<UpdateUserAttributeResult> updateUserAttribute({
-  required UserAttributeKey key,
+  required AuthUserAttributeKey key,
   required String value,
   CognitoUpdateUserAttributeOptions? options,
 }) async {
@@ -122,7 +122,8 @@ Future<UpdateUserAttributeResult> updateUserAttribute({
   );
 }
 
-Future<Map<UserAttributeKey, UpdateUserAttributeResult>> updateUserAttributes({
+Future<Map<AuthUserAttributeKey, UpdateUserAttributeResult>>
+    updateUserAttributes({
   required List<AuthUserAttribute> attributes,
   CognitoUpdateUserAttributesOptions? options,
 }) async {
@@ -133,7 +134,7 @@ Future<Map<UserAttributeKey, UpdateUserAttributeResult>> updateUserAttributes({
 }
 
 Future<ConfirmUserAttributeResult> confirmUserAttribute({
-  required UserAttributeKey key,
+  required AuthUserAttributeKey key,
   required String confirmationCode,
 }) async {
   return Amplify.Auth.confirmUserAttribute(
@@ -144,7 +145,7 @@ Future<ConfirmUserAttributeResult> confirmUserAttribute({
 
 Future<ResendUserAttributeConfirmationCodeResult>
     resendUserAttributeConfirmationCode({
-  required UserAttributeKey key,
+  required AuthUserAttributeKey key,
   CognitoResendUserAttributeConfirmationCodeOptions? options,
 }) async {
   return Amplify.Auth.resendUserAttributeConfirmationCode(


### PR DESCRIPTION
For consistency with other platforms
