### PR TITLE
feat(storage): make access level optional for storage APIs

### DIFF
--- a/packages/amplify_core/lib/src/types/storage/base/storage_operation_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/base/storage_operation_options.dart
@@ -5,8 +5,8 @@ import 'package:amplify_core/src/types/storage/access_level.dart';
 
 abstract class StorageOperationOptions {
   const StorageOperationOptions({
-    required this.accessLevel,
+    this.accessLevel,
   });
 
-  final StorageAccessLevel accessLevel;
+  final StorageAccessLevel? accessLevel;
 }

--- a/packages/amplify_core/lib/src/types/storage/download_data_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/download_data_options.dart
@@ -14,7 +14,7 @@ class StorageDownloadDataOptions extends StorageOperationOptions
         AWSDebuggable {
   /// {@macro amplify_core.storage.download_data_options}
   const StorageDownloadDataOptions({
-    required super.accessLevel,
+    super.accessLevel,
     this.pluginOptions,
   });
 
@@ -29,7 +29,7 @@ class StorageDownloadDataOptions extends StorageOperationOptions
 
   @override
   Map<String, Object?> toJson() => {
-        'accessLevel': accessLevel.name,
+        'accessLevel': accessLevel?.name,
         'pluginOptions': pluginOptions?.toJson(),
       };
 }

--- a/packages/amplify_core/lib/src/types/storage/download_file_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/download_file_options.dart
@@ -14,7 +14,7 @@ class StorageDownloadFileOptions extends StorageOperationOptions
         AWSDebuggable {
   /// {@macro amplify_core.storage.download_file_options}
   const StorageDownloadFileOptions({
-    required super.accessLevel,
+    super.accessLevel,
     this.pluginOptions,
   });
 
@@ -29,7 +29,7 @@ class StorageDownloadFileOptions extends StorageOperationOptions
 
   @override
   Map<String, Object?> toJson() => {
-        'accessLevel': accessLevel.name,
+        'accessLevel': accessLevel?.name,
         'pluginOptions': pluginOptions?.toJson(),
       };
 }

--- a/packages/amplify_core/lib/src/types/storage/get_properties_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/get_properties_options.dart
@@ -14,7 +14,7 @@ class StorageGetPropertiesOptions extends StorageOperationOptions
         AWSDebuggable {
   /// {@macro amplify_core.storage.get_properties_options}
   const StorageGetPropertiesOptions({
-    required super.accessLevel,
+    super.accessLevel,
     this.pluginOptions,
   });
 
@@ -29,7 +29,7 @@ class StorageGetPropertiesOptions extends StorageOperationOptions
 
   @override
   Map<String, Object?> toJson() => {
-        'accessLevel': accessLevel.name,
+        'accessLevel': accessLevel?.name,
         'pluginOptions': pluginOptions?.toJson(),
       };
 }

--- a/packages/amplify_core/lib/src/types/storage/get_url_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/get_url_options.dart
@@ -14,7 +14,7 @@ class StorageGetUrlOptions extends StorageOperationOptions
         AWSDebuggable {
   /// {@macro amplify_core.storage.get_url_options}
   const StorageGetUrlOptions({
-    required super.accessLevel,
+    super.accessLevel,
     this.pluginOptions,
   });
 
@@ -29,7 +29,7 @@ class StorageGetUrlOptions extends StorageOperationOptions
 
   @override
   Map<String, Object?> toJson() => {
-        'accessLevel': accessLevel.name,
+        'accessLevel': accessLevel?.name,
         'pluginOptions': pluginOptions?.toJson(),
       };
 }

