### PR TITLE
chore(core): Mark event completer methods with `@useResult`

### DIFF
--- a/packages/amplify_core/lib/src/state_machine/event.dart
+++ b/packages/amplify_core/lib/src/state_machine/event.dart
@@ -86,4 +86,10 @@ class EventCompleter<Event extends StateMachineEvent,
       _completer.completeError(error, stackTrace);
     }
   }
+
+  /// Ignores the result of the event completer.
+  ///
+  /// Since state machine methods are marked with `@useResult`, this allows
+  /// opting into fire-and-forget behavior explicitly.
+  void ignore() {}
 }

--- a/packages/amplify_core/lib/src/state_machine/state_machine.dart
+++ b/packages/amplify_core/lib/src/state_machine/state_machine.dart
@@ -9,10 +9,26 @@ import 'package:stack_trace/stack_trace.dart';
 
 /// Interface for dispatching an event to a state machine.
 @optionalTypeArgs
-abstract class Dispatcher<E extends StateMachineEvent,
-    S extends StateMachineState> {
-  /// Dispatches an event.
+mixin Dispatcher<E extends StateMachineEvent, S extends StateMachineState> {
+  /// Dispatches an event to the appropriate state machine.
+  @useResult
   EventCompleter<E, S> dispatch(E event);
+
+  /// Dispatches an event to the appropriate state machine and awaits its
+  /// completion.
+  ///
+  /// See also:
+  /// - [dispatch] which returns an [EventCompleter] instead of a [Future].
+  Future<SuccessState> dispatchAndComplete<SuccessState extends S>(
+    E event,
+  ) async {
+    final completer = dispatch(event);
+    final state = await completer.completed;
+    if (state is ErrorState) {
+      Error.throwWithStackTrace(state.exception, state.stackTrace);
+    }
+    return state as SuccessState;
+  }
 }
 
 /// Interface for emitting a state from a state machine.
@@ -48,7 +64,8 @@ abstract class StateMachineManager<
         E extends StateMachineEvent,
         S extends StateMachineState,
         Manager extends StateMachineManager<E, S, Manager>>
-    implements DependencyManager, Dispatcher<E, S>, Closeable {
+    with Dispatcher<E, S>
+    implements DependencyManager, Closeable {
   /// {@macro amplify_core.state_machinedispatcher}
   StateMachineManager(
     Map<StateMachineToken, Function> stateMachineBuilders,
@@ -123,6 +140,7 @@ abstract class StateMachineManager<
   /// fully processed by its state machine, the [EventCompleter.completed]
   /// property will complete with the stopping state reached. At this point,
   /// the event is done processing.
+  @useResult
   EventCompleter<E, S> accept(E event) {
     final completer = EventCompleter<E, S>(event);
     _eventController.add(completer);
@@ -150,6 +168,7 @@ abstract class StateMachineManager<
   @override
   @protected
   @visibleForTesting
+  @useResult
   EventCompleter<E, S> dispatch(E event, [EventCompleter<E, S>? completer]) {
     final token = mapEventToMachine(event);
     completer ??= EventCompleter(event);
@@ -157,21 +176,13 @@ abstract class StateMachineManager<
     return completer;
   }
 
-  /// Dispatches an event to the appropriate state machine and awaits its
-  /// completion.
-  ///
-  /// See also:
-  /// - [dispatch] which returns an [EventCompleter] instead of a [Future].
+  @override
+  @protected
+  @visibleForTesting
   Future<SuccessState> dispatchAndComplete<SuccessState extends S>(
     E event,
-  ) async {
-    final completer = dispatch(event);
-    final state = await completer.completed;
-    if (state is ErrorState) {
-      Error.throwWithStackTrace(state.exception, state.stackTrace);
-    }
-    return state as SuccessState;
-  }
+  ) =>
+      super.dispatchAndComplete(event);
 
   /// Maps [event] to its state machine.
   StateMachineToken mapEventToMachine(E event);
@@ -388,8 +399,15 @@ abstract class StateMachine<
 
   /// Dispatches an event to the state machine.
   @override
+  @useResult
   EventCompleter<ManagerEvent, ManagerState> dispatch(ManagerEvent event) =>
       manager.dispatch(event);
+
+  @override
+  Future<SuccessState> dispatchAndComplete<SuccessState extends ManagerState>(
+    ManagerEvent event,
+  ) =>
+      manager.dispatchAndComplete(event);
 
   /// Closes the state machine and all stream controllers.
   @override

--- a/packages/amplify_core/test/state_machine/dependency_manager_test.dart
+++ b/packages/amplify_core/test/state_machine/dependency_manager_test.dart
@@ -30,7 +30,7 @@ class NeedsDependencyManagerAndDispatcher {
   final Dispatcher dispatcher;
 }
 
-class MyDispatcher implements Dispatcher {
+class MyDispatcher with Dispatcher {
   @override
   EventCompleter<StateMachineEvent, StateMachineState> dispatch(
     StateMachineEvent event,

--- a/packages/amplify_core/test/state_machine/my_state_machine.dart
+++ b/packages/amplify_core/test/state_machine/my_state_machine.dart
@@ -189,7 +189,7 @@ class WorkerMachine extends StateMachine<WorkerEvent, WorkerState,
         break;
       case WorkType.doWork:
         await Future<void>.delayed(Duration.zero);
-        dispatch(const WorkerEvent(WorkType.success));
+        dispatch(const WorkerEvent(WorkType.success)).ignore();
         break;
     }
   }
@@ -213,7 +213,7 @@ class MyStateMachineManager extends StateMachineManager<StateMachineEvent,
   ) : super(_builders, dependencyManager);
 
   Future<void> delegateWork() async {
-    dispatch(const WorkerEvent(WorkType.doWork));
+    dispatch(const WorkerEvent(WorkType.doWork)).ignore();
     final machine = getOrCreate(WorkerMachine.type);
     await for (final state in machine.stream) {
       switch (state.type) {

--- a/packages/amplify_core/test/state_machine/state_machine_test.dart
+++ b/packages/amplify_core/test/state_machine/state_machine_test.dart
@@ -20,7 +20,7 @@ void main() {
           stateMachine.getOrCreate(MyStateMachine.type).currentState;
       expect(currentState.type, equals(MyType.initial));
 
-      stateMachine.accept(const MyEvent(MyType.initial));
+      stateMachine.accept(const MyEvent(MyType.initial)).ignore();
       expect(
         stateMachine.stream,
         neverEmits(anything),
@@ -30,7 +30,7 @@ void main() {
     });
 
     test('dispatches correctly', () {
-      stateMachine.accept(const MyEvent(MyType.doWork));
+      stateMachine.accept(const MyEvent(MyType.doWork)).ignore();
       expect(
         stateMachine.stream,
         emitsThrough(const MyState(MyType.success)),
@@ -68,7 +68,7 @@ void main() {
             ),
           ),
         );
-        stateMachine.accept(const MyEvent(MyType.tryWork));
+        stateMachine.accept(const MyEvent(MyType.tryWork)).ignore();
       });
 
       test('accept', () async {
@@ -125,7 +125,7 @@ void main() {
 
     group('subscribeTo', () {
       test('can listen to other machines', () {
-        stateMachine.accept(const MyEvent(MyType.delegateWork));
+        stateMachine.accept(const MyEvent(MyType.delegateWork)).ignore();
         expect(
           stateMachine.stream,
           emitsInOrder([
@@ -138,7 +138,7 @@ void main() {
       });
 
       test('can listen multiple times to other machines', () async {
-        stateMachine.accept(const MyEvent(MyType.delegateWork));
+        stateMachine.accept(const MyEvent(MyType.delegateWork)).ignore();
         await expectLater(
           stateMachine.stream,
           emitsInOrder([
@@ -149,7 +149,7 @@ void main() {
           ]),
         );
 
-        stateMachine.accept(const MyEvent(MyType.delegateWork));
+        stateMachine.accept(const MyEvent(MyType.delegateWork)).ignore();
         await expectLater(
           stateMachine.stream,
           emitsInOrder([

--- a/packages/auth/amplify_auth_cognito/example/integration_test/hosted_ui_webview_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/hosted_ui_webview_test.dart
@@ -181,8 +181,8 @@ loginButton.click();
       rethrow;
     }
     final oauthParameters = await _oauthParameters.future;
-    dispatcher.dispatch(
-      HostedUiEvent.exchange(oauthParameters),
+    unawaited(
+      dispatcher.dispatchAndComplete(HostedUiEvent.exchange(oauthParameters)),
     );
   }
 

--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -233,7 +233,11 @@ class _NativeAmplifyAuthCognito
     final oauthParameters = OAuthParameters.fromJson(params.cast());
     final hostedUiStateMachine = _stateMachine.get(HostedUiStateMachine.type);
     if (hostedUiStateMachine != null) {
-      _stateMachine.accept(HostedUiEvent.exchange(oauthParameters));
+      unawaited(
+        _stateMachine.acceptAndComplete(
+          HostedUiEvent.exchange(oauthParameters),
+        ),
+      );
     } else {
       // Cache them as initial route parameters.
       _stateMachine.addInstance(oauthParameters);

--- a/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_flutter.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_flutter.dart
@@ -74,13 +74,17 @@ class HostedUiPlatformImpl extends io.HostedUiPlatformImpl {
         options.isPreferPrivateSession,
         options.browserPackageName,
       );
-      dispatcher.dispatch(
-        HostedUiEvent.exchange(
-          OAuthParameters.fromJson(queryParameters.cast()),
+      unawaited(
+        dispatcher.dispatchAndComplete(
+          HostedUiEvent.exchange(
+            OAuthParameters.fromJson(queryParameters.cast()),
+          ),
         ),
       );
     } on Exception catch (e) {
-      dispatcher.dispatch(const HostedUiEvent.cancelSignIn());
+      unawaited(
+        dispatcher.dispatchAndComplete(const HostedUiEvent.cancelSignIn()),
+      );
       if (e is PlatformException) {
         if (e.code == 'CANCELLED') {
           throw const UserCancelledException(

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_io.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_io.dart
@@ -247,9 +247,11 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
           );
           continue;
         }
-        dispatcher.dispatch(
-          HostedUiEvent.exchange(
-            OAuthParameters.fromJson(queryParams),
+        unawaited(
+          dispatcher.dispatchAndComplete(
+            HostedUiEvent.exchange(
+              OAuthParameters.fromJson(queryParams),
+            ),
           ),
         );
         await _respond(

--- a/packages/auth/amplify_auth_cognito_test/test/common/mock_dispatcher.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/common/mock_dispatcher.dart
@@ -4,7 +4,7 @@
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
 
-class MockDispatcher implements Dispatcher<AuthEvent, AuthState> {
+class MockDispatcher with Dispatcher<AuthEvent, AuthState> {
   const MockDispatcher({
     this.onDispatch,
   });

--- a/packages/auth/amplify_auth_cognito_test/test/credentials/auth_plugin_credentials_provider_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/credentials/auth_plugin_credentials_provider_test.dart
@@ -22,7 +22,7 @@ void main() {
     setUp(() async {
       stateMachine = CognitoAuthStateMachine()
         ..addBuilder<SecureStorageInterface>(MockSecureStorage.new)
-        ..dispatch(ConfigurationEvent.configure(mockConfig));
+        ..dispatch(ConfigurationEvent.configure(mockConfig)).ignore();
       provider = AuthPluginCredentialsProviderImpl(stateMachine);
 
       await stateMachine.stream.firstWhere((state) => state is Configured);

--- a/packages/auth/amplify_auth_cognito_test/test/state/configuration_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/configuration_state_machine_test.dart
@@ -28,7 +28,7 @@ void main() {
       final configurationStateMachine =
           stateMachine.getOrCreate(ConfigurationStateMachine.type);
 
-      stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+      stateMachine.dispatch(ConfigurationEvent.configure(mockConfig)).ignore();
       await expectLater(
         configurationStateMachine.stream
             .startWith(configurationStateMachine.currentState),
@@ -64,7 +64,7 @@ void main() {
       final configurationStateMachine =
           stateMachine.getOrCreate(ConfigurationStateMachine.type);
 
-      stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+      stateMachine.dispatch(ConfigurationEvent.configure(mockConfig)).ignore();
       await expectLater(
         configurationStateMachine.stream
             .startWith(configurationStateMachine.currentState),
@@ -75,7 +75,7 @@ void main() {
         ]),
       );
 
-      stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+      stateMachine.dispatch(ConfigurationEvent.configure(mockConfig)).ignore();
       expect(
         configurationStateMachine.stream,
         emitsDone,

--- a/packages/auth/amplify_auth_cognito_test/test/state/credential_store_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/credential_store_state_machine_test.dart
@@ -37,9 +37,11 @@ void main() {
 
     // Load an empty credential store.
     test('loadCredentialStore (empty)', () async {
-      stateMachine.dispatch(
-        const CredentialStoreEvent.loadCredentialStore(),
-      );
+      stateMachine
+          .dispatch(
+            const CredentialStoreEvent.loadCredentialStore(),
+          )
+          .ignore();
 
       final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
       await expectLater(
@@ -63,9 +65,11 @@ void main() {
         identityPoolKeys: identityPoolKeys,
         version: CredentialStoreVersion.v1,
       );
-      stateMachine.dispatch(
-        const CredentialStoreEvent.loadCredentialStore(),
-      );
+      stateMachine
+          .dispatch(
+            const CredentialStoreEvent.loadCredentialStore(),
+          )
+          .ignore();
 
       final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
       await expectLater(
@@ -94,9 +98,11 @@ void main() {
 
     group('storeCredentials', () {
       test('all', () async {
-        stateMachine.dispatch(
-          const CredentialStoreEvent.loadCredentialStore(),
-        );
+        stateMachine
+            .dispatch(
+              const CredentialStoreEvent.loadCredentialStore(),
+            )
+            .ignore();
 
         final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
         await expectLater(
@@ -125,7 +131,7 @@ void main() {
             ),
           ),
         );
-        stateMachine.dispatch(storeCredentialsEvent);
+        stateMachine.dispatch(storeCredentialsEvent).ignore();
 
         await expectLater(
           sm.stream.startWith(sm.currentState),
@@ -158,9 +164,11 @@ void main() {
           identityPoolKeys: identityPoolKeys,
           version: CredentialStoreVersion.v1,
         );
-        stateMachine.dispatch(
-          const CredentialStoreEvent.loadCredentialStore(),
-        );
+        stateMachine
+            .dispatch(
+              const CredentialStoreEvent.loadCredentialStore(),
+            )
+            .ignore();
 
         final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
         await expectLater(
@@ -172,13 +180,15 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(
-          const CredentialStoreEvent.storeCredentials(
-            CredentialStoreData(
-              identityId: identityId,
-            ),
-          ),
-        );
+        stateMachine
+            .dispatch(
+              const CredentialStoreEvent.storeCredentials(
+                CredentialStoreData(
+                  identityId: identityId,
+                ),
+              ),
+            )
+            .ignore();
         await expectLater(
           sm.stream.startWith(sm.currentState),
           emitsInOrder(<Matcher>[
@@ -210,9 +220,11 @@ void main() {
           identityPoolKeys: identityPoolKeys,
           version: CredentialStoreVersion.v1,
         );
-        stateMachine.dispatch(
-          const CredentialStoreEvent.loadCredentialStore(),
-        );
+        stateMachine
+            .dispatch(
+              const CredentialStoreEvent.loadCredentialStore(),
+            )
+            .ignore();
 
         final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
         await expectLater(
@@ -230,13 +242,15 @@ void main() {
           newAccessKeyId,
           newSecretAccessKey,
         );
-        stateMachine.dispatch(
-          const CredentialStoreEvent.storeCredentials(
-            CredentialStoreData(
-              awsCredentials: newCredentials,
-            ),
-          ),
-        );
+        stateMachine
+            .dispatch(
+              const CredentialStoreEvent.storeCredentials(
+                CredentialStoreData(
+                  awsCredentials: newCredentials,
+                ),
+              ),
+            )
+            .ignore();
         await expectLater(
           sm.stream.startWith(sm.currentState),
           emitsInOrder(<Matcher>[
@@ -323,9 +337,11 @@ void main() {
           identityPoolKeys: identityPoolKeys,
           version: CredentialStoreVersion.v1,
         );
-        stateMachine.dispatch(
-          const CredentialStoreEvent.loadCredentialStore(),
-        );
+        stateMachine
+            .dispatch(
+              const CredentialStoreEvent.loadCredentialStore(),
+            )
+            .ignore();
 
         final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
         await expectLater(
@@ -337,9 +353,11 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(
-          const CredentialStoreEvent.clearCredentials(),
-        );
+        stateMachine
+            .dispatch(
+              const CredentialStoreEvent.clearCredentials(),
+            )
+            .ignore();
 
         await expectLater(
           sm.stream.startWith(sm.currentState),
@@ -365,9 +383,11 @@ void main() {
           identityPoolKeys: identityPoolKeys,
           version: CredentialStoreVersion.v1,
         );
-        stateMachine.dispatch(
-          const CredentialStoreEvent.loadCredentialStore(),
-        );
+        stateMachine
+            .dispatch(
+              const CredentialStoreEvent.loadCredentialStore(),
+            )
+            .ignore();
 
         final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
         await expectLater(
@@ -379,11 +399,13 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(
-          CredentialStoreEvent.clearCredentials(
-            identityPoolKeys,
-          ),
-        );
+        stateMachine
+            .dispatch(
+              CredentialStoreEvent.clearCredentials(
+                identityPoolKeys,
+              ),
+            )
+            .ignore();
 
         await expectLater(
           sm.stream.startWith(sm.currentState),
@@ -410,9 +432,11 @@ void main() {
         // verify credential store is not migrated.
         expect(await sm.getVersion(), CredentialStoreVersion.none);
 
-        stateMachine.dispatch(
-          const CredentialStoreEvent.loadCredentialStore(),
-        );
+        stateMachine
+            .dispatch(
+              const CredentialStoreEvent.loadCredentialStore(),
+            )
+            .ignore();
 
         await expectLater(
           sm.stream.startWith(sm.currentState),
@@ -447,9 +471,11 @@ void main() {
         // verify credential store is not migrated.
         expect(await sm.getVersion(), CredentialStoreVersion.none);
 
-        stateMachine.dispatch(
-          const CredentialStoreEvent.loadCredentialStore(),
-        );
+        stateMachine
+            .dispatch(
+              const CredentialStoreEvent.loadCredentialStore(),
+            )
+            .ignore();
 
         await expectLater(
           sm.stream.startWith(sm.currentState),
@@ -496,9 +522,11 @@ void main() {
         // verify credential store is not migrated.
         expect(await sm.getVersion(), CredentialStoreVersion.none);
 
-        stateMachine.dispatch(
-          const CredentialStoreEvent.loadCredentialStore(),
-        );
+        stateMachine
+            .dispatch(
+              const CredentialStoreEvent.loadCredentialStore(),
+            )
+            .ignore();
 
         await expectLater(
           sm.stream.startWith(sm.currentState),
@@ -544,9 +572,11 @@ void main() {
         // seed version to v1.
         seedStorage(secureStorage, version: CredentialStoreVersion.v1);
 
-        stateMachine.dispatch(
-          const CredentialStoreEvent.loadCredentialStore(),
-        );
+        stateMachine
+            .dispatch(
+              const CredentialStoreEvent.loadCredentialStore(),
+            )
+            .ignore();
 
         final sm = stateMachine.getOrCreate(CredentialStoreStateMachine.type);
         await expectLater(

--- a/packages/auth/amplify_auth_cognito_test/test/state/fetch_auth_session_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/fetch_auth_session_state_machine_test.dart
@@ -47,7 +47,7 @@ void main() {
     const newSecretAccessKey = 'newSecretAccessKey';
 
     Future<void> configureAmplify(AmplifyConfig config) async {
-      stateMachine.dispatch(ConfigurationEvent.configure(config));
+      stateMachine.dispatch(ConfigurationEvent.configure(config)).ignore();
       await stateMachine.stream.whereType<Configured>().first;
     }
 

--- a/packages/auth/amplify_auth_cognito_test/test/state/hosted_ui_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/hosted_ui_state_machine_test.dart
@@ -125,9 +125,11 @@ void main() {
 
     group('onFoundState', () {
       test('nothing in storage', () {
-        stateMachine.dispatch(
-          ConfigurationEvent.configure(mockConfig),
-        );
+        stateMachine
+            .dispatch(
+              ConfigurationEvent.configure(mockConfig),
+            )
+            .ignore();
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         expect(
@@ -146,7 +148,9 @@ void main() {
             value: codeVerifier,
           );
 
-        stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -165,7 +169,9 @@ void main() {
     group('onConfigure', () {
       test('logged in', () async {
         seedStorage(secureStorage, hostedUiKeys: keys);
-        stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -184,7 +190,9 @@ void main() {
 
     group('onSignIn', () {
       test('no provider', () async {
-        stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -195,12 +203,14 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(const HostedUiEvent.signIn());
+        stateMachine.dispatch(const HostedUiEvent.signIn()).ignore();
         expect(_launchUrl.future, completes);
       });
 
       test('w/ provider', () async {
-        stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -211,11 +221,13 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(
-          const HostedUiEvent.signIn(
-            provider: AuthProvider.amazon,
-          ),
-        );
+        stateMachine
+            .dispatch(
+              const HostedUiEvent.signIn(
+                provider: AuthProvider.amazon,
+              ),
+            )
+            .ignore();
         expect(_launchUrl.future, completes);
       });
 
@@ -225,7 +237,7 @@ void main() {
             FailingHostedUiPlatform.new,
             HostedUiPlatform.token,
           )
-          ..dispatch(ConfigurationEvent.configure(mockConfig));
+          ..dispatch(ConfigurationEvent.configure(mockConfig)).ignore();
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -236,11 +248,13 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(
-          const HostedUiEvent.signIn(
-            provider: AuthProvider.amazon,
-          ),
-        );
+        stateMachine
+            .dispatch(
+              const HostedUiEvent.signIn(
+                provider: AuthProvider.amazon,
+              ),
+            )
+            .ignore();
         expect(
           sm.stream,
           emitsInOrder(<Matcher>[
@@ -253,7 +267,9 @@ void main() {
 
     group('onExchange', () {
       test('no provider', () async {
-        stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -264,9 +280,9 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(const HostedUiEvent.signIn());
+        stateMachine.dispatch(const HostedUiEvent.signIn()).ignore();
         final params = await server.authorize(await _launchUrl.future);
-        stateMachine.dispatch(HostedUiEvent.exchange(params));
+        stateMachine.dispatch(HostedUiEvent.exchange(params)).ignore();
 
         expect(
           sm.stream,
@@ -298,7 +314,9 @@ void main() {
       });
 
       test('w/ provider', () async {
-        stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -310,11 +328,13 @@ void main() {
         );
 
         const provider = AuthProvider.oidc('providerName', 'issuer');
-        stateMachine.dispatch(
-          const HostedUiEvent.signIn(provider: provider),
-        );
+        stateMachine
+            .dispatch(
+              const HostedUiEvent.signIn(provider: provider),
+            )
+            .ignore();
         final params = await server.authorize(await _launchUrl.future);
-        stateMachine.dispatch(HostedUiEvent.exchange(params));
+        stateMachine.dispatch(HostedUiEvent.exchange(params)).ignore();
 
         expect(
           sm.stream,
@@ -350,7 +370,9 @@ void main() {
       });
 
       test('fails with remote error', () async {
-        stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -361,19 +383,21 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(const HostedUiEvent.signIn());
+        stateMachine.dispatch(const HostedUiEvent.signIn()).ignore();
         await server.authorize(await _launchUrl.future);
 
         final state = await secureStorage.read(key: keys[HostedUiKey.state]);
-        stateMachine.dispatch(
-          HostedUiEvent.exchange(
-            OAuthParameters(
-              (b) => b
-                ..error = OAuthErrorCode.invalidRequest
-                ..state = state,
-            ),
-          ),
-        );
+        stateMachine
+            .dispatch(
+              HostedUiEvent.exchange(
+                OAuthParameters(
+                  (b) => b
+                    ..error = OAuthErrorCode.invalidRequest
+                    ..state = state,
+                ),
+              ),
+            )
+            .ignore();
 
         expect(
           sm.stream,
@@ -385,7 +409,9 @@ void main() {
       });
 
       test('fails with bad code', () async {
-        stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
 
         final sm = stateMachine.getOrCreate(HostedUiStateMachine.type);
         await expectLater(
@@ -396,17 +422,19 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(const HostedUiEvent.signIn());
+        stateMachine.dispatch(const HostedUiEvent.signIn()).ignore();
         await server.authorize(await _launchUrl.future);
-        stateMachine.dispatch(
-          HostedUiEvent.exchange(
-            OAuthParameters(
-              (b) => b
-                ..code = 'badCode'
-                ..state = 'badState',
-            ),
-          ),
-        );
+        stateMachine
+            .dispatch(
+              HostedUiEvent.exchange(
+                OAuthParameters(
+                  (b) => b
+                    ..code = 'badCode'
+                    ..state = 'badState',
+                ),
+              ),
+            )
+            .ignore();
 
         expect(
           sm.stream,
@@ -421,7 +449,9 @@ void main() {
     group('onSignOut', () {
       test('succeeds', () async {
         seedStorage(secureStorage, hostedUiKeys: keys);
-        stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
         await expectLater(
           stateMachine.stream.whereType<HostedUiState>(),
           emitsInOrder(<Matcher>[
@@ -430,7 +460,7 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(const HostedUiEvent.signOut());
+        stateMachine.dispatch(const HostedUiEvent.signOut()).ignore();
         expect(
           stateMachine.stream.whereType<HostedUiState>(),
           emitsInOrder(<Matcher>[
@@ -442,7 +472,9 @@ void main() {
 
       test('multiple events are ignored', () async {
         seedStorage(secureStorage, hostedUiKeys: keys);
-        stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
         await expectLater(
           stateMachine.stream.whereType<HostedUiState>(),
           emitsInOrder(<Matcher>[
@@ -452,8 +484,8 @@ void main() {
         );
 
         stateMachine
-          ..dispatch(const HostedUiEvent.signOut())
-          ..dispatch(const HostedUiEvent.signOut());
+          ..dispatch(const HostedUiEvent.signOut()).ignore()
+          ..dispatch(const HostedUiEvent.signOut()).ignore();
         expect(
           stateMachine.stream.whereType<HostedUiState>(),
           emitsInOrder(<Matcher>[
@@ -470,7 +502,7 @@ void main() {
             FailingHostedUiPlatform.new,
             HostedUiPlatform.token,
           )
-          ..dispatch(ConfigurationEvent.configure(mockConfig));
+          ..dispatch(ConfigurationEvent.configure(mockConfig)).ignore();
         await expectLater(
           stateMachine.stream.whereType<HostedUiState>(),
           emitsInOrder(<Matcher>[
@@ -479,7 +511,7 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(const HostedUiEvent.signOut());
+        stateMachine.dispatch(const HostedUiEvent.signOut()).ignore();
         expect(
           stateMachine.stream.whereType<HostedUiState>(),
           emitsInOrder(<Matcher>[
@@ -512,7 +544,7 @@ void main() {
             ),
             HostedUiPlatform.token,
           )
-          ..dispatch(ConfigurationEvent.configure(mockConfig));
+          ..dispatch(ConfigurationEvent.configure(mockConfig)).ignore();
 
         await expectLater(
           stateMachine.stream.whereType<HostedUiState>(),
@@ -522,15 +554,17 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(
-          const HostedUiEvent.signIn(
-            options: CognitoSignInWithWebUIOptions(
-              isPreferPrivateSession: true,
-            ),
-          ),
-        );
+        stateMachine
+            .dispatch(
+              const HostedUiEvent.signIn(
+                options: CognitoSignInWithWebUIOptions(
+                  isPreferPrivateSession: true,
+                ),
+              ),
+            )
+            .ignore();
         final params = await server.authorize(await _launchUrl.future);
-        stateMachine.dispatch(HostedUiEvent.exchange(params));
+        stateMachine.dispatch(HostedUiEvent.exchange(params)).ignore();
 
         await expectLater(
           stateMachine.stream.whereType<HostedUiState>(),
@@ -540,7 +574,7 @@ void main() {
           ]),
         );
 
-        stateMachine.dispatch(const HostedUiEvent.signOut());
+        stateMachine.dispatch(const HostedUiEvent.signOut()).ignore();
       });
     });
   });

--- a/packages/auth/amplify_auth_cognito_test/test/state/sign_in_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/sign_in_state_machine_test.dart
@@ -57,9 +57,11 @@ void main() {
           },
         ),
       );
-      stateMachine.dispatch(
-        const ConfigurationEvent.configure(config),
-      );
+      stateMachine
+          .dispatch(
+            const ConfigurationEvent.configure(config),
+          )
+          .ignore();
       await expectLater(
         stateMachine.stream.whereType<ConfigurationState>().firstWhere(
               (event) => event is Configured || event is ConfigureFailure,
@@ -85,7 +87,7 @@ void main() {
                 ..password = 'password',
             ),
           ),
-        );
+        ).ignore();
 
       final signInStateMachine = stateMachine.expect(SignInStateMachine.type);
       await signInStateMachine.stream.whereType<SignInChallenge>().first;
@@ -96,9 +98,11 @@ void main() {
     });
 
     test('smoke test', () async {
-      stateMachine.dispatch(
-        ConfigurationEvent.configure(userPoolOnlyConfig),
-      );
+      stateMachine
+          .dispatch(
+            ConfigurationEvent.configure(userPoolOnlyConfig),
+          )
+          .ignore();
       await expectLater(
         stateMachine.stream.whereType<ConfigurationState>().firstWhere(
               (event) => event is Configured || event is ConfigureFailure,
@@ -128,7 +132,7 @@ void main() {
                 ..password = 'password',
             ),
           ),
-        );
+        ).ignore();
 
       final signInStateMachine = stateMachine.expect(SignInStateMachine.type);
       expect(
@@ -146,9 +150,11 @@ void main() {
 
     group('custom auth', () {
       test('customAuthWithSrp requires password', () async {
-        stateMachine.dispatch(
-          ConfigurationEvent.configure(userPoolOnlyConfig),
-        );
+        stateMachine
+            .dispatch(
+              ConfigurationEvent.configure(userPoolOnlyConfig),
+            )
+            .ignore();
         await expectLater(
           stateMachine.stream.whereType<ConfigurationState>().firstWhere(
                 (event) => event is Configured || event is ConfigureFailure,
@@ -156,14 +162,16 @@ void main() {
           completion(isA<Configured>()),
         );
 
-        stateMachine.dispatch(
-          SignInEvent.initiate(
-            authFlowType: AuthenticationFlowType.customAuthWithSrp,
-            parameters: SignInParameters(
-              (p) => p..username = 'username',
-            ),
-          ),
-        );
+        stateMachine
+            .dispatch(
+              SignInEvent.initiate(
+                authFlowType: AuthenticationFlowType.customAuthWithSrp,
+                parameters: SignInParameters(
+                  (p) => p..username = 'username',
+                ),
+              ),
+            )
+            .ignore();
         final signInStateMachine = stateMachine.expect(SignInStateMachine.type);
         expect(
           signInStateMachine.stream,
@@ -179,9 +187,11 @@ void main() {
       });
 
       test('customAuthWithoutSrp forbids password', () async {
-        stateMachine.dispatch(
-          ConfigurationEvent.configure(userPoolOnlyConfig),
-        );
+        stateMachine
+            .dispatch(
+              ConfigurationEvent.configure(userPoolOnlyConfig),
+            )
+            .ignore();
         await expectLater(
           stateMachine.stream.whereType<ConfigurationState>().firstWhere(
                 (event) => event is Configured || event is ConfigureFailure,
@@ -189,16 +199,18 @@ void main() {
           completion(isA<Configured>()),
         );
 
-        stateMachine.dispatch(
-          SignInEvent.initiate(
-            authFlowType: AuthenticationFlowType.customAuthWithoutSrp,
-            parameters: SignInParameters(
-              (p) => p
-                ..username = 'username'
-                ..password = 'password',
-            ),
-          ),
-        );
+        stateMachine
+            .dispatch(
+              SignInEvent.initiate(
+                authFlowType: AuthenticationFlowType.customAuthWithoutSrp,
+                parameters: SignInParameters(
+                  (p) => p
+                    ..username = 'username'
+                    ..password = 'password',
+                ),
+              ),
+            )
+            .ignore();
         final signInStateMachine = stateMachine.expect(SignInStateMachine.type);
         expect(
           signInStateMachine.stream,
@@ -214,9 +226,11 @@ void main() {
       });
 
       test('customAuth uses old behavior', () async {
-        stateMachine.dispatch(
-          ConfigurationEvent.configure(userPoolOnlyConfig),
-        );
+        stateMachine
+            .dispatch(
+              ConfigurationEvent.configure(userPoolOnlyConfig),
+            )
+            .ignore();
         await expectLater(
           stateMachine.stream.whereType<ConfigurationState>().firstWhere(
                 (event) => event is Configured || event is ConfigureFailure,
@@ -247,7 +261,7 @@ void main() {
                   ..password = 'password',
               ),
             ),
-          );
+          ).ignore();
 
         final signInStateMachine = stateMachine.expect(SignInStateMachine.type);
         expect(
@@ -264,9 +278,11 @@ void main() {
       late DeviceMetadataRepository deviceRepo;
 
       setUp(() async {
-        stateMachine.dispatch(
-          ConfigurationEvent.configure(mockConfig),
-        );
+        stateMachine
+            .dispatch(
+              ConfigurationEvent.configure(mockConfig),
+            )
+            .ignore();
         await expectLater(
           stateMachine.stream.whereType<ConfigurationState>().firstWhere(
                 (event) => event is Configured || event is ConfigureFailure,

--- a/packages/auth/amplify_auth_cognito_test/test/state/sign_up_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/sign_up_state_machine_test.dart
@@ -44,12 +44,12 @@ void main() {
           userConfirmed: true,
         ),
       );
-      stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+      stateMachine.dispatch(ConfigurationEvent.configure(mockConfig)).ignore();
       await stateMachine.stream.whereType<Configured>().first;
 
       stateMachine
         ..addInstance<CognitoIdentityProviderClient>(client)
-        ..dispatch(signUpEvent);
+        ..dispatch(signUpEvent).ignore();
 
       expect(
         stateMachine.stream.whereType<SignUpState>(),
@@ -72,12 +72,12 @@ void main() {
         ),
         confirmSignUp: () async => ConfirmSignUpResponse(),
       );
-      stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+      stateMachine.dispatch(ConfigurationEvent.configure(mockConfig)).ignore();
       await stateMachine.stream.whereType<Configured>().first;
 
       stateMachine
         ..addInstance<CognitoIdentityProviderClient>(client)
-        ..dispatch(signUpEvent);
+        ..dispatch(signUpEvent).ignore();
 
       await expectLater(
         stateMachine.stream.whereType<SignUpState>(),
@@ -91,12 +91,14 @@ void main() {
         ]),
       );
 
-      stateMachine.dispatch(
-        const SignUpEvent.confirm(
-          username: username,
-          confirmationCode: '12345',
-        ),
-      );
+      stateMachine
+          .dispatch(
+            const SignUpEvent.confirm(
+              username: username,
+              confirmationCode: '12345',
+            ),
+          )
+          .ignore();
       expect(
         stateMachine.stream.whereType<SignUpState>(),
         emitsInOrder(<Matcher>[
@@ -110,12 +112,12 @@ void main() {
       var client = MockCognitoIdentityProviderClient(
         signUp: () async => throw _SignUpException(),
       );
-      stateMachine.dispatch(ConfigurationEvent.configure(mockConfig));
+      stateMachine.dispatch(ConfigurationEvent.configure(mockConfig)).ignore();
       await stateMachine.stream.whereType<Configured>().first;
 
       stateMachine
         ..addInstance<CognitoIdentityProviderClient>(client)
-        ..dispatch(signUpEvent);
+        ..dispatch(signUpEvent).ignore();
 
       await expectLater(
         stateMachine.stream.whereType<SignUpState>(),
@@ -137,7 +139,7 @@ void main() {
       );
       stateMachine
         ..addInstance<CognitoIdentityProviderClient>(client)
-        ..dispatch(signUpEvent);
+        ..dispatch(signUpEvent).ignore();
 
       expect(
         stateMachine.stream.whereType<SignUpState>(),


### PR DESCRIPTION
Event completers should be used or explicitly ignored since any errors are swallowed by them.