### PR TITLE
chore(storage): add fromJson factory for plugin options

### DIFF
--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_copy_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_copy_plugin_options.dart
@@ -15,6 +15,10 @@ class S3CopyPluginOptions extends StorageCopyPluginOptions {
     this.getProperties = false,
   });
 
+  /// {@macro storage.amplify_storage_s3.copy_plugin_options}
+  factory S3CopyPluginOptions.fromJson(Map<String, Object?> json) =>
+      _$S3CopyPluginOptionsFromJson(json);
+
   /// Whether to retrieve properties for the copied object using the
   /// `getProperties` API.
   final bool getProperties;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_data_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_data_plugin_options.dart
@@ -11,7 +11,7 @@ part 's3_download_data_plugin_options.g.dart';
 /// {@endtemplate}
 @zAmplifySerializable
 class S3DownloadDataPluginOptions extends StorageDownloadDataPluginOptions {
-  /// {@macro storage.amplify_storage_s3.download_data_options}
+  /// {@macro storage.amplify_storage_s3.download_data_plugin_options}
   const S3DownloadDataPluginOptions({
     bool getProperties = false,
     S3DataBytesRange? bytesRange,
@@ -29,7 +29,7 @@ class S3DownloadDataPluginOptions extends StorageDownloadDataPluginOptions {
     this.useAccelerateEndpoint = false,
   });
 
-  /// {@macro storage.amplify_storage_s3.download_data_options}
+  /// {@macro storage.amplify_storage_s3.download_data_plugin_options}
   ///
   /// Use this when calling `downloadData` on an object that belongs to another
   /// user (identified by [targetIdentityId]) rather than the currently
@@ -45,6 +45,10 @@ class S3DownloadDataPluginOptions extends StorageDownloadDataPluginOptions {
           bytesRange: bytesRange,
           useAccelerateEndpoint: useAccelerateEndpoint,
         );
+
+  /// {@macro storage.amplify_storage_s3.download_data_plugin_options}
+  factory S3DownloadDataPluginOptions.fromJson(Map<String, Object?> json) =>
+      _$S3DownloadDataPluginOptionsFromJson(json);
 
   /// The byte range to download from the object.
   final S3DataBytesRange? bytesRange;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_file_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_download_file_plugin_options.dart
@@ -25,7 +25,7 @@ class S3DownloadFilePluginOptions extends StorageDownloadFilePluginOptions {
     this.useAccelerateEndpoint = false,
   });
 
-  /// {@macro storage.amplify_storage_s3.download_data_plugin_options}
+  /// {@macro storage.amplify_storage_s3.download_file_plugin_options}
   ///
   /// Use this when calling `downloadFile` on an object that belongs to other
   /// user (identified by [targetIdentityId]) rather than the currently signed
@@ -39,6 +39,10 @@ class S3DownloadFilePluginOptions extends StorageDownloadFilePluginOptions {
           getProperties: getProperties,
           useAccelerateEndpoint: useAccelerateEndpoint,
         );
+
+  /// {@macro storage.amplify_storage_s3.download_file_plugin_options}
+  factory S3DownloadFilePluginOptions.fromJson(Map<String, Object?> json) =>
+      _$S3DownloadFilePluginOptionsFromJson(json);
 
   /// The identity ID of the user who uploaded the object.
   ///

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_properties_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_properties_plugin_options.dart
@@ -28,6 +28,10 @@ class S3GetPropertiesPluginOptions extends StorageGetPropertiesPluginOptions {
           targetIdentityId: targetIdentityId,
         );
 
+  /// {@macro storage.amplify_storage_s3.get_properties_plugin_options}
+  factory S3GetPropertiesPluginOptions.fromJson(Map<String, Object?> json) =>
+      _$S3GetPropertiesPluginOptionsFromJson(json);
+
   /// The identity ID of another user who uploaded the object.
   ///
   /// This can be set by using [S3GetPropertiesPluginOptions.forIdentity].

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_plugin_options.dart
@@ -45,6 +45,10 @@ class S3GetUrlPluginOptions extends StorageGetUrlPluginOptions {
           useAccelerateEndpoint: useAccelerateEndpoint,
         );
 
+  /// {@macro storage.amplify_storage_s3.get_url_plugin_options}
+  factory S3GetUrlPluginOptions.fromJson(Map<String, Object?> json) =>
+      _$S3GetUrlPluginOptionsFromJson(json);
+
   /// Specifies the period of time that the generated url expires in.
   final Duration expiresIn;
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_plugin_options.dart
@@ -58,6 +58,10 @@ class S3ListPluginOptions extends StorageListPluginOptions {
           excludeSubPaths: excludeSubPaths,
         );
 
+  /// {@macro storage.amplify_storage_s3.list_plugin_options}
+  factory S3ListPluginOptions.fromJson(Map<String, Object?> json) =>
+      _$S3ListPluginOptionsFromJson(json);
+
   /// The identity ID of another user who uploaded the objects.
   ///
   /// This can be set by using [S3ListPluginOptions.forIdentity].

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_move_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_move_plugin_options.dart
@@ -16,6 +16,10 @@ class S3MovePluginOptions extends StorageMovePluginOptions {
     this.getProperties = false,
   });
 