--- a/packages/amplify_core/lib/src/types/storage/list_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/list_options.dart
@@ -14,7 +14,7 @@ class StorageListOptions extends StorageOperationOptions
         AWSDebuggable {
   /// {@macro amplify_core.storage.list_options}
   const StorageListOptions({
-    required super.accessLevel,
+    super.accessLevel,
     this.pageSize = 1000,
     this.nextToken,
     this.pluginOptions,
@@ -37,7 +37,7 @@ class StorageListOptions extends StorageOperationOptions
 
   @override
   Map<String, Object?> toJson() => {
-        'accessLevel': accessLevel.name,
+        'accessLevel': accessLevel?.name,
         'pageSize': pageSize,
         'nextToken': nextToken,
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/storage/remove_many_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/remove_many_options.dart
@@ -14,7 +14,7 @@ class StorageRemoveManyOptions extends StorageOperationOptions
         AWSDebuggable {
   /// {@macro amplify_core.storage.remove_many_options}
   const StorageRemoveManyOptions({
-    required super.accessLevel,
+    super.accessLevel,
     this.pluginOptions,
   });
 
@@ -29,7 +29,7 @@ class StorageRemoveManyOptions extends StorageOperationOptions
 
   @override
   Map<String, Object?> toJson() => {
-        'accessLevel': accessLevel.name,
+        'accessLevel': accessLevel?.name,
         'pluginOptions': pluginOptions?.toJson(),
       };
 }

--- a/packages/amplify_core/lib/src/types/storage/remove_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/remove_options.dart
@@ -14,7 +14,7 @@ class StorageRemoveOptions extends StorageOperationOptions
         AWSDebuggable {
   /// {@macro amplify_core.storage.remove_options}
   const StorageRemoveOptions({
-    required super.accessLevel,
+    super.accessLevel,
     this.pluginOptions,
   });
 
@@ -29,7 +29,7 @@ class StorageRemoveOptions extends StorageOperationOptions
 
   @override
   Map<String, Object?> toJson() => {
-        'accessLevel': accessLevel.name,
+        'accessLevel': accessLevel?.name,
         'pluginOptions': pluginOptions?.toJson(),
       };
 }

--- a/packages/amplify_core/lib/src/types/storage/upload_data_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/upload_data_options.dart
@@ -14,7 +14,7 @@ class StorageUploadDataOptions extends StorageOperationOptions
         AWSDebuggable {
   /// {@macro amplify_core.storage.upload_data_options}
   const StorageUploadDataOptions({
-    required super.accessLevel,
+    super.accessLevel,
     this.pluginOptions,
   });
 
@@ -29,7 +29,7 @@ class StorageUploadDataOptions extends StorageOperationOptions
 
   @override
   Map<String, Object?> toJson() => {
-        'accessLevel': accessLevel.name,
+        'accessLevel': accessLevel?.name,
         'pluginOptions': pluginOptions?.toJson(),
       };
 }

--- a/packages/amplify_core/lib/src/types/storage/upload_file_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/upload_file_options.dart
@@ -14,7 +14,7 @@ class StorageUploadFileOptions extends StorageOperationOptions
         AWSDebuggable {
   /// {@macro amplify_core.storage.upload_file_options}
   const StorageUploadFileOptions({
-    required super.accessLevel,
+    super.accessLevel,
     this.pluginOptions,
   });
 
@@ -29,7 +29,7 @@ class StorageUploadFileOptions extends StorageOperationOptions
 
   @override
   Map<String, Object?> toJson() => {
-        'accessLevel': accessLevel.name,
+        'accessLevel': accessLevel?.name,
         'pluginOptions': pluginOptions?.toJson(),
       };
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -143,8 +143,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
       ..addInstance<StorageS3Service>(
         StorageS3Service(
           credentialsProvider: credentialsProvider,
-          defaultBucket: s3pluginConfig.bucket,
-          defaultRegion: s3pluginConfig.region,
+          s3PluginConfig: s3PluginConfig,
           delimiter: _delimiter,
           prefixResolver: _prefixResolver!,
           logger: logger,

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -170,7 +170,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
       defaultPluginOptions: const S3ListPluginOptions(),
     );
     final s3Options = StorageListOptions(
-      accessLevel: options?.accessLevel ?? s3pluginConfig.defaultAccessLevel,
+      accessLevel: options?.accessLevel,
       pluginOptions: s3PluginOptions,
     );
 
@@ -197,7 +197,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     );
 
     final s3Options = StorageGetPropertiesOptions(
-      accessLevel: options?.accessLevel ?? s3pluginConfig.defaultAccessLevel,
+      accessLevel: options?.accessLevel,
       pluginOptions: s3PluginOptions,
     );
 
@@ -224,7 +224,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     );
 
     final s3Options = StorageGetUrlOptions(
-      accessLevel: options?.accessLevel ?? s3pluginConfig.defaultAccessLevel,
+      accessLevel: options?.accessLevel,
       pluginOptions: s3PluginOptions,
     );
 
@@ -252,7 +252,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     );
 
     final s3Options = StorageDownloadDataOptions(
-      accessLevel: options?.accessLevel ?? s3pluginConfig.defaultAccessLevel,
+      accessLevel: options?.accessLevel,
       pluginOptions: s3PluginOptions,
     );
 
@@ -293,7 +293,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
       defaultPluginOptions: const S3DownloadFilePluginOptions(),
     );
     options = StorageDownloadFileOptions(
-      accessLevel: options?.accessLevel ?? s3pluginConfig.defaultAccessLevel,
+      accessLevel: options?.accessLevel,
       pluginOptions: s3PluginOptions,
     );
     return download_file_impl.downloadFile(
@@ -320,7 +320,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     );
 
     final s3Options = StorageUploadDataOptions(
-      accessLevel: options?.accessLevel ?? s3pluginConfig.defaultAccessLevel,
+      accessLevel: options?.accessLevel,
       pluginOptions: s3PluginOptions,
     );
 
@@ -357,7 +357,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     );
 
     final s3Options = StorageUploadFileOptions(
-      accessLevel: options?.accessLevel ?? s3pluginConfig.defaultAccessLevel,
+      accessLevel: options?.accessLevel,
       pluginOptions: s3PluginOptions,
     );
 
@@ -458,7 +458,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     );
 
     final s3Options = StorageRemoveOptions(
-      accessLevel: options?.accessLevel ?? s3pluginConfig.defaultAccessLevel,
+      accessLevel: options?.accessLevel,
       pluginOptions: s3PluginOptions,
     );
 
