### PR TITLE
feat(storage): web implementation of transfer database using local storage

### DIFF
--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -8,6 +8,7 @@ import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/database/transfer_record.dart';
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/transfer.dart'
     as transfer;
 import 'package:async/async.dart';
@@ -463,8 +464,6 @@ class S3UploadTask {
         ..metadata.addAll(_options.metadata ?? const {});
     });
 
-    final createdAt = DateTime.now().toIso8601String();
-
     try {
       final output = await _s3Client.createMultipartUpload(request).result;
       final uploadId = output.uploadId;
@@ -473,10 +472,10 @@ class S3UploadTask {
         throw S3Exception.unexpectedMultipartUploadId();
       } else {
         await _transferDatabase.insertTransferRecord(
-          transfer.TransferRecordsCompanion.insert(
+          TransferRecord(
             uploadId: uploadId,
             objectKey: _resolvedKey,
-            createdAt: createdAt,
+            createdAt: DateTime.now(),
           ),
         );
         _multipartUploadId = uploadId;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/database_html.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/database_html.dart
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:html';
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/database/database_stub.dart'
+    as stub;
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/database/transfer_record.dart';
+
+/// a key prefix used by [TransferDatabase] when adding a key value pair into local storage.
+/// it is an identifier to differentiate the data stored by [TransferDatabase] into local storage from others.
+const _localStorageKeyPrefix = 'amplify_storage_transfer_data_';
+
+/// {@macro amplify_storage_s3_dart.transfer_database}
+class TransferDatabase implements stub.TransferDatabase {
+  /// {@macro amplify_storage_s3_dart.transfer_database_token}
+  static const token = Token<TransferDatabase>();
+
+  Iterable<MapEntry<String, String>> get _entries => window.localStorage.entries
+      .where((element) => element.key.startsWith(_localStorageKeyPrefix));
+
+  @override
+  Future<int> deleteTransferRecords(String uploadId) async {
+    var result = 0;
+    for (final element in _entries) {
+      final transferRecord = TransferRecord.fromJsonString(element.value);
+      if (transferRecord.uploadId == uploadId) {
+        window.localStorage.remove(element.key);
+        result++;
+      }
+    }
+
+    return result;
+  }
+
+  @override
+  Future<List<TransferRecord>> getMultipartUploadRecordsCreatedBefore(
+    DateTime dateTime,
+  ) async {
+    final result = <TransferRecord>[];
+    for (final element in _entries) {
+      final value = element.value;
+      final transferRecord = TransferRecord.fromJsonString(value);
+      if (transferRecord.createdAt.isBefore(dateTime)) {
+        result.add(transferRecord);
+      }
+    }
+    return result;
+  }
+
+  @override
+  Future<String> insertTransferRecord(TransferRecord data) async {
+    final key = _localStorageKeyPrefix + uuid();
+    window.localStorage[key] = data.toJsonString();
+    return key;
+  }
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/database_io.g.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/database_io.g.dart
@@ -1,0 +1,270 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'database_io.dart';
+
+// ignore_for_file: type=lint
+class $TransferRecordsTable extends TransferRecords
+    with TableInfo<$TransferRecordsTable, TransferRecord> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $TransferRecordsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _uploadIdMeta =
+      const VerificationMeta('uploadId');
+  @override
+  late final GeneratedColumn<String> uploadId = GeneratedColumn<String>(
+      'upload_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _objectKeyMeta =
+      const VerificationMeta('objectKey');
+  @override
+  late final GeneratedColumn<String> objectKey = GeneratedColumn<String>(
+      'object_key', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
+  @override
+  late final GeneratedColumn<String> createdAt = GeneratedColumn<String>(
+      'created_at', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  @override
+  List<GeneratedColumn> get $columns => [id, uploadId, objectKey, createdAt];
+  @override
+  String get aliasedName => _alias ?? 'transfer_records';
+  @override
+  String get actualTableName => 'transfer_records';
+  @override
+  VerificationContext validateIntegrity(Insertable<TransferRecord> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('upload_id')) {
+      context.handle(_uploadIdMeta,
+          uploadId.isAcceptableOrUnknown(data['upload_id']!, _uploadIdMeta));
+    } else if (isInserting) {
+      context.missing(_uploadIdMeta);
+    }
+    if (data.containsKey('object_key')) {
+      context.handle(_objectKeyMeta,
+          objectKey.isAcceptableOrUnknown(data['object_key']!, _objectKeyMeta));
+    } else if (isInserting) {
+      context.missing(_objectKeyMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  TransferRecord map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return TransferRecord(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uploadId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}upload_id'])!,
+      objectKey: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}object_key'])!,
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}created_at'])!,
+    );
+  }
+
+  @override
+  $TransferRecordsTable createAlias(String alias) {
+    return $TransferRecordsTable(attachedDatabase, alias);
+  }
+}
+
+class TransferRecord extends DataClass implements Insertable<TransferRecord> {
+  /// The record id.
+  final int id;
+
+  /// The multipart upload id.
+  final String uploadId;
+
+  /// The object key associated with the [uploadId].
+  final String objectKey;
+
+  /// Timestamp of [uploadId] creation.
+  final String createdAt;
+  const TransferRecord(
+      {required this.id,
+      required this.uploadId,
+      required this.objectKey,
+      required this.createdAt});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['upload_id'] = Variable<String>(uploadId);
+    map['object_key'] = Variable<String>(objectKey);
+    map['created_at'] = Variable<String>(createdAt);
+    return map;
+  }
+
+  TransferRecordsCompanion toCompanion(bool nullToAbsent) {
+    return TransferRecordsCompanion(
+      id: Value(id),
+      uploadId: Value(uploadId),
+      objectKey: Value(objectKey),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory TransferRecord.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return TransferRecord(
+      id: serializer.fromJson<int>(json['id']),
+      uploadId: serializer.fromJson<String>(json['uploadId']),
+      objectKey: serializer.fromJson<String>(json['objectKey']),
+      createdAt: serializer.fromJson<String>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'uploadId': serializer.toJson<String>(uploadId),
+      'objectKey': serializer.toJson<String>(objectKey),
+      'createdAt': serializer.toJson<String>(createdAt),
+    };
+  }
+
+  TransferRecord copyWith(
+          {int? id, String? uploadId, String? objectKey, String? createdAt}) =>
+      TransferRecord(
+        id: id ?? this.id,
+        uploadId: uploadId ?? this.uploadId,
+        objectKey: objectKey ?? this.objectKey,
+        createdAt: createdAt ?? this.createdAt,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('TransferRecord(')
+          ..write('id: $id, ')
+          ..write('uploadId: $uploadId, ')
+          ..write('objectKey: $objectKey, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, uploadId, objectKey, createdAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is TransferRecord &&
+          other.id == this.id &&
+          other.uploadId == this.uploadId &&
+          other.objectKey == this.objectKey &&
+          other.createdAt == this.createdAt);
+}
+
+class TransferRecordsCompanion extends UpdateCompanion<TransferRecord> {
+  final Value<int> id;
+  final Value<String> uploadId;
+  final Value<String> objectKey;
+  final Value<String> createdAt;
+  const TransferRecordsCompanion({
+    this.id = const Value.absent(),
+    this.uploadId = const Value.absent(),
+    this.objectKey = const Value.absent(),
+    this.createdAt = const Value.absent(),
+  });
+  TransferRecordsCompanion.insert({
+    this.id = const Value.absent(),
+    required String uploadId,
+    required String objectKey,
+    required String createdAt,
+  })  : uploadId = Value(uploadId),
+        objectKey = Value(objectKey),
+        createdAt = Value(createdAt);
+  static Insertable<TransferRecord> custom({
+    Expression<int>? id,
+    Expression<String>? uploadId,
+    Expression<String>? objectKey,
+    Expression<String>? createdAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (uploadId != null) 'upload_id': uploadId,
+      if (objectKey != null) 'object_key': objectKey,
+      if (createdAt != null) 'created_at': createdAt,
+    });
+  }
+
+  TransferRecordsCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? uploadId,
+      Value<String>? objectKey,
+      Value<String>? createdAt}) {
+    return TransferRecordsCompanion(
+      id: id ?? this.id,
+      uploadId: uploadId ?? this.uploadId,
+      objectKey: objectKey ?? this.objectKey,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (uploadId.present) {
+      map['upload_id'] = Variable<String>(uploadId.value);
+    }
+    if (objectKey.present) {
+      map['object_key'] = Variable<String>(objectKey.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<String>(createdAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('TransferRecordsCompanion(')
+          ..write('id: $id, ')
+          ..write('uploadId: $uploadId, ')
+          ..write('objectKey: $objectKey, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$TransferDatabase extends GeneratedDatabase {
+  _$TransferDatabase(QueryExecutor e) : super(e);
+  late final $TransferRecordsTable transferRecords =
+      $TransferRecordsTable(this);
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [transferRecords];
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/database_stub.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/database_stub.dart
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/database/transfer_record.dart';
+
+/// {@template amplify_storage_s3_dart.transfer_database}
+/// Database to persist [TransferRecord] created by Storage S3 plugin upload
+/// operations.
+/// {@endtemplate}
+class TransferDatabase {
+  /// {@template amplify_storage_s3_dart.transfer_database_token}
+  /// The dependency token for [TransferDatabase].
+  /// {@endtemplate}
+  static Token<TransferDatabase> token = const Token<TransferDatabase>();
+
+  /// {@template amplify_storage_s3_dart.transfer_database_get}
+  /// Gets a list of multipart upload records that are created earlier than
+  /// [dateTime].
+  /// {@endtemplate}
+  Future<List<TransferRecord>> getMultipartUploadRecordsCreatedBefore(
+    DateTime dateTime,
+  ) {
+    throw UnimplementedError(
+      'getMultipartUploadRecordsCreatedBefore method is not implemented in the current platform.',
+    );
+  }
+
+  /// {@template amplify_storage_s3_dart.transfer_database_insert}
+  /// Inserts [record], a [TransferRecord], to the database.
+  /// returns the key for the inserted record into the database.
+  /// {@endtemplate}
+  Future<String> insertTransferRecord(TransferRecord record) {
+    throw UnimplementedError(
+      'insertTransferRecord method is not implemented in the current platform.',
+    );
+  }
+
+  /// {@template amplify_storage_s3_dart.transfer_database_delete}
+  /// Deletes [TransferRecord]s from the database where
+  /// [TransferRecord.uploadId] is equal to [uploadId].
+  /// returns number of recordes deleted from the database.
+  /// {@endtemplate}
+  Future<int> deleteTransferRecords(String uploadId) {
+    throw UnimplementedError(
+      'deleteTransferRecords method is not implemented in the current platform.',
+    );
+  }
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/tables.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/tables.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/database/database.dart';
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/database/database_io.dart';
 import 'package:drift/drift.dart';
 
 /// Schema of the TransferRecords table in SQLite

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/transfer_record.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/transfer_record.dart
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:convert';
+
+import 'package:json_annotation/json_annotation.dart';
+
+part 'transfer_record.g.dart';
+
+/// {@template amplify_storage_s3_dart.transfer_data}
+/// the type used by Storage S3 plugin upload operations when using s3 multipart upload.
+/// it is persisted to TransferDatabase.
+/// {@endtemplate amplify_storage_s3_dart.transfer_data}
+@JsonSerializable()
+class TransferRecord {
+  /// {@macro amplify_storage_s3_dart.transfer_data}
+  const TransferRecord({
+    required this.uploadId,
+    required this.objectKey,
+    required this.createdAt,
+  });
+
+  /// creates new [TransferRecord] object from a [json] map.
+  factory TransferRecord.fromJson(Map<String, dynamic> json) =>
+      _$TransferRecordFromJson(json);
+
+  /// creates new [TransferRecord] object from [jsonString].
+  factory TransferRecord.fromJsonString(String jsonString) {
+    return TransferRecord.fromJson(
+      jsonDecode(jsonString) as Map<String, dynamic>,
+    );
+  }
+
+  /// The multipart upload id.
+  final String uploadId;
+
+  /// The object key associated with the [uploadId].
+  final String objectKey;
+
+  /// Timestamp of [uploadId] creation.
+  final DateTime createdAt;
+
+  /// return json map representation of [TransferRecord] object.
+  Map<String, dynamic> toJson() => _$TransferRecordToJson(this);
+
+  /// return json string representation of [TransferRecord] object.
+  String toJsonString() => jsonEncode(toJson());
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/transfer_record.g.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/transfer_record.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'transfer_record.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TransferRecord _$TransferRecordFromJson(Map<String, dynamic> json) =>
+    TransferRecord(
+      uploadId: json['uploadId'] as String,
+      objectKey: json['objectKey'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+
+Map<String, dynamic> _$TransferRecordToJson(TransferRecord instance) =>
+    <String, dynamic>{
+      'uploadId': instance.uploadId,
+      'objectKey': instance.objectKey,
+      'createdAt': instance.createdAt.toIso8601String(),
+    };

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/transfer.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/transfer.dart
@@ -1,4 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export 'database/database.dart';
+export 'database/database_stub.dart'
+    if (dart.library.html) 'database/database_html.dart'
+    if (dart.library.io) 'database/database_io.dart';

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   built_value: ">=8.4.0 <8.5.0"
   drift: ">=2.4.0 <2.6.0"
   fixnum: ^1.0.0
+  json_annotation: ">=4.8.0 <4.9.0"
   meta: ^1.7.0
   path: ^1.8.0
   smithy: ">=0.4.0+2 <0.5.0"
@@ -29,5 +30,6 @@ dev_dependencies:
   build_verify: ^3.0.0
   built_value_generator: 8.4.3
   drift_dev: ^2.2.0+1
+  json_serializable: 6.6.1
   mocktail: ^0.3.0
   test: ^1.16.0

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
@@ -8,6 +8,7 @@ import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/database/transfer_record.dart';
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/transfer.dart'
     as transfer;
 import 'package:mocktail/mocktail.dart';
@@ -71,7 +72,11 @@ void main() {
       );
 
       registerFallbackValue(
-        const transfer.TransferRecordsCompanion(),
+        TransferRecord(
+          uploadId: 'uploadId',
+          objectKey: 'dummy key',
+          createdAt: DateTime(2022, 1, 1),
+        ),
       );
 
       registerFallbackValue(const smithy_aws.S3ClientConfig());
@@ -698,8 +703,8 @@ void main() {
         ).thenAnswer((_) => createMultipartUploadSmithyOperation);
 
         when(
-          () => transferDatabase.insertTransferRecord(any()),
-        ).thenAnswer((_) async => 1);
+          () => transferDatabase.insertTransferRecord(any<TransferRecord>()),
+        ).thenAnswer((_) async => '1');
 
         final testUploadPartOutput1 = s3.UploadPartOutput(eTag: 'eTag-part-1');
         final testUploadPartOutput2 = s3.UploadPartOutput(eTag: 'eTag-part-2');
@@ -817,13 +822,13 @@ void main() {
         );
         final capturedTransferDBInsertParam = verify(
           () => transferDatabase.insertTransferRecord(
-            captureAny<transfer.TransferRecordsCompanion>(),
+            captureAny<TransferRecord>(),
           ),
         ).captured.last;
         expect(
           capturedTransferDBInsertParam,
-          isA<transfer.TransferRecordsCompanion>().having(
-            (o) => o.uploadId.value,
+          isA<TransferRecord>().having(
+            (o) => o.uploadId,
             'uploadId',
             testMultipartUploadId,
           ),
@@ -928,7 +933,7 @@ void main() {
 
         when(
           () => transferDatabase.insertTransferRecord(any()),
-        ).thenAnswer((_) async => 1);
+        ).thenAnswer((_) async => '1');
 
         final testUploadPartOutput = s3.UploadPartOutput(eTag: 'eTag');
         final uploadPartSmithyOperation =
@@ -1024,7 +1029,7 @@ void main() {
 
         when(
           () => transferDatabase.insertTransferRecord(any()),
-        ).thenAnswer((_) async => 1);
+        ).thenAnswer((_) async => '1');
 
         final testUploadPartOutput = s3.UploadPartOutput(eTag: 'eTag-part-1');
         final uploadPartSmithyOperation =
@@ -1243,7 +1248,7 @@ void main() {
 
         when(
           () => transferDatabase.insertTransferRecord(any()),
-        ).thenAnswer((_) async => 1);
+        ).thenAnswer((_) async => '1');
 
         final testUploadPartOutput = s3.UploadPartOutput(eTag: 'eTag-part-1');
         final uploadPartSmithyOperation =
@@ -1324,7 +1329,7 @@ void main() {
 
         when(
           () => transferDatabase.insertTransferRecord(any()),
-        ).thenAnswer((_) async => 1);
+        ).thenAnswer((_) async => '1');
 
         const testException = smithy.UnknownSmithyHttpException(
           statusCode: 403,
@@ -1415,7 +1420,7 @@ void main() {
 
         when(
           () => transferDatabase.insertTransferRecord(any()),
-        ).thenAnswer((_) async => 1);
+        ).thenAnswer((_) async => '1');
 
         final testUploadPartOutput = s3.UploadPartOutput(eTag: null);
         final uploadPartSmithyOperation =
@@ -1485,7 +1490,7 @@ void main() {
 
         when(
           () => transferDatabase.insertTransferRecord(any()),
-        ).thenAnswer((_) async => 1);
+        ).thenAnswer((_) async => '1');
 
         final testException = s3.NoSuchUpload();
         when(
@@ -1551,7 +1556,7 @@ void main() {
 
           when(
             () => transferDatabase.insertTransferRecord(any()),
-          ).thenAnswer((_) async => 1);
+          ).thenAnswer((_) async => '1');
 
           when(
             uploadPartSmithyOperation1.cancel,

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/transfer/database_html_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/transfer/database_html_test.dart
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@TestOn('browser')
+
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/database/database_html.dart';
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/database/transfer_record.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TransferDatabase for web', () {
+    const testUploadId = 'test-upload-Id';
+    const testObjectKey = 'test-object-Key';
+    final testCreatedAt = DateTime(2022, 1, 1);
+
+    final testTransferRecord = TransferRecord(
+      uploadId: testUploadId,
+      objectKey: testObjectKey,
+      createdAt: testCreatedAt,
+    );
+
+    final testTransferRecordJsonString = testTransferRecord.toJsonString();
+
+    late TransferDatabase transferDatabase;
+
+    setUp(() async {
+      transferDatabase = TransferDatabase();
+      await transferDatabase.deleteTransferRecords(testUploadId);
+    });
+
+    test('insert and deleteTransferRecords from local storage', () async {
+      final recordId =
+          await transferDatabase.insertTransferRecord(testTransferRecord);
+      expect(recordId, isNotNull);
+      final actual = await transferDatabase.deleteTransferRecords(testUploadId);
+      expect(actual, 1);
+    });
+
+    test('getMultipartUploadRecordsCreatedBefore should return one item',
+        () async {
+      await transferDatabase.insertTransferRecord(testTransferRecord);
+      final actual =
+          await transferDatabase.getMultipartUploadRecordsCreatedBefore(
+        testCreatedAt.add(const Duration(days: 1)),
+      );
+      expect(actual.length, 1);
+      expect(actual.first.toJsonString(), testTransferRecordJsonString);
+    });
+
+    test('getMultipartUploadRecordsCreatedBefore should return empty list',
+        () async {
+      await transferDatabase.insertTransferRecord(testTransferRecord);
+      final actual =
+          await transferDatabase.getMultipartUploadRecordsCreatedBefore(
+        testCreatedAt,
+      );
+      expect(actual.length, 0);
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3_dart/test/test_utils/mocks.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/test_utils/mocks.dart
@@ -4,7 +4,7 @@
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';
-import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/database/database.dart';
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/transfer.dart';
 import 'package:aws_signature_v4/aws_signature_v4.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:smithy/smithy.dart';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add web implementation of TransferDataBase to stop using drift in web.
- add TransferDatabase stub
- add TransferData class
- update native implementation to implement the TransferDatabase stub
- implement TransferDatabase for web using local storage
- add unit tests 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
