### PR TITLE
chore(analytics): expose pinpoint id in hub

### DIFF
--- a/packages/amplify_core/lib/src/hub/hub_channel.dart
+++ b/packages/amplify_core/lib/src/hub/hub_channel.dart
@@ -18,5 +18,8 @@ enum HubChannel<HubEventPayload, E extends HubEvent<HubEventPayload>> {
   DataStore<DataStoreHubEventPayload, DataStoreHubEvent>(),
 
   /// Events of the API category
-  Api<ApiHubEventPayload, ApiHubEvent>();
+  Api<ApiHubEventPayload, ApiHubEvent>(),
+
+  /// Events of the Analytics category
+  Analytics<AnalyticsHubEventPayload, AnalyticsHubEvent>();
 }

--- a/packages/amplify_core/lib/src/types/analytics/analytics_types.dart
+++ b/packages/amplify_core/lib/src/types/analytics/analytics_types.dart
@@ -6,3 +6,4 @@ export 'analytics/analytics_properties.dart';
 export 'analytics/analytics_user_profile.dart';
 export 'analytics/analytics_user_profile_location.dart';
 export 'exceptions/analytics_exception.dart';
+export 'hub/analytics_hub_event.dart';

--- a/packages/amplify_core/lib/src/types/analytics/hub/analytics_hub_event.dart
+++ b/packages/amplify_core/lib/src/types/analytics/hub/analytics_hub_event.dart
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+/// {@template amplify_common.hub.analytics_hub_event_type}
+/// Hub Event types for the Analytics category.
+/// {@endtemplate}
+enum AnalyticsHubEventType {
+  /// {@template amplify_common.hub.analytics_hub_event_endpoint_configured}
+  /// Emitted when the user's endpoint is configured during application start.
+  /// {@endtemplate}
+  endpointConfigured('ENDPOINT_CONFIGURED');
+
+  /// The event name.
+  final String eventName;
+
+  /// {@macro amplify_common.hub.analytics_hub_event_type}
+  const AnalyticsHubEventType(this.eventName);
+}
+
+/// The base class for hub events of the Analytics category.
+///
+/// One of [AnalyticsHubEventType].
+class AnalyticsHubEvent extends HubEvent<AnalyticsHubEventPayload>
+    with AWSEquatable<AnalyticsHubEvent>, AWSDebuggable {
+  AnalyticsHubEvent._(
+    this.type, {
+    AnalyticsHubEventPayload? payload,
+  }) : super(type.eventName, payload: payload);
+
+  /// {@macro amplify_common.hub.analytics_hub_event_type}
+  final AnalyticsHubEventType type;
+
+  /// {@macro amplify_common.hub.analytics_hub_event_endpoint_configured}
+  AnalyticsHubEvent.endpointConfigured(String endpointId)
+      : this._(
+          AnalyticsHubEventType.endpointConfigured,
+          payload: EndpointConfiguredPayload(endpointId),
+        );
+
+  @override
+  List<Object?> get props => [type, payload];
+
+  @override
+  String get runtimeTypeName => 'AnalyticsHubEvent';
+}
+
+abstract class AnalyticsHubEventPayload {
+  const AnalyticsHubEventPayload();
+}
+
+/// {@macro amplify_common.hub.analytics_hub_event_endpoint_configured}
+class EndpointConfiguredPayload extends AnalyticsHubEventPayload {
+  const EndpointConfiguredPayload(this.endpointId);
+
+  /// The unique ID of the user's endpoint.
+  final String endpointId;
+}

--- a/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/DebugProfile.entitlements
@@ -10,5 +10,9 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.amazonaws.amplify.amplify-analytics-pinpoint-example</string>
+	</array>
 </dict>
 </plist>

--- a/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/Release.entitlements
+++ b/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/Release.entitlements
@@ -8,5 +8,9 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.amazonaws.amplify.amplify-analytics-pinpoint-example</string>
+	</array>
 </dict>
 </plist>

--- a/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
@@ -1,9 +1,7 @@
 name: amplify_analytics_pinpoint_example
 description: Demonstrates how to use the amplify_analytics_pinpoint plugin.
-
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: "none" # Remove this line if you wish to publish to pub.dev
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Send the Pinpoint ID in Analytics Hub Events so that Auth can register and send it on their side to Cognito.  iOS and Android already do this in their own way (sending Pinpoint ID to Cognito so it can be registered there). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
