### PR TITLE
chore(repo): add shortcuts to run unit tests from IDE on Chrome

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "configurations": [
+    {
+      "name": "Dart Test in Chrome",
+      "type": "dart",
+      "request": "launch",
+      "args": ["-p", "chrome"],
+      "codeLens": {
+        "for": ["run-test", "run-test-file", "debug-test", "debug-test-file"],
+        "path": "packages",
+        "title": "${debugType} Dart test with Chrome"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Run unit tests on Chrome by clicking codelens link in VSCode.

<img width="524" alt="image" src="https://user-images.githubusercontent.com/10602282/216199602-69f04ea2-9056-4e16-bfd3-435f5f11e4b0.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
