### PR TITLE
ci(repo): Use Dart `beta` channel instead of `dev`

### DIFF
--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -21,7 +21,7 @@ jobs:
           # TODO(dnys1): Remove when repo bump to 2.19 happens
           # - 2.19.0
           - stable
-          - dev
+          - beta
         browser:
           - chrome
           - firefox

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -25,7 +25,7 @@ jobs:
           # TODO(dnys1): Remove when repo bump to 2.19 happens
           # - 2.19.0
           - stable
-          - dev
+          - beta
         browser:
           - chrome
           - firefox
@@ -75,6 +75,6 @@ jobs:
           fi
 
       - name: Run Tests
-        if: "always() && steps.bootstrap.conclusion == 'success' && (matrix.sdk == 'dev' || inputs.test-ddc-stable)"
+        if: "always() && steps.bootstrap.conclusion == 'success' && (matrix.sdk == 'beta' || inputs.test-ddc-stable)"
         run: dart run build_runner test --delete-conflicting-outputs -- -p ${{ matrix.browser }} --exclude-tags=no-ddc
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -21,7 +21,7 @@ jobs:
           # TODO(dnys1): Remove when repo bump to 2.19 happens
           # - 2.19.0
           - stable
-          - dev
+          - beta
     steps:
       - name: Cache Pub dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # 3.0.11


### PR DESCRIPTION
Testing on the bleeding edge leads to too many false negatives in CI workflows. The `beta` channel gives us enough of a heads up for changes coming down the pipeline.