### PR TITLE
refactor(storage)!: simplify storage s3 exceptions throwing

### DIFF
--- a/packages/amplify_core/lib/src/types/exception/analytics/analytics_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/analytics/analytics_exception.dart
@@ -26,11 +26,7 @@ abstract class AnalyticsException extends AmplifyException {
       );
     }
     if (e is AWSHttpException) {
-      return NetworkException(
-        'The request failed due to a network error.',
-        recoverySuggestion: 'Ensure that you have an active network connection',
-        underlyingException: e,
-      );
+      return e.toNetworkException();
     }
     String message;
     try {

--- a/packages/amplify_core/lib/src/types/exception/auth/auth_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/auth/auth_exception.dart
@@ -29,11 +29,7 @@ abstract class AuthException extends AmplifyException with AWSDebuggable {
       );
     }
     if (e is AWSHttpException) {
-      return NetworkException(
-        'The request failed due to a network error.',
-        recoverySuggestion: 'Ensure that you have an active network connection',
-        underlyingException: e,
-      );
+      return e.toNetworkException();
     }
     String message;
     try {

--- a/packages/amplify_core/lib/src/types/exception/network_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/network_exception.dart
@@ -20,3 +20,15 @@ class NetworkException extends AmplifyException
     super.underlyingException,
   });
 }
+
+extension AWSHttpExceptionToAmplifyException on AWSHttpException {
+  /// Creates a [NetworkException] with the [AWSHttpException] as the underlying
+  /// exception.
+  NetworkException toNetworkException() {
+    return NetworkException(
+      'The request failed due to a network error.',
+      recoverySuggestion: 'Ensure that you have an active network connection',
+      underlyingException: this,
+    );
+  }
+}

--- a/packages/amplify_core/lib/src/types/exception/storage/operation_canceled_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/storage/operation_canceled_exception.dart
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+/// {@template amplify_core.storage.operation_canceled_exception}
+/// Exception thrown when a storage operation is canceled.
+/// {@endtemplate}
+class StorageOperationCanceledException extends StorageException {
+  /// {@macro amplify_core.storage.operation_canceled_exception}
+  const StorageOperationCanceledException(
+    super.message, {
+    super.recoverySuggestion,
+    super.underlyingException,
+  });
+
+  @override
+  String get runtimeTypeName => 'StorageOperationCanceledException';
+}

--- a/packages/amplify_core/lib/src/types/storage/storage_types.dart
+++ b/packages/amplify_core/lib/src/types/storage/storage_types.dart
@@ -5,6 +5,7 @@ export '../exception/storage/access_denied_exception.dart';
 export '../exception/storage/http_status_exception.dart';
 export '../exception/storage/key_not_found_exception.dart';
 export '../exception/storage/local_file_not_found_exception.dart';
+export '../exception/storage/operation_canceled_exception.dart';
 export '../exception/storage/storage_exception.dart';
 export 'access_level.dart';
 export 'copy_operation.dart';

--- a/packages/amplify_core/lib/src/types/storage/transfer_progress.dart
+++ b/packages/amplify_core/lib/src/types/storage/transfer_progress.dart
@@ -1,30 +1,51 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/// {@template amplify_storage_s3.transfer_progress}
+/// {@template amplify_core.storage.transfer_state}
+/// State of a download task.
+/// {@endtemplate}
+enum StorageTransferState {
+  /// The download task is in progress.
+  inProgress,
+
+  /// The download task is paused.
+  paused,
+
+  /// The download task is canceled.
+  canceled,
+
+  /// The download task completed successfully.
+  success,
+
+  /// The download task failed.
+  failure,
+}
+
+/// {@template amplify_core.storage.transfer_progress}
 /// The progress of a storage transfer operation.
 /// {@endtemplate}
 class StorageTransferProgress {
-  /// {@macro amplify_storage_s3.transfer_progress}
+  /// {@macro amplify_core.transfer_progress}
   const StorageTransferProgress({
     required this.transferredBytes,
     required this.totalBytes,
+    required this.state,
   });
 
   /// The current progress, in bytes, for the storage transfer operation.
   final int transferredBytes;
 
   /// The total number of bytes for the storage transfer operation.
+  ///
+  /// In an upload operation, the value may be `-1` if the upload source size
+  /// cannot be determined.
   final int totalBytes;
 
-  @Deprecated('Use transferredBytes instead')
-  int get currentBytes => transferredBytes;
+  /// The [StorageTransferState] of the [StorageTransferProgress].
+  final StorageTransferState state;
 
   /// The fractional progress of the storage transfer operation.
   ///
   /// 0 <= `fractionCompleted` <= 1
   double get fractionCompleted => transferredBytes / totalBytes;
-
-  @Deprecated('Use fractionCompleted instead')
-  double getFractionCompleted() => fractionCompleted;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
@@ -77,15 +77,6 @@ class S3Exception extends StorageException {
     );
   }
 
