### PR TITLE
fix(authenticator): Various fixes

### DIFF
--- a/packages/authenticator/amplify_authenticator/example/integration_test/confirm_sign_up_email_or_phone_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/confirm_sign_up_email_or_phone_test.dart
@@ -13,6 +13,7 @@ import 'utils/mock_data.dart';
 import 'utils/test_utils.dart';
 
 void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   // resolves issue on iOS. See: https://github.com/flutter/flutter/issues/89651
   binding.deferFirstFrame();
@@ -39,6 +40,17 @@ void main() {
         final signInPage = SignInPage(tester: tester);
 
         await loadAuthenticator(tester: tester);
+
+        expect(
+          tester.bloc.stream,
+          emitsInOrder([
+            UnauthenticatedState.signIn,
+            UnauthenticatedState.signUp,
+            UnauthenticatedState.confirmSignUp,
+            isA<AuthenticatedState>(),
+            emitsDone,
+          ]),
+        );
 
         final email = generateEmail();
         final phoneNumber = generateUSPhoneNumber();
@@ -77,6 +89,8 @@ void main() {
 
         // Then I see "Sign out"
         await signInPage.expectAuthenticated();
+
+        await tester.bloc.close();
       },
     );
 
@@ -88,6 +102,17 @@ void main() {
         final signInPage = SignInPage(tester: tester);
 
         await loadAuthenticator(tester: tester);
+
+        expect(
+          tester.bloc.stream,
+          emitsInOrder([
+            UnauthenticatedState.signIn,
+            UnauthenticatedState.signUp,
+            UnauthenticatedState.confirmSignUp,
+            isA<AuthenticatedState>(),
+            emitsDone,
+          ]),
+        );
 
         final email = generateEmail();
         final phoneNumber = generateUSPhoneNumber();
@@ -126,6 +151,8 @@ void main() {
 
         // Then I see "Sign out"
         await signInPage.expectAuthenticated();
+
+        await tester.bloc.close();
       },
     );
   });

--- a/packages/authenticator/amplify_authenticator/example/integration_test/custom_ui_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/custom_ui_test.dart
@@ -83,6 +83,17 @@ void main() {
       addTearDown(() => deleteUser(cognitoUsername));
 
       await loadAuthenticator(tester: tester, authenticator: authenticator);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          isA<AuthenticatedState>(),
+          UnauthenticatedState.signIn,
+          emitsDone,
+        ]),
+      );
+
       final SignInPage signInPage = SignInPage(tester: tester);
       signInPage.expectUsername(label: 'Email');
 
@@ -103,6 +114,8 @@ void main() {
 
       // Then I see "Sign in"
       signInPage.expectUsername(label: 'Email');
+
+      await tester.bloc.close();
     });
   });
 }

--- a/packages/authenticator/amplify_authenticator/example/integration_test/main_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/main_test.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -25,6 +26,7 @@ import 'unprotected_routes_test.dart' as unprotected_routes_tests;
 import 'verify_user_test.dart' as verify_user_tests;
 
 void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('Authenticator', () {

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_force_new_password_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_force_new_password_test.dart
@@ -17,6 +17,7 @@ import 'utils/test_utils.dart';
 // https://github.com/aws-amplify/amplify-ui/blob/main/packages/e2e/features/ui/components/authenticator/sign-in-force-new-password.feature
 
 void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   // resolves issue on iOS. See: https://github.com/flutter/flutter/issues/89651
   binding.deferFirstFrame();
@@ -62,6 +63,15 @@ void main() {
         final po = SignInPage(tester: tester);
         await loadAuthenticator(tester: tester);
 
+        expect(
+          tester.bloc.stream,
+          emitsInOrder([
+            UnauthenticatedState.signIn,
+            UnauthenticatedState.confirmSignInNewPassword,
+            emitsDone,
+          ]),
+        );
+
         // When I select my country code with status "FORCE_CHANGE_PASSWORD"
         await po.selectCountryCode();
 
@@ -76,6 +86,8 @@ void main() {
 
         // Then I should see the Force Change Password step
         po.expectStep(AuthenticatorStep.confirmSignInNewPassword);
+
+        await tester.bloc.close();
       },
     );
 
@@ -87,6 +99,15 @@ void main() {
       (WidgetTester tester) async {
         final po = SignInPage(tester: tester);
         await loadAuthenticator(tester: tester);
+
+        expect(
+          tester.bloc.stream,
+          emitsInOrder([
+            UnauthenticatedState.signIn,
+            UnauthenticatedState.confirmSignInNewPassword,
+            emitsDone,
+          ]),
+        );
 
         // When I select my country code with status "FORCE_CHANGE_PASSWORD"
         await po.selectCountryCode();
@@ -117,6 +138,8 @@ void main() {
           keyNewPasswordConfirmSignInFormField,
           'Password must include',
         );
+
+        await tester.bloc.close();
       },
     );
 
@@ -128,6 +151,16 @@ void main() {
       (WidgetTester tester) async {
         final po = SignInPage(tester: tester);
         await loadAuthenticator(tester: tester);
+
+        expect(
+          tester.bloc.stream,
+          emitsInOrder([
+            UnauthenticatedState.signIn,
+            UnauthenticatedState.confirmSignInNewPassword,
+            isA<AuthenticatedState>(),
+            emitsDone,
+          ]),
+        );
 
         // When I select my country code with status "FORCE_CHANGE_PASSWORD"
         await po.selectCountryCode();
@@ -156,6 +189,8 @@ void main() {
 
         // Then I should be authenticated
         await cpo.expectAuthenticated();
+
+        await tester.bloc.close();
       },
     );
   });

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_mfa_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_mfa_test.dart
@@ -3,9 +3,9 @@
 
 // This test follows the Amplify UI feature "sign-in-with-username"
 // https://github.com/aws-amplify/amplify-ui/blob/main/packages/e2e/features/ui/components/authenticator/sign-up-with-username.feature
-import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:amplify_authenticator_test/amplify_authenticator_test.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -15,6 +15,7 @@ import 'utils/mock_data.dart';
 import 'utils/test_utils.dart';
 
 void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   // resolves issue on iOS. See: https://github.com/flutter/flutter/issues/89651
   binding.deferFirstFrame();
@@ -55,6 +56,16 @@ void main() {
     testWidgets('Sign in using a valid phone number and SMS MFA',
         (tester) async {
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.confirmSignInMfa,
+          emitsDone,
+        ]),
+      );
+
       SignInPage signInPage = SignInPage(tester: tester);
       ConfirmSignInPage confirmSignInPage = ConfirmSignInPage(tester: tester);
 
@@ -74,11 +85,24 @@ void main() {
 
       // Then I will be redirected to the confirm sms mfa page
       await confirmSignInPage.expectConfirmSignInMFAIsPresent();
+
+      await tester.bloc.close();
     });
 
     // Scenario: Redirect to sign in page
     testWidgets('Redirect to sign in page', (tester) async {
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.confirmSignInMfa,
+          UnauthenticatedState.signIn,
+          emitsDone,
+        ]),
+      );
+
       SignInPage signInPage = SignInPage(tester: tester);
       ConfirmSignInPage confirmSignInPage = ConfirmSignInPage(tester: tester);
 
