### PR TITLE
test(api): Expand custom authorizer tests

### DIFF
--- a/infra/lib/auth/common.ts
+++ b/infra/lib/auth/common.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Custom headers used in API Gateways.
+ * 
+ * Needed for enabling CORS.
+ */
+export const CUSTOM_HEADERS = [
+  "x-amz-content-sha256",
+  "x-lower-case",
+  "x-upper-case",
+  "x-query-test-key",
+  "x-query-special-key",
+];

--- a/infra/lib/auth/custom-authorizer-iam/stack.api-handler.ts
+++ b/infra/lib/auth/custom-authorizer-iam/stack.api-handler.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type * as lambda from "aws-lambda";
+import { CUSTOM_HEADERS } from "../common";
 
 export const handler: lambda.APIGatewayProxyHandler = async (
   event: lambda.APIGatewayProxyEvent
@@ -17,6 +18,7 @@ export const handler: lambda.APIGatewayProxyHandler = async (
     }),
     headers: {
       "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Credentials": "true",
       "Content-Type": "application/json",
       ...Object.fromEntries(Object.entries(event.headers).filter(([key]) => {
         return key.toLowerCase().startsWith('x');
@@ -25,5 +27,8 @@ export const handler: lambda.APIGatewayProxyHandler = async (
         return [`x-query-${key}`, value ?? ''];
       })),
     },
+    multiValueHeaders: {
+      "Access-Control-Expose-Headers": CUSTOM_HEADERS,
+    }
   };
 };

--- a/infra/lib/auth/custom-authorizer-iam/stack.api-handler.ts
+++ b/infra/lib/auth/custom-authorizer-iam/stack.api-handler.ts
@@ -18,6 +18,12 @@ export const handler: lambda.APIGatewayProxyHandler = async (
     headers: {
       "Access-Control-Allow-Origin": "*",
       "Content-Type": "application/json",
+      ...Object.fromEntries(Object.entries(event.headers).filter(([key]) => {
+        return key.toLowerCase().startsWith('x');
+      })),
+      ...Object.fromEntries(Object.entries(event.queryStringParameters ?? {}).map(([key, value]) => {
+        return [`x-query-${key}`, value ?? ''];
+      })),
     },
   };
 };

--- a/infra/lib/auth/custom-authorizer-iam/stack.ts
+++ b/infra/lib/auth/custom-authorizer-iam/stack.ts
@@ -99,6 +99,13 @@ export class CustomAuthorizerIamStackEnvironment extends IntegrationTestStackEnv
           new targets.ApiGateway(apiGateway)
         ),
       });
+      new route53.AaaaRecord(this, "CustomDomainAaaaRecord", {
+        zone: domainProperties.hostedZone,
+        recordName: domainProperties.domainName,
+        target: route53.RecordTarget.fromAlias(
+          new targets.ApiGateway(apiGateway)
+        ),
+      })
     }
 
     // Create the Cognito Identity Pool with permissions to invoke the API.
@@ -148,7 +155,7 @@ export class CustomAuthorizerIamStackEnvironment extends IntegrationTestStackEnv
 
     let domainName = apiGateway.url;
     if (apiGateway.domainName?.domainName) {
-      domainName = `https://${apiGateway.domainName?.domainName}`;
+      domainName = `https://${apiGateway.domainName?.domainName}/prod/`;
     }
 
     this.config = {
@@ -157,7 +164,7 @@ export class CustomAuthorizerIamStackEnvironment extends IntegrationTestStackEnv
           [apiGateway.restApiName]: {
             endpointType: "REST",
             endpoint: domainName,
-            authorizationType: "AMAZON_COGNITO_USER_POOLS",
+            authorizationType: "AWS_IAM",
           },
         },
       },

--- a/infra/lib/auth/custom-authorizer-iam/stack.ts
+++ b/infra/lib/auth/custom-authorizer-iam/stack.ts
@@ -11,6 +11,7 @@ import * as route53 from "aws-cdk-lib/aws-route53";
 import * as targets from "aws-cdk-lib/aws-route53-targets";
 import { Construct } from "constructs";
 import { IntegrationTestStackEnvironment } from "../../common";