-  /// An exception created when attempt to resume a canceled operation.
-  factory S3Exception.resumeCanceledOperation() {
-    return const S3Exception(
-      'The operation has been canceled and can\'t be resumed.',
-      recoverySuggestion:
-          'You can only resume an operation that is paused by calling `pause()`.',
-    );
-  }
-
   /// An exception thrown when the service doesn't return a valid uploadId on a
   /// successful `CreateMultipartUploadRequest`.
   factory S3Exception.unexpectedMultipartUploadId() {

--- a/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
@@ -59,16 +59,6 @@ class S3Exception extends StorageException {
     );
   }
 
-  /// Creates a [S3Exception] that represents an expected exception
-  /// thrown when invoke cancel() on an eligible storage operation object.
-  factory S3Exception.controllableOperationCanceled() {
-    return const S3Exception(
-      'The requested operation has been canceled.',
-      recoverySuggestion:
-          'This is an expected exception when you call cancel() API on the storage operation object. You need to handle this exception to take further action on operation cancellation.',
-    );
-  }
-
   /// An exception thrown when the `body` returned from GetObject is unexpectedly null.
   factory S3Exception.unexpectedGetObjectBody() {
     return const S3Exception(
@@ -228,3 +218,11 @@ class S3Exception extends StorageException {
   @override
   String get runtimeTypeName => 'S3Exception';
 }
+
+/// The exception thrown when cancel a controllable operation.
+const s3ControllableOperationCanceledException =
+    StorageOperationCanceledException(
+  'The operation has been canceled.',
+  recoverySuggestion:
+      'This is an expected exception when you call cancel() API on the storage operation object. You need to handle this exception to take further action on operation cancellation.',
+);

--- a/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
@@ -5,185 +5,70 @@
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 import 'package:meta/meta.dart';
-import 'package:smithy/smithy.dart';
+import 'package:smithy/smithy.dart' as smithy;
 
 const _keyNotFoundRecoveryMessage =
-    'Please ensure that correct object key is provided, and/or correct `StorageAccessLevel` and `targetIdentityId` are included in the options.';
+    'Ensure that correct object key is provided, and/or correct `StorageAccessLevel`'
+    ' and `targetIdentityId` are included in the options.';
 const _httpErrorRecoveryMessage =
-    'HTTP error returned from service, please review the `underlyingException` for details.';
+    'HTTP error returned from service, review the `underlyingException` for details.';
 
-/// {@template amplify_storage_s3_dart.s3_storage_exception}
-/// Represents exceptions that may be thrown calling Storage S3 plugin APIs.
-/// {@endtemplate}
-class S3Exception extends StorageException {
-  /// {@macro amplify_storage_s3_dart.s3_storage_exception}
-  const S3Exception(
-    super.message, {
-    required String super.recoverySuggestion,
-    super.underlyingException,
-  });
+/// The exception thrown when cancel a controllable operation.
+const s3ControllableOperationCanceledException =
+    StorageOperationCanceledException(
+  'The operation has been canceled.',
+  recoverySuggestion:
+      'This is expected when you call cancel() on a storage operation. This'
+      ' exception allows you to take further action when an operation is canceled.',
+);
 
-  /// Creates a [S3Exception] from a FileSystemException.
-  factory S3Exception.fromFileSystemException(Exception exception) {
-    return S3Exception(
-      'Error occurred while reading/writing file in the local file system.',
-      recoverySuggestion: 'Please review the underlying exception.',
-      underlyingException: exception,
+/// Extension of [s3.NoSuchKey] to add util methods.
+extension NoSuchKeyToStorageKeyNotFoundException on s3.NoSuchKey {
+  /// Creates a [StorageKeyNotFoundException] with the [s3.NoSuchKey] as the
+  /// underlying exception.
+  StorageKeyNotFoundException toStorageKeyNotFoundException() {
+    return StorageKeyNotFoundException(
+      'Cannot find the item specified by the key and access level.',
+      recoverySuggestion: _keyNotFoundRecoveryMessage,
+      underlyingException: this,
     );
   }
+}
 
-  /// Creates a [S3Exception] that represents an error that shouldn't
-  /// happen normally.
-  factory S3Exception.unknownException([String? extraMessage]) {
-    return S3Exception(
-      'Unknown exception occurred. $extraMessage',
-      recoverySuggestion: AmplifyExceptionMessages.missingExceptionMessage,
-    );
-  }
-
-  /// Creates a [S3Exception] that represents an unexpected error
-  /// when download operation doesn't receive all bytes when download completes.
-  factory S3Exception.incompleteDownload() {
-    return const S3Exception(
-      'Download has completed, but it has not received all bytes of content.',
-      recoverySuggestion: AmplifyExceptionMessages.missingExceptionMessage,
-    );
-  }
-
-  /// Creates a [S3Exception] that represents an unexpected error
-  /// when service API call doesn't return a valid content-length header.
-  factory S3Exception.unexpectedContentLengthFromService() {
-    return const S3Exception(
-      'Service has not returned a valid content length for requested object.',
-      recoverySuggestion: AmplifyExceptionMessages.missingExceptionMessage,
-    );
-  }
-
-  /// An exception thrown when the `body` returned from GetObject is unexpectedly null.
-  factory S3Exception.unexpectedGetObjectBody() {
-    return const S3Exception(
-      'Unexpected null body from GetObject.',
-      recoverySuggestion: AmplifyExceptionMessages.missingExceptionMessage,
-    );
-  }
-
-  /// An exception thrown when the service doesn't return a valid uploadId on a
-  /// successful `CreateMultipartUploadRequest`.
-  factory S3Exception.unexpectedMultipartUploadId() {
-    return const S3Exception(
-      'Create multipart upload request succeeded, but it did not return a valid uploadId.',
-      recoverySuggestion: AmplifyExceptionMessages.missingExceptionMessage,
-    );
-  }
-
-  /// An exception thrown when the file to be uploaded is too large to create
-  /// a multipart upload.
-  factory S3Exception.uploadSourceIsTooLarge() {
-    return const S3Exception(
-      'Upload source is too large to initiate multipart upload.',
-      recoverySuggestion:
-          'Make sure the size of the uploaded file is less than 5TiB.',
-    );
-  }
-
-  /// An exception thrown when attempting to upload part with a non-existing
-  /// multipart upload.
-  factory S3Exception.fromS3NoSuchUpload(Object? exception) {
-    return S3Exception(
-      'Multipart upload is not found while initiating a part upload.',
-      recoverySuggestion: AmplifyExceptionMessages.missingExceptionMessage,
-      underlyingException: exception,
-    );
-  }
-
-  /// An exception thrown when any step during multipart upload fails.
-  factory S3Exception.multipartUploadAborted(Object? exception) {
-    return S3Exception(
-      'An error occurred during multipart upload. The upload has been canceled.',
-      recoverySuggestion: AmplifyExceptionMessages.missingExceptionMessage,
-      underlyingException: exception,
-    );
-  }
-
-  /// An exception thrown when service response doesn't contain a valid eTag.
-  /// e.g. the response of an [s3.UploadPartRequest] must contain a eTag in order to
-  /// close multipart upload correctly.
-  factory S3Exception.unexpectedETagFromService() {
-    return const S3Exception(
-      'Service API call output doesn\'t contain a valid eTag.',
-      recoverySuggestion: AmplifyExceptionMessages.missingExceptionMessage,
-    );
-  }
-
-  /// An exception thrown when the Storage S3 API
-  /// does not support the provided plugin options.
-  factory S3Exception.invalidPluginOptions({
-    required String providedPluginOptionsType,
-    required String expectedPluginOptionsType,
-  }) {
-    return S3Exception(
-      'Storage S3 API does not support the $providedPluginOptionsType',
-      recoverySuggestion:
-          'Use $expectedPluginOptionsType instead of $providedPluginOptionsType.',
-    );
-  }
-
-  /// A [StorageLocalFileNotFoundException] thrown when download destination file
-  /// path points to a directory.
-  static const StorageLocalFileNotFoundException
-      downloadDestinationFilePathIsDirectory =
-      StorageLocalFileNotFoundException(
-    'Download destination file path is a directory',
-    recoverySuggestion:
-        'Ensure the path provided with `AWSFile` is pointing to a file, and not a directory.',
-  );
-
-  /// A [StorageLocalFileNotFoundException] thrown when download destination file
-  /// path is `null`.
-  static const StorageLocalFileNotFoundException
-      downloadDestinationFilePathIsNull = StorageLocalFileNotFoundException(
-    'Download destination file path is null',
-    recoverySuggestion: 'Ensure a valid file path with `AWSFile` was provided.',
-  );
-
-  /// Creates a [StorageKeyNotFoundException] from an [Exception]
-  static StorageKeyNotFoundException getKeyNotFoundException(
-    Exception underlyingException,
-  ) =>
-      StorageKeyNotFoundException(
-        'Key is not found.',
-        recoverySuggestion: _keyNotFoundRecoveryMessage,
-        underlyingException: underlyingException,
-      );
-
-  /// Creates [StorageException] variants from [UnknownSmithyHttpException].
-  static StorageException fromUnknownSmithyHttpException(
-    UnknownSmithyHttpException exception,
-  ) {
-    final statusCode = exception.statusCode;
+/// Extension of [smithy.UnknownSmithyHttpException] to add util methods.
+extension UnknownSmithyHttpExceptionToStorageException
+    on smithy.UnknownSmithyHttpException {
+  /// Creates a [StorageException] with the [smithy.UnknownSmithyHttpException]
+  /// as the underlying exception.
+  StorageException toStorageException() {
+    final statusCode = this.statusCode;
 
     if (statusCode ~/ 100 == 3 || statusCode ~/ 100 == 5) {
       return StorageHttpStatusException(
         statusCode,
         recoverySuggestion: _httpErrorRecoveryMessage,
-        underlyingException: exception,
+        underlyingException: this,
       );
     }
 
     if (statusCode ~/ 100 == 4) {
-      if ([401, 403].contains(statusCode)) {
+      if (statusCode == 401 || statusCode == 403) {
         return StorageAccessDeniedException(
           'S3 access denied when making the API call.',
           recoverySuggestion: _httpErrorRecoveryMessage,
-          underlyingException: exception,
+          underlyingException: this,
         );
       } else if (statusCode == 404) {
-        return getKeyNotFoundException(exception);
+        return StorageKeyNotFoundException(
+          'Cannot find the item specified by the key and access level.',
+          recoverySuggestion: _keyNotFoundRecoveryMessage,
+          underlyingException: this,
+        );
       } else {
         return StorageHttpStatusException(
           statusCode,
           recoverySuggestion: _httpErrorRecoveryMessage,
-          underlyingException: exception,
+          underlyingException: this,
         );
       }
     }
@@ -191,38 +76,7 @@ class S3Exception extends StorageException {
     return UnknownException(
       'Unknown service error.',
       recoverySuggestion: AmplifyExceptionMessages.missingExceptionMessage,
-      underlyingException: exception,
+      underlyingException: this,
     );
   }
-
-  /// Creates a [UnknownException] for a [s3.S3Object] that is missing
-  /// a valid `key`, this exception should not happen normally.
-  static UnknownException getS3ObjectMissingKeyException(
-    s3.S3Object object,
-  ) =>
-      UnknownException(
-        'Missing key in a S3Object: $object',
-        recoverySuggestion: AmplifyExceptionMessages.missingExceptionMessage,
-      );
-
-  /// Creates a [NetworkException] over a [AWSHttpException] thrown from
-  /// [s3.S3Client] APIs.
-  static NetworkException fromAWSHttpException(AWSHttpException exception) {
-    return NetworkException(
-      'The request failed due to a network error.',
-      recoverySuggestion: 'Ensure that you have an active network connection',
-      underlyingException: exception,
-    );
-  }
-
-  @override
-  String get runtimeTypeName => 'S3Exception';
 }
-
-/// The exception thrown when cancel a controllable operation.
-const s3ControllableOperationCanceledException =
-    StorageOperationCanceledException(
-  'The operation has been canceled.',
-  recoverySuggestion:
-      'This is an expected exception when you call cancel() API on the storage operation object. You need to handle this exception to take further action on operation cancellation.',
-);

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_item.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_item.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:amplify_storage_s3_dart/src/exception/s3_storage_exception.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 import 'package:meta/meta.dart';
 
@@ -42,9 +41,13 @@ class S3Item extends StorageItem {
   }) {
     final key = object.key;
 
-    // In S3 plugin, key is required property presenting an object
+    // Sanity check, key property should never be null in a S3Object returned
+    // from service.
     if (key == null) {
-      throw S3Exception.getS3ObjectMissingKeyException(object);
+      throw const UnknownException(
+        '`key` property is null in S3Object.',
+        recoverySuggestion: AmplifyExceptionMessages.missingExceptionMessage,
+      );
     }
 
     final keyDroppedPrefix = dropPrefixFromKey(

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_transfer_progress.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_transfer_progress.dart
@@ -3,41 +3,7 @@
 
 import 'package:amplify_core/amplify_core.dart';
 
-/// {@template amplify_storage_s3_dart.transfer_state}
-/// State of a download task.
-/// {@endtemplate}
-enum S3TransferState {
-  /// The download task is in progress.
-  inProgress,
-
-  /// The download task is paused.
-  paused,
-
-  /// The download task is canceled.
-  canceled,
-
-  /// The download task completed successfully.
-  success,
-
-  /// The download task failed.
-  failure,
-}
-
 /// {@template storage.amplify_storage_s3.transfer_progress}
 /// The transfer progress.
-///
-/// In a [S3TransferProgress] emitted by a upload data operation , the field
-/// [totalBytes] always has value `-1`, as the file size is unknown when upload
-/// was initiated.
 /// {@endtemplate}
-class S3TransferProgress extends StorageTransferProgress {
-  /// {@macro storage.amplify_storage_s3.transfer_progress}
-  const S3TransferProgress({
-    required super.totalBytes,
-    required super.transferredBytes,
-    required this.state,
-  });
-
-  /// The state of a transfer process.
-  final S3TransferState state;
-}
+typedef S3TransferProgress = StorageTransferProgress;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -123,7 +123,7 @@ class StorageS3Service {
         // S3Client.headObject may return 403 error
         throw error.toStorageException();
       } on AWSHttpException catch (error) {
-        throw s3_exception.createNetworkExceptionFromAWSHttpException(error);
+        throw error.toNetworkException();
       }
     }
 
@@ -159,7 +159,7 @@ class StorageS3Service {
       // S3Client.headObject may return 403 error
       throw error.toStorageException();
     } on AWSHttpException catch (error) {
-      throw s3_exception.createNetworkExceptionFromAWSHttpException(error);
+      throw error.toNetworkException();
     }
   }
 
@@ -432,7 +432,7 @@ class StorageS3Service {
       // S3Client.copyObject may return 403 or 404 error
       throw error.toStorageException();
     } on AWSHttpException catch (error) {
-      throw s3_exception.createNetworkExceptionFromAWSHttpException(error);
+      throw error.toNetworkException();
     }
 
     return S3CopyResult(
@@ -608,7 +608,7 @@ class StorageS3Service {
         // S3Client.deleteObjects may return 403
         throw error.toStorageException();
       } on AWSHttpException catch (error) {
-        throw s3_exception.createNetworkExceptionFromAWSHttpException(error);
+        throw error.toNetworkException();
       } finally {
         objectIdentifiersToRemove.removeRange(0, numOfBatchedItems);
       }
@@ -640,7 +640,7 @@ class StorageS3Service {
       // object, the API call returns a successful response
       throw error.toStorageException();
     } on AWSHttpException catch (error) {
-      throw s3_exception.createNetworkExceptionFromAWSHttpException(error);
+      throw error.toNetworkException();
     }
   }
 
@@ -702,7 +702,7 @@ class StorageS3Service {
       // S3Client.headObject may return 403 or 404 error
       throw error.toStorageException();
     } on AWSHttpException catch (error) {
-      throw s3_exception.createNetworkExceptionFromAWSHttpException(error);
+      throw error.toNetworkException();
     }
   }
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
@@ -362,7 +362,7 @@ class S3DownloadTask {
       // 404 error is wrapped by s3.NoSuchKey for getObject :/
       throw error.toStorageKeyNotFoundException();
     } on AWSHttpException catch (error) {
-      throw s3_exception.createNetworkExceptionFromAWSHttpException(error);
+      throw error.toNetworkException();
     }
   }
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
@@ -195,16 +195,8 @@ class S3DownloadTask {
     // stream listers were canceled.
     await _pausedCompleted;
 
-    if (_state == StorageTransferState.inProgress ||
-        _state == StorageTransferState.success ||
-        _state == StorageTransferState.failure) {
+    if (_state != StorageTransferState.paused) {
       return;
-    }
-
-    if (_state == StorageTransferState.canceled) {
-      // throws exception here as _downloadCompleter has completed by the
-      // cancel
-      throw S3Exception.resumeCanceledOperation();
     }
 
     _resetGetObjectCompleter();

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
@@ -242,7 +242,7 @@ class S3DownloadTask {
 
     _emitTransferProgress();
     _downloadCompleter.completeError(
-      S3Exception.controllableOperationCanceled(),
+      s3ControllableOperationCanceledException,
     );
   }
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -353,8 +353,7 @@ class S3UploadTask {
     } on CancellationException {
       _logger.debug('PutObject HTTP operation has been canceled.');
       _state = StorageTransferState.canceled;
-      _uploadCompleter
-          .completeError(S3Exception.controllableOperationCanceled());
+      _uploadCompleter.completeError(s3ControllableOperationCanceledException);
     } on smithy.UnknownSmithyHttpException catch (error, stackTrace) {
       _completeUploadWithError(
         S3Exception.fromUnknownSmithyHttpException(error),
@@ -414,7 +413,7 @@ class S3UploadTask {
         }
         _cancelOngoingUploadPartOperations();
         await _terminateMultipartUploadOnError(
-          S3Exception.controllableOperationCanceled(),
+          s3ControllableOperationCanceledException,
           isCancel: true,
         );
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -264,12 +264,9 @@ class S3UploadTask {
   /// For single putObject, resume doesn't take any effect.
   /// For multipart upload, resume reschedules remaining subtasks.
   Future<void> resume() async {
-    // can resume when upload is actually started
+    // can resume when upload is actually started and not canceled
     await _uploadModelDetermined;
-    if (!_isMultipartUpload ||
-        _state == StorageTransferState.inProgress ||
-        _state == StorageTransferState.failure ||
-        _state == StorageTransferState.success) {
+    if (!_isMultipartUpload || _state != StorageTransferState.paused) {
       return;
     }
     await _uploadPartBatchingCompleted;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -369,7 +369,7 @@ class S3UploadTask {
       );
     } on AWSHttpException catch (error) {
       _completeUploadWithError(
-        s3_exception.createNetworkExceptionFromAWSHttpException(error),
+        error.toNetworkException(),
       );
     } finally {
       _emitTransferProgress();
@@ -504,7 +504,7 @@ class S3UploadTask {
     } on smithy.UnknownSmithyHttpException catch (error) {
       throw error.toStorageException();
     } on AWSHttpException catch (error) {
-      throw s3_exception.createNetworkExceptionFromAWSHttpException(error);
+      throw error.toNetworkException();
     }
   }
 
@@ -542,7 +542,7 @@ class S3UploadTask {
       //  wrapping errors extracted from a 200 response.
       throw error.toStorageException();
     } on AWSHttpException catch (error) {
-      throw s3_exception.createNetworkExceptionFromAWSHttpException(error);
+      throw error.toNetworkException();
     }
   }
 
@@ -682,7 +682,7 @@ class S3UploadTask {
     } on smithy.UnknownSmithyHttpException catch (error) {
       throw error.toStorageException();
     } on AWSHttpException catch (error) {
-      throw s3_exception.createNetworkExceptionFromAWSHttpException(error);
+      throw error.toNetworkException();
     }
   }
 

--- a/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
@@ -140,7 +140,7 @@ void main() {
       const testProgress = S3TransferProgress(
         totalBytes: 1024,
         transferredBytes: 1024,
-        state: S3TransferState.inProgress,
+        state: StorageTransferState.inProgress,
       );
       onProgress(testProgress);
       expect(testProgress, expectedProgress);

--- a/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
@@ -291,7 +291,7 @@ void main() {
           ),
         ).captured.last;
         final preStart = capturedPreStart as FutureOr<void> Function();
-        expect(preStart(), throwsA(isA<StorageLocalFileNotFoundException>()));
+        expect(preStart(), throwsA(isA<UnknownException>()));
       });
 
       test(
@@ -324,7 +324,7 @@ void main() {
           ),
         ).captured.last;
         final preStart = capturedPreStart as FutureOr<void> Function();
-        expect(preStart(), throwsA(isA<StorageLocalFileNotFoundException>()));
+        expect(preStart(), throwsA(isA<UnknownException>()));
       });
     });
 

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
@@ -1072,7 +1072,13 @@ void main() {
             destination: testDestination,
             options: testOptions,
           ),
-          throwsA(isA<StorageAccessDeniedException>()),
+          throwsA(
+            isA<UnknownException>().having(
+              (o) => o.underlyingException,
+              'underlyingException',
+              isA<StorageAccessDeniedException>(),
+            ),
+          ),
         );
       });
 