@@ -101,11 +125,23 @@ void main() {
 
       // Then I see "Sign in"
       signInPage.expectStep(AuthenticatorStep.signIn);
+
+      await tester.bloc.close();
     });
 
     // Scenario: Incorrect SMS code
     testWidgets('Incorrect SMS code', (tester) async {
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.confirmSignInMfa,
+          emitsDone,
+        ]),
+      );
+
       SignInPage signInPage = SignInPage(tester: tester);
       ConfirmSignInPage confirmSignInPage = ConfirmSignInPage(tester: tester);
 
@@ -132,12 +168,23 @@ void main() {
 
       // Then I see 'Invalid code or auth state for the user'.
       await confirmSignInPage.expectInvalidCode();
+
+      await tester.bloc.close();
     });
 
     // Scenario: Sign in with unknown credentials
     testWidgets('Sign in with unknown credentials', (tester) async {
       final phoneNumber = generateUSPhoneNumber();
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          emitsDone,
+        ]),
+      );
+
       SignInPage signInPage = SignInPage(tester: tester);
 
       // When I select my country code
@@ -154,6 +201,8 @@ void main() {
 
       // Then I see "User does not exist"
       signInPage.expectUserNotFound();
+
+      await tester.bloc.close();
     });
   });
 }

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_with_username_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_with_username_test.dart
@@ -5,6 +5,7 @@
 // https://github.com/aws-amplify/amplify-ui/blob/main/packages/e2e/features/ui/components/authenticator/sign-up-with-username.feature
 
 import 'package:amplify_authenticator_test/amplify_authenticator_test.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -13,6 +14,7 @@ import 'config.dart';
 import 'utils/test_utils.dart';
 
 void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   // resolves issue on iOS. See: https://github.com/flutter/flutter/issues/89651
   binding.deferFirstFrame();
@@ -33,6 +35,14 @@ void main() {
       SignInPage signInPage = SignInPage(tester: tester);
       signInPage.expectUsername();
 
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          emitsDone,
+        ]),
+      );
+
       // When I type my "username" with status "UNKNOWN"
       await signInPage.enterUsername('UNKNOWN');
 
@@ -43,6 +53,8 @@ void main() {
       await signInPage.submitSignIn();
 
       signInPage.expectUserNotFound();
+
+      await tester.bloc.close();
     });
 
     // Scenario: Sign in with confirmed credentials
@@ -61,6 +73,15 @@ void main() {
       SignInPage signInPage = SignInPage(tester: tester);
       signInPage.expectUsername();
 
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          isA<AuthenticatedState>(),
+          emitsDone,
+        ]),
+      );
+
       // When I type my "username"
       await signInPage.enterUsername(username);
 
@@ -72,6 +93,8 @@ void main() {
 
       /// Then I see "Sign out"
       await signInPage.expectAuthenticated();
+
+      await tester.bloc.close();
     });
 
     // Scenario: Sign in with confirmed credentials then sign out
@@ -91,6 +114,16 @@ void main() {
       SignInPage signInPage = SignInPage(tester: tester);
       signInPage.expectUsername();
 
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          isA<AuthenticatedState>(),
+          UnauthenticatedState.signIn,
+          emitsDone,
+        ]),
+      );
+
       // When I type my "username" with status "UNKNOWN"
       await signInPage.enterUsername(username);
 
