### PR TITLE
feat(storage): allow configuring transfer acceleration 

### DIFF
--- a/infra/lib/storage/stack.ts
+++ b/infra/lib/storage/stack.ts
@@ -53,7 +53,7 @@ interface StorageIntegrationTestEnvironmentProps
 
 export class StorageIntegrationTestStack extends IntegrationTestStack<
   StorageIntegrationTestEnvironmentProps,
-  StorageIntgrationTestEnvironment
+  StorageIntegrationTestEnvironment
 > {
   constructor(
     scope: Construct,
@@ -70,15 +70,15 @@ export class StorageIntegrationTestStack extends IntegrationTestStack<
 
   protected buildEnvironments(
     environments: StorageIntegrationTestEnvironmentProps[]
-  ): StorageIntgrationTestEnvironment[] {
+  ): StorageIntegrationTestEnvironment[] {
     return environments.map(
       (environment) =>
-        new StorageIntgrationTestEnvironment(this, this.baseName, environment)
+        new StorageIntegrationTestEnvironment(this, this.baseName, environment)
     );
   }
 }
 
-class StorageIntgrationTestEnvironment extends IntegrationTestStackEnvironment<StorageIntegrationTestEnvironmentProps> {
+class StorageIntegrationTestEnvironment extends IntegrationTestStackEnvironment<StorageIntegrationTestEnvironmentProps> {
   constructor(
     scope: Construct,
     baseName: string,
@@ -89,6 +89,7 @@ class StorageIntgrationTestEnvironment extends IntegrationTestStackEnvironment<S
     // Create the bucket
 
     const bucket = new s3.Bucket(this, "Bucket", {
+      transferAcceleration: true,
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
       enforceSSL: true,

--- a/packages/aws_common/lib/src/io/aws_file_platform_html.dart
+++ b/packages/aws_common/lib/src/io/aws_file_platform_html.dart
@@ -125,18 +125,24 @@ class AWSFilePlatform extends AWSFile {
           return externalContentType;
         }
 
-        String blobType;
+        String? blobType;
 
         final file = _inputFile ?? _inputBlob;
+        final path = super.path;
+
         if (file != null) {
           blobType = file.type;
-        } else {
+        } else if (path != null) {
           blobType = (await _resolvedBlob).type;
         }
 
         // on Web blob.type may return an empty string
         // https://developer.mozilla.org/en-US/docs/Web/API/Blob/type#value
-        return blobType.isEmpty ? null : blobType;
+        if (blobType != null) {
+          return blobType.isEmpty ? null : blobType;
+        }
+
+        return blobType;
       });
 
   Future<Blob> get _resolvedBlob async {

--- a/packages/aws_common/test/io/aws_file_html_test.dart
+++ b/packages/aws_common/test/io/aws_file_html_test.dart
@@ -93,6 +93,42 @@ void main() {
 
         expect(await awsFile.contentType, testExternalContentType);
       });
+
+      test('should resolve contentType from underlying html File', () async {
+        final awsFile = AWSFilePlatform.fromFile(
+          testFile,
+        );
+
+        expect(await awsFile.contentType, testFile.type);
+      });
+
+      test('should resolve contentType from underlying html Blob', () async {
+        final awsFile = AWSFilePlatform.fromBlob(
+          testBlob,
+        );
+
+        expect(await awsFile.contentType, testBlob.type);
+      });
+
+      test(
+          'should resolve contentType from the blob that is resolved from the path',
+          () async {
+        final awsFile = AWSFilePlatform.fromPath(
+          testFilePath,
+        );
+
+        expect(await awsFile.contentType, testFile.type);
+      });
+
+      test('should return null as contentType if contentType is unresolvable',
+          () async {
+        final awsFile = AWSFile.fromStream(
+          Stream.value(testBytes),
+          size: testBytes.length,
+        );
+
+        expect(await awsFile.contentType, isNull);
+      });
     });
   });
 }

--- a/packages/aws_common/test/io/aws_file_io_test.dart
+++ b/packages/aws_common/test/io/aws_file_io_test.dart
@@ -82,6 +82,24 @@ void main() {
 
         expect(await awsFile.contentType, testExternalContentType);
       });
+
+      test('should resolve contentType from the underlying file', () async {
+        final awsFile = AWSFilePlatform.fromFile(
+          testFile,
+        );
+
+        expect(await awsFile.contentType, testContentType);
+      });
+
+      test('should return null as contentType if contentType is unresolvable',
+          () async {
+        final awsFile = AWSFile.fromStream(
+          Stream.value(testBytes),
+          size: testBytes.length,
+        );
+
+        expect(await awsFile.contentType, isNull);
+      });
     });
   });
 }

