### PR TITLE
chore(repo): Relax `intl` constraint

### DIFF
--- a/packages/amplify_authenticator/pubspec.yaml
+++ b/packages/amplify_authenticator/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  intl: ^0.17.0
+  intl: '>=0.17.0 <1.0.0'
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   collection: ^1.15.0
   flutter:
     sdk: flutter
-  intl: ^0.17.0
+  intl: '>=0.17.0 <1.0.0'
   json_annotation: ^4.3.0
   meta: ^1.7.0
   plugin_platform_interface: ^2.0.0


### PR DESCRIPTION
Fixes https://github.com/aws-amplify/amplify-flutter/issues/2642

Our current constraint, `^0.17.0`, means `>=0.17.0 <0.18.0` but we should accept whichever version the customer uses (which is most often the one pinned by `flutter`)