+import { CUSTOM_HEADERS } from "../common";
 import {
   AuthBaseEnvironmentProps,
   AuthCustomAuthorizerEnvironmentProps
@@ -83,7 +84,13 @@ export class CustomAuthorizerIamStackEnvironment extends IntegrationTestStackEnv
       handler: apiHandler,
       defaultCorsPreflightOptions: {
         allowOrigins: apigw.Cors.ALL_ORIGINS,
-        allowHeaders: [...apigw.Cors.DEFAULT_HEADERS, "x-amz-content-sha256"],
+        allowHeaders: [
+          ...apigw.Cors.DEFAULT_HEADERS,
+          ...CUSTOM_HEADERS
+        ],
+        exposeHeaders: CUSTOM_HEADERS,
+        allowCredentials: true,
+        disableCache: true,
       },
       defaultMethodOptions: {
         authorizationType: apigw.AuthorizationType.IAM,

--- a/infra/lib/auth/custom-authorizer-user-pools/stack.api-handler.ts
+++ b/infra/lib/auth/custom-authorizer-user-pools/stack.api-handler.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type * as lambda from "aws-lambda";
+import { CUSTOM_HEADERS } from "../common";
 
 export const handler: lambda.APIGatewayProxyHandler = async (
   event: lambda.APIGatewayProxyEvent
@@ -17,6 +18,7 @@ export const handler: lambda.APIGatewayProxyHandler = async (
     }),
     headers: {
       "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Credentials": "true",
       "Content-Type": "application/json",
       ...Object.fromEntries(Object.entries(event.headers).filter(([key]) => {
         return key.toLowerCase().startsWith('x');
@@ -25,5 +27,8 @@ export const handler: lambda.APIGatewayProxyHandler = async (
         return [`x-query-${key}`, value ?? ''];
       })),
     },
+    multiValueHeaders: {
+      "Access-Control-Expose-Headers": CUSTOM_HEADERS,
+    }
   };
 };

--- a/infra/lib/auth/custom-authorizer-user-pools/stack.api-handler.ts
+++ b/infra/lib/auth/custom-authorizer-user-pools/stack.api-handler.ts
@@ -18,6 +18,12 @@ export const handler: lambda.APIGatewayProxyHandler = async (
     headers: {
       "Access-Control-Allow-Origin": "*",
       "Content-Type": "application/json",
+      ...Object.fromEntries(Object.entries(event.headers).filter(([key]) => {
+        return key.toLowerCase().startsWith('x');
+      })),
+      ...Object.fromEntries(Object.entries(event.queryStringParameters ?? {}).map(([key, value]) => {
+        return [`x-query-${key}`, value ?? ''];
+      })),
     },
   };
 };

--- a/infra/lib/auth/custom-authorizer-user-pools/stack.ts
+++ b/infra/lib/auth/custom-authorizer-user-pools/stack.ts
@@ -8,6 +8,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as lambda_nodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
 import { IntegrationTestStackEnvironment } from "../../common";
+import { CUSTOM_HEADERS } from "../common";
 import {
   AuthBaseEnvironmentProps,
   AuthCustomAuthorizerEnvironmentProps
@@ -73,6 +74,13 @@ export class CustomAuthorizerUserPoolsStackEnvironment extends IntegrationTestSt
       handler: apiHandler,
       defaultCorsPreflightOptions: {
         allowOrigins: apigw.Cors.ALL_ORIGINS,
+        allowHeaders: [
+          ...apigw.Cors.DEFAULT_HEADERS,
+          ...CUSTOM_HEADERS
+        ],
+        exposeHeaders: CUSTOM_HEADERS,
+        allowCredentials: true,
+        disableCache: true,
       },
       defaultMethodOptions: {
         authorizer,

--- a/infra/lib/auth/custom-authorizer-user-pools/stack.ts
+++ b/infra/lib/auth/custom-authorizer-user-pools/stack.ts
@@ -85,7 +85,10 @@ export class CustomAuthorizerUserPoolsStackEnvironment extends IntegrationTestSt
           [apiGateway.restApiName]: {
             endpointType: "REST",
             endpoint: apiGateway.url,
-            authorizationType: "AMAZON_COGNITO_USER_POOLS",
+            // We use OIDC instead of AMAZON_COGNITO_USER_POOLS so that we can use
+            // the ID token by default instead of the access token:
+            // https://docs.amplify.aws/lib/graphqlapi/authz/q/platform/flutter/#oidc
+            authorizationType: "OPENID_CONNECT",
           },
         },
       },

--- a/infra/lib/auth/stack.ts
+++ b/infra/lib/auth/stack.ts
@@ -16,7 +16,7 @@ import {
   AmplifyCategory,
   IntegrationTestStack,
   IntegrationTestStackEnvironment,
-  IntegrationTestStackEnvironmentProps,
+  IntegrationTestStackEnvironmentProps
 } from "../common";
 import { CustomAuthorizerIamStackEnvironment } from "./custom-authorizer-iam/stack";
 import { CustomAuthorizerUserPoolsStackEnvironment } from "./custom-authorizer-user-pools/stack";