--- a/packages/smithy/smithy_aws/lib/src/s3/s3_client_config.dart
+++ b/packages/smithy/smithy_aws/lib/src/s3/s3_client_config.dart
@@ -35,4 +35,19 @@ class S3ClientConfig {
   ///
   /// Defaults to [S3ServiceConfiguration.new].
   final S3ServiceConfiguration? signerConfiguration;
+
+  /// Returns a new [S3ClientConfig] with overrides.
+  S3ClientConfig copyWith({
+    bool? usePathStyle,
+    bool? useDualStack,
+    bool? useAcceleration,
+    S3ServiceConfiguration? signerConfiguration,
+  }) {
+    return S3ClientConfig(
+      usePathStyle: usePathStyle ?? this.useAcceleration,
+      useDualStack: useDualStack ?? this.useDualStack,
+      useAcceleration: useAcceleration ?? this.useAcceleration,
+      signerConfiguration: signerConfiguration ?? this.signerConfiguration,
+    );
+  }
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
@@ -328,7 +328,7 @@ void main() async {
               getProperties: true,
               bytesRange: S3DataBytesRange(
                 start: start,
-                end: 5 * 1024 + 12,
+                end: end,
               ),
             ),
           ).result;

--- a/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
@@ -17,6 +17,8 @@ import 'package:integration_test/integration_test.dart';
 import 'package:path/path.dart' as path;
 
 import 'content_type_infer/content_type_infer.dart';
+import 'transfer_acceleration/test_acceleration_config.dart';
+import 'transfer_acceleration/transfer_acceleration.dart';
 
 class CustomPrefixResolver implements S3PrefixResolver {
   const CustomPrefixResolver();
@@ -438,6 +440,27 @@ void main() async {
         testContentTypeInferTest(
           smallFileBytes: testBytes,
           largeFileBytes: testLargeFileBytes,
+        );
+
+        testTransferAcceleration(
+          dataPayloads: [
+            TestTransferAccelerationConfig(
+              targetKey: 'transfer-acceleration-datapayload-${uuid()}',
+              targetAccessLevel: StorageAccessLevel.guest,
+              uploadSource: S3DataPayload.bytes(
+                testBytes,
+              ),
+              referenceBytes: testBytes,
+            ),
+          ],
+          awsFiles: [
+            TestTransferAccelerationConfig(
+              targetKey: 'transfer-acceleration-awsfile-${uuid()}',
+              targetAccessLevel: StorageAccessLevel.private,
+              uploadSource: AWSFile.fromData(testLargeFileBytes),
+              referenceBytes: testLargeFileBytes,
+            )
+          ],
         );
       });
 

