### PR TITLE
fix(datastore): prevent unhandled exception crashing App rebuilding s…

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -537,7 +537,14 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
                             }
                         )
                     }
-                    latch.await()
+                    try {
+                        latch.await()
+                    } catch (e: InterruptedException) {
+                        LOG.error(
+                            "Failed to resolve query predicate due to ${e}. Reverting to original query " +
+                                    "predicate."
+                        )
+                    }
                     resolvedQueryPredicate
                 }
             } catch (e: Exception) {


### PR DESCRIPTION
…ync expression

*Issue #, if available:*

Related: https://github.com/aws-amplify/amplify-flutter/issues/1816

*Description of changes:*

There is reported that a unhandled exception causes App to crash on Android while DataStore building sync expression for amplify-android implementation from Dart implementation. I haven't figure out why the latch await would be interrupted, at least we can handle this exception thrown from `latch.await()` to prevent App from crashing. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
