### PR TITLE
chore(version): Bump version

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,10 +7,10 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_analytics_pinpoint: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_auth_cognito: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_storage_s3: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_analytics_pinpoint: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_auth_cognito: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_storage_s3: ">=1.0.0-next.6 <1.0.0-next.7"
   file_picker: ^5.0.0
   flutter:
     sdk: flutter

--- a/infra/pubspec.yaml
+++ b/infra/pubspec.yaml
@@ -5,5 +5,5 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   path: any

--- a/packages/amplify/amplify_flutter/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0-next.6
+
+### Breaking Changes
+- chore(core)!: Chain stack traces for state machines
+- feat(api)!: custom primary key support for GraphQL model helpers ([#2606](https://github.com/aws-amplify/amplify-flutter/pull/2606))
+
+### Fixes
+- fix(auth): Await `signInUri` in Hosted UI platform ([#2706](https://github.com/aws-amplify/amplify-flutter/pull/2706))
+
 ## 1.0.0-next.5+1
 
 - Minor bug fixes and improvements

--- a/packages/amplify/amplify_flutter/example/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/example/pubspec.yaml
@@ -6,12 +6,12 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_analytics_pinpoint: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_api: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_auth_cognito: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_datastore: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_storage_s3: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_analytics_pinpoint: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_api: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_auth_cognito: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_datastore: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_storage_s3: ">=1.0.0-next.6 <1.0.0-next.7"
   flutter:
     sdk: flutter
 

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter
 description: The top level Flutter package for the AWS Amplify libraries.
-version: 1.0.0-next.5+1
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,10 +19,10 @@ platforms:
   web:
 
 dependencies:
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_datastore_plugin_interface: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_flutter_android: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_flutter_ios: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_datastore_plugin_interface: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter_android: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter_ios: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_secure_storage: ">=0.2.0 <0.3.0"
   aws_common: ">=0.4.0+1 <0.5.0"
   collection: ^1.15.0
@@ -32,12 +32,12 @@ dependencies:
   plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
-  amplify_analytics_pinpoint: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_api: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_auth_cognito: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_datastore: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_analytics_pinpoint: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_api: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_auth_cognito: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_datastore: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_lints: ">=2.0.2 <2.1.0"
-  amplify_storage_s3: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_storage_s3: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_test:
     path: ../../amplify_test
   build_runner: ^2.0.0

--- a/packages/amplify/amplify_flutter_android/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.6
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.5
 
 - Minor bug fixes and improvements

--- a/packages/amplify/amplify_flutter_android/pubspec.yaml
+++ b/packages/amplify/amplify_flutter_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter_android
 description: The method channel implementation for amplify_flutter on Android
-version: 1.0.0-next.5
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter_android
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/amplify/amplify_flutter_ios/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.6
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.5
 
 - Minor bug fixes and improvements

--- a/packages/amplify/amplify_flutter_ios/example/pubspec.yaml
+++ b/packages/amplify/amplify_flutter_ios/example/pubspec.yaml
@@ -8,19 +8,19 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_flutter_ios: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_flutter_ios: ">=1.0.0-next.6 <1.0.0-next.7"
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  amplify_analytics_pinpoint: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_api: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_auth_cognito: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_datastore: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_analytics_pinpoint: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_api: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_auth_cognito: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_datastore: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_lints: ^2.0.0
-  amplify_storage_s3: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_storage_s3: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_test:
     path: ../../../amplify_test
   flutter_test:

--- a/packages/amplify/amplify_flutter_ios/pubspec.yaml
+++ b/packages/amplify/amplify_flutter_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter_ios
 description: The method channel implementation for amplify_flutter on iOS
-version: 1.0.0-next.5
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   flutter:
     sdk: flutter
 

--- a/packages/amplify_core/CHANGELOG.md
+++ b/packages/amplify_core/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.0.0-next.6
+
+### Breaking Changes
+- chore(auth)!: Chain stack traces in state machine
+- chore(core)!: Chain stack traces for state machines
+- feat(api)!: custom primary key support for GraphQL model helpers ([#2606](https://github.com/aws-amplify/amplify-flutter/pull/2606))
+
+### Fixes
+- fix(api): early call of Amplify creates wrong instance of AmplifyClass
+- fix(api): write null values in ModelMutations.create() unless owner field ([#2679](https://github.com/aws-amplify/amplify-flutter/pull/2679))
+- fix(auth): Transform session expired exceptions ([#2688](https://github.com/aws-amplify/amplify-flutter/pull/2688))
+- fix(storage): GetUrl signing
+
+### Features
+- feat(api): GraphQL Subscription Where Filter ([#2650](https://github.com/aws-amplify/amplify-flutter/pull/2650))
+- feat(storage): optimize part size for multipart upload
+- feat(storage): web implementation of transfer database using local storage ([#2631](https://github.com/aws-amplify/amplify-flutter/pull/2631))
+
 ## 1.0.0-next.5+1
 
 ### Fixes

--- a/packages/amplify_core/lib/src/amplify_class.dart
+++ b/packages/amplify_core/lib/src/amplify_class.dart
@@ -133,7 +133,7 @@ abstract class AmplifyClass {
   static AmplifyClass? instance;
 
   /// The library version.
-  String get version => '1.0.0-next.2';
+  String get version => '1.0.0-next.6';
 
   /// Resets the Amplify implementation, removing all traces of Amplify from
   /// the device.

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_core
 description: The base package containing common types and utilities that are shared across the Amplify Flutter packages.
-version: 1.0.0-next.5+1
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_core
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/amplify_datastore/CHANGELOG.md
+++ b/packages/amplify_datastore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.6
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.5
 
 - Minor bug fixes and improvements

--- a/packages/amplify_datastore/example/pubspec.yaml
+++ b/packages/amplify_datastore/example/pubspec.yaml
@@ -12,9 +12,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_api: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_datastore: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_api: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_datastore: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
   flutter_driver:
     sdk: flutter
   integration_test:

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore
 description: The Amplify Flutter DataStore category plugin, providing a queryable, on-device data store.
-version: 1.0.0-next.5
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_datastore
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_datastore_plugin_interface: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_datastore_plugin_interface: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   plugin_platform_interface: ^2.0.0
   meta: ^1.7.0
   collection: ^1.14.13

--- a/packages/amplify_datastore_plugin_interface/CHANGELOG.md
+++ b/packages/amplify_datastore_plugin_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.6
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.5
 
 - Minor bug fixes and improvements

--- a/packages/amplify_datastore_plugin_interface/pubspec.yaml
+++ b/packages/amplify_datastore_plugin_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore_plugin_interface
 description: The platform interface for the DataStore module of Amplify Flutter.
-version: 1.0.0-next.5
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_datastore_plugin_interface
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   collection: ^1.15.0
   flutter:
     sdk: flutter

--- a/packages/amplify_test/pubspec.yaml
+++ b/packages/amplify_test/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_auth_cognito_dart: ">=0.6.0+1 <0.7.0"
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_auth_cognito_dart: ">=0.7.0 <0.8.0"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   aws_common: ">=0.4.0 <0.5.0"
   collection: ^1.15.0
   meta: ^1.8.0

--- a/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.6
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.5+1
 
 - Minor bug fixes and improvements

--- a/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_analytics_pinpoint: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_api: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_auth_cognito: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_analytics_pinpoint: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_api: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_auth_cognito: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
 
   flutter:
     sdk: flutter
@@ -22,7 +22,7 @@ dependency_overrides:
   async: ^2.10.0
 
 dev_dependencies:
-  amplify_analytics_pinpoint_dart: ">=0.1.4+1 <0.2.0"
+  amplify_analytics_pinpoint_dart: ">=0.1.4+2 <0.2.0"
   amplify_lints:
     path: ../../../amplify_lints
   amplify_test:

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint
 description: The Amplify Flutter Analytics category plugin using the AWS Pinpoint provider.
-version: 1.0.0-next.5+1
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/analytics/amplify_analytics_pinpoint
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,11 +19,11 @@ platforms:
   web:
 
 dependencies:
-  amplify_analytics_pinpoint_dart: ">=0.1.4+1 <0.2.0"
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_db_common: ">=0.1.2+2 <0.2.0"
+  amplify_analytics_pinpoint_dart: ">=0.1.4+2 <0.2.0"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_db_common: ">=0.1.2+3 <0.2.0"
   amplify_secure_storage: ">=0.2.0 <0.3.0"
-  aws_common: ">=0.4.1 <0.5.0"
+  aws_common: ">=0.4.2 <0.5.0"
   device_info_plus: ^8.0.0
   flutter:
     sdk: flutter

--- a/packages/analytics/amplify_analytics_pinpoint_dart/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4+2
+
+- Minor bug fixes and improvements
+
 ## 0.1.4+1
 
 - Minor bug fixes and improvements

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/drift/drift_queued_item_store.g.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/drift/drift_queued_item_store.g.dart
@@ -66,10 +66,10 @@ class $DriftQueuedItemsTable extends DriftQueuedItems
 }
 
 class DriftQueuedItem extends DataClass implements Insertable<DriftQueuedItem> {
-  /// Identifies object in the SQL database
+  /// Identifies object in the SQL database.
   final int id;
 
-  /// The string value stored for this object
+  /// The string value stored for this object.
   final String value;
   const DriftQueuedItem({required this.id, required this.value});
   @override

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/version.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.1.4';
+const packageVersion = '0.1.4+2';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint_dart
 description: A Dart-only implementation of the Amplify Analytics plugin for Pinpoint.
-version: 0.1.4+1
+version: 0.1.4+2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/analytics/amplify_analytics_pinpoint_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,10 +9,10 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_db_common_dart: ">=0.2.0+2 <0.3.0"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_db_common_dart: ">=0.2.0+3 <0.3.0"
   amplify_secure_storage_dart: ">=0.2.0 <0.3.0"
-  aws_common: ">=0.4.1 <0.5.0"
+  aws_common: ">=0.4.2 <0.5.0"
   aws_signature_v4: ">=0.3.1+3 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"

--- a/packages/api/amplify_api/CHANGELOG.md
+++ b/packages/api/amplify_api/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.0.0-next.6
+
+### Fixes
+- fix(api): early call of Amplify creates wrong instance of AmplifyClass
+- fix(api): write null values in ModelMutations.create() unless owner field ([#2679](https://github.com/aws-amplify/amplify-flutter/pull/2679))
+
+### Breaking Changes
+- feat(api)!: custom primary key support for GraphQL model helpers ([#2606](https://github.com/aws-amplify/amplify-flutter/pull/2606))
+
+### Features
+- feat(api): GraphQL Subscription Where Filter ([#2650](https://github.com/aws-amplify/amplify-flutter/pull/2650))
+
 ## 1.0.0-next.5+1
 
 ### Fixes

--- a/packages/api/amplify_api/example/pubspec.yaml
+++ b/packages/api/amplify_api/example/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_api: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_auth_cognito: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_authenticator: ">=1.0.0-next.4+1 <1.0.0-next.5"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_api: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_auth_cognito: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_authenticator: ">=1.0.0-next.4+2 <1.0.0-next.5"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
   async: ^2.10.0
   aws_common: ">=0.4.0 <0.5.0"
 

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api
 description: The Amplify Flutter API category plugin, supporting GraphQL and REST operations.
-version: 1.0.0-next.5+1
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,11 +19,11 @@ platforms:
   web:
 
 dependencies:
-  amplify_api_android: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_api_dart: ">=0.1.0+2 <0.2.0"
-  amplify_api_ios: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_api_android: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_api_dart: ">=0.2.0 <0.3.0"
+  amplify_api_ios: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
   connectivity_plus: ^3.0.2
   flutter:
     sdk: flutter

--- a/packages/api/amplify_api_android/CHANGELOG.md
+++ b/packages/api/amplify_api_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.6
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.5
 
 - Minor bug fixes and improvements

--- a/packages/api/amplify_api_android/example/pubspec.yaml
+++ b/packages/api/amplify_api_android/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_api: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_api: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
   flutter:
     sdk: flutter
 

--- a/packages/api/amplify_api_android/pubspec.yaml
+++ b/packages/api/amplify_api_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_android
 description: The method channel implementation for amplify_api on Android
-version: 1.0.0-next.5
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api_android
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/api/amplify_api_dart/CHANGELOG.md
+++ b/packages/api/amplify_api_dart/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.2.0
+
+### Fixes
+- fix(api): early call of Amplify creates wrong instance of AmplifyClass
+- fix(api): write null values in ModelMutations.create() unless owner field ([#2679](https://github.com/aws-amplify/amplify-flutter/pull/2679))
+
+### Breaking Changes
+- feat(api)!: custom primary key support for GraphQL model helpers ([#2606](https://github.com/aws-amplify/amplify-flutter/pull/2606))
+
+### Features
+- feat(api): GraphQL Subscription Where Filter ([#2650](https://github.com/aws-amplify/amplify-flutter/pull/2650))
+
 ## 0.1.0+3
 
 ### Fixes

--- a/packages/api/amplify_api_dart/pubspec.yaml
+++ b/packages/api/amplify_api_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_dart
 description: The Amplify API category plugin in Dart-only, supporting GraphQL and REST operations.
-version: 0.1.0+3
+version: 0.2.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   async: ^2.10.0
   aws_common: ">=0.4.0+1 <0.5.0"
   collection: ^1.15.0

--- a/packages/api/amplify_api_ios/CHANGELOG.md
+++ b/packages/api/amplify_api_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.6
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.5
 
 - Minor bug fixes and improvements

--- a/packages/api/amplify_api_ios/example/pubspec.yaml
+++ b/packages/api/amplify_api_ios/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_api: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_api: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
   flutter:
     sdk: flutter
 

--- a/packages/api/amplify_api_ios/pubspec.yaml
+++ b/packages/api/amplify_api_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_ios
 description: The package containing the method channel implementation for amplify_api on iOS
-version: 1.0.0-next.5
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   flutter:
     sdk: flutter
 

--- a/packages/auth/amplify_auth_cognito/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-next.6
+
+### Fixes
+- fix(auth): Await `signInUri` in Hosted UI platform ([#2706](https://github.com/aws-amplify/amplify-flutter/pull/2706))
+
 ## 1.0.0-next.5+1
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_api: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_auth_cognito: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_authenticator: ">=1.0.0-next.4+1 <1.0.0-next.5"
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_api: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_auth_cognito: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_authenticator: ">=1.0.0-next.4+2 <1.0.0-next.5"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
   flutter:
     sdk: flutter
   go_router: ^3.0.0
@@ -23,7 +23,7 @@ dependency_overrides:
   test_api: ^0.4.0
 
 dev_dependencies:
-  amplify_auth_cognito_dart: ">=0.6.0+1 <0.7.0"
+  amplify_auth_cognito_dart: ">=0.7.0 <0.8.0"
   amplify_auth_cognito_test: any
   amplify_lints:
     path: ../../../amplify_lints

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito
 description: The Amplify Flutter Auth category plugin using the AWS Cognito provider.
-version: 1.0.0-next.5+1
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,11 +19,11 @@ platforms:
   web:
 
 dependencies:
-  amplify_auth_cognito_android: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_auth_cognito_dart: ">=0.6.0+1 <0.7.0"
-  amplify_auth_cognito_ios: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_auth_cognito_android: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_auth_cognito_dart: ">=0.7.0 <0.8.0"
+  amplify_auth_cognito_ios: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_secure_storage: ">=0.2.0 <0.3.0"
   async: ^2.10.0
   flutter:

--- a/packages/auth/amplify_auth_cognito_android/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.6
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.5
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito_android/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_android
 description: The method channel implementation for amplify_auth_cognito on Android
-version: 1.0.0-next.5
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_android
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.0
+
+### Fixes
+- fix(auth): Transform session expired exceptions ([#2688](https://github.com/aws-amplify/amplify-flutter/pull/2688))
+
+### Breaking Changes
+- chore(auth)!: Chain stack traces in state machine
+
 ## 0.6.0+1
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
@@ -7,14 +7,14 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_auth_cognito_dart: ">=0.6.0+1 <0.7.0"
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_auth_cognito_dart: ">=0.7.0 <0.8.0"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_secure_storage_dart: ">=0.2.0 <0.3.0"
   example_common:
     path: ../../../example_common
 
 dev_dependencies:
-  amplify_api_dart: ^0.1.0
+  amplify_api_dart: ">=0.2.0 <0.3.0"
   amplify_auth_cognito_test: any
   amplify_lints:
     path: ../../../amplify_lints

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_dart
 description: A Dart-only implementation of the Amplify Auth plugin for Cognito.
-version: 0.6.0+1
+version: 0.7.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_secure_storage_dart: ">=0.2.0 <0.3.0"
   async: ^2.10.0
   aws_common: ">=0.4.1+1 <0.5.0"

--- a/packages/auth/amplify_auth_cognito_ios/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.6
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.5
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito_ios/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_ios
 description: The method channel implementation for amplify_auth_cognito on iOS
-version: 1.0.0-next.5
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   flutter:
     sdk: flutter
 

--- a/packages/auth/amplify_auth_cognito_test/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_test/pubspec.yaml
@@ -6,8 +6,8 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  amplify_auth_cognito_dart: ">=0.6.0+1 <0.7.0"
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_auth_cognito_dart: ">=0.7.0 <0.8.0"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_secure_storage_dart: ">=0.2.0 <0.3.0"
   aws_common: ">=0.4.0 <0.5.0"
   built_collection: ^5.0.0

--- a/packages/authenticator/amplify_authenticator/CHANGELOG.md
+++ b/packages/authenticator/amplify_authenticator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.4+2
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.4+1
 
 - Minor bug fixes and improvements

--- a/packages/authenticator/amplify_authenticator/example/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/example/pubspec.yaml
@@ -22,9 +22,9 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_auth_cognito: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_authenticator: ">=1.0.0-next.4+1 <1.0.0-next.5"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_auth_cognito: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_authenticator: ">=1.0.0-next.4+2 <1.0.0-next.5"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
 
   flutter:
     sdk: flutter
@@ -40,7 +40,7 @@ dependency_overrides:
   async: ^2.10.0
 
 dev_dependencies:
-  amplify_api: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_api: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_authenticator_test:
     path: ../../amplify_authenticator_test
   amplify_lints:

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_authenticator
 description: A prebuilt Sign In and Sign Up experience for the Amplify Auth category
-version: 1.0.0-next.4+1
+version: 1.0.0-next.4+2
 homepage: https://ui.docs.amplify.aws/flutter/connected-components/authenticator
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/authenticator/amplify_authenticator
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,9 +10,9 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_auth_cognito: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_core: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_auth_cognito: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
   async: ^2.10.0
   aws_common: ">=0.4.0+1 <0.5.0"
   collection: ^1.15.0

--- a/packages/authenticator/amplify_authenticator_test/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator_test/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_authenticator: ">=1.0.0-next.4+1 <1.0.0-next.5"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_authenticator: ">=1.0.0-next.4+2 <1.0.0-next.5"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_test:
     path: ../../amplify_test
   flutter:

--- a/packages/aws_common/CHANGELOG.md
+++ b/packages/aws_common/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2
+
+### Features
+- feat(aws_common): add openRead API for AWSFile
+
 ## 0.4.1+1
 
 - Minor bug fixes and improvements

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aws_common
 description: Common types and utilities used across AWS and Amplify packages.
-version: 0.4.1+1
+version: 0.4.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/aws_common
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/common/amplify_db_common/CHANGELOG.md
+++ b/packages/common/amplify_db_common/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2+3
+
+- Minor bug fixes and improvements
+
 ## 0.1.2+2
 
 - Minor bug fixes and improvements

--- a/packages/common/amplify_db_common/example/pubspec.yaml
+++ b/packages/common/amplify_db_common/example/pubspec.yaml
@@ -6,8 +6,7 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  amplify_db_common:
-    path: ../
+  amplify_db_common: ">=0.1.2+3 <0.2.0"
   drift: ">=2.4.0 <2.6.0"
   flutter:
     sdk: flutter

--- a/packages/common/amplify_db_common/pubspec.yaml
+++ b/packages/common/amplify_db_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_db_common
 description: Common utilities for working with databases such as SQLite.
-version: 0.1.2+2
+version: 0.1.2+3
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/common/amplify_db_common
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_db_common_dart: ">=0.2.0+2 <0.3.0"
+  amplify_db_common_dart: ">=0.2.0+3 <0.3.0"
   drift: ">=2.4.0 <2.6.0"
   flutter:
     sdk: flutter

--- a/packages/common/amplify_db_common_dart/CHANGELOG.md
+++ b/packages/common/amplify_db_common_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+3
+
+- Minor bug fixes and improvements
+
 ## 0.2.0+2
 
 - Minor bug fixes and improvements

--- a/packages/common/amplify_db_common_dart/example/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/example/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_db_common_dart: ">=0.2.0+2 <0.3.0"
+  amplify_db_common_dart: ">=0.2.0+3 <0.3.0"
   drift: ">=2.4.0 <2.6.0"
   example_common:
     path: ../../../example_common

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_db_common_dart
 description: Common utilities for working with databases such as sqlite. Used throughout Amplify packages.
-version: 0.2.0+2
+version: 0.2.0+3
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/common/amplify_db_common_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   async: ^2.10.0
   aws_common: ">=0.4.0+1 <0.5.0"
   drift: ">=2.4.0 <2.6.0"

--- a/packages/storage/amplify_storage_s3/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0-next.6
+
+### Features
+- feat(storage): optimize part size for multipart upload
+- feat(storage): web implementation of transfer database using local storage ([#2631](https://github.com/aws-amplify/amplify-flutter/pull/2631))
+
+### Fixes
+- fix(storage): GetUrl signing
+
 ## 1.0.0-next.5
 
 - Minor bug fixes and improvements

--- a/packages/storage/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/example/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_auth_cognito: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_authenticator: ">=1.0.0-next.4+1 <1.0.0-next.5"
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_auth_cognito: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_authenticator: ">=1.0.0-next.4+2 <1.0.0-next.5"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_flutter: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_secure_storage: ">=0.2.0 <0.3.0"
-  amplify_storage_s3: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_storage_s3: ">=1.0.0-next.6 <1.0.0-next.7"
   flutter:
     sdk: flutter
   go_router: ^5.0.5
@@ -24,7 +24,7 @@ dependency_overrides:
 dev_dependencies:
   amplify_lints:
     path: ../../../amplify_lints
-  amplify_storage_s3_dart: ">=0.1.5+1 <0.2.0"
+  amplify_storage_s3_dart: ">=0.1.6+1 <0.2.0"
   amplify_test:
     path: ../../../amplify_test
   aws_common: ">=0.4.0 <0.5.0"

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3
 description: The Amplify Flutter Storage category plugin using the AWS S3 provider.
-version: 1.0.0-next.5
+version: 1.0.0-next.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/storage/amplify_storage_s3
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,9 +19,9 @@ platforms:
   web:
 
 dependencies:
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_db_common: ">=0.1.2+2 <0.2.0"
-  amplify_storage_s3_dart: ">=0.1.6 <0.2.0"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_db_common: ">=0.1.2+3 <0.2.0"
+  amplify_storage_s3_dart: ">=0.1.6+1 <0.2.0"
   aws_common: ">=0.4.0+1 <0.5.0"
   flutter:
     sdk: flutter

--- a/packages/storage/amplify_storage_s3_dart/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3_dart/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.1.7
+
+### Features
+- feat(storage): optimize part size for multipart upload
+- feat(storage): web implementation of transfer database using local storage ([#2631](https://github.com/aws-amplify/amplify-flutter/pull/2631))
+
+### Fixes
+- fix(storage): GetUrl signing
+
 ## 0.1.6
 
 ### Features

--- a/packages/storage/amplify_storage_s3_dart/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/example/pubspec.yaml
@@ -7,10 +7,10 @@ environment:
   sdk: '>=2.17.6 <3.0.0'
 
 dependencies:
-  amplify_auth_cognito_dart: ">=0.6.0+1 <0.7.0"
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
+  amplify_auth_cognito_dart: ">=0.7.0 <0.8.0"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
   amplify_secure_storage_dart: ">=0.2.0 <0.3.0"
-  amplify_storage_s3_dart: ">=0.1.5+1 <0.2.0"
+  amplify_storage_s3_dart: ">=0.1.6+1 <0.2.0"
   example_common:
     path: ../../../example_common
 

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3_dart
 description: A Dart-only implementation of the Amplify Storage plugin for S3.
-version: 0.1.6
+version: 0.1.7
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/storage/amplify_storage_s3_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,10 +9,10 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  amplify_core: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_db_common_dart: ">=0.2.0+2 <0.3.0"
+  amplify_core: ">=1.0.0-next.6 <1.0.0-next.7"
+  amplify_db_common_dart: ">=0.2.0+3 <0.3.0"
   async: ^2.10.0
-  aws_common: ">=0.4.0+1 <0.5.0"
+  aws_common: ">=0.4.2 <0.5.0"
   aws_signature_v4: ">=0.3.1+3 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"


### PR DESCRIPTION
### Breaking Changes
- chore(auth)!: Chain stack traces in state machine
- chore(core)!: Chain stack traces for state machines
- feat(api)!: custom primary key support for GraphQL model helpers ([#2606](https://github.com/aws-amplify/amplify-flutter/pull/2606))

### Fixes
- fix(api): early call of Amplify creates wrong instance of AmplifyClass
- fix(api): write null values in ModelMutations.create() unless owner field ([#2679](https://github.com/aws-amplify/amplify-flutter/pull/2679))
- fix(auth): Await `signInUri` in Hosted UI platform ([#2706](https://github.com/aws-amplify/amplify-flutter/pull/2706))
- fix(auth): Transform session expired exceptions ([#2688](https://github.com/aws-amplify/amplify-flutter/pull/2688))
- fix(storage): GetUrl signing

### Features
- feat(api): GraphQL Subscription Where Filter ([#2650](https://github.com/aws-amplify/amplify-flutter/pull/2650))
- feat(aws_common): add openRead API for AWSFile
- feat(storage): optimize part size for multipart upload
- feat(storage): web implementation of transfer database using local storage ([#2631](https://github.com/aws-amplify/amplify-flutter/pull/2631))

Updated-Components: aws_common, Amplify Flutter, Amplify Dart, Amplify UI, DB Common
