### PR TITLE
fix(analytics): Secure storage on Android

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint/lib/src/analytics_plugin_impl.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/src/analytics_plugin_impl.dart
@@ -6,6 +6,7 @@ import 'package:amplify_analytics_pinpoint/src/flutter_app_lifecycle_provider.da
 import 'package:amplify_analytics_pinpoint/src/flutter_path_provider/flutter_path_provider.dart';
 import 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.dart';
 import 'package:amplify_db_common/amplify_db_common.dart' as db_common;
+import 'package:amplify_secure_storage/amplify_secure_storage.dart';
 import 'package:meta/meta.dart';
 
 /// {@template amplify_analytics_pinpoint.analytics_plugin_impl}
@@ -14,11 +15,17 @@ import 'package:meta/meta.dart';
 class AmplifyAnalyticsPinpoint extends AmplifyAnalyticsPinpointDart {
   /// {@macro amplify_analytics_pinpoint.analytics_plugin_impl}
   AmplifyAnalyticsPinpoint({
-    @visibleForTesting super.endpointInfoStore,
+    @visibleForTesting SecureStorageInterface? endpointInfoStore,
     @visibleForTesting CachedEventsPathProvider? pathProvider,
     @visibleForTesting AppLifecycleProvider? appLifecycleProvider,
     @visibleForTesting DeviceContextInfoProvider? deviceContextInfoProvider,
   }) : super(
+          endpointInfoStore: endpointInfoStore ??
+              AmplifySecureStorage(
+                config: AmplifySecureStorageConfig(
+                  scope: 'analyticsPinpoint',
+                ),
+              ),
           pathProvider: pathProvider ?? FlutterPathProvider(),
           appLifecycleProvider:
               appLifecycleProvider ?? FlutterAppLifecycleProvider(),


### PR DESCRIPTION
The secure storage worker is not supported on Android which is why Flutter clients use the `AmplifySecureStorage` wrapper instead.