### PR TITLE
fix(auth): SessionExpired Auth Hub event

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -221,10 +221,13 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
         if (state is SignInSuccess) {
           hubEvent = AuthHubEvent.signedIn(state.user.authUser);
         }
-        if (state is FetchAuthSessionFailure &&
-            (state.exception is UnauthorizedException ||
-                state.exception is AuthNotAuthorizedException)) {
-          hubEvent = AuthHubEvent.sessionExpired();
+        if (state is FetchAuthSessionSuccess) {
+          final exception = state.session.userPoolTokensResult.exception;
+          if (exception is UnauthorizedException ||
+              exception is AuthNotAuthorizedException ||
+              exception is SessionExpiredException) {
+            hubEvent = AuthHubEvent.sessionExpired();
+          }
         }
 
         if (hubEvent != null) {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -223,6 +223,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
         }
         if (state is FetchAuthSessionSuccess) {
           final exception = state.session.userPoolTokensResult.exception;
+          // TODO(Jordan-Nelson): Update list of exceptions once FetchAuthSession
+          /// is updated to only throw SessionExpiredException for expired
+          /// sessions.
           if (exception is UnauthorizedException ||
               exception is AuthNotAuthorizedException ||
               exception is SessionExpiredException) {

--- a/packages/auth/amplify_auth_cognito_test/test/plugin/fetch_auth_session_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/plugin/fetch_auth_session_test.dart
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_auth_cognito_dart/src/credentials/cognito_keys.dart';
+import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:test/test.dart';
+
+import '../common/jwt.dart';
+import '../common/mock_clients.dart';
+import '../common/mock_config.dart';
+import '../common/mock_secure_storage.dart';
+
+void main() {
+  AmplifyLogger().logLevel = LogLevel.verbose;
+
+  late CognitoAuthStateMachine stateMachine;
+  late AmplifyAuthCognitoDart plugin;
+
+  group('fetchAuthSession', () {
+    group('when session is expired', () {
+      setUp(() async {
+        final expiredIdToken = createJwt(
+          type: TokenType.id,
+          expiration: Duration.zero,
+        );
+        final secureStorage = MockSecureStorage();
+        seedStorage(
+          secureStorage,
+          identityPoolKeys: identityPoolKeys,
+          userPoolKeys: userPoolKeys,
+        );
+        secureStorage.write(
+          key: userPoolKeys[CognitoUserPoolKey.idToken],
+          value: expiredIdToken.raw,
+        );
+        stateMachine = CognitoAuthStateMachine();
+        plugin = AmplifyAuthCognitoDart(credentialStorage: secureStorage)
+          ..stateMachine = stateMachine;
+        await plugin.configure(
+          config: mockConfig,
+          authProviderRepo: AmplifyAuthProviderRepository(),
+        );
+
+        stateMachine.addInstance<CognitoIdentityProviderClient>(
+          MockCognitoIdentityProviderClient(
+            initiateAuth: expectAsync0(
+              () async => throw const AuthNotAuthorizedException(
+                'Refresh Token has expired.',
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('should add a sessionExpired event to Auth Hub', () async {
+        final authStream = Amplify.Hub.availableStreams[HubChannel.Auth];
+        plugin.fetchAuthSession().ignore();
+        await expectLater(authStream, emits(AuthHubEvent.sessionExpired()));
+      });
+    });
+
+    tearDown(() async {
+      await plugin.close();
+    });
+  });
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes a regression introduced by https://github.com/aws-amplify/amplify-flutter/pull/2585. When refreshing user pool tokens fail due to an expired refresh token, a hub event for Session Expired should be emitted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
