### PR TITLE
chore(auth): Reject `signIn` when authenticated

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -131,6 +131,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
 
   /// The underlying state machine, for use in subclasses.
   @protected
+  @visibleForTesting
   CognitoAuthStateMachine get stateMachine => _stateMachine;
 
   @visibleForTesting
@@ -569,6 +570,20 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface<
     String? password,
     SignInOptions? options,
   }) async {
+    bool isSignedIn;
+    try {
+      isSignedIn = (await fetchAuthSession()).isSignedIn;
+    } on Exception {
+      isSignedIn = false;
+    }
+    if (isSignedIn) {
+      throw const InvalidStateException(
+        'A user is already signed in.',
+        recoverySuggestion:
+            'Sign out the current user by calling `Amplify.Auth.signOut` and try the sign in again.',
+      );
+    }
+
     final pluginOptions = reifyPluginOptions(
       pluginOptions: options?.pluginOptions,
       defaultPluginOptions: const CognitoSignInPluginOptions(),

--- a/packages/auth/amplify_auth_cognito_test/lib/hosted_ui/hosted_ui_server.dart
+++ b/packages/auth/amplify_auth_cognito_test/lib/hosted_ui/hosted_ui_server.dart
@@ -127,7 +127,7 @@ class HostedUiServer implements Closeable {
       _currentSignIn = null;
       _currentSignOut = null;
     }
-    // ignore: invalid_use_of_protected_member
+    // ignore: invalid_use_of_protected_member, invalid_use_of_visible_for_testing_member
     final credentials = await _plugin.stateMachine.loadCredentials();
     return credentials.toJson();
   }

--- a/packages/auth/amplify_auth_cognito_test/test/plugin/sign_in_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/plugin/sign_in_test.dart
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
+import 'package:amplify_auth_cognito_test/common/mock_clients.dart';
+import 'package:amplify_auth_cognito_test/common/mock_config.dart';
+import 'package:amplify_auth_cognito_test/common/mock_secure_storage.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late AmplifyAuthCognitoDart plugin;
+  late CognitoAuthStateMachine stateMachine;
+  late MockSecureStorage secureStorage;
+
+  final testAuthRepo = AmplifyAuthProviderRepository();
+
+  group('signIn', () {
+    setUp(() {
+      secureStorage = MockSecureStorage();
+      plugin = AmplifyAuthCognitoDart(
+        secureStorageFactory: (_) => secureStorage,
+      );
+      stateMachine = plugin.stateMachine;
+    });
+
+    tearDown(Amplify.reset);
+
+    test('calling signIn while authenticated should fail', () async {
+      await plugin.configure(
+        config: mockConfig,
+        authProviderRepo: testAuthRepo,
+      );
+
+      final mockIdp = MockCognitoIdentityProviderClient(
+        initiateAuth: (_) async => InitiateAuthResponse(
+          authenticationResult: AuthenticationResultType(
+            accessToken: accessToken.raw,
+            refreshToken: refreshToken,
+            idToken: idToken.raw,
+          ),
+        ),
+        globalSignOut: () async => GlobalSignOutResponse(),
+        revokeToken: () async => RevokeTokenResponse(),
+      );
+      stateMachine.addInstance<CognitoIdentityProviderClient>(mockIdp);
+
+      await expectLater(
+        plugin.signIn(
+          username: username,
+          password: 'password',
+        ),
+        completion(
+          isA<CognitoSignInResult>().having(
+            (res) => res.isSignedIn,
+            'isSignedIn',
+            isTrue,
+          ),
+        ),
+      );
+
+      await expectLater(
+        plugin.signIn(
+          username: username,
+          password: 'password',
+        ),
+        throwsA(isA<InvalidStateException>()),
+        reason: 'Calling signIn while authenticated should fail',
+      );
+
+      await plugin.signOut();
+
+      await expectLater(
+        plugin.signIn(
+          username: username,
+          password: 'password',
+        ),
+        completion(
+          isA<CognitoSignInResult>().having(
+            (res) => res.isSignedIn,
+            'isSignedIn',
+            isTrue,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/auth/amplify_auth_cognito_test/test/plugin/sign_out_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/plugin/sign_out_test.dart
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// ignore_for_file: invalid_use_of_protected_member
-
 import 'dart:async';
 
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart'


### PR DESCRIPTION
Calling `signIn` while authenticated should fail with an `InvalidStateException`.

Based off [docs](https://docs.amplify.aws/lib/auth/signin/q/platform/flutter/#sign-in-a-user) and [iOS impl](https://github.com/aws-amplify/amplify-swift/blob/c65904f79d1796b93cc6f43bd4794daac7f5b3bc/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift#L172)