### PR TITLE
fix(storage): add handling of AWSHttpException

### DIFF
--- a/packages/storage/amplify_storage_s3_dart/lib/amplify_storage_s3_dart.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/amplify_storage_s3_dart.dart
@@ -6,7 +6,6 @@ library amplify_storage_s3_dart;
 
 export 'src/amplify_storage_s3_dart_impl.dart';
 export 'src/error/invalid_bytes_range_error.dart';
-export 'src/exception/s3_storage_exception.dart';
 export 'src/model/s3_models.dart';
 export 'src/prefix_resolver/pass_through_prefix_resolver.dart';
 export 'src/prefix_resolver/s3_prefix_resolver.dart';

--- a/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
@@ -224,6 +224,16 @@ class S3Exception extends StorageException {
         recoverySuggestion: AmplifyExceptionMessages.missingExceptionMessage,
       );
 
+  /// Creates a [NetworkException] over a [AWSHttpException] thrown from
+  /// [s3.S3Client] APIs.
+  static NetworkException fromAWSHttpException(AWSHttpException exception) {
+    return NetworkException(
+      'The request failed due to a network error.',
+      recoverySuggestion: 'Ensure that you have an active network connection',
+      underlyingException: exception,
+    );
+  }
+
   @override
   String get runtimeTypeName => 'S3Exception';
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+@internal
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
+import 'package:meta/meta.dart';
 import 'package:smithy/smithy.dart';
 
 const _keyNotFoundRecoveryMessage =

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_item.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_item.dart
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/exception/s3_storage_exception.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 import 'package:meta/meta.dart';
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_io.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_io.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/exception/s3_storage_exception.dart';
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 
 import 'package:amplify_core/amplify_core.dart' hide PaginatedResult;
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/exception/s3_storage_exception.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 import 'package:amplify_storage_s3_dart/src/sdk/src/s3/common/endpoint_resolver.dart'
     as endpoint_resolver;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -124,6 +124,8 @@ class StorageS3Service {
       } on smithy.UnknownSmithyHttpException catch (error) {
         // S3Client.headObject may return 403 error
         throw S3Exception.fromUnknownSmithyHttpException(error);
+      } on AWSHttpException catch (error) {
+        throw S3Exception.fromAWSHttpException(error);
       }
     }
 
@@ -158,6 +160,8 @@ class StorageS3Service {
     } on smithy.UnknownSmithyHttpException catch (error) {
       // S3Client.headObject may return 403 error
       throw S3Exception.fromUnknownSmithyHttpException(error);
+    } on AWSHttpException catch (error) {
+      throw S3Exception.fromAWSHttpException(error);
     }
   }
 
@@ -425,6 +429,8 @@ class StorageS3Service {
     } on smithy.UnknownSmithyHttpException catch (error) {
       // S3Client.copyObject may return 403 or 404 error
       throw S3Exception.fromUnknownSmithyHttpException(error);
+    } on AWSHttpException catch (error) {
+      throw S3Exception.fromAWSHttpException(error);
     }
 
     return S3CopyResult(
@@ -595,6 +601,8 @@ class StorageS3Service {
       } on smithy.UnknownSmithyHttpException catch (error) {
         // S3Client.deleteObjects may return 403
         throw S3Exception.fromUnknownSmithyHttpException(error);
+      } on AWSHttpException catch (error) {
+        throw S3Exception.fromAWSHttpException(error);
       } finally {
         objectIdentifiersToRemove.removeRange(0, numOfBatchedItems);
       }
@@ -625,6 +633,8 @@ class StorageS3Service {
       // S3Client.deleteObject may return 403, for deleting a non-existing
       // object, the API call returns a successful response
       throw S3Exception.fromUnknownSmithyHttpException(error);
+    } on AWSHttpException catch (error) {
+      throw S3Exception.fromAWSHttpException(error);
     }
   }
 
@@ -685,6 +695,8 @@ class StorageS3Service {
     } on smithy.UnknownSmithyHttpException catch (error) {
       // S3Client.headObject may return 403 or 404 error
       throw S3Exception.fromUnknownSmithyHttpException(error);
+    } on AWSHttpException catch (error) {
+      throw S3Exception.fromAWSHttpException(error);
     }
   }
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/exception/s3_storage_exception.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';
 import 'package:meta/meta.dart';

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
@@ -352,6 +352,8 @@ class S3DownloadTask {
     } on s3.NoSuchKey catch (error) {
       // 404 error is wrapped by s3.NoSuchKey for getObject :/
       throw S3Exception.getKeyNotFoundException(error);
+    } on AWSHttpException catch (error) {
+      throw S3Exception.fromAWSHttpException(error);
     }
   }
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/exception/s3_storage_exception.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/service/task/part_size_util.dart'
     as part_size_util;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -346,18 +346,19 @@ class S3UploadTask {
       );
 
       _state = S3TransferState.success;
