### PR TITLE
fix(auth): Process sign-in events once

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,11 @@
 {
   "configurations": [
     {
+      "name": "Run",
+      "type": "dart",
+      "request": "launch",
+    },
+    {
       "name": "Dart Test in Chrome",
       "type": "dart",
       "request": "launch",

--- a/infra/lib/auth/custom-auth-without-srp/common.ts
+++ b/infra/lib/auth/custom-auth-without-srp/common.ts
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export type ChallengeMetadata = {
+  /// The number of attempts made by the user to enter the custom challenge code.
+  attempts: number;
+};

--- a/infra/lib/auth/custom-auth-without-srp/create-auth-challenge.ts
+++ b/infra/lib/auth/custom-auth-without-srp/create-auth-challenge.ts
@@ -2,15 +2,46 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type * as lambda from "aws-lambda";
+import type {
+  ChallengeResult,
+  CustomChallengeResult
+} from "aws-lambda/trigger/cognito-user-pool-trigger/_common";
+import { ChallengeMetadata } from "./common";
 
 export const handler: lambda.CreateAuthChallengeTriggerHandler = async (
   event: lambda.CreateAuthChallengeTriggerEvent
 ): Promise<lambda.CreateAuthChallengeTriggerEvent> => {
   console.log(`Got request: ${JSON.stringify(event.request, null, 2)}`);
+
+  const session = event.request.session;
+  const currentSession: ChallengeResult | CustomChallengeResult | undefined =
+    session.length > 0 ? session[session.length - 1] : undefined;
+
   if (event.request.challengeName === "CUSTOM_CHALLENGE") {
-    event.response.publicChallengeParameters = { "test-key": "test-value" };
-    event.response.privateChallengeParameters = { answer: "123" };
+    // Allow up to 3 retries. A custom retry mechanism like this is the only way
+    // to enable retrying in a custom challenge flow since there are no built-in
+    // mechanisms besides pass/fail.
+    // https://stackoverflow.com/questions/50692461/aws-cognito-custom-challenge-with-retry?rq=1
+    const metadata: ChallengeMetadata = currentSession
+      ? JSON.parse(currentSession.challengeMetadata!)
+      : { attempts: 0 };
+    const { attempts } = metadata;
+    if (attempts <= 3) {
+      const challengeParams: {
+        "test-key": string;
+        errorCode?: string;
+      } = { "test-key": "test-value" };
+      if (attempts > 0) {
+        challengeParams.errorCode = "NotAuthorizedException";
+      }
+      event.response.publicChallengeParameters = challengeParams;
+      event.response.privateChallengeParameters = { answer: "123" };
+      event.response.challengeMetadata = JSON.stringify({
+        attempts: attempts + 1,
+      });
+    }
   }
 
+  console.log(`Responding with: ${JSON.stringify(event.response, null, 2)}`);
   return event;
 };

--- a/infra/lib/auth/custom-auth-without-srp/define-auth-challenge.ts
+++ b/infra/lib/auth/custom-auth-without-srp/define-auth-challenge.ts
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type * as lambda from "aws-lambda";
+import type {
+  ChallengeResult,
+  CustomChallengeResult
+} from "aws-lambda/trigger/cognito-user-pool-trigger/_common";
+import { ChallengeMetadata } from "./common";
 
 export const handler: lambda.DefineAuthChallengeTriggerHandler = async (
   event: lambda.DefineAuthChallengeTriggerEvent
@@ -13,20 +18,39 @@ export const handler: lambda.DefineAuthChallengeTriggerHandler = async (
     event.response.issueTokens = false;
     return event;
   }
-  if (event.request.session.length === 0) {
+
+  const session = event.request.session;
+  const currentSession: ChallengeResult | CustomChallengeResult | undefined =
+    session.length > 0 ? session[session.length - 1] : undefined;
+
+  if (!currentSession) {
     event.response.failAuthentication = false;
     event.response.issueTokens = false;
     event.response.challengeName = "CUSTOM_CHALLENGE";
-  } else if (
-    event.request.session.length === 1 &&
-    event.request.session[0].challengeName === "CUSTOM_CHALLENGE" &&
-    event.request.session[0].challengeResult === true
-  ) {
-    event.response.failAuthentication = false;
-    event.response.issueTokens = true;
+  } else if (currentSession.challengeName === "CUSTOM_CHALLENGE") {
+    if (currentSession.challengeResult) {
+      event.response.failAuthentication = false;
+      event.response.issueTokens = true;
+    } else {
+      // Allow up to 3 retries. A custom retry mechanism like this is the only way
+      // to enable retrying in a custom challenge flow since there are no built-in
+      // mechanisms besides pass/fail.
+      // https://stackoverflow.com/questions/50692461/aws-cognito-custom-challenge-with-retry?rq=1
+      const metadata = JSON.parse(currentSession.challengeMetadata!) as ChallengeMetadata;
+      if (metadata.attempts <= 3) {
+        event.response.failAuthentication = false;
+        event.response.issueTokens = false;
+        event.response.challengeName = "CUSTOM_CHALLENGE";
+      } else {
+        event.response.issueTokens = false;
+        event.response.failAuthentication = true;
+      }
+    }
   } else {
     event.response.issueTokens = false;
     event.response.failAuthentication = true;
   }
+
+  console.log(`Responding with: ${JSON.stringify(event.response, null, 2)}`);
   return event;
 };

--- a/packages/amplify_core/lib/src/config/auth/cognito/authentication_flow_type.dart
+++ b/packages/amplify_core/lib/src/config/auth/cognito/authentication_flow_type.dart
@@ -15,7 +15,6 @@ enum AuthenticationFlowType {
   userPasswordAuth('USER_PASSWORD_AUTH'),
 
   /// Authentication flow for custom flow which are backed by Lambda triggers.
-  // TODO(dnys1): Remove at GA
   @Deprecated('Use customAuthWithSrp or customAuthWithoutSrp instead')
   @JsonValue('CUSTOM_AUTH')
   customAuth('CUSTOM_AUTH'),

--- a/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_in_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_in_test.dart
@@ -112,5 +112,25 @@ void main() {
         ),
       );
     });
+
+    asyncTest('allows retrying on weak password', (_) async {
+      const weakPassword = 'weak';
+      await expectLater(
+        Amplify.Auth.confirmSignIn(
+          confirmationValue: weakPassword,
+        ),
+        throwsA(isA<InvalidPasswordException>()),
+      );
+
+      final newPassword = generatePassword();
+      final confirmRes = await Amplify.Auth.confirmSignIn(
+        confirmationValue: newPassword,
+      );
+      expect(confirmRes.isSignedIn, isFalse);
+      expect(
+        confirmRes.nextStep.signInStep,
+        AuthSignInStep.confirmSignInWithSmsMfaCode,
+      );
+    });
   });
 }

