### PR TITLE
chore: migrate Flutter unit tests to GH actions

### DIFF
--- a/.github/workflows/amplify_analytics_pinpoint.yaml
+++ b/.github/workflows/amplify_analytics_pinpoint.yaml
@@ -1,0 +1,26 @@
+name: amplify_analytics_pinpoint
+on:
+  push:
+    branches:
+      - main
+      - stable
+  pull_request:
+    paths:
+      - 'packages/analytics/amplify_analytics_pinpoint/**/*.dart'
+      - 'packages/analytics/amplify_analytics_pinpoint/**/*.yaml'
+      - 'packages/analytics/amplify_analytics_pinpoint/lib/**/*'
+      - 'packages/analytics/amplify_analytics_pinpoint/test/**/*'
+      - '.github/workflows/flutter_vm.yaml'
+      - '.github/workflows/amplify_analytics_pinpoint.yaml'
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at 00:00
+defaults:
+  run:
+    shell: bash
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/flutter_vm.yaml
+    with:
+      working-directory: packages/analytics/amplify_analytics_pinpoint

--- a/.github/workflows/amplify_api.yaml
+++ b/.github/workflows/amplify_api.yaml
@@ -1,0 +1,26 @@
+name: amplify_api
+on:
+  push:
+    branches:
+      - main
+      - stable
+  pull_request:
+    paths:
+      - 'packages/api/amplify_api/**/*.dart'
+      - 'packages/api/amplify_api/**/*.yaml'
+      - 'packages/api/amplify_api/lib/**/*'
+      - 'packages/api/amplify_api/test/**/*'
+      - '.github/workflows/flutter_vm.yaml'
+      - '.github/workflows/amplify_api.yaml'
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at 00:00
+defaults:
+  run:
+    shell: bash
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/flutter_vm.yaml
+    with:
+      working-directory: packages/api/amplify_api

--- a/.github/workflows/amplify_auth_cognito.yaml
+++ b/.github/workflows/amplify_auth_cognito.yaml
@@ -1,0 +1,26 @@
+name: amplify_auth_cognito
+on:
+  push:
+    branches:
+      - main
+      - stable
+  pull_request:
+    paths:
+      - 'packages/auth/amplify_auth_cognito/**/*.dart'
+      - 'packages/auth/amplify_auth_cognito/**/*.yaml'
+      - 'packages/auth/amplify_auth_cognito/lib/**/*'
+      - 'packages/auth/amplify_auth_cognito/test/**/*'
+      - '.github/workflows/flutter_vm.yaml'
+      - '.github/workflows/amplify_auth_cognito.yaml'
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at 00:00
+defaults:
+  run:
+    shell: bash
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/flutter_vm.yaml
+    with:
+      working-directory: packages/auth/amplify_auth_cognito

--- a/.github/workflows/amplify_authenticator.yaml
+++ b/.github/workflows/amplify_authenticator.yaml
@@ -1,0 +1,26 @@
+name: amplify_authenticator
+on:
+  push:
+    branches:
+      - main
+      - stable
+  pull_request:
+    paths:
+      - 'packages/amplify_authenticator/**/*.dart'
+      - 'packages/amplify_authenticator/**/*.yaml'
+      - 'packages/amplify_authenticator/lib/**/*'
+      - 'packages/amplify_authenticator/test/**/*'
+      - '.github/workflows/flutter_vm.yaml'
+      - '.github/workflows/amplify_authenticator.yaml'
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at 00:00
+defaults:
+  run:
+    shell: bash
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/flutter_vm.yaml
+    with:
+      working-directory: packages/amplify_authenticator

--- a/.github/workflows/amplify_core.yaml
+++ b/.github/workflows/amplify_core.yaml
@@ -1,0 +1,26 @@
+name: amplify_core
+on:
+  push:
+    branches:
+      - main
+      - stable
+  pull_request:
+    paths:
+      - 'packages/amplify_core/**/*.dart'
+      - 'packages/amplify_core/**/*.yaml'
+      - 'packages/amplify_core/lib/**/*'
+      - 'packages/amplify_core/test/**/*'
+      - '.github/workflows/flutter_vm.yaml'
+      - '.github/workflows/amplify_core.yaml'
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at 00:00
+defaults:
+  run:
+    shell: bash
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/flutter_vm.yaml
+    with:
+      working-directory: packages/amplify_core

--- a/.github/workflows/amplify_datastore.yaml
+++ b/.github/workflows/amplify_datastore.yaml
@@ -1,0 +1,26 @@
+name: amplify_datastore
+on:
+  push:
+    branches:
+      - main
+      - stable
+  pull_request:
+    paths:
+      - 'packages/amplify_datastore/**/*.dart'
+      - 'packages/amplify_datastore/**/*.yaml'
+      - 'packages/amplify_datastore/lib/**/*'
+      - 'packages/amplify_datastore/test/**/*'
+      - '.github/workflows/flutter_vm.yaml'
+      - '.github/workflows/amplify_datastore.yaml'
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at 00:00
+defaults:
+  run:
+    shell: bash
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/flutter_vm.yaml
+    with:
+      working-directory: packages/amplify_datastore

