### PR TITLE
test(auth): Fix mock phone numbers

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
@@ -36,7 +36,7 @@ void main() {
           options: CognitoSignUpOptions(
             userAttributes: {
               CognitoUserAttributeKey.email: generateEmail(),
-              CognitoUserAttributeKey.phoneNumber: mockPhoneNumber
+              CognitoUserAttributeKey.phoneNumber: generatePhoneNumber(),
             },
           ),
         ) as CognitoSignUpResult;

--- a/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
@@ -73,8 +73,8 @@ void main() {
     group(
       'with alias',
       () {
-        const username = mockPhoneNumber;
-        final password = generatePassword();
+        late String username;
+        late String password;
 
         setUpAll(() async {
           await configureAuth(
@@ -86,16 +86,18 @@ void main() {
         tearDownAll(Amplify.reset);
 
         setUp(() async {
+          username = generatePhoneNumber();
+          password = generatePassword();
           await adminCreateUser(
             username,
             password,
             autoConfirm: true,
             verifyAttributes: true,
             enableMfa: true,
-            attributes: const [
+            attributes: [
               AuthUserAttribute(
                 userAttributeKey: CognitoUserAttributeKey.phoneNumber,
-                value: mockPhoneNumber,
+                value: username,
               ),
             ],
           );
@@ -129,7 +131,7 @@ void main() {
             isA<CognitoSignInDetailsApiBased>().having(
               (details) => details.username,
               'username',
-              mockPhoneNumber,
+              username,
             ),
             reason: 'Should return the phone number alias since it '
                 'was used to sign in',

--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_up_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_up_test.dart
@@ -31,7 +31,7 @@ void main() {
         options: CognitoSignUpOptions(
           userAttributes: {
             CognitoUserAttributeKey.email: generateEmail(),
-            CognitoUserAttributeKey.phoneNumber: mockPhoneNumber
+            CognitoUserAttributeKey.phoneNumber: generatePhoneNumber(),
           },
         ),
       ) as CognitoSignUpResult;
@@ -64,7 +64,7 @@ void main() {
         final options = CognitoSignUpOptions(
           userAttributes: {
             CognitoUserAttributeKey.email: generateEmail(),
-            CognitoUserAttributeKey.phoneNumber: mockPhoneNumber
+            CognitoUserAttributeKey.phoneNumber: generatePhoneNumber(),
           },
         );
         await expectLater(
@@ -90,7 +90,7 @@ void main() {
         final userOneOptions = CognitoSignUpOptions(
           userAttributes: {
             CognitoUserAttributeKey.email: generateEmail(),
-            CognitoUserAttributeKey.phoneNumber: mockPhoneNumber
+            CognitoUserAttributeKey.phoneNumber: generatePhoneNumber(),
           },
         );
         await Amplify.Auth.signUp(
@@ -104,7 +104,7 @@ void main() {
         final userTwoOptions = CognitoSignUpOptions(
           userAttributes: {
             CognitoUserAttributeKey.email: generateEmail(),
-            CognitoUserAttributeKey.phoneNumber: mockPhoneNumber
+            CognitoUserAttributeKey.phoneNumber: generatePhoneNumber(),
           },
         );
         await expectLater(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/user_attributes_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/user_attributes_test.dart
@@ -23,7 +23,7 @@ void main() {
   final username = generateUsername();
   final password = generatePassword();
   final email = generateEmail();
-  const phoneNumber = mockPhoneNumber;
+  final phoneNumber = generatePhoneNumber();
   final name = generateNameAttribute();
 
   group('User Attributes', () {
@@ -44,9 +44,9 @@ void main() {
             userAttributeKey: CognitoUserAttributeKey.email,
             value: email,
           ),
-          const AuthUserAttribute(
+          AuthUserAttribute(
             userAttributeKey: CognitoUserAttributeKey.phoneNumber,
-            value: mockPhoneNumber,
+            value: phoneNumber,
           )
         ],
       );

--- a/packages/auth/amplify_auth_cognito/example/integration_test/utils/mock_data.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/utils/mock_data.dart
@@ -11,7 +11,18 @@ const uppercaseLetters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const lowercaseLetters = 'abcdefghijklmnopqrstuvwxyz';
 const digits = '1234567890';
 const symbols = '~/`!@#\$%^&\\"\'*(),._?:;{}|<>';
-const mockPhoneNumber = '+15555551234';
+
+String generatePhoneNumber() {
+  final buf = StringBuffer('+1');
+  for (var i = 0; i < 3; i++) {
+    buf.write(digits[random.nextInt(digits.length)]);
+  }
+  buf.write('55501');
+  for (var i = 0; i < 2; i++) {
+    buf.write(digits[random.nextInt(digits.length)]);
+  }
+  return buf.toString();
+}
 
 String generateEmail() => 'test-amplify-flutter-${uuid()}@test${uuid()}.com';
 


### PR DESCRIPTION
Using a single mock phone number led to exceptions when multiple users were created with the same phone number. Any number in the range `555-0100` through `555-0199` are reserved for fictional use (https://en.wikipedia.org/wiki/555_(telephone_number)), so generate random numbers with this pattern.
