### PR TITLE
chore: run integ tests for Windows in CI

### DIFF
--- a/.github/composite_actions/fetch_backends/action.yaml
+++ b/.github/composite_actions/fetch_backends/action.yaml
@@ -34,12 +34,13 @@ runs:
         parse-json-secrets: true
 
     - name: Pull Amplify Configurations
-      run: melos exec --scope=${{ inputs.scope }} ./tool/pull_test_backend.sh
+      run: |
+        dart pub global run melos exec --scope=${{ inputs.scope }} bash tool/pull_test_backend.sh
       shell: bash
 
     - name: Undo any codegen changes from amplify pull
       run: |    
-        melos exec --scope=${{ inputs.scope }} "[ -d "lib/models" ] && git checkout lib/models/ || exit 0"
+        dart pub global run melos exec --scope=${{ inputs.scope }} "[ -d "lib/models" ] && git checkout lib/models/ || exit 0"
       shell: bash
 
     - name: Delete AWS profile

--- a/.github/composite_actions/fetch_backends/action.yaml
+++ b/.github/composite_actions/fetch_backends/action.yaml
@@ -35,12 +35,12 @@ runs:
 
     - name: Pull Amplify Configurations
       run: |
-        dart pub global run melos exec --scope=${{ inputs.scope }} bash tool/pull_test_backend.sh
+        flutter pub global run melos exec --scope=${{ inputs.scope }} bash tool/pull_test_backend.sh
       shell: bash
 
     - name: Undo any codegen changes from amplify pull
       run: |    
-        dart pub global run melos exec --scope=${{ inputs.scope }} "[ -d "lib/models" ] && git checkout lib/models/ || exit 0"
+        flutter pub global run melos exec --scope=${{ inputs.scope }} "[ -d "lib/models" ] && git checkout lib/models/ || exit 0"
       shell: bash
 
     - name: Delete AWS profile

--- a/.github/composite_actions/install_dependencies/action.yaml
+++ b/.github/composite_actions/install_dependencies/action.yaml
@@ -1,28 +1,24 @@
 name: "Install Non-Platform Dependencies"
-description: "Installs non-platform dependencies: Amplify CLI, Flutter and runs melos bootstrap"
+description: "Installs non-platform dependencies: Flutter, melos, aft
 
 runs:
   using: "composite"
   steps:
-    - name: Install Amplify CLI
-      # retry once
-      run: |
-        yarn global add @aws-amplify/cli --network-timeout 100000 || yarn global add @aws-amplify/cli --network-timeout 100000
-      shell: bash
-
     - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d # 2.8.0
       with:
+        cache: true
         channel: 'stable'
-    
+
     - name: Install Melos
       run: |
-        flutter pub global activate melos 2.8.0
+        dart pub global activate melos 2.8.0
       shell: bash
 
     #  Install aft from path, links packages and runs build runner where needed.
     - name: Partial aft bootstrap
       run: |
-        flutter pub global activate -spath packages/aft
-        aft link
-        melos exec -c 1 --scope="amplify_secure_storage_dart,amplify_auth_cognito_dart" -- dart run build_runner build --delete-conflicting-outputs
+        dart pub global activate -spath packages/aft
+        dart pub global run aft link
+        dart pub global run melos exec -c 1 --scope="amplify_secure_storage_dart,amplify_auth_cognito_dart" -- dart run build_runner build --delete-conflicting-outputs
       shell: bash
+

--- a/.github/composite_actions/install_dependencies/action.yaml
+++ b/.github/composite_actions/install_dependencies/action.yaml
@@ -11,14 +11,14 @@ runs:
 
     - name: Install Melos
       run: |
-        dart pub global activate melos 2.8.0
+        flutter pub global activate melos 2.8.0
       shell: bash
 
     #  Install aft from path, links packages and runs build runner where needed.
     - name: Partial aft bootstrap
       run: |
-        dart pub global activate -spath packages/aft
-        dart pub global run aft link
-        dart pub global run melos exec -c 1 --scope="amplify_secure_storage_dart,amplify_auth_cognito_dart" -- dart run build_runner build --delete-conflicting-outputs
+        flutter pub global activate -spath packages/aft
+        flutter pub global run aft link
+        flutter pub global run melos exec -c 1 --scope="amplify_secure_storage_dart,amplify_auth_cognito_dart" -- dart run build_runner build --delete-conflicting-outputs
       shell: bash
 