--- a/.github/workflows/amplify_datastore_plugin_interface.yaml
+++ b/.github/workflows/amplify_datastore_plugin_interface.yaml
@@ -1,0 +1,26 @@
+name: amplify_datastore_plugin_interface
+on:
+  push:
+    branches:
+      - main
+      - stable
+  pull_request:
+    paths:
+      - 'packages/amplify_datastore_plugin_interface/**/*.dart'
+      - 'packages/amplify_datastore_plugin_interface/**/*.yaml'
+      - 'packages/amplify_datastore_plugin_interface/lib/**/*'
+      - 'packages/amplify_datastore_plugin_interface/test/**/*'
+      - '.github/workflows/flutter_vm.yaml'
+      - '.github/workflows/amplify_datastore_plugin_interface.yaml'
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at 00:00
+defaults:
+  run:
+    shell: bash
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/flutter_vm.yaml
+    with:
+      working-directory: packages/amplify_datastore_plugin_interface

--- a/.github/workflows/amplify_flutter.yaml
+++ b/.github/workflows/amplify_flutter.yaml
@@ -1,0 +1,26 @@
+name: amplify_flutter
+on:
+  push:
+    branches:
+      - main
+      - stable
+  pull_request:
+    paths:
+      - 'packages/amplify/amplify_flutter/**/*.dart'
+      - 'packages/amplify/amplify_flutter/**/*.yaml'
+      - 'packages/amplify/amplify_flutter/lib/**/*'
+      - 'packages/amplify/amplify_flutter/test/**/*'
+      - '.github/workflows/flutter_vm.yaml'
+      - '.github/workflows/amplify_flutter.yaml'
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at 00:00
+defaults:
+  run:
+    shell: bash
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/flutter_vm.yaml
+    with:
+      working-directory: packages/amplify/amplify_flutter

--- a/.github/workflows/amplify_storage_s3.yaml
+++ b/.github/workflows/amplify_storage_s3.yaml
@@ -1,0 +1,26 @@
+name: amplify_storage_s3
+on:
+  push:
+    branches:
+      - main
+      - stable
+  pull_request:
+    paths:
+      - 'packages/storage/amplify_storage_s3/**/*.dart'
+      - 'packages/storage/amplify_storage_s3/**/*.yaml'
+      - 'packages/storage/amplify_storage_s3/lib/**/*'
+      - 'packages/storage/amplify_storage_s3/test/**/*'
+      - '.github/workflows/flutter_vm.yaml'
+      - '.github/workflows/amplify_storage_s3.yaml'
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at 00:00
+defaults:
+  run:
+    shell: bash
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/flutter_vm.yaml
+    with:
+      working-directory: packages/storage/amplify_storage_s3

--- a/.github/workflows/flutter_format_analyze.yaml
+++ b/.github/workflows/flutter_format_analyze.yaml
@@ -1,0 +1,45 @@
+name: Flutter Format and Analyze
+on:
+  push:
+    branches:
+      - main
+      - stable
+  pull_request:
+    paths:
+      - 'packages/**/*.dart'
+      - 'packages/**/*.yaml'
+      - '.github/workflows/flutter_format_analyze.yaml'
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at 00:00
+defaults:
+  run:
+    shell: bash
+permissions: read-all
+
+jobs:
+  flutter_format_analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d # 2.8.0
+        with:
+          cache: true
+
+      - name: Install Melos and Bootstrap
+        id: bootstrap
+        timeout-minutes: 10
+        run: |
+          flutter pub global activate melos 1.3.0
+          melos bootstrap
+
+      - name: Flutter Format
+        if: "always() && steps.bootstrap.conclusion == 'success'"
+        run: melos run format
+
+      - name: Flutter Analyze
+        if: "always() && steps.bootstrap.conclusion == 'success'"
+        run: melos run analyze --no-select

--- a/.github/workflows/flutter_vm.yaml
+++ b/.github/workflows/flutter_vm.yaml
@@ -1,0 +1,33 @@
+name: Flutter (VM)
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: The working directory relative to the repo root
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d # 2.8.0
+        with:
+          cache: true
+
+      - name: Install Melos and Bootstrap
+        timeout-minutes: 10
+        run: |
+          flutter pub global activate melos 1.3.0
+          melos bootstrap
+
+      - name: Run Tests
+        run: flutter test
+        working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
This PR migrates flutter unit tests to GH actions by largely copying/modifying the generated GH actions from next and only running with stable Flutter channel. It also runs `flutter format` and `flutter analyze` in its own job (one for all packages) which is based off the current Circle CI job here.

Removing CCI equivalents should be separate PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
