### PR TITLE
fix(api): prevent GQL subscription race condition error after shutdown

### DIFF
--- a/packages/api/amplify_api/lib/src/graphql/web_socket/blocs/web_socket_bloc.dart
+++ b/packages/api/amplify_api/lib/src/graphql/web_socket/blocs/web_socket_bloc.dart
@@ -116,6 +116,13 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
 
   /// Adds an event to the Bloc.
   void add(WebSocketEvent event) {
+    if (_wsEventController.isClosed &&
+        (_currentState is DisconnectedState ||
+            _currentState is PendingDisconnect)) {
+      // In some cases, the service will keep getting messages during/after
+      // disconnect. Ignore those messages.
+      return;
+    }
     _wsEventController.add(event);
   }
 

--- a/packages/api/amplify_api/lib/src/graphql/web_socket/blocs/web_socket_bloc.dart
+++ b/packages/api/amplify_api/lib/src/graphql/web_socket/blocs/web_socket_bloc.dart
@@ -116,13 +116,6 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
 
   /// Adds an event to the Bloc.
   void add(WebSocketEvent event) {
-    if (_wsEventController.isClosed &&
-        (_currentState is DisconnectedState ||
-            _currentState is PendingDisconnect)) {
-      // In some cases, the service will keep getting messages during/after
-      // disconnect. Ignore those messages.
-      return;
-    }
     _wsEventController.add(event);
   }
 
@@ -150,6 +143,16 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
     logger.debug('Emitting next state: $state');
     _wsStateController.add(state);
     _currentState = state;
+  }
+
+  /// Only add an event if the bloc is open.
+  void _safeAdd(WebSocketEvent event) {
+    if (_wsEventController.isClosed ||
+        _currentState is DisconnectedState ||
+        _currentState is PendingDisconnect) {
+      return;
+    }
+    add(event);
   }
 
   Stream<WebSocketState> _eventTransformer(WebSocketEvent event) async* {
@@ -279,7 +282,9 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
     );
 
     _currentState.service.init(_currentState).listen(
-      add,
+      // In some cases, the service will keep getting messages during/after
+      // disconnect. Ignore those messages.
+      _safeAdd,
       onError: (Object error, StackTrace st) {
         _emit(_currentState.failed(error, st));
       },
@@ -500,13 +505,9 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
     try {
       final res = await _sendPollRequest();
       await checkPollResponse(res);
-      if (!_wsEventController.isClosed) {
-        add(const PollSuccessEvent());
-      }
+      _safeAdd(const PollSuccessEvent());
     } on Exception catch (e) {
-      if (!_wsEventController.isClosed) {
-        add(PollFailedEvent(e));
-      }
+      _safeAdd(PollFailedEvent(e));
     }
   }
 

--- a/packages/api/amplify_api/test/util.dart
+++ b/packages/api/amplify_api/test/util.dart
@@ -185,7 +185,10 @@ class MockWebSocketSink extends DelegatingStreamSink<dynamic>
   MockWebSocketSink(super.sink);
 
   @override
-  Future<void> close([int? closeCode, String? closeReason]) => super.close();
+  Future<void> close([int? closeCode, String? closeReason]) async {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    return super.close();
+  }
 }
 
 class MockWebSocketChannel extends WebSocketChannel {

--- a/packages/api/amplify_api/test/util.dart
+++ b/packages/api/amplify_api/test/util.dart
@@ -186,6 +186,8 @@ class MockWebSocketSink extends DelegatingStreamSink<dynamic>
 
   @override
   Future<void> close([int? closeCode, String? closeReason]) async {
+    // The real sink takes some time to close which can cause race conditions.
+    // Mocking that delay here is needed to reproduce/test those conditions.
     await Future<void>.delayed(const Duration(milliseconds: 10));
     return super.close();
   }

--- a/packages/api/amplify_api/test/web_socket/web_socket_bloc_test.dart
+++ b/packages/api/amplify_api/test/web_socket/web_socket_bloc_test.dart
@@ -327,6 +327,30 @@ void main() {
       mockPollClient.induceTimeout = false;
     });
 
+    test(
+        'subscribe() ignores a WebSocket message that comes while the bloc is disconnected',
+        () async {
+      final establishCompleter = Completer<void>();
+      final subscribeEvent = SubscribeEvent(
+        subscriptionRequest,
+        establishCompleter.complete,
+      );
+
+      final bloc = getWebSocketBloc();
+      bloc
+          .subscribe(
+            subscribeEvent,
+          )
+          .listen(null);
+      await establishCompleter.future;
+
+      bloc.add(const ShutdownEvent());
+      await bloc.done.future;
+
+      service!.channel.sink.add(mockDataString);
+      await expectLater(service!.channel.sink.done, completes);
+    });
+
     group('should close when', () {
       tearDown(() async {
         bloc = null;


### PR DESCRIPTION
This PR prevents a race condition error in GraphQL subscriptions. Sometimes, when a bloc is closing (which closes the underlying websocket) there will be a brief period of time where the bloc's internal event stream controller is closed but it still gets events from the websocket channel. This throws an error bc the stream controller is already closed.

This PR fixes it by ignoring events when the controller is closed and shutdown is pending/complete.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