--- a/.github/composite_actions/install_dependencies/action.yaml
+++ b/.github/composite_actions/install_dependencies/action.yaml
@@ -1,5 +1,5 @@
 name: "Install Non-Platform Dependencies"
-description: "Installs non-platform dependencies: Flutter, melos, aft
+description: "Installs non-platform dependencies: Flutter, melos, aft"
 
 runs:
   using: "composite"

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -201,3 +201,41 @@ jobs:
         run: |
           flutter config --enable-linux-desktop
           melos exec -c 1 --scope ${{ matrix.scope }} -- \$MELOS_ROOT_PATH/build-support/integ_test.sh -d linux --retries 1
+
+  windows:
+    runs-on: windows-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        scope:
+          - "amplify_analytics_pinpoint_example"
+          - "amplify_api_example"
+          - "amplify_auth_cognito_example"
+          - "amplify_storage_s3_example"
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+        with:
+          persist-credentials: false
+
+      - name: Change path restrictions
+        run: git config --global core.longpaths true
+      
+      - name: Install dependencies
+        uses: ./.github/composite_actions/install_dependencies
+
+      - name: Fetch Amplify backend configurations
+        uses: ./.github/composite_actions/fetch_backends
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          scope: ${{ matrix.scope }}
+          secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
+
+      - name: Run integration tests
+        run: |
+          flutter config --enable-windows-desktop
+          melos exec -c 1 --scope ${{ matrix.scope }} -- flutter test integration_test/main_test.dart -d windows

--- a/build-support/pull_backend_by_app_id.sh
+++ b/build-support/pull_backend_by_app_id.sh
@@ -2,6 +2,12 @@
 set -e
 IFS='|'
 
+# Install amplify CLI if not installed
+if ! command -v amplify &> /dev/null
+then
+    npm install -g @aws-amplify/cli
+fi
+
 FLUTTERCONFIG="{\
 \"ResDir\":\"./lib/\",\
 \"SourceDir\":\"lib\",\

--- a/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
@@ -12,6 +12,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+import 'dart:io';
+
 import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_api_example/models/ModelProvider.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
@@ -23,73 +25,80 @@ import '../util.dart';
 void main({bool useExistingTestUser = false}) {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  group('GraphQL API key', () {
-    setUpAll(() async {
-      await configureAmplify();
-      await signOutTestUser();
-    });
-
-    group('queries', () {
-      testWidgets('should query authorized model', (WidgetTester tester) async {
-        final req = ModelQueries.list<Blog>(
-          Blog.classType,
-          authorizationMode: APIAuthorizationType.apiKey,
-        );
-        final res = await Amplify.API.query(request: req).response;
-        final data = res.data;
-        expect(res, hasNoGraphQLErrors);
-        expect(data?.items.length, greaterThanOrEqualTo(0));
+  group(
+    'GraphQL API key',
+    () {
+      setUpAll(() async {
+        await configureAmplify();
+        await signOutTestUser();
       });
 
-      testWidgets('should get error for unauthorized model', (
-        WidgetTester tester,
-      ) async {
-        final req = ModelQueries.list<Post>(
-          Post.classType,
-          authorizationMode: APIAuthorizationType.apiKey,
-        );
-        final res = await Amplify.API.query(request: req).response;
-        expect(res.hasErrors, true);
-        expect(res.data, isNull);
-      });
-    });
-
-    group(
-      'subscriptions',
-      () {
-        setUpAll(() async {
-          if (!useExistingTestUser) {
-            await signUpTestUser();
-          }
-          await signInTestUser();
-        });
-
-        tearDownAll(() async {
-          await deleteTestModels();
-          if (!useExistingTestUser) {
-            await deleteTestUser();
-          }
-        });
-
-        testWidgets(
-            'should emit event when onCreate subscription made with model helper',
+      group('queries', () {
+        testWidgets('should query authorized model',
             (WidgetTester tester) async {
-          String name = 'Integration Test Blog - subscription create ${uuid()}';
-          final subscriptionRequest = ModelSubscriptions.onCreate(
+          final req = ModelQueries.list<Blog>(
             Blog.classType,
             authorizationMode: APIAuthorizationType.apiKey,
           );
-
-          final eventResponse = await establishSubscriptionAndMutate(
-            subscriptionRequest,
-            () => addBlog(name),
-            eventFilter: (Blog? blog) => blog?.name == name,
-          );
-          Blog? blogFromEvent = eventResponse.data;
-
-          expect(blogFromEvent?.name, equals(name));
+          final res = await Amplify.API.query(request: req).response;
+          final data = res.data;
+          expect(res, hasNoGraphQLErrors);
+          expect(data?.items.length, greaterThanOrEqualTo(0));
         });
-      },
-    );
-  });
+
+        testWidgets('should get error for unauthorized model', (
+          WidgetTester tester,
+        ) async {
+          final req = ModelQueries.list<Post>(
+            Post.classType,
+            authorizationMode: APIAuthorizationType.apiKey,
+          );
+          final res = await Amplify.API.query(request: req).response;
+          expect(res.hasErrors, true);
+          expect(res.data, isNull);
+        });
+      });
+
+      group(
+        'subscriptions',
+        () {
+          setUpAll(() async {
+            if (!useExistingTestUser) {
+              await signUpTestUser();
+            }
+            await signInTestUser();
+          });
+
+          tearDownAll(() async {
+            await deleteTestModels();
+            if (!useExistingTestUser) {
+              await deleteTestUser();
+            }
+          });
+
+          testWidgets(
+              'should emit event when onCreate subscription made with model helper',
+              (WidgetTester tester) async {
+            String name =
+                'Integration Test Blog - subscription create ${uuid()}';
+            final subscriptionRequest = ModelSubscriptions.onCreate(
+              Blog.classType,
+              authorizationMode: APIAuthorizationType.apiKey,
+            );
+
+            final eventResponse = await establishSubscriptionAndMutate(
+              subscriptionRequest,
+              () => addBlog(name),
+              eventFilter: (Blog? blog) => blog?.name == name,
+            );
+            Blog? blogFromEvent = eventResponse.data;
+
+            expect(blogFromEvent?.name, equals(name));
+          });
+        },
+        // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
+        skip: Platform.isWindows,
+      );
+    },
+  );
 }

--- a/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
@@ -97,7 +97,7 @@ void main({bool useExistingTestUser = false}) {
           });
         },
         // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
-        skip: Platform.isWindows,
+        skip: !zIsWeb && Platform.isWindows,
       );
     },
   );