@@ -1093,7 +1099,13 @@ void main() {
             destination: testDestination,
             options: testOptions,
           ),
-          throwsA(isA<NetworkException>()),
+          throwsA(
+            isA<UnknownException>().having(
+              (o) => o.underlyingException,
+              'underlyingException',
+              isA<NetworkException>(),
+            ),
+          ),
         );
       });
 
@@ -1129,7 +1141,13 @@ void main() {
             destination: testDestination,
             options: testOptions,
           ),
-          throwsA(isA<StorageHttpStatusException>()),
+          throwsA(
+            isA<UnknownException>().having(
+              (o) => o.underlyingException,
+              'underlyingException',
+              isA<StorageHttpStatusException>(),
+            ),
+          ),
         );
       });
 

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
@@ -86,7 +86,7 @@ void main() {
           body: Stream.value(testBodyBytes),
         );
         final smithyOperation = MockSmithyOperation<GetObjectOutput>();
-        late S3TransferState finalState;
+        late StorageTransferState finalState;
 
         when(
           () => smithyOperation.result,
@@ -135,7 +135,7 @@ void main() {
         expect(request.checksumMode, ChecksumMode.enabled);
 
         await downloadTask.result;
-        expect(finalState, S3TransferState.success);
+        expect(finalState, StorageTransferState.success);
       });
 
       test(
@@ -255,7 +255,7 @@ void main() {
           ),
         );
         final smithyOperation = MockSmithyOperation<GetObjectOutput>();
