### PR TITLE
fix(authenticator): keyboard navigation

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/authenticator/amplify_authenticator/lib/amplify_authenticator.dart
@@ -795,23 +795,25 @@ class AuthenticatedView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _AuthStateBuilder(
-      child: child,
-      builder: (state, child) {
-        if (state is AuthenticatedState) {
-          return child;
-        }
-        return ScaffoldMessenger(
-          key: _AuthenticatorState.scaffoldMessengerKey,
-          child: Scaffold(
-            body: SizedBox.expand(
-              child: child is AuthenticatorScreen
-                  ? SingleChildScrollView(child: child)
-                  : child,
+    return FocusTraversalGroup(
+      child: _AuthStateBuilder(
+        child: child,
+        builder: (state, child) {
+          if (state is AuthenticatedState) {
+            return child;
+          }
+          return ScaffoldMessenger(
+            key: _AuthenticatorState.scaffoldMessengerKey,
+            child: Scaffold(
+              body: SizedBox.expand(
+                child: child is AuthenticatorScreen
+                    ? SingleChildScrollView(child: child)
+                    : child,
+              ),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 }

--- a/packages/authenticator/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/mixins/authenticator_date_field.dart
@@ -84,6 +84,7 @@ mixin AuthenticatorDateField<FieldType,
       ),
       keyboardType: TextInputType.datetime,
       controller: _controller,
+      onFieldSubmitted: onFieldSubmitted,
     );
   }
 }

--- a/packages/authenticator/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/mixins/authenticator_text_field.dart
@@ -56,6 +56,7 @@ mixin AuthenticatorTextField<FieldType,
           maxLengthEnforcement: MaxLengthEnforcement.enforced,
           keyboardType: keyboardType,
           obscureText: obscureText,
+          onFieldSubmitted: onFieldSubmitted,
         );
       },
     );

--- a/packages/authenticator/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/mixins/authenticator_username_field.dart
@@ -260,6 +260,7 @@ mixin AuthenticatorUsernameField<FieldType,
       ),
       keyboardType: keyboardType,
       obscureText: false,
+      onFieldSubmitted: onFieldSubmitted,
     );
   }
 }

--- a/packages/authenticator/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -212,6 +212,42 @@ abstract class AuthenticatorFormFieldState<FieldType, FieldValue,
   /// Widget to show above the label.
   Widget? get surlabel => null;
 