+  /// {@macro storage.amplify_storage_s3.move_plugin_options}
+  factory S3MovePluginOptions.fromJson(Map<String, Object?> json) =>
+      _$S3MovePluginOptionsFromJson(json);
+
   /// Whether to retrieve properties for the moved object using the
   /// `getProperties` API.
   final bool getProperties;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_remove_many_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_remove_many_plugin_options.dart
@@ -14,6 +14,10 @@ class S3RemoveManyPluginOptions extends StorageRemoveManyPluginOptions {
   /// {@macro storage.amplify_storage_s3.remove_many_plugin_options}
   const S3RemoveManyPluginOptions();
 
+  /// {@macro storage.amplify_storage_s3.remove_many_plugin_options}
+  factory S3RemoveManyPluginOptions.fromJson(Map<String, Object?> json) =>
+      _$S3RemoveManyPluginOptionsFromJson(json);
+
   @override
   List<Object?> get props => [];
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_remove_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_remove_plugin_options.dart
@@ -5,7 +5,7 @@ import 'package:amplify_core/amplify_core.dart';
 
 part 's3_remove_plugin_options.g.dart';
 
-/// {@template storage.amplify_storage_s3.remove_options}
+/// {@template storage.amplify_storage_s3.remove_plugin_options}
 /// The configurable parameters invoking the Storage S3 plugin options `remove`
 /// API.
 /// {@endtemplate}
@@ -13,6 +13,10 @@ part 's3_remove_plugin_options.g.dart';
 class S3RemovePluginOptions extends StorageRemovePluginOptions {
   /// {@macro storage.amplify_storage_s3.remove_plugin_options}
   const S3RemovePluginOptions();
+
+  /// {@macro storage.amplify_storage_s3.remove_plugin_options}
+  factory S3RemovePluginOptions.fromJson(Map<String, Object?> json) =>
+      _$S3RemovePluginOptionsFromJson(json);
 
   @override
   List<Object?> get props => [];

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_data_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_data_plugin_options.dart
@@ -18,6 +18,10 @@ class S3UploadDataPluginOptions extends StorageUploadDataPluginOptions {
     this.useAccelerateEndpoint = false,
   });
 
+  /// {@macro storage.amplify_storage_s3.upload_data_plugin_options}
+  factory S3UploadDataPluginOptions.fromJson(Map<String, Object?> json) =>
+      _$S3UploadDataPluginOptionsFromJson(json);
+
   /// The metadata attached to the object to be uploaded.
   final Map<String, String>? metadata;
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_file_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_upload_file_plugin_options.dart
@@ -18,6 +18,10 @@ class S3UploadFilePluginOptions extends StorageUploadFilePluginOptions {
     this.useAccelerateEndpoint = false,
   });
 
+  /// {@macro storage.amplify_storage_s3.upload_file_plugin_options}
+  factory S3UploadFilePluginOptions.fromJson(Map<String, Object?> json) =>
+      _$S3UploadFilePluginOptionsFromJson(json);
+
   /// The metadata attached to the object to be uploaded.
   final Map<String, String>? metadata;
 


### PR DESCRIPTION
… warnings for generated codes

*Issue #, if available:*

*Description of changes:*
- add fromJson factory to all plugin options. this is to fix unused warnings for generated codes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