--- a/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
@@ -14,6 +14,7 @@
  */
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_api_example/models/ModelProvider.dart';
@@ -423,6 +424,8 @@ void main({bool useExistingTestUser = false}) {
           await firstStream.listen(null).cancel();
         });
       },
+      // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
+      skip: Platform.isWindows,
     );
   });
 }

--- a/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
@@ -425,7 +425,7 @@ void main({bool useExistingTestUser = false}) {
         });
       },
       // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
-      skip: Platform.isWindows,
+      skip: !zIsWeb && Platform.isWindows,
     );
   });
 }

--- a/packages/api/amplify_api/example/integration_test/graphql/user_pools_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/user_pools_test.dart
@@ -281,7 +281,7 @@ void main({bool useExistingTestUser = false}) {
         });
       },
       // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
-      skip: Platform.isWindows,
+      skip: !zIsWeb && Platform.isWindows,
     );
   });
 }

--- a/packages/api/amplify_api/example/integration_test/graphql/user_pools_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/user_pools_test.dart
@@ -12,6 +12,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+import 'dart:io';
+
 import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_api_example/models/ModelProvider.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
@@ -278,6 +280,8 @@ void main({bool useExistingTestUser = false}) {
           expect(blogFromEvent?.name, equals(name));
         });
       },
+      // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
+      skip: Platform.isWindows,
     );
   });
 }

--- a/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
@@ -131,6 +131,6 @@ void main() {
       });
     },
     // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
-    skip: Platform.isWindows,
+    skip: !zIsWeb && Platform.isWindows,
   );
 }

--- a/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
@@ -191,7 +191,7 @@ void main() {
         });
       },
       // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
-      skip: Platform.isWindows,
+      skip: !zIsWeb && Platform.isWindows,
     );
 
     group('Always', () {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:io';
+
 import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_auth_cognito_dart/src/credentials/device_metadata_repository.dart';
@@ -147,45 +149,50 @@ void main() {
       });
     });
 