-        final receivedState = <S3TransferState>[];
+        final receivedState = <StorageTransferState>[];
 
         when(
           () => smithyOperation.result,
@@ -286,7 +286,7 @@ void main() {
         unawaited(downloadTask.start());
         await downloadTask.pause();
 
-        expect(receivedState.last, S3TransferState.paused);
+        expect(receivedState.last, StorageTransferState.paused);
         expect(bodyStreamHasBeenCanceled, isTrue);
       });
     });
@@ -301,7 +301,7 @@ void main() {
           ).take(1024),
         );
         final smithyOperation1 = MockSmithyOperation<GetObjectOutput>();
-        final receivedState = <S3TransferState>[];
+        final receivedState = <StorageTransferState>[];
 
         when(
           () => smithyOperation1.result,
@@ -353,7 +353,7 @@ void main() {
 
         await downloadTask.resume();
 
-        expect(receivedState.last, S3TransferState.inProgress);
+        expect(receivedState.last, StorageTransferState.inProgress);
       });
 
       test('should throw exception when attempt to resume a canceled task',
@@ -366,7 +366,7 @@ void main() {
           ).take(1024),
         );
         final smithyOperation = MockSmithyOperation<GetObjectOutput>();
-        final receivedState = <S3TransferState>[];
+        final receivedState = <StorageTransferState>[];
 
         when(
           () => smithyOperation.result,
@@ -416,7 +416,7 @@ void main() {
           ),
         );
         final smithyOperation = MockSmithyOperation<GetObjectOutput>();
