### PR TITLE
fix(secure_storage)!: use correct values for `kSecAttrAccessible`

### DIFF
--- a/packages/secure_storage/amplify_secure_storage/example/integration_test/cupertino_test.dart
+++ b/packages/secure_storage/amplify_secure_storage/example/integration_test/cupertino_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:amplify_secure_storage/amplify_secure_storage.dart';
 import 'package:amplify_secure_storage/src/messages.cupertino.g.dart';
+import 'package:amplify_secure_storage_dart/src/platforms/amplify_secure_storage_cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -16,18 +17,19 @@ const key2 = 'key_2';
 const value1 = 'value_1';
 const value2 = 'value_2';
 
-// Enabling useDataProtection requires that the app is
-// added to at least one access group.
-final macOSOptions = MacOSSecureStorageOptions(useDataProtection: false);
-
-/// MacOS & iOS app uninstall & re-install tests.
-///
-/// These tests are only relevant for amplify_secure_storage
-/// (not amplify_secure_storage_dart) as they use
-/// NSUserDefaultsAPI via pigeon.
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  /// MacOS & iOS app uninstall & re-install tests.
+  ///
+  /// These tests are only relevant for amplify_secure_storage
+  /// (not amplify_secure_storage_dart) as they use
+  /// NSUserDefaultsAPI via pigeon.
   group('${Platform.operatingSystem} app uninstall & re-install', () {
+    // Enabling useDataProtection requires that the app is added to at least one
+    // access group.
+    final macOSOptions = MacOSSecureStorageOptions(useDataProtection: false);
+
     final userDefaults = NSUserDefaultsAPI();
     final storage = AmplifySecureStorage(
       config: AmplifySecureStorageConfig(
@@ -74,4 +76,92 @@ void main() {
       expect(await storage2.read(key: key2), isNull);
     });
   });
+
+  group(
+    '${Platform.operatingSystem} kSecAttrAccessible',
+    // TODO(Jordan-Nelson): Determine if/how these tests can be run on macOS.
+    skip: Platform.isMacOS ? 'keychain entitlement needed' : null,
+    () {
+      late AmplifySecureStorageCupertino storage1;
+      late AmplifySecureStorageCupertino storage2;
+
+      setUp(() async {
+        storage1 = AmplifySecureStorageCupertino(
+          config: AmplifySecureStorageConfig(
+            scope: scope,
+            iOSOptions: IOSSecureStorageOptions(
+              accessible: KeychainAttributeAccessible
+                  .accessibleAfterFirstUnlockThisDeviceOnly,
+            ),
+          ),
+        );
+        storage2 = AmplifySecureStorageCupertino(
+          config: AmplifySecureStorageConfig(
+            scope: scope,
+            iOSOptions: IOSSecureStorageOptions(
+              accessible: KeychainAttributeAccessible
+                  .accessibleWhenUnlockedThisDeviceOnly,
+            ),
+          ),
+        );
+        storage1.removeAll();
+        storage2.removeAll();
+      });
+
+      tearDown(() async {
+        storage1.removeAll();
+        storage2.removeAll();
+      });
+      test(
+        'read returns null when reading keys with a different kSecAttrAccessible value',
+        () async {
+          storage1.write(key: key1, value: value1);
+
+          expect(storage1.read(key: key1), value1);
+          expect(storage2.read(key: key2), isNull);
+        },
+      );
+
+      test(
+        'delete can delete keys regardless of the kSecAttrAccessible value',
+        () async {
+          storage1.write(key: key1, value: value1);
+
+          expect(storage1.read(key: key1), value1);
+
+          storage2.delete(key: key1);
+
+          expect(storage1.read(key: key1), isNull);
+        },
+      );
+
+      test(
+        'removeAll can delete keys regardless of the kSecAttrAccessible value',
+        () async {
+          storage1.write(key: key1, value: value1);
+
+          expect(storage1.read(key: key1), value1);
+
+          storage2.removeAll();
+
+          expect(storage1.read(key: key1), isNull);
+        },
+      );
+
+      test(
+        'write will overwrite values stored with a different kSecAttrAccessible value',
+        () async {
+          storage1.write(key: key1, value: value1);
+
+          expect(storage1.read(key: key1), value1);
+          expect(storage2.read(key: key1), isNull);
+
+          storage2.write(key: key1, value: value1);
+
+          expect(storage1.read(key: key1), isNull);
+          expect(storage2.read(key: key1), value1);
+        },
+      );
+    },
+  );
 }

