### PR TITLE
feat(aft): Add `aft exec` command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
       - activate_pana
       - run:
           name: Run pub analysis and fail if the score is below the max score
-          command: param=<< parameters.plugin_threshold >> && plugin=${param%:*} && threshold=${param#*:} && melos exec -c 1 --fail-fast --scope="$plugin" -- pana --no-warning --exit-code-threshold $threshold .
+          command: param=<< parameters.plugin_threshold >> && plugin=${param%:*} && threshold=${param#*:} && aft exec --include="$plugin" -- pana --no-warning --exit-code-threshold $threshold .
 
   unit_test_flutter:
     executor: docker-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
       - activate_pana
       - run:
           name: Run pub analysis and fail if the score is below the max score
-          command: param=<< parameters.plugin_threshold >> && plugin=${param%:*} && threshold=${param#*:} && aft exec --include="$plugin" -- pana --no-warning --exit-code-threshold $threshold .
+          command: param=<< parameters.plugin_threshold >> && plugin=${param%:*} && threshold=${param#*:} && melos exec -c 1 --fail-fast --scope="$plugin" -- pana --no-warning --exit-code-threshold $threshold .
 
   unit_test_flutter:
     executor: docker-executor

--- a/melos.yaml
+++ b/melos.yaml
@@ -14,27 +14,27 @@ scripts:
   setup_tuneup: >
     flutter pub global activate tuneup
   copy_dummy_config: >
-    aft exec --include="*example*,sample_app" -- \
-      cp -n <AFT_ROOT>/.circleci/dummy_amplifyconfiguration.dart lib/amplifyconfiguration.dart | true
+    melos exec --scope="*example*,sample_app" -- \
+      cp -n "\$MELOS_ROOT_PATH"/.circleci/dummy_amplifyconfiguration.dart lib/amplifyconfiguration.dart | true
 
   build:examples:ios: >
-    aft exec --include="*example*,sample_app" --exclude="*_android*" --fail-fast -- \
+    melos exec -c 1 --scope="*example*,sample_app" --ignore="*_android*" --fail-fast -- \
       flutter build ios --simulator
 
   build:examples:release:ios: >
-    aft exec --include="*example*" --exclude="*_android*" --fail-fast -- \
+    melos exec -c 1 --scope="*example*" --ignore="*_android*" --fail-fast -- \
       flutter build ios --no-codesign
 
   build:examples:android: >
-    aft exec --include="*example*,sample_app" --exclude="*_ios*" --fail-fast -- \
+    melos exec -c 1 --scope="*example*,sample_app" --ignore="*_ios*" --fail-fast -- \
       flutter build apk --debug --verbose
 
   build:examples:release:android: >
-    aft exec --include="*example*" --exclude="*_ios*" --fail-fast -- \
+    melos exec -c 1 --scope="*example*" --ignore="*_ios*" --fail-fast -- \
       flutter build apk --verbose
 
   test:unit:flutter:
-    run: aft exec -- flutter test
+    run: melos exec -c 1 "flutter test"
     description: >
       Runs flutter unit tests in all plugins and example apps. Manually run only, not in CI
     select-package:
@@ -75,7 +75,7 @@ scripts:
   # Analytics
   lint:android:amplify_analytics_pinpoint:
     run: |
-      aft exec --fail-fast -- \
+      melos exec -c 1 --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -86,7 +86,7 @@ scripts:
   # API
   lint:android:amplify_api:
     run: |
-      aft exec --fail-fast -- \
+      melos exec -c 1 --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -97,7 +97,7 @@ scripts:
   # AUTH
   lint:android:amplify_auth_cognito:
     run: |
-      aft exec --fail-fast -- \
+      melos exec -c 1 --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -108,7 +108,7 @@ scripts:
   # CORE
   lint:android:amplify_core:
     run: |
-      aft exec --fail-fast -- \
+      melos exec -c 1 --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -119,7 +119,7 @@ scripts:
   # DATASTORE
   lint:android:amplify_datastore:
     run: |
-      aft exec --fail-fast -- \
+      melos exec -c 1 --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -132,7 +132,7 @@ scripts:
   # as amplify_storage_s3_android_example doesn't exist now
   lint:android:amplify_storage_s3:
     run: |
-      aft exec --fail-fast -- \
+      melos exec -c 1 --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -143,7 +143,7 @@ scripts:
   # AMPLIFY_FLUTTER
   lint:android:amplify_flutter:
     run: |
-      aft exec --fail-fast -- \
+      melos exec -c 1 --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -158,7 +158,7 @@ scripts:
       - Requires running Android and iOS simulators.
 
   test:integration:android:
-    run: aft exec -- "<AFT_ROOT>/build-support/integ_test.sh -d sdk" $@
+    run: melos exec -c 1 -- "$MELOS_ROOT_PATH/build-support/integ_test.sh -d sdk" $@
     description:
       Run integration tests for a single package on an Android emulator.
       - Run with `--no-select` to run for all applicable packages.
@@ -170,7 +170,7 @@ scripts:
       ignore: "*ios_example"
 
   test:integration:ios:
-    run: aft exec -- "<AFT_ROOT>/build-support/integ_test_ios.sh" $@
+    run: melos exec -c 1 -- "$MELOS_ROOT_PATH/build-support/integ_test_ios.sh" $@
     description: Run integration tests for a single package on an iOS simulator.
       - Run with `--no-select` to run for all applicable packages.
       - Requires launching an iOS simulator prior to execution.
@@ -180,7 +180,7 @@ scripts:
       scope: "*example*"
 
   provision_integration_test_resources:
-    run: aft exec "./tool/provision_integration_test_resources.sh"
+    run: melos exec "./tool/provision_integration_test_resources.sh"
     description:
       Creates and pushes amplify environments necessary to run integration tests in example apps. Runs only on apps with provision script.
       - Requires amplify CLI configured and connected to AWS account.
@@ -200,21 +200,21 @@ scripts:
     ./build-support/codecov.sh -F android-unit-tests
 
   format: >
-    aft exec -- \
-      aft format --dry-run --set-exit-if-changed .
+    aft exec --fail-fast --include="Amplify Flutter" -- \
+      flutter format --dry-run --set-exit-if-changed .
   analyze:
-    run: aft exec --fail-fast --include="amplify_analytics_*,amplify_api*,amplify_auth_cognito*,amplify_flutter*" --exclude=amplify_auth_cognito_dart,amplify_analytics_pinpoint_dart -- \
-      flutter analyze --no-fatal-infos .
+    run: aft exec --fail-fast --include="Amplify Flutter" -- \
+      flutter analyze --no-fatal-infos
     description: >
       Analyzes all packages and fails if there are any errors.
 
   lint:pub: >
-    aft exec -c 5 --fail-fast --no-private --ignore="*example*" -- \
+    melos exec -c 5 --fail-fast --no-private --ignore="*example*" -- \
       flutter pub publish --dry-run
 
   packages:fix: |
-    aft exec -- \
-      aft analyze --no-fatal-infos --no-fatal-warnings &>/dev/null || true
+    melos exec -- \
+      flutter analyze --no-fatal-infos --no-fatal-warnings &>/dev/null || true
 
   pod:repo-update:
     run: melos exec -c 8 --scope="*example*,sample_app"  --ignore="*_android_example" "(cd ios && pod repo update)"
@@ -232,7 +232,7 @@ scripts:
     melos run copy_dummy_config && \
     melos run packages:fix
   postclean: >
-    aft exec -- \
+    melos exec -- \
       rm -rf ./build ./android/.gradle ./ios/.symlinks ./ios/Pods ./ios/Podfile.lock
 dev_dependencies:
   pedantic: ^1.9.0

--- a/melos.yaml
+++ b/melos.yaml
@@ -201,9 +201,9 @@ scripts:
 
   format: >
     aft exec -- \
-      flutter format --dry-run --set-exit-if-changed .
+      aft format --dry-run --set-exit-if-changed .
   analyze:
-    run: aft exec --fail-fast --include="amplify_analytics_*,amplify_api*,amplify_auth_cognito*,amplify_flutter*,amplify_core*" -- \
+    run: aft exec --fail-fast --include="amplify_analytics_*,amplify_api*,amplify_auth_cognito*,amplify_flutter*" --exclude=amplify_auth_cognito_dart,amplify_analytics_pinpoint_dart -- \
       flutter analyze --no-fatal-infos .
     description: >
       Analyzes all packages and fails if there are any errors.
@@ -214,7 +214,7 @@ scripts:
 
   packages:fix: |
     aft exec -- \
-      flutter analyze --no-fatal-infos --no-fatal-warnings &>/dev/null || true
+      aft analyze --no-fatal-infos --no-fatal-warnings &>/dev/null || true
 
   pod:repo-update:
     run: melos exec -c 8 --scope="*example*,sample_app"  --ignore="*_android_example" "(cd ios && pod repo update)"

--- a/melos.yaml
+++ b/melos.yaml
@@ -14,27 +14,27 @@ scripts:
   setup_tuneup: >
     flutter pub global activate tuneup
   copy_dummy_config: >
-    melos exec --scope="*example*,sample_app" -- \
-      cp -n "\$MELOS_ROOT_PATH"/.circleci/dummy_amplifyconfiguration.dart lib/amplifyconfiguration.dart | true
+    aft exec --include="*example*,sample_app" -- \
+      cp -n <AFT_ROOT>/.circleci/dummy_amplifyconfiguration.dart lib/amplifyconfiguration.dart | true
 
   build:examples:ios: >
-    melos exec -c 1 --scope="*example*,sample_app" --ignore="*_android*" --fail-fast -- \
+    aft exec --include="*example*,sample_app" --exclude="*_android*" --fail-fast -- \
       flutter build ios --simulator
 
   build:examples:release:ios: >
-    melos exec -c 1 --scope="*example*" --ignore="*_android*" --fail-fast -- \
+    aft exec --include="*example*" --exclude="*_android*" --fail-fast -- \
       flutter build ios --no-codesign
 
   build:examples:android: >
-    melos exec -c 1 --scope="*example*,sample_app" --ignore="*_ios*" --fail-fast -- \
+    aft exec --include="*example*,sample_app" --exclude="*_ios*" --fail-fast -- \
       flutter build apk --debug --verbose
 
   build:examples:release:android: >
-    melos exec -c 1 --scope="*example*" --ignore="*_ios*" --fail-fast -- \
+    aft exec --include="*example*" --exclude="*_ios*" --fail-fast -- \
       flutter build apk --verbose
 
   test:unit:flutter:
-    run: melos exec -c 1 "flutter test"
+    run: aft exec -- flutter test
     description: >
       Runs flutter unit tests in all plugins and example apps. Manually run only, not in CI
     select-package:
@@ -75,7 +75,7 @@ scripts:
   # Analytics
   lint:android:amplify_analytics_pinpoint:
     run: |
-      melos exec -c 1 --fail-fast -- \
+      aft exec --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -86,7 +86,7 @@ scripts:
   # API
   lint:android:amplify_api:
     run: |
-      melos exec -c 1 --fail-fast -- \
+      aft exec --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -97,7 +97,7 @@ scripts:
   # AUTH
   lint:android:amplify_auth_cognito:
     run: |
-      melos exec -c 1 --fail-fast -- \
+      aft exec --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -108,7 +108,7 @@ scripts:
   # CORE
   lint:android:amplify_core:
     run: |
-      melos exec -c 1 --fail-fast -- \
+      aft exec --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -119,7 +119,7 @@ scripts:
   # DATASTORE
   lint:android:amplify_datastore:
     run: |
-      melos exec -c 1 --fail-fast -- \
+      aft exec --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -132,7 +132,7 @@ scripts:
   # as amplify_storage_s3_android_example doesn't exist now
   lint:android:amplify_storage_s3:
     run: |
-      melos exec -c 1 --fail-fast -- \
+      aft exec --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -143,7 +143,7 @@ scripts:
   # AMPLIFY_FLUTTER
   lint:android:amplify_flutter:
     run: |
-      melos exec -c 1 --fail-fast -- \
+      aft exec --fail-fast -- \
         bash "$PWD/build-support/lint_android.sh"
     description: >
       Lints Android (Kotlin) files against global rules and fails if there are any errors.
@@ -158,7 +158,7 @@ scripts:
       - Requires running Android and iOS simulators.
 
   test:integration:android:
-    run: melos exec -c 1 -- "$MELOS_ROOT_PATH/build-support/integ_test.sh -d sdk" $@
+    run: aft exec -- "<AFT_ROOT>/build-support/integ_test.sh -d sdk" $@
     description:
       Run integration tests for a single package on an Android emulator.
       - Run with `--no-select` to run for all applicable packages.
@@ -170,7 +170,7 @@ scripts:
       ignore: "*ios_example"
 
   test:integration:ios:
-    run: melos exec -c 1 -- "$MELOS_ROOT_PATH/build-support/integ_test_ios.sh" $@
+    run: aft exec -- "<AFT_ROOT>/build-support/integ_test_ios.sh" $@
     description: Run integration tests for a single package on an iOS simulator.
       - Run with `--no-select` to run for all applicable packages.
       - Requires launching an iOS simulator prior to execution.
@@ -180,7 +180,7 @@ scripts:
       scope: "*example*"
 
   provision_integration_test_resources:
-    run: melos exec "./tool/provision_integration_test_resources.sh"
+    run: aft exec "./tool/provision_integration_test_resources.sh"
     description:
       Creates and pushes amplify environments necessary to run integration tests in example apps. Runs only on apps with provision script.
       - Requires amplify CLI configured and connected to AWS account.
@@ -200,27 +200,20 @@ scripts:
     ./build-support/codecov.sh -F android-unit-tests
 
   format: >
-    melos exec -c 1 -- \
+    aft exec -- \
       flutter format --dry-run --set-exit-if-changed .
   analyze:
-    run: melos exec -c 1 --fail-fast -- \
-      flutter analyze --no-fatal-infos
+    run: aft exec --fail-fast --include="amplify_analytics_*,amplify_api*,amplify_auth_cognito*,amplify_flutter*,amplify_core*" -- \
+      flutter analyze --no-fatal-infos .
     description: >
       Analyzes all packages and fails if there are any errors.
-    select-package:
-      scope:
-        - amplify_analytics_*
-        - amplify_api*
-        - amplify_auth_cognito*
-        - amplify_flutter*
-        - amplify_core*
 
   lint:pub: >
-    melos exec -c 5 --fail-fast --no-private --ignore="*example*" -- \
+    aft exec -c 5 --fail-fast --no-private --ignore="*example*" -- \
       flutter pub publish --dry-run
 
   packages:fix: |
-    melos exec -- \
+    aft exec -- \
       flutter analyze --no-fatal-infos --no-fatal-warnings &>/dev/null || true
 
   pod:repo-update:
@@ -239,7 +232,7 @@ scripts:
     melos run copy_dummy_config && \
     melos run packages:fix
   postclean: >
-    melos exec -- \
+    aft exec -- \
       rm -rf ./build ./android/.gradle ./ios/.symlinks ./ios/Pods ./ios/Podfile.lock
 dev_dependencies:
   pedantic: ^1.9.0

--- a/melos.yaml
+++ b/melos.yaml
@@ -200,8 +200,8 @@ scripts:
     ./build-support/codecov.sh -F android-unit-tests
 
   format: >
-    aft exec --fail-fast --include="Amplify Flutter" -- \
-      flutter format --dry-run --set-exit-if-changed .
+    aft exec --fail-fast -- \
+      aft format --set-exit-if-changed .
   analyze:
     run: aft exec --fail-fast --include="Amplify Flutter" -- \
       flutter analyze --no-fatal-infos

--- a/packages/aft/README.md
+++ b/packages/aft/README.md
@@ -15,10 +15,7 @@ A CLI tool for managing the Amplify Flutter repository.
   - `workflows`: Generates GitHub actions workflows for all packages in the repo
 - `link`: Links all packages together using `pubspec_overrides.yaml`
 - `list`: Lists all packages in the repo
-- `pub`: Run pub commands for all packages in the repo
-  - `get`: Runs `dart pub get`/`flutter pub get` for all packages
-  - `upgrade`: Runs `dart pub upgrade`/`flutter pub upgrade` for all packages
-  - `publish`: Runs `dart pub publish`/`flutter pub publish` for all packages which need publishing
+- `publish`: Runs `dart pub publish`/`flutter pub publish` for all packages which need publishing
 - `version-bump`: Bumps version using git history
 
 ## Setup

--- a/packages/aft/README.md
+++ b/packages/aft/README.md
@@ -10,6 +10,7 @@ A CLI tool for managing the Amplify Flutter repository.
   - `check`: Checks dependencies against `aft.yaml`, for use in CI
   - `update`: Updates dependency constraints in `aft.yaml` to match latest in `pub.dev`
   - `apply`: Applies dependency constraints in `aft.yaml` to all repo packages
+- `exec`: Execute a command in all repo packages
 - `generate`: Generates various repo items
   - `workflows`: Generates GitHub actions workflows for all packages in the repo
 - `link`: Links all packages together using `pubspec_overrides.yaml`

--- a/packages/aft/bin/aft.dart
+++ b/packages/aft/bin/aft.dart
@@ -26,7 +26,8 @@ Future<void> main(List<String> args) async {
     ..addCommand(CleanCommand())
     ..addCommand(PubCommand())
     ..addCommand(BootstrapCommand())
-    ..addCommand(VersionBumpCommand());
+    ..addCommand(VersionBumpCommand())
+    ..addCommand(ExecCommand());
   try {
     await runner.run(args);
   } on UsageException catch (e) {

--- a/packages/aft/bin/aft.dart
+++ b/packages/aft/bin/aft.dart
@@ -3,33 +3,12 @@
 
 import 'dart:io';
 
-import 'package:aft/aft.dart';
+import 'package:aft/src/command_runner.dart' as command_runner;
 import 'package:args/command_runner.dart';
 
 Future<void> main(List<String> args) async {
-  final runner = CommandRunner<void>('aft', 'Amplify Flutter repo tools')
-    ..argParser.addFlag(
-      'verbose',
-      abbr: 'v',
-      help: 'Prints verbose logs',
-      defaultsTo: false,
-    )
-    ..argParser.addOption(
-      'directory',
-      help: 'Directory to run commands from. Defaults to current directory.',
-      hide: true,
-    )
-    ..addCommand(GenerateCommand())
-    ..addCommand(ListPackagesCommand())
-    ..addCommand(DepsCommand())
-    ..addCommand(LinkCommand())
-    ..addCommand(CleanCommand())
-    ..addCommand(PubCommand())
-    ..addCommand(BootstrapCommand())
-    ..addCommand(VersionBumpCommand())
-    ..addCommand(ExecCommand());
   try {
-    await runner.run(args);
+    await command_runner.run(args);
   } on UsageException catch (e) {
     stderr
       ..writeln(e.message)
@@ -41,10 +20,6 @@ Future<void> main(List<String> args) async {
       ..writeln(st);
     exitCode = 1;
   } finally {
-    // Free up resources before exiting..
-    for (final command in runner.commands.values.whereType<AmplifyCommand>()) {
-      command.close();
-    }
     exit(exitCode);
   }
 }

--- a/packages/aft/lib/aft.dart
+++ b/packages/aft/lib/aft.dart
@@ -7,6 +7,7 @@ export 'src/commands/amplify_command.dart';
 export 'src/commands/bootstrap_command.dart';
 export 'src/commands/clean_command.dart';
 export 'src/commands/deps_command.dart';
+export 'src/commands/exec_command.dart';
 export 'src/commands/generate/generate_command.dart';
 export 'src/commands/link_command.dart';
 export 'src/commands/list_packages_command.dart';

--- a/packages/aft/lib/src/changelog/changelog.dart
+++ b/packages/aft/lib/src/changelog/changelog.dart
@@ -1,16 +1,5 @@
-// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 

--- a/packages/aft/lib/src/changelog/commit_message.dart
+++ b/packages/aft/lib/src/changelog/commit_message.dart
@@ -1,16 +1,5 @@
-// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 

--- a/packages/aft/lib/src/changelog/parser.dart
+++ b/packages/aft/lib/src/changelog/parser.dart
@@ -1,16 +1,5 @@
-// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'changelog.dart';
 

--- a/packages/aft/lib/src/changelog/printer.dart
+++ b/packages/aft/lib/src/changelog/printer.dart
@@ -1,16 +1,5 @@
-// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:aft/src/changelog/changelog.dart';
 import 'package:markdown/markdown.dart';

--- a/packages/aft/lib/src/command_runner.dart
+++ b/packages/aft/lib/src/command_runner.dart
@@ -3,8 +3,17 @@
 
 import 'package:aft/aft.dart';
 import 'package:aft/src/commands/passthrough_command.dart';
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 
+/// Passes through the command specified by [args] to either `dart`/`flutter`
+/// depending on the package in the current working directory.
+Future<void> passthrough(List<String> args) async {
+  final passthroughCommand = PassthroughCommand(args);
+  return passthroughCommand.run();
+}
+
+/// Runs the `aft` command using the given [args].
 Future<void> run(List<String> args) async {
   final runner = CommandRunner<void>('aft', 'Amplify Flutter repo tools')
     ..argParser.addFlag(
@@ -27,14 +36,23 @@ Future<void> run(List<String> args) async {
     ..addCommand(BootstrapCommand())
     ..addCommand(VersionBumpCommand())
     ..addCommand(ExecCommand());
+
   try {
-    final argResults = runner.argParser.parse(args);
-    // If we cannot resolve a command, try a passthrough to `dart`/`flutter`.
-    if (argResults.command == null) {
-      final passthroughCommand = PassthroughCommand(argResults.arguments);
-      return await passthroughCommand.run();
+    try {
+      final argResults = runner.argParser.parse(args);
+      // If we cannot resolve a command, try a passthrough to `dart`/`flutter`.
+      if (argResults.command == null) {
+        return await passthrough(argResults.arguments);
+      }
+      await runner.runCommand(argResults);
+    } on ArgParserException {
+      // If we fail to parse the arguments, also passthrough the command since
+      // adding flags or options will trigger a parse failure.
+      if (args.isNotEmpty) {
+        return await passthrough(args);
+      }
+      rethrow;
     }
-    await runner.runCommand(argResults);
   } finally {
     // Free up resources before exiting..
     for (final command in runner.commands.values.whereType<AmplifyCommand>()) {

--- a/packages/aft/lib/src/command_runner.dart
+++ b/packages/aft/lib/src/command_runner.dart
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:aft/aft.dart';
+import 'package:aft/src/commands/passthrough_command.dart';
+import 'package:args/command_runner.dart';
+
+Future<void> run(List<String> args) async {
+  final runner = CommandRunner<void>('aft', 'Amplify Flutter repo tools')
+    ..argParser.addFlag(
+      'verbose',
+      abbr: 'v',
+      help: 'Prints verbose logs',
+      defaultsTo: false,
+    )
+    ..argParser.addOption(
+      'directory',
+      help: 'Directory to run commands from. Defaults to current directory.',
+      hide: true,
+    )
+    ..addCommand(GenerateCommand())
+    ..addCommand(ListPackagesCommand())
+    ..addCommand(DepsCommand())
+    ..addCommand(LinkCommand())
+    ..addCommand(CleanCommand())
+    ..addCommand(PublishCommand())
+    ..addCommand(BootstrapCommand())
+    ..addCommand(VersionBumpCommand())
+    ..addCommand(ExecCommand());
+  try {
+    final argResults = runner.argParser.parse(args);
+    // If we cannot resolve a command, try a passthrough to `dart`/`flutter`.
+    if (argResults.command == null) {
+      final passthroughCommand = PassthroughCommand(argResults.arguments);
+      return await passthroughCommand.run();
+    }
+    await runner.runCommand(argResults);
+  } finally {
+    // Free up resources before exiting..
+    for (final command in runner.commands.values.whereType<AmplifyCommand>()) {
+      command.close();
+    }
+  }
+}

--- a/packages/aft/lib/src/commands/amplify_command.dart
+++ b/packages/aft/lib/src/commands/amplify_command.dart
@@ -145,6 +145,12 @@ abstract class AmplifyCommand extends Command<void>
     return config;
   }();
 
+  /// The environment to inject into subcommands.
+  late final Map<String, String> environment = {
+    ...Platform.environment,
+    'AFT_ROOT': rootDir.uri.toFilePath(),
+  };
+
   late final Repo repo = Repo(
     rootDir,
     allPackages: allPackages,

--- a/packages/aft/lib/src/commands/amplify_command.dart
+++ b/packages/aft/lib/src/commands/amplify_command.dart
@@ -101,7 +101,7 @@ abstract class AmplifyCommand extends Command<void>
   }();
 
   /// All packages in the Amplify Flutter repo.
-  late final Map<String, PackageInfo> allPackages = () {
+  late final Map<String, PackageInfo> repoPackages = () {
     final allDirs = rootDir
         .listSync(recursive: true, followLinks: false)
         .whereType<Directory>();
@@ -129,6 +129,12 @@ abstract class AmplifyCommand extends Command<void>
     });
   }();
 
+  /// All packages included in this command's operation.
+  ///
+  /// This may be overriden by mixins such that it is a subset of
+  /// [repoPackages].
+  late final Map<String, PackageInfo> commandPackages = repoPackages;
+
   /// The absolute path to the `aft.yaml` document.
   late final String aftConfigPath = () {
     final rootDir = this.rootDir;
@@ -153,7 +159,7 @@ abstract class AmplifyCommand extends Command<void>
 
   late final Repo repo = Repo(
     rootDir,
-    allPackages: allPackages,
+    allPackages: repoPackages,
     aftConfig: aftConfig,
     logger: logger,
   );

--- a/packages/aft/lib/src/commands/bootstrap_command.dart
+++ b/packages/aft/lib/src/commands/bootstrap_command.dart
@@ -4,10 +4,11 @@
 import 'dart:io';
 
 import 'package:aft/aft.dart';
+import 'package:aft/src/options/glob_options.dart';
 import 'package:path/path.dart' as path;
 
 /// Command to bootstrap/link Dart/Flutter packages in the repo.
-class BootstrapCommand extends AmplifyCommand {
+class BootstrapCommand extends AmplifyCommand with GlobOptions {
   BootstrapCommand() {
     argParser
       ..addFlag(
@@ -67,9 +68,9 @@ const amplifyEnvironments = <String, String>{};
   @override
   Future<void> run() async {
     await super.run();
-    await linkPackages(allPackages);
+    await linkPackages();
 
-    final bootstrapPackages = allPackages.values.where(
+    final bootstrapPackages = commandPackages.values.where(
       // Skip bootstrap for `aft` since it has already had `dart pub upgrade`
       // run with the native command, and running it again with the embedded
       // command could cause issues later on, esp. when the native `pub`

--- a/packages/aft/lib/src/commands/clean_command.dart
+++ b/packages/aft/lib/src/commands/clean_command.dart
@@ -45,7 +45,7 @@ class CleanCommand extends AmplifyCommand {
   Future<void> run() async {
     await super.run();
     await Future.wait([
-      for (final package in allPackages.values) _cleanBuildFolder(package),
+      for (final package in commandPackages.values) _cleanBuildFolder(package),
     ]);
 
     stdout.writeln('Project successfully cleaned');

--- a/packages/aft/lib/src/commands/deps_command.dart
+++ b/packages/aft/lib/src/commands/deps_command.dart
@@ -105,7 +105,7 @@ class _DepsSubcommand extends AmplifyCommand {
 
   Future<void> _run(_DepsAction action) async {
     final globalDependencyConfig = aftConfig.dependencies;
-    for (final package in allPackages.values) {
+    for (final package in commandPackages.values) {
       for (final globalDep in globalDependencyConfig.entries) {
         _checkDependency(
           package,

--- a/packages/aft/lib/src/commands/exec_command.dart
+++ b/packages/aft/lib/src/commands/exec_command.dart
@@ -22,7 +22,7 @@ class ExecCommand extends AmplifyCommand with GlobOptions, FailFastOption {
     if (rawCommand.isEmpty) {
       usageException('Invalid command. Run `aft exec -- <command>`');
     }
-    await linkPackages(allPackages);
+    await linkPackages();
 
     // Process command to handle some quirks of bash and how Dart initially
     // captures these scripts.
@@ -40,7 +40,7 @@ class ExecCommand extends AmplifyCommand with GlobOptions, FailFastOption {
       return arg;
     }).toList();
 
-    for (final package in allPackages.values) {
+    for (final package in commandPackages.values) {
       logger.info(
         'Running "${command.join(' ')}" in "${package.path}"...',
       );

--- a/packages/aft/lib/src/commands/exec_command.dart
+++ b/packages/aft/lib/src/commands/exec_command.dart
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:io';
+
+import 'package:aft/aft.dart';
+import 'package:aft/src/options/fail_fast_option.dart';
+import 'package:aft/src/options/glob_options.dart';
+
+/// Command to execute a given script in all packages.
+class ExecCommand extends AmplifyCommand with GlobOptions, FailFastOption {
+  @override
+  String get description => 'Executes a command in all packages';
+
+  @override
+  String get name => 'exec';
+
+  @override
+  Future<void> run() async {
+    await super.run();
+    final rawCommand = argResults!.rest;
+    if (rawCommand.isEmpty) {
+      usageException('Invalid command. Run `aft exec -- <command>`');
+    }
+    await linkPackages(allPackages);
+    for (final package in allPackages.values) {
+      // Process command to handle some quirks of bash and how Dart initially
+      // captures these scripts.
+      final command = rawCommand
+          .map((arg) => arg.trim())
+          .where((arg) => arg.isNotEmpty)
+          .map((arg) {
+        // Inject environment variables for inline scripts.
+        //
+        // We use bracket notation (e.g. <VARIABLE>) to prevent bash expansion
+        // and prevent having to deal with proper quotation and escaping.
+        environment.forEach((key, value) {
+          arg = arg.replaceAll('<$key>', value);
+        });
+        return arg;
+      }).toList();
+
+      logger.info(
+        'Running `${command.join(' ')}` in "${package.path}"...',
+      );
+      final result = await execCommand(command, package);
+      if (result.exitCode != 0) {
+        if (failFast) {
+          exitError(
+            'Failed to execute command for package "${package.name}"',
+            result.exitCode,
+          );
+        } else {
+          exitCode = result.exitCode;
+        }
+      }
+    }
+  }
+}
+
+extension ExecCommandFn on AmplifyCommand {
+  /// Executes a [command] in the given [package] using
+  /// [ProcessStartMode.inheritStdio] and returns the result.
+  Future<ProcessResult> execCommand(
+    List<String> command,
+    PackageInfo package,
+  ) async {
+    final proc = await Process.start(
+      command.first,
+      command.length > 1 ? command.sublist(1) : const [],
+      mode: ProcessStartMode.inheritStdio,
+      includeParentEnvironment: true,
+      environment: environment,
+      workingDirectory: package.path,
+    );
+    return ProcessResult(proc.pid, await proc.exitCode, null, null);
+  }
+}

--- a/packages/aft/lib/src/commands/exec_command.dart
+++ b/packages/aft/lib/src/commands/exec_command.dart
@@ -23,25 +23,26 @@ class ExecCommand extends AmplifyCommand with GlobOptions, FailFastOption {
       usageException('Invalid command. Run `aft exec -- <command>`');
     }
     await linkPackages(allPackages);
-    for (final package in allPackages.values) {
-      // Process command to handle some quirks of bash and how Dart initially
-      // captures these scripts.
-      final command = rawCommand
-          .map((arg) => arg.trim())
-          .where((arg) => arg.isNotEmpty)
-          .map((arg) {
-        // Inject environment variables for inline scripts.
-        //
-        // We use bracket notation (e.g. <VARIABLE>) to prevent bash expansion
-        // and prevent having to deal with proper quotation and escaping.
-        environment.forEach((key, value) {
-          arg = arg.replaceAll('<$key>', value);
-        });
-        return arg;
-      }).toList();
 
+    // Process command to handle some quirks of bash and how Dart initially
+    // captures these scripts.
+    final command = rawCommand
+        .map((arg) => arg.trim())
+        .where((arg) => arg.isNotEmpty)
+        .map((arg) {
+      // Inject environment variables for inline scripts.
+      //
+      // We use bracket notation (e.g. <VARIABLE>) to prevent bash expansion
+      // and prevent having to deal with proper quotation and escaping.
+      environment.forEach((key, value) {
+        arg = arg.replaceAll('<$key>', value);
+      });
+      return arg;
+    }).toList();
+
+    for (final package in allPackages.values) {
       logger.info(
-        'Running `${command.join(' ')}` in "${package.path}"...',
+        'Running "${command.join(' ')}" in "${package.path}"...',
       );
       final result = await execCommand(command, package);
       if (result.exitCode != 0) {

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -19,7 +19,7 @@ class GenerateWorkflowsCommand extends AmplifyCommand {
   @override
   Future<void> run() async {
     await super.run();
-    for (final package in allPackages.values) {
+    for (final package in commandPackages.values) {
       if (package.pubspecInfo.pubspec.publishTo == 'none' &&
           !falsePositiveExamples.contains(package.name)) {
         continue;

--- a/packages/aft/lib/src/commands/link_command.dart
+++ b/packages/aft/lib/src/commands/link_command.dart
@@ -22,7 +22,7 @@ class LinkCommand extends AmplifyCommand {
   @override
   Future<void> run() async {
     await super.run();
-    await linkPackages(allPackages);
+    await linkPackages();
     stdout.writeln('Packages successfully linked!');
   }
 }
@@ -111,19 +111,21 @@ dependency_overrides:
       .writeAsString(yaml.toString());
 }
 
-/// Links [packages] together using `pubspec_overrides.yaml`.
-Future<void> linkPackages(Map<String, PackageInfo> packages) async {
-  final futureGroup = FutureGroup<void>();
-  for (final package in packages.values) {
-    final dependencyPaths = _collectDependencies(package, packages);
-    futureGroup.add(
-      _createPubspecOverride(
-        package,
-        dependencyPaths,
-        package.pubspecInfo.pubspec.dependencyOverrides,
-      ),
-    );
+extension LinkPackages on AmplifyCommand {
+  /// Links [commandPackages] together using `pubspec_overrides.yaml`.
+  Future<void> linkPackages() async {
+    final futureGroup = FutureGroup<void>();
+    for (final package in repoPackages.values) {
+      final dependencyPaths = _collectDependencies(package, repoPackages);
+      futureGroup.add(
+        _createPubspecOverride(
+          package,
+          dependencyPaths,
+          package.pubspecInfo.pubspec.dependencyOverrides,
+        ),
+      );
+    }
+    futureGroup.close();
+    await futureGroup.future;
   }
-  futureGroup.close();
-  await futureGroup.future;
 }

--- a/packages/aft/lib/src/commands/list_packages_command.dart
+++ b/packages/aft/lib/src/commands/list_packages_command.dart
@@ -14,7 +14,7 @@ class ListPackagesCommand extends AmplifyCommand {
   @override
   Future<void> run() async {
     await super.run();
-    for (final package in allPackages.keys) {
+    for (final package in commandPackages.keys) {
       logger.info(package);
     }
   }

--- a/packages/aft/lib/src/commands/passthrough_command.dart
+++ b/packages/aft/lib/src/commands/passthrough_command.dart
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:io';
+
+import 'package:aft/aft.dart';
+
+/// Command to passthrough `dart`/`flutter` commands to the appropriate
+/// runner dependending on the package.
+class PassthroughCommand extends AmplifyCommand {
+  PassthroughCommand(this.arguments);
+
+  final List<String> arguments;
+
+  @override
+  String get description => '';
+
+  @override
+  String get name => '';
+
+  @override
+  Future<void> run() async {
+    await super.run();
+    final currentPackage = PackageInfo.fromDirectory(Directory.current);
+    if (currentPackage == null) {
+      exitError('Command must be run from a package directory');
+    }
+    final command = arguments.first;
+    if (command == 'pub') {
+      return pubAction(
+        arguments: arguments.sublist(1),
+        package: currentPackage,
+      );
+    }
+    final entrypoint = currentPackage.flavor.entrypoint;
+    logger.info(
+      'Running "$entrypoint ${arguments.join(' ')}" in package: '
+      '${currentPackage.path}',
+    );
+    final proc = await Process.start(
+      entrypoint,
+      arguments,
+      workingDirectory: currentPackage.path,
+      mode: ProcessStartMode.inheritStdio,
+    );
+    exitCode = await proc.exitCode;
+  }
+}

--- a/packages/aft/lib/src/commands/passthrough_command.dart
+++ b/packages/aft/lib/src/commands/passthrough_command.dart
@@ -16,7 +16,7 @@ class PassthroughCommand extends AmplifyCommand {
   String get description => '';
 
   @override
-  String get name => '';
+  String get name => arguments.first;
 
   @override
   Future<void> run() async {

--- a/packages/aft/lib/src/commands/publish_command.dart
+++ b/packages/aft/lib/src/commands/publish_command.dart
@@ -5,12 +5,13 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:aft/aft.dart';
+import 'package:aft/src/options/glob_options.dart';
 import 'package:aws_common/aws_common.dart';
 import 'package:graphs/graphs.dart';
 import 'package:path/path.dart' as p;
 
 /// Command to publish all Dart/Flutter packages in the repo.
-class PublishCommand extends AmplifyCommand {
+class PublishCommand extends AmplifyCommand with GlobOptions {
   PublishCommand() {
     argParser
       ..addFlag(
@@ -170,7 +171,8 @@ class PublishCommand extends AmplifyCommand {
   Future<void> run() async {
     await super.run();
     // Gather packages which can be published.
-    final publishablePackages = repo.publishablePackages
+    final publishablePackages = repo
+        .publishablePackages(commandPackages)
         .where((pkg) => pkg.pubspecInfo.pubspec.publishTo != 'none');
 
     // Gather packages which need to be published.

--- a/packages/aft/lib/src/commands/version_bump_command.dart
+++ b/packages/aft/lib/src/commands/version_bump_command.dart
@@ -1,16 +1,5 @@
-// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 import 'dart:io';

--- a/packages/aft/lib/src/commands/version_bump_command.dart
+++ b/packages/aft/lib/src/commands/version_bump_command.dart
@@ -61,7 +61,7 @@ class VersionBumpCommand extends AmplifyCommand
     final changelogUpdates = repo.changelogUpdates;
 
     final bumpedPackages = <PackageInfo>[];
-    for (final package in repo.allPackages.values) {
+    for (final package in commandPackages.values) {
       final edits = package.pubspecInfo.pubspecYamlEditor.edits;
       if (edits.isNotEmpty) {
         bumpedPackages.add(package);
@@ -98,7 +98,7 @@ class VersionBumpCommand extends AmplifyCommand
     await super.run();
 
     // Link packages so that we can run build_runner
-    await linkPackages(repo.allPackages);
+    await linkPackages();
 
     final bumpedPackages = await _updateVersions();
 

--- a/packages/aft/lib/src/options/fail_fast_option.dart
+++ b/packages/aft/lib/src/options/fail_fast_option.dart
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:aft/aft.dart';
+
+/// Adds a `--fail-fast` flag to a command to control execution of long-running
+/// or interdependent operations in multiple packages.
+mixin FailFastOption on AmplifyCommand {
+  @override
+  void init() {
+    super.init();
+    argParser.addFlag(
+      'fail-fast',
+      help: 'When running commands for multiple packages, '
+          'the first command triggers an exit.',
+      defaultsTo: false,
+    );
+  }
+
+  /// Whether to fail fast when running commands in multiple packages.
+  late final failFast = argResults!['fail-fast'] as bool;
+}

--- a/packages/aft/lib/src/options/git_ref_options.dart
+++ b/packages/aft/lib/src/options/git_ref_options.dart
@@ -1,16 +1,5 @@
-// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:io';
 

--- a/packages/aft/lib/src/options/glob_options.dart
+++ b/packages/aft/lib/src/options/glob_options.dart
@@ -1,16 +1,5 @@
-// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:aft/aft.dart';
 

--- a/packages/aft/lib/src/options/glob_options.dart
+++ b/packages/aft/lib/src/options/glob_options.dart
@@ -27,9 +27,9 @@ mixin GlobOptions on AmplifyCommand {
   late final exclude = argResults?['exclude'] as List<String>? ?? const [];
 
   @override
-  Map<String, PackageInfo> get allPackages {
+  Map<String, PackageInfo> get commandPackages {
     return Map.fromEntries(
-      super.allPackages.entries.where((entry) {
+      super.commandPackages.entries.where((entry) {
         final package = entry.value;
         if (include.isNotEmpty) {
           var explicitlyIncluded = false;

--- a/packages/aft/lib/src/pub/pub_runner.dart
+++ b/packages/aft/lib/src/pub/pub_runner.dart
@@ -1,17 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'dart:io';
+
 import 'package:aft/aft.dart';
 import 'package:args/command_runner.dart';
-import 'package:aws_common/aws_common.dart';
-import 'package:cli_util/cli_util.dart';
-import 'package:flutter_tools/src/base/template.dart';
-import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/commands/packages.dart';
-import 'package:flutter_tools/src/context_runner.dart' as flutter;
-import 'package:flutter_tools/src/isolated/mustache_template.dart';
-import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
-import 'package:path/path.dart' as path;
 
 /// Command runner for Dart `pub` commands.
 class PubCommandRunner extends CommandRunner<int> {
@@ -25,34 +18,38 @@ class PubCommandRunner extends CommandRunner<int> {
   }
 }
 
-/// Runs `pub` for a Dart-only package.
-///
-/// We use an embedded `pub` runner to speed things up.
-Future<void> runDartPub(
-  PubAction action,
-  String name,
-  String directory, {
-  required bool verbose,
-  required PubCommandRunner pubRunner,
-}) async {
-  int code;
-  String? errorMessage;
-  try {
-    code = await pubRunner.run([
+extension DartPubAction on PubCommandRunner {
+  /// Runs `pub` for a Dart-only package.
+  ///
+  /// We use an embedded `pub` runner to speed things up.
+  Future<void> runDartPub(
+    List<String> arguments,
+    PackageInfo package,
+  ) async {
+    int code;
+    String? errorMessage;
+    final command = [
       'pub',
-      action.name,
+      ...arguments,
       '--directory',
-      directory,
-    ]);
-  } on Object catch (e) {
-    code = 1;
-    errorMessage = e.toString();
-  }
-  if (code != 0) {
-    throw Exception(
-      errorMessage ??
-          'An error occurred running `pub ${action.name}` for `$name`',
-    );
+      package.path,
+    ];
+    try {
+      code = await run(command);
+    } on Object catch (e) {
+      code = 1;
+      errorMessage = e.toString();
+    }
+    if (code != 0) {
+      throw ProcessException(
+        'dart',
+        arguments,
+        errorMessage ??
+            'An error occurred running `pub ${command.join(' ')}` '
+                'for `${package.name}`',
+        code,
+      );
+    }
   }
 }
 
@@ -61,45 +58,18 @@ Future<void> runDartPub(
 /// We embed the `flutter pub` logic from `flutter_tools` to improve the speed
 /// over spawning a new process.
 Future<void> runFlutterPub(
-  PubAction action,
-  PackageInfo package, {
-  AWSLogger? logger,
-}) async {
-  logger ??= AWSLogger().createChild('runFlutterPub');
-  final flutterRoot = getEnv('FLUTTER_ROOT');
-  Cache.flutterRoot = flutterRoot ??
-      // Assumes using Dart SDK from Flutter
-      path.normalize(
-        path.absolute(path.dirname(path.dirname(path.dirname(getSdkPath())))),
-      );
-  logger.verbose('Resolved flutter root: ${Cache.flutterRoot}');
-  await flutter.runInContext(
-    () async {
-      final runner = FlutterCommandRunner()
-        ..addCommand(
-          PackagesGetCommand(action.name, action == PubAction.upgrade),
-        )
-        ..addCommand(
-          PackagesForwardCommand(
-            'publish',
-            'Publish the current package to pub.dartlang.org.',
-            requiresPubspec: true,
-          ),
-        );
-      await runner.run([action.name, package.path]);
-    },
-    overrides: {
-      // Do not try to run `flutter pub` using normal pub since `PUB_CACHE`
-      // will be wrong and can only be set via an environment variable and
-      // thus an external process.
-      //
-      // Pub: () => _FlutterPub(
-      //       package: package,
-      //       verbose: verbose,
-      //       pubRunner: pubRunner,
-      //     ),
-      // Needed by `flutter_tools` but not automatically provided
-      TemplateRenderer: () => const MustacheTemplateRenderer(),
-    },
+  List<String> arguments,
+  PackageInfo package,
+) async {
+  final proc = await Process.start(
+    'flutter',
+    ['pub', ...arguments],
+    runInShell: true,
+    mode: ProcessStartMode.inheritStdio,
+    workingDirectory: package.path,
   );
+  final exitCode = await proc.exitCode;
+  if (exitCode != 0) {
+    throw ProcessException('flutter', ['pub', ...arguments], '', exitCode);
+  }
 }

--- a/packages/aft/lib/src/pub/pub_runner.dart
+++ b/packages/aft/lib/src/pub/pub_runner.dart
@@ -30,9 +30,9 @@ extension DartPubAction on PubCommandRunner {
     String? errorMessage;
     final command = [
       'pub',
-      ...arguments,
       '--directory',
       package.path,
+      ...arguments,
     ];
     try {
       code = await run(command);

--- a/packages/aft/lib/src/repo.dart
+++ b/packages/aft/lib/src/repo.dart
@@ -33,9 +33,15 @@ class Repo {
   final AftConfig aftConfig;
 
   /// All packages which can be published to `pub.dev`.
-  late final List<PackageInfo> publishablePackages = UnmodifiableListView(
-    allPackages.values.where((pkg) => pkg.isPublishable).toList(),
-  );
+  List<PackageInfo> publishablePackages([
+    Map<String, PackageInfo>? allPackages,
+  ]) =>
+      UnmodifiableListView(
+        (allPackages ?? this.allPackages)
+            .values
+            .where((pkg) => pkg.isPublishable)
+            .toList(),
+      );
 
   /// The components of the repository.
   late final Map<String, AftRepoComponent> components = () {
@@ -233,7 +239,7 @@ class Repo {
   void bumpAllVersions({
     required GitChanges Function(PackageInfo) changesForPackage,
   }) {
-    final sortedPackages = List.of(publishablePackages);
+    final sortedPackages = List.of(publishablePackages());
     sortPackagesTopologically(
       sortedPackages,
       (PackageInfo pkg) => pkg.pubspecInfo.pubspec,

--- a/packages/aft/lib/src/repo.dart
+++ b/packages/aft/lib/src/repo.dart
@@ -1,16 +1,5 @@
-// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:io';
 

--- a/packages/aft/lib/src/util.dart
+++ b/packages/aft/lib/src/util.dart
@@ -13,9 +13,9 @@ String? getEnv(String envName) {
   return value == null || value.isEmpty ? null : value;
 }
 
-Never exitError(Object error) {
+Never exitError(Object error, [int exitCode = 1]) {
   stderr.writeln(error);
-  exit(1);
+  exit(exitCode);
 }
 
 typedef ProcessSink = void Function(String);

--- a/packages/aft/pubspec.yaml
+++ b/packages/aft/pubspec.yaml
@@ -16,11 +16,6 @@ dependencies:
   checked_yaml: ^2.0.0
   cli_util: ^0.3.5
   collection: ^1.16.0
-  flutter_tools:
-    git:
-      url: https://github.com/flutter/flutter.git
-      ref: 7a743c8816fd8ff7df99858c545c1dbe396d1103
-      path: packages/flutter_tools
   git: ^2.0.0
   glob: ^2.1.0
   graphs: ^2.1.0
@@ -50,8 +45,6 @@ dependency_overrides:
     path: ../aws_common
   aws_signature_v4:
     path: ../aws_signature_v4
-  built_value: ">=8.4.0 <8.5.0"
-  frontend_server_client: ^3.2.0
   smithy:
     path: ../smithy/smithy
   smithy_aws:


### PR DESCRIPTION
Adds an `aft exec` command to run scripts in all packages or a subset of packages in the repo.

As part of this, some refactoring work is included which passes through any command not implemented by `aft` to `dart`/`flutter`. For example, `aft analyze` will run `dart analyze` or `flutter analyze` depending on the package.

Also removes dependency on `flutter_tools` package which should make working with `aft` easier.

Example usage:
- `aft exec ls` -- runs `ls` in all packages and logs the outputs
- `aft exec --include="Smithy" -- aft pub upgrade` -- runs `dart pub upgrade` in all Smithy component packages
- `aft exec --include="*example*,sample_app" -- cp -n <AFT_ROOT>/.circleci/dummy_amplifyconfiguration.dart lib/amplifyconfiguration.dart` -- copies default configuration to all example packages