-        final receivedState = <S3TransferState>[];
+        final receivedState = <StorageTransferState>[];
 
         when(
           () => smithyOperation.result,
@@ -445,7 +445,7 @@ void main() {
 
         await downloadTask.start();
         await downloadTask.cancel();
-        expect(receivedState.last, S3TransferState.canceled);
+        expect(receivedState.last, StorageTransferState.canceled);
         expect(downloadTask.result, throwsA(isA<StorageException>()));
         expect(bodyStreamHasBeenCanceled, isTrue);
       });
@@ -613,7 +613,7 @@ void main() {
           body: Stream.value(testBodyBytes),
         );
         final smithOperation = MockSmithyOperation<GetObjectOutput>();
-        late S3TransferState finalState;
+        late StorageTransferState finalState;
 
         when(
           () => smithOperation.result,
@@ -643,7 +643,7 @@ void main() {
         unawaited(downloadTask.start());
 
         await downloadTask.result;
-        expect(finalState, S3TransferState.success);
+        expect(finalState, StorageTransferState.success);
       });
       test(
           '`onDone` should be invoked when body stream is completed and ripples exception from onDone to the result Future',
@@ -656,7 +656,7 @@ void main() {
         final smithyOperation = MockSmithyOperation<GetObjectOutput>();
         final testOnDoneException = Exception('some exception');
         var onDoneHasBeenCalled = false;
-        late S3TransferState finalState;
+        late StorageTransferState finalState;
 
         when(
           () => smithyOperation.result,
@@ -691,7 +691,7 @@ void main() {
 
         await expectLater(downloadTask.result, throwsA(testOnDoneException));
         expect(onDoneHasBeenCalled, isTrue);
-        expect(finalState, S3TransferState.failure);
+        expect(finalState, StorageTransferState.failure);
       });
 
       test(

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
-import 'package:amplify_storage_s3_dart/src/exception/s3_storage_exception.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/service/task/s3_download_task.dart';
 import 'package:mocktail/mocktail.dart';
@@ -55,7 +54,7 @@ void main() {
       test(
           'it should ripple exception thrown from `preStart` to the result Future',
           () {
-        final testException = S3Exception.unknownException();
+        const testException = UnknownException('test exception');
         Future<void> testPreStart() async {
           throw testException;
         }

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
@@ -715,7 +715,7 @@ void main() {
       test(
           'should invoke corresponding S3Client APIs with in a happy path to complete the upload',
           () async {
-        final receivedState = <S3TransferState>[];
+        final receivedState = <StorageTransferState>[];
         void onProgress(S3TransferProgress progress) {
           receivedState.add(progress.state);
         }
@@ -910,8 +910,8 @@ void main() {
         expect(partNumbers, equals([1, 2, 3]));
         expect(
           receivedState,
-          List.generate(4, (_) => S3TransferState.inProgress)
-            ..add(S3TransferState.success),
+          List.generate(4, (_) => StorageTransferState.inProgress)
+            ..add(StorageTransferState.success),
         ); // upload start + 3 parts
 
         // verify the CompleteMultipartUpload request
@@ -1267,7 +1267,7 @@ void main() {
       test(
           'should throw exception if the file to be upload is too large to initiate a multipart upload',
           () async {
-        late S3TransferState finalState;
+        late StorageTransferState finalState;
         final testBadFile = AWSFile.fromStream(
           Stream.value([]),
           size: 5 * 1024 * 1024 * 1024 * 1024 + 1, // > 5TiB
@@ -1294,14 +1294,14 @@ void main() {
           uploadTask.result,
           throwsA(isA<StorageException>()),
         );
-        expect(finalState, S3TransferState.failure);
+        expect(finalState, StorageTransferState.failure);
       });
 
       test(
           'should complete with StorageAccessDeniedException when CreateMultipartUploadRequest'
           ' returned UnknownSmithyHttpException with status code 403',
           () async {
-        late S3TransferState finalState;
+        late StorageTransferState finalState;
         final uploadTask = S3UploadTask.fromAWSFile(
           testLocalFile,
           s3Client: s3Client,
@@ -1340,13 +1340,13 @@ void main() {
           ),
         );
 
-        expect(finalState, S3TransferState.failure);
+        expect(finalState, StorageTransferState.failure);
       });
 
       test(
           'should complete with NetworkException when CreateMultipartUploadRequest'
           ' returned AWSHttpException', () async {
-        late S3TransferState finalState;
+        late StorageTransferState finalState;
         final uploadTask = S3UploadTask.fromAWSFile(
           testLocalFile,
           s3Client: s3Client,
@@ -1386,13 +1386,13 @@ void main() {
           ),
         );
 
-        expect(finalState, S3TransferState.failure);
+        expect(finalState, StorageTransferState.failure);
       });
 
       test(
           'should complete with error when CreateMultipartUploadRequest does NOT return a valid uploadId',
           () async {
-        late S3TransferState finalState;
+        late StorageTransferState finalState;
         final uploadTask = S3UploadTask.fromAWSFile(
           testLocalFile,
           s3Client: s3Client,
@@ -1429,14 +1429,14 @@ void main() {
           uploadTask.result,
           throwsA(isA<StorageException>()),
         );
-        expect(finalState, S3TransferState.failure);
+        expect(finalState, StorageTransferState.failure);
       });
 
       test(
           'should complete with StorageAccessDeniedException when'
           ' CompleteMultipartUploadRequest fails (should not happen just in case)',
           () async {
-        late S3TransferState finalState;
+        late StorageTransferState finalState;
         final uploadTask = S3UploadTask.fromAWSFile(
           testLocalFile,
           s3Client: s3Client,
@@ -1512,13 +1512,13 @@ void main() {
             ),
           ),
         );
-        expect(finalState, S3TransferState.failure);
+        expect(finalState, StorageTransferState.failure);
       });
 
       test(
           'should terminate multipart upload when a UploadPartRequest fails due to 403'
           ' and should complete with StorageAccessDeniedException', () async {
-        late S3TransferState finalState;
+        late StorageTransferState finalState;
         final uploadTask = S3UploadTask.fromAWSFile(
           testLocalFile,
           s3Client: s3Client,
@@ -1605,13 +1605,13 @@ void main() {
             testMultipartUploadId,
           ),
         );
-        expect(finalState, S3TransferState.failure);
+        expect(finalState, StorageTransferState.failure);
       });
 
       test(
           'should terminate multipart upload when a UploadPartRequest fails due to AWSHttpException'
           ' and should complete with NetworkException', () async {
-        late S3TransferState finalState;
+        late StorageTransferState finalState;
         final uploadTask = S3UploadTask.fromAWSFile(
           testLocalFile,
           s3Client: s3Client,
@@ -1699,13 +1699,13 @@ void main() {
             testMultipartUploadId,
           ),
         );
-        expect(finalState, S3TransferState.failure);
+        expect(finalState, StorageTransferState.failure);
       });
 
       test(
           'should terminate multipart upload when a UploadPartRequest does NOT return a valid eTag and complete with error',
           () async {
-        late S3TransferState finalState;
+        late StorageTransferState finalState;
         final uploadTask = S3UploadTask.fromAWSFile(
           testLocalFile,
           s3Client: s3Client,
@@ -1770,13 +1770,13 @@ void main() {
           throwsA(isA<StorageException>()),
         );
 
-        expect(finalState, S3TransferState.failure);
+        expect(finalState, StorageTransferState.failure);
       });
 
       test(
           'should terminate multipart upload when a UploadPartRequest encountered NoSuchUpload error and complete with error',
           () async {
-        late S3TransferState finalState;
+        late StorageTransferState finalState;
         final uploadTask = S3UploadTask.fromAWSFile(
           testLocalFile,
           s3Client: s3Client,
@@ -1844,7 +1844,7 @@ void main() {
             ),
           ),
         );
-        expect(finalState, S3TransferState.failure);
+        expect(finalState, StorageTransferState.failure);
       });
 
       group('Control APIs', () {
@@ -1937,7 +1937,7 @@ void main() {
 
         test('pause()/resume() should emit paused stat and complete the upload',
             () async {
-          final receivedState = <S3TransferState>[];
+          final receivedState = <StorageTransferState>[];
           final uploadTask = S3UploadTask.fromAWSFile(
             testLocalFile,
             s3Client: s3Client,
@@ -1985,7 +1985,7 @@ void main() {
           await uploadTask.result;
           expect(
             receivedState,
-            contains(S3TransferState.paused),
+            contains(StorageTransferState.paused),
           );
 
           verify(uploadPartSmithyOperation1.cancel).called(1);
@@ -1996,7 +1996,7 @@ void main() {
         test(
             'cancel() should terminate ongoing multipart upload and throw a StorageException',
             () async {
-          final receivedState = <S3TransferState>[];
+          final receivedState = <StorageTransferState>[];
           final uploadTask = S3UploadTask.fromAWSFile(
             testLocalFile,
             s3Client: s3Client,

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
@@ -1833,14 +1833,10 @@ void main() {
         await expectLater(
           uploadTask.result,
           throwsA(
-            isA<StorageException>().having(
+            isA<UnknownException>().having(
               (o) => o.underlyingException,
               'underlyingException',
-              isA<StorageException>().having(
-                (o) => o.underlyingException,
-                'underlyingException',
-                testException,
-              ),
+              testException,
             ),
           ),
         );

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
@@ -2049,7 +2049,7 @@ void main() {
 
           await expectLater(
             uploadTask.result,
-            throwsA(isA<StorageException>()),
+            throwsA(isA<StorageOperationCanceledException>()),
           );
 
           verify(uploadPartSmithyOperation1.cancel).called(1);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR depends on https://github.com/aws-amplify/amplify-flutter/pull/2774

* Promoted `StorageTransferState` to amplify_core package
* No longer throwing exception on resuming already canceled task (the call of `resume()` doesn't do anything)
* Added generic `StorageOperationCanceled` exception to amplify_core
* Simplified `S3Exception` handling and remove unnecessary logics around it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
