### PR TITLE
fix(api): SubscriptionDataPayload error decoding type fix

### DIFF
--- a/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
@@ -116,6 +116,27 @@ void main({bool useExistingTestUser = false}) {
 
             expect(blogFromEvent?.name, equals(name));
           });
+
+          testWidgets('should parse errors within a web socket data message',
+              (WidgetTester tester) async {
+            final name =
+                'Integration Test Blog - subscription create ${uuid()}';
+            const error =
+                'Cannot return null for non-nullable type: \'AWSDateTime\' within parent \'Blog\' (/onCreateBlog/createdAt)';
+            final subscriptionRequest = ModelSubscriptions.onCreate(
+              Blog.classType,
+              authorizationMode: APIAuthorizationType.apiKey,
+            );
+
+            final eventResponse = await establishSubscriptionAndMutate(
+              subscriptionRequest,
+              () => addBlogBadMutation(name),
+              canFail: true,
+            );
+            final dataErrors = eventResponse.errors;
+
+            expect(dataErrors.first.message, equals(error));
+          });
         },
       );
     },

--- a/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
@@ -122,7 +122,8 @@ void main({bool useExistingTestUser = false}) {
             final name =
                 'Integration Test Blog - subscription create ${uuid()}';
             const error =
-                'Cannot return null for non-nullable type: \'AWSDateTime\' within parent \'Blog\' (/onCreateBlog/createdAt)';
+                "Cannot return null for non-nullable type: 'AWSDateTime' within "
+                "parent 'Blog' (/onCreateBlog/createdAt)";
             final subscriptionRequest = ModelSubscriptions.onCreate(
               Blog.classType,
               authorizationMode: APIAuthorizationType.apiKey,

--- a/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
@@ -131,7 +131,7 @@ void main({bool useExistingTestUser = false}) {
 
             final eventResponse = await establishSubscriptionAndMutate(
               subscriptionRequest,
-              () => addBlogBadMutation(name),
+              () => runPartialMutation(name),
               canFail: true,
             );
             final dataErrors = eventResponse.errors;

--- a/packages/api/amplify_api/example/integration_test/util.dart
+++ b/packages/api/amplify_api/example/integration_test/util.dart
@@ -146,8 +146,11 @@ Future<Blog> addBlog(String name) async {
   return blog;
 }
 
-// Run a mutation with an incorrect document
-Future<GraphQLResponse<String>> addBlogBadMutation(String name) async {
+/// Run a mutation on [Blog] with a partial selection set.
+///
+/// This is used to trigger an error on subscriptions listening for the
+/// full selection set.
+Future<GraphQLResponse<String>> runPartialMutation(String name) async {
   const graphQLDocument = r'''mutation MyMutation($name: String!) {
       createBlog(input: {name: $name}) {
         id

--- a/packages/api/amplify_api/example/integration_test/util.dart
+++ b/packages/api/amplify_api/example/integration_test/util.dart
@@ -147,7 +147,7 @@ Future<Blog> addBlog(String name) async {
 }
 
 // Run a mutation with an incorrect document
-Future<GraphQLResponse<Blog>> addBlogBadMutation(String name) async {
+Future<GraphQLResponse<String>> addBlogBadMutation(String name) async {
   const graphQLDocument = r'''mutation MyMutation($name: String!) {
       createBlog(input: {name: $name}) {
         id
@@ -155,7 +155,7 @@ Future<GraphQLResponse<Blog>> addBlogBadMutation(String name) async {
       }
     }''';
 
-  final request = GraphQLRequest<Blog>(
+  final request = GraphQLRequest<String>(
     document: graphQLDocument,
     variables: <String, dynamic>{'name': name},
     authorizationMode: APIAuthorizationType.userPools,

--- a/packages/api/amplify_api/lib/src/graphql/web_socket/types/web_socket_types.dart
+++ b/packages/api/amplify_api/lib/src/graphql/web_socket/types/web_socket_types.dart
@@ -129,14 +129,14 @@ class SubscriptionRegistrationPayload extends WebSocketMessagePayload {
 class SubscriptionDataPayload extends WebSocketMessagePayload {
   const SubscriptionDataPayload(this.data, this.errors);
   final Map<String, dynamic>? data;
-  final Map<String, dynamic>? errors;
+  final List<Map<String, dynamic>>? errors;
 
   static SubscriptionDataPayload fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map?;
-    final errors = json['errors'] as Map?;
+    final errors = json['errors'] as List?;
     return SubscriptionDataPayload(
       data?.cast<String, dynamic>(),
-      errors?.cast<String, dynamic>(),
+      errors?.map((e) => (e as Map).cast<String, dynamic>()).toList(),
     );
   }
 

--- a/packages/api/amplify_api/test/web_socket/web_socket_types_test.dart
+++ b/packages/api/amplify_api/test/web_socket/web_socket_types_test.dart
@@ -85,5 +85,26 @@ void main() {
         expect(message.messageType, entry.expectedMessageType);
       });
     }
+
+    test('should decode data errors as a list', () {
+      final errors = [
+        {
+          'message':
+              'Cannot return null for non-nullable type: "AWSDateTime" within parent "Blog" (/onCreateBlog/updatedAt)',
+          'path': ['onCreateBlog', 'updatedAt']
+        }
+      ];
+      final entry = {
+        'id': 'xyz-456',
+        'type': 'data',
+        'payload': {'data': null, 'errors': errors}
+      };
+      final message = WebSocketMessage.fromJson(entry);
+      expect(message.messageType, MessageType.data);
+      expect(
+        message.payload!.toJson()['errors'],
+        errors,
+      );
+    });
   });
 }

--- a/packages/api/amplify_api/test/web_socket/web_socket_types_test.dart
+++ b/packages/api/amplify_api/test/web_socket/web_socket_types_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:amplify_api/amplify_api.dart';
+import 'package:amplify_api/src/graphql/helpers/graphql_response_decoder.dart';
 import 'package:amplify_api/src/graphql/web_socket/types/web_socket_types.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -85,12 +87,15 @@ void main() {
         expect(message.messageType, entry.expectedMessageType);
       });
     }
+  });
 
-    test('should decode data errors as a list', () {
+  group('Error handling', () {
+    test('WebsocketMessage should decode data errors as a list', () {
+      const errorMessage =
+          'Cannot return null for non-nullable type: "AWSDateTime" within parent "Blog" (/onCreateBlog/updatedAt)';
       final errors = [
         {
-          'message':
-              'Cannot return null for non-nullable type: "AWSDateTime" within parent "Blog" (/onCreateBlog/updatedAt)',
+          'message': errorMessage,
           'path': ['onCreateBlog', 'updatedAt']
         }
       ];
@@ -104,6 +109,18 @@ void main() {
       expect(
         message.payload!.toJson()['errors'],
         errors,
+      );
+
+      /// GraphQLResponseDecoder should handle a payload with errors.
+      final response = GraphQLResponseDecoder.instance.decode<String>(
+        request: GraphQLRequest(
+          document: '',
+        ),
+        response: message.payload!.toJson(),
+      );
+      expect(
+        response.errors.first.message,
+        errorMessage,
       );
     });
   });


### PR DESCRIPTION
*Description of changes:*
This provides a fix for an error I saw when errors were present in the SubscriptionDataPayload fromJson method. Errors come from AppSync as a List not a Map.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
