### PR TITLE
feat(core): add granular model read operations

### DIFF
--- a/packages/amplify_core/lib/src/types/models/auth_rule.dart
+++ b/packages/amplify_core/lib/src/types/models/auth_rule.dart
@@ -10,7 +10,17 @@ import 'package:meta/meta.dart';
 
 enum AuthStrategy { OWNER, GROUPS, PRIVATE, PUBLIC }
 
-enum ModelOperation { CREATE, UPDATE, DELETE, READ }
+enum ModelOperation {
+  CREATE,
+  UPDATE,
+  DELETE,
+  READ,
+  GET,
+  LIST,
+  SYNC,
+  LISTEN,
+  SEARCH
+}
 
 enum AuthRuleProvider { APIKEY, OIDC, IAM, USERPOOLS, FUNCTION }
 


### PR DESCRIPTION
*Issue #, if available:*
Fix https://github.com/aws-amplify/amplify-flutter/issues/2526
The purpose of adding enum in library is to ensure the model files generated by modelgen will be compiled. However, this is not intended for Datastore usage but for those who use modelgen files along with API plugin. It is not recommended to use them in the datastore due to the prerequisite of `sync` and `listen`. This is documented in the [callout](https://github.com/aws-amplify/docs/pull/5084). 
*Description of changes:*
Add granular read operation enums in model auth operation rule
Refer https://docs.amplify.aws/cli/graphql/authorization-rules/#how-it-works

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