--- a/packages/secure_storage/amplify_secure_storage/example/integration_test/cupertino_test.dart
+++ b/packages/secure_storage/amplify_secure_storage/example/integration_test/cupertino_test.dart
@@ -20,7 +20,7 @@ const value2 = 'value_2';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  /// MacOS & iOS app uninstall & re-install tests.
+  /// macOS & iOS app uninstall & re-install tests.
   ///
   /// These tests are only relevant for amplify_secure_storage
   /// (not amplify_secure_storage_dart) as they use
@@ -77,6 +77,8 @@ void main() {
     });
   });
 
+  // kSecAttrAccessible tests are added as integ test since they require
+  // keychain entitlement.
   group(
     '${Platform.operatingSystem} kSecAttrAccessible',
     // TODO(Jordan-Nelson): Determine if/how these tests can be run on macOS.
@@ -118,7 +120,7 @@ void main() {
           storage1.write(key: key1, value: value1);
 
           expect(storage1.read(key: key1), value1);
-          expect(storage2.read(key: key2), isNull);
+          expect(storage2.read(key: key1), isNull);
         },
       );
 
@@ -138,13 +140,17 @@ void main() {
       test(
         'removeAll can delete keys regardless of the kSecAttrAccessible value',
         () async {
+          // storage2.removeAll clears storage1
           storage1.write(key: key1, value: value1);
-
           expect(storage1.read(key: key1), value1);
-
           storage2.removeAll();
-
           expect(storage1.read(key: key1), isNull);
+
+          // storage1.removeAll clears storage2
+          storage2.write(key: key1, value: value1);
+          expect(storage2.read(key: key1), value1);
+          storage1.removeAll();
+          expect(storage2.read(key: key1), isNull);
         },
       );
 

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/cupertino/cupertino.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/cupertino/cupertino.dart
@@ -46,9 +46,9 @@ extension KeychainAttributeAccessibleX on KeychainAttributeAccessible {
   CFStringRef toCFStringRef() {
     switch (this) {
       case KeychainAttributeAccessible.accessibleAfterFirstUnlock:
-        return security.kSecAttrAccessibleWhenUnlocked;
+        return security.kSecAttrAccessibleAfterFirstUnlock;
       case KeychainAttributeAccessible.accessibleAfterFirstUnlockThisDeviceOnly:
-        return security.kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
+        return security.kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
       case KeychainAttributeAccessible.accessibleWhenPasscodeSetThisDeviceOnly:
         return security.kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
       case KeychainAttributeAccessible.accessibleWhenUnlocked:

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/interfaces/amplify_secure_storage_interface.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/interfaces/amplify_secure_storage_interface.dart
@@ -21,7 +21,7 @@ abstract class AmplifySecureStorageInterface extends SecureStorageInterface
   /// {@template amplify_secure_storage_dart.amplify_secure_storage_interface.remove_all}
   /// Removes all key-value pairs for the current scope.
   ///
-  /// Only available on iOS, MacOs, and Linux. Will throw [UnimplementedError]
+  /// Only available on iOS, macOs, and Linux. Will throw [UnimplementedError]
   /// on other platforms.
   /// {@endtemplate}
   @internal

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/interfaces/amplify_secure_storage_interface.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/interfaces/amplify_secure_storage_interface.dart
@@ -21,7 +21,7 @@ abstract class AmplifySecureStorageInterface extends SecureStorageInterface
   /// {@template amplify_secure_storage_dart.amplify_secure_storage_interface.remove_all}
   /// Removes all key-value pairs for the current scope.
   ///
-  /// Only available on Linux. Will throw [UnimplementedError]
+  /// Only available on iOS, MacOs, and Linux. Will throw [UnimplementedError]
   /// on other platforms.
   /// {@endtemplate}
   @internal


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/2535

*Description of changes:*
- Map KeychainAttributeAccessible value to correct values in keychain.
- Gracefully handle the scenario when KeychainAttributeAccessible changes
- Add tests for the updated behavior

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
