### PR TITLE
feat(logger): create the dart package and generate dart sdk for cloudwatchlogs service

### DIFF
--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/.gitignore
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/CHANGELOG.md
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+- Initial version.

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/LICENSE
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/README.md
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/README.md
@@ -1,0 +1,1 @@
+# Amplify Logging with AWS CloudWatchLogs for Dart

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/analysis_options.yaml
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:amplify_lints/library.yaml
+
+analyzer:
+  exclude:
+    - '**/*.g.dart'
+    - lib/src/sdk/src/**

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/example/amplify_logging_cloudwatchlogs_dart_example.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/example/amplify_logging_cloudwatchlogs_dart_example.dart
@@ -1,6 +1,13 @@
+import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_logging_cloudwatchlogs_dart/amplify_logging_cloudwatchlogs_dart.dart';
 
 void main() {
-  var awesome = Awesome();
-  print('awesome: ${awesome.isAwesome}');
+  final logger = AmplifyLogger();
+  final cwLoggerPlugin = CloudWatchLoggerPluginDart();
+  for (var i = 0; i <= 20; i = i + 2) {
+    logger
+      ..registerPlugin(cwLoggerPlugin)
+      ..info('info: log#$i from example app ')
+      ..error('error: log#${i + 1} from example app');
+  }
 }

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/example/amplify_logging_cloudwatchlogs_dart_example.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/example/amplify_logging_cloudwatchlogs_dart_example.dart
@@ -1,0 +1,6 @@
+import 'package:amplify_logging_cloudwatchlogs_dart/amplify_logging_cloudwatchlogs_dart.dart';
+
+void main() {
+  var awesome = Awesome();
+  print('awesome: ${awesome.isAwesome}');
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/amplify_logging_cloudwatchlogs_dart.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/amplify_logging_cloudwatchlogs_dart.dart
@@ -1,0 +1,8 @@
+/// Support for doing something awesome.
+///
+/// More dartdocs go here.
+library amplify_logging_cloudwatchlogs_dart;
+
+export 'src/amplify_logging_cloudwatchlogs_dart_base.dart';
+
+// TODO: Export any libraries intended for clients of this package.

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/amplify_logging_cloudwatchlogs_dart_base.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/amplify_logging_cloudwatchlogs_dart_base.dart
@@ -1,0 +1,6 @@
+// TODO: Put public facing types in this file.
+
+/// Checks if you are awesome. Spoiler: you are.
+class Awesome {
+  bool get isAwesome => true;
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/amplify_logging_cloudwatchlogs_dart_base.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/amplify_logging_cloudwatchlogs_dart_base.dart
@@ -1,6 +1,60 @@
-// TODO: Put public facing types in this file.
+// ignore_for_file: public_member_api_docs
 
-/// Checks if you are awesome. Spoiler: you are.
-class Awesome {
-  bool get isAwesome => true;
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/cloud_watch_logs.dart';
+import 'package:fixnum/fixnum.dart';
+
+const _region = 'us-west-2';
+const _accessKeyId = '_accessKeyId';
+const _secretAccessKey = '_secretAccessKey';
+const _credentialsProvider = AWSCredentialsProvider(
+  AWSCredentials(
+    _accessKeyId,
+    _secretAccessKey,
+  ),
+);
+
+const _client = CloudWatchLogsClient(
+  region: _region,
+  credentialsProvider: _credentialsProvider,
+);
+
+const _limit = 10;
+const _duration = Duration(minutes: 10);
+const _token = '_token';
+const _logGroupName = 'test';
+const _logStreamName = 'poc';
+
+class CloudWatchLoggerPluginDart extends AmplifyLoggerPlugin {
+  static String? token = _token;
+  static final List<InputLogEvent> logEvents = [];
+
+  @override
+  Future<void> handleLogEntry(LogEntry logEntry) async {
+    final logEvent = InputLogEvent(
+      message: logEntry.message,
+      timestamp: Int64(DateTime.now().millisecondsSinceEpoch),
+    );
+    logEvents.add(logEvent);
+    if (logEvents.isNotEmpty &&
+        (logEvents.length >= _limit ||
+            logEvents.first.timestamp >=
+                Int64(DateTime.now().add(_duration).millisecondsSinceEpoch))) {
+      await putLogEvents(logEvents);
+    }
+  }
+
+  Future<void> putLogEvents(List<InputLogEvent> logEvents) async {
+    final input = PutLogEventsRequest(
+      logEvents: logEvents,
+      logGroupName: _logGroupName,
+      logStreamName: _logStreamName,
+      sequenceToken: token,
+    );
+    final res = await _client.putLogEvents(input).result;
+    if (res.rejectedLogEventsInfo != null) {
+      token ??= res.nextSequenceToken;
+      logEvents = [];
+    }
+  }
 }

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/cloud_watch_logs.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/cloud_watch_logs.dart
@@ -1,0 +1,26 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+/// # Amazon CloudWatch Logs
+///
+/// You can use Amazon CloudWatch Logs to monitor, store, and access your log files from EC2 instances, CloudTrail, and other sources. You can then retrieve the associated log data from CloudWatch Logs using the CloudWatch console, CloudWatch Logs commands in the Amazon Web Services CLI, CloudWatch Logs API, or CloudWatch Logs SDK.
+///
+/// You can use CloudWatch Logs to:
+///
+/// *   **Monitor logs from EC2 instances in real-time**: You can use CloudWatch Logs to monitor applications and systems using log data. For example, CloudWatch Logs can track the number of errors that occur in your application logs and send you a notification whenever the rate of errors exceeds a threshold that you specify. CloudWatch Logs uses your log data for monitoring so no code changes are required. For example, you can monitor application logs for specific literal terms (such as "NullReferenceException") or count the number of occurrences of a literal term at a particular position in log data (such as "404" status codes in an Apache access log). When the term you are searching for is found, CloudWatch Logs reports the data to a CloudWatch metric that you specify.
+///
+/// *   **Monitor CloudTrail logged events**: You can create alarms in CloudWatch and receive notifications of particular API activity as captured by CloudTrail. You can use the notification to perform troubleshooting.
+///
+/// *   **Archive log data**: You can use CloudWatch Logs to store your log data in highly durable storage. You can change the log retention setting so that any log events older than this setting are automatically deleted. The CloudWatch Logs agent makes it easy to quickly send both rotated and non-rotated log data off of a host and into the log service. You can then access the raw log data when you need it.
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs;
+
+export 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/cloud_watch_logs_client.dart';
+export 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.dart';
+export 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/input_log_event.dart';
+export 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart';
+export 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.dart';
+export 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart';
+export 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart';
+export 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.dart';
+export 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart';
+export 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart';
+export 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.dart';

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/cloud_watch_logs_client.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/cloud_watch_logs_client.dart
@@ -1,0 +1,87 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.cloud_watch_logs_client; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart'
+    as _i5;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart'
+    as _i4;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/operation/put_log_events_operation.dart'
+    as _i6;
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:aws_signature_v4/aws_signature_v4.dart' as _i2;
+import 'package:smithy/smithy.dart' as _i3;
+
+/// You can use Amazon CloudWatch Logs to monitor, store, and access your log files from EC2 instances, CloudTrail, and other sources. You can then retrieve the associated log data from CloudWatch Logs using the CloudWatch console, CloudWatch Logs commands in the Amazon Web Services CLI, CloudWatch Logs API, or CloudWatch Logs SDK.
+///
+/// You can use CloudWatch Logs to:
+///
+/// *   **Monitor logs from EC2 instances in real-time**: You can use CloudWatch Logs to monitor applications and systems using log data. For example, CloudWatch Logs can track the number of errors that occur in your application logs and send you a notification whenever the rate of errors exceeds a threshold that you specify. CloudWatch Logs uses your log data for monitoring so no code changes are required. For example, you can monitor application logs for specific literal terms (such as "NullReferenceException") or count the number of occurrences of a literal term at a particular position in log data (such as "404" status codes in an Apache access log). When the term you are searching for is found, CloudWatch Logs reports the data to a CloudWatch metric that you specify.
+///
+/// *   **Monitor CloudTrail logged events**: You can create alarms in CloudWatch and receive notifications of particular API activity as captured by CloudTrail. You can use the notification to perform troubleshooting.
+///
+/// *   **Archive log data**: You can use CloudWatch Logs to store your log data in highly durable storage. You can change the log retention setting so that any log events older than this setting are automatically deleted. The CloudWatch Logs agent makes it easy to quickly send both rotated and non-rotated log data off of a host and into the log service. You can then access the raw log data when you need it.
+class CloudWatchLogsClient {
+  /// You can use Amazon CloudWatch Logs to monitor, store, and access your log files from EC2 instances, CloudTrail, and other sources. You can then retrieve the associated log data from CloudWatch Logs using the CloudWatch console, CloudWatch Logs commands in the Amazon Web Services CLI, CloudWatch Logs API, or CloudWatch Logs SDK.
+  ///
+  /// You can use CloudWatch Logs to:
+  ///
+  /// *   **Monitor logs from EC2 instances in real-time**: You can use CloudWatch Logs to monitor applications and systems using log data. For example, CloudWatch Logs can track the number of errors that occur in your application logs and send you a notification whenever the rate of errors exceeds a threshold that you specify. CloudWatch Logs uses your log data for monitoring so no code changes are required. For example, you can monitor application logs for specific literal terms (such as "NullReferenceException") or count the number of occurrences of a literal term at a particular position in log data (such as "404" status codes in an Apache access log). When the term you are searching for is found, CloudWatch Logs reports the data to a CloudWatch metric that you specify.
+  ///
+  /// *   **Monitor CloudTrail logged events**: You can create alarms in CloudWatch and receive notifications of particular API activity as captured by CloudTrail. You can use the notification to perform troubleshooting.
+  ///
+  /// *   **Archive log data**: You can use CloudWatch Logs to store your log data in highly durable storage. You can change the log retention setting so that any log events older than this setting are automatically deleted. The CloudWatch Logs agent makes it easy to quickly send both rotated and non-rotated log data off of a host and into the log service. You can then access the raw log data when you need it.
+  const CloudWatchLogsClient({
+    _i1.AWSHttpClient? client,
+    required String region,
+    Uri? baseUri,
+    required _i2.AWSCredentialsProvider credentialsProvider,
+  })  : _client = client,
+        _region = region,
+        _baseUri = baseUri,
+        _credentialsProvider = credentialsProvider;
+
+  final _i1.AWSHttpClient? _client;
+
+  final String _region;
+
+  final Uri? _baseUri;
+
+  final _i2.AWSCredentialsProvider _credentialsProvider;
+
+  /// Uploads a batch of log events to the specified log stream.
+  ///
+  /// You must include the sequence token obtained from the response of the previous call. An upload in a newly created log stream does not require a sequence token. You can also get the sequence token in the `expectedSequenceToken` field from `InvalidSequenceTokenException`. If you call `PutLogEvents` twice within a narrow time period using the same value for `sequenceToken`, both calls might be successful or one might be rejected.
+  ///
+  /// The batch of events must satisfy the following constraints:
+  ///
+  /// *   The maximum batch size is 1,048,576 bytes. This size is calculated as the sum of all event messages in UTF-8, plus 26 bytes for each log event.
+  ///
+  /// *   None of the log events in the batch can be more than 2 hours in the future.
+  ///
+  /// *   None of the log events in the batch can be older than 14 days or older than the retention period of the log group.
+  ///
+  /// *   The log events in the batch must be in chronological order by their timestamp. The timestamp is the time the event occurred, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC. (In Amazon Web Services Tools for PowerShell and the Amazon Web Services SDK for .NET, the timestamp is specified in .NET format: yyyy-mm-ddThh:mm:ss. For example, 2017-09-15T13:45:30.)
+  ///
+  /// *   A batch of log events in a single request cannot span more than 24 hours. Otherwise, the operation fails.
+  ///
+  /// *   The maximum number of log events in a batch is 10,000.
+  ///
+  /// *   There is a quota of 5 requests per second per log stream. Additional requests are throttled. This quota can't be changed.
+  ///
+  ///
+  /// If a call to `PutLogEvents` returns "UnrecognizedClientException" the most likely cause is an invalid Amazon Web Services access key ID or secret key.
+  _i3.SmithyOperation<_i4.PutLogEventsResponse> putLogEvents(
+    _i5.PutLogEventsRequest input, {
+    _i1.AWSHttpClient? client,
+  }) {
+    return _i6.PutLogEventsOperation(
+      region: _region,
+      baseUri: _baseUri,
+      credentialsProvider: _credentialsProvider,
+    ).run(
+      input,
+      client: client ?? _client,
+    );
+  }
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/common/endpoint_resolver.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/common/endpoint_resolver.dart
@@ -1,0 +1,201 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.common.endpoint_resolver; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:meta/meta.dart' as _i2;
+import 'package:smithy_aws/smithy_aws.dart' as _i1;
+
+final _partitions = [
+  _i1.Partition(
+    id: 'aws',
+    regionRegex: RegExp(r'^(us|eu|ap|sa|ca|me|af)\-\w+\-\d+$'),
+    partitionEndpoint: null,
+    isRegionalized: true,
+    defaults: const _i1.EndpointDefinition(
+      hostname: 'logs.{region}.amazonaws.com',
+      protocols: ['https'],
+      signatureVersions: [_i1.AWSSignatureVersion.v4],
+      credentialScope: _i1.CredentialScope(),
+      variants: [],
+    ),
+    regions: const {
+      'af-south-1',
+      'ap-east-1',
+      'ap-northeast-1',
+      'ap-northeast-2',
+      'ap-northeast-3',
+      'ap-south-1',
+      'ap-southeast-1',
+      'ap-southeast-2',
+      'ap-southeast-3',
+      'ca-central-1',
+      'eu-central-1',
+      'eu-north-1',
+      'eu-south-1',
+      'eu-west-1',
+      'eu-west-2',
+      'eu-west-3',
+      'me-south-1',
+      'sa-east-1',
+      'us-east-1',
+      'us-east-2',
+      'us-west-1',
+      'us-west-2',
+    },
+    endpoints: const {
+      'af-south-1': _i1.EndpointDefinition(variants: []),
+      'ap-east-1': _i1.EndpointDefinition(variants: []),
+      'ap-northeast-1': _i1.EndpointDefinition(variants: []),
+      'ap-northeast-2': _i1.EndpointDefinition(variants: []),
+      'ap-northeast-3': _i1.EndpointDefinition(variants: []),
+      'ap-south-1': _i1.EndpointDefinition(variants: []),
+      'ap-southeast-1': _i1.EndpointDefinition(variants: []),
+      'ap-southeast-2': _i1.EndpointDefinition(variants: []),
+      'ap-southeast-3': _i1.EndpointDefinition(variants: []),
+      'ca-central-1': _i1.EndpointDefinition(variants: []),
+      'eu-central-1': _i1.EndpointDefinition(variants: []),
+      'eu-north-1': _i1.EndpointDefinition(variants: []),
+      'eu-south-1': _i1.EndpointDefinition(variants: []),
+      'eu-west-1': _i1.EndpointDefinition(variants: []),
+      'eu-west-2': _i1.EndpointDefinition(variants: []),
+      'eu-west-3': _i1.EndpointDefinition(variants: []),
+      'fips-us-east-1': _i1.EndpointDefinition(
+        hostname: 'logs-fips.us-east-1.amazonaws.com',
+        credentialScope: _i1.CredentialScope(region: 'us-east-1'),
+        variants: [],
+      ),
+      'fips-us-east-2': _i1.EndpointDefinition(
+        hostname: 'logs-fips.us-east-2.amazonaws.com',
+        credentialScope: _i1.CredentialScope(region: 'us-east-2'),
+        variants: [],
+      ),
+      'fips-us-west-1': _i1.EndpointDefinition(
+        hostname: 'logs-fips.us-west-1.amazonaws.com',
+        credentialScope: _i1.CredentialScope(region: 'us-west-1'),
+        variants: [],
+      ),
+      'fips-us-west-2': _i1.EndpointDefinition(
+        hostname: 'logs-fips.us-west-2.amazonaws.com',
+        credentialScope: _i1.CredentialScope(region: 'us-west-2'),
+        variants: [],
+      ),
+      'me-south-1': _i1.EndpointDefinition(variants: []),
+      'sa-east-1': _i1.EndpointDefinition(variants: []),
+      'us-east-1': _i1.EndpointDefinition(variants: [
+        _i1.EndpointDefinitionVariant(
+          hostname: 'logs-fips.us-east-1.amazonaws.com',
+          tags: ['fips'],
+        )
+      ]),
+      'us-east-2': _i1.EndpointDefinition(variants: [
+        _i1.EndpointDefinitionVariant(
+          hostname: 'logs-fips.us-east-2.amazonaws.com',
+          tags: ['fips'],
+        )
+      ]),
+      'us-west-1': _i1.EndpointDefinition(variants: [
+        _i1.EndpointDefinitionVariant(
+          hostname: 'logs-fips.us-west-1.amazonaws.com',
+          tags: ['fips'],
+        )
+      ]),
+      'us-west-2': _i1.EndpointDefinition(variants: [
+        _i1.EndpointDefinitionVariant(
+          hostname: 'logs-fips.us-west-2.amazonaws.com',
+          tags: ['fips'],
+        )
+      ]),
+    },
+  ),
+  _i1.Partition(
+    id: 'aws-cn',
+    regionRegex: RegExp(r'^cn\-\w+\-\d+$'),
+    partitionEndpoint: null,
+    isRegionalized: true,
+    defaults: const _i1.EndpointDefinition(
+      hostname: 'logs.{region}.amazonaws.com.cn',
+      protocols: ['https'],
+      signatureVersions: [_i1.AWSSignatureVersion.v4],
+      credentialScope: _i1.CredentialScope(),
+      variants: [],
+    ),
+    regions: const {
+      'cn-north-1',
+      'cn-northwest-1',
+    },
+    endpoints: const {
+      'cn-north-1': _i1.EndpointDefinition(variants: []),
+      'cn-northwest-1': _i1.EndpointDefinition(variants: []),
+    },
+  ),
+  _i1.Partition(
+    id: 'aws-iso',
+    regionRegex: RegExp(r'^us\-iso\-\w+\-\d+$'),
+    partitionEndpoint: null,
+    isRegionalized: true,
+    defaults: const _i1.EndpointDefinition(
+      hostname: 'logs.{region}.c2s.ic.gov',
+      protocols: ['https'],
+      signatureVersions: [_i1.AWSSignatureVersion.v4],
+      credentialScope: _i1.CredentialScope(),
+      variants: [],
+    ),
+    regions: const {
+      'us-iso-east-1',
+      'us-iso-west-1',
+    },
+    endpoints: const {
+      'us-iso-east-1': _i1.EndpointDefinition(variants: []),
+      'us-iso-west-1': _i1.EndpointDefinition(variants: []),
+    },
+  ),
+  _i1.Partition(
+    id: 'aws-iso-b',
+    regionRegex: RegExp(r'^us\-isob\-\w+\-\d+$'),
+    partitionEndpoint: null,
+    isRegionalized: true,
+    defaults: const _i1.EndpointDefinition(
+      hostname: 'logs.{region}.sc2s.sgov.gov',
+      protocols: ['https'],
+      signatureVersions: [_i1.AWSSignatureVersion.v4],
+      credentialScope: _i1.CredentialScope(),
+      variants: [],
+    ),
+    regions: const {'us-isob-east-1'},
+    endpoints: const {'us-isob-east-1': _i1.EndpointDefinition(variants: [])},
+  ),
+  _i1.Partition(
+    id: 'aws-us-gov',
+    regionRegex: RegExp(r'^us\-gov\-\w+\-\d+$'),
+    partitionEndpoint: null,
+    isRegionalized: true,
+    defaults: const _i1.EndpointDefinition(
+      hostname: 'logs.{region}.amazonaws.com',
+      protocols: ['https'],
+      signatureVersions: [_i1.AWSSignatureVersion.v4],
+      credentialScope: _i1.CredentialScope(),
+      variants: [],
+    ),
+    regions: const {
+      'us-gov-east-1',
+      'us-gov-west-1',
+    },
+    endpoints: const {
+      'us-gov-east-1': _i1.EndpointDefinition(
+        hostname: 'logs.us-gov-east-1.amazonaws.com',
+        credentialScope: _i1.CredentialScope(region: 'us-gov-east-1'),
+        variants: [],
+      ),
+      'us-gov-west-1': _i1.EndpointDefinition(
+        hostname: 'logs.us-gov-west-1.amazonaws.com',
+        credentialScope: _i1.CredentialScope(region: 'us-gov-west-1'),
+        variants: [],
+      ),
+    },
+  ),
+];
+@_i2.internal
+final _i1.AWSEndpointResolver endpointResolver =
+    _i1.AWSEndpointResolver(_partitions);
+@_i2.internal
+const String sdkId = 'CloudWatch Logs';

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/common/serializers.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/common/serializers.dart
@@ -1,0 +1,46 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.common.serializers; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.dart'
+    as _i6;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/input_log_event.dart'
+    as _i2;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart'
+    as _i7;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.dart'
+    as _i8;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart'
+    as _i3;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart'
+    as _i5;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.dart'
+    as _i4;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart'
+    as _i9;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart'
+    as _i10;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.dart'
+    as _i11;
+import 'package:built_collection/built_collection.dart' as _i12;
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i1;
+
+const List<_i1.SmithySerializer> serializers = [
+  ..._i2.InputLogEvent.serializers,
+  ..._i3.PutLogEventsRequest.serializers,
+  ..._i4.RejectedLogEventsInfo.serializers,
+  ..._i5.PutLogEventsResponse.serializers,
+  ..._i6.DataAlreadyAcceptedException.serializers,
+  ..._i7.InvalidParameterException.serializers,
+  ..._i8.InvalidSequenceTokenException.serializers,
+  ..._i9.ResourceNotFoundException.serializers,
+  ..._i10.ServiceUnavailableException.serializers,
+  ..._i11.UnrecognizedClientException.serializers,
+];
+final Map<FullType, Function> builderFactories = {
+  const FullType(
+    _i12.BuiltList,
+    [FullType(_i2.InputLogEvent)],
+  ): _i12.ListBuilder<_i2.InputLogEvent>.new
+};

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.dart
@@ -1,0 +1,170 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.data_already_accepted_exception; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i2;
+
+part 'data_already_accepted_exception.g.dart';
+
+/// The event was already logged.
+abstract class DataAlreadyAcceptedException
+    with
+        _i1.AWSEquatable<DataAlreadyAcceptedException>
+    implements
+        Built<DataAlreadyAcceptedException,
+            DataAlreadyAcceptedExceptionBuilder>,
+        _i2.SmithyHttpException {
+  /// The event was already logged.
+  factory DataAlreadyAcceptedException({
+    String? expectedSequenceToken,
+    String? message,
+  }) {
+    return _$DataAlreadyAcceptedException._(
+      expectedSequenceToken: expectedSequenceToken,
+      message: message,
+    );
+  }
+
+  /// The event was already logged.
+  factory DataAlreadyAcceptedException.build(
+          [void Function(DataAlreadyAcceptedExceptionBuilder) updates]) =
+      _$DataAlreadyAcceptedException;
+
+  const DataAlreadyAcceptedException._();
+
+  /// Constructs a [DataAlreadyAcceptedException] from a [payload] and [response].
+  factory DataAlreadyAcceptedException.fromResponse(
+    DataAlreadyAcceptedException payload,
+    _i1.AWSBaseHttpResponse response,
+  ) =>
+      payload.rebuild((b) {
+        b.statusCode = response.statusCode;
+        b.headers = response.headers;
+      });
+
+  static const List<_i2.SmithySerializer> serializers = [
+    DataAlreadyAcceptedExceptionAwsJson11Serializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(DataAlreadyAcceptedExceptionBuilder b) {}
+  String? get expectedSequenceToken;
+  @override
+  String? get message;
+  @override
+  _i2.ShapeId get shapeId => const _i2.ShapeId(
+        namespace: 'com.amazonaws.cloudwatchlogs',
+        shape: 'DataAlreadyAcceptedException',
+      );
+  @override
+  _i2.RetryConfig? get retryConfig => null;
+  @override
+  @BuiltValueField(compare: false)
+  int? get statusCode;
+  @override
+  @BuiltValueField(compare: false)
+  Map<String, String>? get headers;
+  @override
+  Exception? get underlyingException => null;
+  @override
+  List<Object?> get props => [
+        expectedSequenceToken,
+        message,
+      ];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('DataAlreadyAcceptedException');
+    helper.add(
+      'expectedSequenceToken',
+      expectedSequenceToken,
+    );
+    helper.add(
+      'message',
+      message,
+    );
+    return helper.toString();
+  }
+}
+
+class DataAlreadyAcceptedExceptionAwsJson11Serializer
+    extends _i2.StructuredSmithySerializer<DataAlreadyAcceptedException> {
+  const DataAlreadyAcceptedExceptionAwsJson11Serializer()
+      : super('DataAlreadyAcceptedException');
+
+  @override
+  Iterable<Type> get types => const [
+        DataAlreadyAcceptedException,
+        _$DataAlreadyAcceptedException,
+      ];
+  @override
+  Iterable<_i2.ShapeId> get supportedProtocols => const [
+        _i2.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'awsJson1_1',
+        )
+      ];
+  @override
+  DataAlreadyAcceptedException deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = DataAlreadyAcceptedExceptionBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'expectedSequenceToken':
+          if (value != null) {
+            result.expectedSequenceToken = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+        case 'message':
+          if (value != null) {
+            result.message = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = (object as DataAlreadyAcceptedException);
+    final result = <Object?>[];
+    if (payload.expectedSequenceToken != null) {
+      result
+        ..add('expectedSequenceToken')
+        ..add(serializers.serialize(
+          payload.expectedSequenceToken!,
+          specifiedType: const FullType(String),
+        ));
+    }
+    if (payload.message != null) {
+      result
+        ..add('message')
+        ..add(serializers.serialize(
+          payload.message!,
+          specifiedType: const FullType(String),
+        ));
+    }
+    return result;
+  }
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.g.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.g.dart
@@ -1,0 +1,115 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.data_already_accepted_exception;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$DataAlreadyAcceptedException extends DataAlreadyAcceptedException {
+  @override
+  final String? expectedSequenceToken;
+  @override
+  final String? message;
+  @override
+  final int? statusCode;
+  @override
+  final Map<String, String>? headers;
+
+  factory _$DataAlreadyAcceptedException(
+          [void Function(DataAlreadyAcceptedExceptionBuilder)? updates]) =>
+      (new DataAlreadyAcceptedExceptionBuilder()..update(updates))._build();
+
+  _$DataAlreadyAcceptedException._(
+      {this.expectedSequenceToken, this.message, this.statusCode, this.headers})
+      : super._();
+
+  @override
+  DataAlreadyAcceptedException rebuild(
+          void Function(DataAlreadyAcceptedExceptionBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DataAlreadyAcceptedExceptionBuilder toBuilder() =>
+      new DataAlreadyAcceptedExceptionBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DataAlreadyAcceptedException &&
+        expectedSequenceToken == other.expectedSequenceToken &&
+        message == other.message;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc($jc(0, expectedSequenceToken.hashCode), message.hashCode));
+  }
+}
+
+class DataAlreadyAcceptedExceptionBuilder
+    implements
+        Builder<DataAlreadyAcceptedException,
+            DataAlreadyAcceptedExceptionBuilder> {
+  _$DataAlreadyAcceptedException? _$v;
+
+  String? _expectedSequenceToken;
+  String? get expectedSequenceToken => _$this._expectedSequenceToken;
+  set expectedSequenceToken(String? expectedSequenceToken) =>
+      _$this._expectedSequenceToken = expectedSequenceToken;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(String? message) => _$this._message = message;
+
+  int? _statusCode;
+  int? get statusCode => _$this._statusCode;
+  set statusCode(int? statusCode) => _$this._statusCode = statusCode;
+
+  Map<String, String>? _headers;
+  Map<String, String>? get headers => _$this._headers;
+  set headers(Map<String, String>? headers) => _$this._headers = headers;
+
+  DataAlreadyAcceptedExceptionBuilder() {
+    DataAlreadyAcceptedException._init(this);
+  }
+
+  DataAlreadyAcceptedExceptionBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _expectedSequenceToken = $v.expectedSequenceToken;
+      _message = $v.message;
+      _statusCode = $v.statusCode;
+      _headers = $v.headers;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(DataAlreadyAcceptedException other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$DataAlreadyAcceptedException;
+  }
+
+  @override
+  void update(void Function(DataAlreadyAcceptedExceptionBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DataAlreadyAcceptedException build() => _build();
+
+  _$DataAlreadyAcceptedException _build() {
+    final _$result = _$v ??
+        new _$DataAlreadyAcceptedException._(
+            expectedSequenceToken: expectedSequenceToken,
+            message: message,
+            statusCode: statusCode,
+            headers: headers);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/input_log_event.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/input_log_event.dart
@@ -1,0 +1,137 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.input_log_event; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:fixnum/fixnum.dart' as _i2;
+import 'package:smithy/smithy.dart' as _i3;
+
+part 'input_log_event.g.dart';
+
+/// Represents a log event, which is a record of activity that was recorded by the application or resource being monitored.
+abstract class InputLogEvent
+    with _i1.AWSEquatable<InputLogEvent>
+    implements Built<InputLogEvent, InputLogEventBuilder> {
+  /// Represents a log event, which is a record of activity that was recorded by the application or resource being monitored.
+  factory InputLogEvent({
+    required String message,
+    _i2.Int64? timestamp,
+  }) {
+    timestamp ??= _i2.Int64.ZERO;
+    return _$InputLogEvent._(
+      message: message,
+      timestamp: timestamp,
+    );
+  }
+
+  /// Represents a log event, which is a record of activity that was recorded by the application or resource being monitored.
+  factory InputLogEvent.build([void Function(InputLogEventBuilder) updates]) =
+      _$InputLogEvent;
+
+  const InputLogEvent._();
+
+  static const List<_i3.SmithySerializer> serializers = [
+    InputLogEventAwsJson11Serializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(InputLogEventBuilder b) {
+    b.timestamp = _i2.Int64.ZERO;
+  }
+
+  /// The raw event message.
+  String get message;
+
+  /// The time the event occurred, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.
+  _i2.Int64 get timestamp;
+  @override
+  List<Object?> get props => [
+        message,
+        timestamp,
+      ];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('InputLogEvent');
+    helper.add(
+      'message',
+      message,
+    );
+    helper.add(
+      'timestamp',
+      timestamp,
+    );
+    return helper.toString();
+  }
+}
+
+class InputLogEventAwsJson11Serializer
+    extends _i3.StructuredSmithySerializer<InputLogEvent> {
+  const InputLogEventAwsJson11Serializer() : super('InputLogEvent');
+
+  @override
+  Iterable<Type> get types => const [
+        InputLogEvent,
+        _$InputLogEvent,
+      ];
+  @override
+  Iterable<_i3.ShapeId> get supportedProtocols => const [
+        _i3.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'awsJson1_1',
+        )
+      ];
+  @override
+  InputLogEvent deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = InputLogEventBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'message':
+          result.message = (serializers.deserialize(
+            value!,
+            specifiedType: const FullType(String),
+          ) as String);
+          break;
+        case 'timestamp':
+          result.timestamp = (serializers.deserialize(
+            value!,
+            specifiedType: const FullType(_i2.Int64),
+          ) as _i2.Int64);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = (object as InputLogEvent);
+    final result = <Object?>[
+      'message',
+      serializers.serialize(
+        payload.message,
+        specifiedType: const FullType(String),
+      ),
+      'timestamp',
+      serializers.serialize(
+        payload.timestamp,
+        specifiedType: const FullType(_i2.Int64),
+      ),
+    ];
+    return result;
+  }
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/input_log_event.g.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/input_log_event.g.dart
@@ -1,0 +1,98 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.input_log_event;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$InputLogEvent extends InputLogEvent {
+  @override
+  final String message;
+  @override
+  final _i2.Int64 timestamp;
+
+  factory _$InputLogEvent([void Function(InputLogEventBuilder)? updates]) =>
+      (new InputLogEventBuilder()..update(updates))._build();
+
+  _$InputLogEvent._({required this.message, required this.timestamp})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(message, r'InputLogEvent', 'message');
+    BuiltValueNullFieldError.checkNotNull(
+        timestamp, r'InputLogEvent', 'timestamp');
+  }
+
+  @override
+  InputLogEvent rebuild(void Function(InputLogEventBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  InputLogEventBuilder toBuilder() => new InputLogEventBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is InputLogEvent &&
+        message == other.message &&
+        timestamp == other.timestamp;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc($jc(0, message.hashCode), timestamp.hashCode));
+  }
+}
+
+class InputLogEventBuilder
+    implements Builder<InputLogEvent, InputLogEventBuilder> {
+  _$InputLogEvent? _$v;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(String? message) => _$this._message = message;
+
+  _i2.Int64? _timestamp;
+  _i2.Int64? get timestamp => _$this._timestamp;
+  set timestamp(_i2.Int64? timestamp) => _$this._timestamp = timestamp;
+
+  InputLogEventBuilder() {
+    InputLogEvent._init(this);
+  }
+
+  InputLogEventBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _message = $v.message;
+      _timestamp = $v.timestamp;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(InputLogEvent other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$InputLogEvent;
+  }
+
+  @override
+  void update(void Function(InputLogEventBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  InputLogEvent build() => _build();
+
+  _$InputLogEvent _build() {
+    final _$result = _$v ??
+        new _$InputLogEvent._(
+            message: BuiltValueNullFieldError.checkNotNull(
+                message, r'InputLogEvent', 'message'),
+            timestamp: BuiltValueNullFieldError.checkNotNull(
+                timestamp, r'InputLogEvent', 'timestamp'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart
@@ -1,0 +1,138 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.invalid_parameter_exception; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i2;
+
+part 'invalid_parameter_exception.g.dart';
+
+/// A parameter is specified incorrectly.
+abstract class InvalidParameterException
+    with _i1.AWSEquatable<InvalidParameterException>
+    implements
+        Built<InvalidParameterException, InvalidParameterExceptionBuilder>,
+        _i2.SmithyHttpException {
+  /// A parameter is specified incorrectly.
+  factory InvalidParameterException({String? message}) {
+    return _$InvalidParameterException._(message: message);
+  }
+
+  /// A parameter is specified incorrectly.
+  factory InvalidParameterException.build(
+          [void Function(InvalidParameterExceptionBuilder) updates]) =
+      _$InvalidParameterException;
+
+  const InvalidParameterException._();
+
+  /// Constructs a [InvalidParameterException] from a [payload] and [response].
+  factory InvalidParameterException.fromResponse(
+    InvalidParameterException payload,
+    _i1.AWSBaseHttpResponse response,
+  ) =>
+      payload.rebuild((b) {
+        b.statusCode = response.statusCode;
+        b.headers = response.headers;
+      });
+
+  static const List<_i2.SmithySerializer> serializers = [
+    InvalidParameterExceptionAwsJson11Serializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(InvalidParameterExceptionBuilder b) {}
+  @override
+  String? get message;
+  @override
+  _i2.ShapeId get shapeId => const _i2.ShapeId(
+        namespace: 'com.amazonaws.cloudwatchlogs',
+        shape: 'InvalidParameterException',
+      );
+  @override
+  _i2.RetryConfig? get retryConfig => null;
+  @override
+  @BuiltValueField(compare: false)
+  int? get statusCode;
+  @override
+  @BuiltValueField(compare: false)
+  Map<String, String>? get headers;
+  @override
+  Exception? get underlyingException => null;
+  @override
+  List<Object?> get props => [message];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('InvalidParameterException');
+    helper.add(
+      'message',
+      message,
+    );
+    return helper.toString();
+  }
+}
+
+class InvalidParameterExceptionAwsJson11Serializer
+    extends _i2.StructuredSmithySerializer<InvalidParameterException> {
+  const InvalidParameterExceptionAwsJson11Serializer()
+      : super('InvalidParameterException');
+
+  @override
+  Iterable<Type> get types => const [
+        InvalidParameterException,
+        _$InvalidParameterException,
+      ];
+  @override
+  Iterable<_i2.ShapeId> get supportedProtocols => const [
+        _i2.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'awsJson1_1',
+        )
+      ];
+  @override
+  InvalidParameterException deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = InvalidParameterExceptionBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'message':
+          if (value != null) {
+            result.message = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = (object as InvalidParameterException);
+    final result = <Object?>[];
+    if (payload.message != null) {
+      result
+        ..add('message')
+        ..add(serializers.serialize(
+          payload.message!,
+          specifiedType: const FullType(String),
+        ));
+    }
+    return result;
+  }
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.g.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.g.dart
@@ -1,0 +1,100 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.invalid_parameter_exception;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$InvalidParameterException extends InvalidParameterException {
+  @override
+  final String? message;
+  @override
+  final int? statusCode;
+  @override
+  final Map<String, String>? headers;
+
+  factory _$InvalidParameterException(
+          [void Function(InvalidParameterExceptionBuilder)? updates]) =>
+      (new InvalidParameterExceptionBuilder()..update(updates))._build();
+
+  _$InvalidParameterException._({this.message, this.statusCode, this.headers})
+      : super._();
+
+  @override
+  InvalidParameterException rebuild(
+          void Function(InvalidParameterExceptionBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  InvalidParameterExceptionBuilder toBuilder() =>
+      new InvalidParameterExceptionBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is InvalidParameterException && message == other.message;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, message.hashCode));
+  }
+}
+
+class InvalidParameterExceptionBuilder
+    implements
+        Builder<InvalidParameterException, InvalidParameterExceptionBuilder> {
+  _$InvalidParameterException? _$v;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(String? message) => _$this._message = message;
+
+  int? _statusCode;
+  int? get statusCode => _$this._statusCode;
+  set statusCode(int? statusCode) => _$this._statusCode = statusCode;
+
+  Map<String, String>? _headers;
+  Map<String, String>? get headers => _$this._headers;
+  set headers(Map<String, String>? headers) => _$this._headers = headers;
+
+  InvalidParameterExceptionBuilder() {
+    InvalidParameterException._init(this);
+  }
+
+  InvalidParameterExceptionBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _message = $v.message;
+      _statusCode = $v.statusCode;
+      _headers = $v.headers;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(InvalidParameterException other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$InvalidParameterException;
+  }
+
+  @override
+  void update(void Function(InvalidParameterExceptionBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  InvalidParameterException build() => _build();
+
+  _$InvalidParameterException _build() {
+    final _$result = _$v ??
+        new _$InvalidParameterException._(
+            message: message, statusCode: statusCode, headers: headers);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.dart
@@ -1,0 +1,170 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.invalid_sequence_token_exception; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i2;
+
+part 'invalid_sequence_token_exception.g.dart';
+
+/// The sequence token is not valid. You can get the correct sequence token in the `expectedSequenceToken` field in the `InvalidSequenceTokenException` message.
+abstract class InvalidSequenceTokenException
+    with
+        _i1.AWSEquatable<InvalidSequenceTokenException>
+    implements
+        Built<InvalidSequenceTokenException,
+            InvalidSequenceTokenExceptionBuilder>,
+        _i2.SmithyHttpException {
+  /// The sequence token is not valid. You can get the correct sequence token in the `expectedSequenceToken` field in the `InvalidSequenceTokenException` message.
+  factory InvalidSequenceTokenException({
+    String? expectedSequenceToken,
+    String? message,
+  }) {
+    return _$InvalidSequenceTokenException._(
+      expectedSequenceToken: expectedSequenceToken,
+      message: message,
+    );
+  }
+
+  /// The sequence token is not valid. You can get the correct sequence token in the `expectedSequenceToken` field in the `InvalidSequenceTokenException` message.
+  factory InvalidSequenceTokenException.build(
+          [void Function(InvalidSequenceTokenExceptionBuilder) updates]) =
+      _$InvalidSequenceTokenException;
+
+  const InvalidSequenceTokenException._();
+
+  /// Constructs a [InvalidSequenceTokenException] from a [payload] and [response].
+  factory InvalidSequenceTokenException.fromResponse(
+    InvalidSequenceTokenException payload,
+    _i1.AWSBaseHttpResponse response,
+  ) =>
+      payload.rebuild((b) {
+        b.statusCode = response.statusCode;
+        b.headers = response.headers;
+      });
+
+  static const List<_i2.SmithySerializer> serializers = [
+    InvalidSequenceTokenExceptionAwsJson11Serializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(InvalidSequenceTokenExceptionBuilder b) {}
+  String? get expectedSequenceToken;
+  @override
+  String? get message;
+  @override
+  _i2.ShapeId get shapeId => const _i2.ShapeId(
+        namespace: 'com.amazonaws.cloudwatchlogs',
+        shape: 'InvalidSequenceTokenException',
+      );
+  @override
+  _i2.RetryConfig? get retryConfig => null;
+  @override
+  @BuiltValueField(compare: false)
+  int? get statusCode;
+  @override
+  @BuiltValueField(compare: false)
+  Map<String, String>? get headers;
+  @override
+  Exception? get underlyingException => null;
+  @override
+  List<Object?> get props => [
+        expectedSequenceToken,
+        message,
+      ];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('InvalidSequenceTokenException');
+    helper.add(
+      'expectedSequenceToken',
+      expectedSequenceToken,
+    );
+    helper.add(
+      'message',
+      message,
+    );
+    return helper.toString();
+  }
+}
+
+class InvalidSequenceTokenExceptionAwsJson11Serializer
+    extends _i2.StructuredSmithySerializer<InvalidSequenceTokenException> {
+  const InvalidSequenceTokenExceptionAwsJson11Serializer()
+      : super('InvalidSequenceTokenException');
+
+  @override
+  Iterable<Type> get types => const [
+        InvalidSequenceTokenException,
+        _$InvalidSequenceTokenException,
+      ];
+  @override
+  Iterable<_i2.ShapeId> get supportedProtocols => const [
+        _i2.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'awsJson1_1',
+        )
+      ];
+  @override
+  InvalidSequenceTokenException deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = InvalidSequenceTokenExceptionBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'expectedSequenceToken':
+          if (value != null) {
+            result.expectedSequenceToken = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+        case 'message':
+          if (value != null) {
+            result.message = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = (object as InvalidSequenceTokenException);
+    final result = <Object?>[];
+    if (payload.expectedSequenceToken != null) {
+      result
+        ..add('expectedSequenceToken')
+        ..add(serializers.serialize(
+          payload.expectedSequenceToken!,
+          specifiedType: const FullType(String),
+        ));
+    }
+    if (payload.message != null) {
+      result
+        ..add('message')
+        ..add(serializers.serialize(
+          payload.message!,
+          specifiedType: const FullType(String),
+        ));
+    }
+    return result;
+  }
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.g.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.g.dart
@@ -1,0 +1,115 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.invalid_sequence_token_exception;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$InvalidSequenceTokenException extends InvalidSequenceTokenException {
+  @override
+  final String? expectedSequenceToken;
+  @override
+  final String? message;
+  @override
+  final int? statusCode;
+  @override
+  final Map<String, String>? headers;
+
+  factory _$InvalidSequenceTokenException(
+          [void Function(InvalidSequenceTokenExceptionBuilder)? updates]) =>
+      (new InvalidSequenceTokenExceptionBuilder()..update(updates))._build();
+
+  _$InvalidSequenceTokenException._(
+      {this.expectedSequenceToken, this.message, this.statusCode, this.headers})
+      : super._();
+
+  @override
+  InvalidSequenceTokenException rebuild(
+          void Function(InvalidSequenceTokenExceptionBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  InvalidSequenceTokenExceptionBuilder toBuilder() =>
+      new InvalidSequenceTokenExceptionBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is InvalidSequenceTokenException &&
+        expectedSequenceToken == other.expectedSequenceToken &&
+        message == other.message;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc($jc(0, expectedSequenceToken.hashCode), message.hashCode));
+  }
+}
+
+class InvalidSequenceTokenExceptionBuilder
+    implements
+        Builder<InvalidSequenceTokenException,
+            InvalidSequenceTokenExceptionBuilder> {
+  _$InvalidSequenceTokenException? _$v;
+
+  String? _expectedSequenceToken;
+  String? get expectedSequenceToken => _$this._expectedSequenceToken;
+  set expectedSequenceToken(String? expectedSequenceToken) =>
+      _$this._expectedSequenceToken = expectedSequenceToken;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(String? message) => _$this._message = message;
+
+  int? _statusCode;
+  int? get statusCode => _$this._statusCode;
+  set statusCode(int? statusCode) => _$this._statusCode = statusCode;
+
+  Map<String, String>? _headers;
+  Map<String, String>? get headers => _$this._headers;
+  set headers(Map<String, String>? headers) => _$this._headers = headers;
+
+  InvalidSequenceTokenExceptionBuilder() {
+    InvalidSequenceTokenException._init(this);
+  }
+
+  InvalidSequenceTokenExceptionBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _expectedSequenceToken = $v.expectedSequenceToken;
+      _message = $v.message;
+      _statusCode = $v.statusCode;
+      _headers = $v.headers;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(InvalidSequenceTokenException other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$InvalidSequenceTokenException;
+  }
+
+  @override
+  void update(void Function(InvalidSequenceTokenExceptionBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  InvalidSequenceTokenException build() => _build();
+
+  _$InvalidSequenceTokenException _build() {
+    final _$result = _$v ??
+        new _$InvalidSequenceTokenException._(
+            expectedSequenceToken: expectedSequenceToken,
+            message: message,
+            statusCode: statusCode,
+            headers: headers);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart
@@ -1,0 +1,198 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.put_log_events_request; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/input_log_event.dart'
+    as _i3;
+import 'package:aws_common/aws_common.dart' as _i2;
+import 'package:built_collection/built_collection.dart' as _i4;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i1;
+
+part 'put_log_events_request.g.dart';
+
+abstract class PutLogEventsRequest
+    with
+        _i1.HttpInput<PutLogEventsRequest>,
+        _i2.AWSEquatable<PutLogEventsRequest>
+    implements Built<PutLogEventsRequest, PutLogEventsRequestBuilder> {
+  factory PutLogEventsRequest({
+    required List<_i3.InputLogEvent> logEvents,
+    required String logGroupName,
+    required String logStreamName,
+    String? sequenceToken,
+  }) {
+    return _$PutLogEventsRequest._(
+      logEvents: _i4.BuiltList(logEvents),
+      logGroupName: logGroupName,
+      logStreamName: logStreamName,
+      sequenceToken: sequenceToken,
+    );
+  }
+
+  factory PutLogEventsRequest.build(
+          [void Function(PutLogEventsRequestBuilder) updates]) =
+      _$PutLogEventsRequest;
+
+  const PutLogEventsRequest._();
+
+  factory PutLogEventsRequest.fromRequest(
+    PutLogEventsRequest payload,
+    _i2.AWSBaseHttpRequest request, {
+    Map<String, String> labels = const {},
+  }) =>
+      payload;
+
+  static const List<_i1.SmithySerializer> serializers = [
+    PutLogEventsRequestAwsJson11Serializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(PutLogEventsRequestBuilder b) {}
+
+  /// The log events.
+  _i4.BuiltList<_i3.InputLogEvent> get logEvents;
+
+  /// The name of the log group.
+  String get logGroupName;
+
+  /// The name of the log stream.
+  String get logStreamName;
+
+  /// The sequence token obtained from the response of the previous `PutLogEvents` call. An upload in a newly created log stream does not require a sequence token. You can also get the sequence token using [DescribeLogStreams](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogStreams.html). If you call `PutLogEvents` twice within a narrow time period using the same value for `sequenceToken`, both calls might be successful or one might be rejected.
+  String? get sequenceToken;
+  @override
+  PutLogEventsRequest getPayload() => this;
+  @override
+  List<Object?> get props => [
+        logEvents,
+        logGroupName,
+        logStreamName,
+        sequenceToken,
+      ];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('PutLogEventsRequest');
+    helper.add(
+      'logEvents',
+      logEvents,
+    );
+    helper.add(
+      'logGroupName',
+      logGroupName,
+    );
+    helper.add(
+      'logStreamName',
+      logStreamName,
+    );
+    helper.add(
+      'sequenceToken',
+      sequenceToken,
+    );
+    return helper.toString();
+  }
+}
+
+class PutLogEventsRequestAwsJson11Serializer
+    extends _i1.StructuredSmithySerializer<PutLogEventsRequest> {
+  const PutLogEventsRequestAwsJson11Serializer() : super('PutLogEventsRequest');
+
+  @override
+  Iterable<Type> get types => const [
+        PutLogEventsRequest,
+        _$PutLogEventsRequest,
+      ];
+  @override
+  Iterable<_i1.ShapeId> get supportedProtocols => const [
+        _i1.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'awsJson1_1',
+        )
+      ];
+  @override
+  PutLogEventsRequest deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = PutLogEventsRequestBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'logEvents':
+          result.logEvents.replace((serializers.deserialize(
+            value,
+            specifiedType: const FullType(
+              _i4.BuiltList,
+              [FullType(_i3.InputLogEvent)],
+            ),
+          ) as _i4.BuiltList<_i3.InputLogEvent>));
+          break;
+        case 'logGroupName':
+          result.logGroupName = (serializers.deserialize(
+            value!,
+            specifiedType: const FullType(String),
+          ) as String);
+          break;
+        case 'logStreamName':
+          result.logStreamName = (serializers.deserialize(
+            value!,
+            specifiedType: const FullType(String),
+          ) as String);
+          break;
+        case 'sequenceToken':
+          if (value != null) {
+            result.sequenceToken = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = (object as PutLogEventsRequest);
+    final result = <Object?>[
+      'logEvents',
+      serializers.serialize(
+        payload.logEvents,
+        specifiedType: const FullType(
+          _i4.BuiltList,
+          [FullType(_i3.InputLogEvent)],
+        ),
+      ),
+      'logGroupName',
+      serializers.serialize(
+        payload.logGroupName,
+        specifiedType: const FullType(String),
+      ),
+      'logStreamName',
+      serializers.serialize(
+        payload.logStreamName,
+        specifiedType: const FullType(String),
+      ),
+    ];
+    if (payload.sequenceToken != null) {
+      result
+        ..add('sequenceToken')
+        ..add(serializers.serialize(
+          payload.sequenceToken!,
+          specifiedType: const FullType(String),
+        ));
+    }
+    return result;
+  }
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_request.g.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_request.g.dart
@@ -1,0 +1,146 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.put_log_events_request;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$PutLogEventsRequest extends PutLogEventsRequest {
+  @override
+  final _i4.BuiltList<_i3.InputLogEvent> logEvents;
+  @override
+  final String logGroupName;
+  @override
+  final String logStreamName;
+  @override
+  final String? sequenceToken;
+
+  factory _$PutLogEventsRequest(
+          [void Function(PutLogEventsRequestBuilder)? updates]) =>
+      (new PutLogEventsRequestBuilder()..update(updates))._build();
+
+  _$PutLogEventsRequest._(
+      {required this.logEvents,
+      required this.logGroupName,
+      required this.logStreamName,
+      this.sequenceToken})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        logEvents, r'PutLogEventsRequest', 'logEvents');
+    BuiltValueNullFieldError.checkNotNull(
+        logGroupName, r'PutLogEventsRequest', 'logGroupName');
+    BuiltValueNullFieldError.checkNotNull(
+        logStreamName, r'PutLogEventsRequest', 'logStreamName');
+  }
+
+  @override
+  PutLogEventsRequest rebuild(
+          void Function(PutLogEventsRequestBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PutLogEventsRequestBuilder toBuilder() =>
+      new PutLogEventsRequestBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PutLogEventsRequest &&
+        logEvents == other.logEvents &&
+        logGroupName == other.logGroupName &&
+        logStreamName == other.logStreamName &&
+        sequenceToken == other.sequenceToken;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc($jc($jc(0, logEvents.hashCode), logGroupName.hashCode),
+            logStreamName.hashCode),
+        sequenceToken.hashCode));
+  }
+}
+
+class PutLogEventsRequestBuilder
+    implements Builder<PutLogEventsRequest, PutLogEventsRequestBuilder> {
+  _$PutLogEventsRequest? _$v;
+
+  _i4.ListBuilder<_i3.InputLogEvent>? _logEvents;
+  _i4.ListBuilder<_i3.InputLogEvent> get logEvents =>
+      _$this._logEvents ??= new _i4.ListBuilder<_i3.InputLogEvent>();
+  set logEvents(_i4.ListBuilder<_i3.InputLogEvent>? logEvents) =>
+      _$this._logEvents = logEvents;
+
+  String? _logGroupName;
+  String? get logGroupName => _$this._logGroupName;
+  set logGroupName(String? logGroupName) => _$this._logGroupName = logGroupName;
+
+  String? _logStreamName;
+  String? get logStreamName => _$this._logStreamName;
+  set logStreamName(String? logStreamName) =>
+      _$this._logStreamName = logStreamName;
+
+  String? _sequenceToken;
+  String? get sequenceToken => _$this._sequenceToken;
+  set sequenceToken(String? sequenceToken) =>
+      _$this._sequenceToken = sequenceToken;
+
+  PutLogEventsRequestBuilder() {
+    PutLogEventsRequest._init(this);
+  }
+
+  PutLogEventsRequestBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _logEvents = $v.logEvents.toBuilder();
+      _logGroupName = $v.logGroupName;
+      _logStreamName = $v.logStreamName;
+      _sequenceToken = $v.sequenceToken;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(PutLogEventsRequest other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PutLogEventsRequest;
+  }
+
+  @override
+  void update(void Function(PutLogEventsRequestBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PutLogEventsRequest build() => _build();
+
+  _$PutLogEventsRequest _build() {
+    _$PutLogEventsRequest _$result;
+    try {
+      _$result = _$v ??
+          new _$PutLogEventsRequest._(
+              logEvents: logEvents.build(),
+              logGroupName: BuiltValueNullFieldError.checkNotNull(
+                  logGroupName, r'PutLogEventsRequest', 'logGroupName'),
+              logStreamName: BuiltValueNullFieldError.checkNotNull(
+                  logStreamName, r'PutLogEventsRequest', 'logStreamName'),
+              sequenceToken: sequenceToken);
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'logEvents';
+        logEvents.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'PutLogEventsRequest', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart
@@ -1,0 +1,150 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.put_log_events_response; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.dart'
+    as _i2;
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i3;
+
+part 'put_log_events_response.g.dart';
+
+abstract class PutLogEventsResponse
+    with _i1.AWSEquatable<PutLogEventsResponse>
+    implements Built<PutLogEventsResponse, PutLogEventsResponseBuilder> {
+  factory PutLogEventsResponse({
+    String? nextSequenceToken,
+    _i2.RejectedLogEventsInfo? rejectedLogEventsInfo,
+  }) {
+    return _$PutLogEventsResponse._(
+      nextSequenceToken: nextSequenceToken,
+      rejectedLogEventsInfo: rejectedLogEventsInfo,
+    );
+  }
+
+  factory PutLogEventsResponse.build(
+          [void Function(PutLogEventsResponseBuilder) updates]) =
+      _$PutLogEventsResponse;
+
+  const PutLogEventsResponse._();
+
+  /// Constructs a [PutLogEventsResponse] from a [payload] and [response].
+  factory PutLogEventsResponse.fromResponse(
+    PutLogEventsResponse payload,
+    _i1.AWSBaseHttpResponse response,
+  ) =>
+      payload;
+
+  static const List<_i3.SmithySerializer> serializers = [
+    PutLogEventsResponseAwsJson11Serializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(PutLogEventsResponseBuilder b) {}
+
+  /// The next sequence token.
+  String? get nextSequenceToken;
+
+  /// The rejected events.
+  _i2.RejectedLogEventsInfo? get rejectedLogEventsInfo;
+  @override
+  List<Object?> get props => [
+        nextSequenceToken,
+        rejectedLogEventsInfo,
+      ];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('PutLogEventsResponse');
+    helper.add(
+      'nextSequenceToken',
+      nextSequenceToken,
+    );
+    helper.add(
+      'rejectedLogEventsInfo',
+      rejectedLogEventsInfo,
+    );
+    return helper.toString();
+  }
+}
+
+class PutLogEventsResponseAwsJson11Serializer
+    extends _i3.StructuredSmithySerializer<PutLogEventsResponse> {
+  const PutLogEventsResponseAwsJson11Serializer()
+      : super('PutLogEventsResponse');
+
+  @override
+  Iterable<Type> get types => const [
+        PutLogEventsResponse,
+        _$PutLogEventsResponse,
+      ];
+  @override
+  Iterable<_i3.ShapeId> get supportedProtocols => const [
+        _i3.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'awsJson1_1',
+        )
+      ];
+  @override
+  PutLogEventsResponse deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = PutLogEventsResponseBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'nextSequenceToken':
+          if (value != null) {
+            result.nextSequenceToken = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+        case 'rejectedLogEventsInfo':
+          if (value != null) {
+            result.rejectedLogEventsInfo.replace((serializers.deserialize(
+              value,
+              specifiedType: const FullType(_i2.RejectedLogEventsInfo),
+            ) as _i2.RejectedLogEventsInfo));
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = (object as PutLogEventsResponse);
+    final result = <Object?>[];
+    if (payload.nextSequenceToken != null) {
+      result
+        ..add('nextSequenceToken')
+        ..add(serializers.serialize(
+          payload.nextSequenceToken!,
+          specifiedType: const FullType(String),
+        ));
+    }
+    if (payload.rejectedLogEventsInfo != null) {
+      result
+        ..add('rejectedLogEventsInfo')
+        ..add(serializers.serialize(
+          payload.rejectedLogEventsInfo!,
+          specifiedType: const FullType(_i2.RejectedLogEventsInfo),
+        ));
+    }
+    return result;
+  }
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_response.g.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_response.g.dart
@@ -1,0 +1,113 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.put_log_events_response;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$PutLogEventsResponse extends PutLogEventsResponse {
+  @override
+  final String? nextSequenceToken;
+  @override
+  final _i2.RejectedLogEventsInfo? rejectedLogEventsInfo;
+
+  factory _$PutLogEventsResponse(
+          [void Function(PutLogEventsResponseBuilder)? updates]) =>
+      (new PutLogEventsResponseBuilder()..update(updates))._build();
+
+  _$PutLogEventsResponse._({this.nextSequenceToken, this.rejectedLogEventsInfo})
+      : super._();
+
+  @override
+  PutLogEventsResponse rebuild(
+          void Function(PutLogEventsResponseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PutLogEventsResponseBuilder toBuilder() =>
+      new PutLogEventsResponseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PutLogEventsResponse &&
+        nextSequenceToken == other.nextSequenceToken &&
+        rejectedLogEventsInfo == other.rejectedLogEventsInfo;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc(0, nextSequenceToken.hashCode), rejectedLogEventsInfo.hashCode));
+  }
+}
+
+class PutLogEventsResponseBuilder
+    implements Builder<PutLogEventsResponse, PutLogEventsResponseBuilder> {
+  _$PutLogEventsResponse? _$v;
+
+  String? _nextSequenceToken;
+  String? get nextSequenceToken => _$this._nextSequenceToken;
+  set nextSequenceToken(String? nextSequenceToken) =>
+      _$this._nextSequenceToken = nextSequenceToken;
+
+  _i2.RejectedLogEventsInfoBuilder? _rejectedLogEventsInfo;
+  _i2.RejectedLogEventsInfoBuilder get rejectedLogEventsInfo =>
+      _$this._rejectedLogEventsInfo ??= new _i2.RejectedLogEventsInfoBuilder();
+  set rejectedLogEventsInfo(
+          _i2.RejectedLogEventsInfoBuilder? rejectedLogEventsInfo) =>
+      _$this._rejectedLogEventsInfo = rejectedLogEventsInfo;
+
+  PutLogEventsResponseBuilder() {
+    PutLogEventsResponse._init(this);
+  }
+
+  PutLogEventsResponseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _nextSequenceToken = $v.nextSequenceToken;
+      _rejectedLogEventsInfo = $v.rejectedLogEventsInfo?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(PutLogEventsResponse other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PutLogEventsResponse;
+  }
+
+  @override
+  void update(void Function(PutLogEventsResponseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PutLogEventsResponse build() => _build();
+
+  _$PutLogEventsResponse _build() {
+    _$PutLogEventsResponse _$result;
+    try {
+      _$result = _$v ??
+          new _$PutLogEventsResponse._(
+              nextSequenceToken: nextSequenceToken,
+              rejectedLogEventsInfo: _rejectedLogEventsInfo?.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'rejectedLogEventsInfo';
+        _rejectedLogEventsInfo?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'PutLogEventsResponse', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.dart
@@ -1,0 +1,170 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.rejected_log_events_info; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i2;
+
+part 'rejected_log_events_info.g.dart';
+
+/// Represents the rejected events.
+abstract class RejectedLogEventsInfo
+    with _i1.AWSEquatable<RejectedLogEventsInfo>
+    implements Built<RejectedLogEventsInfo, RejectedLogEventsInfoBuilder> {
+  /// Represents the rejected events.
+  factory RejectedLogEventsInfo({
+    int? expiredLogEventEndIndex,
+    int? tooNewLogEventStartIndex,
+    int? tooOldLogEventEndIndex,
+  }) {
+    return _$RejectedLogEventsInfo._(
+      expiredLogEventEndIndex: expiredLogEventEndIndex,
+      tooNewLogEventStartIndex: tooNewLogEventStartIndex,
+      tooOldLogEventEndIndex: tooOldLogEventEndIndex,
+    );
+  }
+
+  /// Represents the rejected events.
+  factory RejectedLogEventsInfo.build(
+          [void Function(RejectedLogEventsInfoBuilder) updates]) =
+      _$RejectedLogEventsInfo;
+
+  const RejectedLogEventsInfo._();
+
+  static const List<_i2.SmithySerializer> serializers = [
+    RejectedLogEventsInfoAwsJson11Serializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(RejectedLogEventsInfoBuilder b) {}
+
+  /// The expired log events.
+  int? get expiredLogEventEndIndex;
+
+  /// The log events that are too new.
+  int? get tooNewLogEventStartIndex;
+
+  /// The log events that are too old.
+  int? get tooOldLogEventEndIndex;
+  @override
+  List<Object?> get props => [
+        expiredLogEventEndIndex,
+        tooNewLogEventStartIndex,
+        tooOldLogEventEndIndex,
+      ];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('RejectedLogEventsInfo');
+    helper.add(
+      'expiredLogEventEndIndex',
+      expiredLogEventEndIndex,
+    );
+    helper.add(
+      'tooNewLogEventStartIndex',
+      tooNewLogEventStartIndex,
+    );
+    helper.add(
+      'tooOldLogEventEndIndex',
+      tooOldLogEventEndIndex,
+    );
+    return helper.toString();
+  }
+}
+
+class RejectedLogEventsInfoAwsJson11Serializer
+    extends _i2.StructuredSmithySerializer<RejectedLogEventsInfo> {
+  const RejectedLogEventsInfoAwsJson11Serializer()
+      : super('RejectedLogEventsInfo');
+
+  @override
+  Iterable<Type> get types => const [
+        RejectedLogEventsInfo,
+        _$RejectedLogEventsInfo,
+      ];
+  @override
+  Iterable<_i2.ShapeId> get supportedProtocols => const [
+        _i2.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'awsJson1_1',
+        )
+      ];
+  @override
+  RejectedLogEventsInfo deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = RejectedLogEventsInfoBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'expiredLogEventEndIndex':
+          if (value != null) {
+            result.expiredLogEventEndIndex = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(int),
+            ) as int);
+          }
+          break;
+        case 'tooNewLogEventStartIndex':
+          if (value != null) {
+            result.tooNewLogEventStartIndex = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(int),
+            ) as int);
+          }
+          break;
+        case 'tooOldLogEventEndIndex':
+          if (value != null) {
+            result.tooOldLogEventEndIndex = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(int),
+            ) as int);
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = (object as RejectedLogEventsInfo);
+    final result = <Object?>[];
+    if (payload.expiredLogEventEndIndex != null) {
+      result
+        ..add('expiredLogEventEndIndex')
+        ..add(serializers.serialize(
+          payload.expiredLogEventEndIndex!,
+          specifiedType: const FullType(int),
+        ));
+    }
+    if (payload.tooNewLogEventStartIndex != null) {
+      result
+        ..add('tooNewLogEventStartIndex')
+        ..add(serializers.serialize(
+          payload.tooNewLogEventStartIndex!,
+          specifiedType: const FullType(int),
+        ));
+    }
+    if (payload.tooOldLogEventEndIndex != null) {
+      result
+        ..add('tooOldLogEventEndIndex')
+        ..add(serializers.serialize(
+          payload.tooOldLogEventEndIndex!,
+          specifiedType: const FullType(int),
+        ));
+    }
+    return result;
+  }
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.g.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.g.dart
@@ -1,0 +1,113 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.rejected_log_events_info;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$RejectedLogEventsInfo extends RejectedLogEventsInfo {
+  @override
+  final int? expiredLogEventEndIndex;
+  @override
+  final int? tooNewLogEventStartIndex;
+  @override
+  final int? tooOldLogEventEndIndex;
+
+  factory _$RejectedLogEventsInfo(
+          [void Function(RejectedLogEventsInfoBuilder)? updates]) =>
+      (new RejectedLogEventsInfoBuilder()..update(updates))._build();
+
+  _$RejectedLogEventsInfo._(
+      {this.expiredLogEventEndIndex,
+      this.tooNewLogEventStartIndex,
+      this.tooOldLogEventEndIndex})
+      : super._();
+
+  @override
+  RejectedLogEventsInfo rebuild(
+          void Function(RejectedLogEventsInfoBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RejectedLogEventsInfoBuilder toBuilder() =>
+      new RejectedLogEventsInfoBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RejectedLogEventsInfo &&
+        expiredLogEventEndIndex == other.expiredLogEventEndIndex &&
+        tooNewLogEventStartIndex == other.tooNewLogEventStartIndex &&
+        tooOldLogEventEndIndex == other.tooOldLogEventEndIndex;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc($jc(0, expiredLogEventEndIndex.hashCode),
+            tooNewLogEventStartIndex.hashCode),
+        tooOldLogEventEndIndex.hashCode));
+  }
+}
+
+class RejectedLogEventsInfoBuilder
+    implements Builder<RejectedLogEventsInfo, RejectedLogEventsInfoBuilder> {
+  _$RejectedLogEventsInfo? _$v;
+
+  int? _expiredLogEventEndIndex;
+  int? get expiredLogEventEndIndex => _$this._expiredLogEventEndIndex;
+  set expiredLogEventEndIndex(int? expiredLogEventEndIndex) =>
+      _$this._expiredLogEventEndIndex = expiredLogEventEndIndex;
+
+  int? _tooNewLogEventStartIndex;
+  int? get tooNewLogEventStartIndex => _$this._tooNewLogEventStartIndex;
+  set tooNewLogEventStartIndex(int? tooNewLogEventStartIndex) =>
+      _$this._tooNewLogEventStartIndex = tooNewLogEventStartIndex;
+
+  int? _tooOldLogEventEndIndex;
+  int? get tooOldLogEventEndIndex => _$this._tooOldLogEventEndIndex;
+  set tooOldLogEventEndIndex(int? tooOldLogEventEndIndex) =>
+      _$this._tooOldLogEventEndIndex = tooOldLogEventEndIndex;
+
+  RejectedLogEventsInfoBuilder() {
+    RejectedLogEventsInfo._init(this);
+  }
+
+  RejectedLogEventsInfoBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _expiredLogEventEndIndex = $v.expiredLogEventEndIndex;
+      _tooNewLogEventStartIndex = $v.tooNewLogEventStartIndex;
+      _tooOldLogEventEndIndex = $v.tooOldLogEventEndIndex;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(RejectedLogEventsInfo other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RejectedLogEventsInfo;
+  }
+
+  @override
+  void update(void Function(RejectedLogEventsInfoBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RejectedLogEventsInfo build() => _build();
+
+  _$RejectedLogEventsInfo _build() {
+    final _$result = _$v ??
+        new _$RejectedLogEventsInfo._(
+            expiredLogEventEndIndex: expiredLogEventEndIndex,
+            tooNewLogEventStartIndex: tooNewLogEventStartIndex,
+            tooOldLogEventEndIndex: tooOldLogEventEndIndex);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart
@@ -1,0 +1,138 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.resource_not_found_exception; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i2;
+
+part 'resource_not_found_exception.g.dart';
+
+/// The specified resource does not exist.
+abstract class ResourceNotFoundException
+    with _i1.AWSEquatable<ResourceNotFoundException>
+    implements
+        Built<ResourceNotFoundException, ResourceNotFoundExceptionBuilder>,
+        _i2.SmithyHttpException {
+  /// The specified resource does not exist.
+  factory ResourceNotFoundException({String? message}) {
+    return _$ResourceNotFoundException._(message: message);
+  }
+
+  /// The specified resource does not exist.
+  factory ResourceNotFoundException.build(
+          [void Function(ResourceNotFoundExceptionBuilder) updates]) =
+      _$ResourceNotFoundException;
+
+  const ResourceNotFoundException._();
+
+  /// Constructs a [ResourceNotFoundException] from a [payload] and [response].
+  factory ResourceNotFoundException.fromResponse(
+    ResourceNotFoundException payload,
+    _i1.AWSBaseHttpResponse response,
+  ) =>
+      payload.rebuild((b) {
+        b.statusCode = response.statusCode;
+        b.headers = response.headers;
+      });
+
+  static const List<_i2.SmithySerializer> serializers = [
+    ResourceNotFoundExceptionAwsJson11Serializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(ResourceNotFoundExceptionBuilder b) {}
+  @override
+  String? get message;
+  @override
+  _i2.ShapeId get shapeId => const _i2.ShapeId(
+        namespace: 'com.amazonaws.cloudwatchlogs',
+        shape: 'ResourceNotFoundException',
+      );
+  @override
+  _i2.RetryConfig? get retryConfig => null;
+  @override
+  @BuiltValueField(compare: false)
+  int? get statusCode;
+  @override
+  @BuiltValueField(compare: false)
+  Map<String, String>? get headers;
+  @override
+  Exception? get underlyingException => null;
+  @override
+  List<Object?> get props => [message];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('ResourceNotFoundException');
+    helper.add(
+      'message',
+      message,
+    );
+    return helper.toString();
+  }
+}
+
+class ResourceNotFoundExceptionAwsJson11Serializer
+    extends _i2.StructuredSmithySerializer<ResourceNotFoundException> {
+  const ResourceNotFoundExceptionAwsJson11Serializer()
+      : super('ResourceNotFoundException');
+
+  @override
+  Iterable<Type> get types => const [
+        ResourceNotFoundException,
+        _$ResourceNotFoundException,
+      ];
+  @override
+  Iterable<_i2.ShapeId> get supportedProtocols => const [
+        _i2.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'awsJson1_1',
+        )
+      ];
+  @override
+  ResourceNotFoundException deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = ResourceNotFoundExceptionBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'message':
+          if (value != null) {
+            result.message = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = (object as ResourceNotFoundException);
+    final result = <Object?>[];
+    if (payload.message != null) {
+      result
+        ..add('message')
+        ..add(serializers.serialize(
+          payload.message!,
+          specifiedType: const FullType(String),
+        ));
+    }
+    return result;
+  }
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.g.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.g.dart
@@ -1,0 +1,100 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.resource_not_found_exception;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$ResourceNotFoundException extends ResourceNotFoundException {
+  @override
+  final String? message;
+  @override
+  final int? statusCode;
+  @override
+  final Map<String, String>? headers;
+
+  factory _$ResourceNotFoundException(
+          [void Function(ResourceNotFoundExceptionBuilder)? updates]) =>
+      (new ResourceNotFoundExceptionBuilder()..update(updates))._build();
+
+  _$ResourceNotFoundException._({this.message, this.statusCode, this.headers})
+      : super._();
+
+  @override
+  ResourceNotFoundException rebuild(
+          void Function(ResourceNotFoundExceptionBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ResourceNotFoundExceptionBuilder toBuilder() =>
+      new ResourceNotFoundExceptionBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ResourceNotFoundException && message == other.message;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, message.hashCode));
+  }
+}
+
+class ResourceNotFoundExceptionBuilder
+    implements
+        Builder<ResourceNotFoundException, ResourceNotFoundExceptionBuilder> {
+  _$ResourceNotFoundException? _$v;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(String? message) => _$this._message = message;
+
+  int? _statusCode;
+  int? get statusCode => _$this._statusCode;
+  set statusCode(int? statusCode) => _$this._statusCode = statusCode;
+
+  Map<String, String>? _headers;
+  Map<String, String>? get headers => _$this._headers;
+  set headers(Map<String, String>? headers) => _$this._headers = headers;
+
+  ResourceNotFoundExceptionBuilder() {
+    ResourceNotFoundException._init(this);
+  }
+
+  ResourceNotFoundExceptionBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _message = $v.message;
+      _statusCode = $v.statusCode;
+      _headers = $v.headers;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ResourceNotFoundException other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ResourceNotFoundException;
+  }
+
+  @override
+  void update(void Function(ResourceNotFoundExceptionBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ResourceNotFoundException build() => _build();
+
+  _$ResourceNotFoundException _build() {
+    final _$result = _$v ??
+        new _$ResourceNotFoundException._(
+            message: message, statusCode: statusCode, headers: headers);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart
@@ -1,0 +1,138 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.service_unavailable_exception; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i2;
+
+part 'service_unavailable_exception.g.dart';
+
+/// The service cannot complete the request.
+abstract class ServiceUnavailableException
+    with _i1.AWSEquatable<ServiceUnavailableException>
+    implements
+        Built<ServiceUnavailableException, ServiceUnavailableExceptionBuilder>,
+        _i2.SmithyHttpException {
+  /// The service cannot complete the request.
+  factory ServiceUnavailableException({String? message}) {
+    return _$ServiceUnavailableException._(message: message);
+  }
+
+  /// The service cannot complete the request.
+  factory ServiceUnavailableException.build(
+          [void Function(ServiceUnavailableExceptionBuilder) updates]) =
+      _$ServiceUnavailableException;
+
+  const ServiceUnavailableException._();
+
+  /// Constructs a [ServiceUnavailableException] from a [payload] and [response].
+  factory ServiceUnavailableException.fromResponse(
+    ServiceUnavailableException payload,
+    _i1.AWSBaseHttpResponse response,
+  ) =>
+      payload.rebuild((b) {
+        b.statusCode = response.statusCode;
+        b.headers = response.headers;
+      });
+
+  static const List<_i2.SmithySerializer> serializers = [
+    ServiceUnavailableExceptionAwsJson11Serializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(ServiceUnavailableExceptionBuilder b) {}
+  @override
+  String? get message;
+  @override
+  _i2.ShapeId get shapeId => const _i2.ShapeId(
+        namespace: 'com.amazonaws.cloudwatchlogs',
+        shape: 'ServiceUnavailableException',
+      );
+  @override
+  _i2.RetryConfig? get retryConfig => null;
+  @override
+  @BuiltValueField(compare: false)
+  int? get statusCode;
+  @override
+  @BuiltValueField(compare: false)
+  Map<String, String>? get headers;
+  @override
+  Exception? get underlyingException => null;
+  @override
+  List<Object?> get props => [message];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('ServiceUnavailableException');
+    helper.add(
+      'message',
+      message,
+    );
+    return helper.toString();
+  }
+}
+
+class ServiceUnavailableExceptionAwsJson11Serializer
+    extends _i2.StructuredSmithySerializer<ServiceUnavailableException> {
+  const ServiceUnavailableExceptionAwsJson11Serializer()
+      : super('ServiceUnavailableException');
+
+  @override
+  Iterable<Type> get types => const [
+        ServiceUnavailableException,
+        _$ServiceUnavailableException,
+      ];
+  @override
+  Iterable<_i2.ShapeId> get supportedProtocols => const [
+        _i2.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'awsJson1_1',
+        )
+      ];
+  @override
+  ServiceUnavailableException deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = ServiceUnavailableExceptionBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'message':
+          if (value != null) {
+            result.message = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = (object as ServiceUnavailableException);
+    final result = <Object?>[];
+    if (payload.message != null) {
+      result
+        ..add('message')
+        ..add(serializers.serialize(
+          payload.message!,
+          specifiedType: const FullType(String),
+        ));
+    }
+    return result;
+  }
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.g.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.g.dart
@@ -1,0 +1,101 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.service_unavailable_exception;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$ServiceUnavailableException extends ServiceUnavailableException {
+  @override
+  final String? message;
+  @override
+  final int? statusCode;
+  @override
+  final Map<String, String>? headers;
+
+  factory _$ServiceUnavailableException(
+          [void Function(ServiceUnavailableExceptionBuilder)? updates]) =>
+      (new ServiceUnavailableExceptionBuilder()..update(updates))._build();
+
+  _$ServiceUnavailableException._({this.message, this.statusCode, this.headers})
+      : super._();
+
+  @override
+  ServiceUnavailableException rebuild(
+          void Function(ServiceUnavailableExceptionBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ServiceUnavailableExceptionBuilder toBuilder() =>
+      new ServiceUnavailableExceptionBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ServiceUnavailableException && message == other.message;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, message.hashCode));
+  }
+}
+
+class ServiceUnavailableExceptionBuilder
+    implements
+        Builder<ServiceUnavailableException,
+            ServiceUnavailableExceptionBuilder> {
+  _$ServiceUnavailableException? _$v;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(String? message) => _$this._message = message;
+
+  int? _statusCode;
+  int? get statusCode => _$this._statusCode;
+  set statusCode(int? statusCode) => _$this._statusCode = statusCode;
+
+  Map<String, String>? _headers;
+  Map<String, String>? get headers => _$this._headers;
+  set headers(Map<String, String>? headers) => _$this._headers = headers;
+
+  ServiceUnavailableExceptionBuilder() {
+    ServiceUnavailableException._init(this);
+  }
+
+  ServiceUnavailableExceptionBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _message = $v.message;
+      _statusCode = $v.statusCode;
+      _headers = $v.headers;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ServiceUnavailableException other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ServiceUnavailableException;
+  }
+
+  @override
+  void update(void Function(ServiceUnavailableExceptionBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ServiceUnavailableException build() => _build();
+
+  _$ServiceUnavailableException _build() {
+    final _$result = _$v ??
+        new _$ServiceUnavailableException._(
+            message: message, statusCode: statusCode, headers: headers);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.dart
@@ -1,0 +1,138 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.unrecognized_client_exception; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'package:aws_common/aws_common.dart' as _i1;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:smithy/smithy.dart' as _i2;
+
+part 'unrecognized_client_exception.g.dart';
+
+/// The most likely cause is an invalid Amazon Web Services access key ID or secret key.
+abstract class UnrecognizedClientException
+    with _i1.AWSEquatable<UnrecognizedClientException>
+    implements
+        Built<UnrecognizedClientException, UnrecognizedClientExceptionBuilder>,
+        _i2.SmithyHttpException {
+  /// The most likely cause is an invalid Amazon Web Services access key ID or secret key.
+  factory UnrecognizedClientException({String? message}) {
+    return _$UnrecognizedClientException._(message: message);
+  }
+
+  /// The most likely cause is an invalid Amazon Web Services access key ID or secret key.
+  factory UnrecognizedClientException.build(
+          [void Function(UnrecognizedClientExceptionBuilder) updates]) =
+      _$UnrecognizedClientException;
+
+  const UnrecognizedClientException._();
+
+  /// Constructs a [UnrecognizedClientException] from a [payload] and [response].
+  factory UnrecognizedClientException.fromResponse(
+    UnrecognizedClientException payload,
+    _i1.AWSBaseHttpResponse response,
+  ) =>
+      payload.rebuild((b) {
+        b.statusCode = response.statusCode;
+        b.headers = response.headers;
+      });
+
+  static const List<_i2.SmithySerializer> serializers = [
+    UnrecognizedClientExceptionAwsJson11Serializer()
+  ];
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _init(UnrecognizedClientExceptionBuilder b) {}
+  @override
+  String? get message;
+  @override
+  _i2.ShapeId get shapeId => const _i2.ShapeId(
+        namespace: 'com.amazonaws.cloudwatchlogs',
+        shape: 'UnrecognizedClientException',
+      );
+  @override
+  _i2.RetryConfig? get retryConfig => null;
+  @override
+  @BuiltValueField(compare: false)
+  int? get statusCode;
+  @override
+  @BuiltValueField(compare: false)
+  Map<String, String>? get headers;
+  @override
+  Exception? get underlyingException => null;
+  @override
+  List<Object?> get props => [message];
+  @override
+  String toString() {
+    final helper = newBuiltValueToStringHelper('UnrecognizedClientException');
+    helper.add(
+      'message',
+      message,
+    );
+    return helper.toString();
+  }
+}
+
+class UnrecognizedClientExceptionAwsJson11Serializer
+    extends _i2.StructuredSmithySerializer<UnrecognizedClientException> {
+  const UnrecognizedClientExceptionAwsJson11Serializer()
+      : super('UnrecognizedClientException');
+
+  @override
+  Iterable<Type> get types => const [
+        UnrecognizedClientException,
+        _$UnrecognizedClientException,
+      ];
+  @override
+  Iterable<_i2.ShapeId> get supportedProtocols => const [
+        _i2.ShapeId(
+          namespace: 'aws.protocols',
+          shape: 'awsJson1_1',
+        )
+      ];
+  @override
+  UnrecognizedClientException deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = UnrecognizedClientExceptionBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final value = iterator.current;
+      switch (key) {
+        case 'message':
+          if (value != null) {
+            result.message = (serializers.deserialize(
+              value,
+              specifiedType: const FullType(String),
+            ) as String);
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Object? object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final payload = (object as UnrecognizedClientException);
+    final result = <Object?>[];
+    if (payload.message != null) {
+      result
+        ..add('message')
+        ..add(serializers.serialize(
+          payload.message!,
+          specifiedType: const FullType(String),
+        ));
+    }
+    return result;
+  }
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.g.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.g.dart
@@ -1,0 +1,101 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.model.unrecognized_client_exception;
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$UnrecognizedClientException extends UnrecognizedClientException {
+  @override
+  final String? message;
+  @override
+  final int? statusCode;
+  @override
+  final Map<String, String>? headers;
+
+  factory _$UnrecognizedClientException(
+          [void Function(UnrecognizedClientExceptionBuilder)? updates]) =>
+      (new UnrecognizedClientExceptionBuilder()..update(updates))._build();
+
+  _$UnrecognizedClientException._({this.message, this.statusCode, this.headers})
+      : super._();
+
+  @override
+  UnrecognizedClientException rebuild(
+          void Function(UnrecognizedClientExceptionBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UnrecognizedClientExceptionBuilder toBuilder() =>
+      new UnrecognizedClientExceptionBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UnrecognizedClientException && message == other.message;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, message.hashCode));
+  }
+}
+
+class UnrecognizedClientExceptionBuilder
+    implements
+        Builder<UnrecognizedClientException,
+            UnrecognizedClientExceptionBuilder> {
+  _$UnrecognizedClientException? _$v;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(String? message) => _$this._message = message;
+
+  int? _statusCode;
+  int? get statusCode => _$this._statusCode;
+  set statusCode(int? statusCode) => _$this._statusCode = statusCode;
+
+  Map<String, String>? _headers;
+  Map<String, String>? get headers => _$this._headers;
+  set headers(Map<String, String>? headers) => _$this._headers = headers;
+
+  UnrecognizedClientExceptionBuilder() {
+    UnrecognizedClientException._init(this);
+  }
+
+  UnrecognizedClientExceptionBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _message = $v.message;
+      _statusCode = $v.statusCode;
+      _headers = $v.headers;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(UnrecognizedClientException other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UnrecognizedClientException;
+  }
+
+  @override
+  void update(void Function(UnrecognizedClientExceptionBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UnrecognizedClientException build() => _build();
+
+  _$UnrecognizedClientException _build() {
+    final _$result = _$v ??
+        new _$UnrecognizedClientException._(
+            message: message, statusCode: statusCode, headers: headers);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/operation/put_log_events_operation.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/lib/src/sdk/src/cloud_watch_logs/operation/put_log_events_operation.dart
@@ -1,0 +1,228 @@
+// Generated with smithy-dart 0.3.0. DO NOT MODIFY.
+
+library amplify_logging_cloudwatchlogs_dart.cloud_watch_logs.operation.put_log_events_operation; // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+import 'dart:async' as _i15;
+
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/common/endpoint_resolver.dart'
+    as _i8;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/common/serializers.dart'
+    as _i6;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.dart'
+    as _i9;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart'
+    as _i10;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.dart'
+    as _i11;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart'
+    as _i2;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart'
+    as _i3;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart'
+    as _i12;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart'
+    as _i13;
+import 'package:amplify_logging_cloudwatchlogs_dart/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.dart'
+    as _i14;
+import 'package:aws_common/aws_common.dart' as _i7;
+import 'package:aws_signature_v4/aws_signature_v4.dart' as _i4;
+import 'package:smithy/smithy.dart' as _i1;
+import 'package:smithy_aws/smithy_aws.dart' as _i5;
+
+/// Uploads a batch of log events to the specified log stream.
+///
+/// You must include the sequence token obtained from the response of the previous call. An upload in a newly created log stream does not require a sequence token. You can also get the sequence token in the `expectedSequenceToken` field from `InvalidSequenceTokenException`. If you call `PutLogEvents` twice within a narrow time period using the same value for `sequenceToken`, both calls might be successful or one might be rejected.
+///
+/// The batch of events must satisfy the following constraints:
+///
+/// *   The maximum batch size is 1,048,576 bytes. This size is calculated as the sum of all event messages in UTF-8, plus 26 bytes for each log event.
+///
+/// *   None of the log events in the batch can be more than 2 hours in the future.
+///
+/// *   None of the log events in the batch can be older than 14 days or older than the retention period of the log group.
+///
+/// *   The log events in the batch must be in chronological order by their timestamp. The timestamp is the time the event occurred, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC. (In Amazon Web Services Tools for PowerShell and the Amazon Web Services SDK for .NET, the timestamp is specified in .NET format: yyyy-mm-ddThh:mm:ss. For example, 2017-09-15T13:45:30.)
+///
+/// *   A batch of log events in a single request cannot span more than 24 hours. Otherwise, the operation fails.
+///
+/// *   The maximum number of log events in a batch is 10,000.
+///
+/// *   There is a quota of 5 requests per second per log stream. Additional requests are throttled. This quota can't be changed.
+///
+///
+/// If a call to `PutLogEvents` returns "UnrecognizedClientException" the most likely cause is an invalid Amazon Web Services access key ID or secret key.
+class PutLogEventsOperation extends _i1.HttpOperation<
+    _i2.PutLogEventsRequest,
+    _i2.PutLogEventsRequest,
+    _i3.PutLogEventsResponse,
+    _i3.PutLogEventsResponse> {
+  /// Uploads a batch of log events to the specified log stream.
+  ///
+  /// You must include the sequence token obtained from the response of the previous call. An upload in a newly created log stream does not require a sequence token. You can also get the sequence token in the `expectedSequenceToken` field from `InvalidSequenceTokenException`. If you call `PutLogEvents` twice within a narrow time period using the same value for `sequenceToken`, both calls might be successful or one might be rejected.
+  ///
+  /// The batch of events must satisfy the following constraints:
+  ///
+  /// *   The maximum batch size is 1,048,576 bytes. This size is calculated as the sum of all event messages in UTF-8, plus 26 bytes for each log event.
+  ///
+  /// *   None of the log events in the batch can be more than 2 hours in the future.
+  ///
+  /// *   None of the log events in the batch can be older than 14 days or older than the retention period of the log group.
+  ///
+  /// *   The log events in the batch must be in chronological order by their timestamp. The timestamp is the time the event occurred, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC. (In Amazon Web Services Tools for PowerShell and the Amazon Web Services SDK for .NET, the timestamp is specified in .NET format: yyyy-mm-ddThh:mm:ss. For example, 2017-09-15T13:45:30.)
+  ///
+  /// *   A batch of log events in a single request cannot span more than 24 hours. Otherwise, the operation fails.
+  ///
+  /// *   The maximum number of log events in a batch is 10,000.
+  ///
+  /// *   There is a quota of 5 requests per second per log stream. Additional requests are throttled. This quota can't be changed.
+  ///
+  ///
+  /// If a call to `PutLogEvents` returns "UnrecognizedClientException" the most likely cause is an invalid Amazon Web Services access key ID or secret key.
+  PutLogEventsOperation({
+    required String region,
+    Uri? baseUri,
+    _i4.AWSCredentialsProvider credentialsProvider =
+        const _i4.AWSCredentialsProvider.environment(),
+  })  : _region = region,
+        _baseUri = baseUri,
+        _credentialsProvider = credentialsProvider;
+
+  @override
+  late final List<
+      _i1.HttpProtocol<_i2.PutLogEventsRequest, _i2.PutLogEventsRequest,
+          _i3.PutLogEventsResponse, _i3.PutLogEventsResponse>> protocols = [
+    _i5.AwsJson1_1Protocol(
+      serializers: _i6.serializers,
+      builderFactories: _i6.builderFactories,
+      requestInterceptors: [
+        const _i1.WithHost(),
+        const _i1.WithContentLength(),
+        const _i1.WithHeader(
+          'X-Amz-Target',
+          'Logs_20140328.PutLogEvents',
+        ),
+        _i5.WithSigV4(
+          region: _region,
+          service: _i7.AWSService.cloudWatchLogs,
+          credentialsProvider: _credentialsProvider,
+        ),
+        const _i1.WithUserAgent('aws-sdk-dart/0.3.0'),
+        const _i5.WithSdkInvocationId(),
+        const _i5.WithSdkRequest(),
+      ],
+      responseInterceptors: [],
+    )
+  ];
+
+  late final _i5.AWSEndpoint _awsEndpoint = _i8.endpointResolver.resolve(
+    _i8.sdkId,
+    _region,
+  );
+
+  final String _region;
+
+  final Uri? _baseUri;
+
+  final _i4.AWSCredentialsProvider _credentialsProvider;
+
+  @override
+  _i1.HttpRequest buildRequest(_i2.PutLogEventsRequest input) =>
+      _i1.HttpRequest((b) {
+        b.method = 'POST';
+        b.path = r'/';
+      });
+  @override
+  int successCode([_i3.PutLogEventsResponse? output]) => 200;
+  @override
+  _i3.PutLogEventsResponse buildOutput(
+    _i3.PutLogEventsResponse payload,
+    _i7.AWSBaseHttpResponse response,
+  ) =>
+      _i3.PutLogEventsResponse.fromResponse(
+        payload,
+        response,
+      );
+  @override
+  List<_i1.SmithyError> get errorTypes => const [
+        _i1.SmithyError(
+          _i1.ShapeId(
+            namespace: 'com.amazonaws.cloudwatchlogs',
+            shape: 'DataAlreadyAcceptedException',
+          ),
+          _i1.ErrorKind.client,
+          _i9.DataAlreadyAcceptedException,
+          builder: _i9.DataAlreadyAcceptedException.fromResponse,
+        ),
+        _i1.SmithyError(
+          _i1.ShapeId(
+            namespace: 'com.amazonaws.cloudwatchlogs',
+            shape: 'InvalidParameterException',
+          ),
+          _i1.ErrorKind.client,
+          _i10.InvalidParameterException,
+          builder: _i10.InvalidParameterException.fromResponse,
+        ),
+        _i1.SmithyError(
+          _i1.ShapeId(
+            namespace: 'com.amazonaws.cloudwatchlogs',
+            shape: 'InvalidSequenceTokenException',
+          ),
+          _i1.ErrorKind.client,
+          _i11.InvalidSequenceTokenException,
+          builder: _i11.InvalidSequenceTokenException.fromResponse,
+        ),
+        _i1.SmithyError(
+          _i1.ShapeId(
+            namespace: 'com.amazonaws.cloudwatchlogs',
+            shape: 'ResourceNotFoundException',
+          ),
+          _i1.ErrorKind.client,
+          _i12.ResourceNotFoundException,
+          builder: _i12.ResourceNotFoundException.fromResponse,
+        ),
+        _i1.SmithyError(
+          _i1.ShapeId(
+            namespace: 'com.amazonaws.cloudwatchlogs',
+            shape: 'ServiceUnavailableException',
+          ),
+          _i1.ErrorKind.server,
+          _i13.ServiceUnavailableException,
+          builder: _i13.ServiceUnavailableException.fromResponse,
+        ),
+        _i1.SmithyError(
+          _i1.ShapeId(
+            namespace: 'com.amazonaws.cloudwatchlogs',
+            shape: 'UnrecognizedClientException',
+          ),
+          _i1.ErrorKind.client,
+          _i14.UnrecognizedClientException,
+          builder: _i14.UnrecognizedClientException.fromResponse,
+        ),
+      ];
+  @override
+  String get runtimeTypeName => 'PutLogEvents';
+  @override
+  _i5.AWSRetryer get retryer => _i5.AWSRetryer();
+  @override
+  Uri get baseUri => _baseUri ?? endpoint.uri;
+  @override
+  _i1.Endpoint get endpoint => _awsEndpoint.endpoint;
+  @override
+  _i1.SmithyOperation<_i3.PutLogEventsResponse> run(
+    _i2.PutLogEventsRequest input, {
+    _i7.AWSHttpClient? client,
+    _i1.ShapeId? useProtocol,
+  }) {
+    return _i15.runZoned(
+      () => super.run(
+        input,
+        client: client,
+        useProtocol: useProtocol,
+      ),
+      zoneValues: {
+        ...?_awsEndpoint.credentialScope?.zoneValues,
+        ...{_i7.AWSHeaders.sdkInvocationId: _i7.uuid(secure: true)}
+      },
+    );
+  }
+}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/pubspec.yaml
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/pubspec.yaml
@@ -1,0 +1,16 @@
+name: amplify_logging_cloudwatchlogs_dart
+description: Dart implementation of the Amplify Logging plugin using CloudWatchLogs.
+version: 0.1.0
+homepage: https://docs.amplify.aws/lib/q/platform/flutter/
+repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/logging/amplify_logging_cloudwatchlogs_dart
+issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
+
+environment:
+  sdk: '>=2.18.4 <3.0.0'
+
+# dependencies:
+#   path: ^1.8.0
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.16.0

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/pubspec.yaml
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/pubspec.yaml
@@ -11,6 +11,36 @@ environment:
 # dependencies:
 #   path: ^1.8.0
 
+dependencies:
+  amplify_core: ">=1.0.0-next.1 <1.0.0-next.2"
+  async: ^2.8.0
+  aws_common: ">=0.3.2 <0.4.0"
+  aws_signature_v4: ">=0.3.0 <0.4.0"
+  built_collection: ^5.0.0
+  built_value: ">=8.4.0 <8.5.0"
+  drift: ">=2.3.0 <2.4.0"
+  fixnum: ^1.0.0
+  meta: ^1.7.0
+  path: ^1.8.0
+  smithy: ">=0.3.0 <0.4.0"
+  smithy_aws: ">=0.3.0 <0.4.0"
+  
+# dependencies:
+#   amplify_core: ^1.0.0-next.1+1
+#   smithy: ">=0.3.0 <0.4.0"
+#   smithy_aws: ">=0.3.0 <0.4.0"
+#   aws_common: ">=0.3.2 <0.4.0"
+#   built_value: ">=8.4.0 <8.5.0"
+#   fixnum: ^1.0.0
+#   built_collection: ^5.0.0
+
 dev_dependencies:
-  lints: ^2.0.0
+  amplify_lints:
+    path: ../../amplify_lints
+  build_runner: ^2.0.0
+  build_verify: ^3.0.0
+  built_value_generator: 8.4.2
+  drift_dev: ^2.2.0+1
+  mocktail: ^0.3.0
   test: ^1.16.0
+

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/sdk.yaml
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/sdk.yaml
@@ -1,0 +1,3 @@
+apis:
+  logs:
+  - com.amazonaws.cloudwatchlogs#PutLogEvents

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/test/amplify_logging_cloudwatchlogs_dart_test.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/test/amplify_logging_cloudwatchlogs_dart_test.dart
@@ -1,16 +1,1 @@
-import 'package:amplify_logging_cloudwatchlogs_dart/amplify_logging_cloudwatchlogs_dart.dart';
-import 'package:test/test.dart';
-
-void main() {
-  group('A group of tests', () {
-    final awesome = Awesome();
-
-    setUp(() {
-      // Additional setup goes here.
-    });
-
-    test('First Test', () {
-      expect(awesome.isAwesome, isTrue);
-    });
-  });
-}
+void main() {}

--- a/packages/logging/amplify_logging_cloudwatchlogs_dart/test/amplify_logging_cloudwatchlogs_dart_test.dart
+++ b/packages/logging/amplify_logging_cloudwatchlogs_dart/test/amplify_logging_cloudwatchlogs_dart_test.dart
@@ -1,0 +1,16 @@
+import 'package:amplify_logging_cloudwatchlogs_dart/amplify_logging_cloudwatchlogs_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests', () {
+    final awesome = Awesome();
+
+    setUp(() {
+      // Additional setup goes here.
+    });
+
+    test('First Test', () {
+      expect(awesome.isAwesome, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
- create a new dart package for logging.
- add sdk.yaml for CloudWatchLogs service.
- generate dart sdk for CloudWatchLogs using aft generate sdk command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
