### PR TITLE
ci(repo): Skip failing Windows tests

### DIFF
--- a/.github/workflows/amplify_analytics_pinpoint_dart.yaml
+++ b/.github/workflows/amplify_analytics_pinpoint_dart.yaml
@@ -12,8 +12,11 @@ on:
       - 'packages/analytics/amplify_analytics_pinpoint_dart/**/*.yaml'
       - 'packages/analytics/amplify_analytics_pinpoint_dart/lib/**/*'
       - 'packages/analytics/amplify_analytics_pinpoint_dart/test/**/*'
+      - '.github/composite_actions/setup_firefox/action.yaml'
       - '.github/workflows/dart_vm.yaml'
       - '.github/workflows/dart_native.yaml'
+      - '.github/workflows/dart_ddc.yaml'
+      - '.github/workflows/dart_dart2js.yaml'
       - '.github/workflows/amplify_analytics_pinpoint_dart.yaml'
   schedule:
     - cron: "0 0 * * 0" # Every Sunday at 00:00
@@ -30,5 +33,16 @@ jobs:
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
+    with:
+      working-directory: packages/analytics/amplify_analytics_pinpoint_dart
+      skip-on-windows: true
+  ddc_test:
+    needs: test
+    uses: ./.github/workflows/dart_ddc.yaml
+    with:
+      working-directory: packages/analytics/amplify_analytics_pinpoint_dart
+  dart2js_test:
+    needs: test
+    uses: ./.github/workflows/dart_dart2js.yaml
     with:
       working-directory: packages/analytics/amplify_analytics_pinpoint_dart

--- a/.github/workflows/amplify_api_dart.yaml
+++ b/.github/workflows/amplify_api_dart.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/api/amplify_api_dart
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/amplify_auth_cognito_dart.yaml
+++ b/.github/workflows/amplify_auth_cognito_dart.yaml
@@ -32,3 +32,4 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/auth/amplify_auth_cognito_dart
+      skip-on-windows: false

--- a/.github/workflows/amplify_auth_cognito_test.yaml
+++ b/.github/workflows/amplify_auth_cognito_test.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/auth/amplify_auth_cognito_test
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/amplify_core.yaml
+++ b/.github/workflows/amplify_core.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/amplify_core
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/amplify_db_common_dart.yaml
+++ b/.github/workflows/amplify_db_common_dart.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/common/amplify_db_common_dart
+      skip-on-windows: true
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/amplify_secure_storage_test.yaml
+++ b/.github/workflows/amplify_secure_storage_test.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/secure_storage/amplify_secure_storage_test
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/amplify_storage_s3_dart.yaml
+++ b/.github/workflows/amplify_storage_s3_dart.yaml
@@ -32,3 +32,4 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/storage/amplify_storage_s3_dart
+      skip-on-windows: true

--- a/.github/workflows/aws_common.yaml
+++ b/.github/workflows/aws_common.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/aws_common
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/aws_json1_0_v1.yaml
+++ b/.github/workflows/aws_json1_0_v1.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/awsJson1_0
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/aws_json1_0_v2.yaml
+++ b/.github/workflows/aws_json1_0_v2.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/awsJson1_0
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/aws_json1_1_v1.yaml
+++ b/.github/workflows/aws_json1_1_v1.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/awsJson1_1
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/aws_json1_1_v2.yaml
+++ b/.github/workflows/aws_json1_1_v2.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/awsJson1_1
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/aws_signature_v4.yaml
+++ b/.github/workflows/aws_signature_v4.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/aws_signature_v4
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -7,6 +7,10 @@ on:
         description: The working directory relative to the repo root
         required: true
         type: string
+      skip-on-windows:
+        description: Whether the current package cannot be tested on Windows
+        required: true
+        type: boolean
 
 jobs:
   native_test:
@@ -71,6 +75,6 @@ jobs:
           fi
 
       - name: Run Tests
-        if: "always() && steps.bootstrap.conclusion == 'success'"
+        if: "always() && steps.bootstrap.conclusion == 'success' && (runner.os != 'Windows' || !inputs.skip-on-windows)"
         run: dart test --exclude-tags=build
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/rest_json1_v1.yaml
+++ b/.github/workflows/rest_json1_v1.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/restJson1
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/rest_json1_v2.yaml
+++ b/.github/workflows/rest_json1_v2.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/restJson1
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/rest_xml_v1.yaml
+++ b/.github/workflows/rest_xml_v1.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/restXml
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/rest_xml_v2.yaml
+++ b/.github/workflows/rest_xml_v2.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/restXml
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/rest_xml_with_namespace_v1.yaml
+++ b/.github/workflows/rest_xml_with_namespace_v1.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/restXmlWithNamespace
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/rest_xml_with_namespace_v2.yaml
+++ b/.github/workflows/rest_xml_with_namespace_v2.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/restXmlWithNamespace
+      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/smithy.yaml
+++ b/.github/workflows/smithy.yaml
@@ -32,3 +32,4 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/smithy
+      skip-on-windows: false

--- a/.github/workflows/smithy_aws.yaml
+++ b/.github/workflows/smithy_aws.yaml
@@ -32,3 +32,4 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/smithy_aws
+      skip-on-windows: false

--- a/.github/workflows/smithy_codegen.yaml
+++ b/.github/workflows/smithy_codegen.yaml
@@ -32,3 +32,4 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/smithy_codegen
+      skip-on-windows: false

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -56,6 +56,14 @@ class GenerateWorkflowsCommand extends AmplifyCommand {
           isDartPackage ? 'dart_vm.yaml' : 'flutter_vm.yaml';
       final needsNativeTest =
           isDartPackage && package.unitTestDirectory != null;
+      // Packages which use DB Common (SQLite) will not work on Windows until
+      // native assets are supported.
+      // TODO(dnys1): https://github.com/dart-lang/sdk/issues/50565
+      final skipOnWindows = const [
+        'amplify_db_common_dart',
+        'amplify_analytics_pinpoint_dart',
+        'amplify_storage_s3_dart',
+      ].contains(package.name);
       final needsWebTest =
           package.pubspecInfo.pubspec.devDependencies.containsKey('build_test');
       final workflows = [
@@ -109,6 +117,7 @@ jobs:
     uses: ./.github/workflows/$nativeWorkflow
     with:
       working-directory: $repoRelativePath
+      skip-on-windows: $skipOnWindows
 ''',
         );
 


### PR DESCRIPTION
Packages which use DB Common (SQLite) will not work on Windows until [native assets](https://github.com/dart-lang/sdk/issues/50565) are supported.
