### PR TITLE
fix(secure_storage): clear SharedPreferences on first app launch after install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,6 +247,7 @@ workflows:
                   "amplify_auth_cognito",
                   "amplify_datastore",
                   "amplify_flutter",
+                  "amplify_secure_storage",
                 ]
       - unit_test_ios:
           matrix:

--- a/.circleci/test_all_plugins.sh
+++ b/.circleci/test_all_plugins.sh
@@ -13,6 +13,9 @@ category_dir=$(echo $plugin | cut -d'_' -f 2)
 if [[ "$plugin" =~ "amplify_flutter" ]]; then
     category_dir="amplify" 
 fi
+if [[ "$plugin" =~ "amplify_secure_storage" ]]; then
+    category_dir="secure_storage" 
+fi
 
 set +e
 set -o pipefail

--- a/packages/secure_storage/amplify_secure_storage/android/build.gradle
+++ b/packages/secure_storage/amplify_secure_storage/android/build.gradle
@@ -51,8 +51,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.security:security-crypto:1.0.0'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-inline:3.11.2'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
     testImplementation 'org.robolectric:robolectric:4.9'
     testImplementation 'androidx.test:core-ktx:1.5.0'
 }

--- a/packages/secure_storage/amplify_secure_storage/android/build.gradle
+++ b/packages/secure_storage/amplify_secure_storage/android/build.gradle
@@ -43,9 +43,16 @@ android {
     defaultConfig {
         minSdkVersion 23
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.security:security-crypto:1.0.0'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-inline:3.11.2'
+    testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
+    testImplementation 'org.robolectric:robolectric:4.9'
+    testImplementation 'androidx.test:core-ktx:1.5.0'
 }

--- a/packages/secure_storage/amplify_secure_storage/android/gradle.properties
+++ b/packages/secure_storage/amplify_secure_storage/android/gradle.properties
@@ -1,0 +1,1 @@
+android.enableUnitTestBinaryResources=true

--- a/packages/secure_storage/amplify_secure_storage/android/src/main/kotlin/com/amazonaws/amplify/amplify_secure_storage/amplify_secure_storage/EncryptedKeyValueRepository.kt
+++ b/packages/secure_storage/amplify_secure_storage/android/src/main/kotlin/com/amazonaws/amplify/amplify_secure_storage/amplify_secure_storage/EncryptedKeyValueRepository.kt
@@ -4,35 +4,27 @@
 package com.amazonaws.amplify.amplify_secure_storage.amplify_secure_storage
 
 import android.content.Context
+import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV
 import androidx.security.crypto.EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
 import androidx.security.crypto.MasterKeys
+import java.io.File
 
 class EncryptedKeyValueRepository(
     private val context: Context,
     private val sharedPreferencesName: String,
 ) : KeyValueRepository {
 
-    override fun put(dataKey: String, value: String?) {
-        with(getSharedPreferences().edit()) {
-            putString(dataKey, value)
-            apply()
+    private val sharedPreferences: SharedPreferences by lazy {
+        // Attempt to remove previous SharedPreferences file if not initialized.
+        if (!initializationFlagFile.exists()) {
+            context.getSharedPreferences(sharedPreferencesName, MODE_PRIVATE).edit().clear().commit()
+            initializationFlagFile.createNewFile()
         }
-    }
-
-    override fun get(dataKey: String): String? = getSharedPreferences().getString(dataKey, null)
-
-    override fun remove(dataKey: String) {
-        with(getSharedPreferences().edit()) {
-            remove(dataKey)
-            apply()
-        }
-    }
-
-    private fun getSharedPreferences(): SharedPreferences {
-        return EncryptedSharedPreferences.create(
+        EncryptedSharedPreferences.create(
             sharedPreferencesName,
             MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
             context,
@@ -40,4 +32,34 @@ class EncryptedKeyValueRepository(
             AES256_GCM
         )
     }
+
+    private val editor: SharedPreferences.Editor by lazy {
+        sharedPreferences.edit()
+    }
+
+    override fun put(dataKey: String, value: String?) {
+        with(editor) {
+            putString(dataKey, value)
+            apply()
+        }
+    }
+
+    override fun get(dataKey: String): String? = sharedPreferences.getString(dataKey, null)
+
+    override fun remove(dataKey: String) {
+        with(editor) {
+            remove(dataKey)
+            apply()
+        }
+    }
+
+    /**
+     * A file used as a flag to indicate if the SharedPreferences file has been created since the
+     * most recent app install.
+     */
+    @VisibleForTesting
+    val initializationFlagFile: File by lazy {
+        File(context.noBackupFilesDir, "amplify_EncryptedSharedPreferences_$sharedPreferencesName")
+    }
+
 }

--- a/packages/secure_storage/amplify_secure_storage/android/src/test/kotlin/com/amazonaws/amplify/amplify_secure_storage/amplify_secure_storage/EncryptedKeyValueRepositoryTest.kt
+++ b/packages/secure_storage/amplify_secure_storage/android/src/test/kotlin/com/amazonaws/amplify/amplify_secure_storage/amplify_secure_storage/EncryptedKeyValueRepositoryTest.kt
@@ -1,0 +1,64 @@
+package com.amazonaws.amplify.amplify_secure_storage.amplify_secure_storage
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [23,33])
+class EncryptedKeyValueRepositoryTest {
+    private var context: Context = ApplicationProvider.getApplicationContext()
+    private var repo: EncryptedKeyValueRepository = EncryptedKeyValueRepository(context, "test")
+
+    private fun clearNoBackUpDir() {
+        repo.initializationFlagFile.delete()
+    }
+
+    @Before
+    fun setup() {
+        FakeAndroidKeyStore.setup
+        clearNoBackUpDir()
+    }
+
+    @After
+    fun tearDown() {
+        clearNoBackUpDir()
+    }
+
+    @Test
+    fun `can read, write, and delete`()  {
+        repo.put("key_1", "val_1")
+        assertEquals("val_1", repo.get("key_1"))
+
+        repo.remove("key_1")
+        assertNull(repo.get("key_1"))
+    }
+
+    @Test
+    fun `data persists across EncryptedKeyValueRepository instances `()  {
+        repo.put("key_1", "val_1")
+        assertEquals("val_1", repo.get("key_1"))
+
+        val repo2 = EncryptedKeyValueRepository(context, "test")
+        assertEquals("val_1", repo2.get("key_1"))
+    }
+
+    @Test
+    fun `data does not persist app re-install`()  {
+        repo.put("key_1", "val_1")
+        assertEquals("val_1", repo.get("key_1"))
+
+        clearNoBackUpDir() // simulate a re-install by clearing the no backup dir
+
+        val repo2 = EncryptedKeyValueRepository(context, "test")
+        assertNull(repo2.get("key_1"))
+    }
+
+}

--- a/packages/secure_storage/amplify_secure_storage/android/src/test/kotlin/com/amazonaws/amplify/amplify_secure_storage/amplify_secure_storage/EncryptedKeyValueRepositoryTest.kt
+++ b/packages/secure_storage/amplify_secure_storage/android/src/test/kotlin/com/amazonaws/amplify/amplify_secure_storage/amplify_secure_storage/EncryptedKeyValueRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.amazonaws.amplify.amplify_secure_storage.amplify_secure_storage
 
 import android.content.Context
+import android.content.Context.MODE_PRIVATE
 import androidx.test.core.app.ApplicationProvider
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -15,7 +16,8 @@ import org.robolectric.annotation.Config
 @Config(manifest = Config.NONE, sdk = [23,33])
 class EncryptedKeyValueRepositoryTest {
     private var context: Context = ApplicationProvider.getApplicationContext()
-    private var repo: EncryptedKeyValueRepository = EncryptedKeyValueRepository(context, "test")
+
+    private var repo: EncryptedKeyValueRepository = TestEncryptedKeyValueRepository(context, "test")
 
     private fun clearNoBackUpDir() {
         repo.initializationFlagFile.delete()
@@ -46,7 +48,7 @@ class EncryptedKeyValueRepositoryTest {
         repo.put("key_1", "val_1")
         assertEquals("val_1", repo.get("key_1"))
 
-        val repo2 = EncryptedKeyValueRepository(context, "test")
+        val repo2 = TestEncryptedKeyValueRepository(context, "test")
         assertEquals("val_1", repo2.get("key_1"))
     }
 
@@ -57,8 +59,22 @@ class EncryptedKeyValueRepositoryTest {
 
         clearNoBackUpDir() // simulate a re-install by clearing the no backup dir
 
-        val repo2 = EncryptedKeyValueRepository(context, "test")
+        val repo2 = TestEncryptedKeyValueRepository(context, "test")
         assertNull(repo2.get("key_1"))
     }
 
+}
+
+class TestEncryptedKeyValueRepository(
+    private val context: Context,
+    sharedPreferencesName: String,
+): EncryptedKeyValueRepository(context, sharedPreferencesName) {
+
+    /**
+     * Override removeSharedPreferencesFile in test because File().delete() will not clear
+     * data in test environment.
+     */
+    override fun removeSharedPreferencesFile() {
+        context.getSharedPreferences("test", MODE_PRIVATE).edit().clear().commit()
+    }
 }

--- a/packages/secure_storage/amplify_secure_storage/android/src/test/kotlin/com/amazonaws/amplify/amplify_secure_storage/amplify_secure_storage/FakeAndroidKeyStore.kt
+++ b/packages/secure_storage/amplify_secure_storage/android/src/test/kotlin/com/amazonaws/amplify/amplify_secure_storage/amplify_secure_storage/FakeAndroidKeyStore.kt
@@ -1,0 +1,70 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.amplify.amplify_secure_storage.amplify_secure_storage
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.security.Key
+import java.security.KeyStore
+import java.security.KeyStoreSpi
+import java.security.Provider
+import java.security.SecureRandom
+import java.security.Security
+import java.security.cert.Certificate
+import java.security.spec.AlgorithmParameterSpec
+import java.util.Date
+import java.util.Enumeration
+import javax.crypto.KeyGenerator
+import javax.crypto.KeyGeneratorSpi
+import javax.crypto.SecretKey
+
+/**
+ * A Fake Keystore implementation to use in Tests since it is not available in robolectric.
+ * See: https://github.com/robolectric/robolectric/issues/1518
+ */
+object FakeAndroidKeyStore {
+
+    val setup by lazy {
+        Security.addProvider(object : Provider("AndroidKeyStore", 1.0, "") {
+            init {
+                put("KeyStore.AndroidKeyStore", FakeKeyStore::class.java.name)
+                put("KeyGenerator.AES", FakeAesKeyGenerator::class.java.name)
+            }
+        })
+    }
+
+    @Suppress("unused")
+    class FakeKeyStore : KeyStoreSpi() {
+        private val wrapped = KeyStore.getInstance(KeyStore.getDefaultType())
+
+        override fun engineIsKeyEntry(alias: String?): Boolean = wrapped.isKeyEntry(alias)
+        override fun engineIsCertificateEntry(alias: String?): Boolean = wrapped.isCertificateEntry(alias)
+        override fun engineGetCertificate(alias: String?): Certificate = wrapped.getCertificate(alias)
+        override fun engineGetCreationDate(alias: String?): Date = wrapped.getCreationDate(alias)
+        override fun engineDeleteEntry(alias: String?) = wrapped.deleteEntry(alias)
+        override fun engineSetKeyEntry(alias: String?, key: Key?, password: CharArray?, chain: Array<out Certificate>?) =
+            wrapped.setKeyEntry(alias, key, password, chain)
+
+        override fun engineSetKeyEntry(alias: String?, key: ByteArray?, chain: Array<out Certificate>?) = wrapped.setKeyEntry(alias, key, chain)
+        override fun engineStore(stream: OutputStream?, password: CharArray?) = wrapped.store(stream, password)
+        override fun engineSize(): Int = wrapped.size()
+        override fun engineAliases(): Enumeration<String> = wrapped.aliases()
+        override fun engineContainsAlias(alias: String?): Boolean = wrapped.containsAlias(alias)
+        override fun engineLoad(stream: InputStream?, password: CharArray?) = wrapped.load(stream, password)
+        override fun engineGetCertificateChain(alias: String?): Array<Certificate> = wrapped.getCertificateChain(alias)
+        override fun engineSetCertificateEntry(alias: String?, cert: Certificate?) = wrapped.setCertificateEntry(alias, cert)
+        override fun engineGetCertificateAlias(cert: Certificate?): String = wrapped.getCertificateAlias(cert)
+        override fun engineGetKey(alias: String?, password: CharArray?): Key? = wrapped.getKey(alias, password)
+    }
+
+    @Suppress("unused")
+    class FakeAesKeyGenerator : KeyGeneratorSpi() {
+        private val wrapped = KeyGenerator.getInstance("AES")
+
+        override fun engineInit(random: SecureRandom?) = Unit
+        override fun engineInit(params: AlgorithmParameterSpec?, random: SecureRandom?) = Unit
+        override fun engineInit(keysize: Int, random: SecureRandom?) = Unit
+        override fun engineGenerateKey(): SecretKey = wrapped.generateKey()
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #2500

**Context:** EncryptedSharedPreferences data can/will get backed up, but the keys to decrypt the data will not, meaning there is no way to decrypt the data.

*Description of changes:*
- Create a file in the noBackupDir to track EncryptedSharedPreferences init after an app install, and clear SharedPreferences if the file does not exist already.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
