### PR TITLE
feat(analytics): refactor event/endpoint clients

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint/example/integration_test/utils/mock_key_value_store.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/example/integration_test/utils/mock_key_value_store.dart
@@ -12,7 +12,7 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 /// between relaunches (e.g. between test groups).
 final SecureStorageInterface mockEndpointInfoStore = _MockEndpointInfoStore()
   ..write(
-    key: AmplifyAnalyticsPinpointDart.endpointIdStorageKey,
+    key: EndpointStoreKey.endpointId.name,
     value: mockEndpointId,
   );
 final String mockEndpointId = uuid();

--- a/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/DebugProfile.entitlements
@@ -10,9 +10,5 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)com.amazonaws.amplify.amplify-analytics-pinpoint-example</string>
-	</array>
 </dict>
 </plist>

--- a/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/DebugProfile.entitlements
@@ -10,5 +10,9 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.amazonaws.amplify.amplify-analytics-pinpoint-example</string>
+	</array>
 </dict>
 </plist>

--- a/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/Release.entitlements
+++ b/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/Release.entitlements
@@ -8,5 +8,9 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.amazonaws.amplify.amplify-analytics-pinpoint-example</string>
+	</array>
 </dict>
 </plist>

--- a/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/Release.entitlements
+++ b/packages/analytics/amplify_analytics_pinpoint/example/macos/Runner/Release.entitlements
@@ -8,9 +8,5 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)com.amazonaws.amplify.amplify-analytics-pinpoint-example</string>
-	</array>
 </dict>
 </plist>

--- a/packages/analytics/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
@@ -4,9 +4,9 @@
 /// Amplify Analytics Pinpoint
 library amplify_analytics_pinpoint;
 
-/// Overridable Flutter injected dependencies
+/// Overridable Flutter injected dependencies.
 export 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.dart'
     show AppLifecycleProvider, AWSPinpointUserProfile;
 
-/// Category Implementation
+/// Category Implementation.
 export 'src/analytics_plugin_impl.dart';

--- a/packages/analytics/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
@@ -10,6 +10,3 @@ export 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.
 
 /// Category Implementation
 export 'src/analytics_plugin_impl.dart';
-
-/// For Push Notifications
-export 'src/device_context_info_provider/flutter_device_context_info_provider.dart';

--- a/packages/analytics/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
@@ -4,6 +4,9 @@
 /// Amplify Analytics Pinpoint
 library amplify_analytics_pinpoint;
 
+/// For Push Notifications
+export 'package:amplify_analytics_pinpoint/src/device_context_info_provider/flutter_device_context_info_provider.dart';
+
 /// Overridable Flutter injected dependencies
 export 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.dart'
     show AppLifecycleProvider, AWSPinpointUserProfile;

--- a/packages/analytics/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/amplify_analytics_pinpoint.dart
@@ -4,12 +4,12 @@
 /// Amplify Analytics Pinpoint
 library amplify_analytics_pinpoint;
 
-/// For Push Notifications
-export 'package:amplify_analytics_pinpoint/src/device_context_info_provider/flutter_device_context_info_provider.dart';
-
 /// Overridable Flutter injected dependencies
 export 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.dart'
     show AppLifecycleProvider, AWSPinpointUserProfile;
 
 /// Category Implementation
 export 'src/analytics_plugin_impl.dart';
+
+/// For Push Notifications
+export 'src/device_context_info_provider/flutter_device_context_info_provider.dart';

--- a/packages/analytics/amplify_analytics_pinpoint/lib/src/device_context_info_provider/device_info_provider/device_info.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/src/device_context_info_provider/device_info_provider/device_info.dart
@@ -18,18 +18,18 @@ class DeviceInfo {
     this.platformVersion,
   });
 
-  /// Manufacturer
+  /// Manufacturer.
   final String? make;
 
-  /// Model name or number of device
+  /// Model name or number of device.
   final String? model;
 
-  /// Model version of device
+  /// Model version of device.
   final String? modelVersion;
 
   /// Platform: iOS/Android, etc.
   final DevicePlatform? platform;
 
-  /// Version of platform
+  /// Version of platform.
   final String? platformVersion;
 }

--- a/packages/analytics/amplify_analytics_pinpoint/lib/src/device_context_info_provider/device_info_provider/device_info_provider.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/src/device_context_info_provider/device_info_provider/device_info_provider.dart
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// {@template amplify_analytics_pinpoint.device_info_provider}
-/// Provides DeviceInfo from Flutter -> Dart
+/// Provides DeviceInfo from Flutter -> Dart.
 /// {@endtemplate}
 
-/// Multi platform class that provides DeviceInfo
-/// Requires Flutter specific dependencies
+/// Multi platform class that provides DeviceInfo.
+/// Requires Flutter specific dependencies.
 export 'device_info_provider_stub.dart'
     if (dart.library.html) 'device_info_provider_html.dart'
     if (dart.library.io) 'device_info_provider_io.dart';

