### PR TITLE
chore(repo): Bump Amplify Android/iOS

### DIFF
--- a/packages/amplify/amplify_flutter_android/android/build.gradle
+++ b/packages/amplify/amplify_flutter_android/android/build.gradle
@@ -66,7 +66,7 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:core:1.38.1'
+    implementation 'com.amplifyframework:core:1.38.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 
     testImplementation 'junit:junit:4.13.2'
@@ -75,6 +75,6 @@ dependencies {
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'com.google.code.gson:gson:2.8.6'
-    testImplementation 'com.amplifyframework:aws-auth-cognito:1.38.1'
+    testImplementation 'com.amplifyframework:aws-auth-cognito:1.38.2'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9'
 }

--- a/packages/amplify/amplify_flutter_ios/ios/amplify_flutter_ios.podspec
+++ b/packages/amplify/amplify_flutter_ios/ios/amplify_flutter_ios.podspec
@@ -17,9 +17,9 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.3'
-  s.dependency 'AWSPluginsCore', '1.28.3'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.28.3'
+  s.dependency 'Amplify', '1.29.1'
+  s.dependency 'AWSPluginsCore', '1.29.1'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.29.1'
   s.dependency 'amplify_core'
   s.dependency 'SwiftLint', '0.48.0'
   s.dependency 'SwiftFormat/CLI'

--- a/packages/amplify_core/android/build.gradle
+++ b/packages/amplify_core/android/build.gradle
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.amplifyframework:core:1.38.1'
+    implementation 'com.amplifyframework:core:1.38.2'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -68,8 +68,8 @@ dependencies {
     // Support for Java 8 features
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
-    implementation "com.amplifyframework:aws-datastore:1.38.1"
-    implementation "com.amplifyframework:aws-api-appsync:1.38.1"
+    implementation "com.amplifyframework:aws-datastore:1.38.2"
+    implementation "com.amplifyframework:aws-api-appsync:1.38.2"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,8 +15,8 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.3'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.28.3'
+  s.dependency 'Amplify', '1.29.1'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.29.1'
   s.dependency 'amplify_core'
   s.platform = :ios, '13.0'
 

--- a/packages/analytics/amplify_analytics_pinpoint_android/android/build.gradle
+++ b/packages/analytics/amplify_analytics_pinpoint_android/android/build.gradle
@@ -66,8 +66,8 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.38.1'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.38.1'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.38.2'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.38.2'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/packages/analytics/amplify_analytics_pinpoint_ios/ios/amplify_analytics_pinpoint_ios.podspec
+++ b/packages/analytics/amplify_analytics_pinpoint_ios/ios/amplify_analytics_pinpoint_ios.podspec
@@ -15,8 +15,8 @@ This code is the iOS part of the Amplify Flutter Pinpoint Analytics Plugin.  The
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.3'
-  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.28.3'
+  s.dependency 'Amplify', '1.29.1'
+  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.29.1'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/api/amplify_api_android/android/build.gradle
+++ b/packages/api/amplify_api_android/android/build.gradle
@@ -66,8 +66,8 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation "com.amplifyframework:aws-api:1.38.1"
-    implementation "com.amplifyframework:aws-api-appsync:1.38.1"
+    implementation "com.amplifyframework:aws-api:1.38.2"
+    implementation "com.amplifyframework:aws-api-appsync:1.38.2"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 
     testImplementation 'junit:junit:4.13.2'

--- a/packages/api/amplify_api_ios/ios/amplify_api_ios.podspec
+++ b/packages/api/amplify_api_ios/ios/amplify_api_ios.podspec
@@ -15,8 +15,8 @@ The API module for Amplify Flutter.
   s.source           = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.3'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.28.3'
+  s.dependency 'Amplify', '1.29.1'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.29.1'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/auth/amplify_auth_cognito_android/android/build.gradle
+++ b/packages/auth/amplify_auth_cognito_android/android/build.gradle
@@ -68,7 +68,7 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:aws-auth-cognito:1.38.1'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.38.2'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
+++ b/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.3'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.28.3'
+  s.dependency 'Amplify', '1.29.1'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.29.1'
   s.dependency 'ObjectMapper'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'

--- a/packages/storage/amplify_storage_s3_android/android/build.gradle
+++ b/packages/storage/amplify_storage_s3_android/android/build.gradle
@@ -56,5 +56,5 @@ android {
 dependencies {
     api amplifyCore
 
-    implementation 'com.amplifyframework:aws-storage-s3:1.38.1'
+    implementation 'com.amplifyframework:aws-storage-s3:1.38.2'
 }

--- a/packages/storage/amplify_storage_s3_ios/ios/amplify_storage_s3_ios.podspec
+++ b/packages/storage/amplify_storage_s3_ios/ios/amplify_storage_s3_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.28.3'
-  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.28.3'
+  s.dependency 'Amplify', '1.29.1'
+  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.29.1'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
- Bumps Amplify iOS dependency to [1.29.1](https://github.com/aws-amplify/amplify-swift/releases/tag/1.29.1)
- Bumps Amplify Android dependency to [1.38.2](https://github.com/aws-amplify/amplify-android/releases/tag/release_v1.38.2)
