### PR TITLE
fix(api): early call of Amplify creates wrong instance of AmplifyClass

### DIFF
--- a/packages/api/amplify_api_dart/lib/src/api_plugin_impl.dart
+++ b/packages/api/amplify_api_dart/lib/src/api_plugin_impl.dart
@@ -29,7 +29,6 @@ class AmplifyAPIDart extends APIPluginInterface with AWSDebuggable {
   })  : _baseHttpClient = baseHttpClient,
         _connectivity = connectivity {
     authProviders.forEach(registerAuthProvider);
-    Amplify.Hub.addChannel(HubChannel.Api, _hubEventController.stream);
   }
 
   late final AWSApiPluginConfig _apiConfig;
@@ -94,6 +93,7 @@ class AmplifyAPIDart extends APIPluginInterface with AWSDebuggable {
     _apiConfig = apiConfig;
     _authProviderRepo = authProviderRepo;
     _registerApiPluginAuthProviders();
+    Amplify.Hub.addChannel(HubChannel.Api, _hubEventController.stream);
   }
 
   /// Register AmplifyAuthProviders that are specific to API category (API key,


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-flutter/issues/2647

*Description of changes:*

The constructor of `AmplifyAPIDart` invokes `Amplify.hub` to add channel, as this happen during initiating the API plugin

```dart
final apiPlugin = AmplifyAPI();
```

https://github.com/aws-amplify/amplify-flutter/blob/d21259d326cd1ad2215d9cdba4cf6c04872f6e57/packages/api/amplify_api_dart/lib/src/api_plugin_impl.dart#L23-L33

It causes `Amplify` to be backed back wrong instance of `AmplifyClass` provided by  `amplify_core`, which should be the `AmplifyClass` provided by `amplify_flutter`. Therefore, when `Amplify.configure()` is called, the native plugins won't be configured via the `AmplifyHybridImpl.configurePlatform()` provided by `amplify_flutter`.

Moving the adding hub to `AmplifyAPIDart.configure()`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
