### PR TITLE
chore(datastore): skip flutter unit tests in Circle CI

### DIFF
--- a/.circleci/test_all_plugins.sh
+++ b/.circleci/test_all_plugins.sh
@@ -26,6 +26,13 @@ cd "./$plugin"
 case $test_suite in
     flutter-test)
         echo "=== Running Flutter unit tests for $plugin ==="
+
+        # These tests are also running in GH actions. Until we remove the Circle CI check in repo settings,
+        # just skip here.
+        if [[ "$plugin" = "amplify_datastore" ]]; then
+          echo "Skipping redundant flutter tests for datastore."
+          exit 0
+        fi
         
         # Navigate into the app-facing plugin for federated plugin structures
         if [ -d "${plugin}" ]; then


### PR DESCRIPTION
Are you tired of all PR/merge builds failing no matter how awesome they are? Do you want it to stop? This PR is for you.

Datastore flutter unit tests consistently fail in Circle CI. No one has been able to repro or explain it. The same tests run in Github actions without issue. This PR just makes the datastore flutter unit tests skip and exit w status 0 in Circle CI. We need to actually remove them as a check in the repo settings, but access to repo settings is limited so this will help builds be green until that happens.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
