### PR TITLE
chore(test): change test dep to local

### DIFF
--- a/packages/auth/amplify_auth_cognito_test/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_test/pubspec.yaml
@@ -36,11 +36,7 @@ dev_dependencies:
   convert: ^3.0.0
   http: ^0.13.0
   smithy:
-    hosted: https://pub.dillonnys.com
-    version: ^0.5.0
   smithy_aws:
-    hosted: https://pub.dillonnys.com
-    version: ^0.5.0
   stream_transform: ^2.0.0
   test: ^1.16.0
   worker_bee:


### PR DESCRIPTION
This PR changes a test dependency that got missed in recent migration. It just leaves version/path blank bc `aft` will override with local path when linking repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