--- a/infra/lib/stack.ts
+++ b/infra/lib/stack.ts
@@ -9,12 +9,12 @@ import { Construct } from "constructs";
 import { AnalyticsIntegrationTestStack } from "./analytics/stack";
 import {
   AuthIntegrationTestStack,
-  AuthIntegrationTestStackEnvironmentProps,
+  AuthIntegrationTestStackEnvironmentProps
 } from "./auth/stack";
 import { IntegrationTestStack } from "./common";
 import {
   StorageAccessLevel,
-  StorageIntegrationTestStack,
+  StorageIntegrationTestStack
 } from "./storage/stack";
 
 export class AmplifyFlutterIntegStack extends cdk.Stack {

--- a/packages/api/amplify_api/lib/src/api_plugin_impl.dart
+++ b/packages/api/amplify_api/lib/src/api_plugin_impl.dart
@@ -15,19 +15,13 @@ import 'package:flutter/services.dart';
 class AmplifyAPI extends AmplifyAPIDart with AWSDebuggable {
   /// {@macro amplify_api.amplify_api}
   AmplifyAPI({
-    List<APIAuthProvider> authProviders = const [],
+    super.authProviders,
     super.baseHttpClient,
     super.modelProvider,
     super.subscriptionOptions,
   }) : super(
-          authProviders: authProviders,
           connectivity: const ConnectivityPlusPlatform(),
-        ) {
-    authProviders.forEach(registerAuthProvider);
-  }
-
-  /// The registered [APIAuthProvider] instances.
-  final Map<APIAuthorizationType, APIAuthProvider> _authProviders = {};
+        );
 
   @override
   Future<void> addPlugin({
@@ -40,13 +34,13 @@ class AmplifyAPI extends AmplifyAPIDart with AWSDebuggable {
     }
 
     // Configure this plugin to act as a native iOS/Android plugin.
-    final nativePlugin = _NativeAmplifyApi(_authProviders);
+    final nativePlugin = _NativeAmplifyApi(authProviders);
     NativeApiPlugin.setup(nativePlugin);
 
     final nativeBridge = NativeApiBridge();
     try {
       final authProvidersList =
-          _authProviders.keys.map((key) => key.rawValue).toList();
+          authProviders.keys.map((key) => key.rawValue).toList();
       await nativeBridge.addPlugin(authProvidersList);
     } on PlatformException catch (e) {
       if (e.code.contains('AmplifyAlreadyConfiguredException') ||
@@ -66,11 +60,6 @@ class AmplifyAPI extends AmplifyAPIDart with AWSDebuggable {
 
   @override
   String get runtimeTypeName => 'AmplifyAPI';
-
-  @override
-  void registerAuthProvider(APIAuthProvider authProvider) {
-    _authProviders[authProvider.type] = authProvider;
-  }
 }
 
 class _NativeAmplifyApi

--- a/packages/api/amplify_api_dart/lib/src/api_plugin_impl.dart
+++ b/packages/api/amplify_api_dart/lib/src/api_plugin_impl.dart
@@ -47,7 +47,8 @@ class AmplifyAPIDart extends APIPluginInterface with AWSDebuggable {
   final Map<String, WebSocketBloc> _webSocketBlocPool = {};
 
   /// The registered [APIAuthProvider] instances.
-  final Map<APIAuthorizationType, APIAuthProvider> _authProviders = {};
+  @protected
+  final Map<APIAuthorizationType, APIAuthProvider> authProviders = {};
 
   final StreamController<ApiHubEvent> _hubEventController =
       StreamController<ApiHubEvent>.broadcast();
@@ -115,7 +116,7 @@ class AmplifyAPIDart extends APIPluginInterface with AWSDebuggable {
     });
 
     // Register OIDC/Lambda auth providers.
-    for (final authProvider in _authProviders.values) {
+    for (final authProvider in authProviders.values) {
       _authProviderRepo.registerAuthProvider(
         authProvider.type.authProviderToken,
         OidcFunctionAuthProvider(authProvider),
@@ -219,7 +220,7 @@ class AmplifyAPIDart extends APIPluginInterface with AWSDebuggable {
 
   @override
   void registerAuthProvider(APIAuthProvider authProvider) {
-    _authProviders[authProvider.type] = authProvider;
+    authProviders[authProvider.type] = authProvider;
   }
 
   // ====== GraphQL ======

--- a/packages/api/amplify_api_dart/lib/src/api_plugin_impl.dart
+++ b/packages/api/amplify_api_dart/lib/src/api_plugin_impl.dart
@@ -161,7 +161,7 @@ class AmplifyAPIDart extends APIPluginInterface with AWSDebuggable {
         authorizationMode: authorizationMode,
         authProviderRepo: _authProviderRepo,
       ),
-    )..supportedProtocols = SupportedProtocols.http1;
+    );
   }
 
   WebSocketBloc _webSocketBloc({String? apiName}) {

--- a/packages/api/amplify_api_dart/lib/src/decorators/authorize_http_request.dart
+++ b/packages/api/amplify_api_dart/lib/src/decorators/authorize_http_request.dart
@@ -87,7 +87,7 @@ T _validateAuthProvider<T extends AmplifyAuthProvider>(
   if (authProvider == null) {
     throw ApiException(
       'No auth provider found for auth mode ${authType.name}.',
-      recoverySuggestion: 'Ensure auth plugin correctly configured.',
+      recoverySuggestion: 'Ensure API plugin correctly configured.',
     );
   }
   return authProvider;

--- a/packages/api/amplify_api_dart/lib/src/util/amplify_authorization_rest_client.dart
+++ b/packages/api/amplify_api_dart/lib/src/util/amplify_authorization_rest_client.dart
@@ -18,7 +18,8 @@ class AmplifyAuthorizationRestClient extends AWSBaseHttpClient {
     required this.authProviderRepo,
     this.authorizationMode,
     AWSHttpClient? baseClient,
-  }) : baseClient = baseClient ?? AWSHttpClient();
+  }) : baseClient = baseClient ??
+            (AWSHttpClient()..supportedProtocols = SupportedProtocols.http1);
 
   /// [AmplifyAuthProviderRepository] for any auth modes this client may use.
   final AmplifyAuthProviderRepository authProviderRepo;

--- a/packages/auth/amplify_auth_cognito/example/integration_test/custom_authorizer_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/custom_authorizer_test.dart
@@ -201,11 +201,12 @@ void main() {
           backend,
           skip: shouldSkip(backend),
           () {
-            final configJson = amplifyEnvironments[backend]!;
+            final configJson = amplifyEnvironments[backend];
+            if (configJson == null) return;
+
             final config = AmplifyConfig.fromJson(
               jsonDecode(configJson) as Map<String, Object?>,
             );
-
             for (final supportedProtocols in SupportedProtocols.values) {
               group(supportedProtocols.name, () {
                 late AWSHttpClient client;

--- a/packages/auth/amplify_auth_cognito/example/integration_test/custom_authorizer_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/custom_authorizer_test.dart
@@ -5,7 +5,6 @@ import 'dart:convert';
 
 import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
-import 'package:amplify_auth_cognito_dart/src/credentials/auth_plugin_credentials_provider.dart';
 import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
@@ -16,11 +15,30 @@ import 'package:integration_test/integration_test.dart';
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
+class CognitoUserPoolsAuthorizer extends OIDCAuthProvider {
+  const CognitoUserPoolsAuthorizer();
+
+  @override
+  Future<String?> getLatestAuthToken() async {
+    final session = await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
+    return session.userPoolTokensResult.valueOrNull?.idToken.raw;
+  }
+}
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  AWSLogger().logLevel = LogLevel.debug;
+  AWSLogger().logLevel = LogLevel.verbose;
 
   group('Custom Authorizer', () {
+    const customHeaders = {
+      'x-lower-case': 'value',
+      'X-UPPER-CASE': 'VALUE',
+    };
+    const queryParameters = {
+      'test-key': 'test-value',
+      'special-key': r'!@#$%^&*() _-+={}[]\/;',
+    };
+
     group(
       'User Pools',
       skip: shouldSkip('custom-authorizer-user-pools'),
@@ -30,68 +48,147 @@ void main() {
           jsonDecode(configJson) as Map<String, Object?>,
         );
 
-        setUpAll(() async {
-          await configureAuth(
-            config: configJson,
-          );
-        });
+        for (final supportedProtocols in SupportedProtocols.values) {
+          group(supportedProtocols.name, () {
+            late AWSHttpClient client;
 
-        asyncTest('can invoke with HTTP client', (_) async {
-          final username = generateUsername();
-          final password = generatePassword();
+            Future<void> deleteAndSignOut() async {
+              try {
+                await Amplify.Auth.deleteUser();
+              } on Exception {
+                // no-op
+              }
+              await signOutUser();
+            }
 
-          final signUpRes = await Amplify.Auth.signUp(
-            username: username,
-            password: password,
-          );
-          expect(signUpRes.isSignUpComplete, isTrue);
+            setUp(() async {
+              client = AWSHttpClient()..supportedProtocols = supportedProtocols;
+              addTearDown(client.close);
+              await configureAuth(
+                config: configJson,
+                additionalPlugins: [
+                  AmplifyAPI(
+                    authProviders: const [
+                      CognitoUserPoolsAuthorizer(),
+                    ],
+                    baseHttpClient: client,
+                  ),
+                ],
+              );
+              addTearDown(deleteAndSignOut);
+            });
 
-          final signInRes = await Amplify.Auth.signIn(
-            username: username,
-            password: password,
-          );
-          expect(signInRes.isSignedIn, isTrue);
+            asyncTest('can invoke with HTTP client', (_) async {
+              final username = generateUsername();
+              final password = generatePassword();
 
-          final session =
-              await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
-          expect(session.userPoolTokensResult.value, isNotNull);
+              final signUpRes = await Amplify.Auth.signUp(
+                username: username,
+                password: password,
+              );
+              expect(signUpRes.isSignUpComplete, isTrue);
 
-          final apiUrl = config.api!.awsPlugin!.values
-              .singleWhere((e) => e.endpointType == EndpointType.rest)
-              .endpoint;
+              final signInRes = await Amplify.Auth.signIn(
+                username: username,
+                password: password,
+              );
+              expect(signInRes.isSignedIn, isTrue);
 
-          final client = AWSHttpClient()
-            ..supportedProtocols = SupportedProtocols.http1;
-          addTearDown(client.close);
+              final session =
+                  await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
+              expect(session.userPoolTokensResult.valueOrNull, isNotNull);
 
-          // Verifies invocation with the ID token. Invocation with an access
-          // token requires integration with a resource server/OAuth and is, thus,
-          // not tested.
-          //
-          // https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-enable-cognito-user-pool.html
+              final apiUrl = config.api!.awsPlugin!.values
+                  .singleWhere((e) => e.endpointType == EndpointType.rest)
+                  .endpoint;
 
-          final payload = jsonEncode({'request': 'hello'});
-          final request = AWSHttpRequest.post(
-            Uri.parse(apiUrl).replace(
-              queryParameters: {
-                'key': 'value',
-              },
-            ),
-            headers: {
-              AWSHeaders.accept: 'application/json;charset=utf-8',
-              AWSHeaders.authorization:
-                  session.userPoolTokensResult.value.idToken.raw,
-            },
-            body: utf8.encode(payload),
-          );
-          final resp = await client.send(request).response;
-          final body = await resp.decodeBody();
-          expect(resp.statusCode, 200, reason: body);
-          expect(
-            jsonDecode(body),
-            equals({'response': 'hello'}),
-          );
-        });
+              // Verifies invocation with the ID token. Invocation with an access
+              // token requires integration with a resource server/OAuth and is, thus,
+              // not tested.
+              //
+              // https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-enable-cognito-user-pool.html
+
+              final request = AWSStreamedHttpRequest.post(
+                Uri.parse(apiUrl).replace(
+                  queryParameters: queryParameters,
+                ),
+                headers: {
+                  AWSHeaders.accept: 'application/json;charset=utf-8',
+                  AWSHeaders.authorization:
+                      session.userPoolTokensResult.value.idToken.raw,
+                  ...customHeaders,
+                },
+                body: HttpPayload.json({'request': 'hello'}),
+              );
+              final resp = await client.send(request).response;
+              final body = await resp.decodeBody();
+              expect(resp.statusCode, 200, reason: body);
+              expect(
+                jsonDecode(body),
+                equals({'response': 'hello'}),
+              );
+              customHeaders.forEach((key, value) {
+                expect(
+                  resp.headers,
+                  containsPair(key, value),
+                );
+              });
+              queryParameters.forEach((key, value) {
+                expect(
+                  resp.headers,
+                  containsPair('x-query-$key', value),
+                );
+              });
+            });
+
+            asyncTest('can invoke with API plugin', (_) async {
+              final username = generateUsername();
+              final password = generatePassword();
+
+              final signUpRes = await Amplify.Auth.signUp(
+                username: username,
+                password: password,
+              );
+              expect(signUpRes.isSignUpComplete, isTrue);
+
+              final signInRes = await Amplify.Auth.signIn(
+                username: username,
+                password: password,
+              );
+              expect(signInRes.isSignedIn, isTrue);
+
+              final restOperation = Amplify.API.post(
+                '/',
+                queryParameters: queryParameters,
+                headers: customHeaders,
+                body: HttpPayload.json({'request': 'hello'}),
+              );
+              try {
+                final resp = await restOperation.response;
+                final body = resp.decodeBody();
+                expect(resp.statusCode, 200, reason: body);
+                expect(
+                  jsonDecode(body),
+                  equals({'response': 'hello'}),
+                );
+                customHeaders.forEach((key, value) {
+                  expect(
+                    resp.headers,
+                    containsPair(key, value),
+                  );
+                });
+                queryParameters.forEach((key, value) {
+                  expect(
+                    resp.headers,
+                    containsPair('x-query-$key', value),
+                  );
+                });
+              } on RestException catch (e) {
+                fail('${e.response.statusCode}: ${e.response.decodeBody()}');
+              }
+            });
+          });
+        }
       },
     );
 
@@ -109,138 +206,122 @@ void main() {
               jsonDecode(configJson) as Map<String, Object?>,
             );
 
-            asyncTest('can invoke with HTTP client', (_) async {
-              await configureAuth(
-                config: configJson,
-              );
-              final cognitoPlugin = Amplify.Auth.getPlugin(
-                AmplifyAuthCognito.pluginKey,
-              );
-              final session = await cognitoPlugin.fetchAuthSession();
-              expect(session.credentialsResult.value, isNotNull);
+            for (final supportedProtocols in SupportedProtocols.values) {
+              group(supportedProtocols.name, () {
+                late AWSHttpClient client;
 
-              final restApi = config.api!.awsPlugin!.values
-                  .singleWhere((e) => e.endpointType == EndpointType.rest);
-              final apiUrl = restApi.endpoint;
+                setUp(() async {
+                  client = AWSHttpClient()
+                    ..supportedProtocols = supportedProtocols;
+                  addTearDown(client.close);
+                  await configureAuth(
+                    config: configJson,
+                    additionalPlugins: [
+                      AmplifyAPI(
+                        baseHttpClient: client,
+                      ),
+                    ],
+                  );
+                  addTearDown(signOutUser);
+                });
 
-              final client = AWSHttpClient()
-                ..supportedProtocols = SupportedProtocols.http1;
-              addTearDown(client.close);
+                asyncTest('can invoke with HTTP client', (_) async {
+                  final cognitoPlugin = Amplify.Auth.getPlugin(
+                    AmplifyAuthCognito.pluginKey,
+                  );
+                  final session = await cognitoPlugin.fetchAuthSession();
+                  expect(session.credentialsResult.valueOrNull, isNotNull);
 
-              final payload = jsonEncode({'request': 'hello'});
-              final request = AWSHttpRequest.post(
-                Uri.parse(apiUrl).replace(
-                  queryParameters: {
-                    'key': 'value',
-                  },
-                ),
-                headers: const {
-                  AWSHeaders.accept: 'application/json;charset=utf-8',
-                },
-                body: utf8.encode(payload),
-              );
-              final signer = AWSSigV4Signer(
-                credentialsProvider: AuthPluginCredentialsProviderImpl(
-                  // ignore: invalid_use_of_protected_member
-                  cognitoPlugin.stateMachine,
-                ),
-              );
-              final scope = AWSCredentialScope(
-                region: restApi.region,
-                service: AWSService.apiGatewayManagementApi,
-              );
-              final signedRequest = await signer.sign(
-                request,
-                credentialScope: scope,
-              );
-              final resp = await client.send(signedRequest).response;
-              final body = await resp.decodeBody();
-              expect(resp.statusCode, 200, reason: body);
-              expect(
-                jsonDecode(body),
-                equals({'response': 'hello'}),
-              );
-            });
+                  final restApi = config.api!.awsPlugin!.values
+                      .singleWhere((e) => e.endpointType == EndpointType.rest);
+                  final apiUrl = Uri.parse(restApi.endpoint);
 
-            asyncTest('can invoke with API plugin', (_) async {
-              await configureAuth(
-                config: configJson,
-              );
-              final cognitoPlugin = Amplify.Auth.getPlugin(
-                AmplifyAuthCognito.pluginKey,
-              );
-              final session = await cognitoPlugin.fetchAuthSession();
-              expect(session.credentialsResult.value, isNotNull);
+                  final payload = jsonEncode({'request': 'hello'});
+                  final request = AWSHttpRequest.post(
+                    apiUrl.replace(
+                      queryParameters: queryParameters,
+                    ),
+                    headers: const {
+                      AWSHeaders.accept: 'application/json;charset=utf-8',
+                      ...customHeaders,
+                    },
+                    body: utf8.encode(payload),
+                  );
+                  final signer = AWSSigV4Signer(
+                    credentialsProvider: AWSCredentialsProvider(
+                      session.credentialsResult.value,
+                    ),
+                  );
+                  final scope = AWSCredentialScope(
+                    region: restApi.region,
+                    service: AWSService.apiGatewayManagementApi,
+                  );
+                  final signedRequest = await signer.sign(
+                    request,
+                    credentialScope: scope,
+                  );
+                  final resp = await client.send(signedRequest).response;
+                  final body = await resp.decodeBody();
+                  expect(resp.statusCode, 200, reason: body);
+                  expect(
+                    jsonDecode(body),
+                    equals({'response': 'hello'}),
+                  );
+                  customHeaders.forEach((key, value) {
+                    expect(
+                      resp.headers,
+                      containsPair(key, value),
+                    );
+                  });
+                  queryParameters.forEach((key, value) {
+                    expect(
+                      resp.headers,
+                      containsPair('x-query-$key', value),
+                    );
+                  });
+                });
 
-              final restApi = config.api!.awsPlugin!.values
-                  .singleWhere((e) => e.endpointType == EndpointType.rest);
-              final apiUrl = restApi.endpoint;
+                asyncTest('can invoke with API plugin', (_) async {
+                  final cognitoPlugin = Amplify.Auth.getPlugin(
+                    AmplifyAuthCognito.pluginKey,
+                  );
+                  final session = await cognitoPlugin.fetchAuthSession();
+                  expect(session.credentialsResult.valueOrNull, isNotNull);
 
-              final client = AWSHttpClient()
-                ..supportedProtocols = SupportedProtocols.http1;
-              addTearDown(client.close);
-
-              final payload = jsonEncode({'request': 'hello'});
-              final request = AWSHttpRequest.post(
-                Uri.parse(apiUrl).replace(
-                  queryParameters: {
-                    'key': 'value',
-                  },
-                ),
-                headers: const {
-                  AWSHeaders.accept: 'application/json;charset=utf-8',
-                },
-                body: utf8.encode(payload),
-              );
-              final signer = AWSSigV4Signer(
-                credentialsProvider: AuthPluginCredentialsProviderImpl(
-                  // ignore: invalid_use_of_protected_member
-                  cognitoPlugin.stateMachine,
-                ),
-              );
-              final scope = AWSCredentialScope(
-                region: restApi.region,
-                service: AWSService.apiGatewayManagementApi,
-              );
-              final signedRequest = await signer.sign(
-                request,
-                credentialScope: scope,
-              );
-              final resp = await client.send(signedRequest).response;
-              final body = await resp.decodeBody();
-              expect(resp.statusCode, 200, reason: body);
-              expect(
-                jsonDecode(body),
-                equals({'response': 'hello'}),
-              );
-            });
-
-            asyncTest('can invoke with API plugin', (_) async {
-              await configureAuth(
-                config: configJson,
-                additionalPlugins: [AmplifyAPI()],
-              );
-              final cognitoPlugin = Amplify.Auth.getPlugin(
-                AmplifyAuthCognito.pluginKey,
-              );
-              final session = await cognitoPlugin.fetchAuthSession();
-              expect(session.credentialsResult.value, isNotNull);
-
-              final restOperation = Amplify.API.post(
-                '/',
-                body: HttpPayload.json({'request': 'hello'}),
-                queryParameters: {
-                  'key': 'value',
-                },
-              );
-              final resp = await restOperation.response;
-              final body = resp.decodeBody();
-              expect(resp.statusCode, 200, reason: body);
-              expect(
-                jsonDecode(body),
-                equals({'response': 'hello'}),
-              );
-            });
+                  final restOperation = Amplify.API.post(
+                    '/',
+                    queryParameters: queryParameters,
+                    headers: customHeaders,
+                    body: HttpPayload.json({'request': 'hello'}),
+                  );
+                  try {
+                    final resp = await restOperation.response;
+                    final body = resp.decodeBody();
+                    expect(resp.statusCode, 200, reason: body);
+                    expect(
+                      jsonDecode(body),
+                      equals({'response': 'hello'}),
+                    );
+                    customHeaders.forEach((key, value) {
+                      expect(
+                        resp.headers,
+                        containsPair(key, value),
+                      );
+                    });
+                    queryParameters.forEach((key, value) {
+                      expect(
+                        resp.headers,
+                        containsPair('x-query-$key', value),
+                      );
+                    });
+                  } on RestException catch (e) {
+                    fail(
+                      '${e.response.statusCode}: ${e.response.decodeBody()}',
+                    );
+                  }
+                });
+              });
+            }
           },
         );
       }

--- a/packages/auth/amplify_auth_cognito/example/integration_test/main_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/main_test.dart
@@ -7,7 +7,7 @@ import 'package:integration_test/integration_test.dart';
 import 'confirm_sign_in_test.dart' as confirm_sign_in_tests;
 import 'confirm_sign_up_test.dart' as confirm_sign_up_tests;
 import 'custom_auth_test.dart' as custom_auth_tests;
-// import 'custom_authorizer_test.dart' as custom_authorizer_tests;
+import 'custom_authorizer_test.dart' as custom_authorizer_tests;
 import 'delete_user_test.dart' as delete_user_tests;
 import 'device_tracking_test.dart' as device_tracking_tests;
 import 'federated_sign_in_test.dart' as federated_sign_in_tests;
@@ -33,8 +33,7 @@ void main() async {
     confirm_sign_in_tests.main();
     confirm_sign_up_tests.main();
     custom_auth_tests.main();
-    // TODO(dnys1): Re-enable when custom authorizer backends are deployed
-    // custom_authorizer_tests.main();
+    custom_authorizer_tests.main();
     delete_user_tests.main();
     device_tracking_tests.main();
     federated_sign_in_tests.main();

--- a/packages/aws_common/lib/src/http/aws_http_client_io.dart
+++ b/packages/aws_common/lib/src/http/aws_http_client_io.dart
@@ -212,7 +212,12 @@ class AWSHttpClientImpl extends AWSHttpClient {
         for (final entry in request.headers.entries)
           if (redirects.isEmpty ||
               _shouldCopyHeaderOnRedirect(entry.key, request.uri, uri))
-            Header(utf8.encode(entry.key), utf8.encode(entry.value)),
+            Header(
+              // Lower-case headers due to:
+              // https://github.com/dart-lang/http2/issues/49
+              utf8.encode(entry.key.toLowerCase()),
+              utf8.encode(entry.value),
+            ),
       ];
 
   /// Sends an HTTP/2 request using `package:http2`.

--- a/packages/aws_common/test/http/client_conformance_tests/redirect_server_test.dart
+++ b/packages/aws_common/test/http/client_conformance_tests/redirect_server_test.dart
@@ -30,36 +30,29 @@ void main() {
       expect(response.statusCode, 200);
     });
 
-    test(
-      'allow redirect, 0 maxRedirects, ',
-      () async {
-        final request = AWSHttpRequest.get(
-          createUri('/1'),
-          followRedirects: true,
-          maxRedirects: 0,
-        );
-        expect(
-          client().send(request).response,
-          throwsA(
-            isA<AWSHttpException>().having(
-              (e) => e.toString(),
-              'message',
-              contains(
-                zIsWeb
-                    ?
-                    // Only cross-browser similarity
-                    'Error'
-                    : 'Redirect limit exceeded',
-              ),
+    test('allow redirect, 0 maxRedirects, ', () async {
+      final request = AWSHttpRequest.get(
+        createUri('/1'),
+        followRedirects: true,
+        maxRedirects: 0,
+      );
+      expect(
+        client().send(request).response,
+        throwsA(
+          isA<AWSHttpException>().having(
+            (e) => e.toString(),
+            'message',
+            contains(
+              zIsWeb
+                  ?
+                  // Only cross-browser similarity
+                  'Error'
+                  : 'Redirect limit exceeded',
             ),
           ),
-        );
-      },
-      skip: !zIsWeb
-          ? 'Re-enable after https://github.com/dart-lang/sdk/issues/49012 '
-              'is fixed'
-          : null,
-    );
+        ),
+      );
+    });
 
     test(
       'exactly the right number of allowed redirects',

--- a/packages/aws_signature_v4/lib/src/request/canonical_request/canonical_request_util.dart
+++ b/packages/aws_signature_v4/lib/src/request/canonical_request/canonical_request_util.dart
@@ -3,11 +3,16 @@
 
 part of 'canonical_request.dart';
 
+final RegExp _encodedComponent = RegExp('%[A-F0-9]{2}');
+
 /// Encodes a query parameter while preventing double-encoding.
 String _safeEncode(String queryComponent) {
-  return queryComponent.contains('%')
+  return queryComponent.contains(_encodedComponent)
       ? queryComponent
-      : Uri.encodeComponent(queryComponent);
+      // encodeQueryComponent percent-encodes all the characters we care about
+      // except spaces, which it encodes as `+`. However, Sigv4 expects percent
+      // encoding even for spaces.
+      : Uri.encodeQueryComponent(queryComponent).replaceAll('+', '%20');
 }
 
 /// The SHA-256/Hex-encoded hash for empty requests.

--- a/packages/aws_signature_v4/test/canonical_request_test.dart
+++ b/packages/aws_signature_v4/test/canonical_request_test.dart
@@ -61,4 +61,42 @@ void main() {
       expect(canonicalPath, '/');
     });
   });
+
+  group('CanonicalQueryParameters', () {
+    const queryParameters = {
+      'test-key': 'test-value',
+      'special-key': r'!@#$%^&*()_-+={}[]\/;',
+      'already-encoded': 'hello%21',
+    };
+    const encodedQueryParameters = {
+      'test-key': 'test-value',
+      'special-key':
+          '%21%40%23%24%25%5E%26%2A%28%29_-%2B%3D%7B%7D%5B%5D%5C%2F%3B',
+      'already-encoded': 'hello%21',
+    };
+
+    test('handles special characters', () {
+      final uri = Uri.parse('https://example.com').replace(
+        queryParameters: queryParameters,
+      );
+      final request = AWSHttpRequest.get(uri);
+      expect(
+        CanonicalQueryParameters(request.queryParameters),
+        equals(encodedQueryParameters),
+      );
+    });
+
+    test('handles special characters (raw)', () {
+      final request = AWSHttpRequest.raw(
+        method: AWSHttpMethod.get,
+        host: 'example.com',
+        path: '/',
+        queryParameters: queryParameters,
+      );
+      expect(
+        CanonicalQueryParameters(request.queryParameters),
+        equals(encodedQueryParameters),
+      );
+    });
+  });
 }


### PR DESCRIPTION
- Adds more custom authorizer tests for query parameters, headers, and HTTP/2.
- Fixes header casing in HTTP/2 requests
- Fixes query parameter encoding issue
- Fixes API using access token instead of ID token