### PR TITLE
fix(auth): legacy data migration for iOS

### DIFF
--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_cupertino.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_cupertino.dart
@@ -51,9 +51,9 @@ class AmplifySecureStorageCupertino extends AmplifySecureStorageInterface {
       ? config.iOSOptions.accessGroup
       : config.macOSOptions.accessGroup;
 
-  CFStringRef get _accessible => Platform.isIOS
-      ? config.iOSOptions.accessible.toCFStringRef()
-      : config.macOSOptions.accessible.toCFStringRef();
+  KeychainAttributeAccessible? get _accessible => Platform.isIOS
+      ? config.iOSOptions.accessible
+      : config.macOSOptions.accessible;
 
   bool get _useDataProtection =>
       Platform.isMacOS && config.macOSOptions.useDataProtection;
@@ -234,7 +234,8 @@ class AmplifySecureStorageCupertino extends AmplifySecureStorageInterface {
     return {
       security.kSecClass: security.kSecClassGenericPassword,
       security.kSecAttrService: service,
-      security.kSecAttrAccessible: _accessible,
+      if (_accessible != null)
+        security.kSecAttrAccessible: _accessible!.toCFStringRef(),
       if (key != null)
         security.kSecAttrAccount: _createCFString(value: key, arena: arena),
       if (_accessGroup != null)

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/amplify_secure_storage_config.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/amplify_secure_storage_config.dart
@@ -102,6 +102,7 @@ abstract class AmplifySecureStorageConfig
 
   AmplifySecureStorageConfig copyWith({
     String? scope,
+    String? namespace,
     WebSecureStorageOptions? webOptions,
     WindowsSecureStorageOptions? windowsOptions,
     LinuxSecureStorageOptions? linuxOptions,
@@ -110,6 +111,7 @@ abstract class AmplifySecureStorageConfig
   }) {
     return _$AmplifySecureStorageConfig._(
       scope: scope ?? this.scope,
+      namespace: namespace ?? this.namespace,
       webOptions: webOptions ?? this.webOptions,
       windowsOptions: windowsOptions ?? this.windowsOptions,
       linuxOptions: linuxOptions ?? this.linuxOptions,

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/amplify_secure_storage_config.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/amplify_secure_storage_config.dart
@@ -56,8 +56,8 @@ abstract class AmplifySecureStorageConfig
       webOptions: WebSecureStorageOptions(),
       windowsOptions: WindowsSecureStorageOptions(),
       linuxOptions: LinuxSecureStorageOptions(),
-      macOSOptions: MacOSSecureStorageOptions(),
-      iOSOptions: IOSSecureStorageOptions(),
+      macOSOptions: MacOSSecureStorageOptions.empty(),
+      iOSOptions: IOSSecureStorageOptions.empty(),
     );
   }
 

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/ios_secure_storage_options.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/ios_secure_storage_options.dart
@@ -15,6 +15,7 @@
 import 'package:amplify_secure_storage_dart/src/types/keychain_attribute_accessible.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
+import 'package:meta/meta.dart';
 
 part 'ios_secure_storage_options.g.dart';
 
@@ -25,8 +26,10 @@ abstract class IOSSecureStorageOptions
     implements Built<IOSSecureStorageOptions, IOSSecureStorageOptionsBuilder> {
   /// {@macro amplify_secure_storage_dart.ios_secure_storage_options}
   ///
+  /// #### [accessible]
   /// {@macro amplify_secure_storage_dart.macos_secure_storage_options.accessible}
   ///
+  /// #### [accessGroup]
   /// {@macro amplify_secure_storage_dart.macos_secure_storage_options.accessGroup}
   factory IOSSecureStorageOptions({
     KeychainAttributeAccessible accessible =
@@ -39,13 +42,25 @@ abstract class IOSSecureStorageOptions
     );
   }
 
+  /// A constructor for creating an [IOSSecureStorageOptions] with all null
+  /// values.
+  ///
+  /// This will result in the default values being used.
+  @internal
+  factory IOSSecureStorageOptions.empty() {
+    return _$IOSSecureStorageOptions._(
+      accessible: null,
+      accessGroup: null,
+    );
+  }
+
   const IOSSecureStorageOptions._();
 
   /// {@macro amplify_secure_storage_dart.macos_secure_storage_options.accessGroup}
   String? get accessGroup;
 
   /// {@macro amplify_secure_storage_dart.macos_secure_storage_options.accessible}
-  KeychainAttributeAccessible get accessible;
+  KeychainAttributeAccessible? get accessible;
 
   /// The [IOSSecureStorageOptions] serializer.
   static Serializer<IOSSecureStorageOptions> get serializer =>

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/ios_secure_storage_options.g.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/ios_secure_storage_options.g.dart
@@ -23,11 +23,7 @@ class _$IOSSecureStorageOptionsSerializer
   Iterable<Object?> serialize(
       Serializers serializers, IOSSecureStorageOptions object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[
-      'accessible',
-      serializers.serialize(object.accessible,
-          specifiedType: const FullType(KeychainAttributeAccessible)),
-    ];
+    final result = <Object?>[];
     Object? value;
     value = object.accessGroup;
     if (value != null) {
@@ -35,6 +31,13 @@ class _$IOSSecureStorageOptionsSerializer
         ..add('accessGroup')
         ..add(serializers.serialize(value,
             specifiedType: const FullType(String)));
+    }
+    value = object.accessible;
+    if (value != null) {
+      result
+        ..add('accessible')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(KeychainAttributeAccessible)));
     }
     return result;
   }
@@ -57,8 +60,8 @@ class _$IOSSecureStorageOptionsSerializer
           break;
         case 'accessible':
           result.accessible = serializers.deserialize(value,
-                  specifiedType: const FullType(KeychainAttributeAccessible))!
-              as KeychainAttributeAccessible;
+                  specifiedType: const FullType(KeychainAttributeAccessible))
+              as KeychainAttributeAccessible?;
           break;
       }
     }
