### PR TITLE
chore(api): reduce integ test flakiness

### DIFF
--- a/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/api_key_test.dart
@@ -107,10 +107,10 @@ void main({bool useExistingTestUser = false}) {
               authorizationMode: APIAuthorizationType.apiKey,
             );
 
-            final eventResponse = await establishSubscriptionAndMutate(
+            final eventResponse = await establishSubscriptionAndMutate<Blog>(
               subscriptionRequest,
               () => addBlog(name),
-              eventFilter: (Blog? blog) => blog?.name == name,
+              eventFilter: (response) => response.data?.name == name,
             );
             final blogFromEvent = eventResponse.data;
 
@@ -129,9 +129,10 @@ void main({bool useExistingTestUser = false}) {
               authorizationMode: APIAuthorizationType.apiKey,
             );
 
-            final eventResponse = await establishSubscriptionAndMutate(
+            final eventResponse = await establishSubscriptionAndMutate<Blog>(
               subscriptionRequest,
               () => runPartialMutation(name),
+              eventFilter: (response) => response.errors.isNotEmpty,
               canFail: true,
             );
             final dataErrors = eventResponse.errors;

--- a/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
@@ -103,19 +103,13 @@ void main({bool useExistingTestUser = false}) {
 
       testWidgets('should LIST blogs with Model helper',
           (WidgetTester tester) async {
-        const blog1Name = 'Integration Test Blog 1';
-        const blog2Name = 'Integration Test Blog 2';
-        const blog3Name = 'Integration Test Blog 3';
-        final blog1 = await addBlog(blog1Name);
-        final blog2 = await addBlog(blog2Name);
-        final blog3 = await addBlog(blog3Name);
+        await addBlog('Integration Test Blog 1');
         final req = ModelQueries.list<Blog>(Blog.classType);
         final operation = Amplify.API.query(request: req);
         final res = await operation.response;
         final data = res.data;
-        final blogs = [blog1, blog2, blog3];
         expect(res, hasNoGraphQLErrors);
-        expect(data?.items, containsAll(blogs));
+        expect(data?.items.length, greaterThan(0));
       });
 
       testWidgets(
@@ -290,10 +284,10 @@ void main({bool useExistingTestUser = false}) {
           final subscriptionRequest =
               ModelSubscriptions.onCreate(Blog.classType);
 
-          final eventResponse = await establishSubscriptionAndMutate(
+          final eventResponse = await establishSubscriptionAndMutate<Blog>(
             subscriptionRequest,
             () => addBlog(name),
-            eventFilter: (Blog? blog) => blog?.name == name,
+            eventFilter: (response) => response.data?.name == name,
           );
           final blogFromEvent = eventResponse.data;
 
@@ -310,7 +304,7 @@ void main({bool useExistingTestUser = false}) {
 
           final subscriptionRequest =
               ModelSubscriptions.onUpdate(Blog.classType);
-          final eventResponse = await establishSubscriptionAndMutate(
+          final eventResponse = await establishSubscriptionAndMutate<Blog>(
             subscriptionRequest,
             () async {
               blogToUpdate = blogToUpdate.copyWith(name: updatedName);
@@ -320,7 +314,7 @@ void main({bool useExistingTestUser = false}) {
               );
               await Amplify.API.mutate(request: updateReq).response;
             },
-            eventFilter: (Blog? blog) => blog?.id == blogToUpdate.id,
+            eventFilter: (response) => response.data?.id == blogToUpdate.id,
           );
           final blogFromEvent = eventResponse.data;
 
@@ -335,10 +329,10 @@ void main({bool useExistingTestUser = false}) {
 
           final subscriptionRequest =
               ModelSubscriptions.onDelete(Blog.classType);
-          final eventResponse = await establishSubscriptionAndMutate(
+          final eventResponse = await establishSubscriptionAndMutate<Blog>(
             subscriptionRequest,
             () => deleteBlog(blogToDelete.id),
-            eventFilter: (Blog? blog) => blog?.id == blogToDelete.id,
+            eventFilter: (response) => response.data?.id == blogToDelete.id,
           );
           final blogFromEvent = eventResponse.data;
 
@@ -370,10 +364,10 @@ void main({bool useExistingTestUser = false}) {
           final subscriptionRequest =
               ModelSubscriptions.onCreate(Post.classType);
 
-          final eventResponse = await establishSubscriptionAndMutate(
+          final eventResponse = await establishSubscriptionAndMutate<Post>(
             subscriptionRequest,
             () => addPostAndBlog(title, 0),
-            eventFilter: (Post? post) => post?.title == title,
+            eventFilter: (response) => response.data?.title == title,
           );
           final postFromEvent = eventResponse.data;
 

--- a/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
@@ -109,7 +109,7 @@ void main({bool useExistingTestUser = false}) {
         final res = await operation.response;
         final data = res.data;
         expect(res, hasNoGraphQLErrors);
-        expect(data?.items.length, greaterThan(0));
+        expect(data?.items, isNotEmpty);
       });
 
       testWidgets(

--- a/packages/api/amplify_api/example/integration_test/graphql/user_pools_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/user_pools_test.dart
@@ -269,10 +269,10 @@ void main({bool useExistingTestUser = false}) {
             authorizationMode: APIAuthorizationType.userPools,
           );
 
-          final eventResponse = await establishSubscriptionAndMutate(
+          final eventResponse = await establishSubscriptionAndMutate<Blog>(
             subscriptionRequest,
             () => addBlog(name),
-            eventFilter: (Blog? blog) => blog?.name == name,
+            eventFilter: (response) => response.data?.name == name,
           );
           final blogFromEvent = eventResponse.data;
 


### PR DESCRIPTION
This PR modifies a few API integ tests to reduce flakiness:
* no longer looks for specific blog entries in a list request response because there is no guarantee first page of responses will have newly created entries if the backend already has a lot of data. Just checking that the list has some blogs is sufficient.
* Require all subscription tests that use a util to pass a filter callback for the events. If this is not provided, it causes issues with getting events from other clients using the backend at the same time (like tests on another platform in CI). This came up in a recently added test for errors but should be required for all similar tests in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