+  /// A function that will be called when the Form Field is submitted, for
+  /// example when the enter key is pressed down on web/desktop.
+  void onFieldSubmitted(String _) {
+    switch (state.currentStep) {
+      case AuthenticatorStep.signUp:
+        state.signUp();
+        break;
+      case AuthenticatorStep.signIn:
+        state.signIn();
+        break;
+      case AuthenticatorStep.confirmSignUp:
+        state.confirmSignUp();
+        break;
+      case AuthenticatorStep.confirmSignInCustomAuth:
+        state.confirmSignInCustomAuth();
+        break;
+      case AuthenticatorStep.confirmSignInMfa:
+        state.confirmSignInMFA();
+        break;
+      case AuthenticatorStep.confirmSignInNewPassword:
+        state.confirmSignInNewPassword();
+        break;
+      case AuthenticatorStep.resetPassword:
+        state.resetPassword();
+        break;
+      case AuthenticatorStep.confirmResetPassword:
+        state.confirmResetPassword();
+        break;
+      case AuthenticatorStep.verifyUser:
+        state.verifyUser();
+        break;
+      default:
+        break;
+    }
+  }
+
   @nonVirtual
   @override
   Widget build(BuildContext context) {

--- a/packages/authenticator/amplify_authenticator/test/authenticated_view_test.dart
+++ b/packages/authenticator/amplify_authenticator/test/authenticated_view_test.dart
@@ -1,3 +1,17 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
 import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:amplify_authenticator/src/state/inherited_authenticator_state.dart';
 import 'package:amplify_authenticator_test/amplify_authenticator_test.dart';

--- a/packages/authenticator/amplify_authenticator/test/authenticated_view_test.dart
+++ b/packages/authenticator/amplify_authenticator/test/authenticated_view_test.dart
@@ -1,15 +1,15 @@
-// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); 
-// you may not use this file except in compliance with the License. 
-// You may obtain a copy of the License at 
-// 
-//      http://www.apache.org/licenses/LICENSE-2.0 
-// 
-// Unless required by applicable law or agreed to in writing, software 
-// distributed under the License is distributed on an "AS IS" BASIS, 
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-// See the License for the specific language governing permissions and 
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
 // limitations under the License.
 
 import 'package:amplify_authenticator/amplify_authenticator.dart';

--- a/packages/authenticator/amplify_authenticator/test/authenticated_view_test.dart
+++ b/packages/authenticator/amplify_authenticator/test/authenticated_view_test.dart
@@ -1,0 +1,156 @@
+import 'package:amplify_authenticator/amplify_authenticator.dart';
+import 'package:amplify_authenticator/src/state/inherited_authenticator_state.dart';
+import 'package:amplify_authenticator_test/amplify_authenticator_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+void main() {
+  group('AuthenticatedView', () {
+    late AuthenticatorState mockState;
+    setUp(() {
+      mockState = MockAuthenticatorState();
+      when(mockState.signIn).thenAnswer((_) => Future.value());
+    });
+
+    /// Completes the sign in form via keyboard events (Tab & Enter).
+    Future<void> verifySignInWithKeyboard(WidgetTester tester) async {
+      // Move focus to first widget via keyboard (Sign In Tab).
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+
+      // Move focus to next widget via keyboard (Sign Up Tab).
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+
+      // Move focus to next widget via keyboard (Username TextField).
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+
+      // Enter text to currently focused widget (Username TextField).
+      tester.testTextInput.enterText('user@example.com');
+
+      // Move focus to next widget via keyboard (Password TextField).
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+
+      // Enter text to currently focused widget (Password TextField).
+      tester.testTextInput.enterText('Password123');
+
+      expect(mockState.username, 'user@example.com');
+      expect(mockState.password, 'Password123');
+
+      // Move focus to first next widget via keyboard (Password Hide/Show toggle).
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+
+      // Move focus to first next widget via keyboard (Sign In Button).
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+
+      verifyNever(mockState.signIn);
+
+      // Submit form with Enter key.
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+
+      await tester.pump();
+
+      verify(mockState.signIn).called(1);
+    }
+
+    testWidgets(
+      'should be navigable by keyboard events',
+      (tester) async {
+        final testWidget = MaterialApp(
+          home: Scaffold(
+            body: MockAuthenticatorApp(
+              child: InheritedAuthenticatorState(
+                state: mockState,
+                child: const AuthenticatedView(
+                  child: Center(child: Text('You are signed in.')),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpWidget(testWidget);
+        await tester.pumpAndSettle();
+
+        // Set initial focus to window.
+        await tester.tapAt(const Offset(0, 0));
+
+        await verifySignInWithKeyboard(tester);
+      },
+    );
+
+    testWidgets(
+      'Tab order should not be impacted by other Tab-able widgets in the tree',
+      (tester) async {
+        final testWidget = MaterialApp(
+          home: Scaffold(
+            body: MockAuthenticatorApp(
+              child: InheritedAuthenticatorState(
+                state: mockState,
+                child: Row(
+                  children: [
+                    Column(
+                      children: [
+                        for (var i = 0; i < 10; i++)
+                          TextButton(
+                            onPressed: () {},
+                            child: Text('Button $i'),
+                          ),
+                      ],
+                    ),
+                    const Expanded(
+                      child: AuthenticatedView(
+                        child: Center(child: Text('You are signed in.')),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpWidget(testWidget);
+        await tester.pumpAndSettle();
+
+        // Set initial focus to window.
+        await tester.tapAt(const Offset(0, 0));
+
+        // Move focus to last button in group.
+        for (var i = 0; i < 10; i++) {
+          await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        }
+
+        await verifySignInWithKeyboard(tester);
+      },
+    );
+  });
+}
+
+class MockAuthenticatorState extends Mock implements AuthenticatorState {
+  final GlobalKey<FormState> _formKey = GlobalKey();
+
+  @override
+  GlobalKey<FormState> get formKey => _formKey;
+
+  @override
+  String get username => _username;
+
+  @override
+  set username(String value) {
+    _username = value;
+  }
+
+  String _username = '';
+
+  @override
+  String get password => _password;
+
+  @override
+  set password(String value) {
+    _password = value.trim();
+  }
+
+  String _password = '';
+
+  @override
+  bool get isBusy => false;
+}

--- a/packages/authenticator/amplify_authenticator_test/lib/src/mock_authenticator_app.dart
+++ b/packages/authenticator/amplify_authenticator_test/lib/src/mock_authenticator_app.dart
@@ -32,6 +32,7 @@ class MockAuthenticatorApp extends StatefulWidget {
     this.darkTheme,
     this.initialStep = AuthenticatorStep.signIn,
     this.authPlugin,
+    this.child,
   });
 
   final String config;
@@ -39,6 +40,7 @@ class MockAuthenticatorApp extends StatefulWidget {
   final ThemeData? darkTheme;
   final AuthenticatorStep initialStep;
   final AuthPluginInterface? authPlugin;
+  final Widget? child;
 
   @override
   State<MockAuthenticatorApp> createState() => _MockAuthenticatorAppState();
@@ -66,19 +68,20 @@ class _MockAuthenticatorAppState extends State<MockAuthenticatorApp> {
     return Authenticator(
       initialStep: widget.initialStep,
       key: authenticatorKey,
-      child: MaterialApp(
-        debugShowCheckedModeBanner: false,
-        theme: widget.lightTheme,
-        darkTheme: widget.darkTheme,
-        themeMode: ThemeMode.system,
-        builder: Authenticator.builder(),
-        home: const Scaffold(
-          key: authenticatedAppKey,
-          body: Center(
-            child: SignOutButton(),
+      child: widget.child ??
+          MaterialApp(
+            debugShowCheckedModeBanner: false,
+            theme: widget.lightTheme,
+            darkTheme: widget.darkTheme,
+            themeMode: ThemeMode.system,
+            builder: Authenticator.builder(),
+            home: const Scaffold(
+              key: authenticatedAppKey,
+              body: Center(
+                child: SignOutButton(),
+              ),
+            ),
           ),
-        ),
-      ),
     );
   }
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/1999

*Description of changes:*
- Add `onFieldSubmitted` callback to form fields to handle form submission via keyboard enter key
- wrap AuthenticatedView in a FocusTraversalGroup to ensure consistent tab order even when used alongside other widgets
- Add widget tests for AuthenticatedView keyboard navigation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
