### PR TITLE
fix(storage): incorrect transferred bytes emitted from upload task

### DIFF
--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -304,7 +304,7 @@ class S3UploadTask {
       _putObjectOperation = _s3Client.putObject(putObjectRequest);
 
       _putObjectOperation!.requestProgress.listen((bytesSent) {
-        _transferredBytes += bytesSent;
+        _transferredBytes = bytesSent;
         _emitTransferProgress();
       });
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-flutter/issues/2591

*Description of changes:*




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
