### PR TITLE
chore(storage)!: remove unnecessary HeadObject call from download operations

### DIFF
--- a/infra/lib/storage/stack.ts
+++ b/infra/lib/storage/stack.ts
@@ -110,6 +110,10 @@ class StorageIntegrationTestEnvironment extends IntegrationTestStackEnvironment<
             "x-amz-request-id",
             "x-amz-id-2",
             "ETag",
+            // This is required workaround on Web to retrieve metadata fields
+            // via GetObject and HeadObject.
+            // https://github.com/aws-amplify/amplify-js/issues/2903#issuecomment-475012164
+            "x-amz-meta-filename",
           ],
           maxAge: 3000,
         },

--- a/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
@@ -298,16 +298,22 @@ void main() {
         testWidgets(
             'download object as bytes data in memory with access level private'
             ' for the currently signed in user', (WidgetTester tester) async {
-          final result = await Amplify.Storage.downloadData(
-            key: testObjectKey3,
-            options: const S3DownloadDataOptions(
-              accessLevel: StorageAccessLevel.private,
-              getProperties: true,
-            ),
-          ).result;
+          final plugin = Amplify.Storage.getPlugin(AmplifyStorageS3.pluginKey);
+          final result = await plugin
+              .downloadData(
+                key: testObjectKey3,
+                options: const S3DownloadDataOptions(
+                  accessLevel: StorageAccessLevel.private,
+                ),
+              )
+              .result;
 
           expect(result.bytes, equals(testLargeFileBytes));
           expect(result.downloadedItem.eTag, object3Etag);
+          expect(
+            result.downloadedItem.metadata,
+            containsPair('filename', testObjectFileName3),
+          );
         });
 
         testWidgets(
@@ -315,17 +321,19 @@ void main() {
             ' for the currently signed in user', (WidgetTester tester) async {
           const start = 5 * 1024;
           const end = 5 * 1024 + 12;
-          final result = await Amplify.Storage.downloadData(
-            key: testObjectKey3,
-            options: S3DownloadDataOptions(
-              accessLevel: StorageAccessLevel.private,
-              getProperties: true,
-              bytesRange: S3DataBytesRange(
-                start: start,
-                end: end,
-              ),
-            ),
-          ).result;
+          final plugin = Amplify.Storage.getPlugin(AmplifyStorageS3.pluginKey);
+          final result = await plugin
+              .downloadData(
+                key: testObjectKey3,
+                options: S3DownloadDataOptions(
+                  accessLevel: StorageAccessLevel.private,
+                  bytesRange: S3DataBytesRange(
+                    start: start,
+                    end: end,
+                  ),
+                ),
+              )
+              .result;
 
           expect(
             result.bytes,
@@ -333,6 +341,10 @@ void main() {
             equals(testLargeFileBytes.sublist(start, end + 1)),
           );
           expect(result.downloadedItem.eTag, object3Etag);
+          expect(
+            result.downloadedItem.metadata,
+            containsPair('filename', testObjectFileName3),
+          );
         });
 
         testWidgets(
@@ -350,7 +362,6 @@ void main() {
                   localFile: localFile,
                   options: const S3DownloadFileOptions(
                     accessLevel: StorageAccessLevel.private,
-                    getProperties: true,
                   ),
                 )
                 .result;
@@ -560,7 +571,6 @@ void main() {
               key: testObjectKey2,
               options: S3DownloadDataOptions.forIdentity(
                 user1IdentityId,
-                getProperties: true,
               ),
             ).result;
 
@@ -575,7 +585,6 @@ void main() {
               key: testObjectKey3,
               options: const S3DownloadDataOptions(
                 accessLevel: StorageAccessLevel.private,
-                getProperties: true,
               ),
             );
 

--- a/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
+++ b/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
@@ -221,7 +221,6 @@ Future<void> downloadDataOperation() async {
     key: key,
     options: S3DownloadDataOptions(
       accessLevel: accessLevel,
-      getProperties: true,
     ),
     onProgress: onTransferProgress,
   );
@@ -263,7 +262,6 @@ Future<void> downloadFileOperation() async {
     key: key,
     localFile: localFile,
     options: S3DownloadFileOptions(
-      getProperties: true,
       accessLevel: accessLevel,
       useAccelerateEndpoint: useAccelerateEndpoint,
     ),

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_data_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_data_options.dart
@@ -11,19 +11,16 @@ class S3DownloadDataOptions extends StorageDownloadDataOptions {
   /// {@macro storage.amplify_storage_s3.download_data_options}
   const S3DownloadDataOptions({
     StorageAccessLevel accessLevel = StorageAccessLevel.guest,
-    bool getProperties = false,
     S3DataBytesRange? bytesRange,
     bool useAccelerateEndpoint = false,
   }) : this._(
           accessLevel: accessLevel,
           bytesRange: bytesRange,
-          getProperties: getProperties,
           useAccelerateEndpoint: useAccelerateEndpoint,
         );
 
   const S3DownloadDataOptions._({
     super.accessLevel = StorageAccessLevel.guest,
-    this.getProperties = false,
     this.bytesRange,
     this.targetIdentityId,
     this.useAccelerateEndpoint = false,
@@ -36,13 +33,11 @@ class S3DownloadDataOptions extends StorageDownloadDataOptions {
   /// signed-in user.
   const S3DownloadDataOptions.forIdentity(
     String targetIdentityId, {
-    bool getProperties = false,
     S3DataBytesRange? bytesRange,
     bool useAccelerateEndpoint = false,
   }) : this._(
           accessLevel: StorageAccessLevel.protected,
           targetIdentityId: targetIdentityId,
-          getProperties: getProperties,
           bytesRange: bytesRange,
           useAccelerateEndpoint: useAccelerateEndpoint,
         );
@@ -54,10 +49,6 @@ class S3DownloadDataOptions extends StorageDownloadDataOptions {
   ///
   /// This can be set by using [S3DownloadDataOptions.forIdentity].
   final String? targetIdentityId;
-
-  /// Whether to retrieve properties for the downloaded object using the
-  /// `getProperties` API.
-  final bool getProperties;
 
   /// {@template storage.amplify_storage_s3.transfer_acceleration}
   /// Whether to use [S3 Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html)

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_file_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_file_options.dart
@@ -10,17 +10,14 @@ class S3DownloadFileOptions extends StorageDownloadFileOptions {
   /// {@macro storage.amplify_storage_s3.download_file_options}
   const S3DownloadFileOptions({
     StorageAccessLevel accessLevel = StorageAccessLevel.guest,
-    bool getProperties = false,
     bool useAccelerateEndpoint = false,
   }) : this._(
           accessLevel: accessLevel,
-          getProperties: getProperties,
           useAccelerateEndpoint: useAccelerateEndpoint,
         );
 
   const S3DownloadFileOptions._({
     super.accessLevel = StorageAccessLevel.guest,
-    this.getProperties = false,
     this.targetIdentityId,
     this.useAccelerateEndpoint = false,
   });
@@ -32,12 +29,10 @@ class S3DownloadFileOptions extends StorageDownloadFileOptions {
   /// user.
   const S3DownloadFileOptions.forIdentity(
     String targetIdentityId, {
-    bool getProperties = false,
     bool useAccelerateEndpoint = false,
   }) : this._(
           accessLevel: StorageAccessLevel.protected,
           targetIdentityId: targetIdentityId,
-          getProperties: getProperties,
           useAccelerateEndpoint: useAccelerateEndpoint,
         );
 
@@ -45,10 +40,6 @@ class S3DownloadFileOptions extends StorageDownloadFileOptions {
   ///
   /// This can be set by using [S3DownloadFileOptions.forIdentity].
   final String? targetIdentityId;
-
-  /// Whether to retrieve properties for the downloaded object using the
-  /// `getProperties` API.
-  final bool getProperties;
 
   /// {@macro storage.amplify_storage_s3.transfer_acceleration}
   final bool useAccelerateEndpoint;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_item.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_item.dart
@@ -49,8 +49,6 @@ class S3Item extends StorageItem {
 
   /// Creates a [S3Item] from [s3.HeadObjectOutput] provided by S3
   /// Client.
-  ///
-  /// This named constructor should be used internally only.
   @internal
   factory S3Item.fromHeadObjectOutput(
     s3.HeadObjectOutput headObjectOutput, {
@@ -67,9 +65,25 @@ class S3Item extends StorageItem {
     );
   }
 
-  /// Removes `prefixToDrop` from `key` string.
-  ///
-  /// This should only be used internally.
+  /// Creates a [S3Item] from [s3.GetObjectOutput] provided by S3
+  /// Client.
+  @internal
+  factory S3Item.fromGetObjectOutput(
+    s3.GetObjectOutput getObjectOutput, {
+    required String key,
+  }) {
+    return S3Item(
+      key: key,
+      lastModified: getObjectOutput.lastModified,
+      eTag: getObjectOutput.eTag,
+      metadata: getObjectOutput.metadata?.toMap() ?? const {},
+      versionId: getObjectOutput.versionId,
+      size: getObjectOutput.contentLength?.toInt(),
+      contentType: getObjectOutput.contentType,
+    );
+  }
+
+  /// Removes [prefixToDrop] from [key] string.
   @internal
   static String dropPrefixFromKey({
     required String prefixToDrop,

--- a/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_html.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_html.dart
@@ -69,18 +69,19 @@ Future<S3DownloadFileResult> _downloadFromUrl({
     name: request.localFile.path,
   );
 
+  // download is based on the presigned url on Web, so we make a separate
+  // HeadObject call to include object metadata in the operation result to
+  // maintain the same behavior of download on VM.
   return S3DownloadFileResult(
-    downloadedItem: s3Options.getProperties
-        ? (await storageS3Service.getProperties(
-            key: request.key,
-            options: targetIdentityId == null
-                ? S3GetPropertiesOptions(
-                    accessLevel: s3Options.accessLevel,
-                  )
-                : S3GetPropertiesOptions.forIdentity(targetIdentityId),
-          ))
-            .storageItem
-        : S3Item(key: request.key),
+    downloadedItem: (await storageS3Service.getProperties(
+      key: request.key,
+      options: targetIdentityId == null
+          ? S3GetPropertiesOptions(
+              accessLevel: s3Options.accessLevel,
+            )
+          : S3GetPropertiesOptions.forIdentity(targetIdentityId),
+    ))
+        .storageItem,
     localFile: request.localFile,
   );
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_io.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_io.dart
@@ -26,12 +26,10 @@ S3DownloadFileOperation downloadFile({
   final downloadDataOptions = targetIdentityId == null
       ? S3DownloadDataOptions(
           accessLevel: s3Options.accessLevel,
-          getProperties: s3Options.getProperties,
           useAccelerateEndpoint: s3Options.useAccelerateEndpoint,
         )
       : S3DownloadDataOptions.forIdentity(
           targetIdentityId,
-          getProperties: s3Options.getProperties,
           useAccelerateEndpoint: s3Options.useAccelerateEndpoint,
         );
 

--- a/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_html_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_html_test.dart
@@ -60,6 +60,9 @@ void main() {
 
       registerFallbackValue(const S3GetUrlOptions());
       registerFallbackValue(const S3GetPropertiesOptions());
+      registerFallbackValue(
+        const S3GetPropertiesResult(storageItem: S3Item(key: testKey)),
+      );
 
       when(
         () => storageS3Service.getUrl(
@@ -69,20 +72,29 @@ void main() {
       ).thenAnswer((_) async => testGetUrlResult);
     });
 
+    setUp(() {
+      when(
+        () => storageS3Service.getProperties(
+          key: testKey,
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) async => testGetPropertiesResult);
+    });
+
     test(
         'should invoke StorageS3Service.getUrl with S3GetUrlOptions with the default storage access level',
-        () {
+        () async {
       final testRequest = StorageDownloadFileRequest(
         key: testKey,
         localFile: AWSFile.fromPath('file_name.jpg'),
       );
 
-      downloadFile(
+      await downloadFile(
         request: testRequest,
         s3pluginConfig: testS3pluginConfig,
         storageS3Service: storageS3Service,
         appPathProvider: const DummyPathProvider(),
-      );
+      ).result;
 
       final capturedOptions = verify(
         () => storageS3Service.getUrl(
@@ -103,7 +115,7 @@ void main() {
 
     test(
         'should invoke StorageS3Service.getUrl with converted S3DownloadFileOptions',
-        () {
+        () async {
       const testTargetIdentity = 'someone-else';
       final testRequest = StorageDownloadFileRequest(
         key: testKey,
@@ -113,12 +125,12 @@ void main() {
         ),
       );
 
-      downloadFile(
+      await downloadFile(
         request: testRequest,
         s3pluginConfig: testS3pluginConfig,
         storageS3Service: storageS3Service,
         appPathProvider: const DummyPathProvider(),
-      );
+      ).result;
 
       final capturedOptions = verify(
         () => storageS3Service.getUrl(
@@ -147,25 +159,15 @@ void main() {
     });
 
     test(
-        'should invoke StorageS3Service.getProperties with expected parameters when getProperties is set as true in the options',
+        'should invoke StorageS3Service.getProperties with expected parameters',
         () async {
       final testRequest = StorageDownloadFileRequest(
         key: testKey,
         localFile: AWSFile.fromPath('download.jpg'),
         options: const S3DownloadFileOptions(
-          getProperties: true,
           accessLevel: StorageAccessLevel.private,
         ),
       );
-
-      when(
-        () => storageS3Service.getProperties(
-          key: testKey,
-          options: any(
-            named: 'options',
-          ),
-        ),
-      ).thenAnswer((_) async => testGetPropertiesResult);
 
       final result = await downloadFile(
         request: testRequest,

--- a/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
@@ -40,7 +40,6 @@ void main() {
       key: testKey,
       localFile: AWSFile.fromPath(testDestinationPath),
       options: const S3DownloadFileOptions(
-        getProperties: true,
         accessLevel: StorageAccessLevel.private,
       ),
     );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `GetObject` call has already included object metadata in the API response, there is no need to make a separate `HeadObject` call to get properties, hence, removing the `getProperties` field from download operation options, and remove the `HeadObject` call from download task handling. 

Add metadata fields verification in the existing integration test suite. 

**NOTE:**
On Web, the CORS policy of Amplify managed S3 bucket doesn't allow exposing `x-amz-meta-*` headers, hence, user defined metadata may not be retrievable out-of-box. A [manual CORS policy update](https://github.com/aws-amplify/amplify-js/issues/2903#issuecomment-475012164) is required to make it work on Web. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