@@ -108,6 +141,8 @@ void main() {
 
       // Then I see "Sign in"
       signInPage.expectUsername();
+
+      await tester.bloc.close();
     });
 
     // Scenario: Sign in with force change password credentials
@@ -123,6 +158,15 @@ void main() {
       ConfirmSignInPage confirmSignInPage = ConfirmSignInPage(tester: tester);
       signInPage.expectUsername();
 
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.confirmSignInNewPassword,
+          emitsDone,
+        ]),
+      );
+
       // When I type my "username"
       await signInPage.enterUsername(username);
 
@@ -135,6 +179,8 @@ void main() {
       /// Then I see "Change Password"
       await confirmSignInPage.expectConfirmSignInNewPasswordIsPresent();
       confirmSignInPage.expectNewPasswordIsPresent();
+
+      await tester.bloc.close();
     });
 
     testWidgets(
@@ -153,6 +199,15 @@ void main() {
       await loadAuthenticator(tester: tester);
       SignInPage signInPage = SignInPage(tester: tester);
       signInPage.expectUsername();
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          isA<AuthenticatedState>(),
+          emitsDone,
+        ]),
+      );
 
       // When I type my "username"
       await signInPage.enterUsername('bad_username');
@@ -177,6 +232,8 @@ void main() {
 
       // Then I am signed in
       await signInPage.expectAuthenticated();
+
+      await tester.bloc.close();
     });
   });
 }

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_out_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_out_test.dart
@@ -12,6 +12,7 @@ import 'config.dart';
 import 'utils/test_utils.dart';
 
 void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   // resolves issue on iOS. See: https://github.com/flutter/flutter/issues/89651
   binding.deferFirstFrame();
@@ -38,6 +39,17 @@ void main() {
       addTearDown(() => deleteUser(cognitoUsername));
 
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          isA<AuthenticatedState>(),
+          UnauthenticatedState.signIn,
+          emitsDone,
+        ]),
+      );
+
       SignInPage signInPage = SignInPage(tester: tester);
 
       // When I sign in with "username" and "password"
@@ -52,6 +64,8 @@ void main() {
 
       // Then I see "Sign in"
       signInPage.expectStep(AuthenticatorStep.signIn);
+
+      await tester.bloc.close();
     });
   });
 }

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_email_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_email_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_authenticator_test/amplify_authenticator_test.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -13,6 +14,7 @@ import 'utils/test_utils.dart';
 // https://github.com/aws-amplify/amplify-ui/blob/main/packages/e2e/features/ui/components/authenticator/sign-up-with-email.feature
 
 void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   // resolves issue on iOS. See: https://github.com/flutter/flutter/issues/89651
   binding.deferFirstFrame();
@@ -30,6 +32,16 @@ void main() {
       SignUpPage signUpPage = SignUpPage(tester: tester);
       SignInPage signInPage = SignInPage(tester: tester);
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.signUp,
+          emitsDone,
+        ]),
+      );
+
       await signInPage.navigateToSignUp();
 
       // Then I see "Email" as an input field
@@ -40,6 +52,8 @@ void main() {
 
       // And I don't see "Phone Number" as an input field
       signUpPage.expectPhoneIsNotPresent();
+
+      await tester.bloc.close();
     });
 
     // Scenario: Sign up a new email & password
@@ -49,6 +63,17 @@ void main() {
       ConfirmSignUpPage confirmSignUpPage = ConfirmSignUpPage(tester: tester);
 
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.signUp,
+          UnauthenticatedState.confirmSignUp,
+          emitsDone,
+        ]),
+      );
+
       await signInPage.navigateToSignUp();
 
       // TODO: Clarify requirements
@@ -73,6 +98,8 @@ void main() {
       // Then I see "Confirmation Code"
       await confirmSignUpPage.expectConfirmSignUpIsPresent();
       confirmSignUpPage.expectConfirmationCodeIsPresent();
+
+      await tester.bloc.close();
     });
 
     // Scenario: Username field autocompletes username

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_email_with_lambda_trigger_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_email_with_lambda_trigger_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_authenticator_test/amplify_authenticator_test.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -13,6 +14,7 @@ import 'utils/test_utils.dart';
 // https://github.com/aws-amplify/amplify-ui/blob/main/packages/e2e/features/ui/components/authenticator/sign-up-with-email-with-lambda-trigger.feature
 
 void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   // resolves issue on iOS. See: https://github.com/flutter/flutter/issues/89651
   binding.deferFirstFrame();
