### PR TITLE
chore(analytics): support Pinpoint User Attributes

### DIFF
--- a/packages/amplify_core/lib/src/types/analytics/analytics/analytics_user_profile.dart
+++ b/packages/amplify_core/lib/src/types/analytics/analytics/analytics_user_profile.dart
@@ -18,14 +18,4 @@ class AnalyticsUserProfile {
     this.location,
     AnalyticsProperties? analyticsProperties,
   }) : properties = analyticsProperties;
-
-  Map<String, Object?> getAllProperties() => {
-        if (name != null) 'name': name,
-        if (email != null) 'email': email,
-        if (plan != null) 'plan': plan,
-        if (location != null) 'location': location!.getAllProperties(),
-        if (properties != null) 'propertiesMap': properties!.getAllProperties(),
-        if (properties != null)
-          'propertiesTypesMap': properties!.getAllPropertiesTypes(),
-      };
 }

--- a/packages/analytics/amplify_analytics_pinpoint/example/integration_test/identify_user_test.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/example/integration_test/identify_user_test.dart
@@ -99,7 +99,7 @@ void main() {
                 .having((e) => e.endpoint.user?.userId, 'UserId', userId)
                 .having(
                   (e) => e.endpoint.user?.userAttributes?.toMap() ?? const {},
-                  'Attributes',
+                  'UserAttributes',
                   equals({
                     boolProperty.key: [stringifiedBoolProperty.value],
                     stringProperty.key: [stringProperty.value],

--- a/packages/analytics/amplify_analytics_pinpoint/example/integration_test/identify_user_test.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/example/integration_test/identify_user_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:amplify_analytics_pinpoint/amplify_analytics_pinpoint.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/sdk/pinpoint.dart'
     show EndpointLocation;
 import 'package:amplify_flutter/amplify_flutter.dart';
@@ -56,12 +57,13 @@ void main() {
 
         await Amplify.Analytics.identifyUser(
           userId: userId,
-          userProfile: AnalyticsUserProfile(
+          userProfile: AWSPinpointUserProfile(
             name: name,
             email: email,
             plan: plan,
             location: location,
             analyticsProperties: properties,
+            userAttributes: properties,
           ),
         );
 
@@ -95,6 +97,16 @@ void main() {
                   ),
                 )
                 .having((e) => e.endpoint.user?.userId, 'UserId', userId)
+                .having(
+                  (e) => e.endpoint.user?.userAttributes?.toMap() ?? const {},
+                  'Attributes',
+                  equals({
+                    boolProperty.key: [stringifiedBoolProperty.value],
+                    stringProperty.key: [stringProperty.value],
+                    intProperty.key: [intProperty.value.toString()],
+                    doubleProperty.key: [doubleProperty.value.toString()],
+                  }),
+                )
                 .having(
                   (e) => e.endpoint.attributes?.toMap() ?? const {},
                   'Attributes',

--- a/packages/analytics/amplify_analytics_pinpoint/example/lib/main.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/example/lib/main.dart
@@ -116,7 +116,12 @@ class _MyAppState extends State<MyApp> {
   }
 
   void _identifyUser() async {
-    final analyticsUserProfile = AnalyticsUserProfile();
+    final analyticsUserProfile = AWSPinpointUserProfile(
+        userAttributes: AnalyticsProperties()
+          ..addStringProperty('${_userId}_user_stringKey', 'stringValue')
+          ..addIntProperty('${_userId}_user_intKey', 10)
+          ..addDoubleProperty('${_userId}_user_doubleKey', 10)
+          ..addBoolProperty('${_userId}_user_boolKey', false));
     analyticsUserProfile.name = '${_userId}_name';
     analyticsUserProfile.email = '${_userId}_email';
     analyticsUserProfile.plan = '${_userId}_plan';
@@ -132,10 +137,11 @@ class _MyAppState extends State<MyApp> {
     analyticsUserProfile.location = analyticsUserLocation;
 
     final properties = AnalyticsProperties();
-    properties.addStringProperty('${_userId}_stringKey', 'stringValue');
-    properties.addIntProperty('${_userId}_intKey', 10);
-    properties.addDoubleProperty('${_userId}_doubleKey', 10);
-    properties.addBoolProperty('${_userId}_boolKey', false);
+    properties.addStringProperty(
+        '${_userId}_endpoint_stringKey', 'stringValue');
+    properties.addIntProperty('${_userId}_endpoint_intKey', 10);
+    properties.addDoubleProperty('${_userId}_endpoint_doubleKey', 10);
+    properties.addBoolProperty('${_userId}_endpoint_boolKey', false);
 
     analyticsUserProfile.properties = properties;
 

--- a/packages/analytics/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
@@ -6,7 +6,7 @@ library amplify_analytics_pinpoint;
 
 /// Overridable Flutter injected dependencies
 export 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.dart'
-    show AppLifecycleProvider;
+    show AppLifecycleProvider, AWSPinpointUserProfile;
 
 /// Category Implementation
 export 'src/analytics_plugin_impl.dart';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/amplify_analytics_pinpoint_dart.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/amplify_analytics_pinpoint_dart.dart
@@ -5,7 +5,7 @@
 library amplify_analytics_pinpoint_dart;
 
 export 'src/analytics_plugin_impl.dart';
-
+export 'src/impl/analytics_client/endpoint_client/aws_pinpoint_user_profile.dart';
 export 'src/impl/flutter_provider_interfaces/app_lifecycle_provider.dart';
 export 'src/impl/flutter_provider_interfaces/cached_events_path_provider.dart';
 export 'src/impl/flutter_provider_interfaces/device_context_info_provider.dart';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/aws_pinpoint_user_profile.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/aws_pinpoint_user_profile.dart
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import 'package:amplify_core/amplify_core.dart';
+
+/// {@template amplify_analytics_pinpoint_dart.aws_pinpoint_user_profile}
+/// Extends the category-defined UserProfile class to
+/// include features supported relevant to Pinpoint only.
+/// {@endtemplate}
+class AWSPinpointUserProfile extends AnalyticsUserProfile {
+  /// {@macro amplify_analytics_pinpoint_dart.aws_pinpoint_user_profile}
+  AWSPinpointUserProfile({
+    super.name,
+    super.email,
+    super.plan,
+    super.location,
+    super.analyticsProperties,
+    required this.userAttributes,
+  });
+
+  /// Analytics attributes for the Pinpoint User
+  final AnalyticsProperties userAttributes;
+}

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/aws_pinpoint_user_profile.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/aws_pinpoint_user_profile.dart
@@ -1,17 +1,5 @@
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_core/amplify_core.dart';
 

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_client.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_client.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/aws_pinpoint_user_profile.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_global_fields_manager.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/sdk/pinpoint.dart';
 import 'package:amplify_core/amplify_core.dart';
@@ -106,6 +107,14 @@ class EndpointClient {
       await _globalFieldsManager
           .addAttributes(userProfile.properties!.attributes);
       await _globalFieldsManager.addMetrics(userProfile.properties!.metrics);
+    }
+
+    if (userProfile is AWSPinpointUserProfile) {
+      final attributes = <String, List<String>>{};
+      userProfile.userAttributes.getAllProperties().forEach((key, value) {
+        attributes[key] = [value.toString()];
+      });
+      newUserBuilder.userAttributes = ListMultimapBuilder(attributes);
     }
 
     _endpointBuilder.user = newUserBuilder;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allow users to call `identifyUser` with an  AWSPinpointUserProfile that has an additional user attributes field so attributes can be related to users and not the endpoint.  This is to have feature parity with Amplify Android which does the same thing.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
