### PR TITLE
ci(repo): Enable DDC/native workflows in PRs

### DIFF
--- a/.github/workflows/amplify_auth_cognito_dart.yaml
+++ b/.github/workflows/amplify_auth_cognito_dart.yaml
@@ -28,7 +28,6 @@ jobs:
     with:
       working-directory: packages/auth/amplify_auth_cognito_dart
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:

--- a/.github/workflows/amplify_auth_cognito_test.yaml
+++ b/.github/workflows/amplify_auth_cognito_test.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/auth/amplify_auth_cognito_test
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/auth/amplify_auth_cognito_test
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/amplify_core.yaml
+++ b/.github/workflows/amplify_core.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/amplify_core
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/amplify_core
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/amplify_db_common_dart.yaml
+++ b/.github/workflows/amplify_db_common_dart.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/common/amplify_db_common_dart
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/common/amplify_db_common_dart
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/amplify_secure_storage_test.yaml
+++ b/.github/workflows/amplify_secure_storage_test.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/secure_storage/amplify_secure_storage_test
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/secure_storage/amplify_secure_storage_test
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/amplify_storage_s3_dart.yaml
+++ b/.github/workflows/amplify_storage_s3_dart.yaml
@@ -28,7 +28,6 @@ jobs:
     with:
       working-directory: packages/storage/amplify_storage_s3_dart
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:

--- a/.github/workflows/aws_common.yaml
+++ b/.github/workflows/aws_common.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/aws_common
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/aws_common
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/aws_json1_0_v1.yaml
+++ b/.github/workflows/aws_json1_0_v1.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/smithy/goldens/lib/awsJson1_0
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/awsJson1_0
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/aws_json1_0_v2.yaml
+++ b/.github/workflows/aws_json1_0_v2.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/smithy/goldens/lib2/awsJson1_0
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/awsJson1_0
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/aws_json1_1_v1.yaml
+++ b/.github/workflows/aws_json1_1_v1.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/smithy/goldens/lib/awsJson1_1
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/awsJson1_1
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/aws_json1_1_v2.yaml
+++ b/.github/workflows/aws_json1_1_v2.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/smithy/goldens/lib2/awsJson1_1
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/awsJson1_1
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/aws_signature_v4.yaml
+++ b/.github/workflows/aws_signature_v4.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/aws_signature_v4
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/aws_signature_v4
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -50,6 +50,7 @@ jobs:
           sdk: ${{ matrix.sdk }}
 
       - name: Setup aft
+        shell: bash # Run in bash regardless of platform
         run: |
           # Patch libgit2dart (see https://github.com/dart-lang/pub/issues/3563)
           ( cd packages/aft/external/libgit2dart; git apply ../libgit2dart.patch )

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -63,6 +63,8 @@ jobs:
       - name: Setup Firefox
         if: ${{ matrix.browser == 'firefox' }}
         uses: ./.github/composite_actions/setup_firefox
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bootstrap
         id: bootstrap

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -54,6 +54,7 @@ jobs:
           sdk: ${{ matrix.sdk }}
 
       - name: Setup aft
+        shell: bash # Run in bash regardless of platform
         run: |
           # Patch libgit2dart (see https://github.com/dart-lang/pub/issues/3563)
           ( cd packages/aft/external/libgit2dart; git apply ../libgit2dart.patch )

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -51,6 +51,7 @@ jobs:
           sdk: stable
 
       - name: Setup aft
+        shell: bash # Run in bash regardless of platform
         run: |
           # Patch libgit2dart (see https://github.com/dart-lang/pub/issues/3563)
           ( cd packages/aft/external/libgit2dart; git apply ../libgit2dart.patch )

--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -47,6 +47,7 @@ jobs:
           sdk: ${{ matrix.sdk }}
 
       - name: Setup aft
+        shell: bash # Run in bash regardless of platform
         run: |
           # Patch libgit2dart (see https://github.com/dart-lang/pub/issues/3563)
           ( cd packages/aft/external/libgit2dart; git apply ../libgit2dart.patch )

--- a/.github/workflows/rest_json1_v1.yaml
+++ b/.github/workflows/rest_json1_v1.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/smithy/goldens/lib/restJson1
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/restJson1
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/rest_json1_v2.yaml
+++ b/.github/workflows/rest_json1_v2.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/smithy/goldens/lib2/restJson1
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/restJson1
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/rest_xml_v1.yaml
+++ b/.github/workflows/rest_xml_v1.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/smithy/goldens/lib/restXml
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/restXml
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/rest_xml_v2.yaml
+++ b/.github/workflows/rest_xml_v2.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/smithy/goldens/lib2/restXml
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/restXml
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/rest_xml_with_namespace_v1.yaml
+++ b/.github/workflows/rest_xml_with_namespace_v1.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/smithy/goldens/lib/restXmlWithNamespace
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/restXmlWithNamespace
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/rest_xml_with_namespace_v2.yaml
+++ b/.github/workflows/rest_xml_with_namespace_v2.yaml
@@ -31,13 +31,11 @@ jobs:
     with:
       working-directory: packages/smithy/goldens/lib2/restXmlWithNamespace
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/restXmlWithNamespace
   ddc_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:

--- a/.github/workflows/smithy.yaml
+++ b/.github/workflows/smithy.yaml
@@ -28,7 +28,6 @@ jobs:
     with:
       working-directory: packages/smithy/smithy
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:

--- a/.github/workflows/smithy_aws.yaml
+++ b/.github/workflows/smithy_aws.yaml
@@ -28,7 +28,6 @@ jobs:
     with:
       working-directory: packages/smithy/smithy_aws
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:

--- a/.github/workflows/smithy_codegen.yaml
+++ b/.github/workflows/smithy_codegen.yaml
@@ -28,7 +28,6 @@ jobs:
     with:
       working-directory: packages/smithy/smithy_codegen
   native_test:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -111,7 +111,6 @@ jobs:
         workflowContents.write(
           '''
   native_test:
-    if: \${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/$nativeWorkflow
     with:
@@ -123,7 +122,6 @@ jobs:
           workflowContents.write(
             '''
   ddc_test:
-    if: \${{ github.event_name == 'push' }}
     needs: test
     uses: ./.github/workflows/$ddcWorkflow
     with:


### PR DESCRIPTION
- Missing GITHUB_TOKEN for Firefox tests
- Enables DDC/native workflows to run on PRs by default