@@ -34,6 +36,16 @@ void main() {
         'Login mechanism set to "email"',
         (WidgetTester tester) async {
           await loadAuthenticator(tester: tester);
+
+          expect(
+            tester.bloc.stream,
+            emitsInOrder([
+              UnauthenticatedState.signIn,
+              UnauthenticatedState.signUp,
+              emitsDone,
+            ]),
+          );
+
           await SignInPage(tester: tester).navigateToSignUp();
           final po = SignUpPage(tester: tester);
 
@@ -45,6 +57,8 @@ void main() {
 
           // And I don't see "Phone Number" as an input field
           po.expectUsername(label: 'Phone Number', isPresent: false);
+
+          await tester.bloc.close();
         },
       );
 
@@ -53,6 +67,17 @@ void main() {
         'Sign up with a new email & password with confirmed info',
         (WidgetTester tester) async {
           await loadAuthenticator(tester: tester);
+
+          expect(
+            tester.bloc.stream,
+            emitsInOrder([
+              UnauthenticatedState.signIn,
+              UnauthenticatedState.signUp,
+              isA<AuthenticatedState>(),
+              emitsDone,
+            ]),
+          );
+
           await SignInPage(tester: tester).navigateToSignUp();
           final po = SignUpPage(tester: tester);
 
@@ -85,6 +110,8 @@ void main() {
 
           // Then I see "Sign out"
           await po.expectAuthenticated();
+
+          await tester.bloc.close();
         },
       );
     },

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_phone_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_phone_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_authenticator_test/amplify_authenticator_test.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -14,6 +15,7 @@ import 'utils/test_utils.dart';
 // https://github.com/aws-amplify/amplify-ui/blob/main/packages/e2e/features/ui/components/authenticator/sign-up-with-phone.feature
 
 void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   // resolves issue on iOS. See: https://github.com/flutter/flutter/issues/89651
   binding.deferFirstFrame();
@@ -31,6 +33,16 @@ void main() {
       SignUpPage signUpPage = SignUpPage(tester: tester);
       SignInPage signInPage = SignInPage(tester: tester);
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.signUp,
+          emitsDone,
+        ]),
+      );
+
       await signInPage.navigateToSignUp();
 
       // Then I see "Phone Number" as an input field
@@ -38,6 +50,8 @@ void main() {
 
       // And I don't see "Username" as an input field
       signUpPage.expectPlainUsernameNotPresent();
+
+      await tester.bloc.close();
     });
 
     // Scenario: "Email" is included from `aws_cognito_verification_mechanisms`
@@ -46,10 +60,22 @@ void main() {
       SignUpPage signUpPage = SignUpPage(tester: tester);
       SignInPage signInPage = SignInPage(tester: tester);
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.signUp,
+          emitsDone,
+        ]),
+      );
+
       await signInPage.navigateToSignUp();
 
       // Then I see "Email" as an "email" field
       signUpPage.expectEmailIsPresent();
+
+      await tester.bloc.close();
     });
 
     // Scenario: Sign up with valid phone number & password
@@ -59,6 +85,17 @@ void main() {
       ConfirmSignUpPage confirmSignUpPage = ConfirmSignUpPage(tester: tester);
 
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.signUp,
+          UnauthenticatedState.confirmSignUp,
+          emitsDone,
+        ]),
+      );
+
       await signInPage.navigateToSignUp();
 
       //   // TODO: Clarify requirements
@@ -88,6 +125,8 @@ void main() {
       // Then I see "Confirmation Code"
       await confirmSignUpPage.expectConfirmSignUpIsPresent();
       confirmSignUpPage.expectConfirmationCodeIsPresent();
+
+      await tester.bloc.close();
     });
 
     testWidgets('Sign up with a non US number', (tester) async {
@@ -96,6 +135,17 @@ void main() {
       ConfirmSignUpPage confirmSignUpPage = ConfirmSignUpPage(tester: tester);
 
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.signUp,
+          UnauthenticatedState.confirmSignUp,
+          emitsDone,
+        ]),
+      );
+
       await signInPage.navigateToSignUp();
 
       final phoneNumber = generateFrenchPhoneNumber();
@@ -124,6 +174,8 @@ void main() {
       // Then I see "Confirmation Code"
       await confirmSignUpPage.expectConfirmSignUpIsPresent();
       confirmSignUpPage.expectConfirmationCodeIsPresent();
+
+      await tester.bloc.close();
     });
 
     // Scenario: Username field autocompletes username

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_username_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_username_test.dart
@@ -5,6 +5,7 @@
 // https://github.com/aws-amplify/amplify-ui/blob/main/packages/e2e/features/ui/components/authenticator/sign-up-with-username.feature
 
 import 'package:amplify_authenticator_test/amplify_authenticator_test.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -13,6 +14,7 @@ import 'config.dart';
 import 'utils/test_utils.dart';
 
 void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   // resolves issue on iOS. See: https://github.com/flutter/flutter/issues/89651
   binding.deferFirstFrame();
@@ -30,8 +32,20 @@ void main() {
       SignUpPage signUpPage = SignUpPage(tester: tester);
       SignInPage signInPage = SignInPage(tester: tester);
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.signUp,
+          emitsDone,
+        ]),
+      );
+
       await signInPage.navigateToSignUp();
       signUpPage.expectUserNameIsPresent();
+
+      await tester.bloc.close();
     });
 
     // Scenario: "Email" is included from `aws_cognito_verification_mechanisms`
@@ -40,6 +54,16 @@ void main() {
       SignUpPage signUpPage = SignUpPage(tester: tester);
       SignInPage signInPage = SignInPage(tester: tester);
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.signUp,
+          emitsDone,
+        ]),
+      );
+
       await signInPage.navigateToSignUp();
       signUpPage.expectEmailIsPresent();
     });
@@ -49,8 +73,20 @@ void main() {
       SignUpPage signUpPage = SignUpPage(tester: tester);
       SignInPage signInPage = SignInPage(tester: tester);
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.signUp,
+          emitsDone,
+        ]),
+      );
+
       await signInPage.navigateToSignUp();
       signUpPage.expectPhoneIsNotPresent();
+
+      await tester.bloc.close();
     });
 
     // Scenario: Sign up a new username & password
