### PR TITLE
fix(authenticator): Navigation via TabBar

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/screens/authenticator_screen.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/screens/authenticator_screen.dart
@@ -244,7 +244,8 @@ class _AuthenticatorTabViewState
   }
 
   void _updateForm() {
-    setState(() {});
+    // Update the Authenticator's internal state on tab changes.
+    state.changeStep(selectedTab, reset: false);
   }
 
   Color getTabLabelColor(BuildContext context) {

--- a/packages/authenticator/amplify_authenticator/lib/src/state/authenticator_state.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/state/authenticator_state.dart
@@ -503,12 +503,20 @@ class AuthenticatorState extends ChangeNotifier {
     ]);
   }
 
-  /// Change to a new step in the authentication flow
-  void changeStep(AuthenticatorStep step) {
+  /// Change to a new step in the authentication flow.
+  ///
+  /// If [reset] is `true`, clears temporary form data including username,
+  /// password, and user attributes.
+  void changeStep(
+    AuthenticatorStep step, {
+    bool reset = true,
+  }) {
     _authBloc.add(AuthChangeScreen(step));
 
     /// Clean [ViewModel] when user manually navigates widgets
-    _resetAttributes();
+    if (reset) {
+      _resetAttributes();
+    }
   }
 
   /// Reset the authentication flow if initiated

--- a/packages/authenticator/amplify_authenticator/test/sign_in_form_test.dart
+++ b/packages/authenticator/amplify_authenticator/test/sign_in_form_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:amplify_authenticator_test/amplify_authenticator_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -19,6 +20,27 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('Sign In View', () {
+    group('navigation', () {
+      testWidgets('via TabBar', (tester) async {
+        await tester.pumpWidget(const MockAuthenticatorApp());
+        await tester.pumpAndSettle();
+
+        final signInPage = SignInPage(tester: tester);
+        signInPage.expectStep(AuthenticatorStep.signIn);
+
+        // Go to Sign Up
+        await tester.tap(signInPage.signUpTab);
+        await tester.pumpAndSettle();
+        signInPage.expectStep(AuthenticatorStep.signUp);
+
+        // Go to Sign In
+        final signUpPage = SignUpPage(tester: tester);
+        await tester.tap(signUpPage.signInTab);
+        await tester.pumpAndSettle();
+        signInPage.expectStep(AuthenticatorStep.signIn);
+      });
+    });
+
     group('form validation', () {
       testWidgets(
         'displays message when submitted without any data',

--- a/packages/authenticator/amplify_authenticator_test/lib/src/pages/sign_in_page.dart
+++ b/packages/authenticator/amplify_authenticator_test/lib/src/pages/sign_in_page.dart
@@ -28,7 +28,7 @@ class SignInPage extends AuthenticatorPage {
   Finder get signInButton => find.byKey(keySignInButton);
   Finder get forgotPasswordButton => find.byKey(keyForgotPasswordButton);
   Finder get confirmSignInField => find.byKey(keyCodeConfirmSignInFormField);
-  Finder get signUpTabBar => find.descendant(
+  Finder get signUpTab => find.descendant(
         of: find.byType(TabBar),
         matching: find.byKey(const ValueKey(AuthenticatorStep.signUp)),
       );
@@ -66,7 +66,7 @@ class SignInPage extends AuthenticatorPage {
 
   /// When I navigate to the "Sign Up" step.
   Future<void> navigateToSignUp() async {
-    await tester.tap(signUpTabBar);
+    await tester.tap(signUpTab);
     await tester.pumpAndSettle();
   }
 

--- a/packages/authenticator/amplify_authenticator_test/lib/src/pages/sign_up_page.dart
+++ b/packages/authenticator/amplify_authenticator_test/lib/src/pages/sign_up_page.dart
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:amplify_authenticator/src/keys.dart';
 import 'package:amplify_authenticator_test/src/pages/authenticator_page.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Sign Up Page Object
@@ -33,6 +35,11 @@ class SignUpPage extends AuthenticatorPage {
 
   Finder get selectEmailButton => find.byKey(keyEmailUsernameToggleButton);
   Finder get selectPhoneButton => find.byKey(keyPhoneUsernameToggleButton);
+
+  Finder get signInTab => find.descendant(
+        of: find.byType(TabBar),
+        matching: find.byKey(const ValueKey(AuthenticatorStep.signIn)),
+      );
 
   /// When I type a new "username"
   Future<void> enterUsername(String username) async {


### PR DESCRIPTION
Currently, navigation via the `TabBar` does not change the internal step which causes issues submitting forms after navigation.

**Repro**
- Fill in username/password on signIn page
- Press tab to go to signUp
- Fill in remaining fields & press Enter to submit
- Notice signIn is called instead of signUp