@@ -71,17 +74,13 @@ class _$IOSSecureStorageOptions extends IOSSecureStorageOptions {
   @override
   final String? accessGroup;
   @override
-  final KeychainAttributeAccessible accessible;
+  final KeychainAttributeAccessible? accessible;
 
   factory _$IOSSecureStorageOptions(
           [void Function(IOSSecureStorageOptionsBuilder)? updates]) =>
       (new IOSSecureStorageOptionsBuilder()..update(updates))._build();
 
-  _$IOSSecureStorageOptions._({this.accessGroup, required this.accessible})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-        accessible, r'IOSSecureStorageOptions', 'accessible');
-  }
+  _$IOSSecureStorageOptions._({this.accessGroup, this.accessible}) : super._();
 
   @override
   IOSSecureStorageOptions rebuild(
@@ -157,9 +156,7 @@ class IOSSecureStorageOptionsBuilder
   _$IOSSecureStorageOptions _build() {
     final _$result = _$v ??
         new _$IOSSecureStorageOptions._(
-            accessGroup: accessGroup,
-            accessible: BuiltValueNullFieldError.checkNotNull(
-                accessible, r'IOSSecureStorageOptions', 'accessible'));
+            accessGroup: accessGroup, accessible: accessible);
     replace(_$result);
     return _$result;
   }

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/macos_secure_storage_options.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/macos_secure_storage_options.dart
@@ -78,6 +78,19 @@ abstract class MacOSSecureStorageOptions
     );
   }
 
+  /// A constructor for creating an [MacOSSecureStorageOptions] with all null
+  /// values.
+  ///
+  /// This will result in the default values being used.
+  @internal
+  factory MacOSSecureStorageOptions.empty() {
+    return _$MacOSSecureStorageOptions._(
+      useDataProtection: false,
+      accessible: null,
+      accessGroup: null,
+    );
+  }
+
   const MacOSSecureStorageOptions._();
 
   /// {@macro amplify_secure_storage_dart.macos_secure_storage_options.useDataProtection}
@@ -87,7 +100,7 @@ abstract class MacOSSecureStorageOptions
   String? get accessGroup;
 
   /// {@macro amplify_secure_storage_dart.macos_secure_storage_options.accessible}
-  KeychainAttributeAccessible get accessible;
+  KeychainAttributeAccessible? get accessible;
 
   /// The [MacOSSecureStorageOptions] serializer.
   static Serializer<MacOSSecureStorageOptions> get serializer =>

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/macos_secure_storage_options.g.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/types/macos_secure_storage_options.g.dart
@@ -27,9 +27,6 @@ class _$MacOSSecureStorageOptionsSerializer
       'useDataProtection',
       serializers.serialize(object.useDataProtection,
           specifiedType: const FullType(bool)),
-      'accessible',
-      serializers.serialize(object.accessible,
-          specifiedType: const FullType(KeychainAttributeAccessible)),
     ];
     Object? value;
     value = object.accessGroup;
@@ -38,6 +35,13 @@ class _$MacOSSecureStorageOptionsSerializer
         ..add('accessGroup')
         ..add(serializers.serialize(value,
             specifiedType: const FullType(String)));
+    }
+    value = object.accessible;
+    if (value != null) {
+      result
+        ..add('accessible')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(KeychainAttributeAccessible)));
     }
     return result;
   }
@@ -64,8 +68,8 @@ class _$MacOSSecureStorageOptionsSerializer
           break;
         case 'accessible':
           result.accessible = serializers.deserialize(value,
-                  specifiedType: const FullType(KeychainAttributeAccessible))!
-              as KeychainAttributeAccessible;
+                  specifiedType: const FullType(KeychainAttributeAccessible))
+              as KeychainAttributeAccessible?;
           break;
       }
     }
@@ -80,21 +84,17 @@ class _$MacOSSecureStorageOptions extends MacOSSecureStorageOptions {
   @override
   final String? accessGroup;
   @override
-  final KeychainAttributeAccessible accessible;
+  final KeychainAttributeAccessible? accessible;
 
   factory _$MacOSSecureStorageOptions(
           [void Function(MacOSSecureStorageOptionsBuilder)? updates]) =>
       (new MacOSSecureStorageOptionsBuilder()..update(updates))._build();
 
   _$MacOSSecureStorageOptions._(
-      {required this.useDataProtection,
-      this.accessGroup,
-      required this.accessible})
+      {required this.useDataProtection, this.accessGroup, this.accessible})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
         useDataProtection, r'MacOSSecureStorageOptions', 'useDataProtection');
-    BuiltValueNullFieldError.checkNotNull(
-        accessible, r'MacOSSecureStorageOptions', 'accessible');
   }
 
   @override
@@ -186,8 +186,7 @@ class MacOSSecureStorageOptionsBuilder
                 r'MacOSSecureStorageOptions',
                 'useDataProtection'),
             accessGroup: accessGroup,
-            accessible: BuiltValueNullFieldError.checkNotNull(
-                accessible, r'MacOSSecureStorageOptions', 'accessible'));
+            accessible: accessible);
     replace(_$result);
     return _$result;
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes iOS legacy data migration which was broken when https://github.com/aws-amplify/amplify-flutter/pull/2023 was merged, which added a default `accessible` value for Keychain queries. The PR changes the default iOS/MacOS Keychain options to all be `null` when using the `byNameSpace` constructor so that keychain defaults are used. This aligns with the iOS SDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
