### PR TITLE
chore(version): vNext release

### DIFF
--- a/packages/amplify_core/CHANGELOG.md
+++ b/packages/amplify_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0-next.2+1
+
+### Fixes
+- fix(api): Race condition at bloc close
+- fix(auth): Add `no-store` cache control header
+
 ## 1.0.0-next.2
 
 ### Breaking Changes

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_core
 description: The base package containing common types and utilities that are shared across the Amplify Flutter packages.
-version: 1.0.0-next.2
+version: 1.0.0-next.2+1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_core
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.8.0
-  aws_common: ">=0.3.3 <0.4.0"
+  aws_common: ">=0.3.5 <0.4.0"
   aws_signature_v4: ">=0.3.1 <0.4.0"
   collection: ^1.15.0
   intl: ^0.17.0

--- a/packages/api/amplify_api/CHANGELOG.md
+++ b/packages/api/amplify_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-next.2+1
+
+### Fixes
+- fix(api): Race condition at bloc close
+
 ## 1.0.0-next.2
 
 ### Breaking Changes

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api
 description: The Amplify Flutter API category plugin, supporting GraphQL and REST operations.
-version: 1.0.0-next.2
+version: 1.0.0-next.2+1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/auth/amplify_auth_cognito/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-next.2+1
+
+### Fixes
+- fix(auth): Add `no-store` cache control header
+
 ## 1.0.0-next.2
 
 ### Fixes

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito
 description: The Amplify Flutter Auth category plugin using the AWS Cognito provider.
-version: 1.0.0-next.2
+version: 1.0.0-next.2+1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -20,9 +20,9 @@ platforms:
 
 dependencies:
   amplify_auth_cognito_android: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_auth_cognito_dart: ">=0.3.0 <0.4.0"
+  amplify_auth_cognito_dart: ">=0.3.1 <0.4.0"
   amplify_auth_cognito_ios: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_core: ">=1.0.0-next.2+1 <1.0.0-next.3"
   amplify_flutter: ">=1.0.0-next.2 <1.0.0-next.3"
   amplify_secure_storage: ">=0.1.4 <0.2.0"
   async: ^2.8.0

--- a/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1
+
+### Fixes
+- fix(auth): Add `no-store` cache control header
+
 ## 0.3.0
 
 ### Fixes

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_dart
 description: A Dart-only implementation of the Amplify Auth plugin for Cognito.
-version: 0.3.0
+version: 0.3.1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -12,7 +12,7 @@ dependencies:
   amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   amplify_secure_storage_dart: ">=0.1.4 <0.2.0"
   async: ^2.8.0
-  aws_common: ">=0.3.3 <0.4.0"
+  aws_common: ">=0.3.5 <0.4.0"
   aws_signature_v4: ">=0.3.1 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"

--- a/packages/authenticator/amplify_authenticator/CHANGELOG.md
+++ b/packages/authenticator/amplify_authenticator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-next.1+3
+
+### Fixes
+- fix(authenticator): keyboard navigation ([#2473](https://github.com/aws-amplify/amplify-flutter/pull/2473))
+
 ## 1.0.0-next.1+2
 
 - Minor bug fixes and improvements

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_authenticator
 description: A prebuilt Sign In and Sign Up experience for the Amplify Auth category
-version: 1.0.0-next.1+2
+version: 1.0.0-next.1+3
 homepage: https://ui.docs.amplify.aws/flutter/connected-components/authenticator
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/authenticator/amplify_authenticator
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_auth_cognito: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_auth_cognito: ">=1.0.0-next.2+1 <1.0.0-next.3"
   amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
   amplify_flutter: ">=1.0.0-next.2 <1.0.0-next.3"
   async: ^2.8.0

--- a/packages/aws_common/CHANGELOG.md
+++ b/packages/aws_common/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5
+
+- Minor bug fixes and improvements
+
 ## 0.3.4
 
 ### Features

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aws_common
 description: Common types and utilities used across AWS and Amplify packages.
-version: 0.3.4
+version: 0.3.5
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/aws_common
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/smithy/smithy/CHANGELOG.md
+++ b/packages/smithy/smithy/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.2
+
+### Features
+- feat(smithy): Add `intEnum` support
+- feat(smithy): Custom interceptor support
+
 ## 0.3.1
 
 - Minor bug fixes and improvements

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smithy
 description: Smithy client runtime for Dart with common utilities for I/O and serialization.
-version: 0.3.1
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/smithy/smithy
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.8.0
-  aws_common: ">=0.3.3 <0.4.0"
+  aws_common: ">=0.3.5 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
   collection: ^1.15.0

--- a/packages/smithy/smithy_aws/CHANGELOG.md
+++ b/packages/smithy/smithy_aws/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+- Minor bug fixes and improvements
+
 ## 0.3.1
 
 - Minor bug fixes and improvements

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smithy_aws
 description: Smithy runtime for AWS clients with utilities for endpoint resolution, retry behavior, and SigV4 signing.
-version: 0.3.1
+version: 0.3.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/smithy/smithy_aws
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  aws_common: ">=0.3.3 <0.4.0"
+  aws_common: ">=0.3.5 <0.4.0"
   aws_signature_v4: ">=0.3.1 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
@@ -21,7 +21,7 @@ dependencies:
   json_annotation: ^4.7.0
   meta: ^1.7.0
   path: ^1.8.0
-  smithy: ">=0.3.1 <0.4.0"
+  smithy: ">=0.3.2 <0.4.0"
   xml: ">=6.1.0 <=6.2.2"
 
 dev_dependencies:


### PR DESCRIPTION
### Fixes
- fix(api): Race condition at bloc close
- fix(auth): Add `no-store` cache control header
- fix(authenticator): keyboard navigation ([#2473](https://github.com/aws-amplify/amplify-flutter/pull/2473))

Updated-Components: Smithy, Amplify Dart, amplify_core, amplify_api, amplify_auth_cognito