--- a/packages/analytics/amplify_analytics_pinpoint/lib/src/device_context_info_provider/device_info_provider/device_info_provider_html.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/src/device_context_info_provider/device_info_provider/device_info_provider_html.dart
@@ -15,12 +15,10 @@ Future<DeviceInfo> getDeviceInfo() async {
     final webInfo = await deviceInfo.webBrowserInfo;
     return DeviceInfo(
       make: webInfo.vendor,
-      // vendor of the browser
       model: webInfo.browserName.toString(),
       modelVersion: osIdentifier.split('/')[1],
-      // version of browser
       platform: DevicePlatform.web,
-      platformVersion: webInfo.platform, // version of browser?
+      platformVersion: webInfo.platform,
     );
   } on PlatformException {
     return const DeviceInfo(

--- a/packages/analytics/amplify_analytics_pinpoint/lib/src/device_context_info_provider/device_info_provider/device_info_provider_html.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/src/device_context_info_provider/device_info_provider/device_info_provider_html.dart
@@ -14,9 +14,11 @@ Future<DeviceInfo> getDeviceInfo() async {
   try {
     final webInfo = await deviceInfo.webBrowserInfo;
     return DeviceInfo(
-      make: webInfo.vendor, // vendor of the browser
+      make: webInfo.vendor,
+      // vendor of the browser
       model: webInfo.browserName.toString(),
-      modelVersion: osIdentifier.split('/')[1], // version of browser
+      modelVersion: osIdentifier.split('/')[1],
+      // version of browser
       platform: DevicePlatform.web,
       platformVersion: webInfo.platform, // version of browser?
     );

--- a/packages/analytics/amplify_analytics_pinpoint/lib/src/device_context_info_provider/flutter_device_context_info_provider.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/src/device_context_info_provider/flutter_device_context_info_provider.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 /// {@template amplify_analytics_pinpoint.flutter_device_context_info_provider}
-/// Provide information required for Pinpoint EndpointDemographic object
+/// Provide information required for Pinpoint EndpointDemographic object.
 ///
 /// For more details see Pinpoint [Endpoint](https://docs.aws.amazon.com/pinpoint/latest/apireference/apps-application-id-endpoints.html) online spec.
 /// {@endtemplate}

--- a/packages/analytics/amplify_analytics_pinpoint/lib/src/flutter_app_lifecycle_provider.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/src/flutter_app_lifecycle_provider.dart
@@ -17,6 +17,7 @@ class FlutterAppLifecycleProvider extends WidgetsBindingObserver
   @override
   void setOnForegroundListener(void Function() onForeground) =>
       _onForeground = onForeground;
+
   @override
   void setOnBackgroundListener(void Function() onBackground) =>
       _onBackground = onBackground;

--- a/packages/analytics/amplify_analytics_pinpoint/lib/src/flutter_app_lifecycle_provider.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/src/flutter_app_lifecycle_provider.dart
@@ -5,7 +5,7 @@ import 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.
 import 'package:flutter/material.dart';
 
 /// {@template amplify_analytics_pinpoint.flutter_app_lifecycle_provider}
-/// Provides callbacks to notify listeners when app is foregrounded or backgrounded
+/// Provides callbacks to notify listeners when app is foregrounded or backgrounded.
 /// {@endtemplate}
 class FlutterAppLifecycleProvider extends WidgetsBindingObserver
     implements AppLifecycleProvider {
@@ -36,10 +36,10 @@ class FlutterAppLifecycleProvider extends WidgetsBindingObserver
     WidgetsBinding.instance.removeObserver(this);
   }
 
-  // Current implementation based on Android
-  // TODO(fjnoyp): consider supporting session pause like iOS
-  // If app paused for X seconds, on app resume, a new session is created
-  // But the old session is sent as session end
+  // Current implementation based on Android.
+  // TODO(fjnoyp): consider supporting session pause like iOS:
+  // If app paused for X seconds, on app resume, a new session is created.
+  // But the old session is sent as session end.
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {

--- a/packages/analytics/amplify_analytics_pinpoint/lib/src/flutter_path_provider/flutter_path_provider.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/lib/src/flutter_path_provider/flutter_path_provider.dart
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// {@template amplify_analytics_pinpoint.flutter_path_provider}
-/// Provides device storage location
+/// Provides device storage location.
 /// {@endtemplate}
 export 'flutter_path_provider_stub.dart'
     if (dart.library.html) 'flutter_path_provider_html.dart'

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/amplify_analytics_pinpoint_dart.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/amplify_analytics_pinpoint_dart.dart
@@ -6,6 +6,7 @@ library amplify_analytics_pinpoint_dart;
 
 export 'src/analytics_plugin_impl.dart';
 export 'src/impl/analytics_client/endpoint_client/aws_pinpoint_user_profile.dart';
+export 'src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart';
 export 'src/impl/flutter_provider_interfaces/app_lifecycle_provider.dart';
 export 'src/impl/flutter_provider_interfaces/cached_events_path_provider.dart';
 export 'src/impl/flutter_provider_interfaces/device_context_info_provider.dart';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/amplify_analytics_pinpoint_dart.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/amplify_analytics_pinpoint_dart.dart
@@ -4,9 +4,10 @@
 /// Amplify Analytics Pinpoint for Dart
 library amplify_analytics_pinpoint_dart;
 
+export 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/event_client.dart';
 export 'src/analytics_plugin_impl.dart';
-
 export 'src/impl/analytics_client/endpoint_client/aws_pinpoint_user_profile.dart';
+export 'src/impl/analytics_client/endpoint_client/endpoint_client.dart';
 export 'src/impl/flutter_provider_interfaces/app_lifecycle_provider.dart';
 export 'src/impl/flutter_provider_interfaces/cached_events_path_provider.dart';
 export 'src/impl/flutter_provider_interfaces/device_context_info_provider.dart';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/amplify_analytics_pinpoint_dart.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/amplify_analytics_pinpoint_dart.dart
@@ -6,8 +6,6 @@ library amplify_analytics_pinpoint_dart;
 
 export 'src/analytics_plugin_impl.dart';
 export 'src/impl/analytics_client/endpoint_client/aws_pinpoint_user_profile.dart';
-export 'src/impl/analytics_client/endpoint_client/endpoint_client.dart';
-export 'src/impl/analytics_client/event_client/event_client.dart';
 export 'src/impl/flutter_provider_interfaces/app_lifecycle_provider.dart';
 export 'src/impl/flutter_provider_interfaces/cached_events_path_provider.dart';
 export 'src/impl/flutter_provider_interfaces/device_context_info_provider.dart';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/amplify_analytics_pinpoint_dart.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/amplify_analytics_pinpoint_dart.dart
@@ -4,10 +4,10 @@
 /// Amplify Analytics Pinpoint for Dart
 library amplify_analytics_pinpoint_dart;
 
-export 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/event_client.dart';
 export 'src/analytics_plugin_impl.dart';
 export 'src/impl/analytics_client/endpoint_client/aws_pinpoint_user_profile.dart';
 export 'src/impl/analytics_client/endpoint_client/endpoint_client.dart';
+export 'src/impl/analytics_client/event_client/event_client.dart';
 export 'src/impl/flutter_provider_interfaces/app_lifecycle_provider.dart';
 export 'src/impl/flutter_provider_interfaces/cached_events_path_provider.dart';
 export 'src/impl/flutter_provider_interfaces/device_context_info_provider.dart';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/analytics_plugin_impl.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/analytics_plugin_impl.dart
@@ -4,7 +4,6 @@
 import 'dart:async';
 
 import 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.dart';
-import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/event_storage_adapter.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/string_database/dart_string_database.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/session_manager.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/stoppable_timer.dart';
@@ -66,7 +65,6 @@ class AmplifyAnalyticsPinpointDart extends AnalyticsPluginInterface {
   late final EndpointClient _endpointClient;
   late final EventClient _eventClient;
   late final SessionManager _sessionManager;
-  late final EventStorageAdapter _eventStorageAdapter;
   late final StoppableTimer _autoEventSubmitter;
 
   final SecureStorageInterface _endpointInfoStore;
@@ -213,6 +211,7 @@ class AmplifyAnalyticsPinpointDart extends AnalyticsPluginInterface {
     _ensureConfigured();
     await _eventClient.recordEvent(
       eventType: event.name,
+      session: _sessionManager.session,
       properties: event.properties,
     );
   }
@@ -251,6 +250,5 @@ class AmplifyAnalyticsPinpointDart extends AnalyticsPluginInterface {
     _isConfigured = false;
     _autoEventSubmitter.stop();
     await _eventClient.close();
-    await _eventStorageAdapter.close();
   }
 }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/analytics_plugin_impl.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/analytics_plugin_impl.dart
@@ -4,7 +4,8 @@
 import 'dart:async';
 
 import 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.dart';
-import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/string_database/dart_string_database.dart';
+import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/queued_item_store/dart_queued_item_store.dart';
+import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/queued_item_store/queued_item_store.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/session_manager.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/stoppable_timer.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/sdk/pinpoint.dart';
@@ -125,19 +126,14 @@ class AmplifyAnalyticsPinpointDart extends AnalyticsPluginInterface {
       }),
     );
 
-    final driftStoragePath = await _pathProvider?.getApplicationSupportPath();
-    final driftQueryExecutor = _dbConnectFunction(
-      name: 'analytics_cached_events',
-      path: driftStoragePath,
-    );
-
-    final stringDatabase = DartStringDatabase(driftQueryExecutor);
+    final eventStoragePath = await _pathProvider?.getApplicationSupportPath();
+    final eventStore = DartQueuedItemStore(eventStoragePath);
     _eventClient = EventClient(
       pinpointAppId: pinpointAppId,
       deviceContextInfo: deviceContextInfo,
       pinpointClient: pinpointClient,
       endpointClient: _endpointClient,
-      eventDatabase: stringDatabase,
+      eventStore: eventStore,
     );
 
     _sessionManager = SessionManager(

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/analytics_plugin_impl.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/analytics_plugin_impl.dart
@@ -25,8 +25,8 @@ const zSessionStopEventType = '_session.stop';
 /// {@template amplify_analytics_pinpoint_dart.amplify_analytics_pinpoint_dart}
 /// The AWS Pinpoint Dart implementation of the Amplify Analytics category.
 ///
-/// - Validates and parses inputs
-/// - Receives and provides external Flutter Provider implementations
+/// - Validates and parses inputs.
+/// - Receives and provides external Flutter Provider implementations.
 /// {@endtemplate}
 class AmplifyAnalyticsPinpointDart extends AnalyticsPluginInterface {
   /// {@macro amplify_analytics_pinpoint_dart.amplify_analytics_pinpoint_dart}
@@ -67,7 +67,7 @@ class AmplifyAnalyticsPinpointDart extends AnalyticsPluginInterface {
 
   final SecureStorageInterface _endpointInfoStore;
 
-  /// External Flutter Provider implementations
+  /// External Flutter Provider implementations.
   final CachedEventsPathProvider? _pathProvider;
   final AppLifecycleProvider? _appLifecycleProvider;
   final DeviceContextInfoProvider? _deviceContextInfoProvider;

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/analytics_plugin_impl.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/analytics_plugin_impl.dart
@@ -60,10 +60,6 @@ class AmplifyAnalyticsPinpointDart extends AnalyticsPluginInterface {
   var _isConfigured = false;
   var _analyticsEnabled = false;
 
-  /// Storage key for the static Pinpoint endpoint id
-  @visibleForTesting
-  static const String endpointIdStorageKey = 'UniqueId';
-
   late final EndpointClient _endpointClient;
   late final EventClient _eventClient;
   late final SessionManager _sessionManager;
@@ -218,7 +214,7 @@ class AmplifyAnalyticsPinpointDart extends AnalyticsPluginInterface {
     required AnalyticsProperties globalProperties,
   }) async {
     _ensureConfigured();
-    await _eventClient.registerGlobalProperties(globalProperties);
+    _eventClient.registerGlobalProperties(globalProperties);
   }
 
   @override
@@ -226,7 +222,7 @@ class AmplifyAnalyticsPinpointDart extends AnalyticsPluginInterface {
     List<String> propertyNames = const <String>[],
   }) async {
     _ensureConfigured();
-    await _eventClient.unregisterGlobalProperties(propertyNames);
+    _eventClient.unregisterGlobalProperties(propertyNames);
   }
 
   @override

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/analytics_plugin_impl.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/analytics_plugin_impl.dart
@@ -4,8 +4,9 @@
 import 'dart:async';
 
 import 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.dart';
+import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_client.dart';
+import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/event_client.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/queued_item_store/dart_queued_item_store.dart';
-import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/queued_item_store/queued_item_store.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/session_manager.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/stoppable_timer.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/sdk/pinpoint.dart';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/aws_pinpoint_user_profile.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/aws_pinpoint_user_profile.dart
@@ -18,6 +18,6 @@ class AWSPinpointUserProfile extends AnalyticsUserProfile {
     required this.userAttributes,
   });
 
-  /// Analytics attributes for the Pinpoint User
+  /// Analytics attributes for the Pinpoint User.
   final AnalyticsProperties userAttributes;
 }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_client.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_client.dart
@@ -54,6 +54,7 @@ class EndpointClient {
     final endpointIdManager = EndpointIdManager(
       store: endpointInfoStore,
       legacyNativeDataProvider: legacyNativeDataProvider,
+      pinpointAppId: _pinpointAppId,
     );
     _fixedEndpointId = await endpointIdManager.retrieveEndpointId();
 
@@ -109,17 +110,10 @@ class EndpointClient {
   Future<void> removeMetric(String name) async =>
       _globalFieldsManager.removeMetric(name);
 
-  /// Set provided fields of the Endpoint
-  void setFields({
-    ChannelType? channelType,
-    String? address,
-    String? optOut,
-  }) {
-    _endpointBuilder
-      ..channelType = channelType
-      ..address = address
-      ..optOut = optOut;
-  }
+  set channelType(ChannelType? channelType) =>
+      _endpointBuilder.channelType = channelType;
+  set address(String? address) => _endpointBuilder.address = address;
+  set optOut(String? optOut) => _endpointBuilder.optOut = optOut;
 
   /// Update the UserProfile object of the EndpointProfile.
   ///

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_client.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_client.dart
@@ -45,7 +45,8 @@ class EndpointClient {
           ),
         ).toBuilder();
 
-  /// {@macro amplify_analytics_pinpoint_dart.endpoint_client}
+  /// Initialize [EndpointClient] by retrieving the endpoint id and
+  /// initializing the [EndpointGlobalFieldsManager]
   @visibleForTesting
   Future<void> init({
     required SecureStorageInterface endpointInfoStore,
@@ -62,7 +63,7 @@ class EndpointClient {
         await EndpointGlobalFieldsManager.create(endpointInfoStore);
   }
 
-  /// {@macro amplify_analytics_pinpoint_dart.endpoint_client}
+  /// Create and initialize an [EndpointClient]
   static Future<EndpointClient> create({
     required String pinpointAppId,
     required PinpointClient pinpointClient,

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_client.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_client.dart
@@ -10,7 +10,6 @@ import 'package:amplify_analytics_pinpoint_dart/src/sdk/pinpoint.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 import 'package:built_collection/built_collection.dart';
-import 'package:meta/meta.dart';
 
 /// {@template amplify_analytics_pinpoint_dart.endpoint_client}
 /// Manages fields of a Pinpoint Endpoint local object.
@@ -21,8 +20,7 @@ import 'package:meta/meta.dart';
 /// {@endtemplate}
 class EndpointClient {
   /// {@macro amplify_analytics_pinpoint_dart.endpoint_client}
-  @visibleForTesting
-  EndpointClient({
+  EndpointClient._({
     required String pinpointAppId,
     required PinpointClient pinpointClient,
     DeviceContextInfo? deviceContextInfo,
@@ -46,9 +44,8 @@ class EndpointClient {
         ).toBuilder();
 
   /// Initialize [EndpointClient] by retrieving the endpoint id and
-  /// initializing the [EndpointGlobalFieldsManager]
-  @visibleForTesting
-  Future<void> init({
+  /// initializing the [EndpointGlobalFieldsManager].
+  Future<void> _init({
     required SecureStorageInterface endpointInfoStore,
     LegacyNativeDataProvider? legacyNativeDataProvider,
   }) async {
@@ -71,12 +68,12 @@ class EndpointClient {
     DeviceContextInfo? deviceContextInfo,
     LegacyNativeDataProvider? legacyNativeDataProvider,
   }) async {
-    final endpointClient = EndpointClient(
+    final endpointClient = EndpointClient._(
       pinpointAppId: pinpointAppId,
       pinpointClient: pinpointClient,
       deviceContextInfo: deviceContextInfo,
     );
-    await endpointClient.init(
+    await endpointClient._init(
       endpointInfoStore: endpointInfoStore,
       legacyNativeDataProvider: legacyNativeDataProvider,
     );

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_client.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_client.dart
@@ -60,7 +60,7 @@ class EndpointClient {
         await EndpointGlobalFieldsManager.create(endpointInfoStore);
   }
 
-  /// Create and initialize an [EndpointClient]
+  /// Create and initialize an [EndpointClient].
   static Future<EndpointClient> create({
     required String pinpointAppId,
     required PinpointClient pinpointClient,
@@ -89,22 +89,22 @@ class EndpointClient {
   // Current Endpoint being managed
   final PublicEndpointBuilder _endpointBuilder;
 
-  /// Retrieve unique id for identifying the Endpoint on this device
+  /// Retrieve unique id for identifying the Endpoint on this device.
   String get fixedEndpointId => _fixedEndpointId;
 
-  /// Add an attribute that will be sent with all future events
+  /// Add an attribute that will be sent with all future events.
   Future<void> addAttribute(String name, String value) async =>
       _globalFieldsManager.addAttribute(name, value);
 
-  /// Remove an attribute so it is not sent with all future events
+  /// Remove an attribute so it is not sent with all future events.
   Future<void> removeAttribute(String name) async =>
       _globalFieldsManager.removeAttribute(name);
 
-  /// Add a metric that will be sent with all future events
+  /// Add a metric that will be sent with all future events.
   Future<void> addMetric(String name, double value) async =>
       _globalFieldsManager.addMetric(name, value);
 
-  /// Remove a metric so it is not sent with all future events
+  /// Remove a metric so it is not sent with all future events.
   Future<void> removeMetric(String name) async =>
       _globalFieldsManager.removeMetric(name);
 
@@ -159,8 +159,8 @@ class EndpointClient {
       }
     }
 
-    // Note that the [copyFromProfile]'s properties are copied to Endpoint metrics/attributes
-    // Instead of the [EndpointUserBuilder] object
+    // Note that the [copyFromProfile]'s properties are copied to Endpoint metrics/attributes.
+    // Instead of the [EndpointUserBuilder] object.
     if (userProfile.properties != null) {
       await _globalFieldsManager
           .addAttributes(userProfile.properties!.attributes);
@@ -178,8 +178,8 @@ class EndpointClient {
     _endpointBuilder.user = newUserBuilder;
   }
 
-  /// Return Endpoint instance
-  /// Copy globalAttributes and globalMetrics into EndpointBuilder before build()
+  /// Return Endpoint instance.
+  /// Copy globalAttributes and globalMetrics into EndpointBuilder before build().
   PublicEndpoint getPublicEndpoint() {
     // Attributes must be sent with map value type List<String>, not String
     final attributes = <String, List<String>>{};
@@ -193,7 +193,7 @@ class EndpointClient {
     return _endpointBuilder.build();
   }
 
-  /// Send local Endpoint instance to AWS Pinpoint
+  /// Send local Endpoint instance to AWS Pinpoint.
   Future<void> updateEndpoint() async {
     await _pinpointClient
         .updateEndpoint(
@@ -206,7 +206,7 @@ class EndpointClient {
         .result;
   }
 
-  /// Create an EndpointRequest object from a local Endpoint instance
+  /// Create an EndpointRequest object from a local Endpoint instance.
   EndpointRequest _endpointToRequest(PublicEndpoint publicEndpoint) {
     return EndpointRequest.build(
       (b) => b

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_global_fields_manager.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_global_fields_manager.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
-import 'package:meta/meta.dart';
 
 /// {@template amplify_analytics_pinpoint_dart.endpoint_global_fields_manager}
 /// Manages the storage, retrieval, and update of Attributes and Metrics of a PinpointEndpoint.
@@ -37,7 +36,7 @@ class EndpointGlobalFieldsManager {
   Future<void> _init() async {
     // Retrieve stored GlobalAttributes.
     final cachedAttributes = await _endpointInfoStore.read(
-      key: EndpointStoreKey.endpointGlobalAttributesKey.name,
+      key: EndpointStoreKey.globalAttributesKey.name,
     );
     _globalAttributes = cachedAttributes == null
         ? <String, String>{}
@@ -46,7 +45,7 @@ class EndpointGlobalFieldsManager {
 
     // Retrieve stored GlobalMetrics.
     final cachedMetrics = await _endpointInfoStore.read(
-      key: EndpointStoreKey.endpointGlobalMetricsKey.name,
+      key: EndpointStoreKey.globalMetricsKey.name,
     );
     _globalMetrics = cachedMetrics == null
         ? <String, double>{}
@@ -136,7 +135,7 @@ class EndpointGlobalFieldsManager {
 
   Future<void> _saveAttributes() async {
     await _endpointInfoStore.write(
-      key: EndpointStoreKey.endpointGlobalAttributesKey.name,
+      key: EndpointStoreKey.globalAttributesKey.name,
       value: jsonEncode(_globalAttributes),
     );
   }
@@ -172,7 +171,7 @@ class EndpointGlobalFieldsManager {
 
   Future<void> _saveMetrics() async {
     await _endpointInfoStore.write(
-      key: EndpointStoreKey.endpointGlobalMetricsKey.name,
+      key: EndpointStoreKey.globalMetricsKey.name,
       value: jsonEncode(_globalMetrics),
     );
   }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_global_fields_manager.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_global_fields_manager.dart
@@ -38,7 +38,7 @@ class EndpointGlobalFieldsManager {
   Future<void> init() async {
     /// Retrieve stored GlobalAttributes
     final cachedAttributes = await _endpointInfoStore.read(
-      key: EndpointStoreKey.EndpointGlobalAttributesKey.name,
+      key: EndpointStoreKey.endpointGlobalAttributesKey.name,
     );
     _globalAttributes = cachedAttributes == null
         ? <String, String>{}
@@ -47,7 +47,7 @@ class EndpointGlobalFieldsManager {
 
     /// Retrieve stored GlobalMetrics
     final cachedMetrics = await _endpointInfoStore.read(
-      key: EndpointStoreKey.EndpointGlobalMetricsKey.name,
+      key: EndpointStoreKey.endpointGlobalMetricsKey.name,
     );
     _globalMetrics = cachedMetrics == null
         ? <String, double>{}
@@ -137,7 +137,7 @@ class EndpointGlobalFieldsManager {
 
   Future<void> _saveAttributes() async {
     await _endpointInfoStore.write(
-      key: EndpointStoreKey.EndpointGlobalAttributesKey.name,
+      key: EndpointStoreKey.endpointGlobalAttributesKey.name,
       value: jsonEncode(_globalAttributes),
     );
   }
@@ -173,7 +173,7 @@ class EndpointGlobalFieldsManager {
 
   Future<void> _saveMetrics() async {
     await _endpointInfoStore.write(
-      key: EndpointStoreKey.EndpointGlobalMetricsKey.name,
+      key: EndpointStoreKey.endpointGlobalMetricsKey.name,
       value: jsonEncode(_globalMetrics),
     );
   }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_global_fields_manager.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_global_fields_manager.dart
@@ -10,7 +10,7 @@ import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 import 'package:meta/meta.dart';
 
 /// {@template amplify_analytics_pinpoint_dart.endpoint_global_fields_manager}
-/// Manages the storage, retrieval, and update of Attributes and Metrics of a PinpointEndpoint
+/// Manages the storage, retrieval, and update of Attributes and Metrics of a PinpointEndpoint.
 ///
 /// - Attributes are String/Bool
 /// - Metrics are Double/Int
@@ -19,24 +19,23 @@ import 'package:meta/meta.dart';
 /// {@endtemplate}
 class EndpointGlobalFieldsManager {
   /// {@macro amplify_analytics_pinpoint_dart.endpoint_global_fields_manager}
-  @visibleForTesting
-  EndpointGlobalFieldsManager(
+  EndpointGlobalFieldsManager._(
     this._endpointInfoStore,
   );
 
-  /// {@macro amplify_analytics_pinpoint_dart.endpoint_global_fields_manager}
+  /// Create and initialize an [EndpointGlobalFieldsManager].
   static Future<EndpointGlobalFieldsManager> create(
     SecureStorageInterface endpointInfoStore,
   ) async {
-    final fieldsManager = EndpointGlobalFieldsManager(endpointInfoStore);
-    await fieldsManager.init();
+    final fieldsManager = EndpointGlobalFieldsManager._(endpointInfoStore);
+    await fieldsManager._init();
     return fieldsManager;
   }
 
-  /// {@macro amplify_analytics_pinpoint_dart.endpoint_global_fields_manager}
-  @visibleForTesting
-  Future<void> init() async {
-    /// Retrieve stored GlobalAttributes
+  /// Initialize [EndpointGlobalFieldsManager] by retrieving
+  /// the stored attributes and metrics in storage.
+  Future<void> _init() async {
+    // Retrieve stored GlobalAttributes.
     final cachedAttributes = await _endpointInfoStore.read(
       key: EndpointStoreKey.endpointGlobalAttributesKey.name,
     );
@@ -45,7 +44,7 @@ class EndpointGlobalFieldsManager {
         : (jsonDecode(cachedAttributes) as Map<String, Object?>)
             .cast<String, String>();
 
-    /// Retrieve stored GlobalMetrics
+    // Retrieve stored GlobalMetrics.
     final cachedMetrics = await _endpointInfoStore.read(
       key: EndpointStoreKey.endpointGlobalMetricsKey.name,
     );
@@ -64,11 +63,11 @@ class EndpointGlobalFieldsManager {
       AmplifyLogger.category(Category.analytics)
           .createChild('EndpointGlobalFieldsManager');
 
-  /// Get GlobalAttributes managed by this instance
+  /// Get GlobalAttributes managed by this instance.
   UnmodifiableMapView<String, String> get globalAttributes =>
       UnmodifiableMapView(_globalAttributes);
 
-  /// Get GlobalMetrics managed by this instance
+  /// Get GlobalMetrics managed by this instance.
   UnmodifiableMapView<String, double> get globalMetrics =>
       UnmodifiableMapView(_globalMetrics);
 
@@ -106,7 +105,7 @@ class EndpointGlobalFieldsManager {
     return value;
   }
 
-  /// Add multiple attributes
+  /// Add multiple attributes.
   Future<void> addAttributes(Map<String, String> attributes) async {
     attributes.forEach((key, value) {
       if (_globalAttributes.length + _globalMetrics.length < _maxAttributes) {
@@ -119,7 +118,7 @@ class EndpointGlobalFieldsManager {
     await _saveAttributes();
   }
 
-  /// Add an attribute by [key] with value of [value]
+  /// Add an attribute by [key] with value of [value].
   Future<void> addAttribute(String key, String value) async {
     if (_globalAttributes.length + _globalMetrics.length < _maxAttributes) {
       _globalAttributes[_processKey(key)] = _processAttributeValue(value);
@@ -129,7 +128,7 @@ class EndpointGlobalFieldsManager {
     }
   }
 
-  /// Remove an attribute by [key]
+  /// Remove an attribute by [key].
   Future<void> removeAttribute(String key) async {
     _globalAttributes.remove(key);
     await _saveAttributes();
@@ -142,7 +141,7 @@ class EndpointGlobalFieldsManager {
     );
   }
 
-  /// Add multiple metrics
+  /// Add multiple metrics.
   Future<void> addMetrics(Map<String, double> metrics) async {
     metrics.forEach((key, value) {
       if (_globalAttributes.length + _globalMetrics.length < _maxAttributes) {
@@ -155,7 +154,7 @@ class EndpointGlobalFieldsManager {
     await _saveMetrics();
   }
 
-  /// Add a metric by [key] with value of [value]
+  /// Add a metric by [key] with value of [value].
   Future<void> addMetric(String key, double value) async {
     if (_globalAttributes.length + _globalMetrics.length < _maxAttributes) {
       _globalMetrics[_processKey(key)] = value;
@@ -165,7 +164,7 @@ class EndpointGlobalFieldsManager {
     }
   }
 
-  /// Remove a metric by [key]
+  /// Remove a metric by [key].
   Future<void> removeMetric(String key) async {
     _globalMetrics.remove(key);
     await _saveMetrics();

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_global_fields_manager.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_global_fields_manager.dart
@@ -4,6 +4,7 @@
 import 'dart:collection';
 import 'dart:convert';
 
+import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 import 'package:meta/meta.dart';
@@ -36,16 +37,18 @@ class EndpointGlobalFieldsManager {
   @visibleForTesting
   Future<void> init() async {
     /// Retrieve stored GlobalAttributes
-    final cachedAttributes =
-        await _endpointInfoStore.read(key: _endpointGlobalAttrsKey);
+    final cachedAttributes = await _endpointInfoStore.read(
+      key: EndpointStoreKey.EndpointGlobalAttributesKey.name,
+    );
     _globalAttributes = cachedAttributes == null
         ? <String, String>{}
         : (jsonDecode(cachedAttributes) as Map<String, Object?>)
             .cast<String, String>();
 
     /// Retrieve stored GlobalMetrics
-    final cachedMetrics =
-        await _endpointInfoStore.read(key: _endpointGlobalMetricsKey);
+    final cachedMetrics = await _endpointInfoStore.read(
+      key: EndpointStoreKey.EndpointGlobalMetricsKey.name,
+    );
     _globalMetrics = cachedMetrics == null
         ? <String, double>{}
         : (jsonDecode(cachedMetrics) as Map<String, Object?>)
@@ -68,9 +71,6 @@ class EndpointGlobalFieldsManager {
   /// Get GlobalMetrics managed by this instance
   UnmodifiableMapView<String, double> get globalMetrics =>
       UnmodifiableMapView(_globalMetrics);
-
-  static const String _endpointGlobalAttrsKey = 'EndpointGlobalAttributesKey';
-  static const String _endpointGlobalMetricsKey = 'EndpointGlobalMetricsKey';
 
   /// {@template amplify_analytics_pinpoint_dart.endpoint_global_fields_manager_limits_by_pinpoint}
   /// Limits defined by Pinpoint.
@@ -137,7 +137,7 @@ class EndpointGlobalFieldsManager {
 
   Future<void> _saveAttributes() async {
     await _endpointInfoStore.write(
-      key: _endpointGlobalAttrsKey,
+      key: EndpointStoreKey.EndpointGlobalAttributesKey.name,
       value: jsonEncode(_globalAttributes),
     );
   }
@@ -173,7 +173,7 @@ class EndpointGlobalFieldsManager {
 
   Future<void> _saveMetrics() async {
     await _endpointInfoStore.write(
-      key: _endpointGlobalMetricsKey,
+      key: EndpointStoreKey.EndpointGlobalMetricsKey.name,
       value: jsonEncode(_globalMetrics),
     );
   }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_id_manager.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_id_manager.dart
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/flutter_provider_interfaces/legacy_native_data_provider.dart';
 import 'package:amplify_core/amplify_core.dart';
@@ -20,8 +23,6 @@ class EndpointIdManager {
   final LegacyNativeDataProvider? _legacyNativeDataProvider;
   final String? _pinpointAppId;
 
-  static const String _endpointIdStorageKey = 'UniqueId';
-
   /// Retrieve the stored pinpoint endpoint id
   Future<String> retrieveEndpointId() async {
     String? fixedEndpointId;
@@ -35,14 +36,14 @@ class EndpointIdManager {
 
     // Read the existing ID.
     fixedEndpointId ??= await _store.read(
-      key: _endpointIdStorageKey,
+      key: EndpointStoreKey.UniqueId.name,
     );
 
     // Generate a new ID if one does not exist.
     if (fixedEndpointId == null) {
       fixedEndpointId = uuid();
       await _store.write(
-        key: _endpointIdStorageKey,
+        key: EndpointStoreKey.UniqueId.name,
         value: fixedEndpointId,
       );
     }
@@ -64,7 +65,7 @@ class EndpointIdManager {
       if (legacyEndpointId != null) {
         fixedEndpointId = legacyEndpointId;
         await _store.write(
-          key: _endpointIdStorageKey,
+          key: EndpointStoreKey.UniqueId.name,
           value: legacyEndpointId,
         );
       }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_id_manager.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_id_manager.dart
@@ -1,0 +1,79 @@
+import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart';
+import 'package:amplify_analytics_pinpoint_dart/src/impl/flutter_provider_interfaces/legacy_native_data_provider.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
+
+/// {@template amplify_analytics_pinpoint_dart.endpoint_info_store}
+/// Manages retrieval, storage, and management of Pinpoint Endpoint id
+/// {@endtemplate}
+class EndpointIdManager {
+  /// {@macro amplify_analytics_pinpoint_dart.endpoint_info_store}
+  EndpointIdManager({
+    required SecureStorageInterface store,
+    LegacyNativeDataProvider? legacyNativeDataProvider,
+    String? pinpointAppId,
+  })  : _store = store,
+        _legacyNativeDataProvider = legacyNativeDataProvider,
+        _pinpointAppId = pinpointAppId;
+
+  final SecureStorageInterface _store;
+  final LegacyNativeDataProvider? _legacyNativeDataProvider;
+  final String? _pinpointAppId;
+
+  static const String _endpointIdStorageKey = 'UniqueId';
+
+  /// Retrieve the stored pinpoint endpoint id
+  Future<String> retrieveEndpointId() async {
+    String? fixedEndpointId;
+
+    if (_pinpointAppId != null && _legacyNativeDataProvider != null) {
+      fixedEndpointId = await _retrieveAndManageLegacyEndpointId(
+        _pinpointAppId!,
+        _legacyNativeDataProvider!,
+      );
+    }
+
+    // Read the existing ID.
+    fixedEndpointId ??= await _store.read(
+      key: _endpointIdStorageKey,
+    );
+
+    // Generate a new ID if one does not exist.
+    if (fixedEndpointId == null) {
+      fixedEndpointId = uuid();
+      await _store.write(
+        key: _endpointIdStorageKey,
+        value: fixedEndpointId,
+      );
+    }
+    return fixedEndpointId;
+  }
+
+  Future<String?> _retrieveAndManageLegacyEndpointId(
+    String appId,
+    LegacyNativeDataProvider dataProvider,
+  ) async {
+    // Retrieve Unique ID
+    final endpointInformationVersion =
+        await _store.read(key: EndpointStoreKey.version.name);
+
+    String? fixedEndpointId;
+    if (endpointInformationVersion == null) {
+      final legacyEndpointId = await dataProvider.getEndpointId(appId);
+      // Migrate legacy data if it is non-null
+      if (legacyEndpointId != null) {
+        fixedEndpointId = legacyEndpointId;
+        await _store.write(
+          key: _endpointIdStorageKey,
+          value: legacyEndpointId,
+        );
+      }
+      // Update the version to prevent future legacy data migrations.
+      await _store.write(
+        key: EndpointStoreKey.version.name,
+        value: EndpointStoreVersion.v1.name,
+      );
+    }
+    return fixedEndpointId;
+  }
+}

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_id_manager.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_id_manager.dart
@@ -36,14 +36,14 @@ class EndpointIdManager {
 
     // Read the existing ID.
     fixedEndpointId ??= await _store.read(
-      key: EndpointStoreKey.UniqueId.name,
+      key: EndpointStoreKey.endpointId.name,
     );
 
     // Generate a new ID if one does not exist.
     if (fixedEndpointId == null) {
       fixedEndpointId = uuid();
       await _store.write(
-        key: EndpointStoreKey.UniqueId.name,
+        key: EndpointStoreKey.endpointId.name,
         value: fixedEndpointId,
       );
     }
@@ -65,7 +65,7 @@ class EndpointIdManager {
       if (legacyEndpointId != null) {
         fixedEndpointId = legacyEndpointId;
         await _store.write(
-          key: EndpointStoreKey.UniqueId.name,
+          key: EndpointStoreKey.endpointId.name,
           value: legacyEndpointId,
         );
       }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_id_manager.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_id_manager.dart
@@ -7,7 +7,7 @@ import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 
 /// {@template amplify_analytics_pinpoint_dart.endpoint_info_store}
-/// Manages retrieval, storage, and management of Pinpoint Endpoint id
+/// Manages retrieval, storage, and management of Pinpoint Endpoint id.
 /// {@endtemplate}
 class EndpointIdManager {
   /// {@macro amplify_analytics_pinpoint_dart.endpoint_info_store}
@@ -23,7 +23,7 @@ class EndpointIdManager {
   final LegacyNativeDataProvider? _legacyNativeDataProvider;
   final String? _pinpointAppId;
 
-  /// Retrieve the stored pinpoint endpoint id
+  /// Retrieve the stored pinpoint endpoint id.
   Future<String> retrieveEndpointId() async {
     String? fixedEndpointId;
 

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart
@@ -3,16 +3,16 @@
 
 /// Keys used to store info about the endpoint version store.
 enum EndpointStoreKey {
-  /// The current version of the endpoint version store
+  /// The current version of the endpoint version store.
   version,
 
-  /// Global attributes key attached to endpoint
+  /// Global attributes key attached to endpoint.
   endpointGlobalAttributesKey,
 
-  /// Global metrics key attached to endpoint
+  /// Global metrics key attached to endpoint.
   endpointGlobalMetricsKey,
 
-  /// Key for storing the Endpoint Id
+  /// Key for storing the Endpoint Id.
   endpointId,
 }
 

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart
@@ -4,13 +4,13 @@
 /// Keys used to store info about the endpoint version store.
 enum EndpointStoreKey {
   /// The current version of the endpoint version store.
-  endpointStoreVersion,
+  version,
 
   /// Global attributes key attached to endpoint.
-  endpointGlobalAttributesKey,
+  globalAttributesKey,
 
   /// Global metrics key attached to endpoint.
-  endpointGlobalMetricsKey,
+  globalMetricsKey,
 
   /// Key for storing the Endpoint Id.
   endpointId,

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart
@@ -4,7 +4,7 @@
 /// Keys used to store info about the endpoint version store.
 enum EndpointStoreKey {
   /// The current version of the endpoint version store.
-  version,
+  endpointStoreVersion,
 
   /// Global attributes key attached to endpoint.
   endpointGlobalAttributesKey,

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart
@@ -7,19 +7,13 @@ enum EndpointStoreKey {
   version,
 
   /// Global attributes key attached to endpoint
-  // Use upper case to support legacy naming
-  // ignore: constant_identifier_names
-  EndpointGlobalAttributesKey,
+  endpointGlobalAttributesKey,
 
   /// Global metrics key attached to endpoint
-  // Use upper case to support legacy naming
-  // ignore: constant_identifier_names
-  EndpointGlobalMetricsKey,
+  endpointGlobalMetricsKey,
 
   /// Key for storing the Endpoint Id
-  // Use upper case to support legacy naming
-  // ignore: constant_identifier_names
-  UniqueId,
+  endpointId,
 }
 
 /// The endpoint store version.

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart
@@ -5,6 +5,21 @@
 enum EndpointStoreKey {
   /// The current version of the endpoint version store
   version,
+
+  /// Global attributes key attached to endpoint
+  // Use upper case to support legacy naming
+  // ignore: constant_identifier_names
+  EndpointGlobalAttributesKey,
+
+  /// Global metrics key attached to endpoint
+  // Use upper case to support legacy naming
+  // ignore: constant_identifier_names
+  EndpointGlobalMetricsKey,
+
+  /// Key for storing the Endpoint Id
+  // Use upper case to support legacy naming
+  // ignore: constant_identifier_names
+  UniqueId,
 }
 
 /// The endpoint store version.

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/event_client.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/event_client.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.dart';
+import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_client.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/event_storage_adapter.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/queued_item_store/index_db/in_memory_queued_item_store.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/queued_item_store/queued_item_store.dart';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/event_client.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/event_client.dart
@@ -14,7 +14,7 @@ import 'package:amplify_core/amplify_core.dart';
 import 'package:smithy/smithy.dart';
 
 /// {@template amplify_analytics_pinpoint_dart.event_client}
-/// Manages storage and flush of analytics events
+/// Manages storage and flush of analytics events.
 ///
 /// - Uses [EventStorageAdapter] to cache analytics events
 /// - Uses [PinpointClient] to flush analytics events to AWS Pinpoint
@@ -71,7 +71,7 @@ class EventClient implements Closeable {
   static final AmplifyLogger _logger =
       AmplifyLogger.category(Category.analytics).createChild('EventClient');
 
-  /// Record event to be sent in the next event batch on [flushEvents]
+  /// Record event to be sent in the next event batch on [flushEvents].
   Future<void> recordEvent({
     required String eventType,
     Session? session,
@@ -85,22 +85,22 @@ class EventClient implements Closeable {
     await _eventStorage.saveEvent(pinpointEvent);
   }
 
-  /// Register [AnalyticsProperties] to be sent with all future events
+  /// Register [AnalyticsProperties] to be sent with all future events.
   void registerGlobalProperties(
     AnalyticsProperties globalProperties,
   ) {
     return _eventCreator.registerGlobalProperties(globalProperties);
   }
 
-  /// Unregister [AnalyticsProperties] to not be sent with all future events
+  /// Unregister [AnalyticsProperties] to not be sent with all future events.
   void unregisterGlobalProperties(
     List<String> propertyNames,
   ) {
     return _eventCreator.unregisterGlobalProperties(propertyNames);
   }
 
-  /// Send cached events as a batch to Pinpoint
-  /// Delete cached events that have been successfully sent
+  /// Send cached events as a batch to Pinpoint.
+  /// Delete cached events that have been successfully sent.
   Future<void> flushEvents() {
     final completer = Completer<void>.sync();
     _flushEventsController.add(completer);

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/event_client.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/event_client.dart
@@ -237,6 +237,7 @@ class EventClient implements Closeable {
 
   @override
   Future<void> close() async {
+    await _storageAdapter.close();
     await _flushEventsController.close();
     await _pendingFlushEvent;
   }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/event_client.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/event_client.dart
@@ -86,16 +86,16 @@ class EventClient implements Closeable {
   }
 
   /// Register [AnalyticsProperties] to be sent with all future events
-  Future<void> registerGlobalProperties(
+  void registerGlobalProperties(
     AnalyticsProperties globalProperties,
-  ) async {
+  ) {
     return _eventCreator.registerGlobalProperties(globalProperties);
   }
 
   /// Unregister [AnalyticsProperties] to not be sent with all future events
-  Future<void> unregisterGlobalProperties(
+  void unregisterGlobalProperties(
     List<String> propertyNames,
-  ) async {
+  ) {
     return _eventCreator.unregisterGlobalProperties(propertyNames);
   }
 

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/event_storage_adapter.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/event_storage_adapter.dart
@@ -17,7 +17,7 @@ class EventStorageAdapter implements Closeable {
   /// {@macro amplify_analytics_pinpoint_dart.event_storage_adapter}
   EventStorageAdapter(this._db);
 
-  /// Underlying database used to store Events
+  /// Underlying database used to store Events.
   final QueuedItemStore _db;
   late final Serializers _serializers = () {
     // Create Serializer
@@ -31,13 +31,13 @@ class EventStorageAdapter implements Closeable {
     return builtSerializers;
   }();
 
-  /// Pinpoint max event size
+  /// Pinpoint max event size.
   static const int _maxEventKbSize = 1000;
 
-  /// Pinpoint max events per event flush batch
+  /// Pinpoint max events per event flush batch.
   static const int _maxEventsInBatch = 100;
 
-  /// Serialize and save Event to device storage
+  /// Serialize and save Event to device storage.
   Future<void> saveEvent(Event event) async {
     final jsonString = jsonEncode(_serializers.serialize(event));
 
@@ -68,7 +68,7 @@ class EventStorageAdapter implements Closeable {
     return storedEvents;
   }
 
-  /// Delete Events from device storage
+  /// Delete Events from device storage.
   Future<void> deleteEvents(Iterable<StoredEvent> items) async {
     final queuedItems = items.map((item) => item.data);
     return _db.deleteItems(queuedItems);
@@ -80,10 +80,10 @@ class EventStorageAdapter implements Closeable {
   }
 }
 
-/// Wrapper class around [Event]
-/// Includes DriftId to identify that event for deletion when calling deleteEvents()
+/// Wrapper class around [Event].
+/// Includes DriftId to identify that event for deletion when calling deleteEvents().
 class StoredEvent {
-  /// Create StoredEvent from [QueuedItem]
+  /// Create StoredEvent from [QueuedItem].
   factory StoredEvent(QueuedItem data, Serializers serializers) {
     final event = serializers.deserialize(jsonDecode(data.value)) as Event;
     return StoredEvent._(data, event);
@@ -91,9 +91,9 @@ class StoredEvent {
 
   StoredEvent._(this.data, this.event);
 
-  /// Underlying [QueuedItem]
+  /// Underlying [QueuedItem].
   final QueuedItem data;
 
-  /// Underlying Event object
+  /// Underlying Event object.
   final Event event;
 }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/dart_queued_item_store.stub.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/dart_queued_item_store.stub.dart
@@ -8,7 +8,7 @@ import 'package:aws_common/aws_common.dart';
 import 'package:meta/meta.dart';
 
 /// {@template amplify_analytics_pinpoint_dart.dart_queued_item_store}
-/// Stores strings using IndexedDB for web and Drift for all other platforms
+/// Stores strings using IndexedDB for web and Drift for all other platforms.
 /// {@endtemplate}
 class DartQueuedItemStore implements QueuedItemStore, Closeable {
   /// {@macro amplify_analytics_pinpoint_dart.dart_queued_item_store}

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/dart_queued_item_store.web.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/dart_queued_item_store.web.dart
@@ -48,7 +48,7 @@ class DartQueuedItemStore
     return db.getCount(count);
   }
 
-  /// Clear IndexedDB data
+  /// Clear IndexedDB data.
   @override
   @visibleForTesting
   Future<void> clear() async {

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/drift/drift_queued_item_store.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/drift/drift_queued_item_store.dart
@@ -9,17 +9,17 @@ import 'package:drift/drift.dart';
 
 part 'drift_queued_item_store.g.dart';
 
-/// SQL schema of data stored in DriftDatabase
+/// SQL schema of data stored in DriftDatabase.
 class DriftQueuedItems extends Table {
-  /// Identifies object in the SQL database
+  /// Identifies object in the SQL database.
   IntColumn get id => integer().autoIncrement()();
 
-  /// The string value stored for this object
+  /// The string value stored for this object.
   TextColumn get value => text()();
 }
 
 /// {@template amplify_analytics_pinpoint_dart.drift_queued_item_store}
-/// Drift class for managing stored [DriftQueuedItems]
+/// Drift class for managing stored [DriftQueuedItems].
 /// {@endtemplate}
 @DriftDatabase(tables: [DriftQueuedItems])
 class DriftQueuedItemStore extends _$DriftQueuedItemStore

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/index_db/in_memory_queued_item_store.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/index_db/in_memory_queued_item_store.dart
@@ -6,13 +6,13 @@ import 'dart:collection';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/queued_item_store/queued_item_store.dart';
 
 /// {@template amplify_analytics_pinpoint_dart.in_memory_queued_item_store}
-/// Stores string elements in device memory
+/// Stores string elements in device memory.
 /// {@endtemplate}
 class InMemoryQueuedItemStore implements QueuedItemStore {
   /// {@macro amplify_analytics_pinpoint_dart.in_memory_queued_item_store}
   InMemoryQueuedItemStore();
 
-  /// The next ID that should be used when adding an item in the DB
+  /// The next ID that should be used when adding an item in the DB.
   int _nextId = 0;
   final LinkedHashMap<int, QueuedItem> _database =
       LinkedHashMap<int, QueuedItem>();

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/index_db/indexed_db_adapter.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/index_db/indexed_db_adapter.dart
@@ -12,18 +12,18 @@ import 'package:collection/collection.dart';
 
 // TODO(kylechen): Consider merging/refactoring with existing 'amplify_secure_storage_web - _IndexedDBStorage' class
 /// {@template amplify_analytics_pinpoint_dart.indexed_db_adapter}
-/// Provide indexDB methods for storing/retrieving Strings
+/// Provide indexDB methods for storing/retrieving Strings.
 /// {@endtemplate}
 class IndexedDbAdapter implements QueuedItemStore {
   /// {@macro amplify_analytics_pinpoint_dart.indexed_db_adapter}
   IndexedDbAdapter();
 
-  /// The name of the database
+  /// The name of the database.
   ///
   /// Reference: https://www.w3.org/TR/IndexedDB/#name
   String get databaseName => 'amplify_analytics_pinpoint';
 
-  /// The name of the object store
+  /// The name of the object store.
   ///
   /// Reference: https://www.w3.org/TR/IndexedDB/#object-store-name
   final storeName = 'analytics_cached_events';
@@ -108,7 +108,7 @@ class IndexedDbAdapter implements QueuedItemStore {
     );
   }
 
-  /// Clear the database
+  /// Clear the database.
   @override
   Future<void> clear() async {
     await _databaseOpenEvent;
@@ -118,7 +118,7 @@ class IndexedDbAdapter implements QueuedItemStore {
   @override
   void close() {}
 
-  /// Check that IndexDB will work on this device
+  /// Check that IndexDB will work on this device.
   static Future<bool> checkIsIndexedDBSupported() async {
     if (indexedDB == null) {
       return false;

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/queued_item_store.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/queued_item_store.dart
@@ -3,7 +3,7 @@
 
 import 'dart:async';
 
-/// Database for storing strings
+/// Database for storing strings.
 abstract class QueuedItemStore {
   /// Insert an item to the end of the queue.
   FutureOr<void> addItem(String string);
@@ -14,24 +14,24 @@ abstract class QueuedItemStore {
   /// Delete [items] from the store.
   FutureOr<void> deleteItems(Iterable<QueuedItem> items);
 
-  /// Clear the queue of items
+  /// Clear the queue of items.
   FutureOr<void> clear();
 
-  /// Closes this store and release resources
+  /// Closes this store and release resources.
   FutureOr<void> close();
 }
 
 /// {@template amplify_analytics_pinpoint_dart.string_database_element}
-/// An item stored in the [QueuedItemStore]
+/// An item stored in the [QueuedItemStore].
 /// {@endtemplate}
 class QueuedItem {
   /// {@macro amplify_analytics_pinpoint_dart.string_database_element}
   const QueuedItem({required this.id, required this.value});
 
-  /// The ID in the item
+  /// The ID in the item.
   final int id;
 
-  /// The value of the item
+  /// The value of the item.
   final String value;
 
   @override

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_creator/event_creator.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_creator/event_creator.dart
@@ -16,14 +16,13 @@ import 'package:amplify_core/amplify_core.dart';
 class EventCreator {
   /// {@macro amplify_analytics_pinpoint_dart.event_creator}
   EventCreator({
-    required EventGlobalFieldsManager globalFieldsManager,
     DeviceContextInfo? deviceContextInfo,
-  })  : _globalFieldsManager = globalFieldsManager,
-        _deviceContextInfo = deviceContextInfo;
+  }) : _deviceContextInfo = deviceContextInfo;
 
   static const int _maxEventTypeLength = 50;
 
-  final EventGlobalFieldsManager _globalFieldsManager;
+  final EventGlobalFieldsManager _globalFieldsManager =
+      EventGlobalFieldsManager();
   final DeviceContextInfo? _deviceContextInfo;
 
   /// Create a Pinpoint [Event] from a [AnalyticsEvent] received from the public API
@@ -31,7 +30,7 @@ class EventCreator {
   Event createPinpointEvent(
     String eventType,
     Session? session, [
-    AnalyticsEvent? analyticsEvent,
+    AnalyticsProperties? analyticsProperties,
   ]) {
     if (eventType.length > _maxEventTypeLength) {
       throw const AnalyticsException(
@@ -54,9 +53,9 @@ class EventCreator {
       ..metrics.addAll(_globalFieldsManager.globalMetrics);
 
     /// Read attributes and metrics from [analyticsEvent]
-    if (analyticsEvent != null) {
-      eventBuilder.attributes.addAll(analyticsEvent.properties.attributes);
-      eventBuilder.metrics.addAll(analyticsEvent.properties.metrics);
+    if (analyticsProperties != null) {
+      eventBuilder.attributes.addAll(analyticsProperties.attributes);
+      eventBuilder.metrics.addAll(analyticsProperties.metrics);
     }
 
     return eventBuilder.build();

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_creator/event_creator.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_creator/event_creator.dart
@@ -25,8 +25,8 @@ class EventCreator {
       EventGlobalFieldsManager();
   final DeviceContextInfo? _deviceContextInfo;
 
-  /// Create a Pinpoint [Event] from a [AnalyticsEvent] received from the public API
-  /// Also, auto fill fields of [Event]
+  /// Create a Pinpoint [Event] from a [AnalyticsEvent] received from the public API.
+  /// Also, auto fill fields of [Event].
   Event createPinpointEvent(
     String eventType,
     Session? session, [
@@ -52,7 +52,7 @@ class EventCreator {
       ..attributes.addAll(_globalFieldsManager.globalAttributes)
       ..metrics.addAll(_globalFieldsManager.globalMetrics);
 
-    /// Read attributes and metrics from [analyticsEvent]
+    /// Read attributes and metrics from [analyticsEvent].
     if (analyticsProperties != null) {
       eventBuilder.attributes.addAll(analyticsProperties.attributes);
       eventBuilder.metrics.addAll(analyticsProperties.metrics);
@@ -61,13 +61,13 @@ class EventCreator {
     return eventBuilder.build();
   }
 
-  /// Register new global properties that will be added to all newly created events
+  /// Register new global properties that will be added to all newly created events.
   void registerGlobalProperties(
     AnalyticsProperties globalProperties,
   ) =>
       _globalFieldsManager.addGlobalProperties(globalProperties);
 
-  /// Unregister global properties that will no longer be added to all newly created events
+  /// Unregister global properties that will no longer be added to all newly created events.
   void unregisterGlobalProperties(List<String> propertyNames) =>
       _globalFieldsManager.removeGlobalProperties(propertyNames);
 }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_creator/event_global_fields_manager.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_creator/event_global_fields_manager.dart
@@ -6,7 +6,7 @@ import 'dart:collection';
 import 'package:amplify_core/amplify_core.dart';
 
 /// {@template amplify_analytics_pinpoint_dart.event_global_fields_manager}
-/// Manages the storage, retrieval, and update of Attributes and Metrics for Events
+/// Manages the storage, retrieval, and update of Attributes and Metrics for Events.
 ///
 /// - Attributes are String/Bool
 /// - Metrics are Double/Int
@@ -15,9 +15,9 @@ import 'package:amplify_core/amplify_core.dart';
 ///
 /// The stored attributes and metrics conform to the [Pinpoint Event](https://docs.aws.amazon.com/pinpoint/latest/apireference/apps-application-id-events.html) online spec.
 ///
-/// Unlike EndpointGlobalFieldsManager, we DO NOT persist these values between sessions
+/// Unlike EndpointGlobalFieldsManager, we DO NOT persist these values between sessions.
 ///
-/// To be consistent with Amplify Native behavior
+/// To be consistent with Amplify Native behavior.
 /// {@endtemplate}
 class EventGlobalFieldsManager {
   /// {@macro amplify_analytics_pinpoint_dart.event_global_fields_manager}
@@ -26,22 +26,22 @@ class EventGlobalFieldsManager {
   final Map<String, String> _globalAttributes = {};
   final Map<String, double> _globalMetrics = {};
 
-  /// Get GlobalAttributes managed by this instance
+  /// Get GlobalAttributes managed by this instance.
   UnmodifiableMapView<String, String> get globalAttributes =>
       UnmodifiableMapView(_globalAttributes);
 
-  /// Get GlobalMetrics managed by this instance
+  /// Get GlobalMetrics managed by this instance.
   UnmodifiableMapView<String, double> get globalMetrics =>
       UnmodifiableMapView(_globalMetrics);
 
   // Note: no max size for global properties
-  /// Add [AnalyticsProperties].  The object will be parsed and stored as Attributes and Metrics
+  /// Add [AnalyticsProperties].  The object will be parsed and stored as Attributes and Metrics.
   void addGlobalProperties(AnalyticsProperties globalProperties) {
     _globalAttributes.addAll(globalProperties.attributes);
     _globalMetrics.addAll(globalProperties.metrics);
   }
 
-  /// Remove properties by their name
+  /// Remove properties by their name.
   void removeGlobalProperties(List<String> propertyNames) {
     if (propertyNames.isEmpty) {
       _globalAttributes.clear();

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/session_manager.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/session_manager.dart
@@ -6,25 +6,25 @@ import 'package:amplify_analytics_pinpoint_dart/src/sdk/pinpoint.dart';
 import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
 
-/// Enum indicating the state of the app session
+/// Enum indicating the state of the app session.
 enum SessionState {
-  /// App is not active (backgrounded)
+  /// App is not active (backgrounded).
   inactive,
 
-  /// App is running (foregrounded)
+  /// App is running (foregrounded).
   active,
 
-  /// App is paused
+  /// App is paused.
   paused,
 }
 
-/// Function that listens to Session lifecycle updates
+/// Function that listens to Session lifecycle updates.
 typedef OnSessionUpdated = void Function(Session);
 
 /// {@template amplify_analytics_pinpoint_dart.session_manager}
 /// Manage creation and deletion of current Session.
 ///
-/// Updates session based on App foreground/background events
+/// Updates session based on App foreground/background events.
 /// Used for provisioning Events sent to Pinpoint with a Session.
 /// {@endtemplate}
 class SessionManager {
@@ -54,10 +54,10 @@ class SessionManager {
 
   _SessionCreator? _sessionCreator;
 
-  /// Get the current session
+  /// Get the current session.
   Session? get session => _sessionCreator?.session;
 
-  /// Start a new session
+  /// Start a new session.
   void startSession() {
     if (session != null) {
       stopSession();
@@ -65,35 +65,35 @@ class SessionManager {
     _executeStart();
   }
 
-  /// Stop the current session
+  /// Stop the current session.
   void stopSession() {
     _executeStop();
   }
 
-  /// Start auto tracking sessions
+  /// Start auto tracking sessions.
   void startSessionTracking() {
     _appLifecycleProvider?.startObserving();
   }
 
-  /// Stop auto tracking sessions
+  /// Stop auto tracking sessions.
   void stopSessionTracking() {
     _appLifecycleProvider?.stopObserving();
   }
 
-  /// Get the current session state
+  /// Get the current session state.
   SessionState getSessionState() {
     if (_sessionCreator == null) return SessionState.inactive;
 
     return SessionState.active;
   }
 
-  /// Start a session
+  /// Start a session.
   void _executeStart() {
     _sessionCreator = _SessionCreator.createSession(_fixedEndpointId);
     _onSessionStart(_sessionCreator!.session);
   }
 
-  /// Stop and delete current session
+  /// Stop and delete current session.
   void _executeStop() {
     if (_sessionCreator == null) {
       return;

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/stoppable_timer.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/stoppable_timer.dart
@@ -26,13 +26,13 @@ class StoppableTimer {
   final Duration _duration;
   final void Function() _callback;
 
-  /// Start the timer
+  /// Start the timer.
   void start() {
     if (_timer.isActive) return;
     _timer = Timer.periodic(_duration, (Timer t) => _callback());
   }
 
-  /// Stop the timer
+  /// Stop the timer.
   void stop() {
     _timer.cancel();
   }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/flutter_provider_interfaces/app_lifecycle_provider.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/flutter_provider_interfaces/app_lifecycle_provider.dart
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// {@template amplify_analytics_pinpoint_dart.app_lifecycle_provider}
-/// Provides callbacks to notify listeners when app is foregrounded or backgrounded
+/// Provides callbacks to notify listeners when app is foregrounded or backgrounded.
 /// {@endtemplate}
 abstract class AppLifecycleProvider {
   /// {@macro amplify_analytics_pinpoint_dart.app_lifecycle_provider}
   AppLifecycleProvider();
 
-  /// [onForeground] should be called when app goes to foreground
+  /// [onForeground] should be called when app goes to foreground.
   void setOnForegroundListener(void Function() onForeground);
 
-  /// [onBackground] should be called when app goes to background
+  /// [onBackground] should be called when app goes to background.
   void setOnBackgroundListener(void Function() onBackground);
 
-  /// Start observing app foreground/background changes
+  /// Start observing app foreground/background changes.
   void startObserving();
 
-  /// Stop observing app foreground/background changes
+  /// Stop observing app foreground/background changes.
   void stopObserving();
 }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/flutter_provider_interfaces/cached_events_path_provider.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/flutter_provider_interfaces/cached_events_path_provider.dart
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// {@template amplify_analytics_pinpoint_dart.cached_events_path_provider}
-/// Provides storage location for the Drift Database used for caching Analytics Events
+/// Provides storage location for the Drift Database used for caching Analytics Events.
 /// {@endtemplate}
 abstract class CachedEventsPathProvider {
   /// {@macro amplify_analytics_pinpoint_dart.cached_events_path_provider}

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/flutter_provider_interfaces/device_context_info_provider.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/flutter_provider_interfaces/device_context_info_provider.dart
@@ -4,7 +4,7 @@
 import 'package:amplify_core/amplify_core.dart';
 
 /// {@template amplify_analytics_pinpoint_dart.device_context_info_provider}
-/// Provide information required for Pinpoint EndpointDemographic object
+/// Provide information required for Pinpoint EndpointDemographic object.
 ///
 /// For more details see Pinpoint [Endpoint](https://docs.aws.amazon.com/pinpoint/latest/apireference/apps-application-id-endpoints.html) online spec.
 /// {@endtemplate}
@@ -14,7 +14,7 @@ abstract class DeviceContextInfoProvider {
 }
 
 /// {@template amplify_analytics_pinpoint_dart.device_context_info}
-/// Data representation of all device information sent to Pinpoint EndpointDemographic
+/// Data representation of all device information sent to Pinpoint EndpointDemographic.
 ///
 /// For more details see Pinpoint [Endpoint](https://docs.aws.amazon.com/pinpoint/latest/apireference/apps-application-id-endpoints.html) online spec.
 /// {@endtemplate}
@@ -68,23 +68,23 @@ class DeviceContextInfo {
 
   static const int _maxFieldLength = 50;
 
-  /// ISO 3166-1, Alpha-2, Alpha-3 country code format
+  /// ISO 3166-1, Alpha-2, Alpha-3 country code format.
   ///
-  /// Ex: US or USA
+  /// Ex: US or USA.
   ///
   /// {@template amplify_analytics_pinpoint_dart.device_context_info.sent_to_pinpoint_endpoint}
   /// Sent as a field to Pinpoint [Endpoint](https://docs.aws.amazon.com/pinpoint/latest/apireference/apps-application-id-endpoints.html).
   /// {@endtemplate}
   final String? countryCode;
 
-  /// IETF BCP 47 locale format
+  /// IETF BCP 47 locale format.
   ///
-  /// Ex: en_US es_419 haw_US
+  /// Ex: en_US es_419 haw_US.
   ///
   /// {@macro amplify_analytics_pinpoint_dart.device_context_info.sent_to_pinpoint_endpoint}
   final String? locale;
 
-  /// tz database timezone name
+  /// tz database timezone name.
   ///
   /// Due to complexities with tz database, this field is not auto-set!
   ///
@@ -99,38 +99,38 @@ class DeviceContextInfo {
   /// {@endtemplate}
   final String? appName;
 
-  /// The package name of the app
+  /// The package name of the app.
   ///
   /// {@macro amplify_analytics_pinpoint_dart.device_context_info.sent_to_pinpoint_event}
   final String? appPackageName;
 
-  /// Version of the app
+  /// Version of the app.
   ///
   /// {@macro amplify_analytics_pinpoint_dart.device_context_info.sent_to_pinpoint_endpoint}
   final String? appVersion;
 
-  /// Manufacturer such as Apple or Samsung
+  /// Manufacturer such as Apple or Samsung.
   ///
   /// {@macro amplify_analytics_pinpoint_dart.device_context_info.sent_to_pinpoint_endpoint}
   final String? make;
 
-  /// Model name or number of device
+  /// Model name or number of device.
   ///
-  /// Ex: iPhone SM-G900F
+  /// Ex: iPhone SM-G900F.
   /// {@macro amplify_analytics_pinpoint_dart.device_context_info.sent_to_pinpoint_endpoint}
   final String? model;
 
-  /// Model version
+  /// Model version.
   ///
   /// {@macro amplify_analytics_pinpoint_dart.device_context_info.sent_to_pinpoint_endpoint}
   final String? modelVersion;
 
-  /// Version of the platform
+  /// Version of the platform.
   ///
   /// {@macro amplify_analytics_pinpoint_dart.device_context_info.sent_to_pinpoint_endpoint}
   final String? platformVersion;
 
-  /// Platform of the device
+  /// Platform of the device.
   ///
   /// {@macro amplify_analytics_pinpoint_dart.device_context_info.sent_to_pinpoint_endpoint}
   final DevicePlatform? platform;

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/flutter_provider_interfaces/legacy_native_data_provider.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/flutter_provider_interfaces/legacy_native_data_provider.dart
@@ -5,6 +5,6 @@ import 'dart:async';
 
 /// {@template amplify_analytics_pinpoint.flutter_legacy_native_data_provider}
 abstract class LegacyNativeDataProvider {
-  /// Get stored Pinpoint Endpoint Id
+  /// Get stored Pinpoint Endpoint Id.
   Future<String?> getEndpointId(String pinpointAppId);
 }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/test/analytics_legacy_native_data_test.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/test/analytics_legacy_native_data_test.dart
@@ -43,7 +43,7 @@ void main() {
       expect(storeVersion, EndpointStoreVersion.v1.name);
 
       final migratedEndpointId = await store.read(
-        key: AmplifyAnalyticsPinpointDart.endpointIdStorageKey,
+        key: EndpointStoreKey.endpointId.name,
       );
       expect(migratedEndpointId, isNotNull);
 
@@ -67,7 +67,7 @@ void main() {
       expect(storeVersion, EndpointStoreVersion.v1.name);
 
       final migratedEndpointId = await store.read(
-        key: AmplifyAnalyticsPinpointDart.endpointIdStorageKey,
+        key: EndpointStoreKey.endpointId.name,
       );
       expect(migratedEndpointId, legacyEndpointId);
 
@@ -81,7 +81,7 @@ void main() {
       final endpointId = uuid();
       store.seedData({
         EndpointStoreKey.version.name: EndpointStoreVersion.v1.name,
-        AmplifyAnalyticsPinpointDart.endpointIdStorageKey: endpointId
+        EndpointStoreKey.endpointId.name: endpointId
       });
 
       final endpointIdManager = EndpointIdManager(
@@ -92,7 +92,7 @@ void main() {
       expect(await endpointIdManager.retrieveEndpointId(), endpointId);
 
       final migratedEndpointId = await store.read(
-        key: AmplifyAnalyticsPinpointDart.endpointIdStorageKey,
+        key: EndpointStoreKey.endpointId.name,
       );
       expect(migratedEndpointId, endpointId);
 

--- a/packages/analytics/amplify_analytics_pinpoint_dart/test/analytics_legacy_native_data_test.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/test/analytics_legacy_native_data_test.dart
@@ -14,7 +14,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Analytics Legacy Native Data Tests', () {
+  group('LegacyNativeDataProvider ', () {
     late MockLegacyNativeDataProvider legacyDataProvider;
     late MockSecureStorage store;
 

--- a/packages/analytics/amplify_analytics_pinpoint_dart/test/analytics_legacy_native_data_test.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/test/analytics_legacy_native_data_test.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 
 import 'package:amplify_analytics_pinpoint_dart/amplify_analytics_pinpoint_dart.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_id_manager.dart';
-import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 import 'package:mocktail/mocktail.dart';


### PR DESCRIPTION
Allow for modules to be exported for use in the Push Notification category

Cleaned the internal initialization logic of Event and Endpoint Clients to allow them to be created easily without needing to create their sub dependencies separately. 

Exported necessary classes from Analytics dart and flutter packages. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
