### PR TITLE
chore(aft): fix temp model dir structure for using local models

### DIFF
--- a/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
@@ -81,7 +81,7 @@ class GenerateSdkCommand extends AmplifyCommand {
   }
 
   /// Organizes model files from [baseDir] into a new temporary directory.
-  /// 
+  ///
   /// Returns the new directory.
   Future<Directory> _organizeModels(Directory baseDir) async {
     final modelsDir = await Directory.systemTemp.createTemp('models');

--- a/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
@@ -120,13 +120,13 @@ class GenerateSdkCommand extends AmplifyCommand {
     final modelsPath = args['models'] as String?;
     final Directory modelsDir;
     if (modelsPath != null) {
-      modelsDir = await _getModels(Directory(modelsPath));
+      modelsDir = await _organizeModels(Directory(modelsPath));
       if (!await modelsDir.exists()) {
         exitError('Model directory ($modelsDir) does not exist');
       }
     } else {
       final cloneDir = await _downloadModels(config.ref);
-      modelsDir = await _getModels(cloneDir);
+      modelsDir = await _organizeModels(cloneDir);
     }
 
     final outputPath = args['output'] as String;

--- a/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
@@ -84,7 +84,7 @@ class GenerateSdkCommand extends AmplifyCommand {
   /// if smithy/model.json exists, copy to <servicename>.json inside a temporary directory.
   Future<Directory> _getModels(Directory baseDir) async {
     final modelsDir = await Directory.systemTemp.createTemp('models');
-    logger.stdout('Organizing models in ${modelsDir.path}');
+    logger.trace('Organizing models in ${modelsDir.path}');
     final services = baseDir.list(followLinks: false).whereType<Directory>();
     await for (final serviceDir in services) {
       final serviceName = p.basename(serviceDir.path);

--- a/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
@@ -80,9 +80,10 @@ class GenerateSdkCommand extends AmplifyCommand {
     return cloneDir;
   }
 
-  /// for all folders inside the baseDir,
-  /// if smithy/model.json exists, copy to <servicename>.json inside a temporary directory.
-  Future<Directory> _getModels(Directory baseDir) async {
+  /// Organizes model files from [baseDir] into a new temporary directory.
+  /// 
+  /// Returns the new directory.
+  Future<Directory> _organizeModels(Directory baseDir) async {
     final modelsDir = await Directory.systemTemp.createTemp('models');
     logger.trace('Organizing models in ${modelsDir.path}');
     final services = baseDir.list(followLinks: false).whereType<Directory>();


### PR DESCRIPTION
to create and use flattened model files for local copy of models same as what is done for models’ git repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
