### PR TITLE
chore: Clean up plugin options

### DIFF
--- a/packages/amplify_core/lib/src/plugin/amplify_plugin_interface.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_plugin_interface.dart
@@ -30,10 +30,13 @@ abstract class AmplifyPluginInterface {
   @visibleForTesting
   Future<void> reset() async {}
 
-  /// validate [pluginOptions] is an instance of [T].
-  /// if [pluginOptions] is `null` returns the [defaultPluginOptions].
-  /// throws [ArgumentError] if none of the above.
-  static T reifyPluginOptions<T>({
+  /// Reifies [pluginOptions] as an instance of [T].
+  ///
+  /// If [pluginOptions] is `null` returns the [defaultPluginOptions].
+  /// Otherwise, throws an [ArgumentError] if [pluginOptions] does not conform
+  /// to [T].
+  @protected
+  T reifyPluginOptions<T extends AWSDebuggable>({
     Object? pluginOptions,
     required T defaultPluginOptions,
   }) {
@@ -42,10 +45,10 @@ abstract class AmplifyPluginInterface {
     }
     if (pluginOptions is! T) {
       throw ArgumentError(
-        'Expected pluginOptions with type: ${defaultPluginOptions.runtimeType.toString()}. '
-        'but got: ${pluginOptions.runtimeType.toString()}.',
+        'Expected pluginOptions with type "${defaultPluginOptions.runtimeTypeName}" '
+        'but got: $pluginOptions',
       );
     }
-    return pluginOptions as T;
+    return pluginOptions;
   }
 }

--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -147,9 +147,9 @@ class AmplifyAuthCognito extends AmplifyAuthCognitoDart with AWSDebuggable {
     SignUpOptions? options,
   }) async {
     options ??= const SignUpOptions();
-    final pluginOptions = AmplifyAuthCognitoDart.validatePluginOptions(
-      options.pluginOptions,
-      defaultOptions: const CognitoSignUpPluginOptions(),
+    final pluginOptions = reifyPluginOptions(
+      pluginOptions: options.pluginOptions,
+      defaultPluginOptions: const CognitoSignUpPluginOptions(),
     );
     Map<String, String>? validationData;
     if (!zIsWeb && (Platform.isAndroid || Platform.isIOS)) {

--- a/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
@@ -15,6 +15,8 @@ export 'src/jwt/src/cognito.dart';
 export 'src/jwt/src/token.dart';
 
 /// Models
+export 'src/model/attribute/cognito_confirm_user_attribute_plugin_options.dart';
+export 'src/model/attribute/cognito_fetch_user_attributes_plugin_options.dart';
 export 'src/model/attribute/cognito_resend_user_attribute_confirmation_code_options.dart';
 export 'src/model/attribute/cognito_resend_user_attribute_confirmation_code_plugin_options.dart';
 export 'src/model/attribute/cognito_update_user_attribute_options.dart';
@@ -30,10 +32,12 @@ export 'src/model/password/cognito_confirm_reset_password_plugin_options.dart';
 export 'src/model/password/cognito_reset_password_options.dart';
 export 'src/model/password/cognito_reset_password_plugin_options.dart';
 export 'src/model/password/cognito_reset_password_result.dart';
+export 'src/model/password/cognito_update_password_plugin_options.dart';
 export 'src/model/session/cognito_auth_session.dart';
 export 'src/model/session/cognito_auth_user.dart';
 export 'src/model/session/cognito_fetch_auth_session_options.dart';
 export 'src/model/session/cognito_fetch_auth_session_plugin_options.dart';
+export 'src/model/session/cognito_get_current_user_plugin_options.dart';
 export 'src/model/session/cognito_sign_in_details.dart'
     hide CognitoSignInDetailsFederated;
 export 'src/model/session/cognito_user_pool_tokens.dart';
@@ -48,6 +52,7 @@ export 'src/model/signin/cognito_sign_in_result.dart';
 export 'src/model/signin/cognito_sign_in_step.dart';
 export 'src/model/signin/cognito_sign_in_with_web_ui_options.dart';
 export 'src/model/signin/cognito_sign_in_with_web_ui_plugin_options.dart';
+export 'src/model/signout/cognito_sign_out_plugin_options.dart';
 export 'src/model/signout/cognito_sign_out_result.dart';
 export 'src/model/signup/cognito_confirm_sign_up_options.dart';
 export 'src/model/signup/cognito_confirm_sign_up_plugin_options.dart';

--- a/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
@@ -13,20 +13,27 @@ export 'src/exception/invalid_account_type_exception.dart';
 export 'src/flows/hosted_ui/hosted_ui_platform.dart';
 export 'src/jwt/src/cognito.dart';
 export 'src/jwt/src/token.dart';
-// Models
+
+/// Models
 export 'src/model/attribute/cognito_resend_user_attribute_confirmation_code_options.dart';
+export 'src/model/attribute/cognito_resend_user_attribute_confirmation_code_plugin_options.dart';
 export 'src/model/attribute/cognito_update_user_attribute_options.dart';
+export 'src/model/attribute/cognito_update_user_attribute_plugin_options.dart';
 export 'src/model/attribute/cognito_update_user_attribute_step.dart';
 export 'src/model/attribute/cognito_update_user_attributes_options.dart';
+export 'src/model/attribute/cognito_update_user_attributes_plugin_options.dart';
 export 'src/model/auth_result.dart';
 export 'src/model/device/cognito_device.dart';
 export 'src/model/hosted_ui/oauth_parameters.dart';
 export 'src/model/password/cognito_confirm_reset_password_options.dart';
+export 'src/model/password/cognito_confirm_reset_password_plugin_options.dart';
 export 'src/model/password/cognito_reset_password_options.dart';
+export 'src/model/password/cognito_reset_password_plugin_options.dart';
 export 'src/model/password/cognito_reset_password_result.dart';
 export 'src/model/session/cognito_auth_session.dart';
 export 'src/model/session/cognito_auth_user.dart';
 export 'src/model/session/cognito_fetch_auth_session_options.dart';
+export 'src/model/session/cognito_fetch_auth_session_plugin_options.dart';
 export 'src/model/session/cognito_sign_in_details.dart'
     hide CognitoSignInDetailsFederated;
 export 'src/model/session/cognito_user_pool_tokens.dart';
@@ -34,20 +41,27 @@ export 'src/model/session/federate_to_identity_pool_options.dart';
 export 'src/model/session/federate_to_identity_pool_request.dart';
 export 'src/model/session/federate_to_identity_pool_result.dart';
 export 'src/model/signin/cognito_confirm_sign_in_options.dart';
+export 'src/model/signin/cognito_confirm_sign_in_plugin_options.dart';
 export 'src/model/signin/cognito_sign_in_options.dart';
+export 'src/model/signin/cognito_sign_in_plugin_options.dart';
 export 'src/model/signin/cognito_sign_in_result.dart';
 export 'src/model/signin/cognito_sign_in_step.dart';
 export 'src/model/signin/cognito_sign_in_with_web_ui_options.dart';
+export 'src/model/signin/cognito_sign_in_with_web_ui_plugin_options.dart';
 export 'src/model/signout/cognito_sign_out_result.dart';
 export 'src/model/signup/cognito_confirm_sign_up_options.dart';
+export 'src/model/signup/cognito_confirm_sign_up_plugin_options.dart';
 export 'src/model/signup/cognito_resend_sign_up_code_options.dart';
+export 'src/model/signup/cognito_resend_sign_up_code_plugin_options.dart';
 export 'src/model/signup/cognito_resend_sign_up_code_result.dart';
 export 'src/model/signup/cognito_sign_up_options.dart';
+export 'src/model/signup/cognito_sign_up_plugin_options.dart';
 export 'src/model/signup/cognito_sign_up_result.dart';
 export 'src/model/signup/cognito_sign_up_step.dart';
 export 'src/sdk/sdk_exception.dart' hide transformSdkException;
 export 'src/state/cognito_state_machine.dart';
-// State Machine
+
+/// State Machine
 export 'src/state/event/configuration_event.dart';
 export 'src/state/event/credential_store_event.dart';
 export 'src/state/event/fetch_auth_session_event.dart';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -97,24 +97,6 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
       ResendUserAttributeConfirmationCodeResult,
       AmplifyAuthCognitoDart> pluginKey = _AmplifyAuthCognitoDartPluginKey();
 
-  /// Validates [pluginOptions] is an instance of [T]
-  @protected
-  static T validatePluginOptions<T extends AWSDebuggable>(
-    Object? pluginOptions, {
-    required T defaultOptions,
-  }) {
-    if (pluginOptions == null) {
-      return defaultOptions;
-    }
-    if (pluginOptions is! T) {
-      throw ArgumentError(
-        'Expected pluginOptions with type "${defaultOptions.runtimeTypeName}" '
-        'but got: $pluginOptions',
-      );
-    }
-    return pluginOptions;
-  }
-
   /// Capture the initial parameters on instantiation of this class.
   ///
   /// {@macro amplify_auth_cognito.initial_parameters}
@@ -372,9 +354,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     AuthProvider? provider,
     SignInWithWebUIOptions? options,
   }) async {
-    final pluginOptions = validatePluginOptions(
-      options?.pluginOptions,
-      defaultOptions: const CognitoSignInWithWebUIPluginOptions(),
+    final pluginOptions = reifyPluginOptions(
+      pluginOptions: options?.pluginOptions,
+      defaultPluginOptions: const CognitoSignInWithWebUIPluginOptions(),
     );
 
     // Create a new state machine which will close the previous one and cancel
@@ -423,9 +405,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     SignUpOptions? options,
   }) async {
     options ??= const SignUpOptions();
-    final pluginOptions = validatePluginOptions(
-      options.pluginOptions,
-      defaultOptions: const CognitoSignUpPluginOptions(),
+    final pluginOptions = reifyPluginOptions(
+      pluginOptions: options.pluginOptions,
+      defaultPluginOptions: const CognitoSignUpPluginOptions(),
     );
     await _stateMachine
         .accept(
@@ -485,9 +467,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     ConfirmSignUpOptions? options,
   }) async {
     options ??= const ConfirmSignUpOptions();
-    final pluginOptions = validatePluginOptions(
-      options.pluginOptions,
-      defaultOptions: const CognitoConfirmSignUpPluginOptions(),
+    final pluginOptions = reifyPluginOptions(
+      pluginOptions: options.pluginOptions,
+      defaultPluginOptions: const CognitoConfirmSignUpPluginOptions(),
     );
     await _stateMachine
         .accept(
@@ -540,9 +522,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     required String username,
     ResendSignUpCodeOptions? options,
   }) async {
-    final pluginOptions = validatePluginOptions(
-      options?.pluginOptions,
-      defaultOptions: const CognitoResendSignUpCodePluginOptions(),
+    final pluginOptions = reifyPluginOptions(
+      pluginOptions: options?.pluginOptions,
+      defaultPluginOptions: const CognitoResendSignUpCodePluginOptions(),
     );
     final result = await _cognitoIdp.resendConfirmationCode(
       cognito.ResendConfirmationCodeRequest.build((b) {
@@ -578,9 +560,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     String? password,
     SignInOptions? options,
   }) async {
-    final pluginOptions = validatePluginOptions(
-      options?.pluginOptions,
-      defaultOptions: const CognitoSignInPluginOptions(),
+    final pluginOptions = reifyPluginOptions(
+      pluginOptions: options?.pluginOptions,
+      defaultPluginOptions: const CognitoSignInPluginOptions(),
     );
 
     // Create a new state machine for every call since it caches values
@@ -655,9 +637,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     required String confirmationValue,
     ConfirmSignInOptions? options,
   }) async {
-    final pluginOptions = validatePluginOptions(
-      options?.pluginOptions,
-      defaultOptions: const CognitoConfirmSignInPluginOptions(),
+    final pluginOptions = reifyPluginOptions(
+      pluginOptions: options?.pluginOptions,
+      defaultPluginOptions: const CognitoConfirmSignInPluginOptions(),
     );
     await _stateMachine
         .accept(
@@ -729,9 +711,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     required String value,
     UpdateUserAttributeOptions? options,
   }) async {
-    final pluginOptions = validatePluginOptions(
-      options?.pluginOptions,
-      defaultOptions: const CognitoUpdateUserAttributePluginOptions(),
+    final pluginOptions = reifyPluginOptions(
+      pluginOptions: options?.pluginOptions,
+      defaultPluginOptions: const CognitoUpdateUserAttributePluginOptions(),
     );
     final results = await updateUserAttributes(
       attributes: [
@@ -755,9 +737,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     required List<AuthUserAttribute<AuthUserAttributeKey>> attributes,
     UpdateUserAttributesOptions? options,
   }) async {
-    final pluginOptions = validatePluginOptions(
-      options?.pluginOptions,
-      defaultOptions: const CognitoUpdateUserAttributesPluginOptions(),
+    final pluginOptions = reifyPluginOptions(
+      pluginOptions: options?.pluginOptions,
+      defaultPluginOptions: const CognitoUpdateUserAttributesPluginOptions(),
     );
     final tokens = await stateMachine.getUserPoolTokens();
     final response = await _cognitoIdp
@@ -824,9 +806,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     required CognitoUserAttributeKey userAttributeKey,
     ResendUserAttributeConfirmationCodeOptions? options,
   }) async {
-    final pluginOptions = validatePluginOptions(
-      options?.pluginOptions,
-      defaultOptions:
+    final pluginOptions = reifyPluginOptions(
+      pluginOptions: options?.pluginOptions,
+      defaultPluginOptions:
           const CognitoResendUserAttributeConfirmationCodePluginOptions(),
     );
     final tokens = await stateMachine.getUserPoolTokens();
@@ -873,9 +855,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     required String username,
     ResetPasswordOptions? options,
   }) async {
-    final pluginOptions = validatePluginOptions(
-      options?.pluginOptions,
-      defaultOptions: const CognitoResetPasswordPluginOptions(),
+    final pluginOptions = reifyPluginOptions(
+      pluginOptions: options?.pluginOptions,
+      defaultPluginOptions: const CognitoResetPasswordPluginOptions(),
     );
     final result = await _cognitoIdp.forgotPassword(
       cognito.ForgotPasswordRequest.build((b) {
@@ -919,9 +901,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     required String confirmationCode,
     ConfirmResetPasswordOptions? options,
   }) async {
-    final pluginOptions = validatePluginOptions(
-      options?.pluginOptions,
-      defaultOptions: const CognitoConfirmResetPasswordPluginOptions(),
+    final pluginOptions = reifyPluginOptions(
+      pluginOptions: options?.pluginOptions,
+      defaultPluginOptions: const CognitoConfirmResetPasswordPluginOptions(),
     );
     await _cognitoIdp.confirmForgotPassword(
       cognito.ConfirmForgotPasswordRequest.build((b) {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_confirm_user_attribute_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_confirm_user_attribute_plugin_options.dart
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_confirm_user_attribute_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_confirm_user_attribute_plugin_options}
+/// Cognito options for `Amplify.Auth.confirmUserAttribute`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoConfirmUserAttributePluginOptions
+    extends ConfirmUserAttributePluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_confirm_user_attribute_plugin_options}
+  const CognitoConfirmUserAttributePluginOptions();
+
+  /// {@macro amplify_auth_cognito.model.cognito_confirm_user_attribute_plugin_options}
+  factory CognitoConfirmUserAttributePluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoConfirmUserAttributePluginOptionsFromJson(json);
+
+  @override
+  List<Object?> get props => [];
+
+  @override
+  String get runtimeTypeName => 'CognitoConfirmUserAttributePluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoConfirmUserAttributePluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_confirm_user_attribute_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_confirm_user_attribute_plugin_options.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cognito_confirm_user_attribute_plugin_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CognitoConfirmUserAttributePluginOptions
+    _$CognitoConfirmUserAttributePluginOptionsFromJson(
+            Map<String, dynamic> json) =>
+        CognitoConfirmUserAttributePluginOptions();
+
+Map<String, dynamic> _$CognitoConfirmUserAttributePluginOptionsToJson(
+        CognitoConfirmUserAttributePluginOptions instance) =>
+    <String, dynamic>{};

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_fetch_user_attributes_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_fetch_user_attributes_plugin_options.dart
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_fetch_user_attributes_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_fetch_user_attributes_plugin_options}
+/// Cognito options for `Amplify.Auth.fetchUserAttributes`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoFetchUserAttributesPluginOptions
+    extends FetchUserAttributesPluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_fetch_user_attributes_plugin_options}
+  const CognitoFetchUserAttributesPluginOptions();
+
+  /// {@macro amplify_auth_cognito.model.cognito_fetch_user_attributes_plugin_options}
+  factory CognitoFetchUserAttributesPluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoFetchUserAttributesPluginOptionsFromJson(json);
+
+  @override
+  List<Object?> get props => [];
+
+  @override
+  String get runtimeTypeName => 'CognitoFetchUserAttributesPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoFetchUserAttributesPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_fetch_user_attributes_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_fetch_user_attributes_plugin_options.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cognito_fetch_user_attributes_plugin_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CognitoFetchUserAttributesPluginOptions
+    _$CognitoFetchUserAttributesPluginOptionsFromJson(
+            Map<String, dynamic> json) =>
+        CognitoFetchUserAttributesPluginOptions();
+
+Map<String, dynamic> _$CognitoFetchUserAttributesPluginOptionsToJson(
+        CognitoFetchUserAttributesPluginOptions instance) =>
+    <String, dynamic>{};

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_resend_user_attribute_confirmation_code_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_resend_user_attribute_confirmation_code_options.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 part 'cognito_resend_user_attribute_confirmation_code_options.g.dart';
@@ -53,39 +54,4 @@ class CognitoResendUserAttributeConfirmationCodeOptions
   @override
   Map<String, Object?> toJson() =>
       _$CognitoResendUserAttributeConfirmationCodeOptionsToJson(this);
-}
-
-/// {@template amplify_auth_cognito.model.cognito_resend_user_attribute_confirmation_code_plugin_options}
-/// Cognito options for `Amplify.Auth.resendUserAttributeConfirmationCode`.
-/// {@endtemplate}
-@zAmplifySerializable
-class CognitoResendUserAttributeConfirmationCodePluginOptions
-    extends ResendUserAttributeConfirmationCodePluginOptions {
-  /// {@macro amplify_auth_cognito.model.cognito_resend_user_attribute_confirmation_code_plugin_options}
-  const CognitoResendUserAttributeConfirmationCodePluginOptions({
-    Map<String, String>? clientMetadata,
-  }) : clientMetadata = clientMetadata ?? const {};
-
-  /// {@macro amplify_auth_cognito.model.cognito_resend_user_attribute_confirmation_code_plugin_options}
-  factory CognitoResendUserAttributeConfirmationCodePluginOptions.fromJson(
-    Map<String, Object?> json,
-  ) =>
-      _$CognitoResendUserAttributeConfirmationCodePluginOptionsFromJson(json);
-
-  /// {@template amplify_auth_cognito.model.cognito_resend_user_attribute_confirmation_code_plugin_options.client_metadata}
-  /// A map of custom key-value pairs that you can provide as input for certain
-  /// custom workflows that this action triggers.
-  /// {@endtemplate}
-  final Map<String, String> clientMetadata;
-
-  @override
-  List<Object?> get props => [clientMetadata];
-
-  @override
-  String get runtimeTypeName =>
-      'CognitoResendUserAttributeConfirmationCodePluginOptions';
-
-  @override
-  Map<String, Object?> toJson() =>
-      _$CognitoResendUserAttributeConfirmationCodePluginOptionsToJson(this);
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_resend_user_attribute_confirmation_code_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_resend_user_attribute_confirmation_code_plugin_options.dart
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_resend_user_attribute_confirmation_code_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_resend_user_attribute_confirmation_code_plugin_options}
+/// Cognito options for `Amplify.Auth.resendUserAttributeConfirmationCode`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoResendUserAttributeConfirmationCodePluginOptions
+    extends ResendUserAttributeConfirmationCodePluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_resend_user_attribute_confirmation_code_plugin_options}
+  const CognitoResendUserAttributeConfirmationCodePluginOptions({
+    Map<String, String>? clientMetadata,
+  }) : clientMetadata = clientMetadata ?? const {};
+
+  /// {@macro amplify_auth_cognito.model.cognito_resend_user_attribute_confirmation_code_plugin_options}
+  factory CognitoResendUserAttributeConfirmationCodePluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoResendUserAttributeConfirmationCodePluginOptionsFromJson(json);
+
+  /// {@template amplify_auth_cognito.model.cognito_resend_user_attribute_confirmation_code_plugin_options.client_metadata}
+  /// A map of custom key-value pairs that you can provide as input for certain
+  /// custom workflows that this action triggers.
+  /// {@endtemplate}
+  final Map<String, String> clientMetadata;
+
+  @override
+  List<Object?> get props => [clientMetadata];
+
+  @override
+  String get runtimeTypeName =>
+      'CognitoResendUserAttributeConfirmationCodePluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoResendUserAttributeConfirmationCodePluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_resend_user_attribute_confirmation_code_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_resend_user_attribute_confirmation_code_plugin_options.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cognito_resend_user_attribute_confirmation_code_plugin_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CognitoResendUserAttributeConfirmationCodePluginOptions
+    _$CognitoResendUserAttributeConfirmationCodePluginOptionsFromJson(
+            Map<String, dynamic> json) =>
+        CognitoResendUserAttributeConfirmationCodePluginOptions(
+          clientMetadata:
+              (json['clientMetadata'] as Map<String, dynamic>?)?.map(
+            (k, e) => MapEntry(k, e as String),
+          ),
+        );
+
+Map<String, dynamic>
+    _$CognitoResendUserAttributeConfirmationCodePluginOptionsToJson(
+            CognitoResendUserAttributeConfirmationCodePluginOptions instance) =>
+        <String, dynamic>{
+          'clientMetadata': instance.clientMetadata,
+        };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attribute_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attribute_options.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 part 'cognito_update_user_attribute_options.g.dart';
@@ -49,38 +50,4 @@ class CognitoUpdateUserAttributeOptions extends UpdateUserAttributeOptions {
   @override
   Map<String, Object?> toJson() =>
       _$CognitoUpdateUserAttributeOptionsToJson(this);
-}
-
-/// {@template amplify_auth_cognito.model.cognito_update_user_attribute_plugin_options}
-/// Cognito options for `Amplify.Auth.updateUserAttribute`.
-/// {@endtemplate}
-@zAmplifySerializable
-class CognitoUpdateUserAttributePluginOptions
-    extends UpdateUserAttributePluginOptions {
-  /// {@macro amplify_auth_cognito.model.cognito_update_user_attribute_plugin_options}
-  const CognitoUpdateUserAttributePluginOptions({
-    Map<String, String>? clientMetadata,
-  }) : clientMetadata = clientMetadata ?? const {};
-
-  /// {@macro amplify_auth_cognito.model.cognito_update_user_attribute_plugin_options}
-  factory CognitoUpdateUserAttributePluginOptions.fromJson(
-    Map<String, Object?> json,
-  ) =>
-      _$CognitoUpdateUserAttributePluginOptionsFromJson(json);
-
-  /// {@template amplify_auth_cognito.model.cognito_update_user_attribute_plugin_options.client_metadata}
-  /// A map of custom key-value pairs that you can provide as input for certain
-  /// custom workflows that this action triggers.
-  /// {@endtemplate}
-  final Map<String, String> clientMetadata;
-
-  @override
-  List<Object?> get props => [clientMetadata];
-
-  @override
-  String get runtimeTypeName => 'CognitoUpdateUserAttributePluginOptions';
-
-  @override
-  Map<String, Object?> toJson() =>
-      _$CognitoUpdateUserAttributePluginOptionsToJson(this);
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attribute_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attribute_plugin_options.dart
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_update_user_attribute_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_update_user_attribute_plugin_options}
+/// Cognito options for `Amplify.Auth.updateUserAttribute`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoUpdateUserAttributePluginOptions
+    extends UpdateUserAttributePluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_update_user_attribute_plugin_options}
+  const CognitoUpdateUserAttributePluginOptions({
+    Map<String, String>? clientMetadata,
+  }) : clientMetadata = clientMetadata ?? const {};
+
+  /// {@macro amplify_auth_cognito.model.cognito_update_user_attribute_plugin_options}
+  factory CognitoUpdateUserAttributePluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoUpdateUserAttributePluginOptionsFromJson(json);
+
+  /// {@template amplify_auth_cognito.model.cognito_update_user_attribute_plugin_options.client_metadata}
+  /// A map of custom key-value pairs that you can provide as input for certain
+  /// custom workflows that this action triggers.
+  /// {@endtemplate}
+  final Map<String, String> clientMetadata;
+
+  @override
+  List<Object?> get props => [clientMetadata];
+
+  @override
+  String get runtimeTypeName => 'CognitoUpdateUserAttributePluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoUpdateUserAttributePluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attribute_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attribute_plugin_options.g.dart
@@ -1,23 +1,23 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'cognito_resend_user_attribute_confirmation_code_options.dart';
+part of 'cognito_update_user_attribute_plugin_options.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-CognitoResendUserAttributeConfirmationCodeOptions
-    _$CognitoResendUserAttributeConfirmationCodeOptionsFromJson(
+CognitoUpdateUserAttributePluginOptions
+    _$CognitoUpdateUserAttributePluginOptionsFromJson(
             Map<String, dynamic> json) =>
-        CognitoResendUserAttributeConfirmationCodeOptions(
+        CognitoUpdateUserAttributePluginOptions(
           clientMetadata:
               (json['clientMetadata'] as Map<String, dynamic>?)?.map(
             (k, e) => MapEntry(k, e as String),
           ),
         );
 
-Map<String, dynamic> _$CognitoResendUserAttributeConfirmationCodeOptionsToJson(
-        CognitoResendUserAttributeConfirmationCodeOptions instance) =>
+Map<String, dynamic> _$CognitoUpdateUserAttributePluginOptionsToJson(
+        CognitoUpdateUserAttributePluginOptions instance) =>
     <String, dynamic>{
       'clientMetadata': instance.clientMetadata,
     };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attributes_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attributes_options.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 part 'cognito_update_user_attributes_options.g.dart';
@@ -50,38 +51,4 @@ class CognitoUpdateUserAttributesOptions extends UpdateUserAttributesOptions {
   @override
   Map<String, Object?> toJson() =>
       _$CognitoUpdateUserAttributesOptionsToJson(this);
-}
-
-/// {@template amplify_auth_cognito.model.cognito_update_user_attributes_plugin_options}
-/// Cognito options for `Amplify.Auth.updateUserAttributes`.
-/// {@endtemplate}
-@zAmplifySerializable
-class CognitoUpdateUserAttributesPluginOptions
-    extends UpdateUserAttributesPluginOptions {
-  /// {@macro amplify_auth_cognito.model.cognito_update_user_attributes_plugin_options}
-  const CognitoUpdateUserAttributesPluginOptions({
-    Map<String, String>? clientMetadata,
-  }) : clientMetadata = clientMetadata ?? const {};
-
-  /// {@macro amplify_auth_cognito.model.cognito_update_user_attributes_plugin_options}
-  factory CognitoUpdateUserAttributesPluginOptions.fromJson(
-    Map<String, Object?> json,
-  ) =>
-      _$CognitoUpdateUserAttributesPluginOptionsFromJson(json);
-
-  /// {@template amplify_auth_cognito.model.cognito_update_user_attributes_plugin_options.client_metadata}
-  /// A map of custom key-value pairs that you can provide as input for certain
-  /// custom workflows that this action triggers.
-  /// {@endtemplate}
-  final Map<String, String> clientMetadata;
-
-  @override
-  List<Object?> get props => [clientMetadata];
-
-  @override
-  String get runtimeTypeName => 'CognitoUpdateUserAttributesPluginOptions';
-
-  @override
-  Map<String, Object?> toJson() =>
-      _$CognitoUpdateUserAttributesPluginOptionsToJson(this);
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attributes_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attributes_options.g.dart
@@ -19,19 +19,3 @@ Map<String, dynamic> _$CognitoUpdateUserAttributesOptionsToJson(
     <String, dynamic>{
       'clientMetadata': instance.clientMetadata,
     };
-
-CognitoUpdateUserAttributesPluginOptions
-    _$CognitoUpdateUserAttributesPluginOptionsFromJson(
-            Map<String, dynamic> json) =>
-        CognitoUpdateUserAttributesPluginOptions(
-          clientMetadata:
-              (json['clientMetadata'] as Map<String, dynamic>?)?.map(
-            (k, e) => MapEntry(k, e as String),
-          ),
-        );
-
-Map<String, dynamic> _$CognitoUpdateUserAttributesPluginOptionsToJson(
-        CognitoUpdateUserAttributesPluginOptions instance) =>
-    <String, dynamic>{
-      'clientMetadata': instance.clientMetadata,
-    };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attributes_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attributes_plugin_options.dart
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_update_user_attributes_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_update_user_attributes_plugin_options}
+/// Cognito options for `Amplify.Auth.updateUserAttributes`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoUpdateUserAttributesPluginOptions
+    extends UpdateUserAttributesPluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_update_user_attributes_plugin_options}
+  const CognitoUpdateUserAttributesPluginOptions({
+    Map<String, String>? clientMetadata,
+  }) : clientMetadata = clientMetadata ?? const {};
+
+  /// {@macro amplify_auth_cognito.model.cognito_update_user_attributes_plugin_options}
+  factory CognitoUpdateUserAttributesPluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoUpdateUserAttributesPluginOptionsFromJson(json);
+
+  /// {@template amplify_auth_cognito.model.cognito_update_user_attributes_plugin_options.client_metadata}
+  /// A map of custom key-value pairs that you can provide as input for certain
+  /// custom workflows that this action triggers.
+  /// {@endtemplate}
+  final Map<String, String> clientMetadata;
+
+  @override
+  List<Object?> get props => [clientMetadata];
+
+  @override
+  String get runtimeTypeName => 'CognitoUpdateUserAttributesPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoUpdateUserAttributesPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attributes_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/attribute/cognito_update_user_attributes_plugin_options.g.dart
@@ -1,23 +1,23 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'cognito_resend_user_attribute_confirmation_code_options.dart';
+part of 'cognito_update_user_attributes_plugin_options.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-CognitoResendUserAttributeConfirmationCodeOptions
-    _$CognitoResendUserAttributeConfirmationCodeOptionsFromJson(
+CognitoUpdateUserAttributesPluginOptions
+    _$CognitoUpdateUserAttributesPluginOptionsFromJson(
             Map<String, dynamic> json) =>
-        CognitoResendUserAttributeConfirmationCodeOptions(
+        CognitoUpdateUserAttributesPluginOptions(
           clientMetadata:
               (json['clientMetadata'] as Map<String, dynamic>?)?.map(
             (k, e) => MapEntry(k, e as String),
           ),
         );
 
-Map<String, dynamic> _$CognitoResendUserAttributeConfirmationCodeOptionsToJson(
-        CognitoResendUserAttributeConfirmationCodeOptions instance) =>
+Map<String, dynamic> _$CognitoUpdateUserAttributesPluginOptionsToJson(
+        CognitoUpdateUserAttributesPluginOptions instance) =>
     <String, dynamic>{
       'clientMetadata': instance.clientMetadata,
     };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_confirm_reset_password_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_confirm_reset_password_options.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 part 'cognito_confirm_reset_password_options.g.dart';
@@ -53,36 +54,4 @@ class CognitoConfirmResetPasswordOptions extends ConfirmResetPasswordOptions {
   @override
   Map<String, Object?> toJson() =>
       _$CognitoConfirmResetPasswordOptionsToJson(this);
-}
-
-/// {@template amplify_auth_cognito.model.cognito_confirm_reset_password_plugin_options}
-/// Cognito options for `Amplify.Auth.confirmResetPassword`.
-/// {@endtemplate}
-@zAmplifySerializable
-class CognitoConfirmResetPasswordPluginOptions
-    extends ConfirmResetPasswordPluginOptions {
-  /// {@macro amplify_auth_cognito.model.cognito_confirm_reset_password_plugin_options}
-  const CognitoConfirmResetPasswordPluginOptions({
-    Map<String, String>? clientMetadata,
-  }) : clientMetadata = clientMetadata ?? const {};
-
-  /// {@macro amplify_auth_cognito.model.cognito_confirm_reset_password_plugin_options}
-  factory CognitoConfirmResetPasswordPluginOptions.fromJson(
-    Map<String, Object?> json,
-  ) =>
-      _$CognitoConfirmResetPasswordPluginOptionsFromJson(json);
-
-  /// Additional custom attributes to be sent to the service such as information
-  /// about the client.
-  final Map<String, String> clientMetadata;
-
-  @override
-  List<Object?> get props => [clientMetadata];
-
-  @override
-  String get runtimeTypeName => 'CognitoConfirmResetPasswordPluginOptions';
-
-  @override
-  Map<String, Object?> toJson() =>
-      _$CognitoConfirmResetPasswordPluginOptionsToJson(this);
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_confirm_reset_password_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_confirm_reset_password_options.g.dart
@@ -19,19 +19,3 @@ Map<String, dynamic> _$CognitoConfirmResetPasswordOptionsToJson(
     <String, dynamic>{
       'clientMetadata': instance.clientMetadata,
     };
-
-CognitoConfirmResetPasswordPluginOptions
-    _$CognitoConfirmResetPasswordPluginOptionsFromJson(
-            Map<String, dynamic> json) =>
-        CognitoConfirmResetPasswordPluginOptions(
-          clientMetadata:
-              (json['clientMetadata'] as Map<String, dynamic>?)?.map(
-            (k, e) => MapEntry(k, e as String),
-          ),
-        );
-
-Map<String, dynamic> _$CognitoConfirmResetPasswordPluginOptionsToJson(
-        CognitoConfirmResetPasswordPluginOptions instance) =>
-    <String, dynamic>{
-      'clientMetadata': instance.clientMetadata,
-    };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_confirm_reset_password_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_confirm_reset_password_plugin_options.dart
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_confirm_reset_password_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_confirm_reset_password_plugin_options}
+/// Cognito options for `Amplify.Auth.confirmResetPassword`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoConfirmResetPasswordPluginOptions
+    extends ConfirmResetPasswordPluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_confirm_reset_password_plugin_options}
+  const CognitoConfirmResetPasswordPluginOptions({
+    Map<String, String>? clientMetadata,
+  }) : clientMetadata = clientMetadata ?? const {};
+
+  /// {@macro amplify_auth_cognito.model.cognito_confirm_reset_password_plugin_options}
+  factory CognitoConfirmResetPasswordPluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoConfirmResetPasswordPluginOptionsFromJson(json);
+
+  /// Additional custom attributes to be sent to the service such as information
+  /// about the client.
+  final Map<String, String> clientMetadata;
+
+  @override
+  List<Object?> get props => [clientMetadata];
+
+  @override
+  String get runtimeTypeName => 'CognitoConfirmResetPasswordPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoConfirmResetPasswordPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_confirm_reset_password_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_confirm_reset_password_plugin_options.g.dart
@@ -1,23 +1,23 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'cognito_resend_user_attribute_confirmation_code_options.dart';
+part of 'cognito_confirm_reset_password_plugin_options.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-CognitoResendUserAttributeConfirmationCodeOptions
-    _$CognitoResendUserAttributeConfirmationCodeOptionsFromJson(
+CognitoConfirmResetPasswordPluginOptions
+    _$CognitoConfirmResetPasswordPluginOptionsFromJson(
             Map<String, dynamic> json) =>
-        CognitoResendUserAttributeConfirmationCodeOptions(
+        CognitoConfirmResetPasswordPluginOptions(
           clientMetadata:
               (json['clientMetadata'] as Map<String, dynamic>?)?.map(
             (k, e) => MapEntry(k, e as String),
           ),
         );
 
-Map<String, dynamic> _$CognitoResendUserAttributeConfirmationCodeOptionsToJson(
-        CognitoResendUserAttributeConfirmationCodeOptions instance) =>
+Map<String, dynamic> _$CognitoConfirmResetPasswordPluginOptionsToJson(
+        CognitoConfirmResetPasswordPluginOptions instance) =>
     <String, dynamic>{
       'clientMetadata': instance.clientMetadata,
     };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_reset_password_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_reset_password_options.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 part 'cognito_reset_password_options.g.dart';
@@ -50,35 +51,4 @@ class CognitoResetPasswordOptions extends ResetPasswordOptions {
 
   @override
   Map<String, Object?> toJson() => _$CognitoResetPasswordOptionsToJson(this);
-}
-
-/// {@template amplify_auth_cognito.model.cognito_reset_password_plugin_options}
-/// Cognito options for `Amplify.Auth.resetPassword`.
-/// {@endtemplate}
-@zAmplifySerializable
-class CognitoResetPasswordPluginOptions extends ResetPasswordPluginOptions {
-  /// {@macro amplify_auth_cognito.model.cognito_reset_password_plugin_options}
-  const CognitoResetPasswordPluginOptions({
-    Map<String, String>? clientMetadata,
-  }) : clientMetadata = clientMetadata ?? const {};
-
-  /// {@macro amplify_auth_cognito.model.cognito_reset_password_plugin_options}
-  factory CognitoResetPasswordPluginOptions.fromJson(
-    Map<String, Object?> json,
-  ) =>
-      _$CognitoResetPasswordPluginOptionsFromJson(json);
-
-  /// Additional custom attributes to be sent to the service such as information
-  /// about the client.
-  final Map<String, String> clientMetadata;
-
-  @override
-  List<Object?> get props => [clientMetadata];
-
-  @override
-  String get runtimeTypeName => 'CognitoResetPasswordPluginOptions';
-
-  @override
-  Map<String, Object?> toJson() =>
-      _$CognitoResetPasswordPluginOptionsToJson(this);
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_reset_password_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_reset_password_options.g.dart
@@ -19,17 +19,3 @@ Map<String, dynamic> _$CognitoResetPasswordOptionsToJson(
     <String, dynamic>{
       'clientMetadata': instance.clientMetadata,
     };
-
-CognitoResetPasswordPluginOptions _$CognitoResetPasswordPluginOptionsFromJson(
-        Map<String, dynamic> json) =>
-    CognitoResetPasswordPluginOptions(
-      clientMetadata: (json['clientMetadata'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(k, e as String),
-      ),
-    );
-
-Map<String, dynamic> _$CognitoResetPasswordPluginOptionsToJson(
-        CognitoResetPasswordPluginOptions instance) =>
-    <String, dynamic>{
-      'clientMetadata': instance.clientMetadata,
-    };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_reset_password_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_reset_password_plugin_options.dart
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_reset_password_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_reset_password_plugin_options}
+/// Cognito options for `Amplify.Auth.resetPassword`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoResetPasswordPluginOptions extends ResetPasswordPluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_reset_password_plugin_options}
+  const CognitoResetPasswordPluginOptions({
+    Map<String, String>? clientMetadata,
+  }) : clientMetadata = clientMetadata ?? const {};
+
+  /// {@macro amplify_auth_cognito.model.cognito_reset_password_plugin_options}
+  factory CognitoResetPasswordPluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoResetPasswordPluginOptionsFromJson(json);
+
+  /// Additional custom attributes to be sent to the service such as information
+  /// about the client.
+  final Map<String, String> clientMetadata;
+
+  @override
+  List<Object?> get props => [clientMetadata];
+
+  @override
+  String get runtimeTypeName => 'CognitoResetPasswordPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoResetPasswordPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_reset_password_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_reset_password_plugin_options.g.dart
@@ -1,21 +1,21 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'cognito_update_user_attribute_options.dart';
+part of 'cognito_reset_password_plugin_options.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-CognitoUpdateUserAttributeOptions _$CognitoUpdateUserAttributeOptionsFromJson(
+CognitoResetPasswordPluginOptions _$CognitoResetPasswordPluginOptionsFromJson(
         Map<String, dynamic> json) =>
-    CognitoUpdateUserAttributeOptions(
+    CognitoResetPasswordPluginOptions(
       clientMetadata: (json['clientMetadata'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
     );
 
-Map<String, dynamic> _$CognitoUpdateUserAttributeOptionsToJson(
-        CognitoUpdateUserAttributeOptions instance) =>
+Map<String, dynamic> _$CognitoResetPasswordPluginOptionsToJson(
+        CognitoResetPasswordPluginOptions instance) =>
     <String, dynamic>{
       'clientMetadata': instance.clientMetadata,
     };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_update_password_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_update_password_plugin_options.dart
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_update_password_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_update_password_plugin_options}
+/// Cognito options for `Amplify.Auth.updatePassword`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoUpdatePasswordPluginOptions extends UpdatePasswordPluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_update_password_plugin_options}
+  const CognitoUpdatePasswordPluginOptions();
+
+  /// {@macro amplify_auth_cognito.model.cognito_update_password_plugin_options}
+  factory CognitoUpdatePasswordPluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoUpdatePasswordPluginOptionsFromJson(json);
+
+  @override
+  List<Object?> get props => [];
+
+  @override
+  String get runtimeTypeName => 'CognitoUpdatePasswordPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoUpdatePasswordPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_update_password_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/password/cognito_update_password_plugin_options.g.dart
@@ -1,0 +1,15 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cognito_update_password_plugin_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CognitoUpdatePasswordPluginOptions _$CognitoUpdatePasswordPluginOptionsFromJson(
+        Map<String, dynamic> json) =>
+    CognitoUpdatePasswordPluginOptions();
+
+Map<String, dynamic> _$CognitoUpdatePasswordPluginOptionsToJson(
+        CognitoUpdatePasswordPluginOptions instance) =>
+    <String, dynamic>{};

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_fetch_auth_session_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_fetch_auth_session_plugin_options.dart
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_fetch_auth_session_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_fetch_auth_session_plugin_options}
+/// Cognito options for `Amplify.Auth.fetchAuthSession`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoFetchAuthSessionPluginOptions
+    extends FetchAuthSessionPluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_fetch_auth_session_plugin_options}
+  const CognitoFetchAuthSessionPluginOptions();
+
+  /// {@macro amplify_auth_cognito.model.cognito_fetch_auth_session_plugin_options}
+  factory CognitoFetchAuthSessionPluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoFetchAuthSessionPluginOptionsFromJson(json);
+
+  @override
+  List<Object?> get props => [];
+
+  @override
+  String get runtimeTypeName => 'CognitoFetchAuthSessionPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoFetchAuthSessionPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_fetch_auth_session_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_fetch_auth_session_plugin_options.g.dart
@@ -1,0 +1,15 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cognito_fetch_auth_session_plugin_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CognitoFetchAuthSessionPluginOptions
+    _$CognitoFetchAuthSessionPluginOptionsFromJson(Map<String, dynamic> json) =>
+        CognitoFetchAuthSessionPluginOptions();
+
+Map<String, dynamic> _$CognitoFetchAuthSessionPluginOptionsToJson(
+        CognitoFetchAuthSessionPluginOptions instance) =>
+    <String, dynamic>{};

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_get_current_user_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_get_current_user_plugin_options.dart
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_get_current_user_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_get_current_user_plugin_options}
+/// Cognito options for `Amplify.Auth.getCurrentUser`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoGetCurrentUserPluginOptions extends GetCurrentUserPluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_get_current_user_plugin_options}
+  const CognitoGetCurrentUserPluginOptions();
+
+  /// {@macro amplify_auth_cognito.model.cognito_get_current_user_plugin_options}
+  factory CognitoGetCurrentUserPluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoGetCurrentUserPluginOptionsFromJson(json);
+
+  @override
+  List<Object?> get props => [];
+
+  @override
+  String get runtimeTypeName => 'CognitoGetCurrentUserPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoGetCurrentUserPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_get_current_user_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/session/cognito_get_current_user_plugin_options.g.dart
@@ -1,0 +1,15 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cognito_get_current_user_plugin_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CognitoGetCurrentUserPluginOptions _$CognitoGetCurrentUserPluginOptionsFromJson(
+        Map<String, dynamic> json) =>
+    CognitoGetCurrentUserPluginOptions();
+
+Map<String, dynamic> _$CognitoGetCurrentUserPluginOptionsToJson(
+        CognitoGetCurrentUserPluginOptions instance) =>
+    <String, dynamic>{};

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_confirm_sign_in_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_confirm_sign_in_options.dart
@@ -1,9 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
-
-part 'cognito_confirm_sign_in_options.g.dart';
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 
 const _deprecatedMessage = '''
 Use ConfirmSignInOptions instead. If Cognito-specific options are needed, use `pluginOptions`:
@@ -50,41 +48,4 @@ class CognitoConfirmSignInOptions extends ConfirmSignInOptions {
 
   @override
   String get runtimeTypeName => 'CognitoConfirmSignInOptions';
-}
-
-/// {@template amplify_auth_cognito.model.cognito_confirm_sign_in_plugin_options}
-/// Cognito options for `Amplify.Auth.confirmSignIn`.
-/// {@endtemplate}
-@zAmplifySerializable
-class CognitoConfirmSignInPluginOptions extends ConfirmSignInPluginOptions {
-  /// {@macro amplify_auth_cognito.model.cognito_confirm_sign_in_plugin_options}
-  const CognitoConfirmSignInPluginOptions({
-    Map<String, String>? clientMetadata,
-    Map<CognitoUserAttributeKey, String>? userAttributes,
-  })  : clientMetadata = clientMetadata ?? const {},
-        userAttributes = userAttributes ?? const {};
-
-  /// {@macro amplify_auth_cognito.model.cognito_confirm_sign_in_plugin_options}
-  factory CognitoConfirmSignInPluginOptions.fromJson(
-    Map<String, Object?> json,
-  ) =>
-      _$CognitoConfirmSignInPluginOptionsFromJson(json);
-
-  /// A map of custom key-value pairs that you can provide as input for certain
-  /// custom workflows that this action triggers.
-  final Map<String, String> clientMetadata;
-
-  /// User attributes which were marked as required and have not been previously
-  /// provided.
-  final Map<CognitoUserAttributeKey, String> userAttributes;
-
-  @override
-  List<Object?> get props => [clientMetadata, userAttributes];
-
-  @override
-  String get runtimeTypeName => 'CognitoConfirmSignInPluginOptions';
-
-  @override
-  Map<String, Object?> toJson() =>
-      _$CognitoConfirmSignInPluginOptionsToJson(this);
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_confirm_sign_in_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_confirm_sign_in_plugin_options.dart
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_confirm_sign_in_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_confirm_sign_in_plugin_options}
+/// Cognito options for `Amplify.Auth.confirmSignIn`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoConfirmSignInPluginOptions extends ConfirmSignInPluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_confirm_sign_in_plugin_options}
+  const CognitoConfirmSignInPluginOptions({
+    Map<String, String>? clientMetadata,
+    Map<CognitoUserAttributeKey, String>? userAttributes,
+  })  : clientMetadata = clientMetadata ?? const {},
+        userAttributes = userAttributes ?? const {};
+
+  /// {@macro amplify_auth_cognito.model.cognito_confirm_sign_in_plugin_options}
+  factory CognitoConfirmSignInPluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoConfirmSignInPluginOptionsFromJson(json);
+
+  /// A map of custom key-value pairs that you can provide as input for certain
+  /// custom workflows that this action triggers.
+  final Map<String, String> clientMetadata;
+
+  /// User attributes which were marked as required and have not been previously
+  /// provided.
+  final Map<CognitoUserAttributeKey, String> userAttributes;
+
+  @override
+  List<Object?> get props => [clientMetadata, userAttributes];
+
+  @override
+  String get runtimeTypeName => 'CognitoConfirmSignInPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoConfirmSignInPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_confirm_sign_in_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_confirm_sign_in_plugin_options.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'cognito_confirm_sign_in_options.dart';
+part of 'cognito_confirm_sign_in_plugin_options.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_options.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 part 'cognito_sign_in_options.g.dart';
@@ -50,40 +51,4 @@ class CognitoSignInOptions extends SignInOptions {
 
   @override
   Map<String, Object?> toJson() => _$CognitoSignInOptionsToJson(this);
-}
-
-/// {@template amplify_auth_cognito.model.cognito_sign_in_plugin_options}
-/// Cognito options for `Amplify.Auth.signIn`.
-/// {@endtemplate}
-@zAmplifySerializable
-class CognitoSignInPluginOptions extends SignInPluginOptions {
-  /// {@macro amplify_auth_cognito.model.cognito_sign_in_plugin_options}
-  const CognitoSignInPluginOptions({
-    this.authFlowType,
-    this.clientMetadata = const {},
-  });
-
-  /// {@macro amplify_auth_cognito.model.cognito_sign_in_plugin_options}
-  factory CognitoSignInPluginOptions.fromJson(Map<String, Object?> json) =>
-      _$CognitoSignInPluginOptionsFromJson(json);
-
-  /// {@template amplify_auth_cognito_dart.cognito_sign_in_plugin_options.auth_flow_type}
-  /// Runtime override of the Authentication flow to use for sign in.
-  /// {@endtemplate}
-  final AuthenticationFlowType? authFlowType;
-
-  /// {@template amplify_auth_cognito_dart.cognito_sign_in_plugin_options.client_metadata}
-  /// A map of custom key-value pairs that you can provide as input for certain
-  /// custom workflows that this action triggers.
-  /// {@endtemplate}
-  final Map<String, String> clientMetadata;
-
-  @override
-  List<Object?> get props => [authFlowType, clientMetadata];
-
-  @override
-  String get runtimeTypeName => 'CognitoSignInPluginOptions';
-
-  @override
-  Map<String, Object?> toJson() => _$CognitoSignInPluginOptionsToJson(this);
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_plugin_options.dart
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_sign_in_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_sign_in_plugin_options}
+/// Cognito options for `Amplify.Auth.signIn`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoSignInPluginOptions extends SignInPluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_sign_in_plugin_options}
+  const CognitoSignInPluginOptions({
+    this.authFlowType,
+    this.clientMetadata = const {},
+  });
+
+  /// {@macro amplify_auth_cognito.model.cognito_sign_in_plugin_options}
+  factory CognitoSignInPluginOptions.fromJson(Map<String, Object?> json) =>
+      _$CognitoSignInPluginOptionsFromJson(json);
+
+  /// {@template amplify_auth_cognito_dart.cognito_sign_in_plugin_options.auth_flow_type}
+  /// Runtime override of the Authentication flow to use for sign in.
+  /// {@endtemplate}
+  final AuthenticationFlowType? authFlowType;
+
+  /// {@template amplify_auth_cognito_dart.cognito_sign_in_plugin_options.client_metadata}
+  /// A map of custom key-value pairs that you can provide as input for certain
+  /// custom workflows that this action triggers.
+  /// {@endtemplate}
+  final Map<String, String> clientMetadata;
+
+  @override
+  List<Object?> get props => [authFlowType, clientMetadata];
+
+  @override
+  String get runtimeTypeName => 'CognitoSignInPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() => _$CognitoSignInPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_plugin_options.g.dart
@@ -1,14 +1,14 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'cognito_sign_in_options.dart';
+part of 'cognito_sign_in_plugin_options.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-CognitoSignInOptions _$CognitoSignInOptionsFromJson(
+CognitoSignInPluginOptions _$CognitoSignInPluginOptionsFromJson(
         Map<String, dynamic> json) =>
-    CognitoSignInOptions(
+    CognitoSignInPluginOptions(
       authFlowType: $enumDecodeNullable(
           _$AuthenticationFlowTypeEnumMap, json['authFlowType']),
       clientMetadata: (json['clientMetadata'] as Map<String, dynamic>?)?.map(
@@ -17,8 +17,8 @@ CognitoSignInOptions _$CognitoSignInOptionsFromJson(
           const {},
     );
 
-Map<String, dynamic> _$CognitoSignInOptionsToJson(
-    CognitoSignInOptions instance) {
+Map<String, dynamic> _$CognitoSignInPluginOptionsToJson(
+    CognitoSignInPluginOptions instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_with_web_ui_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_with_web_ui_options.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 part 'cognito_sign_in_with_web_ui_options.g.dart';
@@ -51,49 +52,4 @@ class CognitoSignInWithWebUIOptions extends SignInWithWebUIOptions {
 
   @override
   Map<String, Object?> toJson() => _$CognitoSignInWithWebUIOptionsToJson(this);
-}
-
-/// {@template amplify_auth_cognito.model.cognito_sign_in_with_web_ui_plugin_options}
-/// Cognito options for `Amplify.Auth.signIn`.
-/// {@endtemplate}
-@zAmplifySerializable
-class CognitoSignInWithWebUIPluginOptions extends SignInWithWebUIPluginOptions {
-  /// {@macro amplify_auth_cognito.model.cognito_sign_in_with_web_ui_plugin_options}
-  const CognitoSignInWithWebUIPluginOptions({
-    this.isPreferPrivateSession = false,
-    this.browserPackageName,
-  });
-
-  /// {@macro amplify_auth_cognito.model.cognito_sign_in_with_web_ui_plugin_options}
-  factory CognitoSignInWithWebUIPluginOptions.fromJson(
-    Map<String, Object?> json,
-  ) =>
-      _$CognitoSignInWithWebUIPluginOptionsFromJson(json);
-
-  /// {@template amplify_auth_cognito.model.cognito_sign_in_with_web_ui_options.private_session}
-  /// iOS-only: Starts the webUI signin in a private browser session, if supported by the current browser.
-  ///
-  /// Note that this value internally sets `prefersEphemeralWebBrowserSession` in ASWebAuthenticationSession.
-  /// As per Apple documentation, Whether the request is honored depends on the user’s default web browser.
-  /// Safari always honors the request.
-  ///
-  /// Defaults to `false`.
-  /// {@endtemplate}
-  final bool isPreferPrivateSession;
-
-  /// {@template amplify_auth_cognito.model.cognito_sign_in_with_web_ui_options.browser_package_name}
-  /// Android-only: The browser package name (application ID) to use to launch
-  /// the custom tab.
-  /// {@endtemplate}
-  final String? browserPackageName;
-
-  @override
-  List<Object?> get props => [isPreferPrivateSession, browserPackageName];
-
-  @override
-  String get runtimeTypeName => 'CognitoSignInWithWebUIPluginOptions';
-
-  @override
-  Map<String, Object?> toJson() =>
-      _$CognitoSignInWithWebUIPluginOptionsToJson(this);
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_with_web_ui_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_with_web_ui_plugin_options.dart
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_sign_in_with_web_ui_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_sign_in_with_web_ui_plugin_options}
+/// Cognito options for `Amplify.Auth.signIn`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoSignInWithWebUIPluginOptions extends SignInWithWebUIPluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_sign_in_with_web_ui_plugin_options}
+  const CognitoSignInWithWebUIPluginOptions({
+    this.isPreferPrivateSession = false,
+    this.browserPackageName,
+  });
+
+  /// {@macro amplify_auth_cognito.model.cognito_sign_in_with_web_ui_plugin_options}
+  factory CognitoSignInWithWebUIPluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoSignInWithWebUIPluginOptionsFromJson(json);
+
+  /// {@template amplify_auth_cognito.model.cognito_sign_in_with_web_ui_options.private_session}
+  /// iOS-only: Starts the webUI signin in a private browser session, if supported by the current browser.
+  ///
+  /// Note that this value internally sets `prefersEphemeralWebBrowserSession` in ASWebAuthenticationSession.
+  /// As per Apple documentation, Whether the request is honored depends on the user’s default web browser.
+  /// Safari always honors the request.
+  ///
+  /// Defaults to `false`.
+  /// {@endtemplate}
+  final bool isPreferPrivateSession;
+
+  /// {@template amplify_auth_cognito.model.cognito_sign_in_with_web_ui_options.browser_package_name}
+  /// Android-only: The browser package name (application ID) to use to launch
+  /// the custom tab.
+  /// {@endtemplate}
+  final String? browserPackageName;
+
+  @override
+  List<Object?> get props => [isPreferPrivateSession, browserPackageName];
+
+  @override
+  String get runtimeTypeName => 'CognitoSignInWithWebUIPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoSignInWithWebUIPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_with_web_ui_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_with_web_ui_plugin_options.g.dart
@@ -1,20 +1,21 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'cognito_sign_in_with_web_ui_options.dart';
+part of 'cognito_sign_in_with_web_ui_plugin_options.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-CognitoSignInWithWebUIOptions _$CognitoSignInWithWebUIOptionsFromJson(
-        Map<String, dynamic> json) =>
-    CognitoSignInWithWebUIOptions(
-      isPreferPrivateSession: json['isPreferPrivateSession'] as bool? ?? false,
-      browserPackageName: json['browserPackageName'] as String?,
-    );
+CognitoSignInWithWebUIPluginOptions
+    _$CognitoSignInWithWebUIPluginOptionsFromJson(Map<String, dynamic> json) =>
+        CognitoSignInWithWebUIPluginOptions(
+          isPreferPrivateSession:
+              json['isPreferPrivateSession'] as bool? ?? false,
+          browserPackageName: json['browserPackageName'] as String?,
+        );
 
-Map<String, dynamic> _$CognitoSignInWithWebUIOptionsToJson(
-    CognitoSignInWithWebUIOptions instance) {
+Map<String, dynamic> _$CognitoSignInWithWebUIPluginOptionsToJson(
+    CognitoSignInWithWebUIPluginOptions instance) {
   final val = <String, dynamic>{
     'isPreferPrivateSession': instance.isPreferPrivateSession,
   };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_plugin_options.dart
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_sign_out_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_sign_out_plugin_options}
+/// Cognito options for `Amplify.Auth.signOut`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoSignOutPluginOptions extends SignOutPluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_sign_out_plugin_options}
+  const CognitoSignOutPluginOptions();
+
+  /// {@macro amplify_auth_cognito.model.cognito_sign_out_plugin_options}
+  factory CognitoSignOutPluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoSignOutPluginOptionsFromJson(json);
+
+  @override
+  List<Object?> get props => [];
+
+  @override
+  String get runtimeTypeName => 'CognitoSignOutPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() => _$CognitoSignOutPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_plugin_options.g.dart
@@ -1,0 +1,15 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cognito_sign_out_plugin_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CognitoSignOutPluginOptions _$CognitoSignOutPluginOptionsFromJson(
+        Map<String, dynamic> json) =>
+    CognitoSignOutPluginOptions();
+
+Map<String, dynamic> _$CognitoSignOutPluginOptionsToJson(
+        CognitoSignOutPluginOptions instance) =>
+    <String, dynamic>{};

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_confirm_sign_up_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_confirm_sign_up_options.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 part 'cognito_confirm_sign_up_options.g.dart';
@@ -46,37 +47,4 @@ class CognitoConfirmSignUpOptions extends ConfirmSignUpOptions {
 
   @override
   Map<String, Object?> toJson() => _$CognitoConfirmSignUpOptionsToJson(this);
-}
-
-/// {@template amplify_auth_cognito_dart.cognito_confirm_sign_up_plugin_options}
-/// Cognito options for `Amplify.Auth.confirmSignUp`.
-/// {@endtemplate}
-@zAmplifySerializable
-class CognitoConfirmSignUpPluginOptions extends ConfirmSignUpPluginOptions {
-  /// {@macro amplify_auth_cognito_dart.cognito_confirm_sign_up_plugin_options}
-  const CognitoConfirmSignUpPluginOptions({
-    this.clientMetadata = const {},
-  });
-
-  /// {@macro amplify_auth_cognito_dart.cognito_confirm_sign_up_plugin_options}
-  factory CognitoConfirmSignUpPluginOptions.fromJson(
-    Map<String, Object?> json,
-  ) =>
-      _$CognitoConfirmSignUpPluginOptionsFromJson(json);
-
-  /// {@template amplify_auth_cognito_dart.cognito_confirm_sign_up_plugin_options.client_metadata}
-  /// A map of custom key-value pairs that you can provide as input for certain
-  /// custom workflows that this action triggers.
-  /// {@endtemplate}
-  final Map<String, String> clientMetadata;
-
-  @override
-  List<Object?> get props => [clientMetadata];
-
-  @override
-  String get runtimeTypeName => 'CognitoConfirmSignUpPluginOptions';
-
-  @override
-  Map<String, Object?> toJson() =>
-      _$CognitoConfirmSignUpPluginOptionsToJson(this);
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_confirm_sign_up_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_confirm_sign_up_options.g.dart
@@ -20,18 +20,3 @@ Map<String, dynamic> _$CognitoConfirmSignUpOptionsToJson(
     <String, dynamic>{
       'clientMetadata': instance.clientMetadata,
     };
-
-CognitoConfirmSignUpPluginOptions _$CognitoConfirmSignUpPluginOptionsFromJson(
-        Map<String, dynamic> json) =>
-    CognitoConfirmSignUpPluginOptions(
-      clientMetadata: (json['clientMetadata'] as Map<String, dynamic>?)?.map(
-            (k, e) => MapEntry(k, e as String),
-          ) ??
-          const {},
-    );
-
-Map<String, dynamic> _$CognitoConfirmSignUpPluginOptionsToJson(
-        CognitoConfirmSignUpPluginOptions instance) =>
-    <String, dynamic>{
-      'clientMetadata': instance.clientMetadata,
-    };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_confirm_sign_up_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_confirm_sign_up_plugin_options.dart
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_confirm_sign_up_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito_dart.cognito_confirm_sign_up_plugin_options}
+/// Cognito options for `Amplify.Auth.confirmSignUp`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoConfirmSignUpPluginOptions extends ConfirmSignUpPluginOptions {
+  /// {@macro amplify_auth_cognito_dart.cognito_confirm_sign_up_plugin_options}
+  const CognitoConfirmSignUpPluginOptions({
+    this.clientMetadata = const {},
+  });
+
+  /// {@macro amplify_auth_cognito_dart.cognito_confirm_sign_up_plugin_options}
+  factory CognitoConfirmSignUpPluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoConfirmSignUpPluginOptionsFromJson(json);
+
+  /// {@template amplify_auth_cognito_dart.cognito_confirm_sign_up_plugin_options.client_metadata}
+  /// A map of custom key-value pairs that you can provide as input for certain
+  /// custom workflows that this action triggers.
+  /// {@endtemplate}
+  final Map<String, String> clientMetadata;
+
+  @override
+  List<Object?> get props => [clientMetadata];
+
+  @override
+  String get runtimeTypeName => 'CognitoConfirmSignUpPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoConfirmSignUpPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_confirm_sign_up_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_confirm_sign_up_plugin_options.g.dart
@@ -1,21 +1,22 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'cognito_update_user_attribute_options.dart';
+part of 'cognito_confirm_sign_up_plugin_options.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-CognitoUpdateUserAttributeOptions _$CognitoUpdateUserAttributeOptionsFromJson(
+CognitoConfirmSignUpPluginOptions _$CognitoConfirmSignUpPluginOptionsFromJson(
         Map<String, dynamic> json) =>
-    CognitoUpdateUserAttributeOptions(
+    CognitoConfirmSignUpPluginOptions(
       clientMetadata: (json['clientMetadata'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(k, e as String),
-      ),
+            (k, e) => MapEntry(k, e as String),
+          ) ??
+          const {},
     );
 
-Map<String, dynamic> _$CognitoUpdateUserAttributeOptionsToJson(
-        CognitoUpdateUserAttributeOptions instance) =>
+Map<String, dynamic> _$CognitoConfirmSignUpPluginOptionsToJson(
+        CognitoConfirmSignUpPluginOptions instance) =>
     <String, dynamic>{
       'clientMetadata': instance.clientMetadata,
     };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_resend_sign_up_code_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_resend_sign_up_code_options.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 part 'cognito_resend_sign_up_code_options.g.dart';
@@ -39,38 +40,4 @@ class CognitoResendSignUpCodeOptions extends ResendSignUpCodeOptions {
 
   @override
   String get runtimeTypeName => 'CognitoResendSignUpCodeOptions';
-}
-
-/// {@template amplify_auth_cognito_dart.model.cognito_resend_sign_up_code_plugin_options}
-/// Cognito options for `Amplify.Auth.resendSignUpCode`.
-/// {@endtemplate}
-@zAmplifySerializable
-class CognitoResendSignUpCodePluginOptions
-    extends ResendSignUpCodePluginOptions {
-  /// {@macro amplify_auth_cognito_dart.model.cognito_resend_sign_up_code_plugin_options}
-  const CognitoResendSignUpCodePluginOptions({
-    this.clientMetadata = const {},
-  });
-
-  /// {@macro amplify_auth_cognito_dart.model.cognito_resend_sign_up_code_plugin_options}
-  factory CognitoResendSignUpCodePluginOptions.fromJson(
-    Map<String, Object?> json,
-  ) =>
-      _$CognitoResendSignUpCodePluginOptionsFromJson(json);
-
-  /// {@template amplify_auth_cognito_dart.model.cognito_resend_sign_up_code_plugin_options.client_metadata}
-  /// Additional custom attributes to be sent to the service such as information
-  /// about the client.
-  /// {@endtemplate}
-  final Map<String, String> clientMetadata;
-
-  @override
-  List<Object?> get props => [clientMetadata];
-
-  @override
-  String get runtimeTypeName => 'CognitoResendSignUpCodePluginOptions';
-
-  @override
-  Map<String, Object?> toJson() =>
-      _$CognitoResendSignUpCodePluginOptionsToJson(this);
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_resend_sign_up_code_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_resend_sign_up_code_options.g.dart
@@ -20,19 +20,3 @@ Map<String, dynamic> _$CognitoResendSignUpCodeOptionsToJson(
     <String, dynamic>{
       'clientMetadata': instance.clientMetadata,
     };
-
-CognitoResendSignUpCodePluginOptions
-    _$CognitoResendSignUpCodePluginOptionsFromJson(Map<String, dynamic> json) =>
-        CognitoResendSignUpCodePluginOptions(
-          clientMetadata:
-              (json['clientMetadata'] as Map<String, dynamic>?)?.map(
-                    (k, e) => MapEntry(k, e as String),
-                  ) ??
-                  const {},
-        );
-
-Map<String, dynamic> _$CognitoResendSignUpCodePluginOptionsToJson(
-        CognitoResendSignUpCodePluginOptions instance) =>
-    <String, dynamic>{
-      'clientMetadata': instance.clientMetadata,
-    };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_resend_sign_up_code_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_resend_sign_up_code_plugin_options.dart
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_resend_sign_up_code_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito_dart.model.cognito_resend_sign_up_code_plugin_options}
+/// Cognito options for `Amplify.Auth.resendSignUpCode`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoResendSignUpCodePluginOptions
+    extends ResendSignUpCodePluginOptions {
+  /// {@macro amplify_auth_cognito_dart.model.cognito_resend_sign_up_code_plugin_options}
+  const CognitoResendSignUpCodePluginOptions({
+    this.clientMetadata = const {},
+  });
+
+  /// {@macro amplify_auth_cognito_dart.model.cognito_resend_sign_up_code_plugin_options}
+  factory CognitoResendSignUpCodePluginOptions.fromJson(
+    Map<String, Object?> json,
+  ) =>
+      _$CognitoResendSignUpCodePluginOptionsFromJson(json);
+
+  /// {@template amplify_auth_cognito_dart.model.cognito_resend_sign_up_code_plugin_options.client_metadata}
+  /// Additional custom attributes to be sent to the service such as information
+  /// about the client.
+  /// {@endtemplate}
+  final Map<String, String> clientMetadata;
+
+  @override
+  List<Object?> get props => [clientMetadata];
+
+  @override
+  String get runtimeTypeName => 'CognitoResendSignUpCodePluginOptions';
+
+  @override
+  Map<String, Object?> toJson() =>
+      _$CognitoResendSignUpCodePluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_resend_sign_up_code_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_resend_sign_up_code_plugin_options.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cognito_resend_sign_up_code_plugin_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CognitoResendSignUpCodePluginOptions
+    _$CognitoResendSignUpCodePluginOptionsFromJson(Map<String, dynamic> json) =>
+        CognitoResendSignUpCodePluginOptions(
+          clientMetadata:
+              (json['clientMetadata'] as Map<String, dynamic>?)?.map(
+                    (k, e) => MapEntry(k, e as String),
+                  ) ??
+                  const {},
+        );
+
+Map<String, dynamic> _$CognitoResendSignUpCodePluginOptionsToJson(
+        CognitoResendSignUpCodePluginOptions instance) =>
+    <String, dynamic>{
+      'clientMetadata': instance.clientMetadata,
+    };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_sign_up_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_sign_up_options.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 
 part 'cognito_sign_up_options.g.dart';
@@ -61,43 +62,4 @@ class CognitoSignUpOptions extends SignUpOptions {
 
   @override
   Map<String, Object?> toJson() => _$CognitoSignUpOptionsToJson(this);
-}
-
-/// {@template amplify_auth_cognito.model.cognito_sign_up_plugin_options}
-/// Cognito options for `Amplify.Auth.signUp`.
-/// {@endtemplate}
-@zAmplifySerializable
-class CognitoSignUpPluginOptions extends SignUpPluginOptions {
-  /// {@macro amplify_auth_cognito.model.cognito_sign_up_plugin_options}
-  const CognitoSignUpPluginOptions({
-    Map<String, String>? clientMetadata,
-    Map<String, String>? validationData,
-  })  : validationData = validationData ?? const {},
-        clientMetadata = clientMetadata ?? const {};
-
-  /// {@macro amplify_auth_cognito.model.cognito_sign_up_plugin_options}
-  factory CognitoSignUpPluginOptions.fromJson(Map<String, Object?> json) =>
-      _$CognitoSignUpPluginOptionsFromJson(json);
-
-  /// {@template amplify_auth_cognito_dart.cognito_sign_up_options.client_metadata}
-  /// Additional custom attributes to be sent to the service such as information
-  /// about the client.
-  /// {@endtemplate}
-  final Map<String, String> clientMetadata;
-
-  /// {@template amplify_auth_cognito_dart.cognito_sign_up_options.validation_data}
-  /// An optional map of arbitrary key-value pairs which will be passed to your
-  /// PreAuthentication Lambda trigger as-is, used for implementing additional
-  /// validations around authentication.
-  /// {@endtemplate}
-  final Map<String, String> validationData;
-
-  @override
-  List<Object?> get props => [clientMetadata, validationData];
-
-  @override
-  String get runtimeTypeName => 'CognitoSignUpPluginOptions';
-
-  @override
-  Map<String, Object?> toJson() => _$CognitoSignUpPluginOptionsToJson(this);
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_sign_up_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_sign_up_options.g.dart
@@ -29,21 +29,3 @@ Map<String, dynamic> _$CognitoSignUpOptionsToJson(
       'validationData': instance.validationData,
       'clientMetadata': instance.clientMetadata,
     };
-
-CognitoSignUpPluginOptions _$CognitoSignUpPluginOptionsFromJson(
-        Map<String, dynamic> json) =>
-    CognitoSignUpPluginOptions(
-      clientMetadata: (json['clientMetadata'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(k, e as String),
-      ),
-      validationData: (json['validationData'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(k, e as String),
-      ),
-    );
-
-Map<String, dynamic> _$CognitoSignUpPluginOptionsToJson(
-        CognitoSignUpPluginOptions instance) =>
-    <String, dynamic>{
-      'clientMetadata': instance.clientMetadata,
-      'validationData': instance.validationData,
-    };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_sign_up_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_sign_up_plugin_options.dart
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_sign_up_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito.model.cognito_sign_up_plugin_options}
+/// Cognito options for `Amplify.Auth.signUp`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoSignUpPluginOptions extends SignUpPluginOptions {
+  /// {@macro amplify_auth_cognito.model.cognito_sign_up_plugin_options}
+  const CognitoSignUpPluginOptions({
+    Map<String, String>? clientMetadata,
+    Map<String, String>? validationData,
+  })  : validationData = validationData ?? const {},
+        clientMetadata = clientMetadata ?? const {};
+
+  /// {@macro amplify_auth_cognito.model.cognito_sign_up_plugin_options}
+  factory CognitoSignUpPluginOptions.fromJson(Map<String, Object?> json) =>
+      _$CognitoSignUpPluginOptionsFromJson(json);
+
+  /// {@template amplify_auth_cognito_dart.cognito_sign_up_options.client_metadata}
+  /// Additional custom attributes to be sent to the service such as information
+  /// about the client.
+  /// {@endtemplate}
+  final Map<String, String> clientMetadata;
+
+  /// {@template amplify_auth_cognito_dart.cognito_sign_up_options.validation_data}
+  /// An optional map of arbitrary key-value pairs which will be passed to your
+  /// PreAuthentication Lambda trigger as-is, used for implementing additional
+  /// validations around authentication.
+  /// {@endtemplate}
+  final Map<String, String> validationData;
+
+  @override
+  List<Object?> get props => [clientMetadata, validationData];
+
+  @override
+  String get runtimeTypeName => 'CognitoSignUpPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() => _$CognitoSignUpPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_sign_up_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signup/cognito_sign_up_plugin_options.g.dart
@@ -1,21 +1,25 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'cognito_update_user_attribute_options.dart';
+part of 'cognito_sign_up_plugin_options.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-CognitoUpdateUserAttributeOptions _$CognitoUpdateUserAttributeOptionsFromJson(
+CognitoSignUpPluginOptions _$CognitoSignUpPluginOptionsFromJson(
         Map<String, dynamic> json) =>
-    CognitoUpdateUserAttributeOptions(
+    CognitoSignUpPluginOptions(
       clientMetadata: (json['clientMetadata'] as Map<String, dynamic>?)?.map(
+        (k, e) => MapEntry(k, e as String),
+      ),
+      validationData: (json['validationData'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
     );
 
-Map<String, dynamic> _$CognitoUpdateUserAttributeOptionsToJson(
-        CognitoUpdateUserAttributeOptions instance) =>
+Map<String, dynamic> _$CognitoSignUpPluginOptionsToJson(
+        CognitoSignUpPluginOptions instance) =>
     <String, dynamic>{
       'clientMetadata': instance.clientMetadata,
+      'validationData': instance.validationData,
     };

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -166,7 +166,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     String? path,
     StorageListOptions? options,
   }) {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
+    final s3PluginOptions = reifyPluginOptions(
       pluginOptions: options?.pluginOptions,
       defaultPluginOptions: const S3ListPluginOptions(),
     );
@@ -192,7 +192,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     required String key,
     StorageGetPropertiesOptions? options,
   }) {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
+    final s3PluginOptions = reifyPluginOptions(
       pluginOptions: options?.pluginOptions,
       defaultPluginOptions: const S3GetPropertiesPluginOptions(),
     );
@@ -219,7 +219,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     required String key,
     StorageGetUrlOptions? options,
   }) {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
+    final s3PluginOptions = reifyPluginOptions(
       pluginOptions: options?.pluginOptions,
       defaultPluginOptions: const S3GetUrlPluginOptions(),
     );
@@ -247,7 +247,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     StorageDownloadDataOptions? options,
     void Function(S3TransferProgress)? onProgress,
   }) {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
+    final s3PluginOptions = reifyPluginOptions(
       pluginOptions: options?.pluginOptions,
       defaultPluginOptions: const S3DownloadDataPluginOptions(),
     );
@@ -289,13 +289,18 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     void Function(S3TransferProgress)? onProgress,
     StorageDownloadFileOptions? options,
   }) {
-    final request = StorageDownloadFileRequest(
+    final s3PluginOptions = reifyPluginOptions(
+      pluginOptions: options?.pluginOptions,
+      defaultPluginOptions: const S3DownloadFilePluginOptions(),
+    );
+    options = StorageDownloadFileOptions(
+      accessLevel: options?.accessLevel ?? s3pluginConfig.defaultAccessLevel,
+      pluginOptions: s3PluginOptions,
+    );
+    return download_file_impl.downloadFile(
       key: key,
       localFile: localFile,
       options: options,
-    );
-    return download_file_impl.downloadFile(
-      request: request,
       s3pluginConfig: s3pluginConfig,
       storageS3Service: storageS3Service,
       appPathProvider: _appPathProvider,
@@ -310,7 +315,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     void Function(S3TransferProgress)? onProgress,
     StorageUploadDataOptions? options,
   }) {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
+    final s3PluginOptions = reifyPluginOptions(
       pluginOptions: options?.pluginOptions,
       defaultPluginOptions: const S3UploadDataPluginOptions(),
     );
@@ -347,7 +352,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     void Function(S3TransferProgress)? onProgress,
     StorageUploadFileOptions? options,
   }) {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
+    final s3PluginOptions = reifyPluginOptions(
       pluginOptions: options?.pluginOptions,
       defaultPluginOptions: const S3UploadFilePluginOptions(),
     );
@@ -388,7 +393,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     final s3Source = S3ItemWithAccessLevel.from(source);
     final s3Destination = S3ItemWithAccessLevel.from(destination);
 
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
+    final s3PluginOptions = reifyPluginOptions(
       pluginOptions: options?.pluginOptions,
       defaultPluginOptions: const S3CopyPluginOptions(),
     );
@@ -417,7 +422,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     required StorageItemWithAccessLevel<StorageItem> destination,
     StorageMoveOptions? options,
   }) {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
+    final s3PluginOptions = reifyPluginOptions(
       pluginOptions: options?.pluginOptions,
       defaultPluginOptions: const S3MovePluginOptions(),
     );
@@ -448,7 +453,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     required String key,
     StorageRemoveOptions? options,
   }) {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
+    final s3PluginOptions = reifyPluginOptions(
       pluginOptions: options?.pluginOptions,
       defaultPluginOptions: const S3RemovePluginOptions(),
     );
@@ -475,7 +480,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     required List<String> keys,
     StorageRemoveManyOptions? options,
   }) {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
+    final s3PluginOptions = reifyPluginOptions(
       pluginOptions: options?.pluginOptions,
       defaultPluginOptions: const S3RemoveManyPluginOptions(),
     );

--- a/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_io.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_io.dart
@@ -12,29 +12,22 @@ import 'package:path/path.dart' as path;
 /// The io implementation of `downloadFile` API.
 @internal
 S3DownloadFileOperation downloadFile({
-  required StorageDownloadFileRequest request,
+  required String key,
+  required AWSFile localFile,
+  required StorageDownloadFileOptions options,
   required S3PluginConfig s3pluginConfig,
   required StorageS3Service storageS3Service,
   required AppPathProvider appPathProvider,
   void Function(S3TransferProgress)? onProgress,
 }) {
-  final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
-    pluginOptions: request.options?.pluginOptions,
-    defaultPluginOptions: const S3DownloadFilePluginOptions(),
-  );
-  final s3Options = StorageDownloadFileOptions(
-    accessLevel:
-        request.options?.accessLevel ?? s3pluginConfig.defaultAccessLevel,
-    pluginOptions: s3PluginOptions,
-  );
-
   late final String destinationPath;
   late final IOSink sink;
   late final File tempFile;
 
+  final s3PluginOptions = options.pluginOptions as S3DownloadFilePluginOptions;
   final targetIdentityId = s3PluginOptions.targetIdentityId;
   final downloadDataOptions = StorageDownloadDataOptions(
-    accessLevel: s3Options.accessLevel,
+    accessLevel: options.accessLevel,
     pluginOptions: targetIdentityId == null
         ? S3DownloadDataPluginOptions(
             getProperties: s3PluginOptions.getProperties,
@@ -48,12 +41,12 @@ S3DownloadFileOperation downloadFile({
   );
 
   final downloadDataTask = storageS3Service.downloadData(
-    key: request.key,
+    key: key,
     options: downloadDataOptions,
     // Ensure destination file is writable. Exception thrown in the check
     // will be forwarded to the Future, downloadDataTask.result below
     preStart: () async {
-      destinationPath = await _ensureDestinationWritable(request.localFile);
+      destinationPath = await _ensureDestinationWritable(localFile);
       tempFile = File(
         path.join(
           await appPathProvider.getTemporaryPath(),
@@ -85,15 +78,15 @@ S3DownloadFileOperation downloadFile({
 
   return S3DownloadFileOperation(
     request: StorageDownloadFileRequest(
-      key: request.key,
-      localFile: request.localFile,
-      options: s3Options,
+      key: key,
+      localFile: localFile,
+      options: options,
     ),
     // This future throws exceptions that may occurred in the entire
     // download process, all exceptions are remapped to a S3Exception
     result: downloadDataTask.result.then(
       (downloadedItem) => S3DownloadFileResult(
-        localFile: request.localFile,
+        localFile: localFile,
         downloadedItem: downloadedItem,
       ),
     ),

--- a/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_stub.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_stub.dart
@@ -7,7 +7,9 @@ import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_servic
 
 /// Interface of the platform implementation of the `downloadFile` API.
 S3DownloadFileOperation downloadFile({
-  required StorageDownloadFileRequest request,
+  required String key,
+  required AWSFile localFile,
+  required StorageDownloadFileOptions options,
   required S3PluginConfig s3pluginConfig,
   required StorageS3Service storageS3Service,
   required AppPathProvider appPathProvider,

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -94,10 +94,8 @@ class StorageS3Service {
     String? path,
     required StorageListOptions options,
   }) async {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
-      pluginOptions: options.pluginOptions,
-      defaultPluginOptions: const S3ListPluginOptions(),
-    );
+    final s3PluginOptions = options.pluginOptions as S3ListPluginOptions? ??
+        const S3ListPluginOptions();
     final resolvedPrefix = await getResolvedPrefix(
       prefixResolver: _prefixResolver,
       logger: _logger,
@@ -172,10 +170,9 @@ class StorageS3Service {
     required String key,
     required StorageGetPropertiesOptions options,
   }) async {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
-      pluginOptions: options.pluginOptions,
-      defaultPluginOptions: const S3GetPropertiesPluginOptions(),
-    );
+    final s3PluginOptions =
+        options.pluginOptions as S3GetPropertiesPluginOptions? ??
+            const S3GetPropertiesPluginOptions();
 
     final resolvedPrefix = await getResolvedPrefix(
       prefixResolver: _prefixResolver,
@@ -207,10 +204,8 @@ class StorageS3Service {
     required String key,
     required StorageGetUrlOptions options,
   }) async {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
-      pluginOptions: options.pluginOptions,
-      defaultPluginOptions: const S3GetUrlPluginOptions(),
-    );
+    final s3PluginOptions = options.pluginOptions as S3GetUrlPluginOptions? ??
+        const S3GetUrlPluginOptions();
 
     if (s3PluginOptions.checkObjectExistence) {
       // make a HeadObject call for checking object existence
@@ -350,11 +345,9 @@ class StorageS3Service {
     FutureOr<void> Function()? onDone,
     FutureOr<void> Function()? onError,
   }) {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
-      pluginOptions: options,
-      defaultPluginOptions: const S3UploadFilePluginOptions(),
-    );
-
+    final s3PluginOptions =
+        options.pluginOptions as S3UploadFilePluginOptions? ??
+            const S3UploadFilePluginOptions();
     final uploadDataOptions = StorageUploadDataOptions(
       accessLevel: options.accessLevel,
       pluginOptions: S3UploadDataPluginOptions(
@@ -397,10 +390,8 @@ class StorageS3Service {
     required S3ItemWithAccessLevel destination,
     required StorageCopyOptions options,
   }) async {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
-      pluginOptions: options.pluginOptions,
-      defaultPluginOptions: const S3CopyPluginOptions(),
-    );
+    final s3PluginOptions = options.pluginOptions as S3CopyPluginOptions? ??
+        const S3CopyPluginOptions();
 
     final resolvedPrefixes = await Future.wait([
       getResolvedPrefix(
@@ -467,10 +458,8 @@ class StorageS3Service {
     required S3ItemWithAccessLevel destination,
     required StorageMoveOptions options,
   }) async {
-    final s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
-      pluginOptions: options.pluginOptions,
-      defaultPluginOptions: const S3MovePluginOptions(),
-    );
+    final s3PluginOptions = options.pluginOptions as S3MovePluginOptions? ??
+        const S3MovePluginOptions();
 
     late S3CopyResult copyResult;
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
@@ -72,10 +72,9 @@ class S3DownloadTask {
         _onError = onError,
         _logger = logger,
         _downloadedBytesSize = 0,
-        _s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
-          pluginOptions: options.pluginOptions,
-          defaultPluginOptions: const S3DownloadDataPluginOptions(),
-        );
+        _s3PluginOptions =
+            options.pluginOptions as S3DownloadDataPluginOptions? ??
+                const S3DownloadDataPluginOptions();
 
   // the Completer to complete the final `result` Future.
   final Completer<S3Item> _downloadCompleter;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -66,10 +66,9 @@ class S3UploadTask {
         _onProgress = onProgress,
         _logger = logger,
         _transferDatabase = transferDatabase,
-        _s3PluginOptions = AmplifyPluginInterface.reifyPluginOptions(
-          pluginOptions: options.pluginOptions,
-          defaultPluginOptions: const S3UploadDataPluginOptions(),
-        );
+        _s3PluginOptions =
+            options.pluginOptions as S3UploadDataPluginOptions? ??
+                const S3UploadDataPluginOptions();
 
   /// Initiates an upload task for a [S3DataPayload].
   ///

--- a/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_html_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_html_test.dart
@@ -81,13 +81,13 @@ void main() {
     test(
         'should invoke StorageS3Service.getUrl with S3GetUrlOptions with the default storage access level',
         () {
-      final testRequest = StorageDownloadFileRequest(
+      downloadFile(
         key: testKey,
         localFile: AWSFile.fromPath('file_name.jpg'),
-      );
-
-      downloadFile(
-        request: testRequest,
+        options: StorageDownloadFileOptions(
+          accessLevel: testS3pluginConfig.defaultAccessLevel,
+          pluginOptions: const S3DownloadFilePluginOptions(),
+        ),
         s3pluginConfig: testS3pluginConfig,
         storageS3Service: storageS3Service,
         appPathProvider: const DummyPathProvider(),
@@ -116,7 +116,7 @@ void main() {
         'should invoke StorageS3Service.getUrl with converted S3DownloadFilePluginOptions',
         () {
       const testTargetIdentity = 'someone-else';
-      final testRequest = StorageDownloadFileRequest(
+      downloadFile(
         key: testKey,
         localFile: AWSFile.fromPath('file_name.jpg'),
         options: StorageDownloadFileOptions(
@@ -124,10 +124,6 @@ void main() {
           pluginOptions:
               const S3DownloadFilePluginOptions.forIdentity(testTargetIdentity),
         ),
-      );
-
-      downloadFile(
-        request: testRequest,
         s3pluginConfig: testS3pluginConfig,
         storageS3Service: storageS3Service,
         appPathProvider: const DummyPathProvider(),
@@ -164,17 +160,6 @@ void main() {
     test(
         'should invoke StorageS3Service.getProperties with expected parameters when getProperties is set as true in the plugin options',
         () async {
-      final testRequest = StorageDownloadFileRequest(
-        key: testKey,
-        localFile: AWSFile.fromPath('download.jpg'),
-        options: const StorageDownloadFileOptions(
-          accessLevel: StorageAccessLevel.private,
-          pluginOptions: S3DownloadFilePluginOptions(
-            getProperties: true,
-          ),
-        ),
-      );
-
       when(
         () => storageS3Service.getProperties(
           key: testKey,
@@ -184,8 +169,16 @@ void main() {
         ),
       ).thenAnswer((_) async => testGetPropertiesResult);
 
+      const options = StorageDownloadFileOptions(
+        accessLevel: StorageAccessLevel.private,
+        pluginOptions: S3DownloadFilePluginOptions(
+          getProperties: true,
+        ),
+      );
       final result = await downloadFile(
-        request: testRequest,
+        key: testKey,
+        localFile: AWSFile.fromPath('download.jpg'),
+        options: options,
         s3pluginConfig: testS3pluginConfig,
         storageS3Service: storageS3Service,
         appPathProvider: const DummyPathProvider(),
@@ -205,7 +198,7 @@ void main() {
         isA<StorageGetPropertiesOptions>().having(
           (o) => o.accessLevel,
           'accessLevel',
-          testRequest.options!.accessLevel,
+          options.accessLevel,
         ),
       );
 

--- a/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
@@ -36,16 +36,6 @@ void main() {
     const testFileContent = 'Hello world!';
     const testItem = S3Item(key: testKey);
     final testFileBytes = utf8.encode(testFileContent);
-    final testDownloadFileRequest = StorageDownloadFileRequest(
-      key: testKey,
-      localFile: AWSFile.fromPath(testDestinationPath),
-      options: const StorageDownloadFileOptions(
-        accessLevel: StorageAccessLevel.private,
-        pluginOptions: S3DownloadFilePluginOptions(
-          getProperties: true,
-        ),
-      ),
-    );
 
     late S3TransferProgress expectedProgress;
 
@@ -77,8 +67,16 @@ void main() {
 
     test('should invoke StorageS3Service.downloadData with expected parameters',
         () async {
+      const options = StorageDownloadFileOptions(
+        accessLevel: StorageAccessLevel.private,
+        pluginOptions: S3DownloadFilePluginOptions(
+          getProperties: true,
+        ),
+      );
       final downloadFileOperation = downloadFile(
-        request: testDownloadFileRequest,
+        key: testKey,
+        localFile: AWSFile.fromPath(testDestinationPath),
+        options: options,
         s3pluginConfig: testS3pluginConfig,
         storageS3Service: storageS3Service,
         appPathProvider: appPathProvider,
@@ -109,7 +107,7 @@ void main() {
             .having(
               (o) => o.accessLevel,
               'accessLevel',
-              testDownloadFileRequest.options?.accessLevel,
+              options.accessLevel,
             )
             .having(
               (o) => (o.pluginOptions! as S3DownloadDataPluginOptions)
@@ -161,9 +159,11 @@ void main() {
         'should correctly create S3DownloadDataOptions with default storage access level',
         () {
       downloadFile(
-        request: StorageDownloadFileRequest(
-          key: testKey,
-          localFile: AWSFile.fromPath('path'),
+        key: testKey,
+        localFile: AWSFile.fromPath('path'),
+        options: StorageDownloadFileOptions(
+          accessLevel: testS3pluginConfig.defaultAccessLevel,
+          pluginOptions: const S3DownloadFilePluginOptions(),
         ),
         s3pluginConfig: testS3pluginConfig,
         storageS3Service: storageS3Service,
@@ -203,14 +203,12 @@ void main() {
       const testTargetIdentity = 'someone-else';
       const testAcessLevel = StorageAccessLevel.protected;
       downloadFile(
-        request: StorageDownloadFileRequest(
-          key: testKey,
-          localFile: AWSFile.fromPath('path'),
-          options: const StorageDownloadFileOptions(
-            accessLevel: testAcessLevel,
-            pluginOptions: S3DownloadFilePluginOptions.forIdentity(
-              testTargetIdentity,
-            ),
+        key: testKey,
+        localFile: AWSFile.fromPath('path'),
+        options: const StorageDownloadFileOptions(
+          accessLevel: testAcessLevel,
+          pluginOptions: S3DownloadFilePluginOptions.forIdentity(
+            testTargetIdentity,
           ),
         ),
         s3pluginConfig: testS3pluginConfig,
@@ -267,9 +265,11 @@ void main() {
           'when destination path is null is throws StorageLocalFileNotFoundException',
           () {
         downloadFile(
-          request: StorageDownloadFileRequest(
-            key: testKey,
-            localFile: AWSFile.fromData([101]),
+          key: testKey,
+          localFile: AWSFile.fromData([101]),
+          options: StorageDownloadFileOptions(
+            accessLevel: testS3pluginConfig.defaultAccessLevel,
+            pluginOptions: const S3DownloadFilePluginOptions(),
           ),
           s3pluginConfig: testS3pluginConfig,
           storageS3Service: storageS3Service,
@@ -298,9 +298,11 @@ void main() {
           'when destination path is a directory instead of a file it throws StorageLocalFileNotFoundException',
           () {
         downloadFile(
-          request: StorageDownloadFileRequest(
-            key: testKey,
-            localFile: AWSFile.fromPath(Directory.systemTemp.path),
+          key: testKey,
+          localFile: AWSFile.fromPath(Directory.systemTemp.path),
+          options: StorageDownloadFileOptions(
+            accessLevel: testS3pluginConfig.defaultAccessLevel,
+            pluginOptions: const S3DownloadFilePluginOptions(),
           ),
           s3pluginConfig: testS3pluginConfig,
           storageS3Service: storageS3Service,
@@ -335,9 +337,11 @@ void main() {
       when(downloadTask.cancel).thenAnswer((_) async {});
 
       final downloadFileOperation = downloadFile(
-        request: StorageDownloadFileRequest(
-          key: testKey,
-          localFile: AWSFile.fromPath('path'),
+        key: testKey,
+        localFile: AWSFile.fromPath('path'),
+        options: StorageDownloadFileOptions(
+          accessLevel: testS3pluginConfig.defaultAccessLevel,
+          pluginOptions: const S3DownloadFilePluginOptions(),
         ),
         s3pluginConfig: testS3pluginConfig,
         storageS3Service: storageS3Service,


### PR DESCRIPTION
- Makes `reifyPluginOptions` an instance method and updates Auth+Storage accordingly
- Moves Auth plugin options to separate files (clean up from #2691)
- Adds Cognito plugin options for APIs where the plugin options is empty
- Fixes some Storage integ test failures due to plugin options changes