### PR TITLE
chore(version): vNext release

### DIFF
--- a/packages/amplify/amplify_flutter/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.0.0-next.2
+
+### Breaking Changes
+- chore(auth)!: Make sign in result's `nextStep` non-null ([#2462](https://github.com/aws-amplify/amplify-flutter/pull/2462))
+- feat(api)!: Web Socket State Machine  ([#2458](https://github.com/aws-amplify/amplify-flutter/pull/2458))
+- feat(auth)!: Support partial sign out cases ([#2436](https://github.com/aws-amplify/amplify-flutter/pull/2436))
+
+### Fixes
+- fix(api): support multiple belongsTo ([#2087](https://github.com/aws-amplify/amplify-flutter/pull/2087))
+- fix(auth): Can't resubmit verification code ([#2468](https://github.com/aws-amplify/amplify-flutter/pull/2468))
+
+### Features
+- feat(auth): Add user ID to `CognitoSignUpResult` ([#2437](https://github.com/aws-amplify/amplify-flutter/pull/2437))
+
 ## 1.0.0-next.1+1
 
 ### Fixes

--- a/packages/amplify/amplify_flutter/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/amplify/amplify_flutter/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import amplify_secure_storage
-import connectivity_plus_macos
+import connectivity_plus
 import device_info_plus_macos
 import package_info_plus_macos
 import path_provider_macos

--- a/packages/amplify/amplify_flutter/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/amplify/amplify_flutter/example/windows/flutter/generated_plugin_registrant.cc
@@ -7,7 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <amplify_db_common/amplify_db_common_plugin.h>
-#include <connectivity_plus_windows/connectivity_plus_windows_plugin.h>
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AmplifyDbCommonPluginRegisterWithRegistrar(

--- a/packages/amplify/amplify_flutter/example/windows/flutter/generated_plugins.cmake
+++ b/packages/amplify/amplify_flutter/example/windows/flutter/generated_plugins.cmake
@@ -4,7 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   amplify_db_common
-  connectivity_plus_windows
+  connectivity_plus
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter
 description: The top level Flutter package for the AWS Amplify libraries.
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,10 +19,10 @@ platforms:
   web:
 
 dependencies:
-  amplify_core: ">=1.0.0-next.1 <1.0.0-next.2"
-  amplify_datastore_plugin_interface: ">=1.0.0-next.1 <1.0.0-next.2"
-  amplify_flutter_android: ">=1.0.0-next.1 <1.0.0-next.2"
-  amplify_flutter_ios: ">=1.0.0-next.1 <1.0.0-next.2"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_datastore_plugin_interface: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_flutter_android: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_flutter_ios: ">=1.0.0-next.2 <1.0.0-next.3"
   amplify_secure_storage: ">=0.1.3 <0.2.0"
   aws_common: ">=0.3.1 <0.4.0"
   collection: ^1.15.0

--- a/packages/amplify/amplify_flutter_android/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.1+1
 
 - Minor bug fixes and improvements

--- a/packages/amplify/amplify_flutter_android/pubspec.yaml
+++ b/packages/amplify/amplify_flutter_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter_android
 description: The method channel implementation for amplify_flutter on Android
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter_android
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/amplify/amplify_flutter_ios/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.1+1
 
 - Minor bug fixes and improvements

--- a/packages/amplify/amplify_flutter_ios/pubspec.yaml
+++ b/packages/amplify/amplify_flutter_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter_ios
 description: The method channel implementation for amplify_flutter on iOS
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.1+1 <1.0.0-next.2"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   flutter:
     sdk: flutter
 

--- a/packages/amplify_authenticator/CHANGELOG.md
+++ b/packages/amplify_authenticator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.1+2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.1+1
 
 - Minor bug fixes and improvements

--- a/packages/amplify_authenticator/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/amplify_authenticator/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import amplify_secure_storage
-import connectivity_plus_macos
+import connectivity_plus
 import path_provider_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {

--- a/packages/amplify_authenticator/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/amplify_authenticator/example/windows/flutter/generated_plugin_registrant.cc
@@ -6,7 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <connectivity_plus_windows/connectivity_plus_windows_plugin.h>
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(

--- a/packages/amplify_authenticator/example/windows/flutter/generated_plugins.cmake
+++ b/packages/amplify_authenticator/example/windows/flutter/generated_plugins.cmake
@@ -3,7 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  connectivity_plus_windows
+  connectivity_plus
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/packages/amplify_authenticator/pubspec.yaml
+++ b/packages/amplify_authenticator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_authenticator
 description: A prebuilt Sign In and Sign Up experience for the Amplify Auth category
-version: 1.0.0-next.1+1
+version: 1.0.0-next.1+2
 homepage: https://ui.docs.amplify.aws/flutter/connected-components/authenticator
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_authenticator
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,9 +10,9 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_auth_cognito: ">=1.0.0-next.1+1 <1.0.0-next.2"
-  amplify_core: ">=1.0.0-next.1 <1.0.0-next.2"
-  amplify_flutter: ">=1.0.0-next.1 <1.0.0-next.2"
+  amplify_auth_cognito: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_flutter: ">=1.0.0-next.2 <1.0.0-next.3"
   async: ^2.8.0
   aws_common: ">=0.3.3 <0.4.0"
   collection: ^1.15.0

--- a/packages/amplify_core/CHANGELOG.md
+++ b/packages/amplify_core/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.0.0-next.2
+
+### Breaking Changes
+- chore(auth)!: Make sign in result's `nextStep` non-null ([#2462](https://github.com/aws-amplify/amplify-flutter/pull/2462))
+- feat(api)!: Web Socket State Machine  ([#2458](https://github.com/aws-amplify/amplify-flutter/pull/2458))
+- feat(auth)!: Support partial sign out cases ([#2436](https://github.com/aws-amplify/amplify-flutter/pull/2436))
+
+### Fixes
+- fix(api): support multiple belongsTo ([#2087](https://github.com/aws-amplify/amplify-flutter/pull/2087))
+- fix(auth): Can't resubmit verification code ([#2468](https://github.com/aws-amplify/amplify-flutter/pull/2468))
+
+### Features
+- feat(auth): Add user ID to `CognitoSignUpResult` ([#2437](https://github.com/aws-amplify/amplify-flutter/pull/2437))
+
 ## 1.0.0-next.1+1
 
 ### Fixes

--- a/packages/amplify_core/lib/src/amplify_class.dart
+++ b/packages/amplify_core/lib/src/amplify_class.dart
@@ -145,7 +145,7 @@ abstract class AmplifyClass {
   static AmplifyClass? instance;
 
   /// The library version.
-  String get version => '1.0.0-next.1';
+  String get version => '1.0.0-next.2';
 
   /// Resets the Amplify implementation, removing all traces of Amplify from
   /// the device.

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_core
 description: The base package containing common types and utilities that are shared across the Amplify Flutter packages.
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_core
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/amplify_datastore/CHANGELOG.md
+++ b/packages/amplify_datastore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.1+1
 
 ### Fixes

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore
 description: The Amplify Flutter DataStore category plugin, providing a queryable, on-device data store.
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_datastore
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_datastore_plugin_interface: ">=1.0.0-next.1+1 <1.0.0-next.2"
-  amplify_core: ">=1.0.0-next.1+1 <1.0.0-next.2"
+  amplify_datastore_plugin_interface: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   plugin_platform_interface: ^2.0.0
   meta: ^1.7.0
   collection: ^1.14.13

--- a/packages/amplify_datastore_plugin_interface/CHANGELOG.md
+++ b/packages/amplify_datastore_plugin_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.1+1
 
 ### Fixes

--- a/packages/amplify_datastore_plugin_interface/pubspec.yaml
+++ b/packages/amplify_datastore_plugin_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore_plugin_interface
 description: The platform interface for the DataStore module of Amplify Flutter.
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_datastore_plugin_interface
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.1+1 <1.0.0-next.2"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   collection: ^1.15.0
   flutter:
     sdk: flutter

--- a/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.1+1
 
 - Minor bug fixes and improvements

--- a/packages/analytics/amplify_analytics_pinpoint/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/analytics/amplify_analytics_pinpoint/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import amplify_secure_storage
-import connectivity_plus_macos
+import connectivity_plus
 import device_info_plus_macos
 import package_info_plus_macos
 import path_provider_macos

--- a/packages/analytics/amplify_analytics_pinpoint/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/analytics/amplify_analytics_pinpoint/example/windows/flutter/generated_plugin_registrant.cc
@@ -7,7 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <amplify_db_common/amplify_db_common_plugin.h>
-#include <connectivity_plus_windows/connectivity_plus_windows_plugin.h>
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AmplifyDbCommonPluginRegisterWithRegistrar(

--- a/packages/analytics/amplify_analytics_pinpoint/example/windows/flutter/generated_plugins.cmake
+++ b/packages/analytics/amplify_analytics_pinpoint/example/windows/flutter/generated_plugins.cmake
@@ -4,7 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   amplify_db_common
-  connectivity_plus_windows
+  connectivity_plus
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint
 description: The Amplify Flutter Analytics category plugin using the AWS Pinpoint provider.
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/analytics/amplify_analytics_pinpoint
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -20,7 +20,7 @@ platforms:
 
 dependencies:
   amplify_analytics_pinpoint_dart: ">=0.1.1 <0.2.0"
-  amplify_core: ">=1.0.0-next.1+1 <1.0.0-next.2"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   amplify_db_common: ">=0.1.2 <0.2.0"
   amplify_secure_storage: ">=0.1.4 <0.2.0"
   aws_common: ">=0.3.3 <0.4.0"

--- a/packages/analytics/amplify_analytics_pinpoint_dart/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- Minor bug fixes and improvements
+
 ## 0.1.1
 
 - Minor bug fixes and improvements

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/version.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.1.1';
+const packageVersion = '0.1.2';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint_dart
 description: A Dart-only implementation of the Amplify Analytics plugin for Pinpoint.
-version: 0.1.1
+version: 0.1.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/feat/next-release/packages/analytics
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.1 <1.0.0-next.2"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   amplify_db_common_dart: ">=0.1.2 <0.2.0"
   amplify_secure_storage_dart: ">=0.1.3 <0.2.0"
   aws_common: ">=0.3.1 <0.4.0"

--- a/packages/api/amplify_api/CHANGELOG.md
+++ b/packages/api/amplify_api/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.0-next.2
+
+### Breaking Changes
+- feat(api)!: Web Socket State Machine  ([#2458](https://github.com/aws-amplify/amplify-flutter/pull/2458))
+
+### Fixes
+- fix(api): support multiple belongsTo ([#2087](https://github.com/aws-amplify/amplify-flutter/pull/2087))
+
 ## 1.0.0-next.1+1
 
 ### Fixes

--- a/packages/api/amplify_api/lib/src/graphql/model_helpers/model_mutations.dart
+++ b/packages/api/amplify_api/lib/src/graphql/model_helpers/model_mutations.dart
@@ -24,7 +24,7 @@ class ModelMutations {
   /// Generates a request to create a model.
   ///
   /// ```dart
-  /// Todo todo = Todo(name: 'my first todo', description: 'todo description');
+  /// final todo = Todo(name: 'my first todo', description: 'todo description');
   /// final request = ModelMutations.create(todo);
   /// ```
   static GraphQLRequest<T> create<T extends Model>(

--- a/packages/api/amplify_api/lib/src/graphql/web_socket/blocs/web_socket_bloc.dart
+++ b/packages/api/amplify_api/lib/src/graphql/web_socket/blocs/web_socket_bloc.dart
@@ -500,9 +500,13 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
     try {
       final res = await _sendPollRequest();
       await checkPollResponse(res);
-      add(const PollSuccessEvent());
+      if (!_wsEventController.isClosed) {
+        add(const PollSuccessEvent());
+      }
     } on Exception catch (e) {
-      add(PollFailedEvent(e));
+      if (!_wsEventController.isClosed) {
+        add(PollFailedEvent(e));
+      }
     }
   }
 

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api
 description: The Amplify Flutter API category plugin, supporting GraphQL and REST operations.
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,10 +19,10 @@ platforms:
   web:
 
 dependencies:
-  amplify_api_android: ">=1.0.0-next.1+1 <1.0.0-next.2"
-  amplify_api_ios: ">=1.0.0-next.1+1 <1.0.0-next.2"
-  amplify_core: ">=1.0.0-next.1+1 <1.0.0-next.2"
-  amplify_flutter: ">=1.0.0-next.1 <1.0.0-next.2"
+  amplify_api_android: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_api_ios: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_flutter: ">=1.0.0-next.2 <1.0.0-next.3"
   async: ^2.8.0
   aws_common: ">=0.3.3 <0.4.0"
   collection: ^1.15.0

--- a/packages/api/amplify_api_android/CHANGELOG.md
+++ b/packages/api/amplify_api_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.1+1
 
 - Minor bug fixes and improvements

--- a/packages/api/amplify_api_android/pubspec.yaml
+++ b/packages/api/amplify_api_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_android
 description: The method channel implementation for amplify_api on Android
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api_android
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/api/amplify_api_ios/CHANGELOG.md
+++ b/packages/api/amplify_api_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.1+1
 
 - Minor bug fixes and improvements

--- a/packages/api/amplify_api_ios/pubspec.yaml
+++ b/packages/api/amplify_api_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_ios
 description: The method channel implementation for amplify_api on iOS
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.1+1 <1.0.0-next.2"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   flutter:
     sdk: flutter
 

--- a/packages/auth/amplify_auth_cognito/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.0.0-next.2
+
+### Fixes
+- fix(auth): Can't resubmit verification code ([#2468](https://github.com/aws-amplify/amplify-flutter/pull/2468))
+
+### Breaking Changes
+- chore(auth)!: Make sign in result's `nextStep` non-null ([#2462](https://github.com/aws-amplify/amplify-flutter/pull/2462))
+
+### Features
+- feat(auth): Add user ID to `CognitoSignUpResult` ([#2437](https://github.com/aws-amplify/amplify-flutter/pull/2437))
+
 ## 1.0.0-next.1+1
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/auth/amplify_auth_cognito/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import amplify_secure_storage
-import connectivity_plus_macos
+import connectivity_plus
 import path_provider_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {

--- a/packages/auth/amplify_auth_cognito/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/auth/amplify_auth_cognito/example/windows/flutter/generated_plugin_registrant.cc
@@ -6,7 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <connectivity_plus_windows/connectivity_plus_windows_plugin.h>
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(

--- a/packages/auth/amplify_auth_cognito/example/windows/flutter/generated_plugins.cmake
+++ b/packages/auth/amplify_auth_cognito/example/windows/flutter/generated_plugins.cmake
@@ -3,7 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  connectivity_plus_windows
+  connectivity_plus
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito
 description: The Amplify Flutter Auth category plugin using the AWS Cognito provider.
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,11 +19,11 @@ platforms:
   web:
 
 dependencies:
-  amplify_auth_cognito_android: ">=1.0.0-next.1+1 <1.0.0-next.2"
-  amplify_auth_cognito_dart: ">=0.2.5 <0.3.0"
-  amplify_auth_cognito_ios: ">=1.0.0-next.1+1 <1.0.0-next.2"
-  amplify_core: ">=1.0.0-next.1+1 <1.0.0-next.2"
-  amplify_flutter: ">=1.0.0-next.1 <1.0.0-next.2"
+  amplify_auth_cognito_android: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_auth_cognito_dart: ">=0.3.0 <0.4.0"
+  amplify_auth_cognito_ios: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_flutter: ">=1.0.0-next.2 <1.0.0-next.3"
   amplify_secure_storage: ">=0.1.4 <0.2.0"
   async: ^2.8.0
   flutter:

--- a/packages/auth/amplify_auth_cognito_android/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.1+1
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito_android/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_android
 description: The method channel implementation for amplify_auth_cognito on Android
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_android
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.3.0
+
+### Fixes
+- fix(auth): Can't resubmit verification code ([#2468](https://github.com/aws-amplify/amplify-flutter/pull/2468))
+- fix(auth): globalSignOut failure case
+
+### Breaking Changes
+- chore(auth)!: Make sign in result's `nextStep` non-null ([#2462](https://github.com/aws-amplify/amplify-flutter/pull/2462))
+- feat(auth)!: Support partial sign out cases ([#2436](https://github.com/aws-amplify/amplify-flutter/pull/2436))
+
+### Features
+- feat(auth): Add user ID to `CognitoSignUpResult` ([#2437](https://github.com/aws-amplify/amplify-flutter/pull/2437))
+
 ## 0.2.5
 
 ### Fixes

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_dart
 description: A Dart-only implementation of the Amplify Auth plugin for Cognito.
-version: 0.2.5
+version: 0.3.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.1+1 <1.0.0-next.2"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   amplify_secure_storage_dart: ">=0.1.4 <0.2.0"
   async: ^2.8.0
   aws_common: ">=0.3.3 <0.4.0"

--- a/packages/auth/amplify_auth_cognito_ios/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.1+1
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito_ios/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_ios
 description: The method channel implementation for amplify_auth_cognito on iOS
-version: 1.0.0-next.1+1
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.1+1 <1.0.0-next.2"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   flutter:
     sdk: flutter
 

--- a/packages/aws_common/CHANGELOG.md
+++ b/packages/aws_common/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.3.4
+
+### Features
+- feat(aws_common): AWSFile basic mime type detection based on extension name
+- feat(aws_common): allow specifying contentType initiating AWSFile
+
+### Fixes
+- fix(http): Synchronous cancellations on JS ([#2453](https://github.com/aws-amplify/amplify-flutter/pull/2453))
+
 ## 0.3.3
 
 ### Fixes

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aws_common
 description: Common types and utilities used across AWS and Amplify packages.
-version: 0.3.3
+version: 0.3.4
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/aws_common
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/common/amplify_db_common_dart/CHANGELOG.md
+++ b/packages/common/amplify_db_common_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+- Minor bug fixes and improvements
+
 ## 0.1.2
 
 - Minor bug fixes and improvements

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_db_common_dart
 description: Common utilities for working with databases such as sqlite.
-version: 0.1.2
+version: 0.1.3
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/common/amplify_db_common_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.1+1 <1.0.0-next.2"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   async: ^2.8.0
   aws_common: ">=0.3.3 <0.4.0"
   drift: ">=2.3.0 <2.4.0"

--- a/packages/storage/amplify_storage_s3/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0-next.2
+
+### Fixes
+- fix(storage): adapt updated AWSFile.contentType getter
+- fix(storage): use correct fallback contentType for upload
+
 ## 1.0.0-next.1+2
 
 - Minor bug fixes and improvements

--- a/packages/storage/amplify_storage_s3/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/storage/amplify_storage_s3/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import amplify_secure_storage
-import connectivity_plus_macos
+import connectivity_plus
 import path_provider_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {

--- a/packages/storage/amplify_storage_s3/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/storage/amplify_storage_s3/example/windows/flutter/generated_plugin_registrant.cc
@@ -7,7 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <amplify_db_common/amplify_db_common_plugin.h>
-#include <connectivity_plus_windows/connectivity_plus_windows_plugin.h>
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AmplifyDbCommonPluginRegisterWithRegistrar(

--- a/packages/storage/amplify_storage_s3/example/windows/flutter/generated_plugins.cmake
+++ b/packages/storage/amplify_storage_s3/example/windows/flutter/generated_plugins.cmake
@@ -4,7 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   amplify_db_common
-  connectivity_plus_windows
+  connectivity_plus
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3
 description: The Amplify Flutter Storage category plugin using the AWS S3 provider.
-version: 1.0.0-next.1+2
+version: 1.0.0-next.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/storage/amplify_storage_s3
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,9 +19,9 @@ platforms:
   web:
 
 dependencies:
-  amplify_core: ">=1.0.0-next.1+1 <1.0.0-next.2"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   amplify_db_common: ">=0.1.2 <0.2.0"
-  amplify_storage_s3_dart: ">=0.1.2 <0.2.0"
+  amplify_storage_s3_dart: ">=0.1.3 <0.2.0"
   aws_common: ">=0.3.3 <0.4.0"
   flutter:
     sdk: flutter

--- a/packages/storage/amplify_storage_s3_dart/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3_dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.3
+
+### Fixes
+- fix(storage): adapt updated AWSFile.contentType getter
+- fix(storage): use correct fallback contentType for upload
+
 ## 0.1.2
 
 - Minor bug fixes and improvements

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3_dart
 description: A Dart-only implementation of the Amplify Storage plugin for S3.
-version: 0.1.2
+version: 0.1.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/storage/amplify_storage_s3_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  amplify_core: ">=1.0.0-next.1 <1.0.0-next.2"
+  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   amplify_db_common_dart: ">=0.1.2 <0.2.0"
   async: ^2.8.0
   aws_common: ">=0.3.3 <0.4.0"


### PR DESCRIPTION
### Breaking Changes
- chore(auth)!: Make sign in result's `nextStep` non-null ([https://github.com/aws-amplify/amplify-flutter/pull/2462](https://github.com/aws-amplify/amplify-flutter/pull/2462))
- feat(api)!: Web Socket State Machine  ([https://github.com/aws-amplify/amplify-flutter/pull/2458](https://github.com/aws-amplify/amplify-flutter/pull/2458))
- feat(auth)!: Support partial sign out cases ([https://github.com/aws-amplify/amplify-flutter/pull/2436](https://github.com/aws-amplify/amplify-flutter/pull/2436))

### Fixes
- fix(api): support multiple belongsTo ([https://github.com/aws-amplify/amplify-flutter/pull/2087](https://github.com/aws-amplify/amplify-flutter/pull/2087))
- fix(auth): Can't resubmit verification code ([https://github.com/aws-amplify/amplify-flutter/pull/2468](https://github.com/aws-amplify/amplify-flutter/pull/2468))
- fix(storage): adapt updated AWSFile.contentType getter
- fix(storage): use correct fallback contentType for upload

### Features
- feat(auth): Add user ID to `CognitoSignUpResult` ([https://github.com/aws-amplify/amplify-flutter/pull/2437](https://github.com/aws-amplify/amplify-flutter/pull/2437))