### PR TITLE
chore(version): Bump version

### DIFF
--- a/packages/amplify/amplify_flutter/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.0.0-next.3
+
+### Breaking Changes
+- chore(auth)!: Remove `isPreferPrivateSession` from `CognitoSignOutWithWebUIOptions` ([#2538](https://github.com/aws-amplify/amplify-flutter/pull/2538))
+- refactor(auth)!: Align exception types
+- refactor(auth)!: Remove intermediate request types ([#2475](https://github.com/aws-amplify/amplify-flutter/pull/2475))
+- refactor(core)!: Migrate exception types
+
+### Fixes
+- fix(analytics): Secure storage on Android ([#2530](https://github.com/aws-amplify/amplify-flutter/pull/2530))
+- fix(api): SubscriptionDataPayload error decoding type fix ([#2483](https://github.com/aws-amplify/amplify-flutter/pull/2483))
+- fix(api): improve GQL subscription error visibility/recovery ([#2507](https://github.com/aws-amplify/amplify-flutter/pull/2507))
+- fix(api): prevent GQL subscription race condition error after shutdown ([#2494](https://github.com/aws-amplify/amplify-flutter/pull/2494))
+- fix(storage): update expected exception types in integ tests
+
 ## 1.0.0-next.2
 
 ### Breaking Changes

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter
 description: The top level Flutter package for the AWS Amplify libraries.
-version: 1.0.0-next.2
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,12 +19,12 @@ platforms:
   web:
 
 dependencies:
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_datastore_plugin_interface: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_flutter_android: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_flutter_ios: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_secure_storage: ">=0.1.3 <0.2.0"
-  aws_common: ">=0.3.1 <0.4.0"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_datastore_plugin_interface: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_flutter_android: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_flutter_ios: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_secure_storage: ">=0.1.4+1 <0.2.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
   collection: ^1.15.0
   flutter:
     sdk: flutter

--- a/packages/amplify/amplify_flutter_android/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.3
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.2
 
 - Minor bug fixes and improvements

--- a/packages/amplify/amplify_flutter_android/pubspec.yaml
+++ b/packages/amplify/amplify_flutter_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter_android
 description: The method channel implementation for amplify_flutter on Android
-version: 1.0.0-next.2
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter_android
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/amplify/amplify_flutter_ios/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.3
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.2
 
 - Minor bug fixes and improvements

--- a/packages/amplify/amplify_flutter_ios/pubspec.yaml
+++ b/packages/amplify/amplify_flutter_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter_ios
 description: The method channel implementation for amplify_flutter on iOS
-version: 1.0.0-next.2
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
   flutter:
     sdk: flutter
 

--- a/packages/amplify_core/CHANGELOG.md
+++ b/packages/amplify_core/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0-next.3
+
+### Breaking Changes
+- chore(auth)!: Remove `isPreferPrivateSession` from `CognitoSignOutWithWebUIOptions` ([#2538](https://github.com/aws-amplify/amplify-flutter/pull/2538))
+- refactor(auth)!: Align exception types
+- refactor(auth)!: Make SRP failures errors
+- refactor(auth)!: Remove intermediate request types ([#2475](https://github.com/aws-amplify/amplify-flutter/pull/2475))
+- refactor(core)!: Migrate exception types
+
 ## 1.0.0-next.2+1
 
 ### Fixes

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_core
 description: The base package containing common types and utilities that are shared across the Amplify Flutter packages.
-version: 1.0.0-next.2+1
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_core
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   async: ^2.8.0
-  aws_common: ">=0.3.5 <0.4.0"
-  aws_signature_v4: ">=0.3.1 <0.4.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
+  aws_signature_v4: ">=0.3.1+1 <0.4.0"
   collection: ^1.15.0
   intl: ^0.17.0
   json_annotation: ^4.7.0

--- a/packages/amplify_datastore/CHANGELOG.md
+++ b/packages/amplify_datastore/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-next.3
+
+### Breaking Changes
+- refactor(core)!: Migrate exception types
+
 ## 1.0.0-next.2
 
 - Minor bug fixes and improvements

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore
 description: The Amplify Flutter DataStore category plugin, providing a queryable, on-device data store.
-version: 1.0.0-next.2
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_datastore
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_datastore_plugin_interface: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_datastore_plugin_interface: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
   plugin_platform_interface: ^2.0.0
   meta: ^1.7.0
   collection: ^1.14.13

--- a/packages/amplify_datastore_plugin_interface/CHANGELOG.md
+++ b/packages/amplify_datastore_plugin_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.3
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.2
 
 - Minor bug fixes and improvements

--- a/packages/amplify_datastore_plugin_interface/pubspec.yaml
+++ b/packages/amplify_datastore_plugin_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore_plugin_interface
 description: The platform interface for the DataStore module of Amplify Flutter.
-version: 1.0.0-next.2
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_datastore_plugin_interface
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
   collection: ^1.15.0
   flutter:
     sdk: flutter

--- a/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-next.3
+
+### Fixes
+- fix(analytics): Secure storage on Android ([#2530](https://github.com/aws-amplify/amplify-flutter/pull/2530))
+
 ## 1.0.0-next.2
 
 - Minor bug fixes and improvements

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint
 description: The Amplify Flutter Analytics category plugin using the AWS Pinpoint provider.
-version: 1.0.0-next.2
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/analytics/amplify_analytics_pinpoint
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,11 +19,11 @@ platforms:
   web:
 
 dependencies:
-  amplify_analytics_pinpoint_dart: ">=0.1.1 <0.2.0"
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_db_common: ">=0.1.2 <0.2.0"
-  amplify_secure_storage: ">=0.1.4 <0.2.0"
-  aws_common: ">=0.3.3 <0.4.0"
+  amplify_analytics_pinpoint_dart: ">=0.1.2+1 <0.2.0"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_db_common: ">=0.1.2+1 <0.2.0"
+  amplify_secure_storage: ">=0.1.4+1 <0.2.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
   device_info_plus: ^8.0.0
   flutter:
     sdk: flutter

--- a/packages/analytics/amplify_analytics_pinpoint_dart/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2+1
+
+- Minor bug fixes and improvements
+
 ## 0.1.2
 
 - Minor bug fixes and improvements

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/version.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.1.2';
+const packageVersion = '0.1.2+1';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint_dart
 description: A Dart-only implementation of the Amplify Analytics plugin for Pinpoint.
-version: 0.1.2
+version: 0.1.2+1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/analytics/amplify_analytics_pinpoint_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,19 +9,19 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_db_common_dart: ">=0.1.2 <0.2.0"
-  amplify_secure_storage_dart: ">=0.1.3 <0.2.0"
-  aws_common: ">=0.3.1 <0.4.0"
-  aws_signature_v4: ">=0.3.0 <0.4.0"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_db_common_dart: ">=0.2.0 <0.3.0"
+  amplify_secure_storage_dart: ">=0.1.4+1 <0.2.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
+  aws_signature_v4: ">=0.3.1+1 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
   drift: ">=2.3.0 <2.4.0"
   intl: ^0.17.0
   meta: ^1.7.0
   path: ^1.8.0
-  smithy: ">=0.3.0 <0.4.0"
-  smithy_aws: ">=0.3.0 <0.4.0"
+  smithy: ">=0.4.0 <0.5.0"
+  smithy_aws: ">=0.4.0 <0.5.0"
   uuid: ">=3.0.6 <=3.0.7"
 
 dev_dependencies:

--- a/packages/api/amplify_api/CHANGELOG.md
+++ b/packages/api/amplify_api/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.0.0-next.3
+
+### Breaking Changes
+- refactor(auth)!: Align exception types
+- refactor(core)!: Migrate exception types
+
+### Fixes
+- fix(api): SubscriptionDataPayload error decoding type fix ([#2483](https://github.com/aws-amplify/amplify-flutter/pull/2483))
+- fix(api): improve GQL subscription error visibility/recovery ([#2507](https://github.com/aws-amplify/amplify-flutter/pull/2507))
+- fix(api): prevent GQL subscription race condition error after shutdown ([#2494](https://github.com/aws-amplify/amplify-flutter/pull/2494))
+
 ## 1.0.0-next.2+1
 
 ### Fixes

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api
 description: The Amplify Flutter API category plugin, supporting GraphQL and REST operations.
-version: 1.0.0-next.2+1
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,12 +19,12 @@ platforms:
   web:
 
 dependencies:
-  amplify_api_android: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_api_ios: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_flutter: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_api_android: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_api_ios: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_flutter: ">=1.0.0-next.3 <1.0.0-next.4"
   async: ^2.8.0
-  aws_common: ">=0.3.3 <0.4.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
   collection: ^1.15.0
   connectivity_plus: ^3.0.2
   flutter:

--- a/packages/api/amplify_api_android/CHANGELOG.md
+++ b/packages/api/amplify_api_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.3
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.2
 
 - Minor bug fixes and improvements

--- a/packages/api/amplify_api_android/pubspec.yaml
+++ b/packages/api/amplify_api_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_android
 description: The method channel implementation for amplify_api on Android
-version: 1.0.0-next.2
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api_android
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/api/amplify_api_ios/CHANGELOG.md
+++ b/packages/api/amplify_api_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.3
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.2
 
 - Minor bug fixes and improvements

--- a/packages/api/amplify_api_ios/pubspec.yaml
+++ b/packages/api/amplify_api_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_ios
 description: The package containing the method channel implementation for amplify_api on iOS
-version: 1.0.0-next.2
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
   flutter:
     sdk: flutter
 

--- a/packages/auth/amplify_auth_cognito/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.0-next.3
+
+### Breaking Changes
+- chore(auth)!: Remove `isPreferPrivateSession` from `CognitoSignOutWithWebUIOptions` ([#2538](https://github.com/aws-amplify/amplify-flutter/pull/2538))
+- refactor(auth)!: Align exception types
+- refactor(auth)!: Remove intermediate request types ([#2475](https://github.com/aws-amplify/amplify-flutter/pull/2475))
+- refactor(core)!: Migrate exception types
+
 ## 1.0.0-next.2+1
 
 ### Fixes

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito
 description: The Amplify Flutter Auth category plugin using the AWS Cognito provider.
-version: 1.0.0-next.2+1
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,12 +19,12 @@ platforms:
   web:
 
 dependencies:
-  amplify_auth_cognito_android: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_auth_cognito_dart: ">=0.3.1 <0.4.0"
-  amplify_auth_cognito_ios: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_core: ">=1.0.0-next.2+1 <1.0.0-next.3"
-  amplify_flutter: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_secure_storage: ">=0.1.4 <0.2.0"
+  amplify_auth_cognito_android: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_auth_cognito_dart: ">=0.4.0 <0.5.0"
+  amplify_auth_cognito_ios: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_flutter: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_secure_storage: ">=0.1.4+1 <0.2.0"
   async: ^2.8.0
   flutter:
     sdk: flutter

--- a/packages/auth/amplify_auth_cognito_android/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.3
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.2
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito_android/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_android
 description: The method channel implementation for amplify_auth_cognito on Android
-version: 1.0.0-next.2
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_android
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.0
+
+### Breaking Changes
+- chore(auth)!: Remove `isPreferPrivateSession` from `CognitoSignOutWithWebUIOptions` ([#2538](https://github.com/aws-amplify/amplify-flutter/pull/2538))
+- refactor(auth)!: Align exception types
+- refactor(auth)!: Make SRP failures errors
+- refactor(auth)!: Remove intermediate request types ([#2475](https://github.com/aws-amplify/amplify-flutter/pull/2475))
+
 ## 0.3.1
 
 ### Fixes

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_dart
 description: A Dart-only implementation of the Amplify Auth plugin for Cognito.
-version: 0.3.1
+version: 0.4.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,11 +9,11 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_secure_storage_dart: ">=0.1.4 <0.2.0"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_secure_storage_dart: ">=0.1.4+1 <0.2.0"
   async: ^2.8.0
-  aws_common: ">=0.3.5 <0.4.0"
-  aws_signature_v4: ">=0.3.1 <0.4.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
+  aws_signature_v4: ">=0.3.1+1 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
   collection: ^1.15.0
@@ -27,11 +27,11 @@ dependencies:
   meta: ^1.7.0
   oauth2: ^2.0.0
   path: ^1.8.0
-  smithy: ">=0.3.1 <0.4.0"
-  smithy_aws: ">=0.3.1 <0.4.0"
+  smithy: ">=0.4.0 <0.5.0"
+  smithy_aws: ">=0.4.0 <0.5.0"
   stream_transform: ^2.0.0
   uuid: ">=3.0.6 <=3.0.7"
-  worker_bee: ">=0.1.3 <0.2.0"
+  worker_bee: ">=0.1.3+1 <0.2.0"
 
 dev_dependencies:
   amplify_lints:

--- a/packages/auth/amplify_auth_cognito_ios/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.3
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.2
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito_ios/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_ios
 description: The method channel implementation for amplify_auth_cognito on iOS
-version: 1.0.0-next.2
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
   flutter:
     sdk: flutter
 

--- a/packages/authenticator/amplify_authenticator/CHANGELOG.md
+++ b/packages/authenticator/amplify_authenticator/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.0.0-next.2
+
+### Fixes
+- fix(authenticator): Example Dead Link ([#2505](https://github.com/aws-amplify/amplify-flutter/pull/2505))
+- fix(authenticator): Navigation via TabBar ([#2486](https://github.com/aws-amplify/amplify-flutter/pull/2486))
+- fix(authenticator): keyboard navigation ([#2473](https://github.com/aws-amplify/amplify-flutter/pull/2473))
+
+### Breaking Changes
+- refactor(auth)!: Align exception types
+- refactor(core)!: Migrate exception types
+
 ## 1.0.0-next.1+3
 
 ### Fixes

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_authenticator
 description: A prebuilt Sign In and Sign Up experience for the Amplify Auth category
-version: 1.0.0-next.1+3
+version: 1.0.0-next.2
 homepage: https://ui.docs.amplify.aws/flutter/connected-components/authenticator
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/authenticator/amplify_authenticator
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,11 +10,11 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_auth_cognito: ">=1.0.0-next.2+1 <1.0.0-next.3"
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_flutter: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_auth_cognito: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_flutter: ">=1.0.0-next.3 <1.0.0-next.4"
   async: ^2.8.0
-  aws_common: ">=0.3.3 <0.4.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
   collection: ^1.15.0
   flutter:
     sdk: flutter
@@ -22,7 +22,7 @@ dependencies:
     sdk: flutter
   intl: ^0.17.0
   meta: ^1.7.0
-  smithy: ">=0.3.0 <0.4.0"
+  smithy: ">=0.4.0 <0.5.0"
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/aws_common/CHANGELOG.md
+++ b/packages/aws_common/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5+1
+
+- Minor bug fixes and improvements
+
 ## 0.3.5
 
 - Minor bug fixes and improvements

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aws_common
 description: Common types and utilities used across AWS and Amplify packages.
-version: 0.3.5
+version: 0.3.5+1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/aws_common
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/aws_signature_v4/CHANGELOG.md
+++ b/packages/aws_signature_v4/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1+1
+
+### Fixes
+- fix(sigv4): Allow custom `scheme` ([#2531](https://github.com/aws-amplify/amplify-flutter/pull/2531))
+
 ## 0.3.1
 
 ### Fixes

--- a/packages/aws_signature_v4/build.yaml
+++ b/packages/aws_signature_v4/build.yaml
@@ -1,5 +1,8 @@
 targets:
   $default:
+    sources:
+      exclude:
+        - example/**
     builders:
       build_web_compilers:entrypoint:
         release_options:

--- a/packages/aws_signature_v4/lib/src/version.dart
+++ b/packages/aws_signature_v4/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.3.1';
+const packageVersion = '0.3.1+1';

--- a/packages/aws_signature_v4/pubspec.yaml
+++ b/packages/aws_signature_v4/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aws_signature_v4
 description: Dart implementation of the AWS Signature Version 4 algorithm, for communication with AWS services.
-version: 0.3.1
+version: 0.3.1+1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/aws_signature_v4
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.8.0
-  aws_common: ">=0.3.3 <0.4.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
   collection: ^1.15.0
   convert: ^3.0.0
   crypto: ^3.0.0

--- a/packages/common/amplify_db_common/CHANGELOG.md
+++ b/packages/common/amplify_db_common/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2+1
+
+- Minor bug fixes and improvements
+
 ## 0.1.2
 
 - Minor bug fixes and improvements

--- a/packages/common/amplify_db_common/pubspec.yaml
+++ b/packages/common/amplify_db_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_db_common
 description: Common utilities for working with databases such as SQLite.
-version: 0.1.2
+version: 0.1.2+1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/common/amplify_db_common
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_db_common_dart: ">=0.1.2 <0.2.0"
+  amplify_db_common_dart: ">=0.2.0 <0.3.0"
   drift: ">=2.3.0 <2.4.0"
   flutter:
     sdk: flutter

--- a/packages/common/amplify_db_common_dart/CHANGELOG.md
+++ b/packages/common/amplify_db_common_dart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0
+
+### Breaking Changes
+- refactor(core)!: Migrate exception types
+
 ## 0.1.3
 
 - Minor bug fixes and improvements

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_db_common_dart
 description: Common utilities for working with databases such as sqlite.
-version: 0.1.3
+version: 0.2.0
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/common/amplify_db_common_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,9 +9,9 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
   async: ^2.8.0
-  aws_common: ">=0.3.3 <0.4.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
   drift: ">=2.3.0 <2.4.0"
   meta: ^1.7.0
   path: ^1.8.0

--- a/packages/secure_storage/amplify_secure_storage/CHANGELOG.md
+++ b/packages/secure_storage/amplify_secure_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4+1
+
+- Minor bug fixes and improvements
+
 ## 0.1.4
 
 - Minor bug fixes and improvements

--- a/packages/secure_storage/amplify_secure_storage/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_secure_storage
 description: A package for storing secrets, intended for use in Amplify libraries.
-version: 0.1.4
+version: 0.1.4+1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/secure_storage/amplify_secure_storage
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  amplify_secure_storage_dart: ">=0.1.4 <0.2.0"
+  amplify_secure_storage_dart: ">=0.1.4+1 <0.2.0"
   async: ^2.8.0
   file: ^6.0.0
   flutter:

--- a/packages/secure_storage/amplify_secure_storage_dart/CHANGELOG.md
+++ b/packages/secure_storage/amplify_secure_storage_dart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.4+1
+
+### Fixes
+- fix(auth): legacy data migration for iOS ([#2516](https://github.com/aws-amplify/amplify-flutter/pull/2516))
+
 ## 0.1.4
 
 - Minor bug fixes and improvements

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_secure_storage_dart
 description: A Dart-only implementation of `amplify_secure_storage`, using `dart:ffi` for Desktop and `dart:html` for Web.
-version: 0.1.4
+version: 0.1.4+1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/secure_storage/amplify_secure_storage_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -21,7 +21,7 @@ platforms:
 
 dependencies:
   async: ^2.8.0
-  aws_common: ">=0.3.3 <0.4.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
   ffi: ^2.0.0
@@ -30,7 +30,7 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   win32: ^3.0.0
-  worker_bee: ">=0.1.3 <0.2.0"
+  worker_bee: ">=0.1.3+1 <0.2.0"
 
 dev_dependencies:
   amplify_lints:

--- a/packages/smithy/smithy/CHANGELOG.md
+++ b/packages/smithy/smithy/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.0
+
+### Breaking Changes
+- feat(aft)!: Add plugins to SDK generation
+
+### Fixes
+- fix(smithy): Retry behavior
+
 ## 0.3.2
 
 ### Features

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smithy
 description: Smithy client runtime for Dart with common utilities for I/O and serialization.
-version: 0.3.2
+version: 0.4.0
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/smithy/smithy
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.8.0
-  aws_common: ">=0.3.5 <0.4.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
   collection: ^1.15.0

--- a/packages/smithy/smithy_aws/CHANGELOG.md
+++ b/packages/smithy/smithy_aws/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+- Minor bug fixes and improvements
+
 ## 0.3.2
 
 - Minor bug fixes and improvements

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smithy_aws
 description: Smithy runtime for AWS clients with utilities for endpoint resolution, retry behavior, and SigV4 signing.
-version: 0.3.2
+version: 0.4.0
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/smithy/smithy_aws
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,8 +9,8 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  aws_common: ">=0.3.5 <0.4.0"
-  aws_signature_v4: ">=0.3.1 <0.4.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
+  aws_signature_v4: ">=0.3.1+1 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
   collection: ^1.15.0
@@ -21,7 +21,7 @@ dependencies:
   json_annotation: ^4.7.0
   meta: ^1.7.0
   path: ^1.8.0
-  smithy: ">=0.3.2 <0.4.0"
+  smithy: ">=0.4.0 <0.5.0"
   xml: ">=6.1.0 <=6.2.2"
 
 dev_dependencies:

--- a/packages/storage/amplify_storage_s3/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-next.3
+
+### Fixes
+- fix(storage): update expected exception types in integ tests
+
 ## 1.0.0-next.2+1
 
 ### Fixes

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3
 description: The Amplify Flutter Storage category plugin using the AWS S3 provider.
-version: 1.0.0-next.2+1
+version: 1.0.0-next.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/storage/amplify_storage_s3
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,10 +19,10 @@ platforms:
   web:
 
 dependencies:
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_db_common: ">=0.1.2 <0.2.0"
-  amplify_storage_s3_dart: ">=0.1.4 <0.2.0"
-  aws_common: ">=0.3.3 <0.4.0"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_db_common: ">=0.1.2+1 <0.2.0"
+  amplify_storage_s3_dart: ">=0.1.4+1 <0.2.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
   flutter:
     sdk: flutter
   meta: ^1.7.0

--- a/packages/storage/amplify_storage_s3_dart/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4+1
+
+- Minor bug fixes and improvements
+
 ## 0.1.4
 
 ### Fixes

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3_dart
 description: A Dart-only implementation of the Amplify Storage plugin for S3.
-version: 0.1.4
+version: 0.1.4+1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/storage/amplify_storage_s3_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,19 +9,19 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  amplify_core: ">=1.0.0-next.2 <1.0.0-next.3"
-  amplify_db_common_dart: ">=0.1.2 <0.2.0"
+  amplify_core: ">=1.0.0-next.3 <1.0.0-next.4"
+  amplify_db_common_dart: ">=0.2.0 <0.3.0"
   async: ^2.8.0
-  aws_common: ">=0.3.3 <0.4.0"
-  aws_signature_v4: ">=0.3.1 <0.4.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
+  aws_signature_v4: ">=0.3.1+1 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
   drift: ">=2.3.0 <2.4.0"
   fixnum: ^1.0.0
   meta: ^1.7.0
   path: ^1.8.0
-  smithy: ">=0.3.0 <0.4.0"
-  smithy_aws: ">=0.3.0 <0.4.0"
+  smithy: ">=0.4.0 <0.5.0"
+  smithy_aws: ">=0.4.0 <0.5.0"
 
 dev_dependencies:
   amplify_lints:

--- a/packages/worker_bee/worker_bee/CHANGELOG.md
+++ b/packages/worker_bee/worker_bee/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3+1
+
+- Minor bug fixes and improvements
+
 ## 0.1.3
 
 - Minor bug fixes and improvements

--- a/packages/worker_bee/worker_bee/pubspec.yaml
+++ b/packages/worker_bee/worker_bee/pubspec.yaml
@@ -1,6 +1,6 @@
 name: worker_bee
 description: A cross-platform isolated worker runtime for Dart Web, VM, and Flutter.
-version: 0.1.3
+version: 0.1.3+1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/worker_bee/worker_bee
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.8.0
-  aws_common: ">=0.3.3 <0.4.0"
+  aws_common: ">=0.3.5+1 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
   collection: ^1.15.0

--- a/packages/worker_bee/worker_bee_builder/CHANGELOG.md
+++ b/packages/worker_bee/worker_bee_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4+1
+
+- Minor bug fixes and improvements
+
 ## 0.1.4
 
 - Minor bug fixes and improvements

--- a/packages/worker_bee/worker_bee_builder/pubspec.yaml
+++ b/packages/worker_bee/worker_bee_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: worker_bee_builder
 description: Builder package for worker_bee to quickly generate necessary boilerplate
-version: 0.1.4
+version: 0.1.4+1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/worker_bee/worker_bee_builder
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -20,7 +20,7 @@ dependencies:
   source_gen: ^1.2.1
   stream_channel: ^2.1.0
   tuple: ^2.0.0
-  worker_bee: ">=0.1.3 <0.2.0"
+  worker_bee: ">=0.1.3+1 <0.2.0"
 
 dev_dependencies:
   amplify_lints:


### PR DESCRIPTION
### Breaking Changes
- chore(auth)!: Remove `isPreferPrivateSession` from `CognitoSignOutWithWebUIOptions` ([#2538](https://github.com/aws-amplify/amplify-flutter/pull/2538))
- feat(aft)!: Add plugins to SDK generation
- refactor(auth)!: Align exception types
- refactor(auth)!: Make SRP failures errors
- refactor(auth)!: Remove intermediate request types ([#2475](https://github.com/aws-amplify/amplify-flutter/pull/2475))
- refactor(core)!: Migrate exception types

### Fixes
- fix(analytics): Secure storage on Android ([#2530](https://github.com/aws-amplify/amplify-flutter/pull/2530))
- fix(api): SubscriptionDataPayload error decoding type fix ([#2483](https://github.com/aws-amplify/amplify-flutter/pull/2483))
- fix(api): improve GQL subscription error visibility/recovery ([#2507](https://github.com/aws-amplify/amplify-flutter/pull/2507))
- fix(api): prevent GQL subscription race condition error after shutdown ([#2494](https://github.com/aws-amplify/amplify-flutter/pull/2494))
- fix(auth): legacy data migration for iOS ([#2516](https://github.com/aws-amplify/amplify-flutter/pull/2516))
- fix(authenticator): Example Dead Link ([#2505](https://github.com/aws-amplify/amplify-flutter/pull/2505))
- fix(authenticator): Navigation via TabBar ([#2486](https://github.com/aws-amplify/amplify-flutter/pull/2486))
- fix(authenticator): keyboard navigation ([#2473](https://github.com/aws-amplify/amplify-flutter/pull/2473))
- fix(sigv4): Allow custom `scheme` ([#2531](https://github.com/aws-amplify/amplify-flutter/pull/2531))
- fix(smithy): Retry behavior
- fix(storage): update expected exception types in integ tests

Updated-Components: aws_common, aws_signature_v4, amplify_db_common, amplify_db_common_dart, amplify_secure_storage, amplify_secure_storage_dart, Amplify Flutter, Amplify Dart, Amplify UI, Smithy, Worker Bee