### PR TITLE
chore(core): Use `package:build_version`

### DIFF
--- a/packages/amplify_core/lib/src/amplify_class.dart
+++ b/packages/amplify_core/lib/src/amplify_class.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/src/version.dart';
 import 'package:meta/meta.dart';
 
 import 'amplify_class_impl.dart';
@@ -133,7 +134,7 @@ abstract class AmplifyClass {
   static AmplifyClass? instance;
 
   /// The library version.
-  String get version => '1.0.0-next.6';
+  String get version => packageVersion.split('+').first;
 
   /// Resets the Amplify implementation, removing all traces of Amplify from
   /// the device.

--- a/packages/amplify_core/lib/src/version.dart
+++ b/packages/amplify_core/lib/src/version.dart
@@ -1,0 +1,2 @@
+// Generated code. Do not modify.
+const packageVersion = '1.0.0-next.6';

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -25,6 +25,7 @@ dev_dependencies:
   amplify_lints: ">=2.0.2 <2.1.0"
   build_runner: ^2.0.0
   build_test: ^2.1.5
+  build_version: ^2.1.1
   build_web_compilers: ^3.2.4
   json_serializable: 6.6.1
   path: any


### PR DESCRIPTION
Instead of manually updating the version, use `package:build_version` which gets automatically run when calling `aft version-bump`.