@@ -60,6 +96,17 @@ void main() {
       ConfirmSignUpPage confirmSignUpPage = ConfirmSignUpPage(tester: tester);
 
       await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          UnauthenticatedState.signUp,
+          UnauthenticatedState.confirmSignUp,
+          emitsDone,
+        ]),
+      );
+
       await signInPage.navigateToSignUp();
 
       // TODO: Clarify requirements
@@ -78,6 +125,8 @@ void main() {
 
       await confirmSignUpPage.expectConfirmSignUpIsPresent();
       confirmSignUpPage.expectConfirmationCodeIsPresent();
+
+      await tester.bloc.close();
     });
 
     // Scenario: Username field autocompletes username

--- a/packages/authenticator/amplify_authenticator/example/integration_test/unprotected_routes_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/unprotected_routes_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:amplify_authenticator_test/amplify_authenticator_test.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -12,6 +13,7 @@ import 'config.dart';
 import 'utils/test_utils.dart';
 
 void main() {
+  AWSLogger().logLevel = LogLevel.verbose;
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   // resolves issue on iOS. See: https://github.com/flutter/flutter/issues/89651
   binding.deferFirstFrame();
@@ -56,6 +58,16 @@ void main() {
       // when I launch the authenticator
       await loadAuthenticator(tester: tester, authenticator: authenticator);
 
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          isA<AuthenticatedState>(),
+          UnauthenticatedState.signIn,
+          emitsDone,
+        ]),
+      );
+
       // then I should see route A
       routeAPage.expectIsPresent();
 
@@ -82,6 +94,8 @@ void main() {
 
       // then I should see the sign in page
       signInPage.expectUsername();
+
+      await tester.bloc.close();
     });
   });
 }

--- a/packages/authenticator/amplify_authenticator/example/integration_test/utils/test_utils.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/utils/test_utils.dart
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_authenticator/amplify_authenticator.dart';
+import 'package:amplify_authenticator/src/blocs/auth/auth_bloc.dart';
 import 'package:amplify_authenticator/src/keys.dart';
+import 'package:amplify_authenticator/src/state/inherited_auth_bloc.dart';
 import 'package:amplify_authenticator/src/state/inherited_authenticator_state.dart';
 import 'package:amplify_authenticator_test/amplify_authenticator_test.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
@@ -55,5 +57,14 @@ Future<void> signOut() async {
     await Amplify.Auth.signOut();
   } on Object {
     // OK
+  }
+}
+
+extension BlocAccess on WidgetTester {
+  /// The [StateMachineBloc] of the running Authenticator.
+  StateMachineBloc get bloc {
+    final inheritedBloc =
+        widget<InheritedAuthBloc>(find.byKey(keyInheritedAuthBloc));
+    return inheritedBloc.authBloc;
   }
 }

--- a/packages/authenticator/amplify_authenticator/example/integration_test/verify_user_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/verify_user_test.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_authenticator_test/amplify_authenticator_test.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
@@ -8,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'config.dart';
+import 'utils/mock_data.dart';
 import 'utils/test_utils.dart';
 
 void main() {
@@ -21,6 +23,7 @@ void main() {
     setUpAll(() async {
       await loadConfiguration(
         environmentName: 'sign-in-with-email',
+        additionalConfigs: [AmplifyAPI()],
       );
     });
 
@@ -155,6 +158,7 @@ void main() {
             'userAttributeKey',
             CognitoUserAttributeKey.email,
           ),
+          isA<AuthenticatedState>(),
           emitsDone,
         ]),
       );
@@ -184,6 +188,8 @@ void main() {
       // And I click the "Sign in" button
       await signInPage.submitSignIn();
 
+      final code = await getOtpCode(UserAttribute.email(username));
+
       // And I see "Account recovery requires verified contact information"
       verifyUserPage.expectTitleIsVisible();
 
@@ -195,6 +201,101 @@ void main() {
 
       // Then I see "Code"
       confirmVerifyUserPage.expectCodeFieldIsPresent();
+
+      await confirmVerifyUserPage.enterCode(await code.code);
+
+      await confirmVerifyUserPage.submitConfirmationCode();
+
+      confirmVerifyUserPage.expectNoError();
+
+      await confirmVerifyUserPage.expectAuthenticated();
+
+      await tester.bloc.close();
+    });
+
+    testWidgets('Can confirm phone number attribute', (tester) async {
+      final signInPage = SignInPage(tester: tester);
+      final verifyUserPage = VerifyUserPage(tester: tester);
+      final confirmVerifyUserPage = ConfirmVerifyUserPage(
+        tester: tester,
+      );
+      await loadAuthenticator(tester: tester);
+
+      expect(
+        tester.bloc.stream,
+        emitsInOrder([
+          UnauthenticatedState.signIn,
+          isA<VerifyUserFlow>().having(
+            (state) => state.unverifiedAttributeKeys,
+            'unverifiedAttributeKeys',
+            unorderedEquals([
+              CognitoUserAttributeKey.email,
+              CognitoUserAttributeKey.phoneNumber,
+            ]),
+          ),
+          isA<AttributeVerificationSent>().having(
+            (state) => state.userAttributeKey,
+            'userAttributeKey',
+            CognitoUserAttributeKey.phoneNumber,
+          ),
+          isA<AuthenticatedState>(),
+          emitsDone,
+        ]),
+      );
+
+      final username = generateEmail();
+      final phoneNumber = generateUSPhoneNumber();
+      final password = generatePassword();
+
+      final cognitoUsername = await adminCreateUser(
+        username,
+        password,
+        autoConfirm: true,
+        attributes: [
+          AuthUserAttribute(
+            userAttributeKey: CognitoUserAttributeKey.email,
+            value: username,
+          ),
+          AuthUserAttribute(
+            userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+            value: phoneNumber.toE164(),
+          ),
+        ],
+      );
+      addTearDown(() => deleteUser(cognitoUsername));
+
+      // When I type my "email" with status "UNVERIFIED"
+      await signInPage.enterUsername(username);
+
+      // And I type my password
+      await signInPage.enterPassword(password);
+
+      // And I click the "Sign in" button
+      await signInPage.submitSignIn();
+
+      final code = await getOtpCode(
+        UserAttribute.phone(phoneNumber.toE164()),
+      );
+
+      // And I see "Account recovery requires verified contact information"
+      verifyUserPage.expectTitleIsVisible();
+
+      // And I click the "Email" radio button
+      await verifyUserPage.selectAttribute('Phone Number');
+
+      // And I click the "Verify" button
+      await verifyUserPage.tapVerifyButton();
+
+      // Then I see "Code"
+      confirmVerifyUserPage.expectCodeFieldIsPresent();
+
+      await confirmVerifyUserPage.enterCode(await code.code);
+
+      await confirmVerifyUserPage.submitConfirmationCode();
+
+      confirmVerifyUserPage.expectNoError();
+
+      await confirmVerifyUserPage.expectAuthenticated();
 
       await tester.bloc.close();
     });