@@ -485,7 +485,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
     );
 
     final s3Options = StorageRemoveManyOptions(
-      accessLevel: options?.accessLevel ?? s3pluginConfig.defaultAccessLevel,
+      accessLevel: options?.accessLevel,
       pluginOptions: s3PluginOptions,
     );
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
@@ -50,6 +50,7 @@ class S3DownloadTask {
     required s3.S3Client s3Client,
     required smithy_aws.S3ClientConfig defaultS3ClientConfig,
     required S3PrefixResolver prefixResolver,
+    required StorageAccessLevel defaultAccessLevel,
     required String bucket,
     required String key,
     required StorageDownloadDataOptions options,
@@ -64,6 +65,7 @@ class S3DownloadTask {
         _defaultS3ClientConfig = defaultS3ClientConfig,
         _prefixResolver = prefixResolver,
         _bucket = bucket,
+        _defaultAccessLevel = defaultAccessLevel,
         _key = key,
         _downloadDataOptions = options,
         _preStart = preStart,
@@ -84,6 +86,7 @@ class S3DownloadTask {
   final smithy_aws.S3ClientConfig _defaultS3ClientConfig;
   final S3PrefixResolver _prefixResolver;
   final String _bucket;
+  final StorageAccessLevel _defaultAccessLevel;
   final String _key;
   final StorageDownloadDataOptions _downloadDataOptions;
   final FutureOr<void> Function()? _preStart;
@@ -137,7 +140,7 @@ class S3DownloadTask {
     final resolvedPrefix = await StorageS3Service.getResolvedPrefix(
       prefixResolver: _prefixResolver,
       logger: _logger,
-      accessLevel: _downloadDataOptions.accessLevel,
+      accessLevel: _downloadDataOptions.accessLevel ?? _defaultAccessLevel,
       identityId: _s3PluginOptions.targetIdentityId,
     );
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -49,6 +49,7 @@ class S3UploadTask {
     required smithy_aws.S3ClientConfig defaultS3ClientConfig,
     required S3PrefixResolver prefixResolver,
     required String bucket,
+    required StorageAccessLevel defaultAccessLevel,
     required String key,
     required StorageUploadDataOptions options,
     S3DataPayload? dataPayload,
@@ -60,6 +61,7 @@ class S3UploadTask {
         _defaultS3ClientConfig = defaultS3ClientConfig,
         _prefixResolver = prefixResolver,
         _bucket = bucket,
+        _defaultAccessLevel = defaultAccessLevel,
         _key = key,
         _options = options,
         _dataPayload = dataPayload,
@@ -82,6 +84,7 @@ class S3UploadTask {
     required smithy_aws.S3ClientConfig defaultS3ClientConfig,
     required S3PrefixResolver prefixResolver,
     required String bucket,
+    required StorageAccessLevel defaultAccessLevel,
     required String key,
     required StorageUploadDataOptions options,
     void Function(S3TransferProgress)? onProgress,
@@ -92,6 +95,7 @@ class S3UploadTask {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: prefixResolver,
           bucket: bucket,
+          defaultAccessLevel: defaultAccessLevel,
           key: key,
           dataPayload: dataPayload,
           options: options,
@@ -109,6 +113,7 @@ class S3UploadTask {
     required smithy_aws.S3ClientConfig defaultS3ClientConfig,
     required S3PrefixResolver prefixResolver,
     required String bucket,
+    required StorageAccessLevel defaultAccessLevel,
     required String key,
     required StorageUploadDataOptions options,
     void Function(S3TransferProgress)? onProgress,
@@ -119,6 +124,7 @@ class S3UploadTask {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: prefixResolver,
           bucket: bucket,
+          defaultAccessLevel: defaultAccessLevel,
           key: key,
           localFile: localFile,
           options: options,
@@ -136,6 +142,7 @@ class S3UploadTask {
   final smithy_aws.S3ClientConfig _defaultS3ClientConfig;
   final S3PrefixResolver _prefixResolver;
   final String _bucket;
+  final StorageAccessLevel _defaultAccessLevel;
   final String _key;
   final StorageUploadDataOptions _options;
   final void Function(S3TransferProgress)? _onProgress;
@@ -298,7 +305,7 @@ class S3UploadTask {
     final resolvedPrefix = await StorageS3Service.getResolvedPrefix(
       prefixResolver: _prefixResolver,
       logger: _logger,
-      accessLevel: _options.accessLevel,
+      accessLevel: _options.accessLevel ?? _defaultAccessLevel,
     );
 
     _resolvedKey = '$resolvedPrefix$_key';

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -148,10 +148,8 @@ void main() {
 
       test('should forward default options to StorageS3Service.list() API',
           () async {
-        const defaultOptions = StorageListOptions(
-          accessLevel: testDefaultStorageAccessLevel,
-          pluginOptions: S3ListPluginOptions(),
-        );
+        const defaultOptions =
+            StorageListOptions(pluginOptions: S3ListPluginOptions());
 
         when(
           () => storageS3Service.list(
@@ -176,49 +174,6 @@ void main() {
         expect(
           capturedOptions,
           defaultOptions,
-        );
-
-        final result = await listOperation.result;
-        expect(
-          result,
-          testResult,
-        );
-      });
-
-      test(
-          'should forward options with default access level to StorageS3Service.list() API',
-          () async {
-        const testOptions = StorageListOptions(
-          accessLevel: testDefaultStorageAccessLevel,
-          pluginOptions: S3ListPluginOptions(),
-        );
-
-        when(
-          () => storageS3Service.list(
-            path: testPath,
-            options: testOptions,
-          ),
-        ).thenAnswer(
-          (_) async => testResult,
-        );
-
-        final listOperation = storageS3Plugin.list(
-          path: testPath,
-          options: const StorageListOptions(),
-        );
-
-        final capturedOptions = verify(
-          () => storageS3Service.list(
-            path: testPath,
-            options: captureAny<StorageListOptions>(
-              named: 'options',
-            ),
-          ),
-        ).captured.last;
-
-        expect(
-          capturedOptions,
-          testOptions,
         );
 
         final result = await listOperation.result;
@@ -295,7 +250,6 @@ void main() {
           'should forward default options to StorageS3Service.getProperties() API',
           () async {
         const defaultOptions = StorageGetPropertiesOptions(
-          accessLevel: testDefaultStorageAccessLevel,
           pluginOptions: S3GetPropertiesPluginOptions(),
         );
 
@@ -331,46 +285,6 @@ void main() {
           result,
           testResult,
         );
-      });
-
-      test(
-          'should forward options with default access level to StorageS3Service.getProperties() API',
-          () async {
-        const testOptions = StorageGetPropertiesOptions(
-          accessLevel: testDefaultStorageAccessLevel,
-          pluginOptions: S3GetPropertiesPluginOptions(),
-        );
-
-        when(
-          () => storageS3Service.getProperties(
-            key: testKey,
-            options: testOptions,
-          ),
-        ).thenAnswer(
-          (_) async => testResult,
-        );
-
-        final getPropertiesOperation = storageS3Plugin.getProperties(
-          key: testKey,
-          options: const StorageGetPropertiesOptions(),
-        );
-
-        final capturedOptions = verify(
-          () => storageS3Service.getProperties(
-            key: testKey,
-            options: captureAny<StorageGetPropertiesOptions>(
-              named: 'options',
-            ),
-          ),
-        ).captured.last;
-
-        expect(
-          capturedOptions,
-          testOptions,
-        );
-
-        final result = await getPropertiesOperation.result;
-        expect(result, testResult);
       });
 
       test('should forward options to StorageS3Service.getProperties() API',
@@ -433,7 +347,6 @@ void main() {
       test('should forward default options to StorageS3Service.getUrl() API',
           () async {
         const defaultOptions = StorageGetUrlOptions(
-          accessLevel: testDefaultStorageAccessLevel,
           pluginOptions: S3GetUrlPluginOptions(),
         );
 
@@ -460,49 +373,6 @@ void main() {
         expect(
           capturedOptions,
           defaultOptions,
-        );
-
-        final result = await getUrlOperation.result;
-        expect(
-          result,
-          testResult,
-        );
-      });
-
-      test(
-          'should forward options with default access level to StorageS3Service.getUrl() API',
-          () async {
-        const testOptions = StorageGetUrlOptions(
-          accessLevel: testDefaultStorageAccessLevel,
-          pluginOptions: S3GetUrlPluginOptions(),
-        );
-
-        when(
-          () => storageS3Service.getUrl(
-            key: testKey,
-            options: testOptions,
-          ),
-        ).thenAnswer(
-          (_) async => testResult,
-        );
-
-        final getUrlOperation = storageS3Plugin.getUrl(
-          key: testKey,
-          options: const StorageGetUrlOptions(),
-        );
-
-        final capturedOptions = verify(
-          () => storageS3Service.getUrl(
-            key: testKey,
-            options: captureAny<StorageGetUrlOptions>(
-              named: 'options',
-            ),
-          ),
-        ).captured.last;
-
-        expect(
-          capturedOptions,
-          testOptions,
         );
 
         final result = await getUrlOperation.result;
@@ -583,7 +453,6 @@ void main() {
           'should forward default options to StorageS3Service.downloadData API',
           () async {
         const defaultOptions = StorageDownloadDataOptions(
-          accessLevel: testDefaultStorageAccessLevel,
           pluginOptions: S3DownloadDataPluginOptions(),
         );
 
@@ -625,45 +494,6 @@ void main() {
         final result = await downloadDataOperation.result;
         expect(result.bytes.isEmpty, true);
         expect(result.downloadedItem, testItem);
-      });
-
-      test(
-          'should forward options with default access level to StorageS3Service.downloadData API',
-          () async {
-        const testOptions = StorageDownloadDataOptions(
-          accessLevel: testDefaultStorageAccessLevel,
-          pluginOptions: S3DownloadDataPluginOptions(),
-        );
-
-        when(
-          () => storageS3Service.downloadData(
-            key: testKey,
-            options: testOptions,
-            onData: any(named: 'onData'),
-          ),
-        ).thenAnswer((_) => testS3DownloadTask);
-
-        when(() => testS3DownloadTask.result).thenAnswer((_) async => testItem);
-
-        downloadDataOperation = storageS3Plugin.downloadData(
-          key: testKey,
-          options: const StorageDownloadDataOptions(),
-        );
-
-        final capturedOptions = verify(
-          () => storageS3Service.downloadData(
-            key: testKey,
-            onData: any(named: 'onData'),
-            options: captureAny<StorageDownloadDataOptions>(
-              named: 'options',
-            ),
-          ),
-        ).captured.last;
-
-        expect(
-          capturedOptions,
-          testOptions,
-        );
       });
 
       test('should forward options to StorageS3Service.downloadData API',
@@ -750,7 +580,6 @@ void main() {
       test('should forward default options to StorageS3Service.uploadData API',
           () async {
         const defaultOptions = StorageUploadDataOptions(
-          accessLevel: testDefaultStorageAccessLevel,
           pluginOptions: S3UploadDataPluginOptions(),
         );
 
@@ -799,46 +628,6 @@ void main() {
         expect(
           result.uploadedItem,
           testItem,
-        );
-      });
-
-      test(
-          'should forward options with default access level to StorageS3Service.uploadData API',
-          () async {
-        const testOptions = StorageUploadDataOptions(
-          accessLevel: testDefaultStorageAccessLevel,
-          pluginOptions: S3UploadDataPluginOptions(),
-        );
-
-        when(
-          () => storageS3Service.uploadData(
-            key: testKey,
-            dataPayload: any(named: 'dataPayload'),
-            options: testOptions,
-          ),
-        ).thenAnswer((_) => testS3UploadTask);
-
-        when(() => testS3UploadTask.result).thenAnswer((_) async => testItem);
-
-        uploadDataOperation = storageS3Plugin.uploadData(
-          data: testData,
-          key: testKey,
-          options: const StorageUploadDataOptions(),
-        );
-
-        final capturedOptions = verify(
-          () => storageS3Service.uploadData(
-            key: testKey,
-            dataPayload: any(named: 'dataPayload'),
-            options: captureAny<StorageUploadDataOptions>(
-              named: 'options',
-            ),
-          ),
-        ).captured.last;
-
-        expect(
-          capturedOptions,
-          testOptions,
         );
       });
 
@@ -920,7 +709,6 @@ void main() {
       test('should forward default options to StorageS3Service.uploadFile API',
           () async {
         const defaultOptions = StorageUploadFileOptions(
-          accessLevel: testDefaultStorageAccessLevel,
           pluginOptions: S3UploadFilePluginOptions(),
         );
 
@@ -970,46 +758,6 @@ void main() {
 
         final result = await uploadFileOperation.result;
         expect(result.uploadedItem, testItem);
-      });
-
-      test(
-          'should forward options with default access level to StorageS3Service.uploadFile API',
-          () async {
-        const testOptions = StorageUploadFileOptions(
-          accessLevel: testDefaultStorageAccessLevel,
-          pluginOptions: S3UploadFilePluginOptions(),
-        );
-
-        when(
-          () => storageS3Service.uploadFile(
-            key: testKey,
-            localFile: any(named: 'localFile'),
-            options: testOptions,
-          ),
-        ).thenAnswer((_) => testS3UploadTask);
-
-        when(() => testS3UploadTask.result).thenAnswer((_) async => testItem);
-
-        uploadFileOperation = storageS3Plugin.uploadFile(
-          key: testKey,
-          localFile: testLocalFile,
-          options: const StorageUploadFileOptions(),
-        );
-
-        final capturedOptions = verify(
-          () => storageS3Service.uploadFile(
-            key: testKey,
-            localFile: any(named: 'localFile'),
-            options: captureAny<StorageUploadFileOptions>(
-              named: 'options',
-            ),
-          ),
-        ).captured.last;
-
-        expect(
-          capturedOptions,
-          testOptions,
-        );
       });
 
       test('should forward options to StorageS3Service.uploadFile API',
@@ -1290,7 +1038,6 @@ void main() {
       test('should forward default options to StorageS3Service.remove() API',
           () async {
         const defaultOptions = StorageRemoveOptions(
-          accessLevel: testDefaultStorageAccessLevel,
           pluginOptions: S3RemovePluginOptions(),
         );
         when(
@@ -1314,46 +1061,6 @@ void main() {
         expect(
           capturedOptions,
           defaultOptions,
-        );
-
-        final result = await removeOperation.result;
-        expect(
-          result,
-          testResult,
-        );
-      });
-
-      test(
-          'should forward options with default access level to StorageS3Service.remove() API',
-          () async {
-        const testOptions = StorageRemoveOptions(
-          accessLevel: testDefaultStorageAccessLevel,
-          pluginOptions: S3RemovePluginOptions(),
-        );
-        when(
-          () => storageS3Service.remove(
-            key: testKey,
-            options: testOptions,
-          ),
-        ).thenAnswer((_) async => testResult);
-
-        final removeOperation = storageS3Plugin.remove(
-          key: testKey,
-          options: const StorageRemoveOptions(),
-        );
-
-        final capturedOptions = verify(
-          () => storageS3Service.remove(
-            key: testKey,
-            options: captureAny<StorageRemoveOptions>(
-              named: 'options',
-            ),
-          ),
-        ).captured.last;
-
-        expect(
-          capturedOptions,
-          testOptions,
         );
 
         final result = await removeOperation.result;
@@ -1424,7 +1131,6 @@ void main() {
           'should forward default options to StorageS3Service.removeMany() API',
           () async {
         const defaultOptions = StorageRemoveManyOptions(
-          accessLevel: testDefaultStorageAccessLevel,
           pluginOptions: S3RemoveManyPluginOptions(),
         );
 
@@ -1447,45 +1153,6 @@ void main() {
         expect(
           capturedOptions,
           defaultOptions,
-        );
-
-        final result = await removeManyOperation.result;
-        expect(
-          result.removedItems,
-          resultRemoveItems,
-        );
-      });
-
-      test(
-          'should forward options with default access level to StorageS3Service.removeMany() API',
-          () async {
-        const testOptions = StorageRemoveManyOptions(
-          accessLevel: testDefaultStorageAccessLevel,
-          pluginOptions: S3RemoveManyPluginOptions(),
-        );
-
-        when(
-          () => storageS3Service.removeMany(
-            keys: testKeys,
-            options: testOptions,
-          ),
-        ).thenAnswer((_) async => testResult);
-
-        final removeManyOperation = storageS3Plugin.removeMany(
-          keys: testKeys,
-          options: const StorageRemoveManyOptions(),
-        );
-
-        final capturedOptions = verify(
-          () => storageS3Service.removeMany(
-            keys: testKeys,
-            options: captureAny(named: 'options'),
-          ),
-        ).captured.last;
-
-        expect(
-          capturedOptions,
-          testOptions,
         );
 
         final result = await removeManyOperation.result;

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
@@ -20,9 +20,10 @@ import '../storage_s3_service_test.dart';
 void main() {
   group('S3DownloadTask', () {
     const testBucket = 'bucket1';
+    const testDefaultAccessLevel = StorageAccessLevel.guest;
     const testKey = 'some-object';
     const defaultTestOptions = StorageDownloadDataOptions(
-      accessLevel: StorageAccessLevel.guest,
+      accessLevel: StorageAccessLevel.private,
     );
     final testPrefixResolver = TestPrefixResolver();
     const defaultS3ClientConfig = S3ClientConfig();
@@ -64,6 +65,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: defaultTestOptions,
           logger: logger,
@@ -75,7 +77,8 @@ void main() {
         expect(downloadTask.result, throwsA(testException));
       });
 
-      test('it should invoke S3Client.getObject API with correct parameters',
+      test(
+          'it should invoke S3Client.getObject API with correct parameters and default access level',
           () async {
         const testBodyBytes = [101, 102];
         final testGetObjectOutput = GetObjectOutput(
@@ -101,8 +104,9 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
-          options: defaultTestOptions,
+          options: const StorageDownloadDataOptions(),
           logger: logger,
           onProgress: (progress) {
             finalState = progress.state;
@@ -125,7 +129,7 @@ void main() {
         expect(
           request.key,
           '${await testPrefixResolver.resolvePrefix(
-            accessLevel: defaultTestOptions.accessLevel,
+            accessLevel: testDefaultAccessLevel,
           )}$testKey',
         );
         expect(request.checksumMode, ChecksumMode.enabled);
@@ -167,6 +171,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testOptions,
           logger: logger,
@@ -216,6 +221,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: defaultTestOptions,
           logger: logger,
@@ -266,6 +272,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: defaultTestOptions,
           logger: logger,
@@ -312,6 +319,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: defaultTestOptions,
           logger: logger,
@@ -376,6 +384,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: defaultTestOptions,
           logger: logger,
@@ -425,6 +434,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: defaultTestOptions,
           logger: logger,
@@ -494,6 +504,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: defaultTestOptions,
           logger: logger,
@@ -512,6 +523,7 @@ void main() {
             defaultS3ClientConfig: defaultS3ClientConfig,
             prefixResolver: testPrefixResolver,
             bucket: testBucket,
+            defaultAccessLevel: testDefaultAccessLevel,
             key: testKey,
             options: defaultTestOptions,
             logger: logger,
@@ -564,6 +576,7 @@ void main() {
             defaultS3ClientConfig: defaultS3ClientConfig,
             prefixResolver: testPrefixResolver,
             bucket: testBucket,
+            defaultAccessLevel: testDefaultAccessLevel,
             key: testKey,
             options: defaultTestOptions,
             logger: logger,
@@ -618,6 +631,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: defaultTestOptions,
           logger: logger,
@@ -660,6 +674,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: defaultTestOptions,
           logger: logger,
@@ -725,6 +740,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testOptions,
           logger: logger,
@@ -745,7 +761,7 @@ void main() {
             (o) => o.key,
             'key',
             '${await testPrefixResolver.resolvePrefix(
-              accessLevel: testOptions.accessLevel,
+              accessLevel: testOptions.accessLevel!,
               identityId: testTargetIdentity,
             )}$testKey',
           ),

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
@@ -31,6 +31,7 @@ void main() {
     const testUploadDataOptions = StorageUploadDataOptions(
       accessLevel: StorageAccessLevel.private,
     );
+    const testDefaultAccessLevel = StorageAccessLevel.guest;
 
     setUpAll(() {
       s3Client = MockS3Client();
@@ -91,7 +92,8 @@ void main() {
       final testDataPayloadBytes = S3DataPayload.bytes([101, 102]);
       const testKey = 'object-upload-to';
 
-      test('should invoke S3Client.putObject API with expected parameters',
+      test(
+          'should invoke S3Client.putObject API with expected parameters and default access level',
           () async {
         final testPutObjectOutput = s3.PutObjectOutput();
         final smithyOperation = MockSmithyOperation<s3.PutObjectOutput>();
@@ -115,8 +117,9 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
-          options: testUploadDataOptions,
+          options: const StorageUploadDataOptions(),
           logger: logger,
           transferDatabase: transferDatabase,
         );
@@ -140,7 +143,7 @@ void main() {
         expect(
           request.key,
           '${await testPrefixResolver.resolvePrefix(
-            accessLevel: testUploadDataOptions.accessLevel,
+            accessLevel: testDefaultAccessLevel,
           )}$testKey',
         );
         expect(request.body, testDataPayload);
@@ -177,6 +180,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -227,6 +231,7 @@ void main() {
             defaultS3ClientConfig: defaultS3ClientConfig,
             prefixResolver: testPrefixResolver,
             bucket: testBucket,
+            defaultAccessLevel: testDefaultAccessLevel,
             key: testKey,
             options: testUploadDataOptions,
             logger: logger,
@@ -297,6 +302,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -316,7 +322,7 @@ void main() {
         expect(
           request.key,
           '${await testPrefixResolver.resolvePrefix(
-            accessLevel: testUploadDataOptions.accessLevel,
+            accessLevel: testUploadDataOptions.accessLevel!,
           )}$testKey',
         );
       });
@@ -331,6 +337,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: prefixResolverThrowsException,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -362,6 +369,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -399,6 +407,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -444,6 +453,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -496,6 +506,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -521,7 +532,7 @@ void main() {
         expect(
           request.key,
           '${await testPrefixResolver.resolvePrefix(
-            accessLevel: testUploadDataOptions.accessLevel,
+            accessLevel: testUploadDataOptions.accessLevel!,
           )}$testKey',
         );
         expect(request.contentType, await testLocalFile.contentType);
@@ -559,6 +570,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -615,6 +627,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -669,6 +682,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -808,6 +822,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -840,7 +855,7 @@ void main() {
         expect(
           createMultipartUploadRequest.key,
           '${await testPrefixResolver.resolvePrefix(
-            accessLevel: testUploadDataOptions.accessLevel,
+            accessLevel: testUploadDataOptions.accessLevel!,
           )}$testKey',
         );
         expect(
@@ -881,7 +896,7 @@ void main() {
           expect(
             request.key,
             '${await testPrefixResolver.resolvePrefix(
-              accessLevel: testUploadDataOptions.accessLevel,
+              accessLevel: testUploadDataOptions.accessLevel!,
             )}$testKey',
           );
           partNumbers.add(request.partNumber);
@@ -917,7 +932,7 @@ void main() {
         expect(
           completeMultipartUploadRequest.key,
           '${await testPrefixResolver.resolvePrefix(
-            accessLevel: testUploadDataOptions.accessLevel,
+            accessLevel: testUploadDataOptions.accessLevel!,
           )}$testKey',
         );
 
@@ -998,6 +1013,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -1090,6 +1106,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -1191,6 +1208,7 @@ void main() {
             defaultS3ClientConfig: defaultS3ClientConfig,
             prefixResolver: testPrefixResolver,
             bucket: testBucket,
+            defaultAccessLevel: testDefaultAccessLevel,
             key: testKey,
             options: testUploadDataOptions,
             logger: logger,
@@ -1228,6 +1246,7 @@ void main() {
               defaultS3ClientConfig: defaultS3ClientConfig,
               prefixResolver: testPrefixResolver,
               bucket: testBucket,
+              defaultAccessLevel: testDefaultAccessLevel,
               key: testKey,
               options: testUploadDataOptions,
               logger: logger,
@@ -1260,6 +1279,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -1289,6 +1309,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -1333,6 +1354,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: const StorageUploadDataOptions(
             accessLevel: StorageAccessLevel.guest,
@@ -1378,6 +1400,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -1421,6 +1444,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -1502,6 +1526,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -1594,6 +1619,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: const StorageUploadDataOptions(
             accessLevel: StorageAccessLevel.guest,
@@ -1687,6 +1713,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -1757,6 +1784,7 @@ void main() {
           defaultS3ClientConfig: defaultS3ClientConfig,
           prefixResolver: testPrefixResolver,
           bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
           key: testKey,
           options: testUploadDataOptions,
           logger: logger,
@@ -1917,6 +1945,7 @@ void main() {
             defaultS3ClientConfig: defaultS3ClientConfig,
             prefixResolver: testPrefixResolver,
             bucket: testBucket,
+            defaultAccessLevel: testDefaultAccessLevel,
             key: testKey,
             options: testUploadDataOptions,
             logger: logger,
@@ -1975,6 +2004,7 @@ void main() {
             defaultS3ClientConfig: defaultS3ClientConfig,
             prefixResolver: testPrefixResolver,
             bucket: testBucket,
+            defaultAccessLevel: testDefaultAccessLevel,
             key: testKey,
             options: testUploadDataOptions,
             logger: logger,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- make access level optional for storage APIs
- `defaultAccessLevel` can be set by `Amplify.Amplify.configure(...)` with fallback to `guest`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
