### PR TITLE
chore(aft): Add contributor aft script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@ Thank you for your interest in contributing to our project! <3 Whether it's a bu
 - [Our Design](#our-design)
 - [Development Process](#development-process)
   - [Setting up for local development](#setting-up-for-local-development)
-      - [Amplify Flutter Repo Tool (aft)](#amplify-flutter-repo-tool-aft)
       - [Packages inside Amplify Flutter](#packages-inside-amplify-flutter)
     - [Platform Setup](#platform-setup)
       - [Linux](#linux)
@@ -53,31 +52,28 @@ Our work is done directly on Github and PR's are sent to the github repo by core
 
 This section should get you running with **Amplify Flutter** and get you familiar with the basics of the codebase.
 
-Start by, [Forking](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the main branch of [amplify-flutter](https://github.com/aws-amplify/amplify-flutter).
+Start by [forking](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the main branch of [amplify-flutter](https://github.com/aws-amplify/amplify-flutter) and cloning the repo locally.
 
-You will need to install `melos` for dependency management.
-Run `melos bootstrap` to link local packages together and install remaining dependencies.
-
-Note that running `flutter pub get` in the packages is no longer required, because `melos bootstrap` has
-already installed all the dependencies.
-
-See [invertase/melos](https://github.com/invertase/melos) for more instructions on how to use `melos`.
-
-```
+```sh
 $ git clone git@github.com:[username]/amplify-flutter.git --recurse-submodules
-$ cd amplify-flutter
-$ dart pub global activate melos
-$ melos bootstrap
 ```
-> Note: If you already cloned the project and forgot `--recurse-submodules`, run `git submodule update --init --recursive`.
 
-> Note: If you don't include `melos` on your path, you may execute `dart pub global run melos bootstrap` instead of the last command above.
+> Note: If you already cloned the project and forgot `--recurse-submodules`, run `git submodule update --init --recursive`.
 
 > Note: Make sure to always [sync your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork) with main branch of amplify-flutter
 
-#### Amplify Flutter Repo Tool (aft)
+Then, from the root of the directory, run `./aft bootstrap` to link local packages together and install remaining dependencies. 
 
-Some workflows are being migrated to a tool we call `aft`. This is developed locally in the repo and can be installed using `dart pub global activate -spath packages/aft`. For a list of supported commands, run `aft --help`.
+```sh
+$ cd amplify-flutter
+$ ./aft bootstrap
+```
+
+> The bootstrap command creates `pubspec_override.yaml` files in each of the packages, overriding dependencies to use the local version
+> instead of the published one. This allows changes in one package to be instantly available in all others. It also means that commands
+> like `flutter pub get` will continue to work as expected.
+
+The `aft` command provides See `aft`'s [README](packages/aft/README.md) for more instructions on how to use `aft`.
 
 #### Packages inside Amplify Flutter
 

--- a/aft
+++ b/aft
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+if ! command -v flutter >/dev/null; then
+    echo "Flutter not installed or not in PATH." >&2
+    exit 1
+fi
+
+REPO_ROOT=$(dirname $0)
+
+# Locate Dart SDK
+FLUTTER_EXE=$(which flutter)
+FLUTTER_BIN=$(dirname $FLUTTER_EXE)
+DART_BIN=$FLUTTER_BIN/cache/dart-sdk/bin
+
+# Run `aft` from snapshot
+$DART_BIN/dartaotruntime $REPO_ROOT/build-support/aft.snapshot $@

--- a/packages/aft/README.md
+++ b/packages/aft/README.md
@@ -2,6 +2,12 @@
 
 A CLI tool for managing the Amplify Flutter repository.
 
+To run, use the provided `aft` script from the root of the repository.
+
+```
+$ ./aft bootstrap
+```
+
 ## Commands
 
 - `bootstrap`/`bs`: Sets up repo for development work
@@ -20,34 +26,38 @@ A CLI tool for managing the Amplify Flutter repository.
 - `run`: Run a script defined in `aft.yaml`
 - `version-bump`: Bumps version using git history
 
-## Setup
+A full list of available commands and options can be found by running `aft --help`.
 
-To run some commands, `libgit2` is required and can be installed with the following commands:
+## Development
+
+When developing `aft`, some commands will require the `libgit2` library for interacting with the repo's commit history. This library can be installed with the following commands:
 
 ```sh
+# On macOS
 $ brew install libgit2
 ```
 
 ```sh
+# On Linux
 $ sudo apt-get install libgit2-dev
 ```
 
-To activate `aft`, run:
+To activate and run the local `aft` package:
 
 ```sh
 $ dart pub global activate -spath packages/aft
+$ aft --help
 ```
 
-A full list of available commands and options can be found by running `aft --help`.
+Make sure the Dart pub cache is in your PATH to run `aft` as a global executable after activating. See [here](https://dart.dev/tools/pub/cmd/pub-global#running-a-script-from-your-path) for more information.
 
-
-## Writing Scripts
+### Writing Scripts
 
 `aft` supports running named scripts using the `aft run` command. Scripts are defined in the `scripts` section of the `aft.yaml` and consist of two parts:
 - `from`: defines where the script will run
 - `run`: defines the script which will run
 
-### Package Selectors
+#### Package Selectors
 The `from` option specifies a package selector which is a way to describe which packages (or more specifically, package paths) a script will run from. 
 
 Selectors can be:
@@ -105,7 +115,7 @@ from:
 
 The combinations can get as complex as you want!
 
-### Templated Scripts
+#### Templated Scripts
 
 The `run` option takes in any valid Bash script which will be templated using [`mustache`](https://mustache.github.io/mustache.5.html) to give access to the context in which the script is running.
 


### PR DESCRIPTION
This allows contributors to not need to activate `aft` via `dart pub global`, saving them time and confusion.

## Speed Comparison

![aft](https://user-images.githubusercontent.com/24740863/228877285-7135c835-3652-4636-8d35-799f48336f1f.gif)
