### PR TITLE
chore: update contributing doc to init and update git submodules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ already installed all the dependencies.
 See [invertase/melos](https://github.com/invertase/melos) for more instructions on how to use `melos`.
 
 ```
-$ git clone git@github.com:[username]/amplify-flutter.git
+$ git clone git@github.com:[username]/amplify-flutter.git --recurse-submodules
 $ cd amplify-flutter
 $ dart pub global activate melos
 $ melos bootstrap
@@ -137,7 +137,7 @@ This is mostly the same as GitHub's guide on creating a pull request.
 _[Skip step 1 to 3 if you have already done this]_
 
 1. Fork aws-amplify/amplify-flutter
-2. Clone your fork locally: `git clone git@github.com:YOUR_GITHUB_USERNAME/amplify-flutter.git`
+2. Clone your fork locally: `git clone git@github.com:YOUR_GITHUB_USERNAME/amplify-flutter.git --recurse-submodules`
 3. Install `melos` by running `dart pub global activate melos`, and run `melos bootstrap` (or `dart pub global run melos bootstrap`) in the repository root
 4. Within your fork, create a new branch based on the issue (e.g. Issue #123) you're addressing - `git checkout -b "group-token/short-token-[branch-name]"` or `git checkout -b "short-token/[branch-name]"`
    - Use grouping tokens at the beginning of the branch names. \_For e.g, if you are working on changes specific to `amplify-ui-components`, then you could start the branch name as `ui-components/...`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ $ cd amplify-flutter
 $ dart pub global activate melos
 $ melos bootstrap
 ```
+> Note: If you already cloned the project and forgot `--recurse-submodules`, run `git submodule update --init --recursive`.
 
 > Note: If you don't include `melos` on your path, you may execute `dart pub global run melos bootstrap` instead of the last command above.
 
@@ -138,6 +139,8 @@ _[Skip step 1 to 3 if you have already done this]_
 
 1. Fork aws-amplify/amplify-flutter
 2. Clone your fork locally: `git clone git@github.com:YOUR_GITHUB_USERNAME/amplify-flutter.git --recurse-submodules`
+    > Note: If you already cloned the project and forgot `--recurse-submodules`, run `git submodule update --init --recursive`.
+
 3. Install `melos` by running `dart pub global activate melos`, and run `melos bootstrap` (or `dart pub global run melos bootstrap`) in the repository root
 4. Within your fork, create a new branch based on the issue (e.g. Issue #123) you're addressing - `git checkout -b "group-token/short-token-[branch-name]"` or `git checkout -b "short-token/[branch-name]"`
    - Use grouping tokens at the beginning of the branch names. \_For e.g, if you are working on changes specific to `amplify-ui-components`, then you could start the branch name as `ui-components/...`


### PR DESCRIPTION
*issue:*
- packages/aft uses git submodules. therfore we need to init and update submodules otherwise `melos bootstrap` or `aft bootstrap` will fail. 
- the contributing doc is missing instruction on init and update git submodules when cloning the repo.

*Description of changes:*
- updated the contributing doc to init and update git submodules when cloning the repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
