### PR TITLE
fix(http): Cancel streamed responses

### DIFF
--- a/packages/aws_common/lib/src/http/aws_http_client_io.dart
+++ b/packages/aws_common/lib/src/http/aws_http_client_io.dart
@@ -51,15 +51,16 @@ class AWSHttpClientImpl extends AWSHttpClient {
     required AWSLogger logger,
     required AWSBaseHttpRequest request,
     required CancelableCompleter<AWSBaseHttpResponse> completer,
-    required Future<void> cancelTrigger,
+    required Completer<void> cancelTrigger,
     required StreamSink<int> requestProgress,
     required StreamSink<int> responseProgress,
   }) async {
     void Function()? onCancel;
     unawaited(
-      cancelTrigger.then((_) {
+      cancelTrigger.future.then((_) {
         logger.verbose('Canceling request');
         onCancel?.call();
+        onCancel = null;
       }),
     );
     _inner ??= HttpClient();
@@ -82,6 +83,7 @@ class AWSHttpClientImpl extends AWSHttpClient {
 
     if (completer.isCanceled) return;
     onCancel = () {
+      onCancel = null;
       logger.verbose('Aborting request');
       ioRequest.abort();
     };
@@ -95,31 +97,43 @@ class AWSHttpClientImpl extends AWSHttpClient {
             requestProgress.add(requestBytesRead);
           },
           onDone: () {
-            logger.verbose('Request sent');
+            if (!cancelTrigger.isCompleted) {
+              logger.verbose('Request sent');
+            }
             requestProgress.close();
           },
         )
-        .takeUntil(cancelTrigger)
+        .takeUntil(cancelTrigger.future)
         .pipe(ioRequest) as HttpClientResponse;
 
     if (completer.isCanceled) return;
-    final bodyController = StreamController<List<int>>(sync: true);
+
+    final bodyController = StreamController<List<int>>(
+      sync: true,
+      // In downstream operations, we may only have access to the body stream
+      // so we need to allow cancellation via the subscription.
+      onCancel: () {
+        logger.verbose('Subscription canceled');
+        if (!cancelTrigger.isCompleted) {
+          cancelTrigger.complete();
+        }
+      },
+    );
     onCancel = () {
+      onCancel = null;
       logger.verbose('Detaching socket');
       if (!bodyController.isClosed) {
         bodyController
           ..addError(const CancellationException())
           ..close();
       }
+      responseProgress.close();
       response.detachSocket().then((socket) {
         socket.destroy();
       });
     };
-    response.listen(
-      bodyController.add,
-      onError: bodyController.addError,
-      onDone: bodyController.close,
-      cancelOnError: true,
+    unawaited(
+      response.forward(bodyController, cancelOnError: true),
     );
 
     logger.verbose('Received headers');
@@ -138,7 +152,9 @@ class AWSHttpClientImpl extends AWSHttpClient {
           responseProgress.add(responseBytesRead);
         },
         onDone: () {
-          logger.verbose('Response received');
+          if (!cancelTrigger.isCompleted) {
+            logger.verbose('Response received');
+          }
           onCancel = null;
           responseProgress.close();
         },
@@ -204,13 +220,13 @@ class AWSHttpClientImpl extends AWSHttpClient {
     required AWSBaseHttpRequest request,
     required AWSLogger logger,
     required CancelableCompleter<AWSBaseHttpResponse> completer,
-    required Future<void> cancelTrigger,
+    required Completer<void> cancelTrigger,
     required StreamSink<int> requestProgress,
     required StreamSink<int> responseProgress,
   }) async {
     void Function()? onCancel;
     unawaited(
-      cancelTrigger.then((_) {
+      cancelTrigger.future.then((_) {
         logger.verbose('Canceling request');
         onCancel?.call();
       }),
@@ -265,11 +281,13 @@ class AWSHttpClientImpl extends AWSHttpClient {
             requestProgress.add(requestBytesRead);
             return DataStreamMessage(chunk);
           })
-          .takeUntil(cancelTrigger)
+          .takeUntil(cancelTrigger.future)
           .listen(
             stream.outgoingMessages.add,
             onDone: () {
-              logger.verbose('Request sent');
+              if (!cancelTrigger.isCompleted) {
+                logger.verbose('Request sent');
+              }
               requestProgress.close();
               stream.outgoingMessages.close();
             },
@@ -277,6 +295,7 @@ class AWSHttpClientImpl extends AWSHttpClient {
 
       final gotHeaders = Completer<void>();
       onCancel = () {
+        onCancel = null;
         if (!gotHeaders.isCompleted) {
           gotHeaders.completeError(const CancellationException());
         }
@@ -286,7 +305,17 @@ class AWSHttpClientImpl extends AWSHttpClient {
       };
 
       final headers = CaseInsensitiveMap<String>({});
-      final bodyController = StreamController<List<int>>(sync: true);
+      final bodyController = StreamController<List<int>>(
+        sync: true,
+        // In downstream operations, we may only have access to the body stream
+        // so we need to allow cancellation via the subscription.
+        onCancel: () {
+          logger.verbose('Subscription canceled');
+          if (!cancelTrigger.isCompleted) {
+            cancelTrigger.complete();
+          }
+        },
+      );
 
       late final StreamSubscription<StreamMessage> subscription;
       subscription = stream.incomingMessages.listen(
@@ -345,6 +374,7 @@ class AWSHttpClientImpl extends AWSHttpClient {
       );
       logger.verbose('Subscription established');
       onCancel = () {
+        onCancel = null;
         logger.verbose('Terminating connection');
         subscription.cancel();
         if (!bodyController.isClosed) {
@@ -352,6 +382,7 @@ class AWSHttpClientImpl extends AWSHttpClient {
             ..addError(const CancellationException())
             ..close();
         }
+        responseProgress.close();
       };
       if (completer.isCanceled) return null;
 
@@ -416,7 +447,9 @@ class AWSHttpClientImpl extends AWSHttpClient {
             responseProgress.add(responseBytesRead);
           },
           onDone: () {
-            logger.verbose('Response received');
+            if (!cancelTrigger.isCompleted) {
+              logger.verbose('Response received');
+            }
             onCancel = null;
             responseProgress.close();
           },
@@ -465,7 +498,7 @@ class AWSHttpClientImpl extends AWSHttpClient {
             request: request,
             logger: operation.logger,
             completer: completer,
-            cancelTrigger: cancelTrigger.future,
+            cancelTrigger: cancelTrigger,
             requestProgress: requestProgressController,
             responseProgress: responseProgressController,
           );
@@ -479,7 +512,7 @@ class AWSHttpClientImpl extends AWSHttpClient {
           logger: operation.logger,
           request: request,
           completer: completer,
-          cancelTrigger: cancelTrigger.future,
+          cancelTrigger: cancelTrigger,
           requestProgress: requestProgressController,
           responseProgress: responseProgressController,
         );

--- a/packages/aws_common/lib/src/operation/aws_operation.dart
+++ b/packages/aws_common/lib/src/operation/aws_operation.dart
@@ -36,8 +36,10 @@ abstract class AWSOperation<T extends Object?>
   @override
   Future<void> cancel() => _cancelMemo.runOnce(() async {
         if (operation.isCanceled || operation.isCompleted) {
+          logger.verbose('Operation complete. Calling onCancel...');
           return _onCancel?.call();
         }
+        logger.verbose('Operation canceled.');
         return operation.cancel();
       });
 

--- a/packages/aws_common/test/http/http_common.dart
+++ b/packages/aws_common/test/http/http_common.dart
@@ -56,8 +56,10 @@ void clientTest(
           client = debugClient..supportedProtocols = supportedProtocols;
         });
         tearDown(() async {
-          httpServerChannel.sink.add(null);
-          // await Future<void>.delayed(const Duration(seconds: 30));
+          httpServerChannel.sink.rejectErrors().add(null);
+        });
+        tearDownAll(() async {
+          // await Future<void>.delayed(const Duration(seconds: 60));
         });
 
         testCases(

--- a/packages/smithy/smithy/lib/src/http/http_operation.dart
+++ b/packages/smithy/smithy/lib/src/http/http_operation.dart
@@ -266,8 +266,10 @@ abstract class HttpOperation<InputPayload, Input, OutputPayload, Output>
     StackTrace? stackTrace;
     var successCode = this.successCode();
     try {
-      final payload = await protocol.deserialize(response.split(),
-          specifiedType: FullType(OutputPayload));
+      final payload = await protocol.deserialize(
+        response.split(),
+        specifiedType: FullType(OutputPayload),
+      );
       if (payload is Output) {
         output = payload;
       } else {
@@ -279,36 +281,45 @@ abstract class HttpOperation<InputPayload, Input, OutputPayload, Output>
       stackTrace = st;
     }
     if (response.statusCode == successCode) {
+      // Close the response so that the underlying subscription created by
+      // `split` is cancelled as well.
+      response.close();
       if (output != null) {
         return output;
       }
       Error.throwWithStackTrace(error!, stackTrace!);
     }
 
-    SmithyError? smithyError;
-    final resolvedType = await protocol.resolveErrorType(response);
-    if (resolvedType != null) {
-      smithyError =
-          errorTypes.firstWhereOrNull((t) => t.shapeId.shape == resolvedType);
-    }
-    smithyError ??= errorTypes
-        .singleWhereOrNull((t) => t.statusCode == response.statusCode);
-    if (smithyError == null) {
-      throw SmithyHttpException(
-        statusCode: response.statusCode,
-        body: await response.decodeBody(),
-        headers: response.headers,
+    try {
+      SmithyError? smithyError;
+      final resolvedType = await protocol.resolveErrorType(response);
+      if (resolvedType != null) {
+        smithyError =
+            errorTypes.firstWhereOrNull((t) => t.shapeId.shape == resolvedType);
+      }
+      smithyError ??= errorTypes
+          .singleWhereOrNull((t) => t.statusCode == response.statusCode);
+      if (smithyError == null) {
+        throw SmithyHttpException(
+          statusCode: response.statusCode,
+          body: await response.decodeBody(),
+          headers: response.headers,
+        );
+      }
+      final Type errorType = smithyError.type;
+      final Function builder = smithyError.builder;
+      final Object? errorPayload = await protocol.deserialize(
+        response.body,
+        specifiedType: FullType(errorType),
       );
+      final SmithyException smithyException =
+          builder(errorPayload, response) as SmithyException;
+      throw smithyException;
+    } finally {
+      // Close the response so that the underlying subscription created by
+      // `split` is cancelled as well.
+      response.close();
     }
-    final Type errorType = smithyError.type;
-    final Function builder = smithyError.builder;
-    final Object? errorPayload = await protocol.deserialize(
-      response.body,
-      specifiedType: FullType(errorType),
-    );
-    final SmithyException smithyException =
-        builder(errorPayload, response) as SmithyException;
-    throw smithyException;
   }
 
   SmithyOperation<Output> run(


### PR DESCRIPTION
Allow for the ability to cancel streamed responses via the body `Stream` only (vs. the operation, which will have already completed).
