### PR TITLE
chore(api): model helpers, include parent IDs in selection set

### DIFF
--- a/packages/api/amplify_api_dart/lib/src/graphql/factories/graphql_request_factory.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/factories/graphql_request_factory.dart
@@ -70,6 +70,19 @@ class GraphQLRequestFactory {
           ignoreParents: true,
         ); // always format like a get, stop traversing parents
         fields.add('${belongsTo.name} { $parentSelectionSet }');
+
+        // Include the ID key(s) itself in selection set. This is ignored while
+        // deserializing response because model will use ID nested in `parentSelectionSet`.
+        // However, including the ID in selection set allows subscriptions that
+        // filter by these ID to be triggered by these mutations.
+        var belongsToKeys = belongsTo.association?.targetNames;
+        if (belongsToKeys == null &&
+            belongsTo.association?.targetName != null) {
+          belongsToKeys = [belongsTo.association?.targetName as String];
+        }
+        if (belongsToKeys != null) {
+          fields.addAll(belongsToKeys);
+        }
       }
     }
 

--- a/packages/api/amplify_api_dart/test/graphql_helpers_mtm_test.dart
+++ b/packages/api/amplify_api_dart/test/graphql_helpers_mtm_test.dart
@@ -28,9 +28,9 @@ void main() {
     });
 
     const manyToManyPrimarySelectionSet =
-        'manyToManyPrimary { id name createdAt updatedAt }';
+        'manyToManyPrimary { id name createdAt updatedAt } manyToManyPrimaryId';
     const manyToManySecondarySelectionSet =
-        'manyToManySecondary { id name createdAt updatedAt }';
+        'manyToManySecondary { id name createdAt updatedAt } manyToManySecondaryId';
 
     const mtmRelationSelectionSet = 'id createdAt updatedAt '
         '$manyToManyPrimarySelectionSet '

--- a/packages/api/amplify_api_dart/test/graphql_helpers_test.dart
+++ b/packages/api/amplify_api_dart/test/graphql_helpers_test.dart
@@ -426,7 +426,7 @@ void main() {
           }
         };
         const expectedDoc =
-            'mutation createPost(\$input: CreatePostInput!, \$condition:  ModelPostConditionInput) { createPost(input: \$input, condition: \$condition) { id title rating created likeCount createdAt updatedAt blog { $blogSelectionSet } } }';
+            'mutation createPost(\$input: CreatePostInput!, \$condition:  ModelPostConditionInput) { createPost(input: \$input, condition: \$condition) { id title rating created likeCount createdAt updatedAt blog { $blogSelectionSet } blogID } }';
         final GraphQLRequest<Post> req = ModelMutations.create<Post>(post);
 
         expect(req.document, expectedDoc);
@@ -599,7 +599,7 @@ void main() {
           'condition': null
         };
         const expectedDoc =
-            'mutation updatePost(\$input: UpdatePostInput!, \$condition:  ModelPostConditionInput) { updatePost(input: \$input, condition: \$condition) { id title rating created likeCount createdAt updatedAt blog { $blogSelectionSet } } }';
+            'mutation updatePost(\$input: UpdatePostInput!, \$condition:  ModelPostConditionInput) { updatePost(input: \$input, condition: \$condition) { id title rating created likeCount createdAt updatedAt blog { $blogSelectionSet } blogID } }';
         final GraphQLRequest<Post> req = ModelMutations.update<Post>(post);
 
         expect(req.document, expectedDoc);


### PR DESCRIPTION
This small change will help reduce friction for a paper cut detail I noticed while debugging https://github.com/aws-amplify/amplify-flutter/issues/2646.

problem: If a user does a GQL subscription and filters by parent ID (e.g. get all comments created where post ID equals x) then that subscription won't get updates made creating comments from requests with `ModelMutations.create()`. This is because a subscription with this kind of filter requires the selection set of the mutation include the field itself (e.g. `"postID"`, not the ID of the post in the nested selection set).

This PR simply adds the ID fields to the selection sets of request documents when the schema has `belongsTo`. We already get the parent itself (which has the ID nested). However, here we essentially put the ID in 2 places. The new ID instance is the response is ignored while converted to model with `fromJson` while deserializing the server response. However, any subscription by parent ID will now pickup mutations made with these requests.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