-      _emitTransferProgress();
     } on CancellationException {
       _logger.debug('PutObject HTTP operation has been canceled.');
       _state = S3TransferState.canceled;
       _uploadCompleter
           .completeError(S3Exception.controllableOperationCanceled());
-      _emitTransferProgress();
     } on smithy.UnknownSmithyHttpException catch (error, stackTrace) {
       _completeUploadWithError(
         S3Exception.fromUnknownSmithyHttpException(error),
         stackTrace,
       );
+    } on AWSHttpException catch (error) {
+      _completeUploadWithError(S3Exception.fromAWSHttpException(error));
+    } finally {
       _emitTransferProgress();
     }
   }
@@ -486,6 +487,8 @@ class S3UploadTask {
       }
     } on smithy.UnknownSmithyHttpException catch (error) {
       throw S3Exception.fromUnknownSmithyHttpException(error);
+    } on AWSHttpException catch (error) {
+      throw S3Exception.fromAWSHttpException(error);
     }
   }
 
@@ -522,6 +525,8 @@ class S3UploadTask {
       // TODO(HuiSF): verify if s3Client sdk throws different exception type
       //  wrapping errors extracted from a 200 response.
       throw S3Exception.fromUnknownSmithyHttpException(error);
+    } on AWSHttpException catch (error) {
+      throw S3Exception.fromAWSHttpException(error);
     }
   }
 
@@ -659,6 +664,8 @@ class S3UploadTask {
       throw S3Exception.fromUnknownSmithyHttpException(error);
     } on s3.NoSuchUpload catch (error) {
       throw S3Exception.fromS3NoSuchUpload(error);
+    } on AWSHttpException catch (error) {
+      throw S3Exception.fromAWSHttpException(error);
     }
   }
 

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
@@ -62,7 +62,7 @@ void main() {
 
     group('_getResolvedPrefix()', () {
       test(
-          'should throw a S3Exception if supplied prefix resolver throws an exception',
+          'should throw a StorageException if supplied prefix resolver throws an exception',
           () async {
         const testOptions = StorageListOptions(
           accessLevel: StorageAccessLevel.guest,
@@ -74,7 +74,7 @@ void main() {
 
         await expectLater(
           storageS3Service.list(path: 'a path', options: testOptions),
-          throwsA(isA<S3Exception>()),
+          throwsA(isA<StorageException>()),
         );
 
         verify(() => logger.error(any(), any(), any())).called(1);

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
@@ -370,6 +370,26 @@ void main() {
           equals(testS3Objects.map((e) => e.eTag)),
         );
       });
+
+      test('should handle AWSHttpException and throw NetworkException', () {
+        const testOptions =
+            StorageListOptions(accessLevel: StorageAccessLevel.guest);
+        final testException = AWSHttpException(
+          AWSHttpRequest(method: AWSHttpMethod.get, uri: Uri()),
+        );
+
+        when(
+          () => s3Client.listObjectsV2(any()),
+        ).thenThrow(testException);
+
+        expect(
+          storageS3Service.list(
+            path: 'a path',
+            options: testOptions,
+          ),
+          throwsA(isA<NetworkException>()),
+        );
+      });
     });
 
     group('getProperties() API', () {
@@ -471,6 +491,26 @@ void main() {
             options: testOptions,
           ),
           throwsA(isA<StorageKeyNotFoundException>()),
+        );
+      });
+
+      test('should handle AWSHttpException and throw NetworkException', () {
+        const testOptions =
+            StorageGetPropertiesOptions(accessLevel: StorageAccessLevel.guest);
+        final testException = AWSHttpException(
+          AWSHttpRequest(method: AWSHttpMethod.head, uri: Uri()),
+        );
+
+        when(
+          () => s3Client.headObject(any()),
+        ).thenThrow(testException);
+
+        expect(
+          storageS3Service.getProperties(
+            key: 'a key',
+            options: testOptions,
+          ),
+          throwsA(isA<NetworkException>()),
         );
       });
     });
@@ -803,6 +843,27 @@ void main() {
         );
       });
 
