### PR TITLE
chore(auth): reduce race conditions in integ test GQL subscriptions

### DIFF
--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -130,7 +130,7 @@ jobs:
       - name: Run integration tests
         run: |
           chromedriver --port=4444 &
-          melos exec -c 1 --scope ${{ matrix.scope }} -- flutter drive --driver=test_driver/integration_test.dart --target=integration_test/main_test.dart -d web-server
+          melos exec -c 1 --scope ${{ matrix.scope }} -- \$MELOS_ROOT_PATH/build-support/integ_test.sh -d web-server --retries 1
 
   macos:
     runs-on: macos-latest

--- a/build-support/integ_test.sh
+++ b/build-support/integ_test.sh
@@ -71,7 +71,14 @@ testsList+=("$TARGET")
 n=0
 until [ "$n" -gt $retries ]
 do
-    if flutter test \
+    if [[ $deviceId = "web-server" ]] && flutter drive \
+        --driver=test_driver/integration_test.dart \
+        --target=$TARGET \
+        -d web-server
+    then
+        resultsList+=(0)
+        break
+    elif flutter test \
         --no-pub \
         -d $deviceId \
         $TARGET;
@@ -112,11 +119,19 @@ for ENTRY in $TEST_ENTRIES; do
     n=0
     until [ "$n" -gt $retries ]
     do
-        if flutter test \
-              --no-pub \
-              --dart-define ENABLE_CLOUD_SYNC=$enableCloudSync \
-              -d $deviceId \
-              $ENTRY;
+        if [[ $deviceId = "web-server" ]] && flutter drive \
+            --driver=test_driver/integration_test.dart \
+            --dart-define ENABLE_CLOUD_SYNC=$enableCloudSync \
+            --target=$ENTRY \
+            -d web-server
+        then
+            resultsList+=(0)
+            break
+        elif flutter test \
+            --no-pub \
+            --dart-define ENABLE_CLOUD_SYNC=$enableCloudSync \
+            -d $deviceId \
+            $ENTRY;
         then
             resultsList+=(0)
             break