-    group('Opt-In (Device Tracking)', () {
-      setUpAll(() async {
-        await configureAuth(
-          additionalPlugins: [AmplifyAPI()],
-          config: amplifyEnvironments['device-tracking-opt-in'],
-        );
-      });
+    group(
+      'Opt-In (Device Tracking)',
+      () {
+        setUpAll(() async {
+          await configureAuth(
+            additionalPlugins: [AmplifyAPI()],
+            config: amplifyEnvironments['device-tracking-opt-in'],
+          );
+        });
 
-      setUp(() => signIn(enableMfa: true));
+        setUp(() => signIn(enableMfa: true));
 
-      asyncTest('cannot bypass MFA when device is not remembered', (_) async {
-        await signOutUser();
+        asyncTest('cannot bypass MFA when device is not remembered', (_) async {
+          await signOutUser();
 
-        final res = await Amplify.Auth.signIn(
-          username: username!,
-          password: password,
-        );
-        expect(
-          res.nextStep?.signInStep,
-          'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE',
-          reason: 'Subsequent sign-in attempts should require MFA',
-        );
-      });
+          final res = await Amplify.Auth.signIn(
+            username: username!,
+            password: password,
+          );
+          expect(
+            res.nextStep?.signInStep,
+            'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE',
+            reason: 'Subsequent sign-in attempts should require MFA',
+          );
+        });
 
-      asyncTest('can bypass MFA when device is remembered', (_) async {
-        await Amplify.Auth.rememberDevice();
-        await signOutUser();
+        asyncTest('can bypass MFA when device is remembered', (_) async {
+          await Amplify.Auth.rememberDevice();
+          await signOutUser();
 
-        final res = await Amplify.Auth.signIn(
-          username: username!,
-          password: password,
-        );
-        expect(
-          res.isSignedIn,
-          isTrue,
-          reason: 'Subsequent sign-in attempts should not require MFA',
-        );
-      });
-    });
+          final res = await Amplify.Auth.signIn(
+            username: username!,
+            password: password,
+          );
+          expect(
+            res.isSignedIn,
+            isTrue,
+            reason: 'Subsequent sign-in attempts should not require MFA',
+          );
+        });
+      },
+      // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
+      skip: Platform.isWindows,
+    );
 
     group('Always', () {
       setUpAll(() async {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+import 'dart:io';
+
 import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
@@ -82,69 +84,74 @@ void main() {
       );
     });
 
-    group('with alias', () {
-      const username = mockPhoneNumber;
-      final password = generatePassword();
+    group(
+      'with alias',
+      () {
+        const username = mockPhoneNumber;
+        final password = generatePassword();
 
-      setUpAll(() async {
-        await configureAuth(
-          additionalPlugins: [AmplifyAPI()],
-          config: amplifyEnvironments['sign-in-with-phone'],
-        );
-      });
+        setUpAll(() async {
+          await configureAuth(
+            additionalPlugins: [AmplifyAPI()],
+            config: amplifyEnvironments['sign-in-with-phone'],
+          );
+        });
 
-      tearDownAll(Amplify.reset);
+        tearDownAll(Amplify.reset);
 
-      setUp(() async {
-        await adminCreateUser(
-          username,
-          password,
-          autoConfirm: true,
-          verifyAttributes: true,
-          enableMfa: true,
-          attributes: const [
-            AuthUserAttribute(
-              userAttributeKey: CognitoUserAttributeKey.phoneNumber,
-              value: mockPhoneNumber,
+        setUp(() async {
+          await adminCreateUser(
+            username,
+            password,
+            autoConfirm: true,
+            verifyAttributes: true,
+            enableMfa: true,
+            attributes: const [
+              AuthUserAttribute(
+                userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+                value: mockPhoneNumber,
+              ),
+            ],
+          );
+          addTearDown(() => deleteUser(username));
+
+          final code = getOtpCodes().first;
+          final signInRes = await Amplify.Auth.signIn(
+            username: username,
+            password: password,
+          );
+          expect(
+            signInRes.nextStep?.signInStep,
+            'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE',
+          );
+          final confirmSignInRes = await Amplify.Auth.confirmSignIn(
+            confirmationValue: await code,
+          );
+          expect(confirmSignInRes.isSignedIn, isTrue);
+        });
+
+        asyncTest('should return the current user', (_) async {
+          final authUser = await Amplify.Auth.getCurrentUser();
+          expect(
+            authUser.username,
+            isNot(username),
+            reason: 'Cognito should assign an alias username',
+          );
+          expect(isValidUserSub(authUser.userId), isTrue);
+          expect(
+            authUser.signInDetails,
+            isA<CognitoSignInDetailsApiBased>().having(
+              (details) => details.username,
+              'username',
+              mockPhoneNumber,
             ),
-          ],
-        );
-        addTearDown(() => deleteUser(username));
-
-        final code = getOtpCodes().first;
-        final signInRes = await Amplify.Auth.signIn(
-          username: username,
-          password: password,
-        );
-        expect(
-          signInRes.nextStep?.signInStep,
-          'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE',
-        );
-        final confirmSignInRes = await Amplify.Auth.confirmSignIn(
-          confirmationValue: await code,
-        );
-        expect(confirmSignInRes.isSignedIn, isTrue);
-      });
-
-      asyncTest('should return the current user', (_) async {
-        final authUser = await Amplify.Auth.getCurrentUser();
-        expect(
-          authUser.username,
-          isNot(username),
-          reason: 'Cognito should assign an alias username',
-        );
-        expect(isValidUserSub(authUser.userId), isTrue);
-        expect(
-          authUser.signInDetails,
-          isA<CognitoSignInDetailsApiBased>().having(
-            (details) => details.username,
-            'username',
-            mockPhoneNumber,
-          ),
-          reason: 'Should return the phone number alias since it '
-              'was used to sign in',
-        );
-      });
-    });
+            reason: 'Should return the phone number alias since it '
+                'was used to sign in',
+          );
+        });
+      },
+      // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
+      skip: Platform.isWindows,
+    );
   });
 }

