### PR TITLE
feat(storage): enable pause and cancel APIs for download operations

### DIFF
--- a/packages/amplify_core/lib/src/plugin/amplify_plugin_key.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_plugin_key.dart
@@ -94,7 +94,6 @@ abstract class AuthPluginKey<
   const AuthPluginKey();
 }
 
-// TODO(HuiSF): Define generic parameters for all API types
 abstract class StoragePluginKey<
     PluginStorageListOperation extends StorageListOperation,
     PluginStorageListOptions extends StorageListOptions,

--- a/packages/amplify_core/lib/src/types/storage/download_data_operation.dart
+++ b/packages/amplify_core/lib/src/types/storage/download_data_operation.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/storage/base/storage_controllable_operation.dart';
 
 import 'base/storage_operation.dart';
 
@@ -12,9 +13,7 @@ abstract class StorageDownloadDataOperation<
         Request extends StorageDownloadDataRequest,
         Result extends StorageDownloadDataResult>
     extends StorageOperation<Request, Result>
-// TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
-// can cancel underlying http request.
-/* implements StorageResumableOperation, StorageCancelableOperation */ {
+    implements StorageResumableOperation, StorageCancelableOperation {
   /// {@macro amplify_core.storage.download_data_operation}
   StorageDownloadDataOperation({
     required super.request,

--- a/packages/amplify_core/lib/src/types/storage/download_file_operation.dart
+++ b/packages/amplify_core/lib/src/types/storage/download_file_operation.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/types/storage/base/storage_controllable_operation.dart';
 
 import 'base/storage_operation.dart';
 
@@ -12,9 +13,7 @@ abstract class StorageDownloadFileOperation<
         Request extends StorageDownloadFileRequest,
         Result extends StorageDownloadFileResult>
     extends StorageOperation<Request, Result>
-// TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
-// can cancel underlying http request.
-/* implements StorageResumableOperation, StorageCancelableOperation */ {
+    implements StorageResumableOperation, StorageCancelableOperation {
   /// {@macro amplify_core.storage.download_file_operation}
   StorageDownloadFileOperation({
     required super.request,

--- a/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
+++ b/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
@@ -227,15 +227,14 @@ Future<void> downloadDataOperation() async {
   );
 
   stdout.writeln('Downloading...');
-  // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
-  // can cancel underlying http request.
-  // await Future<void>.delayed(const Duration(seconds: 1));
-  // await downloadDataOperation.pause();
-
-  // await Future<void>.delayed(const Duration(seconds: 4));
-  // await downloadDataOperation.resume();
 
   try {
+    await Future<void>.delayed(const Duration(seconds: 1));
+    await downloadDataOperation.pause();
+
+    await Future<void>.delayed(const Duration(seconds: 4));
+    await downloadDataOperation.resume();
+
     final result = await downloadDataOperation.result;
     stdout.writeln('\nDownload completed!');
     stdout.writeln('Download bytes size: ${result.bytes.length}');
@@ -272,15 +271,14 @@ Future<void> downloadFileOperation() async {
   );
 
   stdout.writeln('Downloading...');
-  // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
-  // can cancel underlying http request.
-  // await Future<void>.delayed(const Duration(seconds: 1));
-  // await downloadFileOperation.pause();
-
-  // await Future<void>.delayed(const Duration(seconds: 4));
-  // await downloadFileOperation.resume();
 
   try {
+    await Future<void>.delayed(const Duration(seconds: 2));
+    await downloadFileOperation.pause();
+
+    await Future<void>.delayed(const Duration(seconds: 30));
+    await downloadFileOperation.resume();
+
     final result = await downloadFileOperation.result;
     stdout.writeln('\nDownload completed!');
     stdout.writeln('Download file eTag: ${result.downloadedItem.eTag}');
@@ -358,13 +356,14 @@ Future<void> uploadFileOperation() async {
   );
 
   stdout.writeln('Uploading...');
-  await Future<void>.delayed(const Duration(seconds: 3));
-  await uploadFileOperation.pause();
-
-  await Future<void>.delayed(const Duration(seconds: 4));
-  await uploadFileOperation.resume();
 
   try {
+    await Future<void>.delayed(const Duration(seconds: 3));
+    await uploadFileOperation.pause();
+
+    await Future<void>.delayed(const Duration(seconds: 4));
+    await uploadFileOperation.resume();
+
     final result = await uploadFileOperation.result;
     stdout.writeln('\nUpload completed!');
     stdout.writeln('Upload file eTag: ${result.uploadedItem.eTag}');

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_data_operation.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_data_operation.dart
@@ -1,9 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO(HuiSF): remove
-// ignore_for_file: unused_field
-
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 
@@ -27,14 +24,12 @@ class S3DownloadDataOperation extends StorageDownloadDataOperation<
   final Future<void> Function() _pause;
   final Future<void> Function() _cancel;
 
-  // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
-  // can cancel underlying http request.
-  // @override
-  // Future<void> resume() => _resume();
+  @override
+  Future<void> resume() => _resume();
 
-  // @override
-  // Future<void> pause() => _pause();
+  @override
+  Future<void> pause() => _pause();
 
-  // @override
-  // Future<void> cancel() => _cancel();
+  @override
+  Future<void> cancel() => _cancel();
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_file_operation.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_file_operation.dart
@@ -1,9 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO(HuiSF): remove
-// ignore_for_file: unused_field
-
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 
@@ -27,18 +24,16 @@ class S3DownloadFileOperation extends StorageDownloadFileOperation<
   final Future<void> Function() _pause;
   final Future<void> Function() _cancel;
 
-  // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
-  // can cancel underlying http request.
-  // /// When using Amplify Storage S3 plugin in a Web App, this doesn't do
-  // /// anything as the download is managed by browser.
-  // @override
-  // Future<void> resume() => _resume();
+  /// When using Amplify Storage S3 plugin in a Web App, this doesn't do
+  /// anything as the download is managed by browser.
+  @override
+  Future<void> resume() => _resume();
 
-  // /// When using Amplify Storage S3 plugin in a Web App, this doesn't do
-  // /// anything as the download is managed by browser.
-  // @override
-  // Future<void> pause() => _pause();
+  /// When using Amplify Storage S3 plugin in a Web App, this doesn't do
+  /// anything as the download is managed by browser.
+  @override
+  Future<void> pause() => _pause();
 
-  // @override
-  // Future<void> cancel() => _cancel();
+  @override
+  Future<void> cancel() => _cancel();
 }

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -351,23 +351,21 @@ void main() {
         expect(result.downloadedItem, testItem);
       });
 
-      // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
-      // can cancel underlying http request.
-      // test(
-      //     'S3DownloadDataOperation pause resume and cancel APIs should interact with S3DownloadTask',
-      //     () async {
-      //   when(testS3DownloadTask.pause).thenAnswer((_) async {});
-      //   when(testS3DownloadTask.resume).thenAnswer((_) async {});
-      //   when(testS3DownloadTask.cancel).thenAnswer((_) async {});
+      test(
+          'S3DownloadDataOperation pause resume and cancel APIs should interact with S3DownloadTask',
+          () async {
+        when(testS3DownloadTask.pause).thenAnswer((_) async {});
+        when(testS3DownloadTask.resume).thenAnswer((_) async {});
+        when(testS3DownloadTask.cancel).thenAnswer((_) async {});
 
-      //   await downloadDataOperation.pause();
-      //   await downloadDataOperation.resume();
-      //   await downloadDataOperation.cancel();
+        await downloadDataOperation.pause();
+        await downloadDataOperation.resume();
+        await downloadDataOperation.cancel();
 
-      //   verify(testS3DownloadTask.pause).called(1);
-      //   verify(testS3DownloadTask.resume).called(1);
-      //   verify(testS3DownloadTask.cancel).called(1);
-      // });
+        verify(testS3DownloadTask.pause).called(1);
+        verify(testS3DownloadTask.resume).called(1);
+        verify(testS3DownloadTask.cancel).called(1);
+      });
     });
 
     group('uploadData() API', () {
@@ -442,21 +440,15 @@ void main() {
         expect(result.uploadedItem, testItem);
       });
 
-      // test(
-      //     'S3UploadDataOperation pause resume and cancel APIs should interact with S3DownloadTask',
-      //     () async {
-      //   when(testS3UploadTask.pause).thenAnswer((_) async {});
-      //   when(testS3UploadTask.resume).thenAnswer((_) async {});
-      //   when(testS3UploadTask.cancel).thenAnswer((_) async {});
+      test(
+          'S3UploadDataOperation cancel APIs should interact with S3DownloadTask',
+          () async {
+        when(testS3UploadTask.cancel).thenAnswer((_) async {});
 
-      //   await uploadDataOperation.pause();
-      //   await uploadDataOperation.resume();
-      //   await uploadDataOperation.cancel();
+        await uploadDataOperation.cancel();
 
-      //   verify(testS3UploadTask.pause).called(1);
-      //   verify(testS3UploadTask.resume).called(1);
-      //   verify(testS3UploadTask.cancel).called(1);
-      // });
+        verify(testS3UploadTask.cancel).called(1);
+      });
     });
 
     group('uploadFile() API', () {
@@ -533,23 +525,21 @@ void main() {
         expect(result.uploadedItem, testItem);
       });
 
-      // TODO(HuiSF): enable this test when upload opeartion regain the control
-      //  APIs.
-      // test(
-      //     'S3DownloadUploadOperation pause resume and cancel APIs should interact with S3DownloadTask',
-      //     () async {
-      //   when(testS3UploadTask.pause).thenAnswer((_) async {});
-      //   when(testS3UploadTask.resume).thenAnswer((_) async {});
-      //   when(testS3UploadTask.cancel).thenAnswer((_) async {});
+      test(
+          'S3DownloadUploadOperation pause resume and cancel APIs should interact with S3DownloadTask',
+          () async {
+        when(testS3UploadTask.pause).thenAnswer((_) async {});
+        when(testS3UploadTask.resume).thenAnswer((_) async {});
+        when(testS3UploadTask.cancel).thenAnswer((_) async {});
 
-      //   await uploadFileOperation.pause();
-      //   await uploadFileOperation.resume();
-      //   await uploadFileOperation.cancel();
+        await uploadFileOperation.pause();
+        await uploadFileOperation.resume();
+        await uploadFileOperation.cancel();
 
-      //   verify(testS3UploadTask.pause).called(1);
-      //   verify(testS3UploadTask.resume).called(1);
-      //   verify(testS3UploadTask.cancel).called(1);
-      // });
+        verify(testS3UploadTask.pause).called(1);
+        verify(testS3UploadTask.resume).called(1);
+        verify(testS3UploadTask.cancel).called(1);
+      });
     });
 
     group('copy() API', () {

--- a/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_html_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_html_test.dart
@@ -26,8 +26,6 @@ class DummyPathProvider implements AppPathProvider {
   }
 }
 
-// ignore: invalid_annotation_target
-
 void main() {
   group('downloadFile() html implementation', () {
     late StorageS3Service storageS3Service;

--- a/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
@@ -295,36 +295,34 @@ void main() {
       });
     });
 
-    // TODO(HuiSF): re-enable controllable APIs when SmithyOperation.cancel
-    // can cancel underlying http request.
-    // test(
-    //     'returned S3DownloadFileOperation pause resume and cancel APIs should interact with S3DownloadTask',
-    //     () async {
-    //   when(() => downloadTask.result).thenAnswer((_) async => testItem);
-    //   when(downloadTask.pause).thenAnswer((_) async {});
-    //   when(downloadTask.resume).thenAnswer((_) async {});
-    //   when(downloadTask.cancel).thenAnswer((_) async {});
+    test(
+        'returned S3DownloadFileOperation pause resume and cancel APIs should interact with S3DownloadTask',
+        () async {
+      when(() => downloadTask.result).thenAnswer((_) async => testItem);
+      when(downloadTask.pause).thenAnswer((_) async {});
+      when(downloadTask.resume).thenAnswer((_) async {});
+      when(downloadTask.cancel).thenAnswer((_) async {});
 
-    //   final downloadFileOperation = downloadFile(
-    //     request: StorageDownloadFileRequest(
-    //       key: testKey,
-    //       localFile: AWSFile.fromPath('path'),
-    //     ),
-    //     s3pluginConfig: testS3pluginConfig,
-    //     storageS3Service: storageS3Service,
-    //     appPathProvider: appPathProvider,
-    //     onProgress: (progress) {
-    //       expectedProgress = progress;
-    //     },
-    //   );
+      final downloadFileOperation = downloadFile(
+        request: StorageDownloadFileRequest(
+          key: testKey,
+          localFile: AWSFile.fromPath('path'),
+        ),
+        s3pluginConfig: testS3pluginConfig,
+        storageS3Service: storageS3Service,
+        appPathProvider: appPathProvider,
+        onProgress: (progress) {
+          expectedProgress = progress;
+        },
+      );
 
-    //   await downloadFileOperation.pause();
-    //   await downloadFileOperation.resume();
-    //   await downloadFileOperation.cancel();
+      await downloadFileOperation.pause();
+      await downloadFileOperation.resume();
+      await downloadFileOperation.cancel();
 
-    //   verify(downloadTask.pause).called(1);
-    //   verify(downloadTask.resume).called(1);
-    //   verify(downloadTask.cancel).called(1);
-    // });
+      verify(downloadTask.pause).called(1);
+      verify(downloadTask.resume).called(1);
+      verify(downloadTask.cancel).called(1);
+    });
   });
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Functionality of canceling a download operation depends on https://github.com/aws-amplify/amplify-flutter/pull/2545.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