--- a/packages/auth/amplify_auth_cognito/example/integration_test/custom_auth_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/custom_auth_test.dart
@@ -14,6 +14,7 @@ import 'utils/test_utils.dart';
 void main() {
   AWSLogger().logLevel = LogLevel.verbose;
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final logger = AWSLogger().createChild('CustomAuth');
 
   group('custom auth', () {
     // Arbitrary challenge answer defined in Lambda
@@ -103,10 +104,64 @@ void main() {
             res.nextStep.signInStep,
             AuthSignInStep.confirmSignInWithCustomChallenge,
           );
-          // '123' is the arbitrary challenge answer defined in lambda code
+          // Can retry 3 times
+          for (var retry = 1; retry <= 3; retry++) {
+            logger.debug('Retry attempt: $retry');
+            final confirmRes = await Amplify.Auth.confirmSignIn(
+              confirmationValue: 'wrong',
+            );
+            expect(
+              confirmRes.nextStep.signInStep,
+              AuthSignInStep.confirmSignInWithCustomChallenge,
+            );
+            expect(
+              confirmRes.nextStep.additionalInfo,
+              containsPair('errorCode', 'NotAuthorizedException'),
+            );
+          }
           await expectLater(
-            Amplify.Auth.confirmSignIn(confirmationValue: 'wrong'),
+            Amplify.Auth.confirmSignIn(
+              confirmationValue: 'wrong',
+            ),
             throwsA(isA<AuthNotAuthorizedException>()),
+            reason: 'After 3 tries, fail completely',
+          );
+        },
+      );
+
+      asyncTest(
+        'challenges can be re-attempted on failure',
+        (_) async {
+          final res = await Amplify.Auth.signIn(
+            username: username,
+            options: options,
+          );
+          expect(
+            res.nextStep.signInStep,
+            AuthSignInStep.confirmSignInWithCustomChallenge,
+          );
+          final confirmRes = await Amplify.Auth.confirmSignIn(
+            confirmationValue: 'wrong',
+          );
+          expect(
+            confirmRes.nextStep.signInStep,
+            AuthSignInStep.confirmSignInWithCustomChallenge,
+          );
+          expect(
+            confirmRes.nextStep.additionalInfo,
+            containsPair('errorCode', 'NotAuthorizedException'),
+          );
+          await expectLater(
+            Amplify.Auth.confirmSignIn(
+              confirmationValue: confirmationValue,
+            ),
+            completion(
+              isA<CognitoSignInResult>().having(
+                (res) => res.isSignedIn,
+                'isSignedIn',
+                isTrue,
+              ),
+            ),
           );
         },
       );
@@ -267,6 +322,25 @@ void main() {
             confirmationValue: confirmationValue,
           );
           expect(res.isSignedIn, true);
+        },
+      );
+
+      asyncTest(
+        'an incorrect challenge reply should throw a NotAuthorizedException',
+        (_) async {
+          final res = await Amplify.Auth.signIn(
+            username: username,
+            password: password,
+            options: options,
+          );
+          expect(
+            res.nextStep.signInStep,
+            AuthSignInStep.confirmSignInWithCustomChallenge,
+          );
+          await expectLater(
+            Amplify.Auth.confirmSignIn(confirmationValue: 'wrong'),
+            throwsA(isA<AuthNotAuthorizedException>()),
+          );
         },
       );
 