--- a/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -9,8 +9,6 @@ import 'package:amplify_authenticator/src/blocs/auth/auth_data.dart';
 import 'package:amplify_authenticator/src/services/amplify_auth_service.dart';
 import 'package:amplify_authenticator/src/state/auth_state.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
-import 'package:async/async.dart';
-import 'package:stream_transform/stream_transform.dart';
 
 part 'auth_event.dart';
 
@@ -48,6 +46,7 @@ class StateMachineBloc
   /// Outputs events into the event transformer.
   late final Stream<AuthEvent> _authEventStream = _authEventController.stream;
   late final StreamSubscription<AuthState> _subscription;
+  late final StreamSubscription<AuthHubEvent> _hubSubscription;
 
   AuthState _currentState = const LoadingState();
   AuthState get currentState => _currentState;
@@ -58,14 +57,16 @@ class StateMachineBloc
     required this.preferPrivateSession,
     this.initialStep = AuthenticatorStep.signIn,
   }) : _authService = authService {
-    final blocStream = _authEventStream.asyncExpand(_eventTransformer);
-    final hubStream =
-        _authService.hubEvents.map(_mapHubEvent).whereType<AuthState>();
-    final mergedStream = StreamGroup<AuthState>()
-      ..add(blocStream)
-      ..add(hubStream)
-      ..close();
-    _subscription = mergedStream.stream.listen(_emit);
+    _hubSubscription = _authService.hubEvents.listen(_mapHubEvent);
+    final blocStream = _authEventStream.asyncExpand((event) async* {
+      // Do not emit Hub events while an event is being processed. This protects
+      // against cases where a Hub event reports a user is signed in but the
+      // bloc is in the middle of performing post-login verifications.
+      _hubSubscription.pause();
+      yield* _eventTransformer(event);
+      _hubSubscription.resume();
+    });
+    _subscription = blocStream.listen(_emit);
   }
 
   /// Adds an event to the Bloc.
