### PR TITLE
chore(auth): Deprecate customAuth flow type

### DIFF
--- a/packages/amplify_core/lib/src/config/auth/cognito/auth.g.dart
+++ b/packages/amplify_core/lib/src/config/auth/cognito/auth.g.dart
@@ -103,6 +103,8 @@ const _$AuthenticationFlowTypeEnumMap = {
   AuthenticationFlowType.userSrpAuth: 'USER_SRP_AUTH',
   AuthenticationFlowType.userPasswordAuth: 'USER_PASSWORD_AUTH',
   AuthenticationFlowType.customAuth: 'CUSTOM_AUTH',
+  AuthenticationFlowType.customAuthWithSrp: 'CUSTOM_AUTH_WITH_SRP',
+  AuthenticationFlowType.customAuthWithoutSrp: 'CUSTOM_AUTH_WITHOUT_SRP',
 };
 
 const _$SocialProviderEnumMap = {

--- a/packages/amplify_core/lib/src/config/auth/cognito/authentication_flow_type.dart
+++ b/packages/amplify_core/lib/src/config/auth/cognito/authentication_flow_type.dart
@@ -16,14 +16,31 @@
 import 'package:json_annotation/json_annotation.dart';
 
 enum AuthenticationFlowType {
+  /// Authentication flow for the Secure Remote Password (SRP) protocol.
   @JsonValue('USER_SRP_AUTH')
   userSrpAuth('USER_SRP_AUTH'),
 
+  /// Non-SRP authentication flow; user name and password are passed directly.
+  /// If a user migration Lambda trigger is set, this flow will invoke the user
+  /// migration Lambda if it doesn't find the user name in the user pool.
   @JsonValue('USER_PASSWORD_AUTH')
   userPasswordAuth('USER_PASSWORD_AUTH'),
 
+  /// Authentication flow for custom flow which are backed by Lambda triggers.
+  // TODO(dnys1): Remove at GA
+  @Deprecated('Use customAuthWithSrp or customAuthWithoutSrp instead')
   @JsonValue('CUSTOM_AUTH')
-  customAuth('CUSTOM_AUTH');
+  customAuth('CUSTOM_AUTH'),
+
+  /// Authentication flow which start with SRP and then move to custom auth
+  /// flow.
+  @JsonValue('CUSTOM_AUTH_WITH_SRP')
+  customAuthWithSrp('CUSTOM_AUTH_WITH_SRP'),
+
+  /// Authentication flow which starts without SRP and directly moves to custom
+  /// auth flow.
+  @JsonValue('CUSTOM_AUTH_WITHOUT_SRP')
+  customAuthWithoutSrp('CUSTOM_AUTH_WITHOUT_SRP');
 
   const AuthenticationFlowType(this.value);
 

--- a/packages/amplify_core/test/config/cli_config_test.dart
+++ b/packages/amplify_core/test/config/cli_config_test.dart
@@ -109,6 +109,7 @@ const expected = {
               authenticationFlowType: AuthenticationFlowType.userSrpAuth,
             ),
             'DefaultCustomAuth': CognitoAuthConfig(
+              // ignore: deprecated_member_use_from_same_package
               authenticationFlowType: AuthenticationFlowType.customAuth,
             ),
           }),

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -577,7 +577,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     final stream = _stateMachine.create(SignInStateMachine.type).stream;
     _stateMachine.dispatch(
       SignInEvent.initiate(
-        authFlowType: options.authFlowType?.sdkValue,
+        authFlowType: options.authFlowType,
         parameters: SignInParameters(
           (p) => p
             ..username = request.username

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_options.g.dart
@@ -36,4 +36,6 @@ const _$AuthenticationFlowTypeEnumMap = {
   AuthenticationFlowType.userSrpAuth: 'USER_SRP_AUTH',
   AuthenticationFlowType.userPasswordAuth: 'USER_PASSWORD_AUTH',
   AuthenticationFlowType.customAuth: 'CUSTOM_AUTH',
+  AuthenticationFlowType.customAuthWithSrp: 'CUSTOM_AUTH_WITH_SRP',
+  AuthenticationFlowType.customAuthWithoutSrp: 'CUSTOM_AUTH_WITHOUT_SRP',
 };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
@@ -91,7 +91,10 @@ extension AuthenticationFlowTypeBridge on AuthenticationFlowType {
     switch (this) {
       case AuthenticationFlowType.userSrpAuth:
         return AuthFlowType.userSrpAuth;
+      // ignore: deprecated_member_use
       case AuthenticationFlowType.customAuth:
+      case AuthenticationFlowType.customAuthWithSrp:
+      case AuthenticationFlowType.customAuthWithoutSrp:
         return AuthFlowType.customAuth;
       case AuthenticationFlowType.userPasswordAuth:
         return AuthFlowType.userPasswordAuth;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_exception.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_exception.dart
@@ -138,7 +138,7 @@ class InternalErrorException extends core.AmplifyException
 class InvalidParameterException extends core.AmplifyException
     with core.AWSDebuggable {
   /// {@macro amplify_auth_cognito_dart.sdk.invalid_parameter_exception}
-  const InvalidParameterException(super.message);
+  const InvalidParameterException(super.message, {super.recoverySuggestion});
 
   @override
   String get runtimeTypeName => 'InvalidParameterException';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/sign_in_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/sign_in_event.dart
@@ -15,7 +15,6 @@
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_auth_cognito_dart/src/model/cognito_user.dart';
 import 'package:amplify_auth_cognito_dart/src/model/sign_in_parameters.dart';
-import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
 
@@ -49,7 +48,7 @@ abstract class SignInEvent
 
   /// {@macro amplify_auth_cognito.sign_in_initiate}
   const factory SignInEvent.initiate({
-    AuthFlowType? authFlowType,
+    AuthenticationFlowType? authFlowType,
     required SignInParameters parameters,
     Map<String, String>? clientMetadata,
   }) = SignInInitiate;
@@ -90,7 +89,7 @@ class SignInInitiate extends SignInEvent {
         super._();
 
   /// Runtime override of the Authentication flow.
-  final AuthFlowType? authFlowType;
+  final AuthenticationFlowType? authFlowType;
 
   /// The flow-specific parameters.
   final SignInParameters parameters;


### PR DESCRIPTION
In favor of more precise `customAuthWithSrp` and `customAuthWithoutSrp`. Retain old behavior for `customAuth` since the new values do not have corresponding `amplifyconfiguration.dart` values.