--- a/packages/storage/amplify_storage_s3/example/integration_test/transfer_acceleration/test_acceleration_config.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/transfer_acceleration/test_acceleration_config.dart
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+class TestTransferAccelerationConfig<T> {
+  const TestTransferAccelerationConfig({
+    required this.targetKey,
+    required this.targetAccessLevel,
+    required this.uploadSource,
+    required this.referenceBytes,
+  });
+
+  final String targetKey;
+  final StorageAccessLevel targetAccessLevel;
+  final T uploadSource;
+  final List<int> referenceBytes;
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/transfer_acceleration/transfer_acceleration.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/transfer_acceleration/transfer_acceleration.dart
@@ -1,0 +1,152 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import 'test_acceleration_config.dart';
+
+void testTransferAcceleration({
+  required List<TestTransferAccelerationConfig<S3DataPayload>> dataPayloads,
+  required List<TestTransferAccelerationConfig<AWSFile>> awsFiles,
+}) {
+  group('Operation on S3DataPayload with transfer acceleration', () {
+    tearDownAll(() async {
+      for (final dataPayload in dataPayloads) {
+        await Amplify.Storage.remove(
+          key: dataPayload.targetKey,
+          options: S3RemoveOptions(accessLevel: dataPayload.targetAccessLevel),
+        ).result;
+      }
+    });
+
+    group('upload', () {
+      for (final entry in dataPayloads.asMap().entries) {
+        test('S3DataPayload ${entry.key}', () async {
+          final dataPayload = entry.value;
+          final operation = Amplify.Storage.uploadData(
+            data: dataPayload.uploadSource,
+            key: dataPayload.targetKey,
+            options: S3UploadDataOptions(
+              accessLevel: dataPayload.targetAccessLevel,
+              useAccelerateEndpoint: true,
+            ),
+          );
+
+          await expectLater(operation.result, completes);
+        });
+      }
+    });
+
+    group(
+      'download',
+      () {
+        group('via getUrl generated downloadable url', () {
+          for (final entry in dataPayloads.asMap().entries) {
+            test('S3DataPayload ${entry.key}', () async {
+              final dataPayload = entry.value;
+              final result = await Amplify.Storage.getUrl(
+                key: dataPayload.targetKey,
+                options: S3GetUrlOptions(
+                  accessLevel: dataPayload.targetAccessLevel,
+                  expiresIn: const Duration(minutes: 5),
+                  useAccelerateEndpoint: true,
+                ),
+              ).result;
+              final downloadedBytes = await http.readBytes(result.url);
+              expect(downloadedBytes, equals(dataPayload.referenceBytes));
+            });
+          }
+        });
+
+        group('via storage downloadData API', () {
+          for (final entry in dataPayloads.asMap().entries) {
+            test('S3DataPayload ${entry.key}', () async {
+              final dataPayload = entry.value;
+              final result = await Amplify.Storage.downloadData(
+                key: dataPayload.targetKey,
+                options: S3DownloadDataOptions(
+                  accessLevel: dataPayload.targetAccessLevel,
+                  useAccelerateEndpoint: true,
+                ),
+              ).result;
+
+              expect(result.bytes, equals(dataPayload.referenceBytes));
+            });
+          }
+        });
+      },
+    );
+  });
+
+  group('Operation on AWSFile with transfer acceleration', () {
+    tearDownAll(() async {
+      for (final awsFile in awsFiles) {
+        await Amplify.Storage.remove(
+          key: awsFile.targetKey,
+          options: S3RemoveOptions(accessLevel: awsFile.targetAccessLevel),
+        ).result;
+      }
+    });
+
+    group('upload', () {
+      for (final entry in awsFiles.asMap().entries) {
+        test('AWSFile ${entry.key}', () async {
+          final awsFile = entry.value;
+          final operation = Amplify.Storage.uploadFile(
+            localFile: awsFile.uploadSource,
+            key: awsFile.targetKey,
+            options: S3UploadFileOptions(
+              accessLevel: awsFile.targetAccessLevel,
+              useAccelerateEndpoint: true,
+            ),
+          );
+
+          await expectLater(operation.result, completes);
+        });
+      }
+    });
+
+    group(
+      'download',
+      () {
+        group('via getUrl generated downloadable url', () {
+          for (final entry in awsFiles.asMap().entries) {
+            test('AWSFile ${entry.key}', () async {
+              final awsFile = entry.value;
+              final result = await Amplify.Storage.getUrl(
+                key: awsFile.targetKey,
+                options: S3GetUrlOptions(
+                  accessLevel: awsFile.targetAccessLevel,
+                  expiresIn: const Duration(minutes: 5),
+                  useAccelerateEndpoint: true,
+                ),
+              ).result;
+              final downloadedBytes = await http.readBytes(result.url);
+              expect(downloadedBytes, equals(awsFile.referenceBytes));
+            });
+          }
+        });
+
+        group('via storage download data API', () {
+          for (final entry in awsFiles.asMap().entries) {
+            test('AWSFile ${entry.key}', () async {
+              final awsFile = entry.value;
+              final result = await Amplify.Storage.downloadData(
+                key: awsFile.targetKey,
+                options: S3DownloadDataOptions(
+                  accessLevel: awsFile.targetAccessLevel,
+                  useAccelerateEndpoint: true,
+                ),
+              ).result;
+
+              expect(result.bytes, equals(awsFile.referenceBytes));
+            });
+          }
+        });
+      },
+    );
+  });
+}

--- a/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
+++ b/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
@@ -183,6 +183,7 @@ Future<void> getUrlOperation() async {
   final accessLevel = promptStorageAccessLevel(
     'Choose the storage access level associated with the object: ',
   );
+  final useAccelerateEndpoint = promptUseAcceleration();
 
   final s3Plugin = Amplify.Storage.getPlugin(AmplifyStorageS3Dart.pluginKey);
   final getUrlOperation = s3Plugin.getUrl(
@@ -193,6 +194,7 @@ Future<void> getUrlOperation() async {
         minutes: 10,
       ),
       checkObjectExistence: true,
+      useAccelerateEndpoint: useAccelerateEndpoint,
     ),
   );
 
@@ -253,6 +255,8 @@ Future<void> downloadFileOperation() async {
   final destinationPath = prompt(
     'Enter the destination file path (ensure the file path is writable): ',
   );
+  final useAccelerateEndpoint = promptUseAcceleration();
+
   final localFile = AWSFile.fromPath(destinationPath);
 
   final s3Plugin = Amplify.Storage.getPlugin(AmplifyStorageS3Dart.pluginKey);
@@ -262,6 +266,7 @@ Future<void> downloadFileOperation() async {
     options: S3DownloadFileOptions(
       getProperties: true,
       accessLevel: accessLevel,
+      useAccelerateEndpoint: useAccelerateEndpoint,
     ),
     onProgress: onTransferProgress,
   );
@@ -330,6 +335,7 @@ Future<void> uploadFileOperation() async {
   final file = AWSFile.fromPath(filePath);
 
   final option = prompt('Upload size ${await file.size}, continue? (Y/n): ');
+  final useAccelerateEndpoint = promptUseAcceleration();
 
   if (option.toLowerCase() != 'y') {
     stdout.writeln('Upload canceled.');
@@ -347,6 +353,7 @@ Future<void> uploadFileOperation() async {
       metadata: {
         'nameTag': nameTag,
       },
+      useAccelerateEndpoint: useAccelerateEndpoint,
     ),
   );
 
@@ -506,6 +513,17 @@ StorageAccessLevel promptStorageAccessLevel(String message) {
   }
 
   return accessLevel;
+}
+
+bool promptUseAcceleration() {
+  String input;
+
+  do {
+    input = prompt('Use transfer acceleration for this operation? (y/n): ')
+        .toLowerCase();
+  } while (input != 'y' && input != 'n');
+
+  return input == 'y';
 }
 
 Never exitError(Object error, [StackTrace? stackTrace]) {

--- a/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
@@ -7,8 +7,10 @@ import 'package:smithy/smithy.dart';
 
 const _fileIssueMessage =
     'This exception is not expected. Please try again. If the exception persists, please file an issue at https://github.com/aws-amplify/amplify-flutter/issues';
-const _clientErrorRecoveryMessage =
+const _keyNotFoundRecoveryMessage =
     'Please ensure that correct object key is provided, and/or correct `StorageAccessLevel` and `targetIdentityId` are included in the options.';
+const _httpErrorRecoveryMessage =
+    'HTTP error returned from service, please review the `underlyingException` for details.';
 
 /// {@template amplify_storage_s3_dart.s3_storage_exception}
 /// Represents exceptions that may be thrown calling Storage S3 plugin APIs.
@@ -156,7 +158,7 @@ class S3Exception extends StorageException {
   ) =>
       StorageKeyNotFoundException(
         'Key is not found.',
-        recoverySuggestion: _clientErrorRecoveryMessage,
+        recoverySuggestion: _keyNotFoundRecoveryMessage,
         underlyingException: underlyingException,
       );
 
@@ -169,7 +171,7 @@ class S3Exception extends StorageException {
     if (statusCode ~/ 100 == 3 || statusCode ~/ 100 == 5) {
       return StorageHttpStatusException(
         statusCode,
-        recoverySuggestion: _clientErrorRecoveryMessage,
+        recoverySuggestion: _httpErrorRecoveryMessage,
         underlyingException: exception,
       );
     }
@@ -178,7 +180,7 @@ class S3Exception extends StorageException {
       if ([401, 403].contains(statusCode)) {
         return StorageAccessDeniedException(
           'S3 access denied when making the API call.',
-          recoverySuggestion: _clientErrorRecoveryMessage,
+          recoverySuggestion: _httpErrorRecoveryMessage,
           underlyingException: exception,
         );
       } else if (statusCode == 404) {
@@ -186,7 +188,7 @@ class S3Exception extends StorageException {
       } else {
         return StorageHttpStatusException(
           statusCode,
-          recoverySuggestion: _clientErrorRecoveryMessage,
+          recoverySuggestion: _httpErrorRecoveryMessage,
           underlyingException: exception,
         );
       }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_data_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_data_options.dart
@@ -13,10 +13,12 @@ class S3DownloadDataOptions extends StorageDownloadDataOptions {
     StorageAccessLevel accessLevel = StorageAccessLevel.guest,
     bool getProperties = false,
     S3DataBytesRange? bytesRange,
+    bool useAccelerateEndpoint = false,
   }) : this._(
           accessLevel: accessLevel,
           bytesRange: bytesRange,
           getProperties: getProperties,
+          useAccelerateEndpoint: useAccelerateEndpoint,
         );
 
   const S3DownloadDataOptions._({
@@ -24,6 +26,7 @@ class S3DownloadDataOptions extends StorageDownloadDataOptions {
     this.getProperties = false,
     this.bytesRange,
     this.targetIdentityId,
+    this.useAccelerateEndpoint = false,
   });
 
   /// {@macro storage.amplify_storage_s3.download_data_options}
@@ -35,11 +38,13 @@ class S3DownloadDataOptions extends StorageDownloadDataOptions {
     String targetIdentityId, {
     bool getProperties = false,
     S3DataBytesRange? bytesRange,
+    bool useAccelerateEndpoint = false,
   }) : this._(
           accessLevel: StorageAccessLevel.protected,
           targetIdentityId: targetIdentityId,
           getProperties: getProperties,
           bytesRange: bytesRange,
+          useAccelerateEndpoint: useAccelerateEndpoint,
         );
 
   /// The byte range to download from the object.
@@ -53,4 +58,10 @@ class S3DownloadDataOptions extends StorageDownloadDataOptions {
   /// Whether to retrieve properties for the downloaded object using the
   /// `getProperties` API.
   final bool getProperties;
+
+  /// {@template storage.amplify_storage_s3.transfer_acceleration}
+  /// Whether to use [S3 Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html)
+  /// enabled endpoint for the operation.
+  /// {@endtemplate}
+  final bool useAccelerateEndpoint;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_file_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_file_options.dart
@@ -11,15 +11,18 @@ class S3DownloadFileOptions extends StorageDownloadFileOptions {
   const S3DownloadFileOptions({
     StorageAccessLevel accessLevel = StorageAccessLevel.guest,
     bool getProperties = false,
+    bool useAccelerateEndpoint = false,
   }) : this._(
           accessLevel: accessLevel,
           getProperties: getProperties,
+          useAccelerateEndpoint: useAccelerateEndpoint,
         );
 
   const S3DownloadFileOptions._({
     super.accessLevel = StorageAccessLevel.guest,
     this.getProperties = false,
     this.targetIdentityId,
+    this.useAccelerateEndpoint = false,
   });
 
   /// {@macro storage.amplify_storage_s3.download_data_options}
@@ -30,10 +33,12 @@ class S3DownloadFileOptions extends StorageDownloadFileOptions {
   const S3DownloadFileOptions.forIdentity(
     String targetIdentityId, {
     bool getProperties = false,
+    bool useAccelerateEndpoint = false,
   }) : this._(
           accessLevel: StorageAccessLevel.protected,
           targetIdentityId: targetIdentityId,
           getProperties: getProperties,
+          useAccelerateEndpoint: useAccelerateEndpoint,
         );
 
   /// The identity ID of the user who uploaded the object.
@@ -44,4 +49,7 @@ class S3DownloadFileOptions extends StorageDownloadFileOptions {
   /// Whether to retrieve properties for the downloaded object using the
   /// `getProperties` API.
   final bool getProperties;
+
+  /// {@macro storage.amplify_storage_s3.transfer_acceleration}
+  final bool useAccelerateEndpoint;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_options.dart
@@ -13,10 +13,12 @@ class S3GetUrlOptions extends StorageGetUrlOptions {
     StorageAccessLevel accessLevel = StorageAccessLevel.guest,
     Duration expiresIn = const Duration(minutes: 15),
     bool checkObjectExistence = false,
+    bool useAccelerateEndpoint = false,
   }) : this._(
           accessLevel: accessLevel,
           expiresIn: expiresIn,
           checkObjectExistence: checkObjectExistence,
+          useAccelerateEndpoint: useAccelerateEndpoint,
         );
 
   const S3GetUrlOptions._({
@@ -24,6 +26,7 @@ class S3GetUrlOptions extends StorageGetUrlOptions {
     this.expiresIn = const Duration(days: 1),
     this.checkObjectExistence = false,
     this.targetIdentityId,
+    this.useAccelerateEndpoint = false,
   });
 
   /// {@macro storage.amplify_storage_s3.get_url_options}
@@ -34,11 +37,13 @@ class S3GetUrlOptions extends StorageGetUrlOptions {
     String targetIdentityId, {
     Duration expiresIn = const Duration(days: 1),
     bool checkObjectExistence = false,
+    bool useAccelerateEndpoint = false,
   }) : this._(
           accessLevel: StorageAccessLevel.protected,
           expiresIn: expiresIn,
           checkObjectExistence: checkObjectExistence,
           targetIdentityId: targetIdentityId,
+          useAccelerateEndpoint: useAccelerateEndpoint,
         );
 
   /// Specifies the period of time that the generated url expires in.
@@ -52,4 +57,7 @@ class S3GetUrlOptions extends StorageGetUrlOptions {
   ///
   /// This can be set by using [S3GetUrlOptions.forIdentity].
   final String? targetIdentityId;
+
+  /// {@macro storage.amplify_storage_s3.transfer_acceleration}
+  final bool useAccelerateEndpoint;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_data_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_data_options.dart
@@ -13,6 +13,7 @@ class S3UploadDataOptions extends StorageUploadDataOptions {
     super.accessLevel = StorageAccessLevel.guest,
     this.getProperties = false,
     this.metadata,
+    this.useAccelerateEndpoint = false,
   });
 
   /// The metadata attached to the object to be uploaded.
@@ -21,4 +22,7 @@ class S3UploadDataOptions extends StorageUploadDataOptions {
   /// Whether to retrieve properties for the uploaded object using the
   /// `getProperties` API.
   final bool getProperties;
+
+  /// {@macro storage.amplify_storage_s3.transfer_acceleration}
+  final bool useAccelerateEndpoint;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_file_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_file_options.dart
@@ -13,6 +13,7 @@ class S3UploadFileOptions extends StorageUploadFileOptions {
     super.accessLevel = StorageAccessLevel.guest,
     this.getProperties = false,
     this.metadata,
+    this.useAccelerateEndpoint = false,
   });
 
   /// The metadata attached to the object to be uploaded.
@@ -21,4 +22,7 @@ class S3UploadFileOptions extends StorageUploadFileOptions {
   /// Whether to retrieve properties for the uploaded object using the
   /// `getProperties` API.
   final bool getProperties;
+
+  /// {@macro storage.amplify_storage_s3.transfer_acceleration}
+  final bool useAccelerateEndpoint;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_html.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_html.dart
@@ -51,10 +51,12 @@ Future<S3DownloadFileResult> _downloadFromUrl({
         ? S3GetUrlOptions(
             accessLevel: s3Options.accessLevel,
             checkObjectExistence: true,
+            useAccelerateEndpoint: s3Options.useAccelerateEndpoint,
           )
         : S3GetUrlOptions.forIdentity(
             targetIdentityId,
             checkObjectExistence: true,
+            useAccelerateEndpoint: s3Options.useAccelerateEndpoint,
           ),
   ))
       .url;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_io.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_io.dart
@@ -27,10 +27,12 @@ S3DownloadFileOperation downloadFile({
       ? S3DownloadDataOptions(
           accessLevel: s3Options.accessLevel,
           getProperties: s3Options.getProperties,
+          useAccelerateEndpoint: s3Options.useAccelerateEndpoint,
         )
       : S3DownloadDataOptions.forIdentity(
           targetIdentityId,
           getProperties: s3Options.getProperties,
+          useAccelerateEndpoint: s3Options.useAccelerateEndpoint,
         );
 
   late final String destinationPath;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
@@ -9,6 +9,7 @@ import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';
 import 'package:meta/meta.dart';
 import 'package:smithy/smithy.dart' as smithy;
+import 'package:smithy_aws/smithy_aws.dart' as smithy_aws;
 
 /// {@template amplify_storage_s3_dart.download_task}
 /// A task created to fulfill a download operation.
@@ -46,6 +47,7 @@ class S3DownloadTask {
   /// {@endtemplate}
   S3DownloadTask({
     required s3.S3Client s3Client,
+    required smithy_aws.S3ClientConfig defaultS3ClientConfig,
     required S3PrefixResolver prefixResolver,
     required String bucket,
     required String key,
@@ -58,6 +60,7 @@ class S3DownloadTask {
     required AWSLogger logger,
   })  : _downloadCompleter = Completer<S3Item>(),
         _s3Client = s3Client,
+        _defaultS3ClientConfig = defaultS3ClientConfig,
         _prefixResolver = prefixResolver,
         _bucket = bucket,
         _key = key,
@@ -74,6 +77,7 @@ class S3DownloadTask {
   final Completer<S3Item> _downloadCompleter;
 
   final s3.S3Client _s3Client;
+  final smithy_aws.S3ClientConfig _defaultS3ClientConfig;
   final S3PrefixResolver _prefixResolver;
   final String _bucket;
   final String _key;
@@ -102,7 +106,8 @@ class S3DownloadTask {
   // Total bytes that need to be downloaded, this field is set when the
   // **very first** (without bytes range specified) `S3Client.getObject`
   // response returns, value is from the response header.
-  late final int _totalBytes;
+  // Before the first response returns, the value remains -1 as "unknown".
+  int _totalBytes = -1;
 
   Future<void>? get _getObjectInitiated => _getObjectCompleter?.future;
   Future<void>? get _pausedCompleted => _pauseCompleter?.future;
@@ -325,7 +330,14 @@ class S3DownloadTask {
     });
 
     try {
-      return await _s3Client.getObject(request).result;
+      return await _s3Client
+          .getObject(
+            request,
+            s3ClientConfig: _defaultS3ClientConfig.copyWith(
+              useAcceleration: _downloadDataOptions.useAccelerateEndpoint,
+            ),
+          )
+          .result;
     } on smithy.UnknownSmithyHttpException catch (error) {
       // S3Client.getObject may return 403 error
       throw S3Exception.fromUnknownSmithyHttpException(error);

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -12,7 +12,8 @@ import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/transfer
     as transfer;
 import 'package:async/async.dart';
 import 'package:meta/meta.dart';
-import 'package:smithy/smithy.dart';
+import 'package:smithy/smithy.dart' as smithy;
+import 'package:smithy_aws/smithy_aws.dart' as smithy_aws;
 
 /// The fallback contentType.
 // https://www.iana.org/assignments/media-types/application/octet-stream
@@ -41,6 +42,7 @@ const fallbackContentType = 'application/octet-stream';
 class S3UploadTask {
   S3UploadTask._({
     required s3.S3Client s3Client,
+    required smithy_aws.S3ClientConfig defaultS3ClientConfig,
     required S3PrefixResolver prefixResolver,
     required String bucket,
     required String key,
@@ -51,6 +53,7 @@ class S3UploadTask {
     required AWSLogger logger,
     required transfer.TransferDatabase transferDatabase,
   })  : _s3Client = s3Client,
+        _defaultS3ClientConfig = defaultS3ClientConfig,
         _prefixResolver = prefixResolver,
         _bucket = bucket,
         _key = key,
@@ -69,6 +72,7 @@ class S3UploadTask {
   S3UploadTask.fromDataPayload(
     S3DataPayload dataPayload, {
     required s3.S3Client s3Client,
+    required smithy_aws.S3ClientConfig defaultS3ClientConfig,
     required S3PrefixResolver prefixResolver,
     required String bucket,
     required String key,
@@ -78,6 +82,7 @@ class S3UploadTask {
     required transfer.TransferDatabase transferDatabase,
   }) : this._(
           s3Client: s3Client,
+          defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: prefixResolver,
           bucket: bucket,
           key: key,
@@ -94,6 +99,7 @@ class S3UploadTask {
   S3UploadTask.fromAWSFile(
     AWSFile localFile, {
     required s3.S3Client s3Client,
+    required smithy_aws.S3ClientConfig defaultS3ClientConfig,
     required S3PrefixResolver prefixResolver,
     required String bucket,
     required String key,
@@ -103,6 +109,7 @@ class S3UploadTask {
     required transfer.TransferDatabase transferDatabase,
   }) : this._(
           s3Client: s3Client,
+          defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: prefixResolver,
           bucket: bucket,
           key: key,
@@ -122,6 +129,7 @@ class S3UploadTask {
   final Completer<S3Item> _uploadCompleter = Completer();
 
   final s3.S3Client _s3Client;
+  final smithy_aws.S3ClientConfig _defaultS3ClientConfig;
   final S3PrefixResolver _prefixResolver;
   final String _bucket;
   final String _key;
@@ -138,19 +146,19 @@ class S3UploadTask {
   late final String _resolvedKey;
 
   // fields used to manage the single upload process
-  SmithyOperation<s3.PutObjectOutput>? _putObjectOperation;
+  smithy.SmithyOperation<s3.PutObjectOutput>? _putObjectOperation;
 
   // fields used to manage the multipart upload process
   late final ChunkedStreamReader<int> _fileReader;
   late final StreamController<_CompletedSubtask> _subtasksStreamController;
   late final StreamSubscription<_CompletedSubtask> _subtasksStreamSubscription;
-  late final int _fileSize;
   late final int _lastPartSize;
   late final String _multipartUploadId;
   late final int _expectedNumOfSubtasks;
   final _ongoingSubtasks = <int, _OngoingSubtask>{};
   final _ongoingUploadPartHttpOperations = <int, _OngoingUploadPartOperation>{};
   final _completedSubtasks = <_CompletedSubtask>[];
+  int _fileSize = -1;
   int _transferredBytes = 0;
   int _currentSubTaskId = 0;
   final Completer<void> _determineUploadModeCompleter = Completer();
@@ -301,7 +309,12 @@ class S3UploadTask {
     });
 
     try {
-      _putObjectOperation = _s3Client.putObject(putObjectRequest);
+      _putObjectOperation = _s3Client.putObject(
+        putObjectRequest,
+        s3ClientConfig: _defaultS3ClientConfig.copyWith(
+          useAcceleration: _options.useAccelerateEndpoint,
+        ),
+      );
 
       _putObjectOperation!.requestProgress.listen((bytesSent) {
         _transferredBytes = bytesSent;
@@ -331,7 +344,7 @@ class S3UploadTask {
       _uploadCompleter
           .completeError(S3Exception.controllableOperationCanceled());
       _emitTransferProgress();
-    } on UnknownSmithyHttpException catch (error, stackTrace) {
+    } on smithy.UnknownSmithyHttpException catch (error, stackTrace) {
       _completeUploadWithError(
         S3Exception.fromUnknownSmithyHttpException(error),
         stackTrace,
@@ -468,7 +481,7 @@ class S3UploadTask {
         );
         _multipartUploadId = uploadId;
       }
-    } on UnknownSmithyHttpException catch (error) {
+    } on smithy.UnknownSmithyHttpException catch (error) {
       throw S3Exception.fromUnknownSmithyHttpException(error);
     }
   }
@@ -502,7 +515,7 @@ class S3UploadTask {
     try {
       await _s3Client.completeMultipartUpload(request).result;
       await _transferDatabase.deleteTransferRecords(_multipartUploadId);
-    } on UnknownSmithyHttpException catch (error) {
+    } on smithy.UnknownSmithyHttpException catch (error) {
       // TODO(HuiSF): verify if s3Client sdk throws different exception type
       //  wrapping errors extracted from a 200 response.
       throw S3Exception.fromUnknownSmithyHttpException(error);
@@ -589,7 +602,12 @@ class S3UploadTask {
     });
 
     try {
-      final operation = _s3Client.uploadPart(request);
+      final operation = _s3Client.uploadPart(
+        request,
+        s3ClientConfig: _defaultS3ClientConfig.copyWith(
+          useAcceleration: _options.useAccelerateEndpoint,
+        ),
+      );
       _ongoingUploadPartHttpOperations[partNumber] =
           _OngoingUploadPartOperation(
         partNumber: partNumber,
@@ -611,7 +629,7 @@ class S3UploadTask {
             partNumber == _expectedNumOfSubtasks ? _lastPartSize : _minPartSize,
         eTag: eTag,
       );
-    } on UnknownSmithyHttpException catch (error) {
+    } on smithy.UnknownSmithyHttpException catch (error) {
       throw S3Exception.fromUnknownSmithyHttpException(error);
     } on s3.NoSuchUpload catch (error) {
       throw S3Exception.fromS3NoSuchUpload(error);
@@ -732,5 +750,5 @@ class _OngoingUploadPartOperation {
   });
 
   final int partNumber;
-  final SmithyOperation<s3.UploadPartOutput> smithyOperation;
+  final smithy.SmithyOperation<s3.UploadPartOutput> smithyOperation;
 }

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
@@ -537,8 +537,8 @@ void main() {
             // assert the signer scope is always freshly initiated upon calling
             // `getUrl`
             expect(
-              AWSDateTime(comparingTime).formatFull(),
-              lessThanOrEqualTo(credentialScopeParam.dateTime.formatFull()),
+              comparingTime.isBefore(credentialScopeParam.dateTime.dateTime),
+              isTrue,
             );
 
             expect(capturedParams[2] is S3ServiceConfiguration, isTrue);

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
@@ -639,6 +639,48 @@ void main() {
           )}$testKey',
         );
       });
+
+      test('generate transfer acceleration enabled URL', () async {
+        const testOptions = S3GetUrlOptions(
+          accessLevel: StorageAccessLevel.private,
+          useAccelerateEndpoint: true,
+        );
+
+        when(
+          () => awsSigV4Signer.presign(
+            any(),
+            credentialScope: any(named: 'credentialScope'),
+            serviceConfiguration: any(named: 'serviceConfiguration'),
+            expiresIn: any(named: 'expiresIn'),
+          ),
+        ).thenAnswer((_) async => testUrl);
+
+        await storageS3Service.getUrl(
+          key: testKey,
+          options: testOptions,
+        );
+
+        final capturedParams = verify(
+          () => awsSigV4Signer.presign(
+            captureAny<AWSHttpRequest>(),
+            credentialScope:
+                captureAny<AWSCredentialScope>(named: 'credentialScope'),
+            expiresIn: captureAny<Duration>(named: 'expiresIn'),
+            serviceConfiguration: captureAny<S3ServiceConfiguration>(
+              named: 'serviceConfiguration',
+            ),
+          ),
+        ).captured;
+
+        expect(
+          capturedParams[0],
+          isA<AWSHttpRequest>().having(
+            (o) => o.uri.host,
+            'AWSHttpRequest URI',
+            contains('.s3-accelerate.'),
+          ),
+        );
+      });
     });
 
     group('copy() API', () {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-flutter/issues/2510

*Description of changes:*

1. Update infra storage stack to enable transfer acceleration for the buckets
2. Add `useAcceleration` param to corresponding operation options interface
3. Update s3 service to create `S3Client` instance per each operation and not using a singleton (S3Client configuration may changes per operation, per use case)
4. Update `DateTime` comparison in unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