--- a/packages/amplify_authenticator/example/integration_test/confirm_sign_up_email_or_phone_test.dart
+++ b/packages/amplify_authenticator/example/integration_test/confirm_sign_up_email_or_phone_test.dart
@@ -77,7 +77,7 @@ void main() {
           final phoneNumber = generateUSPhoneNumber();
           final password = generatePassword();
 
-          final code = getOtpCode(email);
+          final otpResult = await getOtpCode(email);
 
           await signInPage.navigateToSignUp();
 
@@ -103,7 +103,7 @@ void main() {
           confirmSignUpPage.expectConfirmationCodeIsPresent();
 
           // And I type a valid confirmation code
-          await confirmSignUpPage.enterCode(await code);
+          await confirmSignUpPage.enterCode(await otpResult.code);
 
           // And I click the "Confirm" button
           await confirmSignUpPage.submitConfirmSignUp();
@@ -126,7 +126,7 @@ void main() {
           final phoneNumber = generateUSPhoneNumber();
           final password = generatePassword();
 
-          final code = getOtpCode(email);
+          final otpResult = await getOtpCode(email);
 
           await signInPage.navigateToSignUp();
 
@@ -152,7 +152,7 @@ void main() {
           confirmSignUpPage.expectConfirmationCodeIsPresent();
 
           // And I type a valid confirmation code
-          await confirmSignUpPage.enterCode(await code);
+          await confirmSignUpPage.enterCode(await otpResult.code);
 
           // And I click the "Confirm" button
           await confirmSignUpPage.submitConfirmSignUp();

--- a/packages/amplify_authenticator/example/integration_test/confirm_sign_up_test.dart
+++ b/packages/amplify_authenticator/example/integration_test/confirm_sign_up_test.dart
@@ -115,7 +115,7 @@ void main() {
 
         final username = generateEmail();
         final password = generatePassword();
-        final code = getOtpCode(username);
+        final otpResult = await getOtpCode(username);
 
         await signInPage.navigateToSignUp();
 
@@ -135,7 +135,7 @@ void main() {
         confirmSignUpPage.expectConfirmationCodeIsPresent();
 
         // And I type a valid confirmation code
-        await confirmSignUpPage.enterCode(await code);
+        await confirmSignUpPage.enterCode(await otpResult.code);
 
         // And I click the "Confirm" button
         await confirmSignUpPage.submitConfirmSignUp();

--- a/packages/amplify_authenticator/example/integration_test/sign_in_with_email_test.dart
+++ b/packages/amplify_authenticator/example/integration_test/sign_in_with_email_test.dart
@@ -95,7 +95,7 @@ void main() {
         SignInPage signInPage = SignInPage(tester: tester);
         ConfirmSignUpPage confirmSignUpPage = ConfirmSignUpPage(tester: tester);
 
-        final code = getOtpCode(email);
+        final otpResult = await getOtpCode(email);
 
         // Use the standard Amplify API to create the user in the Unconfirmed state
         await Amplify.Auth.signUp(
@@ -121,7 +121,7 @@ void main() {
         confirmSignUpPage.expectConfirmationCodeIsPresent();
 
         /// And I type a valid confirmation code
-        await confirmSignUpPage.enterCode(await code);
+        await confirmSignUpPage.enterCode(await otpResult.code);
 
         // And I click the "Confirm" button
         await confirmSignUpPage.submitConfirmSignUp();

--- a/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:amplify_api/amplify_api.dart';
@@ -67,18 +66,13 @@ void main() {
         final password = generatePassword();
 
         // Sign up, but do not confirm, user
-        final establishedCompleter = Completer<void>();
-        final code = getOtpCode(
-          username,
-          onEstablished: establishedCompleter.complete,
-        );
-        await establishedCompleter.future;
+        final otpResult = await getOtpCode(username);
         await signUpWithoutConfirming(username, password);
 
         // Confirm sign up and complete sign in
         final confirmResult = await Amplify.Auth.confirmSignUp(
           username: username,
-          confirmationCode: await code,
+          confirmationCode: await otpResult.code,
         );
         expect(confirmResult.isSignUpComplete, true);
       });
@@ -88,12 +82,8 @@ void main() {
         final password = generatePassword();
 
         // Sign up, but do not confirm, user
-        final establishedCompleter = Completer<void>();
-        final code = getOtpCode(
-          username,
-          onEstablished: establishedCompleter.complete,
-        );
-        await establishedCompleter.future;
+        final otpResult = await getOtpCode(username);
+
         await signUpWithoutConfirming(username, password);
 
         // Sign in
@@ -106,7 +96,7 @@ void main() {
         // Confirm sign up and complete sign in
         final confirmResult = await Amplify.Auth.confirmSignUp(
           username: username,
-          confirmationCode: await code,
+          confirmationCode: await otpResult.code,
         );
         expect(confirmResult.isSignUpComplete, true);
 
@@ -122,22 +112,12 @@ void main() {
         final password = generatePassword();
 
         // Sign up, but do not confirm, user
-        final establishedCompleter = Completer<void>();
-        var code = getOtpCode(
-          username,
-          onEstablished: establishedCompleter.complete,
-        );
-        await establishedCompleter.future;
+        var otpResult = await getOtpCode(username);
         await signUpWithoutConfirming(username, password);
 
         // Throw away code and get next one
-        await code;
-        final secondEstablishedCompleter = Completer<void>();
-        code = getOtpCode(
-          username,
-          onEstablished: secondEstablishedCompleter.complete,
-        );
-        await secondEstablishedCompleter.future;
+        await otpResult.code;
+        otpResult = await getOtpCode(username);
 
         final resendResult = await Amplify.Auth.resendSignUpCode(
           username: username,
@@ -146,7 +126,7 @@ void main() {
 
         final confirmResult = await Amplify.Auth.confirmSignUp(
           username: username,
-          confirmationCode: await code,
+          confirmationCode: await otpResult.code,
         );
         expect(confirmResult.isSignUpComplete, true);
       });

--- a/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:amplify_api/amplify_api.dart';
@@ -66,7 +67,12 @@ void main() {
         final password = generatePassword();
 
         // Sign up, but do not confirm, user
-        final code = getOtpCode(username);
+        final establishedCompleter = Completer<void>();
+        final code = getOtpCode(
+          username,
+          onEstablished: establishedCompleter.complete,
+        );
+        await establishedCompleter.future;
         await signUpWithoutConfirming(username, password);
 
         // Confirm sign up and complete sign in
@@ -82,7 +88,12 @@ void main() {
         final password = generatePassword();
 
         // Sign up, but do not confirm, user
-        final code = getOtpCode(username);
+        final establishedCompleter = Completer<void>();
+        final code = getOtpCode(
+          username,
+          onEstablished: establishedCompleter.complete,
+        );
+        await establishedCompleter.future;
         await signUpWithoutConfirming(username, password);
 
         // Sign in
@@ -111,12 +122,22 @@ void main() {
         final password = generatePassword();
 
         // Sign up, but do not confirm, user
-        var code = getOtpCode(username);
+        final establishedCompleter = Completer<void>();
+        var code = getOtpCode(
+          username,
+          onEstablished: establishedCompleter.complete,
+        );
+        await establishedCompleter.future;
         await signUpWithoutConfirming(username, password);
 
         // Throw away code and get next one
         await code;
-        code = getOtpCode(username);
+        final secondEstablishedCompleter = Completer<void>();
+        code = getOtpCode(
+          username,
+          onEstablished: secondEstablishedCompleter.complete,
+        );
+        await secondEstablishedCompleter.future;
 
         final resendResult = await Amplify.Auth.resendSignUpCode(
           username: username,

--- a/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:amplify_api/amplify_api.dart';
@@ -85,12 +84,7 @@ void main() {
       }
 
       if (enableMfa) {
-        final establishedCompleter = Completer<void>();
-        final code = getOtpCode(
-          username!,
-          onEstablished: establishedCompleter.complete,
-        );
-        await establishedCompleter.future;
+        final otpResult = await getOtpCode(username!);
         final signInRes = await Amplify.Auth.signIn(
           username: username!,
           password: password,
@@ -98,7 +92,7 @@ void main() {
         if (signInRes.nextStep?.signInStep ==
             'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE') {
           final confirmSignInRes = await Amplify.Auth.confirmSignIn(
-            confirmationValue: await code,
+            confirmationValue: await otpResult.code,
           );
           expect(confirmSignInRes.isSignedIn, isTrue);
         } else {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:amplify_api/amplify_api.dart';
@@ -84,7 +85,12 @@ void main() {
       }
 
       if (enableMfa) {
-        final code = getOtpCode(username!);
+        final establishedCompleter = Completer<void>();
+        final code = getOtpCode(
+          username!,
+          onEstablished: establishedCompleter.complete,
+        );
+        await establishedCompleter.future;
         final signInRes = await Amplify.Auth.signIn(
           username: username!,
           password: password,

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_test.dart
@@ -46,7 +46,7 @@ void main() {
         final username = generateUsername();
         final password = generatePassword();
 
-        final code = getOtpCode(username);
+        final otpResult = await getOtpCode(username);
 
         await adminCreateUser(
           username,
@@ -66,7 +66,7 @@ void main() {
         );
 
         final confirmRes = await Amplify.Auth.confirmSignIn(
-          confirmationValue: await code,
+          confirmationValue: await otpResult.code,
         );
         expect(confirmRes.nextStep?.signInStep, 'DONE');
       });


### PR DESCRIPTION
There is some flakiness in CI with auth integ tests in web where they timeout. Although it's tough to tell exactly where/why they timeout in CI bc the output is opaque, I have been able to reproduce a timeout locally with those tests (likely due to my high latency network). While I'm not certain this PR will fix the CI flakiness, it has a few things to help:
1) adds establish completers to GQL subscriptions related to OTP codes to ensure subscription established before calling the auth method that will cause the code to be sent. (This eliminated the timeouts from my local env.)
2) Uses the integ test script for web in CI so that it will retry like the other platforms.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
