### PR TITLE
chore(amplify_test): Remove `graphql` dependency

### DIFF
--- a/packages/amplify_test/lib/src/integration_test_utils/auth_cognito/integration_test_auth_utils.dart
+++ b/packages/amplify_test/lib/src/integration_test_utils/auth_cognito/integration_test_auth_utils.dart
@@ -15,71 +15,85 @@
 
 import 'dart:async';
 import 'dart:convert';
+
 import 'package:amplify_flutter/amplify_flutter.dart';
-import 'package:graphql/client.dart';
+import 'package:http/http.dart' as http;
 import 'package:stream_transform/stream_transform.dart';
 
 import 'types/confirm_sign_up_response.dart';
 
 /// A GraphQL document used by the [deleteUser] test utility method.
-const deleteDocument = '''mutation DeleteUser(\$Username: String!) {
-  deleteUser(Username: \$Username) {
+const deleteDocument = r'''mutation DeleteUser($Username: String!) {
+  deleteUser(Username: $Username) {
     error
     success
   }
 }''';
+
+final _client = http.Client();
+
+Future<Map<String, Object?>> _graphQL(
+  String document, {
+  Map<String, Object?>? variables,
+}) async {
+  final config = await Amplify.asyncConfig;
+  final api = config.api!.awsPlugin!.default$!;
+  final response = await _client.post(
+    Uri.parse(api.endpoint).replace(path: '/graphql'),
+    headers: {
+      'x-api-key': api.apiKey!,
+    },
+    body: jsonEncode({
+      'query': document,
+      if (variables != null) 'variables': variables,
+    }),
+  );
+  if (response.statusCode != 200) {
+    throw Exception('${response.statusCode}: ${response.body}');
+  }
+  final responseJson = jsonDecode(response.body) as Map<String, Object?>;
+  final result = GraphQLResponse(
+    data: responseJson['data'] as Map<String, Object?>?,
+    errors: (responseJson['errors'] as List?)
+            ?.cast<Map<String, Object?>>()
+            .map(GraphQLResponseError.fromJson)
+            .toList() ??
+        const [],
+  );
+  if (result.errors.isNotEmpty) {
+    throw Exception(result.errors);
+  }
+  return result.data!;
+}
 
 /// Deletes a Cognito user in backend infrastructure.
 ///
 /// This method differs from the Auth.deleteUser API in that
 /// an access token is not required.
 Future<void> deleteUser(String username) async {
-  final config = await Amplify.asyncConfig;
-  final url = config.auth?.awsPlugin?.appSync?.default$?.apiUrl;
-  final key = config.auth?.awsPlugin?.appSync?.default$?.apiKey;
-  final client = GraphQLClient(
-    cache: GraphQLCache(),
-    link: HttpLink(
-      url!,
-      defaultHeaders: {
-        'x-api-key': key!,
-      },
-    ),
+  final result = await _graphQL(
+    deleteDocument,
+    variables: {
+      'Username': username,
+    },
   );
 
-  final options = MutationOptions(
-      document: gql(
-        r'''
-          mutation DeleteUser(
-            $Username: String!
-          ) {
-          deleteUser(Username: $Username) {
-              success
-              exception
-            }
-          }
-      ''',
-      ),
-      variables: <String, dynamic>{
-        'Username': username,
-      });
-
-  final QueryResult result = await client.mutate(options);
-  if (result.data?['deleteUser']?['exception'] != null) {
-    throw Exception(result.data?['deleteUser']?['exception']);
+  final exception = (result['deleteUser'] as Map?)?['exception'] as String?;
+  if (exception != null) {
+    throw Exception(exception);
   }
 }
 
 /// Creates a Cognito user in backend infrastructure. This documention describes
 /// how each parameter is expected to be used in the backend .
 ///
-/// Throws [GraphQLResponseErrors] if present in the response.
+/// Throws an [Exception] if there are errors present in the response.
 ///
 /// The [username] parameter can be plain text or a phone_number or email,
 /// depending on the backend configuration.
-/// The [password] is used as the temporary password if [autoconfirm] is true.
-/// The [autoconfirm] flag will mark the user as confirmed and give them a permanent password.
-/// The [enableMFA] flag will opt-in the user to using SMS MFA.
+/// The [password] is used as the temporary password if [autoConfirm] is true.
+/// The [autoConfirm] flag will mark the user as confirmed and give them a permanent password.
+/// The [enableMfa] flag will opt-in the user to using SMS MFA.
 /// The [verifyAttributes] flag will verify the email and phone, and should be used
 /// if tests need to bypass the verification step.
 /// The [attributes] list passes additional attributes.
@@ -91,22 +105,8 @@ Future<void> adminCreateUser(
   bool verifyAttributes = false,
   List<AuthUserAttribute> attributes = const [],
 }) async {
-  final config = await Amplify.asyncConfig;
-  final url = config.auth?.awsPlugin?.appSync?.default$?.apiUrl;
-  final key = config.auth?.awsPlugin?.appSync?.default$?.apiKey;
-  final client = GraphQLClient(
-    cache: GraphQLCache(),
-    link: HttpLink(
-      url!,
-      defaultHeaders: {
-        'x-api-key': key!,
-      },
-    ),
-  );
-
-  final options = MutationOptions(
-      document: gql(
-        r'''
+  final result = await _graphQL(
+    r'''
           mutation AdminCreateUser(
             $AutoConfirm: Boolean,
             $Email:String,
@@ -133,48 +133,48 @@ Future<void> adminCreateUser(
             }
           }
       ''',
-      ),
-      variables: <String, dynamic>{
-        'AutoConfirm': autoConfirm,
-        'Email': attributes
-            .firstWhere(
-                (el) => el.userAttributeKey == CognitoUserAttributeKey.email,
-                orElse: () => const AuthUserAttribute(
-                    userAttributeKey: CognitoUserAttributeKey.email,
-                    value: 'example@example.com'))
-            .value,
-        'EnabledMFA': enableMfa,
-        'Given_Name': attributes
-            .firstWhere(
-                (el) =>
-                    el.userAttributeKey == CognitoUserAttributeKey.givenName,
-                orElse: () => const AuthUserAttribute(
-                    userAttributeKey: CognitoUserAttributeKey.givenName,
-                    value: 'default_given_name'))
-            .value,
-        'Name': attributes
-            .firstWhere(
-                (el) => el.userAttributeKey == CognitoUserAttributeKey.name,
-                orElse: () => const AuthUserAttribute(
-                    userAttributeKey: CognitoUserAttributeKey.name,
-                    value: 'default_name'))
-            .value,
-        'Password': password,
-        'Phone_Number': attributes
-            .firstWhere(
-                (el) =>
-                    el.userAttributeKey == CognitoUserAttributeKey.phoneNumber,
-                orElse: () => const AuthUserAttribute(
-                    userAttributeKey: CognitoUserAttributeKey.phoneNumber,
-                    value: '+15555555'))
-            .value,
-        'Username': username,
-        'VerifyAttributes': verifyAttributes
-      });
+    variables: {
+      'AutoConfirm': autoConfirm,
+      'Email': attributes
+          .firstWhere(
+              (el) => el.userAttributeKey == CognitoUserAttributeKey.email,
+              orElse: () => const AuthUserAttribute(
+                  userAttributeKey: CognitoUserAttributeKey.email,
+                  value: 'example@example.com'))
+          .value,
+      'EnabledMFA': enableMfa,
+      'Given_Name': attributes
+          .firstWhere(
+              (el) => el.userAttributeKey == CognitoUserAttributeKey.givenName,
+              orElse: () => const AuthUserAttribute(
+                  userAttributeKey: CognitoUserAttributeKey.givenName,
+                  value: 'default_given_name'))
+          .value,
+      'Name': attributes
+          .firstWhere(
+              (el) => el.userAttributeKey == CognitoUserAttributeKey.name,
+              orElse: () => const AuthUserAttribute(
+                  userAttributeKey: CognitoUserAttributeKey.name,
+                  value: 'default_name'))
+          .value,
+      'Password': password,
+      'Phone_Number': attributes
+          .firstWhere(
+              (el) =>
+                  el.userAttributeKey == CognitoUserAttributeKey.phoneNumber,
+              orElse: () => const AuthUserAttribute(
+                  userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+                  value: '+15555555'))
+          .value,
+      'Username': username,
+      'VerifyAttributes': verifyAttributes
+    },
+  );
 
-  final QueryResult result = await client.mutate(options);
-  if (result.data?['adminCreateUser']?['exception'] != null) {
-    throw Exception(result.data?['adminCreateUser']?['exception']);
+  final exception =
+      (result['adminCreateUser'] as Map?)?['exception'] as String?;
+  if (exception != null) {
+    throw Exception(exception);
   }
 }
 

--- a/packages/amplify_test/pubspec.yaml
+++ b/packages/amplify_test/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  graphql: 5.1.1
+  http: ^0.13.5
   stream_transform: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
The `graphql` dependency is not really needed and is currently causing tests to break throughout due to it implementing an interface in a Dart pkg which recently changed.
