### PR TITLE
fix(smithy): Handle uncaught exception

### DIFF
--- a/packages/smithy/smithy/lib/src/http/http_operation.dart
+++ b/packages/smithy/smithy/lib/src/http/http_operation.dart
@@ -226,7 +226,14 @@ abstract class HttpOperation<InputPayload, Input, OutputPayload, Output>
           (response) => deserializeOutput(
             protocol: protocol,
             response: response,
-          ),
+            // Prevents errors thrown from registering as "Uncaught Exceptions"
+            // in the Dart debugger.
+            //
+            // This is a false positive because we do catch errors in the
+            // retryer which wraps this. Likely this is due to the use of
+            // completers in `CancelableOperation` or some other Zone-related
+            // nonsense.
+          ).catchError(Error.throwWithStackTrace),
         );
       },
       onCancel: () {


### PR DESCRIPTION
Related to #2718.

When running a Flutter app in Debug mode w/ breakpoints on "Uncaught Exceptions", there are false negatives being tripped inside Smithy.

I'm not sure why this happens, but it's likely related to the interplay of Completer's and Zone's within CancelableOperation. Since these exceptions are already being handled properly, simply catching and rethrowing them seems to at least suppress the breakpoint trigger.