--- a/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
@@ -151,7 +151,7 @@ void main() {
         });
       },
       // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
-      skip: Platform.isWindows,
+      skip: !zIsWeb && Platform.isWindows,
     );
   });
 }

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_test.dart
@@ -72,6 +72,6 @@ void main() {
       });
     },
     // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
-    skip: Platform.isWindows,
+    skip: !zIsWeb && Platform.isWindows,
   );
 }

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:io';
+
 import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
@@ -25,46 +27,51 @@ import 'utils/test_utils.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  group('MFA (SMS)', () {
-    setUpAll(() async {
-      await configureAuth(
-        additionalPlugins: [AmplifyAPI()],
-      );
-    });
+  group(
+    'MFA (SMS)',
+    () {
+      setUpAll(() async {
+        await configureAuth(
+          additionalPlugins: [AmplifyAPI()],
+        );
+      });
 
-    tearDownAll(Amplify.reset);
+      tearDownAll(Amplify.reset);
 
-    setUp(() async {
-      await signOutUser();
-    });
+      setUp(() async {
+        await signOutUser();
+      });
 
-    asyncTest('can sign in with SMS MFA', (_) async {
-      final username = generateUsername();
-      final password = generatePassword();
+      asyncTest('can sign in with SMS MFA', (_) async {
+        final username = generateUsername();
+        final password = generatePassword();
 
-      final code = getOtpCode(username);
+        final code = getOtpCode(username);
 
-      await adminCreateUser(
-        username,
-        password,
-        autoConfirm: true,
-        verifyAttributes: true,
-        enableMfa: true,
-      );
+        await adminCreateUser(
+          username,
+          password,
+          autoConfirm: true,
+          verifyAttributes: true,
+          enableMfa: true,
+        );
 
-      final signInRes = await Amplify.Auth.signIn(
-        username: username,
-        password: password,
-      );
-      expect(
-        signInRes.nextStep?.signInStep,
-        'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE',
-      );
+        final signInRes = await Amplify.Auth.signIn(
+          username: username,
+          password: password,
+        );
+        expect(
+          signInRes.nextStep?.signInStep,
+          'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE',
+        );
 
-      final confirmRes = await Amplify.Auth.confirmSignIn(
-        confirmationValue: await code,
-      );
-      expect(confirmRes.nextStep?.signInStep, 'DONE');
-    });
-  });
+        final confirmRes = await Amplify.Auth.confirmSignIn(
+          confirmationValue: await code,
+        );
+        expect(confirmRes.nextStep?.signInStep, 'DONE');
+      });
+    },
+    // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.
+    skip: Platform.isWindows,
+  );
 }


### PR DESCRIPTION
This PR enables running integration tests in Windows for applicable packages.

I noticed there is an issue closing WebSocket connections related to GraphQL subscriptions (something related to https://pub.dev/packages/connectivity_plus) so skipping those tests on Windows here until I figure that out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
