### PR TITLE
chore(auth): Fix SignUpResult interface

### DIFF
--- a/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_result.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_result.dart
@@ -26,6 +26,7 @@ class SignUpResult
   const SignUpResult({
     required this.isSignUpComplete,
     required this.nextStep,
+    this.userId,
   });
 
   factory SignUpResult.fromJson(Map<String, Object?> json) =>
@@ -34,8 +35,11 @@ class SignUpResult
   final bool isSignUpComplete;
   final AuthNextSignUpStep nextStep;
 
+  /// The user ID of the signed-up user.
+  final String? userId;
+
   @override
-  List<Object?> get props => [isSignUpComplete, nextStep];
+  List<Object?> get props => [isSignUpComplete, nextStep, userId];
 
   @override
   String get runtimeTypeName => 'SignUpResult';

--- a/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_result.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_result.g.dart
@@ -10,10 +10,21 @@ SignUpResult _$SignUpResultFromJson(Map<String, dynamic> json) => SignUpResult(
       isSignUpComplete: json['isSignUpComplete'] as bool,
       nextStep:
           AuthNextSignUpStep.fromJson(json['nextStep'] as Map<String, dynamic>),
+      userId: json['userId'] as String?,
     );
 
-Map<String, dynamic> _$SignUpResultToJson(SignUpResult instance) =>
-    <String, dynamic>{
-      'isSignUpComplete': instance.isSignUpComplete,
-      'nextStep': instance.nextStep.toJson(),
-    };
+Map<String, dynamic> _$SignUpResultToJson(SignUpResult instance) {
+  final val = <String, dynamic>{
+    'isSignUpComplete': instance.isSignUpComplete,
+    'nextStep': instance.nextStep.toJson(),
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('userId', instance.userId);
+  return val;
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_sign_up_result.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_sign_up_result.dart
@@ -23,11 +23,17 @@ class CognitoSignUpResult extends SignUpResult {
   const CognitoSignUpResult({
     required super.nextStep,
     required super.isSignUpComplete,
-    this.userId,
-  });
+    super.userId,
+  }) : _userId = userId;
+
+  final String? _userId;
 
   /// The user ID of the signed-up user.
   ///
   /// Will not be present for `Amplify.Auth.confirmSignUp` calls.
-  final String? userId;
+  @override
+  String? get userId => _userId;
+
+  @override
+  String get runtimeTypeName => 'CognitoSignUpResult';
 }


### PR DESCRIPTION
Moves `userId` to the category-level result.
