### PR TITLE
chore(core)!: Chain stack traces for state machines

### DIFF
--- a/aft.yaml
+++ b/aft.yaml
@@ -16,6 +16,7 @@ dependencies:
   intl: ">=0.17.0 <1.0.0"
   mime: ^1.0.0
   pigeon: ^7.1.5
+  stack_trace: ^1.10.0
   uuid: ">=3.0.6 <=3.0.7"
   xml: ">=6.1.0 <=6.2.2"
 

--- a/packages/amplify_core/lib/src/state_machine/event.dart
+++ b/packages/amplify_core/lib/src/state_machine/event.dart
@@ -37,10 +37,20 @@ abstract class StateMachineEvent<EventType, StateType>
 class EventCompleter<Event extends StateMachineEvent,
     State extends StateMachineState> {
   /// {@macro amplify_core.event_completer}
-  EventCompleter(this.event);
+  EventCompleter(this.event, [StackTrace? stackTrace])
+      : stackTrace = stackTrace ?? StackTrace.current;
 
   /// The event to dispatch.
   final Event event;
+
+  /// The stack trace from when [event] was created.
+  ///
+  /// When exceptions are raised from within the state machines, the origin of
+  /// the exception should be traceable back to the API called which kicked off
+  /// this event. Since there may be multiple async gaps between the API call
+  /// and a state machine failure, it is necessary to capture the stack trace
+  /// here and chain it with later stack traces.
+  final StackTrace stackTrace;
 
   final Completer<void> _acceptedCompleter = Completer();
   final Completer<State> _completer = Completer();
@@ -76,11 +86,4 @@ class EventCompleter<Event extends StateMachineEvent,
       _completer.completeError(error, stackTrace);
     }
   }
-}
-
-/// Mixin functionality for error/failure events of a state machine.
-mixin ErrorEvent<EventType, StateType>
-    on StateMachineEvent<EventType, StateType> {
-  /// The exception which triggered this event.
-  Exception get exception;
 }

--- a/packages/amplify_core/lib/src/state_machine/state.dart
+++ b/packages/amplify_core/lib/src/state_machine/state.dart
@@ -24,4 +24,7 @@ mixin SuccessState<StateType> on StateMachineState<StateType> {}
 mixin ErrorState<StateType> on StateMachineState<StateType> {
   /// The exception which triggered this state.
   Exception get exception;
+
+  /// The stack trace for [exception].
+  StackTrace get stackTrace;
 }

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   logging: ^1.0.0
   meta: ^1.7.0
   retry: ^3.1.0
+  stack_trace: ^1.10.0
   uuid: ">=3.0.6 <=3.0.7"
 
 dev_dependencies:

--- a/packages/amplify_core/test/state_machine/my_state_machine.dart
+++ b/packages/amplify_core/test/state_machine/my_state_machine.dart
@@ -56,6 +56,16 @@ class MyState extends StateMachineState<MyType> {
   String get runtimeTypeName => 'MyState';
 }
 
+class MyErrorState extends MyState with ErrorState {
+  const MyErrorState(this.exception, this.stackTrace) : super(MyType.error);
+
+  @override
+  final Exception exception;
+
+  @override
+  final StackTrace stackTrace;
+}
+
 class MyStateMachine extends StateMachine<MyEvent, MyState, StateMachineEvent,
     StateMachineState, MyStateMachineManager> {
   MyStateMachine(MyStateMachineManager manager) : super(manager, type);
@@ -96,8 +106,11 @@ class MyStateMachine extends StateMachine<MyEvent, MyState, StateMachineEvent,
   }
 
   @override
