### PR TITLE
fix(auth): Device tracking with alias

### DIFF
--- a/infra/lib/auth/custom-authorizer-iam/stack.ts
+++ b/infra/lib/auth/custom-authorizer-iam/stack.ts
@@ -55,12 +55,12 @@ export class CustomAuthorizerIamStackEnvironment extends IntegrationTestStackEnv
       const hostedZone = route53.HostedZone.fromLookup(this, "HostedZone", {
         domainName: customDomain,
       });
-      const certificate = new acm.DnsValidatedCertificate(
+      const certificate = new acm.Certificate(
         this,
         "SslCertificate",
         {
-          hostedZone,
           domainName,
+          validation: acm.CertificateValidation.fromDns(hostedZone),
         }
       );
       domainProperties = {

--- a/infra/lib/auth/schema.graphql
+++ b/infra/lib/auth/schema.graphql
@@ -28,6 +28,7 @@ input CreateUserInput {
 
 type CreateUserResponse {
   success: Boolean!
+  cognitoUsername: String
   error: String
 }
 

--- a/infra/lib/auth/stack.create-user.ts
+++ b/infra/lib/auth/stack.create-user.ts
@@ -20,6 +20,7 @@ interface CreateUserInput {
 
 interface CreateUserResponse {
   success: boolean;
+  cognitoUsername?: string;
   error?: string;
 }
 
@@ -45,6 +46,7 @@ export const handler: lambda.AppSyncResolverHandler<
   };
 
   console.log(`Creating user ${username}...`);
+  let cognitoUsername: string;
   try {
     const createUserParams: cognito.AdminCreateUserCommandInput = {
       ...baseParams,
@@ -60,6 +62,7 @@ export const handler: lambda.AppSyncResolverHandler<
       new cognito.AdminCreateUserCommand(createUserParams)
     );
     console.log(`Successfully created user: ${username}`, resp);
+    cognitoUsername = resp.User!.Username!;
   } catch (err: any) {
     console.error(`Could not create user ${username}`, err);
     return {
@@ -141,5 +144,6 @@ export const handler: lambda.AppSyncResolverHandler<
 
   return {
     success: true,
+    cognitoUsername,
   };
 };

--- a/infra/lib/auth/stack.ts
+++ b/infra/lib/auth/stack.ts
@@ -35,7 +35,7 @@ export interface AuthBaseEnvironmentProps
   /**
    * Associates `resourceArn` with the shared WAF.
    */
-  associateWithWaf: (resourceArn: string) => void;
+  associateWithWaf: (name: string, resourceArn: string) => void;
 
   /**
    * The type of environment to build.
@@ -321,8 +321,8 @@ class AuthIntegrationTestStackEnvironment extends IntegrationTestStackEnvironmen
       }
     );
 
-    associateWithWaf(graphQLApi.arn);
-    associateWithWaf(userPool.userPoolArn);
+    associateWithWaf(`${this.environmentName}GraphQL`, graphQLApi.arn);
+    associateWithWaf(`${this.environmentName}UserPool`, userPool.userPoolArn);
 
     // Create the DynamoDB table to store MFA codes for AppSync subscriptions
 

--- a/infra/lib/stack.ts
+++ b/infra/lib/stack.ts
@@ -3,6 +3,7 @@
 
 import * as cdk from "aws-cdk-lib";
 import { CfnOutput } from "aws-cdk-lib";
+import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as wafv2 from "aws-cdk-lib/aws-wafv2";
 import { Construct } from "constructs";
 import { AnalyticsIntegrationTestStack } from "./analytics/stack";
@@ -91,29 +92,41 @@ export class AmplifyFlutterIntegStack extends cdk.Stack {
         customDomain,
       });
     }
+
+    const deviceTrackingOptIn: cognito.DeviceTracking = {
+      // Trust remembered devices (allow MFA bypass)
+      challengeRequiredOnNewDevice: true,
+      // Opt-in to tracking
+      deviceOnlyRememberedOnUserPrompt: true,
+    };
+    const deviceTrackingAlways: cognito.DeviceTracking = {
+      // Trust remembered devices (allow MFA bypass)
+      challengeRequiredOnNewDevice: true,
+      // Always track
+      deviceOnlyRememberedOnUserPrompt: false,
+    }
     const auth = new AuthIntegrationTestStack(this, [
       { associateWithWaf, type: "FULL", environmentName: "main" },
       {
         associateWithWaf,
         type: "FULL",
         environmentName: "device-tracking-always",
-        deviceTracking: {
-          // Trust remembered devices (allow MFA bypass)
-          challengeRequiredOnNewDevice: true,
-          // Always track
-          deviceOnlyRememberedOnUserPrompt: false,
-        },
+        deviceTracking: deviceTrackingAlways,
       },
       {
         associateWithWaf,
         type: "FULL",
         environmentName: "device-tracking-opt-in",
-        deviceTracking: {
-          // Trust remembered devices (allow MFA bypass)
-          challengeRequiredOnNewDevice: true,
-          // Opt-in to tracking
-          deviceOnlyRememberedOnUserPrompt: true,
-        },
+        deviceTracking: deviceTrackingOptIn,
+      },
+      {
+        associateWithWaf,
+        type: "FULL",
+        environmentName: "device-tracking-email-alias",
+        deviceTracking: deviceTrackingAlways,
+        signInAliases: {
+          email: true,
+        }
       },
       {
         associateWithWaf,

--- a/infra/lib/stack.ts
+++ b/infra/lib/stack.ts
@@ -62,11 +62,11 @@ export class AmplifyFlutterIntegStack extends cdk.Stack {
 
     // Creates a WAF association on `this` so that they can be chained later
     // and do not block the concurrent creation of environments.
-    const associateWithWaf = (resourceArn: string) => {
+    const associateWithWaf = (name: string, resourceArn: string) => {
       wafAssociations.push(
         new wafv2.CfnWebACLAssociation(
           this,
-          `WAFAssociation${wafAssociations.length}`,
+          `WAFAssociation-${name}`,
           {
             resourceArn,
             webAclArn: waf.attrArn,

--- a/packages/amplify_test/lib/src/integration_test_utils/auth_cognito/integration_test_auth_utils.dart
+++ b/packages/amplify_test/lib/src/integration_test_utils/auth_cognito/integration_test_auth_utils.dart
@@ -118,7 +118,7 @@ mutation DeleteDevice($input: DeleteDeviceInput!) {
 /// The [verifyAttributes] flag will verify the email and phone, and should be used
 /// if tests need to bypass the verification step.
 /// The [attributes] list passes additional attributes.
-Future<void> adminCreateUser(
+Future<String> adminCreateUser(
   String username,
   String password, {
   bool autoConfirm = false,
@@ -166,6 +166,7 @@ Future<void> adminCreateUser(
           mutation CreateUser($input: CreateUserInput!) {
             createUser(input: $input) {
               success
+              cognitoUsername
               error
             }
           }
@@ -182,6 +183,8 @@ Future<void> adminCreateUser(
   if (createError != null) {
     throw Exception(createError);
   }
+
+  return (result['createUser'] as Map)['cognitoUsername'] as String;
 }
 
 class OtpResult {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
@@ -28,11 +28,22 @@ void main() {
   AmplifyLogger().logLevel = LogLevel.debug;
 
   group('Device Tracking', () {
+    // The username selected by the user.
     String? username;
+
+    // The password selected by the user.
     String? password;
 
+    // The username assigned by Cognito.
+    //
+    // This will be the same as [username] except in the case of email alias
+    // where Cognito will assign a random UUID for the "username". Device
+    // tracking relies on this UUID for storing device secrets since it
+    // identifies the user regardless of the alias used to sign in.
+    late String cognitoUsername;
+
     Future<DeviceState> getDeviceState() async {
-      final secrets = await deviceRepo.get(username!);
+      final secrets = await deviceRepo.get(cognitoUsername);
       if (secrets == null) {
         return DeviceState.untracked;
       }
@@ -42,35 +53,51 @@ void main() {
     }
 
     Future<String?> getDeviceKey() async {
-      final secrets = await deviceRepo.get(username!);
+      final secrets = await deviceRepo.get(cognitoUsername);
       return secrets?.deviceKey;
     }
 
     Future<void> signIn({
+      bool emailAlias = false,
       bool enableMfa = false,
     }) async {
       await signOutUser();
 
       if (username == null && password == null) {
-        username = generateUsername();
+        username = emailAlias ? generateEmail() : generateUsername();
         password = generatePassword();
 
-        await adminCreateUser(
+        cognitoUsername = await adminCreateUser(
           username!,
           password!,
           autoConfirm: true,
           verifyAttributes: true,
           enableMfa: enableMfa,
+          attributes: [
+            if (emailAlias)
+              AuthUserAttribute(
+                userAttributeKey: CognitoUserAttributeKey.email,
+                value: username!,
+              ),
+          ],
         );
+        if (emailAlias) {
+          expect(
+            cognitoUsername,
+            isNot(username),
+            reason: 'When using an alias, Cognito should assign a UUID '
+                'as the username',
+          );
+        }
         addTearDown(() async {
-          await deleteUser(username!);
+          await deleteUser(cognitoUsername);
           username = null;
           password = null;
         });
       }
 
       if (enableMfa) {
-        final otpResult = await getOtpCode(username!);
+        final otpResult = await getOtpCode(cognitoUsername);
         final signInRes = await Amplify.Auth.signIn(
           username: username!,
           password: password,
@@ -139,7 +166,7 @@ void main() {
         final deviceKey = await getDeviceKey();
         expect(deviceKey, isNotNull);
         await signOutUser();
-        await deleteDevice(username!, deviceKey!);
+        await deleteDevice(cognitoUsername, deviceKey!);
         await expectLater(signIn(), completes);
         final newDeviceKey = await getDeviceKey();
         expect(newDeviceKey, isNotNull);
@@ -192,7 +219,7 @@ void main() {
           final deviceKey = await getDeviceKey();
           expect(deviceKey, isNotNull);
           await signOutUser();
-          await deleteDevice(username!, deviceKey!);
+          await deleteDevice(cognitoUsername, deviceKey!);
           await expectLater(signIn(enableMfa: true), completes);
           final newDeviceKey = await getDeviceKey();
           expect(newDeviceKey, isNotNull);
@@ -240,7 +267,7 @@ void main() {
         final deviceKey = await getDeviceKey();
         expect(deviceKey, isNotNull);
         await signOutUser();
-        await deleteDevice(username!, deviceKey!);
+        await deleteDevice(cognitoUsername, deviceKey!);
         await expectLater(signIn(), completes);
         final newDeviceKey = await getDeviceKey();
         expect(newDeviceKey, isNotNull);
@@ -276,11 +303,123 @@ void main() {
         final deviceKey = await getDeviceKey();
         expect(deviceKey, isNotNull);
         await signOutUser();
-        await deleteDevice(username!, deviceKey!);
+        await deleteDevice(cognitoUsername, deviceKey!);
         await expectLater(signIn(enableMfa: true), completes);
         final newDeviceKey = await getDeviceKey();
         expect(newDeviceKey, isNotNull);
         expect(newDeviceKey, isNot(deviceKey));
+      });
+    });
+
+    group('Always (Email Alias)', () {
+      setUpAll(() async {
+        await configureAuth(
+          config: amplifyEnvironments['device-tracking-email-alias'],
+        );
+      });
+
+      setUp(() => signIn(emailAlias: true));
+
+      asyncTest('device is automatically remembered', (_) async {
+        expect(await getDeviceState(), DeviceState.remembered);
+      });
+
+      asyncTest('rememberDevice is a no-op when already tracking', (_) async {
+        await expectLater(Amplify.Auth.rememberDevice(), completes);
+      });
+
+      asyncTest('forgetDevice stops tracking', (_) async {
+        expect(await getDeviceState(), DeviceState.remembered);
+        await Amplify.Auth.forgetDevice();
+        expect(await getDeviceState(), DeviceState.untracked);
+      });
+
+      asyncTest('fetchDevices lists remembered devices', (_) async {
+        expect(await Amplify.Auth.fetchDevices(), hasLength(1));
+      });
+
+      asyncTest('multiple logins use the same device key', (_) async {
+        final deviceKey = await getDeviceKey();
+        expect(deviceKey, isNotNull);
+        await signOutUser();
+        await signIn(emailAlias: true);
+        expect(await getDeviceKey(), deviceKey);
+      });
+
+      asyncTest('can login when device is removed in Cognito', (_) async {
+        final deviceKey = await getDeviceKey();
+        expect(deviceKey, isNotNull);
+        await signOutUser();
+        await deleteDevice(cognitoUsername, deviceKey!);
+        await expectLater(signIn(emailAlias: true), completes);
+        final newDeviceKey = await getDeviceKey();
+        expect(newDeviceKey, isNotNull);
+        expect(newDeviceKey, isNot(deviceKey));
+      });
+    });
+
+    group('Always (Email Alias / MFA)', () {
+      setUpAll(() async {
+        await configureAuth(
+          additionalPlugins: [AmplifyAPI()],
+          config: amplifyEnvironments['device-tracking-email-alias'],
+        );
+      });
+
+      setUp(() => signIn(emailAlias: true, enableMfa: true));
+
+      asyncTest('device is automatically remembered', (_) async {
+        expect(await getDeviceState(), DeviceState.remembered);
+      });
+
+      asyncTest('rememberDevice is a no-op when already tracking', (_) async {
+        await expectLater(Amplify.Auth.rememberDevice(), completes);
+      });
+
+      asyncTest('forgetDevice stops tracking', (_) async {
+        expect(await getDeviceState(), DeviceState.remembered);
+        await Amplify.Auth.forgetDevice();
+        expect(await getDeviceState(), DeviceState.untracked);
+      });
+
+      asyncTest('fetchDevices lists remembered devices', (_) async {
+        expect(await Amplify.Auth.fetchDevices(), hasLength(1));
+      });
+
+      asyncTest('multiple logins use the same device key', (_) async {
+        final deviceKey = await getDeviceKey();
+        expect(deviceKey, isNotNull);
+        await signOutUser();
+        await signIn(emailAlias: true, enableMfa: true);
+        expect(await getDeviceKey(), deviceKey);
+      });
+
+      asyncTest('can login when device is removed in Cognito', (_) async {
+        final deviceKey = await getDeviceKey();
+        expect(deviceKey, isNotNull);
+        await signOutUser();
+        await deleteDevice(cognitoUsername, deviceKey!);
+        await expectLater(
+          signIn(emailAlias: true, enableMfa: true),
+          completes,
+        );
+        final newDeviceKey = await getDeviceKey();
+        expect(newDeviceKey, isNotNull);
+        expect(newDeviceKey, isNot(deviceKey));
+      });
+
+      asyncTest('can bypass MFA when device is always remembered', (_) async {
+        await signOutUser();
+
+        final res = await Amplify.Auth.signIn(
+          username: username!,
+          password: password,
+        );
+        expect(
+          res.isSignedIn,
+          isTrue,
+          reason: 'Subsequent sign-in attempts should not require MFA',
+        );
       });
     });
   });


### PR DESCRIPTION
When using an alias (such as email), Cognito will assign a random UUID as the "username" of the user. We should use this to track device information so that sign-in attempts with different aliases can use the same device info.