### PR TITLE
chore(auth)!: Make sign in result's `nextStep` non-null

### DIFF
--- a/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -206,14 +206,14 @@ class StateMachineBloc
         attributes: data.attributes,
       );
 
-      switch (result.nextStep!.signInStep) {
+      switch (result.nextStep.signInStep) {
         case 'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE':
           yield UnauthenticatedState.confirmSignInMfa;
           break;
         case 'CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE':
           yield ConfirmSignInCustom(
             publicParameters:
-                result.nextStep?.additionalInfo ?? <String, String>{},
+                result.nextStep.additionalInfo ?? <String, String>{},
           );
           break;
         case 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD':
@@ -292,15 +292,15 @@ class StateMachineBloc
     SignInResult result, {
     required bool isSocialSignIn,
   }) async {
-    switch (result.nextStep!.signInStep) {
+    switch (result.nextStep.signInStep) {
       case 'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE':
-        _notifyCodeSent(result.nextStep?.codeDeliveryDetails?.destination);
+        _notifyCodeSent(result.nextStep.codeDeliveryDetails?.destination);
         _emit(UnauthenticatedState.confirmSignInMfa);
         break;
       case 'CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE':
         _emit(ConfirmSignInCustom(
           publicParameters:
-              result.nextStep?.additionalInfo ?? <String, String>{},
+              result.nextStep.additionalInfo ?? <String, String>{},
         ));
         break;
       case 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD':
@@ -310,7 +310,7 @@ class StateMachineBloc
         _emit(UnauthenticatedState.confirmResetPassword);
         break;
       case 'CONFIRM_SIGN_UP':
-        _notifyCodeSent(result.nextStep?.codeDeliveryDetails?.destination);
+        _notifyCodeSent(result.nextStep.codeDeliveryDetails?.destination);
         _emit(UnauthenticatedState.confirmSignUp);
         break;
       case 'DONE':

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_result.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_result.dart
@@ -33,7 +33,7 @@ class SignInResult<Key extends AuthUserAttributeKey>
         AWSDebuggable {
   const SignInResult({
     required this.isSignedIn,
-    this.nextStep,
+    required this.nextStep,
   });
 
   factory SignInResult.fromJson(
@@ -42,16 +42,14 @@ class SignInResult<Key extends AuthUserAttributeKey>
   ) =>
       SignInResult<Key>(
         isSignedIn: json['isSignedIn'] as bool,
-        nextStep: json['nextStep'] == null
-            ? null
-            : AuthNextSignInStep<Key>.fromJson(
-                json['nextStep'] as Map<String, Object?>,
-                fromJsonKey,
-              ),
+        nextStep: AuthNextSignInStep<Key>.fromJson(
+          json['nextStep'] as Map<String, Object?>,
+          fromJsonKey,
+        ),
       );
 
   final bool isSignedIn;
-  final AuthNextSignInStep<Key>? nextStep;
+  final AuthNextSignInStep<Key> nextStep;
 
   @override
   List<Object?> get props => [isSignedIn, nextStep];

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_result.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_result.g.dart
@@ -9,20 +9,11 @@ part of 'sign_in_result.dart';
 Map<String, dynamic> _$SignInResultToJson<Key extends AuthUserAttributeKey>(
   SignInResult<Key> instance,
   Object? Function(Key value) toJsonKey,
-) {
-  final val = <String, dynamic>{
-    'hashCode': instance.hashCode,
-    'isSignedIn': instance.isSignedIn,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('nextStep', instance.nextStep?.toJson());
-  val['props'] = instance.props;
-  val['runtimeTypeName'] = instance.runtimeTypeName;
-  return val;
-}
+) =>
+    <String, dynamic>{
+      'hashCode': instance.hashCode,
+      'isSignedIn': instance.isSignedIn,
+      'nextStep': instance.nextStep.toJson(),
+      'props': instance.props,
+      'runtimeTypeName': instance.runtimeTypeName,
+    };

--- a/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
@@ -91,7 +91,7 @@ void main() {
           username: username,
           password: password,
         );
-        expect(signInResult.nextStep?.signInStep, 'CONFIRM_SIGN_UP');
+        expect(signInResult.nextStep.signInStep, 'CONFIRM_SIGN_UP');
 
         // Confirm sign up and complete sign in
         final confirmResult = await Amplify.Auth.confirmSignUp(
@@ -104,7 +104,7 @@ void main() {
           username: username,
           password: password,
         );
-        expect(signInComplete.nextStep?.signInStep, 'DONE');
+        expect(signInComplete.nextStep.signInStep, 'DONE');
       });
 
       asyncTest('can resend sign up code', (_) async {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/custom_auth_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/custom_auth_test.dart
@@ -63,11 +63,11 @@ void main() {
           options: options,
         );
         expect(
-          res.nextStep!.signInStep,
+          res.nextStep.signInStep,
           'CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE',
         );
 
-        final additionalInfo = res.nextStep!.additionalInfo ?? const {};
+        final additionalInfo = res.nextStep.additionalInfo ?? const {};
 
         // additionalInfo key values defined in lambda code
         expect(additionalInfo, hasLength(2));
@@ -147,11 +147,11 @@ void main() {
           options: options,
         );
         expect(
-          res.nextStep?.signInStep,
+          res.nextStep.signInStep,
           'CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE',
         );
 
-        final additionalInfo = res.nextStep!.additionalInfo ?? const {};
+        final additionalInfo = res.nextStep.additionalInfo ?? const {};
 
         // additionalInfo key values defined in lambda code
         expect(additionalInfo, hasLength(1));

--- a/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
@@ -89,7 +89,7 @@ void main() {
           username: username!,
           password: password,
         );
-        if (signInRes.nextStep?.signInStep ==
+        if (signInRes.nextStep.signInStep ==
             'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE') {
           final confirmSignInRes = await Amplify.Auth.confirmSignIn(
             confirmationValue: await otpResult.code,
@@ -169,7 +169,7 @@ void main() {
             password: password,
           );
           expect(
-            res.nextStep?.signInStep,
+            res.nextStep.signInStep,
             'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE',
             reason: 'Subsequent sign-in attempts should require MFA',
           );

--- a/packages/auth/amplify_auth_cognito/example/integration_test/federated_sign_in_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/federated_sign_in_test.dart
@@ -70,7 +70,7 @@ void main() {
         username: username,
         password: password,
       );
-      expect(signInResult.nextStep?.signInStep, 'DONE');
+      expect(signInResult.nextStep.signInStep, 'DONE');
 
       final userPoolTokens =
           (await cognitoPlugin.fetchAuthSession()).userPoolTokens!;
@@ -93,7 +93,7 @@ void main() {
         username: username,
         password: password,
       );
-      expect(signInResult.nextStep?.signInStep, 'DONE');
+      expect(signInResult.nextStep.signInStep, 'DONE');
 
       await expectLater(
         cognitoPlugin.federateToIdentityPool(
@@ -144,7 +144,7 @@ void main() {
         username: username,
         password: password,
       );
-      expect(signInResult.nextStep?.signInStep, 'DONE');
+      expect(signInResult.nextStep.signInStep, 'DONE');
 
       final userPoolTokens =
           (await cognitoPlugin.fetchAuthSession()).userPoolTokens!;

--- a/packages/auth/amplify_auth_cognito/example/integration_test/force_refresh_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/force_refresh_test.dart
@@ -58,7 +58,7 @@ void main() {
         username: username,
         password: password,
       );
-      expect(res.nextStep?.signInStep, 'DONE');
+      expect(res.nextStep.signInStep, 'DONE');
 
       expect(
         await getCustomAttributes(),

--- a/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
@@ -121,7 +121,7 @@ void main() {
             password: password,
           );
           expect(
-            signInRes.nextStep?.signInStep,
+            signInRes.nextStep.signInStep,
             'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE',
           );
           final confirmSignInRes = await Amplify.Auth.confirmSignIn(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_test.dart
@@ -61,14 +61,14 @@ void main() {
           password: password,
         );
         expect(
-          signInRes.nextStep?.signInStep,
+          signInRes.nextStep.signInStep,
           'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE',
         );
 
         final confirmRes = await Amplify.Auth.confirmSignIn(
           confirmationValue: await otpResult.code,
         );
-        expect(confirmRes.nextStep?.signInStep, 'DONE');
+        expect(confirmRes.nextStep.signInStep, 'DONE');
       });
     },
     // TODO(equartey): ensure state machine GQL sub impl doesn't have this issue.

--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_in_sign_out_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_in_sign_out_test.dart
@@ -101,7 +101,7 @@ void main() {
         username: username,
         password: password,
       );
-      expect(result.nextStep?.additionalInfo, isNull);
+      expect(result.nextStep.additionalInfo, isNull);
     });
 
     asyncTest('identity ID should be the same between sessions', (_) async {
@@ -116,7 +116,7 @@ void main() {
           username: username,
           password: password,
         );
-        expect(signInRes.nextStep?.signInStep, 'DONE');
+        expect(signInRes.nextStep.signInStep, 'DONE');
       }
 
       // Get authenticated identity
@@ -141,7 +141,7 @@ void main() {
           username: username,
           password: password,
         );
-        expect(signInRes.nextStep?.signInStep, 'DONE');
+        expect(signInRes.nextStep.signInStep, 'DONE');
       }
 
       final newSession = await Amplify.Auth.fetchAuthSession(

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/confirm_sign_in.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/confirm_sign_in.dart
@@ -44,10 +44,10 @@ class _ConfirmSignInWidgetState extends State<ConfirmSignInWidget> {
         confirmationValue: confirmationCodeController.text.trim(),
       );
       widget.showResult(
-        'Confirm Sign In Status = ${res.nextStep?.signInStep}',
+        'Confirm Sign In Status = ${res.nextStep.signInStep}',
       );
       widget.changeDisplay(
-        res.nextStep?.signInStep == 'DONE'
+        res.nextStep.signInStep == 'DONE'
             ? 'SIGNED_IN'
             : 'SHOW_CONFIRM_SIGN_IN',
       );

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/sign_in.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/sign_in.dart
@@ -52,7 +52,7 @@ class _SignInWidgetState extends State<SignInWidget> {
         password: passwordController.text.trim(),
       );
       widget.showResult(
-        'Sign In Status = ${res.nextStep?.signInStep ?? 'null'}',
+        'Sign In Status = ${res.nextStep.signInStep}',
       );
       widget.changeDisplay(
         res.isSignedIn ? 'SIGNED_IN' : 'SHOW_CONFIRM_SIGN_IN',

--- a/packages/auth/amplify_auth_cognito_dart/example/bin/example.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/bin/example.dart
@@ -132,10 +132,9 @@ Future<SignInResult> _processSignInResult(
   required String username,
   required String password,
 }) async {
-  final nextStep = result.nextStep?.signInStep;
+  final nextStep = result.nextStep.signInStep;
   final missingAttributes =
-      result.nextStep?.missingAttributes.cast<CognitoUserAttributeKey>() ??
-          const [];
+      result.nextStep.missingAttributes.cast<CognitoUserAttributeKey>();
   switch (nextStep) {
     case 'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE':
     case 'CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE':

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/app_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/app_component.dart
@@ -129,7 +129,7 @@ class AppComponent extends StatefulComponent {
 
   void _processSignInResult(SignInResult res) {
     if (!res.isSignedIn) {
-      switch (res.nextStep!.signInStep) {
+      switch (res.nextStep.signInStep) {
         case 'CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE':
           setState(() {
             appState = appState.copyWith(

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_result.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_result.dart
@@ -22,6 +22,6 @@ class CognitoSignInResult extends SignInResult<CognitoUserAttributeKey> {
   /// {@macro amplify_auth_cognito.model.cognito_sign_in_result}
   const CognitoSignInResult({
     required super.isSignedIn,
-    super.nextStep,
+    required super.nextStep,
   });
 }


### PR DESCRIPTION
To align with other platforms and improve DX.