### PR TITLE
ci(repo): Use Dart `beta` channel instead of `dev`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -115,22 +115,22 @@ jobs:
         working-directory: packages/aws_signature_v4
         run: dart analyze --fatal-infos lib test
   job_004:
-    name: "analyze_and_format; Dart dev; PKGS: packages/aws_common, packages/aws_signature_v4/example; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; Dart beta; PKGS: packages/aws_common, packages/aws_signature_v4/example; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_common-packages/aws_signature_v4/example;commands:format-analyze_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:packages/aws_common-packages/aws_signature_v4/example;commands:format-analyze_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_common-packages/aws_signature_v4/example
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:packages/aws_common-packages/aws_signature_v4/example
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: packages_aws_common_pub_upgrade
@@ -160,22 +160,22 @@ jobs:
         working-directory: packages/aws_signature_v4/example
         run: dart analyze --fatal-infos .
   job_005:
-    name: "analyze_and_format; Dart dev; PKG: packages/aws_signature_v4; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos lib test`"
+    name: "analyze_and_format; Dart beta; PKG: packages/aws_signature_v4; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos lib test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_signature_v4;commands:format-analyze_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:packages/aws_signature_v4;commands:format-analyze_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_signature_v4
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:packages/aws_signature_v4
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: packages_aws_signature_v4_pub_upgrade

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,22 +117,22 @@ jobs:
         working-directory: packages/aws_signature_v4
         run: dart test -p chrome
   job_004:
-    name: "unit_test; Dart dev; PKG: packages/aws_common; `dart test`, `dart test -p chrome`"
+    name: "unit_test; Dart beta; PKG: packages/aws_common; `dart test`, `dart test -p chrome`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_common;commands:test_0-test_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:packages/aws_common;commands:test_0-test_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_common
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:packages/aws_common
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: packages_aws_common_pub_upgrade
@@ -149,22 +149,22 @@ jobs:
         working-directory: packages/aws_common
         run: dart test -p chrome
   job_005:
-    name: "unit_test; Dart dev; PKG: packages/aws_signature_v4; `git submodule update --init`, `dart test`"
+    name: "unit_test; Dart beta; PKG: packages/aws_signature_v4; `git submodule update --init`, `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_signature_v4;commands:command-test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:packages/aws_signature_v4;commands:command-test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_signature_v4
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:packages/aws_signature_v4
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: packages_aws_signature_v4_pub_upgrade
@@ -181,22 +181,22 @@ jobs:
         working-directory: packages/aws_signature_v4
         run: dart test
   job_006:
-    name: "unit_test; Dart dev; PKG: packages/aws_signature_v4; `git submodule update --init`, `dart test`, `dart test -p chrome`"
+    name: "unit_test; Dart beta; PKG: packages/aws_signature_v4; `git submodule update --init`, `dart test`, `dart test -p chrome`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_signature_v4;commands:command-test_0-test_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:packages/aws_signature_v4;commands:command-test_0-test_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:packages/aws_signature_v4
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:packages/aws_signature_v4
+            os:ubuntu-latest;pub-cache-hosted;sdk:beta
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: dev
+          sdk: beta
       - id: checkout
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
       - id: packages_aws_signature_v4_pub_upgrade

--- a/packages/aws_common/mono_pkg.yaml
+++ b/packages/aws_common/mono_pkg.yaml
@@ -1,7 +1,7 @@
 sdk:
   - '2.15.0'
   - stable
-  - dev
+  - beta
 
 stages:
   - analyze_and_format:

--- a/packages/aws_signature_v4/example/mono_pkg.yaml
+++ b/packages/aws_signature_v4/example/mono_pkg.yaml
@@ -1,7 +1,7 @@
 sdk:
   - '2.15.0'
   - stable
-  - dev
+  - beta
 
 stages:
   - analyze_and_format:

--- a/packages/aws_signature_v4/lib/src/request/canonical_request/canonical_request.dart
+++ b/packages/aws_signature_v4/lib/src/request/canonical_request/canonical_request.dart
@@ -241,6 +241,7 @@ extension on String {
 
   String ensureEndsWith(String s) {
     if (!endsWith(s)) {
+      // ignore: unnecessary_brace_in_string_interps
       return '${this}$s';
     }
     return this;

--- a/packages/aws_signature_v4/mono_pkg.yaml
+++ b/packages/aws_signature_v4/mono_pkg.yaml
@@ -1,7 +1,7 @@
 sdk:
   - '2.15.0'
   - stable
-  - dev
+  - beta
 
 stages:
   - analyze_and_format:


### PR DESCRIPTION
Testing on the bleeding edge leads to too many false negatives in CI workflows. The beta channel gives us enough of a heads up for changes coming down the pipeline.