### PR TITLE
chore(api): change example app to app.yaml analysis_options

### DIFF
--- a/packages/api/amplify_api/example/analysis_options.yaml
+++ b/packages/api/amplify_api/example/analysis_options.yaml
@@ -1,4 +1,8 @@
-include: package:amplify_lints/app_core.yaml
+include: package:amplify_lints/app.yaml
+
+analyzer:
+  exclude:
+    - lib/models/*
 
 linter:
   rules:

--- a/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
@@ -82,7 +82,7 @@ void main({bool useExistingTestUser = false}) {
               await deleteTestUser();
             }
 
-            hubEventsController.close();
+            await hubEventsController.close();
             Amplify.Hub.close();
           });
 
@@ -101,7 +101,7 @@ void main({bool useExistingTestUser = false}) {
                 ],
               ),
             );
-            String name =
+            final name =
                 'Integration Test Blog - subscription create ${uuid()}';
             final subscriptionRequest = ModelSubscriptions.onCreate(
               Blog.classType,
@@ -113,7 +113,7 @@ void main({bool useExistingTestUser = false}) {
               () => addBlog(name),
               eventFilter: (Blog? blog) => blog?.name == name,
             );
-            Blog? blogFromEvent = eventResponse.data;
+            final blogFromEvent = eventResponse.data;
 
             expect(blogFromEvent?.name, equals(name));
           });

--- a/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
@@ -49,7 +49,7 @@ void main({bool useExistingTestUser = false}) {
       testWidgets('should fetch', (WidgetTester tester) async {
         const listBlogs = 'listBlogs';
         const items = 'items';
-        String graphQLDocument = '''query MyQuery {
+        const graphQLDocument = '''query MyQuery {
         $listBlogs {
           $items {
             id
@@ -62,7 +62,8 @@ void main({bool useExistingTestUser = false}) {
           request: GraphQLRequest(document: graphQLDocument),
         );
         final response = await operation.response;
-        Map data = jsonDecode(response.data!) as Map;
+        final data = jsonDecode(response.data!) as Map;
+        // ignore: avoid_dynamic_calls
         expect(data[listBlogs][items], hasLength(greaterThanOrEqualTo(0)));
       });
 
@@ -71,7 +72,7 @@ void main({bool useExistingTestUser = false}) {
         const listBlogs = 'listBlogs';
         const items = 'items';
         // tab before id and name
-        String graphQLDocument = '''query MyQuery {
+        const graphQLDocument = '''query MyQuery {
         $listBlogs {
           $items {
           \tid
@@ -83,31 +84,32 @@ void main({bool useExistingTestUser = false}) {
         final operation = Amplify.API
             .query<String>(request: GraphQLRequest(document: graphQLDocument));
         final res = await operation.response;
-        Map data = jsonDecode(res.data!) as Map;
+        final data = jsonDecode(res.data!) as Map;
         expect(res, hasNoGraphQLErrors);
+        // ignore: avoid_dynamic_calls
         expect(data[listBlogs][items], hasLength(greaterThanOrEqualTo(0)));
       });
 
       // Queries
       testWidgets('should GET a blog with Model helper',
           (WidgetTester tester) async {
-        String name = 'Integration Test Blog to fetch';
-        Blog blog = await addBlog(name);
+        const name = 'Integration Test Blog to fetch';
+        final blog = await addBlog(name);
         final req = ModelQueries.get(Blog.classType, blog.id);
         final res = await Amplify.API.query(request: req).response;
-        Blog? data = res.data;
+        final data = res.data;
         expect(res, hasNoGraphQLErrors);
         expect(data, equals(blog));
       });
 
       testWidgets('should LIST blogs with Model helper',
           (WidgetTester tester) async {
-        String blog1Name = 'Integration Test Blog 1';
-        String blog2Name = 'Integration Test Blog 2';
-        String blog3Name = 'Integration Test Blog 3';
-        Blog blog1 = await addBlog(blog1Name);
-        Blog blog2 = await addBlog(blog2Name);
-        Blog blog3 = await addBlog(blog3Name);
+        const blog1Name = 'Integration Test Blog 1';
+        const blog2Name = 'Integration Test Blog 2';
+        const blog3Name = 'Integration Test Blog 3';
+        final blog1 = await addBlog(blog1Name);
+        final blog2 = await addBlog(blog2Name);
+        final blog3 = await addBlog(blog3Name);
         final req = ModelQueries.list<Blog>(Blog.classType);
         final operation = Amplify.API.query(request: req);
         final res = await operation.response;
@@ -139,11 +141,13 @@ void main({bool useExistingTestUser = false}) {
 
       testWidgets('should LIST blogs with Model helper with query predicate',
           (WidgetTester tester) async {
-        String blogName = 'Integration Test Blog ${uuid()}';
-        Blog blog = await addBlog(blogName);
+        final blogName = 'Integration Test Blog ${uuid()}';
+        final blog = await addBlog(blogName);
 
-        final req = ModelQueries.list<Blog>(Blog.classType,
-            where: Blog.NAME.eq(blogName) & Blog.ID.eq(blog.id));
+        final req = ModelQueries.list<Blog>(
+          Blog.classType,
+          where: Blog.NAME.eq(blogName) & Blog.ID.eq(blog.id),
+        );
         final res = await Amplify.API.query(request: req).response;
         final data = res.data;
         final blogs = [blog];
@@ -194,7 +198,7 @@ void main({bool useExistingTestUser = false}) {
         await addBlog(name);
 
         const listBlogs = 'listBlogs';
-        String graphQLDocument = '''query GetBlogsCustomDecoder {
+        const graphQLDocument = '''query GetBlogsCustomDecoder {
           $listBlogs {
             items {
               id
@@ -283,7 +287,7 @@ void main({bool useExistingTestUser = false}) {
         testWidgets(
             'should emit event when onCreate subscription made with model helper',
             (WidgetTester tester) async {
-          String name = 'Integration Test Blog - subscription create ${uuid()}';
+          final name = 'Integration Test Blog - subscription create ${uuid()}';
           final subscriptionRequest =
               ModelSubscriptions.onCreate(Blog.classType);
 
@@ -292,7 +296,7 @@ void main({bool useExistingTestUser = false}) {
             () => addBlog(name),
             eventFilter: (Blog? blog) => blog?.name == name,
           );
-          Blog? blogFromEvent = eventResponse.data;
+          final blogFromEvent = eventResponse.data;
 
           expect(blogFromEvent?.name, equals(name));
         });
@@ -303,7 +307,7 @@ void main({bool useExistingTestUser = false}) {
           const originalName = 'Integration Test Blog - subscription update';
           final updatedName =
               'Integration Test Blog - subscription update, name now ${uuid()}';
-          Blog blogToUpdate = await addBlog(originalName);
+          var blogToUpdate = await addBlog(originalName);
 
           final subscriptionRequest =
               ModelSubscriptions.onUpdate(Blog.classType);
@@ -319,7 +323,7 @@ void main({bool useExistingTestUser = false}) {
             },
             eventFilter: (Blog? blog) => blog?.id == blogToUpdate.id,
           );
-          Blog? blogFromEvent = eventResponse.data;
+          final blogFromEvent = eventResponse.data;
 
           expect(blogFromEvent?.name, equals(updatedName));
         });
@@ -328,7 +332,7 @@ void main({bool useExistingTestUser = false}) {
             'should emit event when onDelete subscription made with model helper',
             (WidgetTester tester) async {
           const name = 'Integration Test Blog - subscription delete';
-          Blog blogToDelete = await addBlog(name);
+          final blogToDelete = await addBlog(name);
 
           final subscriptionRequest =
               ModelSubscriptions.onDelete(Blog.classType);
@@ -337,14 +341,14 @@ void main({bool useExistingTestUser = false}) {
             () => deleteBlog(blogToDelete.id),
             eventFilter: (Blog? blog) => blog?.id == blogToDelete.id,
           );
-          Blog? blogFromEvent = eventResponse.data;
+          final blogFromEvent = eventResponse.data;
 
           expect(blogFromEvent?.name, equals(name));
         });
 
         testWidgets('should cancel subscription', (WidgetTester tester) async {
           const name = 'Integration Test Blog - subscription to cancel';
-          Blog blogToDelete = await addBlog(name);
+          final blogToDelete = await addBlog(name);
 
           final subReq = ModelSubscriptions.onDelete(Blog.classType);
           final subscription = await getEstablishedSubscriptionOperation<Blog>(
@@ -363,8 +367,7 @@ void main({bool useExistingTestUser = false}) {
         testWidgets(
             'should emit event when onCreate subscription made with model helper for post (model with parent).',
             (WidgetTester tester) async {
-          String title =
-              'Integration Test post - subscription create ${uuid()}';
+          final title = 'Integration Test post - subscription create ${uuid()}';
           final subscriptionRequest =
               ModelSubscriptions.onCreate(Post.classType);
 
@@ -373,7 +376,7 @@ void main({bool useExistingTestUser = false}) {
             () => addPostAndBlog(title, 0),
             eventFilter: (Post? post) => post?.title == title,
           );
-          Post? postFromEvent = eventResponse.data;
+          final postFromEvent = eventResponse.data;
 
           expect(postFromEvent?.title, equals(title));
         });
@@ -400,19 +403,22 @@ void main({bool useExistingTestUser = false}) {
           }''';
           final invalidSubscriptionRequest =
               GraphQLRequest<String>(document: document);
-          final streamWithError =
-              Amplify.API.subscribe(invalidSubscriptionRequest,
-                  onEstablished: () => fail(
-                        'onEstablished should not be called during failed subscription',
-                      ));
+          final streamWithError = Amplify.API.subscribe(
+            invalidSubscriptionRequest,
+            onEstablished: () => fail(
+              'onEstablished should not be called during failed subscription',
+            ),
+          );
 
           expect(
             streamWithError,
-            emits(predicate<GraphQLResponse<String>>(
-              (GraphQLResponse<String> response) =>
-                  response.hasErrors && response.data == null,
-              'Has GraphQL Errors',
-            )),
+            emits(
+              predicate<GraphQLResponse<String>>(
+                (GraphQLResponse<String> response) =>
+                    response.hasErrors && response.data == null,
+                'Has GraphQL Errors',
+              ),
+            ),
           );
           // Cancel subscription that had an error.
           await streamWithError.listen(null).cancel();

--- a/packages/api/amplify_api/example/integration_test/graphql/user_pools_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/user_pools_test.dart
@@ -47,7 +47,7 @@ void main({bool useExistingTestUser = false}) {
           (WidgetTester tester) async {
         final originalTitle = 'Lorem Ipsum Test Post: ${uuid()}';
         const rating = 0;
-        Post post = await addPostAndBlog(originalTitle, rating);
+        final post = await addPostAndBlog(originalTitle, rating);
         final blogId = post.blog?.id;
         final inputComment =
             Comment(content: 'Lorem ipsum test comment', post: post);
@@ -64,7 +64,7 @@ void main({bool useExistingTestUser = false}) {
         }
 
         const getBlog = 'getBlog';
-        String graphQLDocument = '''query GetBlogPostsComments(\$id: ID!) {
+        const graphQLDocument = '''query GetBlogPostsComments(\$id: ID!) {
         $getBlog(id: \$id) {
             id
             name
@@ -109,8 +109,8 @@ void main({bool useExistingTestUser = false}) {
     group('mutations', () {
       testWidgets('should CREATE a blog with Model helper',
           (WidgetTester tester) async {
-        String name = 'Integration Test Blog - create';
-        Blog blog = Blog(name: name);
+        const name = 'Integration Test Blog - create';
+        final blog = Blog(name: name);
 
         final req = ModelMutations.create(
           blog,
@@ -118,7 +118,7 @@ void main({bool useExistingTestUser = false}) {
         );
         final res = await Amplify.API.mutate(request: req).response;
         expect(res, hasNoGraphQLErrors);
-        Blog? data = res.data;
+        final data = res.data;
         if (data != null) blogCache.add(data);
 
         expect(data?.name, equals(blog.name));
@@ -129,7 +129,7 @@ void main({bool useExistingTestUser = false}) {
           (WidgetTester tester) async {
         final title = 'Lorem Ipsum Test Post: ${uuid()}';
         const rating = 0;
-        Post data = await addPostAndBlog(title, rating);
+        final data = await addPostAndBlog(title, rating);
 
         expect(data.title, equals(title));
         expect(data.rating, equals(rating));
@@ -137,9 +137,9 @@ void main({bool useExistingTestUser = false}) {
 
       testWidgets('should UPDATE a blog with Model helper',
           (WidgetTester tester) async {
-        String oldName = 'Integration Test Blog to update';
-        String newName = 'Integration Test Blog - updated';
-        Blog blog = await addBlog(oldName);
+        const oldName = 'Integration Test Blog to update';
+        const newName = 'Integration Test Blog - updated';
+        var blog = await addBlog(oldName);
         blog = blog.copyWith(name: newName);
 
         final req = ModelMutations.update(
@@ -156,16 +156,16 @@ void main({bool useExistingTestUser = false}) {
           (WidgetTester tester) async {
         final originalTitle = 'Lorem Ipsum Test Post: ${uuid()}';
         const rating = 0;
-        Post originalPost = await addPostAndBlog(originalTitle, rating);
+        final originalPost = await addPostAndBlog(originalTitle, rating);
 
         final updatedTitle = 'Lorem Ipsum Test Post: (title updated) ${uuid()}';
-        Post localUpdatedPost = originalPost.copyWith(title: updatedTitle);
+        final localUpdatedPost = originalPost.copyWith(title: updatedTitle);
         final updateReq = ModelMutations.update(
           localUpdatedPost,
           authorizationMode: APIAuthorizationType.userPools,
         );
         final updateRes = await Amplify.API.mutate(request: updateReq).response;
-        Post? mutatedPost = updateRes.data;
+        final mutatedPost = updateRes.data;
         expect(updateRes, hasNoGraphQLErrors);
         expect(mutatedPost?.title, equals(updatedTitle));
       });
@@ -173,7 +173,7 @@ void main({bool useExistingTestUser = false}) {
       testWidgets(
           'should get AppSync error when trying to CREATE a post (model with parent) without a parent on the instance',
           (WidgetTester tester) async {
-        Post post =
+        final post =
             Post(title: 'Lorem ipsum, fail update', rating: 0, blog: null);
         final createPostReq = ModelMutations.create(
           post,
@@ -194,9 +194,9 @@ void main({bool useExistingTestUser = false}) {
       testWidgets(
           'should not UPDATE a blog with Model helper when where condition not met',
           (WidgetTester tester) async {
-        String oldName = 'Integration Test Blog to update';
-        String newName = 'Integration Test Blog - updated';
-        Blog blog = await addBlog(oldName);
+        const oldName = 'Integration Test Blog to update';
+        const newName = 'Integration Test Blog - updated';
+        var blog = await addBlog(oldName);
         blog = blog.copyWith(name: newName);
         final req = ModelMutations.update(
           blog,
@@ -216,9 +216,9 @@ void main({bool useExistingTestUser = false}) {
 
       testWidgets('should DELETE a blog with Model helper',
           (WidgetTester tester) async {
-        String name = 'Integration Test Blog - delete';
-        Blog blog = await addBlog(name);
-        Blog? data = await deleteBlog(blog.id);
+        const name = 'Integration Test Blog - delete';
+        final blog = await addBlog(name);
+        final data = await deleteBlog(blog.id);
         expect(data, equals(blog));
 
         final checkReq = ModelQueries.get(Blog.classType, blog.id);
@@ -230,17 +230,17 @@ void main({bool useExistingTestUser = false}) {
           (WidgetTester tester) async {
         final title = 'Lorem Ipsum Test Post: ${uuid()}';
         const rating = 0;
-        Post post = await addPostAndBlog(title, rating);
+        final post = await addPostAndBlog(title, rating);
 
-        Post? mutatedPost = await deletePost(post.id);
+        final mutatedPost = await deletePost(post.id);
         expect(mutatedPost?.title, equals(title));
       });
 
       testWidgets(
           'should not DELETE a blog with Model helper when where condition not met',
           (WidgetTester tester) async {
-        String name = 'Integration Test Blog - failed delete';
-        Blog blog = await addBlog(name);
+        const name = 'Integration Test Blog - failed delete';
+        final blog = await addBlog(name);
         final req = ModelMutations.delete(
           blog,
           where: Blog.NAME.eq('THATS_NOT_MY_NAME'),
@@ -264,7 +264,7 @@ void main({bool useExistingTestUser = false}) {
         testWidgets(
             'should emit event when onCreate subscription made with model helper',
             (WidgetTester tester) async {
-          String name = 'Integration Test Blog - subscription create ${uuid()}';
+          final name = 'Integration Test Blog - subscription create ${uuid()}';
           final subscriptionRequest = ModelSubscriptions.onCreate(
             Blog.classType,
             authorizationMode: APIAuthorizationType.userPools,
@@ -275,7 +275,7 @@ void main({bool useExistingTestUser = false}) {
             () => addBlog(name),
             eventFilter: (Blog? blog) => blog?.name == name,
           );
-          Blog? blogFromEvent = eventResponse.data;
+          final blogFromEvent = eventResponse.data;
 
           expect(blogFromEvent?.name, equals(name));
         });

--- a/packages/api/amplify_api/example/integration_test/util.dart
+++ b/packages/api/amplify_api/example/integration_test/util.dart
@@ -150,10 +150,10 @@ Future<Post> addPostAndBlog(
   String title,
   int rating,
 ) async {
-  String name = 'Integration Test Blog with a post - create';
-  Blog createdBlog = await addBlog(name);
+  const name = 'Integration Test Blog with a post - create';
+  final createdBlog = await addBlog(name);
 
-  Post post = Post(title: title, rating: rating, blog: createdBlog);
+  final post = Post(title: title, rating: rating, blog: createdBlog);
   final createPostReq = ModelMutations.create(
     post,
     authorizationMode: APIAuthorizationType.userPools,
@@ -161,7 +161,7 @@ Future<Post> addPostAndBlog(
   final createPostRes =
       await Amplify.API.mutate(request: createPostReq).response;
   expect(createPostRes, hasNoGraphQLErrors);
-  Post? data = createPostRes.data;
+  final data = createPostRes.data;
   if (data == null) {
     throw Exception(
       'Null response while creating post. Response errors: ${createPostRes.errors}',
@@ -207,12 +207,10 @@ Future<StreamSubscription<GraphQLResponse<T>>>
   GraphQLRequest<T> subscriptionRequest,
   void Function(GraphQLResponse<T>) onData,
 ) async {
-  Completer<void> establishedCompleter = Completer();
+  final establishedCompleter = Completer<void>();
   final stream = Amplify.API.subscribe<T>(
     subscriptionRequest,
-    onEstablished: () {
-      establishedCompleter.complete();
-    },
+    onEstablished: establishedCompleter.complete,
   );
   final subscription = stream.listen(
     onData,
@@ -234,7 +232,7 @@ Future<GraphQLResponse<T?>> establishSubscriptionAndMutate<T>(
   Future<void> Function() mutationFunction, {
   bool Function(T?)? eventFilter,
 }) async {
-  Completer<GraphQLResponse<T?>> dataCompleter = Completer();
+  final dataCompleter = Completer<GraphQLResponse<T?>>();
   // With stream established, exec callback with stream events.
   final subscription = await getEstablishedSubscriptionOperation<T>(
     subscriptionRequest,
@@ -257,8 +255,9 @@ Future<GraphQLResponse<T?>> establishSubscriptionAndMutate<T>(
   return response;
 }
 
-final hasNoGraphQLErrors = predicate<GraphQLResponse>(
-  (GraphQLResponse response) => !response.hasErrors && response.data != null,
+final hasNoGraphQLErrors = predicate<GraphQLResponse<dynamic>>(
+  (GraphQLResponse<dynamic> response) =>
+      !response.hasErrors && response.data != null,
   'Has no GraphQL Errors',
 );
 

--- a/packages/api/amplify_api/example/lib/graphql_api_view.dart
+++ b/packages/api/amplify_api/example/lib/graphql_api_view.dart
@@ -19,10 +19,8 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter/material.dart';
 
 class GraphQLApiView extends StatefulWidget {
+  const GraphQLApiView({super.key, this.isAmplifyConfigured = false});
   final bool isAmplifyConfigured;
-
-  const GraphQLApiView({Key? key, this.isAmplifyConfigured = false})
-      : super(key: key);
 
   @override
   State<GraphQLApiView> createState() => _GraphQLApiViewState();
@@ -32,16 +30,17 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
   String _result = '';
   StreamSubscription<GraphQLResponse<String>>? _subscription;
   void Function()? _unsubscribe;
-  CancelableOperation? _lastOperation;
+  GraphQLOperation<String>? _lastOperation;
 
-  final subscriptionReq =
-      GraphQLRequest<String>(document: '''subscription MySubscription {
+  final subscriptionReq = GraphQLRequest<String>(
+    document: '''subscription MySubscription {
     onCreateBlog {
       id
       name
       createdAt
     }
-  }''');
+  }''',
+  );
 
   Future<void> subscribe() async {
     if (_subscription != null) {
@@ -76,7 +75,7 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
   }
 
   Future<void> query() async {
-    String graphQLDocument = '''query MyQuery {
+    const graphQLDocument = '''query MyQuery {
       listBlogs {
         items {
           id
@@ -86,12 +85,12 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
       }
     }''';
 
-    var operation = Amplify.API
+    final operation = Amplify.API
         .query<String>(request: GraphQLRequest(document: graphQLDocument));
-    _lastOperation = operation.operation;
+    _lastOperation = operation;
 
-    var response = await operation.response;
-    var data = response.data;
+    final response = await operation.response;
+    final data = response.data;
     if (data == null) {
       print('errors: ${response.errors}');
       return;
@@ -104,25 +103,25 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
   }
 
   Future<void> mutate() async {
-    String graphQLDocument = '''mutation MyMutation(\$name: String!) {
-      createBlog(input: {name: \$name}) {
+    const graphQLDocument = r'''mutation MyMutation($name: String!) {
+      createBlog(input: {name: $name}) {
         id
         name
         createdAt
       }
     }''';
 
-    var operation = Amplify.API.mutate(
+    final operation = Amplify.API.mutate(
       request: GraphQLRequest<String>(
         document: graphQLDocument,
         variables: <String, dynamic>{'name': 'Test App Blog'},
         authorizationMode: APIAuthorizationType.userPools,
       ),
     );
-    _lastOperation = operation.operation;
+    _lastOperation = operation;
 
-    var response = await operation.response;
-    var data = response.data;
+    final response = await operation.response;
+    final data = response.data;
     if (data == null) {
       print('errors: ${response.errors}');
       return;
@@ -136,7 +135,7 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
 
   void onCancelPressed() async {
     try {
-      _lastOperation?.cancel();
+      await _lastOperation?.cancel();
     } on Exception catch (e) {
       print('Cancel FAILED');
       print(e.toString());
@@ -146,23 +145,23 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
   @override
   Widget build(BuildContext context) {
     return ListView(
-      padding: const EdgeInsets.all(5.0),
+      padding: const EdgeInsets.all(5),
       children: <Widget>[
-        const Padding(padding: EdgeInsets.all(10.0)),
+        const Padding(padding: EdgeInsets.all(10)),
         Center(
           child: ElevatedButton(
             onPressed: widget.isAmplifyConfigured ? query : null,
             child: const Text('Run Query'),
           ),
         ),
-        const Padding(padding: EdgeInsets.all(10.0)),
+        const Padding(padding: EdgeInsets.all(10)),
         Center(
           child: ElevatedButton(
             onPressed: widget.isAmplifyConfigured ? mutate : null,
             child: const Text('Run Mutation'),
           ),
         ),
-        const Padding(padding: EdgeInsets.all(10.0)),
+        const Padding(padding: EdgeInsets.all(10)),
         Center(
           child: ElevatedButton(
             onPressed: widget.isAmplifyConfigured && _subscription == null
@@ -171,7 +170,7 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
             child: const Text('Subscribe'),
           ),
         ),
-        const Padding(padding: EdgeInsets.all(10.0)),
+        const Padding(padding: EdgeInsets.all(10)),
         Center(
           child: ElevatedButton(
             onPressed: _subscription != null
@@ -184,12 +183,12 @@ class _GraphQLApiViewState extends State<GraphQLApiView> {
             child: const Text('Unsubscribe'),
           ),
         ),
-        const Padding(padding: EdgeInsets.all(5.0)),
+        const Padding(padding: EdgeInsets.all(5)),
         Center(
           child: ElevatedButton(
             onPressed: _lastOperation != null &&
-                    _lastOperation!.isCompleted &&
-                    _lastOperation!.isCanceled
+                    _lastOperation!.operation.isCompleted &&
+                    _lastOperation!.operation.isCanceled
                 ? onCancelPressed
                 : null,
             child: const Text('Cancel Operation'),

--- a/packages/api/amplify_api/example/lib/main.dart
+++ b/packages/api/amplify_api/example/lib/main.dart
@@ -28,7 +28,7 @@ void main() {
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   State<MyApp> createState() => _MyAppState();
@@ -65,7 +65,8 @@ class _MyAppState extends State<MyApp> {
       await Amplify.configure(amplifyconfig);
     } on AmplifyAlreadyConfiguredException {
       print(
-          'Amplify was already configured. Looks like app restarted on android.');
+        'Amplify was already configured. Looks like app restarted on android.',
+      );
     }
     setState(() {
       _isAmplifyConfigured = true;
@@ -101,21 +102,23 @@ class _MyAppState extends State<MyApp> {
         home: Scaffold(
           appBar: AppBar(
             title: Padding(
-              padding: const EdgeInsets.all(10.0),
+              padding: const EdgeInsets.all(10),
               child: Row(
                 children: [
                   ElevatedButton(
-                      onPressed: _onRestApiViewButtonClick,
-                      child: const Text('Rest API')),
+                    onPressed: _onRestApiViewButtonClick,
+                    child: const Text('Rest API'),
+                  ),
                   ElevatedButton(
-                      onPressed: _onGraphQlApiViewButtonClick,
-                      child: const Text('GraphQL API'))
+                    onPressed: _onGraphQlApiViewButtonClick,
+                    child: const Text('GraphQL API'),
+                  )
                 ],
               ),
             ),
           ),
           body: Padding(
-            padding: const EdgeInsets.all(10.0),
+            padding: const EdgeInsets.all(10),
             child: _showRestApiView == true
                 ? const RestApiView()
                 : GraphQLApiView(isAmplifyConfigured: _isAmplifyConfigured),

--- a/packages/api/amplify_api/example/lib/rest_api_view.dart
+++ b/packages/api/amplify_api/example/lib/rest_api_view.dart
@@ -17,7 +17,7 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter/material.dart';
 
 class RestApiView extends StatefulWidget {
-  const RestApiView({Key? key}) : super(key: key);
+  const RestApiView({super.key});
 
   @override
   State<RestApiView> createState() => _RestApiViewState();
@@ -25,7 +25,7 @@ class RestApiView extends StatefulWidget {
 
 class _RestApiViewState extends State<RestApiView> {
   late TextEditingController _apiPathController;
-  late CancelableOperation _lastRestOperation;
+  late RestOperation _lastRestOperation;
 
   @override
   void initState() {
@@ -42,7 +42,7 @@ class _RestApiViewState extends State<RestApiView> {
         body: HttpPayload.json({'name': 'Mow the lawn'}),
       );
 
-      _lastRestOperation = restOperation.operation;
+      _lastRestOperation = restOperation;
       final response = await restOperation.response;
 
       print('Put SUCCESS');
@@ -60,7 +60,7 @@ class _RestApiViewState extends State<RestApiView> {
         body: HttpPayload.json({'name': 'Mow the lawn'}),
       );
 
-      _lastRestOperation = restOperation.operation;
+      _lastRestOperation = restOperation;
       final response = await restOperation.response;
 
       print('Post SUCCESS');
@@ -77,7 +77,7 @@ class _RestApiViewState extends State<RestApiView> {
         _apiPathController.text,
       );
 
-      _lastRestOperation = restOperation.operation;
+      _lastRestOperation = restOperation;
       final response = await restOperation.response;
 
       print('Get SUCCESS');
@@ -93,7 +93,7 @@ class _RestApiViewState extends State<RestApiView> {
       final restOperation = Amplify.API.delete(
         _apiPathController.text,
       );
-      _lastRestOperation = restOperation.operation;
+      _lastRestOperation = restOperation;
       final response = await restOperation.response;
 
       print('Delete SUCCESS');
@@ -106,7 +106,7 @@ class _RestApiViewState extends State<RestApiView> {
 
   void onCancelPressed() async {
     try {
-      _lastRestOperation.cancel();
+      await _lastRestOperation.cancel();
     } on Exception catch (e) {
       print('Cancel FAILED');
       print(e.toString());
@@ -119,7 +119,7 @@ class _RestApiViewState extends State<RestApiView> {
         _apiPathController.text,
       );
 
-      _lastRestOperation = restOperation.operation;
+      _lastRestOperation = restOperation;
       await restOperation.response;
 
       print('Head SUCCESS');
@@ -136,7 +136,7 @@ class _RestApiViewState extends State<RestApiView> {
         body: HttpPayload.json({'name': 'Mow the lawn'}),
       );
 
-      _lastRestOperation = restOperation.operation;
+      _lastRestOperation = restOperation;
       final response = await restOperation.response;
 
       print('Patch SUCCESS');
@@ -149,39 +149,41 @@ class _RestApiViewState extends State<RestApiView> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(children: [
-      TextField(
-        controller: _apiPathController,
-        decoration: const InputDecoration(
-          border: OutlineInputBorder(),
-          labelText: 'apiPath',
+    return Column(
+      children: [
+        TextField(
+          controller: _apiPathController,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            labelText: 'apiPath',
+          ),
         ),
-      ),
-      ElevatedButton(
-        onPressed: onPostPressed,
-        child: const Text('Post'),
-      ),
-      ElevatedButton(
-        onPressed: onPutPressed,
-        child: const Text('Put'),
-      ),
-      ElevatedButton(
-        onPressed: onGetPressed,
-        child: const Text('Get'),
-      ),
-      ElevatedButton(
-        onPressed: onCancelPressed,
-        child: const Text('Cancel'),
-      ),
-      ElevatedButton(
-        onPressed: onDeletePressed,
-        child: const Text('Delete'),
-      ),
-      ElevatedButton(
-        onPressed: onHeadPressed,
-        child: const Text('Head'),
-      ),
-      ElevatedButton(onPressed: onPatchPressed, child: const Text('Patch')),
-    ]);
+        ElevatedButton(
+          onPressed: onPostPressed,
+          child: const Text('Post'),
+        ),
+        ElevatedButton(
+          onPressed: onPutPressed,
+          child: const Text('Put'),
+        ),
+        ElevatedButton(
+          onPressed: onGetPressed,
+          child: const Text('Get'),
+        ),
+        ElevatedButton(
+          onPressed: onCancelPressed,
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          onPressed: onDeletePressed,
+          child: const Text('Delete'),
+        ),
+        ElevatedButton(
+          onPressed: onHeadPressed,
+          child: const Text('Head'),
+        ),
+        ElevatedButton(onPressed: onPatchPressed, child: const Text('Patch')),
+      ],
+    );
   }
 }


### PR DESCRIPTION
Formatting changes only here with a small type change. Vast majority were done automatically with a few manual changes.

This PR changes analysis_options.yaml from app_core.yaml to app.yaml and makes necessary changes to pass stricter requirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
