### PR TITLE
chore(repo): Relax `intl` constraints

### DIFF
--- a/aft.yaml
+++ b/aft.yaml
@@ -13,6 +13,7 @@ dependencies:
   drift: ">=2.4.0 <2.6.0"
   json_annotation: ">=4.8.0 <4.9.0"
   json_serializable: 6.6.1
+  intl: ">=0.17.0 <1.0.0"
   mime: ^1.0.0
   pigeon: ^7.1.5
   uuid: ">=3.0.6 <=3.0.7"

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   aws_common: ">=0.4.0+1 <0.5.0"
   aws_signature_v4: ">=0.3.1+3 <0.4.0"
   collection: ^1.15.0
-  intl: ^0.17.0
+  intl: ">=0.17.0 <1.0.0"
   json_annotation: ">=4.8.0 <4.9.0"
   logging: ^1.0.0
   meta: ^1.7.0

--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   built_value: ">=8.4.0 <8.5.0"
   collection: ^1.15.0
   drift: ">=2.4.0 <2.6.0"
-  intl: ^0.17.0
+  intl: ">=0.17.0 <1.0.0"
   meta: ^1.7.0
   path: ^1.8.0
   smithy: ">=0.4.0+2 <0.5.0"

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   crypto: ^3.0.1
   fixnum: ^1.0.0
   http: ^0.13.4
-  intl: ^0.17.0
+  intl: ">=0.17.0 <1.0.0"
   js: ^0.6.4
   json_annotation: ">=4.8.0 <4.9.0"
   meta: ^1.7.0

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  intl: ^0.17.0
+  intl: ">=0.17.0 <1.0.0"
   meta: ^1.7.0
   smithy: ">=0.4.0+2 <0.5.0"
   stream_transform: ^2.0.0

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   crypto: ^3.0.0
   fixnum: ^1.0.0
   http_parser: ^4.0.0
-  intl: ^0.17.0
+  intl: ">=0.17.0 <1.0.0"
   json_annotation: ">=4.8.0 <4.9.0"
   meta: ^1.7.0
   path: ^1.8.0

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   convert: ^3.0.0
   crclib: ^3.0.0
   crypto: ^3.0.0
-  intl: ^0.17.0
+  intl: ">=0.17.0 <1.0.0"
   json_annotation: ">=4.8.0 <4.9.0"
   meta: ^1.7.0
   path: ^1.8.0


### PR DESCRIPTION
Our current constraint, `^0.17.0`, means `>=0.17.0 <0.18.0` but we should accept whichever version the customer uses (which is most often the one pinned by `flutter`).