+      test('should handle AWSHttpException and throw NetworkException',
+          () async {
+        const testOptions = StorageCopyOptions();
+        final testException = AWSHttpException(
+          AWSHttpRequest(method: AWSHttpMethod.put, uri: Uri()),
+        );
+
+        when(
+          () => s3Client.copyObject(any()),
+        ).thenThrow(testException);
+
+        expect(
+          storageS3Service.copy(
+            source: testSource,
+            destination: testDestination,
+            options: testOptions,
+          ),
+          throwsA(isA<NetworkException>()),
+        );
+      });
+
       test(
           'should invoke S3Client.headObject with correct parameters when getProperties option is set to true',
           () async {
@@ -973,6 +1034,27 @@ void main() {
             options: testOptions,
           ),
           throwsA(isA<StorageAccessDeniedException>()),
+        );
+      });
+
+      test('should handle AWSHttpException and throw NetworkException',
+          () async {
+        const testOptions = StorageMoveOptions();
+        final testException = AWSHttpException(
+          AWSHttpRequest(method: AWSHttpMethod.put, uri: Uri()),
+        );
+
+        when(
+          () => s3Client.copyObject(any()),
+        ).thenThrow(testException);
+
+        expect(
+          storageS3Service.move(
+            source: testSource,
+            destination: testDestination,
+            options: testOptions,
+          ),
+          throwsA(isA<NetworkException>()),
         );
       });
 
@@ -1150,6 +1232,27 @@ void main() {
           throwsA(isA<StorageAccessDeniedException>()),
         );
       });
+
+      test('should handle AWSHttpException and throw NetworkException',
+          () async {
+        const testOptions =
+            StorageRemoveOptions(accessLevel: StorageAccessLevel.guest);
+        final testException = AWSHttpException(
+          AWSHttpRequest(method: AWSHttpMethod.delete, uri: Uri()),
+        );
+
+        when(
+          () => s3Client.deleteObject(any()),
+        ).thenThrow(testException);
+
+        expect(
+          storageS3Service.remove(
+            key: 'a key',
+            options: testOptions,
+          ),
+          throwsA(isA<NetworkException>()),
+        );
+      });
     });
 
     group('removeMany() API', () {
@@ -1309,6 +1412,26 @@ void main() {
             options: testOptions,
           ),
           throwsA(isA<StorageAccessDeniedException>()),
+        );
+      });
+
+      test('should handle AWSHttpRequest and throw NetworkException', () async {
+        const testOptions =
+            StorageRemoveManyOptions(accessLevel: StorageAccessLevel.guest);
+        final testException = AWSHttpException(
+          AWSHttpRequest(method: AWSHttpMethod.delete, uri: Uri()),
+        );
+
+        when(
+          () => s3Client.deleteObjects(any()),
+        ).thenThrow(testException);
+
+        expect(
+          storageS3Service.removeMany(
+            keys: testKeys,
+            options: testOptions,
+          ),
+          throwsA(isA<NetworkException>()),
         );
       });
     });

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/exception/s3_storage_exception.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/service/task/s3_download_task.dart';
 import 'package:mocktail/mocktail.dart';
@@ -190,7 +191,7 @@ void main() {
       });
 
       test(
-          'it should throw S3Exception when getObject response doesn\'t include a value contentLength header',
+          'it should throw StorageException when getObject response doesn\'t include a value contentLength header',
           () async {
         final testGetObjectOutput = GetObjectOutput(
           body: Stream.value([101]),
@@ -226,7 +227,7 @@ void main() {
 
         await expectLater(
           downloadTask.result,
-          throwsA(isA<S3Exception>()),
+          throwsA(isA<StorageException>()),
         );
         expect(onErrorHasBeenCalled, isTrue);
       });
@@ -385,8 +386,8 @@ void main() {
         await downloadTask.start();
         await downloadTask.cancel();
 
-        expect(downloadTask.result, throwsA(isA<S3Exception>()));
-        expect(downloadTask.resume, throwsA(isA<S3Exception>()));
+        expect(downloadTask.result, throwsA(isA<StorageException>()));
+        expect(downloadTask.resume, throwsA(isA<StorageException>()));
       });
     });
 
