### PR TITLE
chore(repo): Bump Amplify Android/iOS

### DIFF
--- a/packages/amplify/amplify_flutter_android/android/build.gradle
+++ b/packages/amplify/amplify_flutter_android/android/build.gradle
@@ -64,7 +64,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.amplifyframework:core:2.3.0'
+    implementation 'com.amplifyframework:core:2.4.1'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
 
@@ -74,6 +74,6 @@ dependencies {
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.robolectric:robolectric:4.5.1'
     testImplementation 'com.google.code.gson:gson:2.8.9'
-    testImplementation 'com.amplifyframework:aws-auth-cognito:2.3.0'
+    testImplementation 'com.amplifyframework:aws-auth-cognito:2.4.1'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0'
 }

--- a/packages/amplify/amplify_flutter_ios/ios/amplify_flutter_ios.podspec
+++ b/packages/amplify/amplify_flutter_ios/ios/amplify_flutter_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.3'
-  s.dependency 'AWSPluginsCore', '1.28.3'
+  s.dependency 'Amplify', '1.29.1'
+  s.dependency 'AWSPluginsCore', '1.29.1'
 
   s.platform = :ios, '11.0'
   s.swift_version = '5.0'

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -75,8 +75,8 @@ dependencies {
 
     api amplifyFlutter
 
-    implementation "com.amplifyframework:aws-datastore:2.3.0"
-    implementation "com.amplifyframework:aws-api-appsync:2.3.0"
+    implementation "com.amplifyframework:aws-datastore:2.4.1"
+    implementation "com.amplifyframework:aws-api-appsync:2.4.1"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:4.0.0'

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,8 +15,8 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.3'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.28.3'
+  s.dependency 'Amplify', '1.29.1'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.29.1'
   s.dependency 'amplify_flutter_ios'
   s.platform = :ios, '13.0'
 

--- a/packages/api/amplify_api_android/android/build.gradle
+++ b/packages/api/amplify_api_android/android/build.gradle
@@ -69,8 +69,8 @@ android {
 dependencies {
     api amplifyFlutter
 
-    implementation "com.amplifyframework:aws-api:2.3.0"
-    implementation "com.amplifyframework:aws-api-appsync:2.3.0"
+    implementation "com.amplifyframework:aws-api:2.4.1"
+    implementation "com.amplifyframework:aws-api-appsync:2.4.1"
 
     // Do not update before migration of plugin to Dart.
     //noinspection GradleDependency

--- a/packages/api/amplify_api_ios/ios/amplify_api_ios.podspec
+++ b/packages/api/amplify_api_ios/ios/amplify_api_ios.podspec
@@ -15,8 +15,8 @@ The API module for Amplify Flutter.
   s.source           = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.3'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.28.3'
+  s.dependency 'Amplify', '1.29.1'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.29.1'
   s.dependency 'amplify_flutter_ios'
 
   # These are needed to support async/await with pigeon

--- a/packages/auth/amplify_auth_cognito_android/android/build.gradle
+++ b/packages/auth/amplify_auth_cognito_android/android/build.gradle
@@ -70,7 +70,7 @@ android {
 dependencies {
     api amplifyFlutter
 
-    implementation 'com.amplifyframework:aws-auth-cognito:2.3.0'
+    implementation 'com.amplifyframework:aws-auth-cognito:2.4.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
     implementation 'androidx.browser:browser:1.4.0'
 

--- a/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
+++ b/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.3'
+  s.dependency 'Amplify', '1.29.1'
   s.dependency 'amplify_flutter_ios'
   
   # These are needed to support async/await and ASWebAuthenticationSession


### PR DESCRIPTION
- Bumps Amplify iOS dependency to [1.29.1](https://github.com/aws-amplify/amplify-swift/releases/tag/1.29.1)
- Bumps Amplify Android dependency to [2.4.1](https://github.com/aws-amplify/amplify-android/releases/tag/release_v2.4.1)