--- a/packages/auth/amplify_auth_cognito/example/integration_test/custom_auth_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/custom_auth_test.dart
@@ -166,6 +166,13 @@ void main() {
           ),
           throwsA(isA<AuthNotAuthorizedException>()),
         );
+        await expectLater(
+          Amplify.Auth.confirmSignIn(
+            confirmationValue: confirmationValue,
+          ),
+          throwsA(isA<AuthNotAuthorizedException>()),
+          reason: 'Authorization failures are not retryable',
+        );
       });
 
       asyncTest('works with deprecated auth flow', (_) async {
@@ -336,6 +343,13 @@ void main() {
             ),
           ),
           throwsA(isA<AuthNotAuthorizedException>()),
+        );
+        await expectLater(
+          Amplify.Auth.confirmSignIn(
+            confirmationValue: confirmationValue,
+          ),
+          throwsA(isA<AuthNotAuthorizedException>()),
+          reason: 'Authorization failures are not retryable',
         );
       });
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/exception/auth_precondition_exception.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/exception/auth_precondition_exception.dart
@@ -12,7 +12,12 @@ import 'package:meta/meta.dart';
 class AuthPreconditionException extends AuthException
     implements PreconditionException {
   /// {@macro amplify_auth_cognito.exception.auth_precondition_exception}
-  const AuthPreconditionException(super.message, {this.shouldEmit = true});
+  const AuthPreconditionException(
+    super.message, {
+    super.recoverySuggestion,
+    super.underlyingException,
+    this.shouldEmit = true,
+  });
 
   @override
   String get precondition => message;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -890,7 +890,11 @@ class SignInStateMachine extends AuthStateMachine<SignInEvent, SignInState> {
   @override
   SignInState? resolveError(Object error, StackTrace st) {
     if (error is Exception) {
-      return SignInFailure(error, st);
+      return SignInFailure(
+        previousState: currentState,
+        exception: error,
+        stackTrace: st,
+      );
     }
     return null;
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_in_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_in_state.dart
@@ -56,10 +56,11 @@ abstract class SignInState extends AuthState<SignInStateType> {
   const factory SignInState.cancelling() = SignInCancelling;
 
   /// {@macro amplify_auth_cognito_dart.sign_in_failure}
-  const factory SignInState.failure(
-    Exception exception,
-    StackTrace stackTrace,
-  ) = SignInFailure;
+  const factory SignInState.failure({
+    required SignInState previousState,
+    required Exception exception,
+    required StackTrace stackTrace,
+  }) = SignInFailure;
 
   @override
   String get runtimeTypeName => 'SignInState';
@@ -161,7 +162,14 @@ class SignInCancelling extends SignInState {
 /// {@endtemplate}
 class SignInFailure extends SignInState with ErrorState {
   /// {@macro amplify_auth_cognito_dart.sign_in_failure}
-  const SignInFailure(this.exception, this.stackTrace);
+  const SignInFailure({
+    required this.previousState,
+    required this.exception,
+    required this.stackTrace,
+  });
+
+  /// The state of the machine at the time [exception] was raised.
+  final SignInState previousState;
 
   /// The exception thrown during sign up.
   @override
@@ -174,5 +182,5 @@ class SignInFailure extends SignInState with ErrorState {
   SignInStateType get type => SignInStateType.failure;
 
   @override
-  List<Object?> get props => [type, exception, stackTrace];
+  List<Object?> get props => [type, previousState, exception, stackTrace];
 }


### PR DESCRIPTION
Fixes #2794.

- Fixes a regression caused by a recent change ([8d87ea8#diff-9d1c23e771518da5d10ac1f888bd38c5f865868332b126a16ab6d19fd3ef028fR825](https://github.com/aws-amplify/amplify-flutter/commit/8d87ea871b2d8a716f0f7f087e2660b7a8e61994#diff-9d1c23e771518da5d10ac1f888bd38c5f865868332b126a16ab6d19fd3ef028fR653))
- Improves sign-in exception handling logic (now aligned with iOS/Android)
- Adds more custom auth tests