### PR TITLE
fix(auth): `federateToIdentityPool` discrepancies

### DIFF
--- a/packages/amplify_core/lib/src/types/exception/auth/invalid_state_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/auth/invalid_state_exception.dart
@@ -15,6 +15,15 @@ class InvalidStateException extends AuthException {
     super.underlyingException,
   });
 
+  /// Thrown when trying to access user pool methods while federated to an
+  /// identity pool.
+  const InvalidStateException.federatedToIdentityPool()
+      : this(
+          'Users federated to Identity Pools do not have User Pool access.',
+          recoverySuggestion: 'Call `clearFederationToIdentityPool`, '
+              'then sign in normally to access User Pool data.',
+        );
+
   @override
   String get runtimeTypeName => 'InvalidStateException';
 }

--- a/packages/auth/amplify_auth_cognito/example/integration_test/federated_sign_in_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/federated_sign_in_test.dart
@@ -38,6 +38,37 @@ void main() {
     final username = generateUsername();
     final password = generatePassword();
 
+    Future<CognitoUserPoolTokens> getUserPoolTokens() async {
+      final signInResult = await cognitoPlugin.signIn(
+        username: username,
+        password: password,
+      );
+      expect(signInResult.nextStep.signInStep, AuthSignInStep.done);
+
+      final signInSession = await cognitoPlugin.fetchAuthSession();
+      final userPoolTokens = signInSession.userPoolTokensResult.value;
+      // Clear but do not sign out so that tokens are still valid.
+      // ignore: invalid_use_of_protected_member
+      await cognitoPlugin.stateMachine.clearCredentials();
+
+      return userPoolTokens;
+    }
+
+    Future<FederateToIdentityPoolResult> federateToIdentityPool() async {
+      final userPoolTokens = await getUserPoolTokens();
+      return cognitoPlugin.federateToIdentityPool(
+        token: userPoolTokens.idToken.raw,
+        provider: provider,
+      );
+    }
+
+    Future<void> clearFederation() async {
+      try {
+        await cognitoPlugin.clearFederationToIdentityPool();
+        // ignore: avoid_catches_without_on_clauses
+      } catch (_) {}
+    }
+
     setUpAll(() async {
       await configureAuth();
       await adminCreateUser(
@@ -47,33 +78,16 @@ void main() {
         verifyAttributes: true,
       );
 
+      await clearFederation();
       await signOutUser();
     });
 
     tearDownAll(Amplify.reset);
 
-    tearDown(signOutUser);
-
-    Future<FederateToIdentityPoolResult> federateToIdentityPool() async {
-      final signInResult = await cognitoPlugin.signIn(
-        username: username,
-        password: password,
-      );
-      expect(signInResult.nextStep.signInStep, AuthSignInStep.done);
-
-      final userPoolTokens =
-          (await cognitoPlugin.fetchAuthSession()).userPoolTokensResult.value;
-      // Clear but do not sign out so that tokens are still valid.
-      // ignore: invalid_use_of_protected_member
-      await cognitoPlugin.stateMachine.clearCredentials(
-        CognitoUserPoolKeys(userPoolConfig),
-      );
-
-      return cognitoPlugin.federateToIdentityPool(
-        token: userPoolTokens.idToken.raw,
-        provider: provider,
-      );
-    }
+    tearDown(() async {
+      await clearFederation();
+      await signOutUser();
+    });
 
     asyncTest('throws when signed in', (_) async {
       final signInResult = await cognitoPlugin.signIn(
@@ -102,14 +116,18 @@ void main() {
     });
 
     asyncTest('replaces unauthenticated identity', (_) async {
+      final userPoolTokens = await getUserPoolTokens();
+
       // Get unauthenticated identity
       final unauthSession = await cognitoPlugin.fetchAuthSession();
-
-      final authSession = await federateToIdentityPool();
+      final authSession = await cognitoPlugin.federateToIdentityPool(
+        token: userPoolTokens.idToken.raw,
+        provider: provider,
+      );
       expect(
         authSession.identityId,
-        unauthSession.identityIdResult.value,
-        reason: 'Should retain unauthenticated identity',
+        isNot(unauthSession.identityIdResult.value),
+        reason: 'Should replace unauthenticated identity',
       );
       expect(
         authSession.credentials,
@@ -193,6 +211,56 @@ void main() {
         cognitoPlugin.clearFederationToIdentityPool(),
         completes,
         reason: 'Clearing with no federation is a no-op',
+      );
+    });
+
+    asyncTest('isSignedIn=true when federated', (_) async {
+      await federateToIdentityPool();
+
+      final session = await cognitoPlugin.fetchAuthSession();
+      expect(
+        session.isSignedIn,
+        isTrue,
+        reason: 'API requirement',
+      );
+      await expectLater(
+        cognitoPlugin.getCurrentUser(),
+        throwsA(isA<InvalidStateException>()),
+        reason: 'API requirement. getCurrentUser should throw '
+            'even though isSignedIn=true',
+      );
+    });
+
+    asyncTest('refreshes federated identity when expired', (_) async {
+      final session = await federateToIdentityPool();
+
+      // Update expiration to now.
+      // ignore: invalid_use_of_protected_member
+      final stateMachine = cognitoPlugin.stateMachine;
+      final credentials = await stateMachine.loadCredentials();
+      await stateMachine.storeCredentials(
+        CredentialStoreData(
+          identityId: session.identityId,
+          awsCredentials: AWSCredentials(
+            session.credentials.accessKeyId,
+            session.credentials.secretAccessKey,
+            session.credentials.sessionToken,
+            DateTime.now(),
+          ),
+          signInDetails: credentials.signInDetails,
+        ),
+      );
+
+      final newSession = await cognitoPlugin.fetchAuthSession();
+      expect(
+        newSession.identityIdResult.value,
+        session.identityId,
+        reason: 'Identity ID should not have changed during refresh',
+      );
+      expect(
+        newSession.credentialsResult.value,
+        isNot(session.credentials),
+        reason: 'Credentials should have been refreshed',
       );
     });
   });

--- a/packages/auth/amplify_auth_cognito/example/integration_test/reset_password_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/reset_password_test.dart
@@ -9,6 +9,7 @@ import 'package:integration_test/integration_test.dart';
 
 import 'utils/mock_data.dart';
 import 'utils/setup_utils.dart';
+import 'utils/test_utils.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -59,7 +60,7 @@ void main() {
       await signIn();
     });
 
-    test('can reset password', () async {
+    asyncTest('can reset password', (_) async {
       await signOutUser();
 
       final otpResult = await getOtpCode(username);

--- a/packages/auth/amplify_auth_cognito/example/integration_test/security_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/security_test.dart
@@ -13,6 +13,7 @@ import 'package:integration_test/integration_test.dart';
 
 import 'utils/mock_data.dart';
 import 'utils/setup_utils.dart';
+import 'utils/test_utils.dart';
 
 class InlineHttpClient extends AWSCustomHttpClient {
   InlineHttpClient({
@@ -43,7 +44,7 @@ void main() {
       await Amplify.reset();
     });
 
-    test('adds cache-control header', () async {
+    asyncTest('adds cache-control header', (_) async {
       final plugin = AmplifyAuthCognito(
         credentialStorage: AmplifySecureStorage(
           config: AmplifySecureStorageConfig(

--- a/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
@@ -28,7 +28,8 @@ export 'src/model/password/cognito_update_password_options.dart';
 export 'src/model/session/cognito_auth_session.dart';
 export 'src/model/session/cognito_auth_user.dart';
 export 'src/model/session/cognito_session_options.dart';
-export 'src/model/session/cognito_sign_in_details.dart';
+export 'src/model/session/cognito_sign_in_details.dart'
+    hide CognitoSignInDetailsFederated;
 export 'src/model/session/cognito_user_pool_tokens.dart';
 export 'src/model/session/federate_to_identity_pool_options.dart';
 export 'src/model/session/federate_to_identity_pool_request.dart';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
@@ -68,6 +68,12 @@ enum CognitoIdentityPoolKey {
 
   /// AWS Identity ID.
   identityId,
+
+  /// Third-party [AuthProvider] (only used in federation).
+  provider,
+
+  /// Third-party OIDC token (only used in federation).
+  idToken,
 }
 
 /// Discrete keys stored for Hosted UI operations in secure storage.

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_sign_in_details.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_sign_in_details.dart
@@ -8,6 +8,7 @@ import 'package:amplify_core/amplify_core.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
 
 part 'cognito_sign_in_details.g.dart';
 
@@ -20,6 +21,10 @@ enum CognitoSignInType {
 
   /// {@macro amplify_auth_cognito_dart.cognito_sign_in_details_hosted_ui}
   hostedUi,
+
+  /// {@macro amplify_auth_cognito_dart.cognito_sign_in_details_federated}
+  @internal
+  federated,
 }
 
 /// {@template amplify_auth_cognito_dart.cognito_sign_in_details}
@@ -39,6 +44,8 @@ abstract class CognitoSignInDetails extends SignInDetails {
         return CognitoSignInDetailsApiBased.fromJson(json);
       case CognitoSignInType.hostedUi:
         return CognitoSignInDetailsHostedUi.fromJson(json);
+      case CognitoSignInType.federated:
+        return CognitoSignInDetailsFederated.fromJson(json);
     }
   }
 
@@ -115,6 +122,36 @@ class CognitoSignInDetailsHostedUi extends CognitoSignInDetails
   Map<String, Object?> toJson() => {
         'signInType': signInType.name,
         ..._$CognitoSignInDetailsHostedUiToJson(this),
+      };
+}
+
+/// {@template amplify_auth_cognito_dart.cognito_sign_in_details_federated}
+/// Sign in details for federation to a Cognito Identity Pool.
+/// {@endtemplate}
+@internal
+@zAmplifySerializable
+class CognitoSignInDetailsFederated extends CognitoSignInDetails
+    with AWSSerializable<Map<String, Object?>> {
+  /// {@macro amplify_auth_cognito_dart.cognito_sign_in_details_federated}
+  const CognitoSignInDetailsFederated({
+    required this.token,
+    required this.provider,
+  }) : super(CognitoSignInType.federated);
+
+  /// {@macro amplify_auth_cognito_dart.cognito_sign_in_details_federated}
+  factory CognitoSignInDetailsFederated.fromJson(Map<String, Object?> json) =>
+      _$CognitoSignInDetailsFederatedFromJson(json);
+
+  /// The third-party OIDC token.
+  final String token;
+
+  /// The third-party authentication provider.
+  final AuthProvider provider;
+
+  @override
+  Map<String, Object?> toJson() => {
+        'signInType': signInType.name,
+        ..._$CognitoSignInDetailsFederatedToJson(this),
       };
 }
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_sign_in_details.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_sign_in_details.g.dart
@@ -92,3 +92,17 @@ Map<String, dynamic> _$CognitoSignInDetailsHostedUiToJson(
   writeNotNull('provider', instance.provider?.toJson());
   return val;
 }
+
+CognitoSignInDetailsFederated _$CognitoSignInDetailsFederatedFromJson(
+        Map<String, dynamic> json) =>
+    CognitoSignInDetailsFederated(
+      token: json['token'] as String,
+      provider: AuthProvider.fromJson(json['provider'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$CognitoSignInDetailsFederatedToJson(
+        CognitoSignInDetailsFederated instance) =>
+    <String, dynamic>{
+      'token': instance.token,
+      'provider': instance.provider.toJson(),
+    };


### PR DESCRIPTION
Some discrepancies exist in our implementation of `federateToIdentityPool`:
- `fetchAuthSession` should return `isSignedIn=true` when federated to identity pool
- User Pool APIs should throw a specific `InvalidStateException`, not a generic `SignedOutException`