### PR TITLE
feat(storage): add handling of non-ascii object metadata values

### DIFF
--- a/infra/lib/storage/stack.ts
+++ b/infra/lib/storage/stack.ts
@@ -110,6 +110,12 @@ class StorageIntegrationTestEnvironment extends IntegrationTestStackEnvironment<
             "x-amz-request-id",
             "x-amz-id-2",
             "ETag",
+            // This is required workaround on Web to retrieve metadata fields
+            // via GetObject and HeadObject.
+            // https://github.com/aws-amplify/amplify-js/issues/2903#issuecomment-475012164
+            "x-amz-meta-filename",
+            "x-amz-meta-description",
+            "x-amz-meta-owner",
           ],
           maxAge: 3000,
         },

--- a/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
@@ -301,6 +301,23 @@ void main() {
         });
 
         testWidgets(
+            'should throw generating downloadable url of a non-existent object',
+            (WidgetTester tester) async {
+          final result = Amplify.Storage.getUrl(
+            key: 'random/non-existent/object.png',
+            options: const StorageGetUrlOptions(
+              accessLevel: StorageAccessLevel.private,
+              pluginOptions: S3GetUrlPluginOptions(
+                validateObjectExistence: true,
+                expiresIn: Duration(minutes: 5),
+              ),
+            ),
+          ).result;
+
+          expect(result, throwsA(isA<StorageKeyNotFoundException>()));
+        });
+
+        testWidgets(
             'download object as bytes data in memory with access level private'
             ' for the currently signed in user', (WidgetTester tester) async {
           final result = await Amplify.Storage.downloadData(

--- a/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
@@ -291,7 +291,7 @@ void main() {
             options: const StorageGetUrlOptions(
               accessLevel: StorageAccessLevel.private,
               pluginOptions: S3GetUrlPluginOptions(
-                checkObjectExistence: true,
+                validateObjectExistence: true,
                 expiresIn: Duration(minutes: 5),
               ),
             ),
@@ -535,7 +535,7 @@ void main() {
               options: const StorageGetUrlOptions(
                 accessLevel: StorageAccessLevel.guest,
                 pluginOptions: S3GetUrlPluginOptions(
-                  checkObjectExistence: true,
+                  validateObjectExistence: true,
                 ),
               ),
             );
@@ -552,7 +552,7 @@ void main() {
                 accessLevel: StorageAccessLevel.protected,
                 pluginOptions: S3GetUrlPluginOptions.forIdentity(
                   user1IdentityId,
-                  checkObjectExistence: true,
+                  validateObjectExistence: true,
                 ),
               ),
             );
@@ -569,7 +569,7 @@ void main() {
               options: const StorageGetUrlOptions(
                 accessLevel: StorageAccessLevel.private,
                 pluginOptions: S3GetUrlPluginOptions(
-                  checkObjectExistence: true,
+                  validateObjectExistence: true,
                 ),
               ),
             );

--- a/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
@@ -173,20 +173,25 @@ void main() {
             isA<S3UploadDataResult>().having(
               (o) => o.uploadedItem,
               'uploadedItem',
-              isA<S3Item>().having(
-                (o) => o.contentType,
-                'contentType',
-                testContentType,
-              ),
-            ),
-          );
-
-          expect(
-            result,
-            isA<S3UploadDataResult>().having(
-              (o) => o.uploadedItem,
-              'uploadedItem',
-              isA<S3Item>().having((o) => o.eTag, 'eTag', isNotEmpty),
+              isA<S3Item>()
+                  .having(
+                    (o) => o.contentType,
+                    'contentType',
+                    testContentType,
+                  )
+                  .having(
+                    (o) => o.eTag,
+                    'eTag',
+                    isNotEmpty,
+                  )
+                  .having(
+                    (o) => o.metadata,
+                    'metadata',
+                    containsPair(
+                      'filename',
+                      testObjectFileName1,
+                    ),
+                  ),
             ),
           );
 
@@ -218,20 +223,13 @@ void main() {
             isA<S3UploadDataResult>().having(
               (o) => o.uploadedItem,
               'uploadedItem',
-              isA<S3Item>().having(
-                (o) => o.contentType,
-                'contentType',
-                'image/jpeg',
-              ),
-            ),
-          );
-
-          expect(
-            result,
-            isA<S3UploadDataResult>().having(
-              (o) => o.uploadedItem,
-              'uploadedItem',
-              isA<S3Item>().having((o) => o.eTag, 'eTag', isNotEmpty),
+              isA<S3Item>()
+                  .having(
+                    (o) => o.contentType,
+                    'contentType',
+                    'image/jpeg',
+                  )
+                  .having((o) => o.eTag, 'eTag', isNotEmpty),
             ),
           );
 
@@ -263,20 +261,13 @@ void main() {
             isA<S3UploadFileResult>().having(
               (o) => o.uploadedItem,
               'uploadedItem',
-              isA<S3Item>().having(
-                (o) => o.contentType,
-                'contentType',
-                'application/octet-stream',
-              ),
-            ),
-          );
-
-          expect(
-            result,
-            isA<S3UploadFileResult>().having(
-              (o) => o.uploadedItem,
-              'uploadedItem',
-              isA<S3Item>().having((o) => o.eTag, 'eTag', isNotEmpty),
+              isA<S3Item>()
+                  .having(
+                    (o) => o.contentType,
+                    'contentType',
+                    'application/octet-stream',
+                  )
+                  .having((o) => o.eTag, 'eTag', isNotEmpty),
             ),
           );
 
@@ -489,6 +480,55 @@ void main() {
             )
           ],
         );
+
+        testWidgets(
+            'multiple fields of user defined metadata with non-ascii string values',
+            (widgetTester) async {
+          final objectKey = 'metadata-test-${uuid()}';
+          const testContentType = 'text/plain';
+          final testMetadata = {
+            'filename': objectKey,
+            'description': 'Today is a 🌞 晴天 😎',
+            'owner': '悟空',
+          };
+          final s3Plugin =
+              Amplify.Storage.getPlugin(AmplifyStorageS3.pluginKey);
+          final result = await s3Plugin
+              .uploadData(
+                data: S3DataPayload.bytes(
+                  testBytes,
+                  contentType: testContentType,
+                ),
+                key: objectKey,
+                options: StorageUploadDataOptions(
+                  metadata: testMetadata,
+                  accessLevel: StorageAccessLevel.guest,
+                  pluginOptions: const S3UploadDataPluginOptions(
+                    getProperties: true,
+                  ),
+                ),
+              )
+              .result;
+
+          expect(
+            result,
+            isA<S3UploadDataResult>().having(
+              (o) => o.uploadedItem,
+              'uploadedItem',
+              isA<S3Item>().having(
+                (o) => o.metadata,
+                'metadata',
+                isNotEmpty,
+              ),
+            ),
+          );
+
+          final metadata = result.uploadedItem.metadata;
+
+          expect(metadata, equals(testMetadata));
+
+          await s3Plugin.remove(key: objectKey).result;
+        });
       });
 
       group(

--- a/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
+++ b/packages/storage/amplify_storage_s3_dart/example/bin/example.dart
@@ -197,7 +197,7 @@ Future<void> getUrlOperation() async {
         expiresIn: const Duration(
           minutes: 10,
         ),
-        checkObjectExistence: true,
+        validateObjectExistence: true,
         useAccelerateEndpoint: useAccelerateEndpoint,
       ),
     ),

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_options.dart
@@ -18,12 +18,12 @@ class S3GetUrlOptions extends StorageGetUrlOptions {
   const S3GetUrlOptions({
     StorageAccessLevel accessLevel = StorageAccessLevel.guest,
     Duration expiresIn = const Duration(minutes: 15),
-    bool checkObjectExistence = false,
+    bool validateObjectExistence = false,
     bool useAccelerateEndpoint = false,
   }) : this._(
           accessLevel: accessLevel,
           expiresIn: expiresIn,
-          checkObjectExistence: checkObjectExistence,
+          validateObjectExistence: validateObjectExistence,
           useAccelerateEndpoint: useAccelerateEndpoint,
         );
   @Deprecated(
@@ -32,7 +32,7 @@ class S3GetUrlOptions extends StorageGetUrlOptions {
   const S3GetUrlOptions._({
     super.accessLevel = StorageAccessLevel.guest,
     this.expiresIn = const Duration(minutes: 15),
-    this.checkObjectExistence = false,
+    this.validateObjectExistence = false,
     this.targetIdentityId,
     this.useAccelerateEndpoint = false,
   });
@@ -47,12 +47,12 @@ class S3GetUrlOptions extends StorageGetUrlOptions {
   const S3GetUrlOptions.forIdentity(
     String targetIdentityId, {
     Duration expiresIn = const Duration(minutes: 15),
-    bool checkObjectExistence = false,
+    bool validateObjectExistence = false,
     bool useAccelerateEndpoint = false,
   }) : this._(
           accessLevel: StorageAccessLevel.protected,
           expiresIn: expiresIn,
-          checkObjectExistence: checkObjectExistence,
+          validateObjectExistence: validateObjectExistence,
           targetIdentityId: targetIdentityId,
           useAccelerateEndpoint: useAccelerateEndpoint,
         );
@@ -62,7 +62,7 @@ class S3GetUrlOptions extends StorageGetUrlOptions {
 
   /// Specifies if check object existence in the S3 bucket before generating
   /// a presigned url.
-  final bool checkObjectExistence;
+  final bool validateObjectExistence;
 
   /// The identity ID of another user who uploaded the object.
   ///

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_plugin_options.dart
@@ -14,17 +14,17 @@ class S3GetUrlPluginOptions extends StorageGetUrlPluginOptions {
   /// {@macro storage.amplify_storage_s3.get_url_plugin_options}
   const S3GetUrlPluginOptions({
     Duration expiresIn = const Duration(minutes: 15),
-    bool checkObjectExistence = false,
+    bool validateObjectExistence = false,
     bool useAccelerateEndpoint = false,
   }) : this._(
           expiresIn: expiresIn,
-          checkObjectExistence: checkObjectExistence,
+          validateObjectExistence: validateObjectExistence,
           useAccelerateEndpoint: useAccelerateEndpoint,
         );
 
   const S3GetUrlPluginOptions._({
     this.expiresIn = const Duration(minutes: 15),
-    this.checkObjectExistence = false,
+    this.validateObjectExistence = false,
     this.targetIdentityId,
     this.useAccelerateEndpoint = false,
   });
@@ -36,11 +36,11 @@ class S3GetUrlPluginOptions extends StorageGetUrlPluginOptions {
   const S3GetUrlPluginOptions.forIdentity(
     String targetIdentityId, {
     Duration expiresIn = const Duration(minutes: 15),
-    bool checkObjectExistence = false,
+    bool validateObjectExistence = false,
     bool useAccelerateEndpoint = false,
   }) : this._(
           expiresIn: expiresIn,
-          checkObjectExistence: checkObjectExistence,
+          validateObjectExistence: validateObjectExistence,
           targetIdentityId: targetIdentityId,
           useAccelerateEndpoint: useAccelerateEndpoint,
         );
@@ -54,7 +54,7 @@ class S3GetUrlPluginOptions extends StorageGetUrlPluginOptions {
 
   /// Specifies if check object existence in the S3 bucket before generating
   /// a presigned url.
-  final bool checkObjectExistence;
+  final bool validateObjectExistence;
 
   /// The identity ID of another user who uploaded the object.
   ///
@@ -67,7 +67,7 @@ class S3GetUrlPluginOptions extends StorageGetUrlPluginOptions {
   @override
   List<Object?> get props => [
         expiresIn,
-        checkObjectExistence,
+        validateObjectExistence,
         useAccelerateEndpoint,
         targetIdentityId,
       ];

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_plugin_options.g.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_plugin_options.g.dart
@@ -12,7 +12,8 @@ S3GetUrlPluginOptions _$S3GetUrlPluginOptionsFromJson(
       expiresIn: json['expiresIn'] == null
           ? const Duration(minutes: 15)
           : Duration(microseconds: json['expiresIn'] as int),
-      checkObjectExistence: json['checkObjectExistence'] as bool? ?? false,
+      validateObjectExistence:
+          json['validateObjectExistence'] as bool? ?? false,
       useAccelerateEndpoint: json['useAccelerateEndpoint'] as bool? ?? false,
     );
 
@@ -20,6 +21,6 @@ Map<String, dynamic> _$S3GetUrlPluginOptionsToJson(
         S3GetUrlPluginOptions instance) =>
     <String, dynamic>{
       'expiresIn': instance.expiresIn.inMicroseconds,
-      'checkObjectExistence': instance.checkObjectExistence,
+      'validateObjectExistence': instance.validateObjectExistence,
       'useAccelerateEndpoint': instance.useAccelerateEndpoint,
     };

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_item.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_item.dart
@@ -3,6 +3,7 @@
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';
 import 'package:meta/meta.dart';
 
 /// {@template storage.amplify_storage_s3.storage_s3_item}
@@ -10,15 +11,15 @@ import 'package:meta/meta.dart';
 /// {@endtemplate}
 class S3Item extends StorageItem {
   /// {@macro storage.amplify_storage_s3.storage_s3_item}
-  const S3Item({
+  S3Item({
     required super.key,
     super.size,
     super.lastModified,
     super.eTag,
-    super.metadata = const <String, String>{},
+    Map<String, String> metadata = const <String, String>{},
     this.versionId,
     this.contentType,
-  });
+  }) : super(metadata: decodeMetadata(metadata));
 
   /// Creates [S3Item] from [StorageItem].
   factory S3Item.from(StorageItem storageItem) {
@@ -29,7 +30,7 @@ class S3Item extends StorageItem {
             size: storageItem.size,
             lastModified: storageItem.lastModified,
             eTag: storageItem.eTag,
-            metadata: storageItem.metadata,
+            metadata: decodeMetadata(storageItem.metadata),
           );
   }
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_item.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_item.dart
@@ -65,8 +65,6 @@ class S3Item extends StorageItem {
 
   /// Creates a [S3Item] from [s3.HeadObjectOutput] provided by S3
   /// Client.
-  ///
-  /// This named constructor should be used internally only.
   @internal
   factory S3Item.fromHeadObjectOutput(
     s3.HeadObjectOutput headObjectOutput, {
@@ -83,9 +81,25 @@ class S3Item extends StorageItem {
     );
   }
 
-  /// Removes `prefixToDrop` from `key` string.
-  ///
-  /// This should only be used internally.
+  /// Creates a [S3Item] from [s3.GetObjectOutput] provided by S3
+  /// Client.
+  @internal
+  factory S3Item.fromGetObjectOutput(
+    s3.GetObjectOutput getObjectOutput, {
+    required String key,
+  }) {
+    return S3Item(
+      key: key,
+      lastModified: getObjectOutput.lastModified,
+      eTag: getObjectOutput.eTag,
+      metadata: getObjectOutput.metadata?.toMap() ?? const {},
+      versionId: getObjectOutput.versionId,
+      size: getObjectOutput.contentLength?.toInt(),
+      contentType: getObjectOutput.contentType,
+    );
+  }
+
+  /// Removes [prefixToDrop] from [key] string.
   @internal
   static String dropPrefixFromKey({
     required String prefixToDrop,

--- a/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_html.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_html.dart
@@ -55,7 +55,7 @@ Future<S3DownloadFileResult> _downloadFromUrl({
         ? StorageGetUrlOptions(
             accessLevel: options.accessLevel,
             pluginOptions: S3GetUrlPluginOptions(
-              checkObjectExistence: true,
+              validateObjectExistence: true,
               useAccelerateEndpoint: s3PluginOptions.useAccelerateEndpoint,
             ),
           )
@@ -63,7 +63,7 @@ Future<S3DownloadFileResult> _downloadFromUrl({
             accessLevel: options.accessLevel,
             pluginOptions: S3GetUrlPluginOptions.forIdentity(
               targetIdentityId,
-              checkObjectExistence: true,
+              validateObjectExistence: true,
               useAccelerateEndpoint: s3PluginOptions.useAccelerateEndpoint,
             ),
           ),

--- a/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_html.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/platform_impl/download_file/download_file_html.dart
@@ -48,14 +48,36 @@ Future<S3DownloadFileResult> _downloadFromUrl({
 }) async {
   final s3PluginOptions = options.pluginOptions as S3DownloadFilePluginOptions;
   final targetIdentityId = s3PluginOptions.targetIdentityId;
-  // download url expires in 15 mins by default, see [S3GetUrlOptions]
+  // Calling the `getProperties` by default to verify the existence of the object
+  // before downloading from the presigned URL, as the 404 or 403 should be
+  // handled by the plugin but not be thrown to an end user in browser.
+  // The result of this call will be used as the result when
+  // `options.getProperties` is set to true.
+  // Exception thrown from the getProperties will be thrown as download
+  // operation.
+  final downloadedItem = (await storageS3Service.getProperties(
+    key: key,
+    options: targetIdentityId == null
+        ? StorageGetPropertiesOptions(
+            accessLevel: options.accessLevel,
+          )
+        : StorageGetPropertiesOptions(
+            accessLevel: options.accessLevel,
+            pluginOptions:
+                S3GetPropertiesPluginOptions.forIdentity(targetIdentityId),
+          ),
+  ))
+      .storageItem;
+
+  // A download url expires in 15 mins by default, see [S3GetUrlPluginOptions].
+  // We are not setting validateObjectExistence to true here as we are not
+  // able to directly get the result of underlying HeadObject result.
   final url = (await storageS3Service.getUrl(
     key: key,
     options: targetIdentityId == null
         ? StorageGetUrlOptions(
             accessLevel: options.accessLevel,
             pluginOptions: S3GetUrlPluginOptions(
-              validateObjectExistence: true,
               useAccelerateEndpoint: s3PluginOptions.useAccelerateEndpoint,
             ),
           )
@@ -63,7 +85,6 @@ Future<S3DownloadFileResult> _downloadFromUrl({
             accessLevel: options.accessLevel,
             pluginOptions: S3GetUrlPluginOptions.forIdentity(
               targetIdentityId,
-              validateObjectExistence: true,
               useAccelerateEndpoint: s3PluginOptions.useAccelerateEndpoint,
             ),
           ),
@@ -79,22 +100,8 @@ Future<S3DownloadFileResult> _downloadFromUrl({
   );
 
   return S3DownloadFileResult(
-    downloadedItem: s3PluginOptions.getProperties
-        ? (await storageS3Service.getProperties(
-            key: key,
-            options: targetIdentityId == null
-                ? StorageGetPropertiesOptions(
-                    accessLevel: options.accessLevel,
-                  )
-                : StorageGetPropertiesOptions(
-                    accessLevel: options.accessLevel,
-                    pluginOptions: S3GetPropertiesPluginOptions.forIdentity(
-                      targetIdentityId,
-                    ),
-                  ),
-          ))
-            .storageItem
-        : S3Item(key: key),
+    downloadedItem:
+        s3PluginOptions.getProperties ? downloadedItem : S3Item(key: key),
     localFile: localFile,
   );
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -210,9 +210,10 @@ class StorageS3Service {
     final s3PluginOptions = options.pluginOptions as S3GetUrlPluginOptions? ??
         const S3GetUrlPluginOptions();
 
-    if (s3PluginOptions.checkObjectExistence) {
-      // make a HeadObject call for checking object existence
-      // it may throw 404 if object doesn't exist in bucket
+    if (s3PluginOptions.validateObjectExistence) {
+      // make a HeadObject call for validating object existence
+      // the validation may throw exceptions that are thrown from
+      // the `getProperties` API (i.e. HeadObject)
       final targetIdentityId = s3PluginOptions.targetIdentityId;
       final getPropertiesOptions = targetIdentityId == null
           ? StorageGetPropertiesOptions(

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -190,6 +190,8 @@ class S3UploadTask {
   int get _numOfOngoingSubtasks => _ongoingSubtasks.length;
   int get _numOfCompletedSubtasks => _completedSubtasks.length;
 
+  Map<String, String> get _metadata => encodeMetadata(_options.metadata);
+
   /// The Future of the [S3UploadTask]
   Future<S3Item> get result => _uploadCompleter.future;
 
@@ -325,7 +327,7 @@ class S3UploadTask {
         ..body = body
         ..contentType = body.contentType ?? fallbackContentType
         ..key = _resolvedKey
-        ..metadata.addAll(_options.metadata);
+        ..metadata.addAll(_metadata);
     });
 
     try {
@@ -479,7 +481,7 @@ class S3UploadTask {
         ..bucket = _bucket
         ..contentType = contentType ?? fallbackContentType
         ..key = _resolvedKey
-        ..metadata.addAll(_options.metadata);
+        ..metadata.addAll(_metadata);
     });
 
     try {

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/utils.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/utils.dart
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@internal
+import 'dart:convert';
+
+import 'package:meta/meta.dart';
+
+final _regexp = RegExp(r'^\?UTF-8\?B\?(.*)\?=$');
+
+bool _hasNonAscii(String str) {
+  return str.runes.any((rune) => rune > 127);
+}
+
+String _rfc2047UTF8Encode(String str) {
+  if (_hasNonAscii(str)) {
+    // https://datatracker.ietf.org/doc/html/rfc2047#section-2
+    return '?UTF-8?B?${base64.encode(utf8.encode(str))}?=';
+  }
+
+  return str;
+}
+
+String _rfc2047UTF8Decode(String str) {
+  final encodedStr = _regexp.firstMatch(str)?.group(1);
+
+  if (encodedStr == null) {
+    return str;
+  }
+
+  return utf8.decode(base64.decode(encodedStr));
+}
+
+/// Encode values of [metadata].
+///
+/// A value that contains non-ascii chars will be encoded.
+/// Details see [Working with object metadata](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html).
+Map<String, String> encodeMetadata(Map<String, String> metadata) {
+  return Map.fromEntries(
+    metadata.entries.map((e) => MapEntry(e.key, _rfc2047UTF8Encode(e.value))),
+  );
+}
+
+/// Decode values of [metadata].
+///
+/// A value that is a utf8 encoded string will be decoded.
+Map<String, String> decodeMetadata(Map<String, String> metadata) {
+  return Map.fromEntries(
+    metadata.entries.map((e) => MapEntry(e.key, _rfc2047UTF8Decode(e.value))),
+  );
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/storage_s3_service.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/storage_s3_service.dart
@@ -9,3 +9,4 @@ import 'package:meta/meta.dart';
 export 'service/storage_s3_service_impl.dart';
 export 'service/task/s3_download_task.dart';
 export 'service/task/s3_upload_task.dart';
+export 'service/utils.dart';

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -832,12 +832,12 @@ void main() {
         accessLevel: StorageAccessLevel.protected,
       );
 
-      const testResult = S3CopyResult(copiedItem: S3Item(key: destinationKey));
+      final testResult = S3CopyResult(copiedItem: S3Item(key: destinationKey));
 
       setUpAll(() {
         registerFallbackValue(const StorageCopyOptions());
         registerFallbackValue(
-          const S3ItemWithAccessLevel(
+          S3ItemWithAccessLevel(
             storageItem: S3Item(key: 'some-key'),
           ),
         );
@@ -939,12 +939,12 @@ void main() {
         accessLevel: StorageAccessLevel.protected,
       );
 
-      const testResult = S3MoveResult(movedItem: S3Item(key: destinationKey));
+      final testResult = S3MoveResult(movedItem: S3Item(key: destinationKey));
 
       setUpAll(() {
         registerFallbackValue(const StorageMoveOptions());
         registerFallbackValue(
-          const S3ItemWithAccessLevel(
+          S3ItemWithAccessLevel(
             storageItem: S3Item(key: 'some-key'),
           ),
         );
@@ -1023,7 +1023,7 @@ void main() {
 
     group('remove() API', () {
       const testKey = 'object-to-remove';
-      const testResult = S3RemoveResult(
+      final testResult = S3RemoveResult(
         removedItem: S3Item(
           key: testKey,
         ),

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -386,7 +386,7 @@ void main() {
         const testOptions = StorageGetUrlOptions(
           accessLevel: testAccessLevelProtected,
           pluginOptions: S3GetUrlPluginOptions(
-            checkObjectExistence: true,
+            validateObjectExistence: true,
             expiresIn: Duration(minutes: 10),
             useAccelerateEndpoint: true,
           ),

--- a/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
@@ -34,7 +34,7 @@ void main() {
     );
     const testKey = 'upload-key.text';
     const testFileContent = 'Hello world!';
-    const testItem = S3Item(key: testKey);
+    final testItem = S3Item(key: testKey);
     final testFileBytes = utf8.encode(testFileContent);
 
     late S3TransferProgress expectedProgress;

--- a/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/platform_impl/download_file_io_test.dart
@@ -201,12 +201,12 @@ void main() {
         'should correctly create S3DownloadDataOptions with correct targetIdentityId',
         () {
       const testTargetIdentity = 'someone-else';
-      const testAcessLevel = StorageAccessLevel.protected;
+      const testAccessLevel = StorageAccessLevel.protected;
       downloadFile(
         key: testKey,
         localFile: AWSFile.fromPath('path'),
         options: const StorageDownloadFileOptions(
-          accessLevel: testAcessLevel,
+          accessLevel: testAccessLevel,
           pluginOptions: S3DownloadFilePluginOptions.forIdentity(
             testTargetIdentity,
           ),
@@ -239,7 +239,7 @@ void main() {
             .having(
               (o) => o.accessLevel,
               'accessLevel',
-              testAcessLevel,
+              testAccessLevel,
             )
             .having(
               (o) => (o.pluginOptions! as S3DownloadDataPluginOptions)

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
@@ -795,10 +795,10 @@ void main() {
 
     group('copy() API', () {
       late S3CopyResult copyResult;
-      const testSourceItem = S3Item(key: 'source');
-      const testDestinationItem = S3Item(key: 'destination');
-      const testSource = S3ItemWithAccessLevel(storageItem: testSourceItem);
-      const testDestination =
+      final testSourceItem = S3Item(key: 'source');
+      final testDestinationItem = S3Item(key: 'destination');
+      final testSource = S3ItemWithAccessLevel(storageItem: testSourceItem);
+      final testDestination =
           S3ItemWithAccessLevel(storageItem: testDestinationItem);
 
       setUpAll(() {
@@ -957,10 +957,10 @@ void main() {
 
     group('move() API', () {
       late S3MoveResult moveResult;
-      const testSourceItem = S3Item(key: 'source');
-      const testDestinationItem = S3Item(key: 'destination');
-      const testSource = S3ItemWithAccessLevel(storageItem: testSourceItem);
-      const testDestination =
+      final testSourceItem = S3Item(key: 'source');
+      final testDestinationItem = S3Item(key: 'destination');
+      final testSource = S3ItemWithAccessLevel(storageItem: testSourceItem);
+      final testDestination =
           S3ItemWithAccessLevel(storageItem: testDestinationItem);
 
       setUpAll(() {

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
@@ -663,12 +663,12 @@ void main() {
       });
 
       test(
-          'should invoke s3Client.headObject when checkObjectExistence option is set to true',
+          'should invoke s3Client.headObject when validateObjectExistence option is set to true',
           () async {
         const testOptions = StorageGetUrlOptions(
           accessLevel: StorageAccessLevel.private,
           pluginOptions: S3GetUrlPluginOptions(
-            checkObjectExistence: true,
+            validateObjectExistence: true,
           ),
         );
         const testUnknownException = UnknownSmithyHttpException(
@@ -705,14 +705,14 @@ void main() {
       });
 
       test(
-          'should invoke s3Client.headObject when checkObjectExistence option is'
+          'should invoke s3Client.headObject when validateObjectExistence option is'
           ' set to true and specified targetIdentityId', () async {
         const testTargetIdentityId = 'some-else-id';
         const testOptions = StorageGetUrlOptions(
           accessLevel: StorageAccessLevel.guest,
           pluginOptions: S3GetUrlPluginOptions.forIdentity(
             testTargetIdentityId,
-            checkObjectExistence: true,
+            validateObjectExistence: true,
           ),
         );
         const testUnknownException = UnknownSmithyHttpException(

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
@@ -664,13 +664,13 @@ void main() {
             description:
                 'should include metadata when getPropertiesValue is set to true',
             getPropertiesValue: true,
-            expectedS3Item: const S3Item(key: testKey, metadata: testMetadata),
+            expectedS3Item: S3Item(key: testKey, metadata: testMetadata),
           ),
           GetPropertiesTestItem(
             description:
                 'should NOT include metadata when getPropertiesValue is set to false',
             getPropertiesValue: false,
-            expectedS3Item: const S3Item(key: testKey, metadata: {}),
+            expectedS3Item: S3Item(key: testKey, metadata: {}),
           ),
         ];
 

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/utils_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/utils_test.dart
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('metadata encoding and decoding', () {
+    const metadataOnClient = {
+      'filename': 'sunny_day.jpg',
+      'description': 'Today is a 🌞 晴天 😎',
+      'owner': '悟空 Goku',
+    };
+
+    const metadataOnService = {
+      'filename': 'sunny_day.jpg',
+      'description': '?UTF-8?B?VG9kYXkgaXMgYSDwn4yeIOaZtOWkqSDwn5iO?=',
+      'owner': '?UTF-8?B?5oKf56m6IEdva3U=?=',
+    };
+
+    test('encodeMetadata()', () {
+      expect(encodeMetadata(metadataOnClient), equals(metadataOnService));
+    });
+
+    test('decodeMetadata()', () {
+      expect(decodeMetadata(metadataOnService), equals(metadataOnClient));
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3_dart/test/test_utils/helper_types.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/test_utils/helper_types.dart
@@ -1,7 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
 import 'package:test/test.dart';
+
+class GetPropertiesTestItem {
+  GetPropertiesTestItem({
+    required this.expectedS3Item,
+    required this.description,
+    required this.getPropertiesValue,
+  });
+
+  final String description;
+  final bool getPropertiesValue;
+  final S3Item expectedS3Item;
+}
 
 class DownloadTaskExceptionConversionTestItem<T> {
   DownloadTaskExceptionConversionTestItem({


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Renamed `S3GetUrlPluginOptions` `checkObjectExistence` property as `validateObjectExistence`
2. enabled metadata headers in the `infra` storage stack
3. Added metadata non-ascii value encoding and decoding following [S3 recommendation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html) and integration tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
