### PR TITLE
feat(secure_storage)!: Use Local App Data Directory on Windows

### DIFF
--- a/packages/secure_storage/amplify_secure_storage/lib/src/amplify_secure_storage.vm.dart
+++ b/packages/secure_storage/amplify_secure_storage/lib/src/amplify_secure_storage.vm.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:amplify_secure_storage/src/amplify_secure_storage.android.dart';
 import 'package:amplify_secure_storage/src/messages.cupertino.g.dart';
+import 'package:amplify_secure_storage/src/path_provider_local.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 // ignore: implementation_imports
 import 'package:amplify_secure_storage_dart/src/utils/file_key_value_store.dart';
@@ -43,7 +44,7 @@ class AmplifySecureStorage extends AmplifySecureStorageInterface {
             config: config.copyWith(
               windowsOptions: config.windowsOptions.copyWith(
                 storagePath: config.windowsOptions.storagePath ??
-                    (await getApplicationSupportDirectory()).path,
+                    (await getApplicationLocalSupportDirectory()).path,
               ),
             ),
           );

--- a/packages/secure_storage/amplify_secure_storage/lib/src/path_provider_local.dart
+++ b/packages/secure_storage/amplify_secure_storage/lib/src/path_provider_local.dart
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// ignore_for_file: implementation_imports
+
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+import 'package:path_provider_windows/src/folders.dart';
+import 'package:path_provider_windows/src/path_provider_windows_real.dart';
+
+/// A version of [PathProviderWindows] that uses the
+/// [WindowsKnownFolder.LocalAppData] directory in place of the
+/// [WindowsKnownFolder.RoamingAppData] directory.
+class PathProviderWindowsLocal extends PathProviderWindows {
+  @override
+  Future<String?> getPath(String folderID) {
+    if (folderID == WindowsKnownFolder.RoamingAppData) {
+      return super.getPath(WindowsKnownFolder.LocalAppData);
+    }
+    return super.getPath(folderID);
+  }
+}
+
+/// Returns version of [getApplicationSupportDirectory] that returns the Local
+/// App Data directory on Windows.
+Future<Directory> getApplicationLocalSupportDirectory() async {
+  if (!Platform.isWindows) throw UnsupportedError('Only supported on Windows');
+  final path = await PathProviderWindowsLocal().getApplicationSupportPath();
+  if (path == null) {
+    throw MissingPlatformDirectoryException(
+      'Unable to get application support directory',
+    );
+  }
+  return Directory(path);
+}

--- a/packages/secure_storage/amplify_secure_storage/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   path_provider: ^2.0.0
+  path_provider_windows: ^2.0.0
 
 dev_dependencies:
   amplify_lints: ">=2.0.2 <2.1.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Use Local App Data Directory instead of Roaming dir on Windows

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