@@ -95,6 +96,7 @@ class StateMachineBloc
   Stream<MessageResolverKey> get infoMessages => _infoMessageController.stream;
 
   Stream<AuthState> _eventTransformer(AuthEvent event) async* {
+    logger.debug('Transforming event: $event');
     if (event is AuthLoad) {
       yield* _authLoad();
     } else if (event is AuthSignIn) {
@@ -126,27 +128,34 @@ class StateMachineBloc
 
   /// Listens for asynchronous events which occurred outside the control of the
   /// [Authenticator] and [StateMachineBloc].
-  AuthState? _mapHubEvent(AuthHubEvent event) {
+  void _mapHubEvent(AuthHubEvent event) {
     logger.debug('Handling hub event: ${event.type}');
+    AuthState? nextState;
     switch (event.type) {
       case AuthHubEventType.signedIn:
         if (currentState is! UnauthenticatedState) {
           break;
         }
-        // do not change state if there is a pending user verification.
-        if (currentState is PendingVerificationCheckState) {
+        // Do not change state if there is a pending user verification. The
+        // AuthenticatedState will be emitted by the bloc when the verification
+        // is completed successfully.
+        if (currentState is VerifyUserFlow ||
+            currentState is AttributeVerificationSent) {
           break;
         }
-        return const AuthenticatedState();
+        nextState = const AuthenticatedState();
+        break;
       case AuthHubEventType.signedOut:
       case AuthHubEventType.sessionExpired:
       case AuthHubEventType.userDeleted:
         if (_currentState is AuthenticatedState) {
-          return UnauthenticatedState(step: initialStep);
+          nextState = UnauthenticatedState(step: initialStep);
         }
         break;
     }
-    return null;
+    if (nextState != null) {
+      _emit(nextState);
+    }
   }
 
   Stream<AuthState> _authLoad() async* {
@@ -355,8 +364,6 @@ class StateMachineBloc
       yield UnauthenticatedState.confirmSignUp;
       if (data is AuthUsernamePasswordSignInData) {
         yield* _resendSignUpCode(data.username);
-      } else {
-        // TODO: Is this possible?
       }
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(
@@ -369,10 +376,6 @@ class StateMachineBloc
   }
 
   Stream<AuthState> _checkUserVerification() async* {
-    if (currentState is UnauthenticatedState) {
-      final state = (currentState as UnauthenticatedState);
-      _emit(PendingVerificationCheckState(step: state.step));
-    }
     try {
       var attributeVerificationStatus =
           await _authService.getAttributeVerificationStatus();
@@ -496,9 +499,12 @@ class StateMachineBloc
   }
 
   @override
-  Future<void> close() {
-    return Future.wait<void>([
+  Future<void> close() async {
+    await Future.wait<void>([
       _subscription.cancel(),
+      _hubSubscription.cancel(),
+    ]);
+    await Future.wait<void>([
       _authStateController.close(),
       _authEventController.close(),
       _exceptionController.close(),

--- a/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -480,7 +480,10 @@ class StateMachineBloc
   }
 
   Stream<AuthState> _changeScreen(AuthenticatorStep step) async* {
-    yield UnauthenticatedState(step: step);
+    final currentState = _currentState;
+    if (currentState is! UnauthenticatedState || currentState.step != step) {
+      yield UnauthenticatedState(step: step);
+    }
     // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
     yield* const Stream.empty();
   }

--- a/packages/authenticator/amplify_authenticator/lib/src/mixins/authenticator_radio_field.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/mixins/authenticator_radio_field.dart
@@ -11,8 +11,11 @@ mixin AuthenticatorRadioField<FieldType extends Enum, FieldValue,
     on AuthenticatorFormFieldState<FieldType, FieldValue, T>
     implements SelectableConfig<InputResolverKey, FieldValue> {
   @override
+  FieldValue get initialValue;
+
+  @override
   FieldValue get selectionValue => _selectionValue;
-  late FieldValue _selectionValue = selections.first.value;
+  late FieldValue _selectionValue = initialValue;
 
   @override
   Widget buildFormField(BuildContext context) {
@@ -38,12 +41,18 @@ mixin AuthenticatorRadioField<FieldType extends Enum, FieldValue,
                   setState(() {
                     _selectionValue = value;
                   });
+                  onChanged(value);
                 }
-                if (selectionValue != null) onChanged(selectionValue!);
               },
               activeColor: Theme.of(context).primaryColor,
             ),
-          )
+            onTap: () {
+              setState(() {
+                _selectionValue = selection.value;
+              });
+              onChanged(selection.value);
+            },
+          ),
       ],
     );
   }

--- a/packages/authenticator/amplify_authenticator/lib/src/state/auth_state.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/state/auth_state.dart
@@ -1,26 +1,33 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_authenticator/src/enums/authenticator_step.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter/foundation.dart';
 
 abstract class AuthState {
   const AuthState();
 }
 
-class LoadingState extends AuthState {
+class LoadingState extends AuthState with AWSDebuggable {
   const LoadingState();
 
   AuthenticatorStep get step => AuthenticatorStep.loading;
+
+  @override
+  String get runtimeTypeName => 'LoadingState';
 }
 
-class AuthenticatedState extends AuthState {
+class AuthenticatedState extends AuthState with AWSDebuggable {
   const AuthenticatedState();
+
+  @override
+  String get runtimeTypeName => 'AuthenticatedState';
 }
 
 @immutable
-class UnauthenticatedState extends AuthState {
+class UnauthenticatedState extends AuthState
+    with AWSEquatable<UnauthenticatedState>, AWSDebuggable {
   final AuthenticatorStep _step;
 
   const UnauthenticatedState({required AuthenticatorStep step}) : _step = step;
@@ -44,12 +51,10 @@ class UnauthenticatedState extends AuthState {
       UnauthenticatedState(step: AuthenticatorStep.verifyUser);
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is UnauthenticatedState && other.step == step;
+  List<Object?> get props => [step];
 
   @override
-  int get hashCode => step.hashCode;
+  String get runtimeTypeName => 'UnauthenticatedState';
 }
 
 class AttributeVerificationSent extends UnauthenticatedState {
@@ -57,6 +62,12 @@ class AttributeVerificationSent extends UnauthenticatedState {
       : super(step: AuthenticatorStep.confirmVerifyUser);
 
   final CognitoUserAttributeKey userAttributeKey;
+
+  @override
+  List<Object?> get props => [step, userAttributeKey];
+
+  @override
+  String get runtimeTypeName => 'AttributeVerificationSent';
 }
 
 class VerifyUserFlow extends UnauthenticatedState {
@@ -64,6 +75,12 @@ class VerifyUserFlow extends UnauthenticatedState {
 
   const VerifyUserFlow({required this.unverifiedAttributeKeys})
       : super(step: AuthenticatorStep.verifyUser);
+
+  @override
+  List<Object?> get props => [step, unverifiedAttributeKeys];
+
+  @override
+  String get runtimeTypeName => 'VerifyUserFlow';
 }
 
 class ConfirmSignInCustom extends UnauthenticatedState {
@@ -72,17 +89,10 @@ class ConfirmSignInCustom extends UnauthenticatedState {
   const ConfirmSignInCustom({
     this.publicParameters = const <String, String>{},
   }) : super(step: AuthenticatorStep.confirmSignInCustomAuth);
-}
 
-/// A state that indicates that there is a check to
-/// determine the user's verification state in progress.
-///
-/// This indicates that either Sign In OR Confirm Sign In
-/// has completed, but it is currently unknown if the user needs
-/// to be taken to the `veryUser` step or to an authenticated state
-/// because the call to fetch user attributes is pending.
-class PendingVerificationCheckState extends UnauthenticatedState {
-  const PendingVerificationCheckState({
-    required super.step,
-  });
+  @override
+  List<Object?> get props => [step, publicParameters];
+
+  @override
+  String get runtimeTypeName => 'ConfirmSignInCustom';
 }

--- a/packages/authenticator/amplify_authenticator/lib/src/state/auth_state.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/state/auth_state.dart
@@ -47,9 +47,6 @@ class UnauthenticatedState extends AuthState
   static const confirmResetPassword =
       UnauthenticatedState(step: AuthenticatorStep.confirmResetPassword);
 
-  static const verifyUser =
-      UnauthenticatedState(step: AuthenticatorStep.verifyUser);
-
   @override
   List<Object?> get props => [step];
 

--- a/packages/authenticator/amplify_authenticator/lib/src/state/authenticator_state.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/state/authenticator_state.dart
@@ -278,7 +278,7 @@ class AuthenticatorState extends ChangeNotifier {
     notifyListeners();
   }
 
-  CognitoUserAttributeKey _attributeKeyToVerify = CognitoUserAttributeKey.email;
+  late CognitoUserAttributeKey _attributeKeyToVerify;
   CognitoUserAttributeKey get attributeKeyToVerify => _attributeKeyToVerify;
 
   set attributeKeyToVerify(CognitoUserAttributeKey attributeKey) {

--- a/packages/authenticator/amplify_authenticator/lib/src/widgets/form_fields/verify_user_form_field.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/widgets/form_fields/verify_user_form_field.dart
@@ -178,6 +178,9 @@ class _VerifyAttributeFieldState
         )
     ];
     initialValue = selections.first.value;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      state.attributeKeyToVerify = initialValue;
+    });
   }
 
   @override

--- a/packages/authenticator/amplify_authenticator_test/lib/amplify_authenticator_test.dart
+++ b/packages/authenticator/amplify_authenticator_test/lib/amplify_authenticator_test.dart
@@ -4,6 +4,8 @@
 /// A library containing test utilities for the Authenticator.
 library amplify_authenticator_test;
 
+export 'package:amplify_authenticator/src/state/auth_state.dart';
+
 export 'src/finders/authenticated_app_finder.dart';
 export 'src/finders/authenticator_finder.dart';
 export 'src/finders/confirm_signin_finder.dart';

--- a/packages/authenticator/amplify_authenticator_test/lib/src/pages/authenticator_page.dart
+++ b/packages/authenticator/amplify_authenticator_test/lib/src/pages/authenticator_page.dart
@@ -76,6 +76,11 @@ abstract class AuthenticatorPage {
     );
   }
 
+  /// Expects no error banner.
+  void expectNoError() {
+    expect(bannerFinder, findsNothing);
+  }
+
   // Then I am signed in
   Future<void> expectAuthenticated() async {
     await tester.pumpAndSettle();

--- a/packages/authenticator/amplify_authenticator_test/lib/src/pages/confirm_verify_user_page.dart
+++ b/packages/authenticator/amplify_authenticator_test/lib/src/pages/confirm_verify_user_page.dart
@@ -15,9 +15,25 @@ class ConfirmVerifyUserPage extends AuthenticatorPage {
       throw UnimplementedError('Username does not exist on this page');
 
   Finder get confirmationCodeField => find.byKey(keyVerifyUserConfirmationCode);
+  Finder get submitConfirmVerifyUserButton =>
+      find.byKey(keySubmitConfirmVerifyUserButton);
 
   /// Then I see "Code"
   void expectCodeFieldIsPresent() {
     expect(confirmationCodeField, findsOneWidget);
+  }
+
+  /// When I type my code
+  Future<void> enterCode(String code) async {
+    await tester.ensureVisible(confirmationCodeField);
+    await tester.tap(confirmationCodeField);
+    await tester.enterText(confirmationCodeField, code);
+  }
+
+  /// When I click the "Submit" button
+  Future<void> submitConfirmationCode() async {
+    await tester.ensureVisible(submitConfirmVerifyUserButton);
+    await tester.tap(submitConfirmVerifyUserButton);
+    await tester.pumpAndSettle();
   }
 }


### PR DESCRIPTION
Includes fixes for:

- **Hub event processing:** Hub events should not be processed while a bloc event is being processed. The previous workaround (`PendingVerificationCheckState`) meant to address this problem but there were inherent race conditions to this. Instead, we pause the Hub subscription in the bloc while any incoming event is being processed to ensure it's processed to completion.
- **Attribute verification:** State management around attribute verification was creating discrepancies in values between the `AuthenticatorState` and the local Radio field state.