### PR TITLE
fix(api): improve GQL subscription error visibility/recovery

### DIFF
--- a/packages/api/amplify_api/lib/src/graphql/web_socket/blocs/web_socket_bloc.dart
+++ b/packages/api/amplify_api/lib/src/graphql/web_socket/blocs/web_socket_bloc.dart
@@ -275,7 +275,11 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
       // disconnect. Ignore those messages.
       _safeAdd,
       onError: (Object error, StackTrace st) {
-        _emit(_currentState.failed(error, st));
+        final exception = ApiException(
+          'Exception from WebSocketService.',
+          underlyingException: error.toString(),
+        );
+        _shutdownWithException(exception, st);
       },
     );
 


### PR DESCRIPTION
Fixes some issues I discovered while debugging https://github.com/aws-amplify/amplify-flutter/issues/2499.

While the underlying issues in above issue are 1) subscription selection set was not a subset of mutation selection set which causes AppSync error 2) error not parsed correctly, fixed in https://github.com/aws-amplify/amplify-flutter/pull/2483, I also noticed that any similar error would get completely swallowed making it difficult to debug. Further, the `WebSocketBloc` gets stuck in an error state so that user cannot make a new subscription.

This PR fixes that by calling an error utility already used other places. That error utility passes down the errors to subscription streams so that users can see them. It also disconnects the bloc (and underlying WebSocket) and cleans it up. That way, future subscriptions get a fresh bloc/WebSocket connection.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
