### PR TITLE
chore(authenticator): Remove example dir from .pubignore

### DIFF
--- a/packages/authenticator/amplify_authenticator/.pubignore
+++ b/packages/authenticator/amplify_authenticator/.pubignore
@@ -1,1 +1,2 @@
+example/integration_test
 test

--- a/packages/authenticator/amplify_authenticator/.pubignore
+++ b/packages/authenticator/amplify_authenticator/.pubignore
@@ -1,2 +1,1 @@
-example
 test


### PR DESCRIPTION
*Description of changes:*
Remove example dir from `.pubignore` so Pana can find it when evaluating the pub score. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
