### PR TITLE
fix(auth): Transform session expired exceptions

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -227,12 +227,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
         }
         if (state is FetchAuthSessionSuccess) {
           final exception = state.session.userPoolTokensResult.exception;
-          // TODO(Jordan-Nelson): Update list of exceptions once FetchAuthSession
-          /// is updated to only throw SessionExpiredException for expired
-          /// sessions.
-          if (exception is UnauthorizedException ||
-              exception is AuthNotAuthorizedException ||
-              exception is SessionExpiredException) {
+          if (exception is SessionExpiredException) {
             hubEvent = AuthHubEvent.sessionExpired();
           }
         }


### PR DESCRIPTION
In the fetch auth session state machine, any `NotAuthorizedException` thrown should be considered a `SessionExpiredException` since that is the only time we would get such an error.