### PR TITLE
ci: Add `ci-run-integration-tests` label

### DIFF
--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -2,6 +2,9 @@ name: Amplify Integration Tests
 on:
   push:
     branches: [main, next, stable, feat/*]
+  pull_request:
+    types:
+      - labeled
   schedule:
     # 6am pacific time daily, only runs on default branch
     - cron:  '0 13 * * *'
@@ -17,6 +20,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: github.event_type != 'pull_request' || github.event.label.name == 'ci-run-integration-tests'
     strategy:
       fail-fast: false
       matrix:
@@ -66,6 +70,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: github.event_type != 'pull_request' || github.event.label.name == 'ci-run-integration-tests'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Adds a label which triggers integration tests to run on PRs.