-  MyState? resolveError(Object error, [StackTrace? st]) {
-    return const MyState(MyType.error);
+  MyState? resolveError(Object error, StackTrace st) {
+    if (error is Exception) {
+      return MyErrorState(error, st);
+    }
+    return null;
   }
 
   @override
@@ -140,6 +153,17 @@ class WorkerState extends StateMachineState<WorkType> {
   String get runtimeTypeName => 'WorkerState';
 }
 
+class WorkerErrorState extends WorkerState with ErrorState {
+  const WorkerErrorState(this.exception, this.stackTrace)
+      : super(WorkType.error);
+
+  @override
+  final Exception exception;
+
+  @override
+  final StackTrace stackTrace;
+}
+
 class WorkerMachine extends StateMachine<WorkerEvent, WorkerState,
     StateMachineEvent, StateMachineState, MyStateMachineManager> {
   WorkerMachine(MyStateMachineManager manager) : super(manager, type);
@@ -171,8 +195,11 @@ class WorkerMachine extends StateMachine<WorkerEvent, WorkerState,
   }
 
   @override
-  WorkerState? resolveError(Object error, [StackTrace? st]) {
-    return const WorkerState(WorkType.error);
+  WorkerState? resolveError(Object error, StackTrace st) {
+    if (error is Exception) {
+      return WorkerErrorState(error, st);
+    }
+    return null;
   }
 
   @override

--- a/packages/auth/amplify_auth_cognito_dart/example/integration_test/hosted_ui_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/integration_test/hosted_ui_test.dart
@@ -12,7 +12,7 @@ import 'package:checks/checks.dart';
 import 'package:cognito_example/amplifyconfiguration.dart';
 import 'package:io/io.dart';
 import 'package:test/test.dart';
-import 'package:webdriver/async_io.dart';
+import 'package:webdriver/async_io.dart' hide LogLevel;
 
 import 'common.dart';
 
@@ -52,6 +52,7 @@ void main() {
 
         setUp(() async {
           application = await runApp();
+          addTearDown(application.close);
 
           await Amplify.configure(jsonEncode(config));
           addTearDown(Amplify.reset);

--- a/packages/auth/amplify_auth_cognito_dart/example/integration_test/hosted_ui_web_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/integration_test/hosted_ui_web_test.dart
@@ -310,9 +310,7 @@ window.open = function(url, target) {
     await signOutButton.click();
 
     logger.info('REDIRECTING TO SIGN OUT');
-    await driver.locationChanges.firstWhere(
-      (uri) => uri.host == 'localhost' && uri.path == '/auth',
-    );
+    await driver.locationChanges.firstWhere((uri) => uri.host == 'localhost');
     logger.info('REDIRECTED AFTER SIGN OUT');
 
     await waitFor(const By.id('loginForm'));

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/auth_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/auth_event.dart
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import 'package:amplify_auth_cognito_dart/src/state/cognito_state_machine.dart';
 import 'package:amplify_core/amplify_core.dart';
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/configuration_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/configuration_event.dart
@@ -13,9 +13,6 @@ enum ConfigurationEventType {
 
   /// {@macro amplify_auth_cognito.configuration_event.configure_succeeded}
   configureSucceeded,
-
-  /// {@macro amplify_auth_cognito.configuration_event.configure_failed}
-  configureFailed,
 }
 
 /// {@template amplify_auth_cognito.auth_event}
@@ -32,10 +29,6 @@ abstract class ConfigurationEvent
   const factory ConfigurationEvent.configureSucceeded(
     CognitoPluginConfig config,
   ) = ConfigureSucceeded;
-
-  /// {@macro amplify_auth_cognito.configuration_event.configure_failed}
-  const factory ConfigurationEvent.configureFailed(Exception exception) =
-      ConfigureFailed;
 
   @override
   PreconditionException? checkPrecondition(ConfigurationState currentState) =>
@@ -94,22 +87,4 @@ class ConfigureSucceeded extends ConfigurationEvent {
 
   @override
   List<Object?> get props => [type, config];
-}
-
-/// {@template amplify_auth_cognito.configuration_event.configure_failed}
-/// An exception occurred during configuration of the Auth plugin.
-/// {@endtemplate}
-class ConfigureFailed extends ConfigurationEvent with ErrorEvent {
-  /// {@macro amplify_auth_cognito.configuration_event.configure_failed}
-  const ConfigureFailed(this.exception) : super._();
-
-  /// The configuration exception.
-  @override
-  final Exception exception;
-
-  @override
-  ConfigurationEventType get type => ConfigurationEventType.configureFailed;
-
-  @override
-  List<Object?> get props => [type, exception];
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/credential_store_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/credential_store_event.dart
@@ -19,9 +19,6 @@ enum CredentialStoreEventType {
 
   /// {@macro amplify_auth_cognito.credential_store_succeeded}
   succeeded,
-
-  /// {@macro amplify_auth_cognito.credential_store_failed}
-  failed,
 }
 
 /// {@template amplify_auth_cognito.credential_store_event}
@@ -49,10 +46,6 @@ abstract class CredentialStoreEvent
   /// {@macro amplify_auth_cognito.credential_store_succeeded}
   const factory CredentialStoreEvent.succeeded(CredentialStoreData data) =
       CredentialStoreSucceeded;
-
-  /// {@macro amplify_auth_cognito.credential_store_failed}
-  const factory CredentialStoreEvent.failed(Exception exception) =
-      CredentialStoreFailed;
 
   @override
   PreconditionException? checkPrecondition(
@@ -197,31 +190,6 @@ class CredentialStoreSucceeded extends CredentialStoreEvent {
         'Credential store is not configured',
       );
     }
-    return null;
-  }
-}
-
-/// {@template amplify_auth_cognito.credential_store_failed}
-/// Failure in a credential store task.
-/// {@endtemplate}
-class CredentialStoreFailed extends CredentialStoreEvent with ErrorEvent {
-  /// {@macro amplify_auth_cognito.credential_store_failed}
-  const CredentialStoreFailed(this.exception) : super._();
-
-  /// The credential store exception.
-  @override
-  final Exception exception;
-
-  @override
-  CredentialStoreEventType get type => CredentialStoreEventType.failed;
-
-  @override
-  List<Object?> get props => [type, exception];
-
-  @override
-  PreconditionException? checkPrecondition(
-    CredentialStoreState currentState,
-  ) {
     return null;
   }
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/fetch_auth_session_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/fetch_auth_session_event.dart
@@ -18,9 +18,6 @@ enum FetchAuthSessionEventType {
 
   /// {@macro amplify_auth_cognito.fetch_auth_session_succeeded}
   succeeded,
-
-  /// {@macro amplify_auth_cognito.fetch_auth_session_failed}
-  failed,
 }
 
 /// Discrete events of the fetch auth session state machine.
@@ -48,11 +45,6 @@ abstract class FetchAuthSessionEvent
   const factory FetchAuthSessionEvent.succeeded(
     CognitoAuthSession session,
   ) = FetchAuthSessionSucceeded;
-
-  /// {@macro amplify_auth_cognito.fetch_auth_session_failed}
-  const factory FetchAuthSessionEvent.failed(
-    Exception exception,
-  ) = FetchAuthSessionFailed;
 
   @override
   String get runtimeTypeName => 'FetchAuthSessionEvent';
@@ -179,22 +171,4 @@ class FetchAuthSessionSucceeded extends FetchAuthSessionEvent {
 
   @override
   List<Object?> get props => [type, session];
-}
-
-/// {@template amplify_auth_cognito.fetch_auth_session_failed}
-/// Fetching the current user's auth session failed.
-/// {@endtemplate}
-class FetchAuthSessionFailed extends FetchAuthSessionEvent with ErrorEvent {
-  /// {@macro amplify_auth_cognito.fetch_auth_session_failed}
-  const FetchAuthSessionFailed(this.exception) : super._();
-
-  /// The exception thrown fetching credentials.
-  @override
-  final Exception exception;
-
-  @override
-  FetchAuthSessionEventType get type => FetchAuthSessionEventType.failed;
-
-  @override
-  List<Object?> get props => [type, exception];
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/hosted_ui_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/hosted_ui_event.dart
@@ -27,9 +27,6 @@ enum HostedUiEventType {
 
   /// {@macro amplify_auth_cognito.hosted_ui_succeeded}
   succeeded,
-
-  /// {@macro amplify_auth_cognito.hosted_ui_failed}
-  failed,
 }
 
 /// Discrete events of the hosted UI state machine.
@@ -67,9 +64,6 @@ abstract class HostedUiEvent
   const factory HostedUiEvent.succeeded(
     CognitoUserPoolTokens tokens,
   ) = HostedUiSucceeded;
-
-  /// {@macro amplify_auth_cognito.hosted_ui_failed}
-  const factory HostedUiEvent.failed(Exception exception) = HostedUiFailed;
 
   @override
   String get runtimeTypeName => 'HostedUiEvent';
@@ -241,33 +235,4 @@ class HostedUiSucceeded extends HostedUiEvent {
 
   @override
   HostedUiEventType get type => HostedUiEventType.succeeded;
-}
-
-/// {@template amplify_auth_cognito.hosted_ui_failed}
-/// The Hosted UI flow failed with an [exception].
-/// {@endtemplate}
-class HostedUiFailed extends HostedUiEvent with ErrorEvent {
-  /// {@macro amplify_auth_cognito.hosted_ui_failed}
-  const HostedUiFailed(this.exception) : super._();
-
-  /// The Hosted UI exception.
-  @override
-  final Exception exception;
-
-  @override
-  List<Object?> get props => [type, exception];
-
-  @override
-  HostedUiEventType get type => HostedUiEventType.failed;
-
-  @override
-  PreconditionException? checkPrecondition(HostedUiState currentState) {
-    if (currentState.type == HostedUiStateType.failure) {
-      return const AuthPreconditionException(
-        'The state machine is already in a failure state.',
-        shouldEmit: false,
-      );
-    }
-    return null;
-  }
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/sign_in_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/sign_in_event.dart
@@ -22,9 +22,6 @@ enum SignInEventType {
 
   /// {@macro amplify_auth_cognito.sign_in_succeeded}
   succeeded,
-
-  /// {@macro amplify_auth_cognito.sign_in_failed}
-  failed,
 }
 
 /// {@template amplify_auth_cognito.sign_in_event}
@@ -53,9 +50,6 @@ abstract class SignInEvent extends AuthEvent<SignInEventType, SignInStateType> {
 
   /// {@macro amplify_auth_cognito.sign_in_succeeded}
   const factory SignInEvent.succeeded(CognitoUser user) = SignInSucceeded;
-
-  /// {@macro amplify_auth_cognito.sign_in_failed}
-  const factory SignInEvent.failed(Exception exception) = SignInFailed;
 
   @override
   PreconditionException? checkPrecondition(SignInState currentState) => null;
@@ -187,35 +181,6 @@ class SignInSucceeded extends SignInEvent {
   PreconditionException? checkPrecondition(SignInState currentState) {
     if (currentState.type == SignInStateType.success) {
       return const AuthPreconditionException('Auth flow was already completed');
-    }
-    return null;
-  }
-}
-
-/// {@template amplify_auth_cognito.sign_in_failed}
-/// Failure in the auth flow.
-/// {@endtemplate}
-class SignInFailed extends SignInEvent with ErrorEvent {
-  /// {@macro amplify_auth_cognito.sign_in_failed}
-  const SignInFailed(this.exception) : super._();
-
-  /// The sign in flow exception.
-  @override
-  final Exception exception;
-
-  @override
-  SignInEventType get type => SignInEventType.failed;
-
-  @override
-  List<Object?> get props => [type, exception];
-
-  @override
-  PreconditionException? checkPrecondition(SignInState currentState) {
-    if (currentState.type == SignInStateType.failure) {
-      return const AuthPreconditionException(
-        'Auth flow already completed with error',
-        shouldEmit: false,
-      );
     }
     return null;
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/sign_up_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/sign_up_event.dart
@@ -3,7 +3,6 @@
 
 import 'package:amplify_auth_cognito_dart/src/model/sign_up_parameters.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
-import 'package:amplify_core/amplify_core.dart';
 
 /// Discrete event types of the sign up flow.
 enum SignUpEventType {
@@ -15,9 +14,6 @@ enum SignUpEventType {
 
   /// {@macro amplify_auth_cognito.sign_up_succeeded}
   succeeded,
-
-  /// {@macro amplify_auth_cognito.sign_up_failed}
-  failed,
 }
 
 /// Discrete events of the sign up flow.
@@ -43,9 +39,6 @@ abstract class SignUpEvent extends AuthEvent<SignUpEventType, SignUpStateType> {
   const factory SignUpEvent.succeeded({
     String? userId,
   }) = SignUpSucceeded;
-
-  /// {@macro amplify_auth_cognito.sign_up_failed}
-  const factory SignUpEvent.failed(Exception exception) = SignUpFailed;
 
   @override
   String get runtimeTypeName => 'SignUpEvent';
@@ -141,22 +134,4 @@ class SignUpSucceeded extends SignUpEvent {
 
   @override
   List<Object?> get props => [type, userId];
-}
-
-/// {@template amplify_auth_cognito.sign_up_failed}
-/// A failure in a sign up/confirm sign up event.
-/// {@endtemplate}
-class SignUpFailed extends SignUpEvent with ErrorEvent {
-  /// {@macro amplify_auth_cognito.sign_up_failed}
-  const SignUpFailed(this.exception) : super._();
-
-  /// The exception thrown signing up.
-  @override
-  final Exception exception;
-
-  @override
-  SignUpEventType get type => SignUpEventType.failed;
-
-  @override
-  List<Object?> get props => [type, exception];
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/auth_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/auth_state_machine.dart
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_auth_cognito_dart/src/state/event/auth_event.dart';
+import 'package:amplify_auth_cognito_dart/src/state/state/auth_state.dart';
+import 'package:amplify_core/amplify_core.dart';
+
+/// {@template amplify_auth_cognito_dart.state.auth_state_machine}
+/// Base class for state machines under a [CognitoAuthStateMachine].
+/// {@endtemplate}
+abstract class AuthStateMachine<Event extends AuthEvent,
+        State extends AuthState>
+    extends StateMachine<Event, State, AuthEvent, AuthState,
+        CognitoAuthStateMachine> {
+  /// {@macro amplify_auth_cognito_dart.state.auth_state_machine}
+  AuthStateMachine(super.manager, super.type);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/configuration_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/configuration_state_machine.dart
@@ -15,8 +15,8 @@ import 'package:amplify_core/amplify_core.dart';
 /// {@template amplify_auth_cognito.configuration_state_machine}
 /// Manages configuration of the Auth category.
 /// {@endtemplate}
-class ConfigurationStateMachine extends StateMachine<ConfigurationEvent,
-    ConfigurationState, AuthEvent, AuthState, CognitoAuthStateMachine> {
+class ConfigurationStateMachine
+    extends AuthStateMachine<ConfigurationEvent, ConfigurationState> {
   /// {@macro amplify_auth_cognito.configuration_state_machine}
   ConfigurationStateMachine(CognitoAuthStateMachine manager)
       : super(manager, type);
@@ -55,18 +55,13 @@ class ConfigurationStateMachine extends StateMachine<ConfigurationEvent,
         emit(ConfigurationState.configured(event.config));
         await onConfigureSucceeded(castEvent);
         return;
-      case ConfigurationEventType.configureFailed:
-        final castEvent = event as ConfigureFailed;
-        emit(ConfigurationState.failure(castEvent.exception));
-        await onConfigureFailed(castEvent);
-        return;
     }
   }
 
   @override
-  ConfigurationState? resolveError(Object error, [StackTrace? st]) {
+  ConfigurationState? resolveError(Object error, StackTrace st) {
     if (error is Exception) {
-      return ConfigureFailure(error);
+      return ConfigureFailure(error, st);
     }
     return null;
   }
@@ -123,19 +118,10 @@ class ConfigurationStateMachine extends StateMachine<ConfigurationEvent,
     CognitoPluginConfig config,
     List<Future<void>> futures,
   ) async {
-    try {
-      await Future.wait<void>(futures, eagerError: true);
-      emit(ConfigurationState.configured(config));
-    } on Exception catch (e) {
-      emit(
-        ConfigurationState.failure(AuthException.fromException(e)),
-      );
-    }
+    await Future.wait<void>(futures, eagerError: true);
+    emit(ConfigurationState.configured(config));
   }
 
   /// State machine callback for the [ConfigureSucceeded] event.
   Future<void> onConfigureSucceeded(ConfigureSucceeded event) async {}
-
-  /// State machine callback for the [ConfigureFailed] event.
-  Future<void> onConfigureFailed(ConfigureFailed event) async {}
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart
@@ -16,12 +16,12 @@ import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 import 'package:meta/meta.dart';
 
-/// {@template amplify_auth_cognito.auth_store_state_machine}
+/// {@template amplify_auth_cognito.credential_store_state_machine}
 /// Manages the loading and storing of auth configuration data.
 /// {@endtemplate}
-class CredentialStoreStateMachine extends StateMachine<CredentialStoreEvent,
-    CredentialStoreState, AuthEvent, AuthState, CognitoAuthStateMachine> {
-  /// {@macro amplify_auth_cognito.auth_store_state_machine}
+class CredentialStoreStateMachine
+    extends AuthStateMachine<CredentialStoreEvent, CredentialStoreState> {
+  /// {@macro amplify_auth_cognito.credential_store_state_machine}
   CredentialStoreStateMachine(CognitoAuthStateMachine manager)
       : super(manager, type);
 
@@ -65,17 +65,13 @@ class CredentialStoreStateMachine extends StateMachine<CredentialStoreEvent,
         event as CredentialStoreSucceeded;
         emit(CredentialStoreState.success(event.data));
         return;
-      case CredentialStoreEventType.failed:
-        event as CredentialStoreFailed;
-        emit(CredentialStoreState.failure(event.exception));
-        return;
     }
   }
 
   @override
-  CredentialStoreState? resolveError(Object error, [StackTrace? st]) {
+  CredentialStoreState? resolveError(Object error, StackTrace st) {
     if (error is Exception) {
-      return CredentialStoreFailure(error);
+      return CredentialStoreFailure(error, st);
     }
     return null;
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/fetch_auth_session_state_machine.dart
@@ -20,8 +20,8 @@ import 'package:amplify_core/amplify_core.dart';
 /// Fetches the user's auth session from the credential store and, optionally,
 /// a Cognito Identity Pool.
 /// {@endtemplate}
-class FetchAuthSessionStateMachine extends StateMachine<FetchAuthSessionEvent,
-    FetchAuthSessionState, AuthEvent, AuthState, CognitoAuthStateMachine> {
+class FetchAuthSessionStateMachine
+    extends AuthStateMachine<FetchAuthSessionEvent, FetchAuthSessionState> {
   /// {@macro amplify_auth_cognito.fetch_auth_session_state_machine}
   FetchAuthSessionStateMachine(CognitoAuthStateMachine manager)
       : super(manager, type);
@@ -75,17 +75,13 @@ class FetchAuthSessionStateMachine extends StateMachine<FetchAuthSessionEvent,
         event as FetchAuthSessionSucceeded;
         emit(FetchAuthSessionState.success(event.session));
         break;
-      case FetchAuthSessionEventType.failed:
-        event as FetchAuthSessionFailed;
-        emit(FetchAuthSessionState.failure(event.exception));
-        break;
     }
   }
 
   @override
-  FetchAuthSessionState? resolveError(Object error, [StackTrace? st]) {
+  FetchAuthSessionState? resolveError(Object error, StackTrace st) {
     if (error is Exception) {
-      return FetchAuthSessionFailure(error);
+      return FetchAuthSessionFailure(error, st);
     }
     return null;
   }
@@ -350,12 +346,8 @@ class FetchAuthSessionStateMachine extends StateMachine<FetchAuthSessionEvent,
     var userPoolTokens = result.userPoolTokens;
     if (event.refreshUserPoolTokens) {
       if (userPoolTokens == null) {
-        return emit(
-          const FetchAuthSessionState.failure(
-            UnknownException(
-              'No user pool tokens available for refresh',
-            ),
-          ),
+        throw const UnknownException(
+          'No user pool tokens available for refresh',
         );
       }
       try {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
@@ -14,8 +14,8 @@ import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 /// {@template amplify_auth_cognito.hosted_ui_state_machine}
 /// Manages the Hosted UI lifecycle and OIDC flow.
 /// {@endtemplate}
-class HostedUiStateMachine extends StateMachine<HostedUiEvent, HostedUiState,
-    AuthEvent, AuthState, CognitoAuthStateMachine> {
+class HostedUiStateMachine
+    extends AuthStateMachine<HostedUiEvent, HostedUiState> {
   /// {@macro amplify_auth_cognito.hosted_ui_state_machine}
   HostedUiStateMachine(CognitoAuthStateMachine manager) : super(manager, type);
 
@@ -70,18 +70,13 @@ class HostedUiStateMachine extends StateMachine<HostedUiEvent, HostedUiState,
         event as HostedUiSucceeded;
         await onSucceeded(event);
         break;
-      case HostedUiEventType.failed:
-        event as HostedUiFailed;
-        emit(HostedUiState.failure(event.exception));
-        await onFailed(event);
-        break;
     }
   }
 
   @override
-  HostedUiState? resolveError(Object error, [StackTrace? st]) {
+  HostedUiState? resolveError(Object error, StackTrace st) {
     if (error is Exception) {
-      return HostedUiFailure(error);
+      return HostedUiFailure(error, st);
     }
     return null;
   }
@@ -129,72 +124,56 @@ class HostedUiStateMachine extends StateMachine<HostedUiEvent, HostedUiState,
 
   /// State machine callback for the [HostedUiSignIn] event.
   Future<void> onSignIn(HostedUiSignIn event) async {
-    try {
+    await _secureStorage.write(
+      key: _keys[HostedUiKey.options],
+      value: jsonEncode(event.options),
+    );
+    final provider = event.provider;
+    if (provider != null) {
       await _secureStorage.write(
-        key: _keys[HostedUiKey.options],
-        value: jsonEncode(event.options),
+        key: _keys[HostedUiKey.provider],
+        value: jsonEncode(provider),
       );
-      final provider = event.provider;
-      if (provider != null) {
-        await _secureStorage.write(
-          key: _keys[HostedUiKey.provider],
-          value: jsonEncode(provider),
-        );
-      } else {
-        await _secureStorage.delete(key: _keys[HostedUiKey.provider]);
-      }
-      await _platform.signIn(
-        options: event.options,
-        provider: provider,
-      );
-    } on Exception catch (e) {
-      emit(HostedUiState.failure(e));
+    } else {
+      await _secureStorage.delete(key: _keys[HostedUiKey.provider]);
     }
+    await _platform.signIn(
+      options: event.options,
+      provider: provider,
+    );
   }
 
   /// State machine callback for the [HostedUiCancelSignIn] event.
   Future<void> onCancelSignIn(HostedUiCancelSignIn event) async {
     await _platform.cancelSignIn();
     await manager.clearCredentials(_keys);
-    emit(
-      const HostedUiState.failure(
-        UserCancelledException('The user cancelled the sign-in flow'),
-      ),
-    );
+    throw const UserCancelledException('The user cancelled the sign-in flow');
   }
 
   /// State machine callback for the [HostedUiExchange] event.
   Future<void> onExchange(HostedUiExchange event) async {
-    try {
-      final tokens = await _platform.exchange(event.parameters);
-      return resolve(HostedUiEvent.succeeded(tokens));
-    } on Exception catch (e) {
-      emit(HostedUiState.failure(e));
-    }
+    final tokens = await _platform.exchange(event.parameters);
+    return resolve(HostedUiEvent.succeeded(tokens));
   }
 
   /// State machine callback for the [HostedUiSignOut] event.
   Future<void> onSignOut(HostedUiSignOut event) async {
-    try {
-      final optionsJson = await _secureStorage.read(
-        key: _keys[HostedUiKey.options],
-      );
-      var options = const CognitoSignOutWithWebUIOptions();
-      var isPreferPrivateSession = false;
-      if (optionsJson != null) {
-        final optionsMap = jsonDecode(optionsJson) as Map<String, Object?>;
-        options = CognitoSignOutWithWebUIOptions.fromJson(optionsMap);
-        isPreferPrivateSession =
-            optionsMap['isPreferPrivateSession'] as bool? ?? false;
-      }
-      await _platform.signOut(
-        options: options,
-        isPreferPrivateSession: isPreferPrivateSession,
-      );
-      emit(const HostedUiState.signedOut());
-    } on Exception catch (e) {
-      emit(HostedUiState.failure(e));
+    final optionsJson = await _secureStorage.read(
+      key: _keys[HostedUiKey.options],
+    );
+    var options = const CognitoSignOutWithWebUIOptions();
+    var isPreferPrivateSession = false;
+    if (optionsJson != null) {
+      final optionsMap = jsonDecode(optionsJson) as Map<String, Object?>;
+      options = CognitoSignOutWithWebUIOptions.fromJson(optionsMap);
+      isPreferPrivateSession =
+          optionsMap['isPreferPrivateSession'] as bool? ?? false;
     }
+    await _platform.signOut(
+      options: options,
+      isPreferPrivateSession: isPreferPrivateSession,
+    );
+    emit(const HostedUiState.signedOut());
   }
 
   /// State machine callback for the [HostedUiSucceeded] event.
@@ -229,9 +208,6 @@ class HostedUiStateMachine extends StateMachine<HostedUiEvent, HostedUiState,
       ),
     );
   }
-
-  /// State machine callback for the [HostedUiFailed] event.
-  Future<void> onFailed(HostedUiFailed event) async {}
 
   @override
   Future<void> close() async {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -31,8 +31,7 @@ import 'package:meta/meta.dart';
 /// the same pattern of calling `cognitoIdp.InitiateAuth` plus some number of
 /// challenge responses.
 /// {@endtemplate}
-class SignInStateMachine extends StateMachine<SignInEvent, SignInState,
-    AuthEvent, AuthState, CognitoAuthStateMachine> {
+class SignInStateMachine extends AuthStateMachine<SignInEvent, SignInState> {
   /// {@macro amplify_auth_cognito.sign_in_state_machine}
   SignInStateMachine(CognitoAuthStateMachine manager) : super(manager, type);
 
@@ -878,18 +877,13 @@ class SignInStateMachine extends StateMachine<SignInEvent, SignInState,
         event as SignInSucceeded;
         emit(SignInState.success(event.user));
         return;
-      case SignInEventType.failed:
-        // TODO(dnys1): Transition to challenge state for CodeMismatchException
-        event as SignInFailed;
-        emit(SignInState.failure(event.exception));
-        return;
     }
   }
 
   @override
-  SignInState? resolveError(Object error, [StackTrace? st]) {
+  SignInState? resolveError(Object error, StackTrace st) {
     if (error is Exception) {
-      return SignInFailure(error);
+      return SignInFailure(error, st);
     }
     return null;
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_up_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_up_state_machine.dart
@@ -10,8 +10,7 @@ import 'package:amplify_core/amplify_core.dart';
 /// {@template amplify_auth_cognito.sign_up_state_machine}
 /// Manages user sign up with Cognito.
 /// {@endtemplate}
-class SignUpStateMachine extends StateMachine<SignUpEvent, SignUpState,
-    AuthEvent, AuthState, CognitoAuthStateMachine> {
+class SignUpStateMachine extends AuthStateMachine<SignUpEvent, SignUpState> {
   /// {@macro amplify_auth_cognito.sign_up_state_machine}
   SignUpStateMachine(CognitoAuthStateMachine manager) : super(manager, type);
 
@@ -46,18 +45,13 @@ class SignUpStateMachine extends StateMachine<SignUpEvent, SignUpState,
         emit(SignUpState.success(userId: event.userId));
         await onSucceeded(event);
         break;
-      case SignUpEventType.failed:
-        event as SignUpFailed;
-        emit(SignUpState.failure(event.exception));
-        await onFailed(event);
-        break;
     }
   }
 
   @override
-  SignUpState? resolveError(Object error, [StackTrace? st]) {
+  SignUpState? resolveError(Object error, StackTrace st) {
     if (error is Exception) {
-      return SignUpFailure(error);
+      return SignUpFailure(error, st);
     }
     return null;
   }
@@ -139,7 +133,4 @@ class SignUpStateMachine extends StateMachine<SignUpEvent, SignUpState,
 
   /// State machine callback for the [SignUpSucceeded] event.
   Future<void> onSucceeded(SignUpSucceeded event) async {}
-
-  /// State machine callback for the [SignUpFailed] event.
-  Future<void> onFailed(SignUpFailed event) async {}
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state.dart
@@ -16,6 +16,7 @@ export 'event/fetch_auth_session_event.dart';
 export 'event/hosted_ui_event.dart';
 export 'event/sign_in_event.dart';
 export 'event/sign_up_event.dart';
+export 'machines/auth_state_machine.dart';
 export 'machines/configuration_state_machine.dart';
 export 'machines/credential_store_state_machine.dart';
 export 'machines/fetch_auth_session_state_machine.dart';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/auth_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/auth_state.dart
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import 'package:amplify_auth_cognito_dart/src/state/cognito_state_machine.dart';
 import 'package:amplify_core/amplify_core.dart';
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/configuration_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/configuration_state.dart
@@ -39,8 +39,10 @@ abstract class ConfigurationState extends AuthState<ConfigurationStateType> {
       Configured;
 
   /// {@macro amplify_auth_cognito.configuration_state.configure_failure}
-  const factory ConfigurationState.failure(Exception exception) =
-      ConfigureFailure;
+  const factory ConfigurationState.failure(
+    Exception exception,
+    StackTrace stackTrace,
+  ) = ConfigureFailure;
 
   @override
   String get runtimeTypeName => 'ConfigurationState';
@@ -96,15 +98,18 @@ class Configured extends ConfigurationState with SuccessState {
 /// {@endtemplate}
 class ConfigureFailure extends ConfigurationState with ErrorState {
   /// {@macro amplify_auth_cognito.configuration_state.configure_failure}
-  const ConfigureFailure(this.exception);
+  const ConfigureFailure(this.exception, this.stackTrace);
 
   /// The exception thrown during configuration.
   @override
   final Exception exception;
 
   @override
+  final StackTrace stackTrace;
+
+  @override
   ConfigurationStateType get type => ConfigurationStateType.failure;
 
   @override
-  List<Object?> get props => [type, exception];
+  List<Object?> get props => [type, exception, stackTrace];
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/credential_store_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/credential_store_state.dart
@@ -61,8 +61,10 @@ abstract class CredentialStoreState
       CredentialStoreSuccess;
 
   /// {@macro amplify_auth_cognito.credential_store_failure}
-  const factory CredentialStoreState.failure(Exception exception) =
-      CredentialStoreFailure;
+  const factory CredentialStoreState.failure(
+    Exception exception,
+    StackTrace stackTrace,
+  ) = CredentialStoreFailure;
 
   @override
   String get runtimeTypeName => 'CredentialStoreState';
@@ -167,17 +169,20 @@ class CredentialStoreSuccess extends CredentialStoreState with SuccessState {
 /// {@endtemplate}
 class CredentialStoreFailure extends CredentialStoreState with ErrorState {
   /// {@macro amplify_auth_cognito.credential_store_failure}
-  const CredentialStoreFailure(this.exception) : super._();
+  const CredentialStoreFailure(this.exception, this.stackTrace) : super._();
 
   /// The exception thrown during credential storage.
   @override
   final Exception exception;
 
   @override
+  final StackTrace stackTrace;
+
+  @override
   CredentialStoreStateType get type => CredentialStoreStateType.failure;
 
   @override
-  List<Object?> get props => [type, exception];
+  List<Object?> get props => [type, exception, stackTrace];
 }
 
 /// {@template amplify_auth_cognito_dart.credential_store_state.credential_store_data}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/fetch_auth_session_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/fetch_auth_session_state.dart
@@ -45,6 +45,7 @@ abstract class FetchAuthSessionState
   /// {@macro amplify_auth_cognito.fetch_auth_session_failure}
   const factory FetchAuthSessionState.failure(
     Exception exception,
+    StackTrace stackTrace,
   ) = FetchAuthSessionFailure;
 
   @override
@@ -115,15 +116,18 @@ class FetchAuthSessionSuccess extends FetchAuthSessionState with SuccessState {
 /// {@endtemplate}
 class FetchAuthSessionFailure extends FetchAuthSessionState with ErrorState {
   /// {@macro amplify_auth_cognito.fetch_auth_session_failure}
-  const FetchAuthSessionFailure(this.exception) : super._();
+  const FetchAuthSessionFailure(this.exception, this.stackTrace) : super._();
 
   /// The exception thrown fetching credentials.
   @override
   final Exception exception;
 
   @override
+  final StackTrace stackTrace;
+
+  @override
   FetchAuthSessionStateType get type => FetchAuthSessionStateType.failure;
 
   @override
-  List<Object?> get props => [type, exception];
+  List<Object?> get props => [type, exception, stackTrace];
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/hosted_ui_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/hosted_ui_state.dart
@@ -51,7 +51,10 @@ abstract class HostedUiState extends AuthState<HostedUiStateType> {
   const factory HostedUiState.signedIn(AuthUser user) = HostedUiSignedIn;
 
   /// {@macro amplify_auth_cognito.hosted_ui_failure}
-  const factory HostedUiState.failure(Exception exception) = HostedUiFailure;
+  const factory HostedUiState.failure(
+    Exception exception,
+    StackTrace stackTrace,
+  ) = HostedUiFailure;
 
   @override
   String get runtimeTypeName => 'HostedUiState';
@@ -149,14 +152,17 @@ class HostedUiSignedIn extends HostedUiState with SuccessState {
 /// {@endtemplate}
 class HostedUiFailure extends HostedUiState with ErrorState {
   /// {@macro amplify_auth_cognito.hosted_ui_failure}
-  const HostedUiFailure(this.exception) : super._();
+  const HostedUiFailure(this.exception, this.stackTrace) : super._();
 
   /// The Hosted UI exception.
   @override
   final Exception exception;
 
   @override
-  List<Object?> get props => [type, exception];
+  final StackTrace stackTrace;
+
+  @override
+  List<Object?> get props => [type, exception, stackTrace];
 
   @override
   HostedUiStateType get type => HostedUiStateType.failure;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_in_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_in_state.dart
@@ -56,7 +56,10 @@ abstract class SignInState extends AuthState<SignInStateType> {
   const factory SignInState.cancelling() = SignInCancelling;
 
   /// {@macro amplify_auth_cognito_dart.sign_in_failure}
-  const factory SignInState.failure(Exception exception) = SignInFailure;
+  const factory SignInState.failure(
+    Exception exception,
+    StackTrace stackTrace,
+  ) = SignInFailure;
 
   @override
   String get runtimeTypeName => 'SignInState';
@@ -158,15 +161,18 @@ class SignInCancelling extends SignInState {
 /// {@endtemplate}
 class SignInFailure extends SignInState with ErrorState {
   /// {@macro amplify_auth_cognito_dart.sign_in_failure}
-  const SignInFailure(this.exception);
+  const SignInFailure(this.exception, this.stackTrace);
 
   /// The exception thrown during sign up.
   @override
   final Exception exception;
 
   @override
+  final StackTrace stackTrace;
+
+  @override
   SignInStateType get type => SignInStateType.failure;
 
   @override
-  List<Object?> get props => [type, exception];
+  List<Object?> get props => [type, exception, stackTrace];
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_up_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_up_state.dart
@@ -51,7 +51,10 @@ abstract class SignUpState extends AuthState<SignUpStateType> {
   }) = SignUpSuccess;
 
   /// {@macro amplify_auth_cognito.sign_up_failure}
-  const factory SignUpState.failure(Exception exception) = SignUpFailure;
+  const factory SignUpState.failure(
+    Exception exception,
+    StackTrace stackTrace,
+  ) = SignUpFailure;
 
   @override
   String get runtimeTypeName => 'SignUpState';
@@ -146,15 +149,18 @@ class SignUpSuccess extends SignUpState with SuccessState {
 /// {@endtemplate}
 class SignUpFailure extends SignUpState with ErrorState {
   /// {@macro amplify_auth_cognito.sign_up_failure}
-  const SignUpFailure(this.exception) : super._();
+  const SignUpFailure(this.exception, this.stackTrace) : super._();
 
   /// The exception thrown during sign up.
   @override
   final Exception exception;
 
   @override
+  final StackTrace stackTrace;
+
+  @override
   SignUpStateType get type => SignUpStateType.failure;
 
   @override
-  List<Object?> get props => [type, exception];
+  List<Object?> get props => [type, exception, stackTrace];
 }

--- a/packages/auth/amplify_auth_cognito_test/lib/hosted_ui/hosted_ui_common.dart
+++ b/packages/auth/amplify_auth_cognito_test/lib/hosted_ui/hosted_ui_common.dart
@@ -124,9 +124,7 @@ loginButton.click();
       [],
     );
 
-    await locationChanges.firstWhere(
-      (uri) => uri.host == 'localhost' && uri.path == '/auth',
-    );
+    await locationChanges.firstWhere((uri) => uri.host == 'localhost');
   }
 }
 


### PR DESCRIPTION
Errors originating within state machines lose context when thrown since there is an asynchronous gap between adding an event to a state machine and when it eventually gets processed.

For example, consider the following exception thrown from a state machine:

```
ERROR | MyStateMachine | Emitted error: Exception
#0      MyStateMachine.doWork (file:///Users/nydillon/dev/amplify-dart/packages/amplify_core/test/state_machine/my_state_machine.dart:82:7)
<asynchronous suspension>
#1      MyStateMachine.resolve (file:///Users/nydillon/dev/amplify-dart/packages/amplify_core/test/state_machine/my_state_machine.dart💯9)
<asynchronous suspension>
#2      StateMachine._listenForEvents (package:amplify_core/src/state_machine/state_machine.dart:237:9)
<asynchronous suspension>
```

The trace ends at `listenForEvents` in the state machine, which is where the event was popped off the internal queue. But what happened before? With chaining, we get the following which provides the whole picture:

```
ERROR | MyStateMachine | Emitted error: Exception
test/state_machine/my_state_machine.dart 82:7                     MyStateMachine.doWork
test/state_machine/my_state_machine.dart 100:9                    MyStateMachine.resolve
package:amplify_core/src/state_machine/state_machine.dart 238:9   StateMachine._listenForEvents
===== asynchronous gap ===========================
package:amplify_core/src/state_machine/event.dart 41:47           new EventCompleter
package:amplify_core/src/state_machine/state_machine.dart 127:23  StateMachineManager.accept
test/state_machine/state_machine_test.dart 47:30                  main.<fn>.<fn>
package:test_api/src/backend/declarer.dart 215:19                 Declarer.test.<fn>.<fn>
package:test_api/src/backend/declarer.dart 213:7                  Declarer.test.<fn>
package:test_api/src/backend/invoker.dart 258:9                   Invoker._waitForOutstandingCallbacks.<fn>
```

Now we can see that the exception originated due to an event which was created by calling `StateMachineManager.accept` within a test. Much better!