@@ -434,13 +435,14 @@ void main() {
         await downloadTask.start();
         await downloadTask.cancel();
         expect(receivedState.last, S3TransferState.canceled);
-        expect(downloadTask.result, throwsA(isA<S3Exception>()));
+        expect(downloadTask.result, throwsA(isA<StorageException>()));
         expect(bodyStreamHasBeenCanceled, isTrue);
       });
     });
 
     group('error handling around S3Client.getObject', () {
-      test('should forward S3Exception when getObject returns no body', () {
+      test('should forward StorageException when getObject returns no body',
+          () {
         final testGetObjectOutput = GetObjectOutput(contentLength: Int64(1024));
         final smithyOperation = MockSmithyOperation<GetObjectOutput>();
 
@@ -467,7 +469,7 @@ void main() {
 
         unawaited(downloadTask.start());
 
-        expect(downloadTask.result, throwsA(isA<S3Exception>()));
+        expect(downloadTask.result, throwsA(isA<StorageException>()));
       });
 
       final _ = {

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
@@ -321,7 +321,7 @@ void main() {
         );
       });
 
-      test('should throw S3Exception when prefix resolving fails', () {
+      test('should throw StorageException when prefix resolving fails', () {
         final prefixResolverThrowsException =
             TestCustomPrefixResolverThrowsException();
 
@@ -338,7 +338,7 @@ void main() {
         );
 
         unawaited(uploadDataTask.start());
-        expect(uploadDataTask.result, throwsA(isA<S3Exception>()));
+        expect(uploadDataTask.result, throwsA(isA<StorageException>()));
       });
 
       test(
@@ -377,7 +377,7 @@ void main() {
       });
 
       test(
-          'cancel() should cancel underlying put object request and throw a S3Exception',
+          'cancel() should cancel underlying put object request and throw a StorageException',
           () async {
         final putSmithyOperation = MockSmithyOperation<s3.PutObjectOutput>();
 
@@ -418,7 +418,10 @@ void main() {
 
         completer.complete();
 
-        await expectLater(uploadDataTask.result, throwsA(isA<S3Exception>()));
+        await expectLater(
+          uploadDataTask.result,
+          throwsA(isA<StorageException>()),
+        );
         verify(putSmithyOperation.cancel).called(1);
       });
     });
@@ -545,7 +548,7 @@ void main() {
       });
 
       test(
-          'cancel() should cancel underlying put object request and throw a S3Exception',
+          'cancel() should cancel underlying put object request and throw a StorageException',
           () async {
         final putSmithyOperation = MockSmithyOperation<s3.PutObjectOutput>();
 
@@ -586,7 +589,10 @@ void main() {
 
         completer.complete();
 
-        await expectLater(uploadDataTask.result, throwsA(isA<S3Exception>()));
+        await expectLater(
+          uploadDataTask.result,
+          throwsA(isA<StorageException>()),
+        );
         verify(putSmithyOperation.cancel).called(1);
       });
 
@@ -1230,7 +1236,7 @@ void main() {
 
         await expectLater(
           uploadTask.result,
-          throwsA(isA<S3Exception>()),
+          throwsA(isA<StorageException>()),
         );
         expect(finalState, S3TransferState.failure);
       });
@@ -1317,7 +1323,7 @@ void main() {
 
         await expectLater(
           uploadTask.result,
-          throwsA(isA<S3Exception>()),
+          throwsA(isA<StorageException>()),
         );
         expect(finalState, S3TransferState.failure);
       });
@@ -1467,7 +1473,7 @@ void main() {
         await expectLater(
           uploadTask.result,
           throwsA(
-            isA<S3Exception>().having(
+            isA<StorageException>().having(
               (o) => o.underlyingException,
               'underlyingException',
               isA<StorageAccessDeniedException>().having(
@@ -1560,7 +1566,7 @@ void main() {
 
         await expectLater(
           uploadTask.result,
-          throwsA(isA<S3Exception>()),
+          throwsA(isA<StorageException>()),
         );
 
         expect(finalState, S3TransferState.failure);
@@ -1625,10 +1631,10 @@ void main() {
         await expectLater(
           uploadTask.result,
           throwsA(
-            isA<S3Exception>().having(
+            isA<StorageException>().having(
               (o) => o.underlyingException,
               'underlyingException',
-              isA<S3Exception>().having(
+              isA<StorageException>().having(
                 (o) => o.underlyingException,
                 'underlyingException',
                 testException,
@@ -1785,7 +1791,7 @@ void main() {
         });
 
         test(
-            'cancel() should terminate ongoing multipart upload and throw a S3Exception',
+            'cancel() should terminate ongoing multipart upload and throw a StorageException',
             () async {
           final receivedState = <S3TransferState>[];
           final uploadTask = S3UploadTask.fromAWSFile(
@@ -1839,7 +1845,7 @@ void main() {
 
           await expectLater(
             uploadTask.result,
-            throwsA(isA<S3Exception>()),
+            throwsA(isA<StorageException>()),
           );
 
           verify(uploadPartSmithyOperation1.cancel).called(1);

--- a/packages/storage/amplify_storage_s3_dart/test/test_utils/helper_types.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/test_utils/helper_types.dart
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:test/test.dart';
+
+class DownloadTaskExceptionConversionTestItem<T> {
+  DownloadTaskExceptionConversionTestItem({
+    required this.exceptionTypeMatcher,
+    required this.description,
+    required this.originalException,
+  });
+
+  final String description;
+  final Exception originalException;
+  final TypeMatcher<T> exceptionTypeMatcher;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* No longer export `S3Exception` where `StorageException` from amplify_core should be used to handle exceptions at runtime
* Added handling of `AWSHttpException` calling S3 SDK APIs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
