### PR TITLE
refactor(storage): Remove generic types

### DIFF
--- a/packages/amplify_core/lib/src/category/amplify_storage_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_storage_category.dart
@@ -13,120 +13,30 @@ part of amplify_interface;
 /// The Amplify CLI helps you to create and configure the storage category
 /// and auth category.
 /// {@endtemplate}
-class StorageCategory<
-    PluginStorageListOperation extends StorageListOperation,
-    PluginStorageGetPropertiesOperation extends StorageGetPropertiesOperation,
-    PluginStorageGetUrlOperation extends StorageGetUrlOperation,
-    PluginStorageUploadDataOperation extends StorageUploadDataOperation,
-    PluginStorageUploadFileOperation extends StorageUploadFileOperation,
-    PluginStorageDownloadDataOperation extends StorageDownloadDataOperation,
-    PluginStorageDownloadFileOperation extends StorageDownloadFileOperation,
-    PluginStorageCopyOperation extends StorageCopyOperation,
-    PluginStorageMoveOperation extends StorageMoveOperation,
-    PluginStorageRemoveOperation extends StorageRemoveOperation,
-    PluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
-    PluginStorageItem extends StorageItem,
-    PluginTransferProgress extends StorageTransferProgress,
-    Plugin extends StoragePluginInterface<
-        PluginStorageListOperation,
-        PluginStorageGetPropertiesOperation,
-        PluginStorageGetUrlOperation,
-        PluginStorageUploadDataOperation,
-        PluginStorageUploadFileOperation,
-        PluginStorageDownloadDataOperation,
-        PluginStorageDownloadFileOperation,
-        PluginStorageCopyOperation,
-        PluginStorageMoveOperation,
-        PluginStorageRemoveOperation,
-        PluginStorageRemoveManyOperation,
-        PluginStorageItem,
-        PluginTransferProgress>> extends AmplifyCategory<Plugin> {
-  StorageCategory([Plugin? plugin]) : _pluginOverride = plugin;
-
-  final Plugin? _pluginOverride;
-  Plugin get _plugin => _pluginOverride ?? defaultPlugin;
-
+class StorageCategory extends AmplifyCategory<StoragePluginInterface> {
   @override
   @nonVirtual
   Category get category => Category.storage;
 
-  StorageCategory<
-      GetPluginStorageListOperation,
-      GetPluginStorageGetPropertiesOperation,
-      GetPluginStorageGetUrlOperation,
-      GetPluginStorageUploadDataOperation,
-      GetPluginStorageUploadFileOperation,
-      GetPluginStorageDownloadDataOperation,
-      GetPluginStorageDownloadFileOperation,
-      GetPluginStorageCopyOperation,
-      GetPluginStorageMoveOperation,
-      GetPluginStorageRemoveOperation,
-      GetPluginStorageRemoveManyOperation,
-      GetPluginStorageItem,
-      GetPluginTransferProgress,
-      P> getPlugin<
-          GetPluginStorageListOperation extends StorageListOperation,
-          GetPluginStorageGetPropertiesOperation extends StorageGetPropertiesOperation,
-          GetPluginStorageGetUrlOperation extends StorageGetUrlOperation,
-          GetPluginStorageUploadDataOperation extends StorageUploadDataOperation,
-          GetPluginStorageUploadFileOperation extends StorageUploadFileOperation,
-          GetPluginStorageDownloadDataOperation extends StorageDownloadDataOperation,
-          GetPluginStorageDownloadFileOperation extends StorageDownloadFileOperation,
-          GetPluginStorageCopyOperation extends StorageCopyOperation,
-          GetPluginStorageMoveOperation extends StorageMoveOperation,
-          GetPluginStorageRemoveOperation extends StorageRemoveOperation,
-          GetPluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
-          GetPluginStorageItem extends StorageItem,
-          GetPluginTransferProgress extends StorageTransferProgress,
-          P extends StoragePluginInterface<
-              GetPluginStorageListOperation,
-              GetPluginStorageGetPropertiesOperation,
-              GetPluginStorageGetUrlOperation,
-              GetPluginStorageUploadDataOperation,
-              GetPluginStorageUploadFileOperation,
-              GetPluginStorageDownloadDataOperation,
-              GetPluginStorageDownloadFileOperation,
-              GetPluginStorageCopyOperation,
-              GetPluginStorageMoveOperation,
-              GetPluginStorageRemoveOperation,
-              GetPluginStorageRemoveManyOperation,
-              GetPluginStorageItem,
-              GetPluginTransferProgress>>(
-    StoragePluginKey<
-            GetPluginStorageListOperation,
-            GetPluginStorageGetPropertiesOperation,
-            GetPluginStorageGetUrlOperation,
-            GetPluginStorageUploadDataOperation,
-            GetPluginStorageUploadFileOperation,
-            GetPluginStorageDownloadDataOperation,
-            GetPluginStorageDownloadFileOperation,
-            GetPluginStorageCopyOperation,
-            GetPluginStorageMoveOperation,
-            GetPluginStorageRemoveOperation,
-            GetPluginStorageRemoveManyOperation,
-            GetPluginStorageItem,
-            GetPluginTransferProgress,
-            P>
-        pluginKey,
+  P getPlugin<P extends StoragePluginInterface>(
+    StoragePluginKey<P> pluginKey,
   ) =>
-      StorageCategory(
-        plugins.singleWhere(
-          (p) => p is P,
-          orElse: () => throw PluginError(
-            'No plugin registered for $pluginKey',
-          ),
-        ) as P,
-      );
+      plugins.singleWhere(
+        (p) => p is P,
+        orElse: () => throw PluginError(
+          'No plugin registered for $pluginKey',
+        ),
+      ) as P;
 
   /// {@template amplify_core.amplify_storage_category.list}
   /// Lists objects under the [path] with optional [StorageListOptions] and
   /// returns a [StorageListOperation].
   /// {@endtemplate}
-  PluginStorageListOperation list({
+  StorageListOperation list({
     String? path,
     StorageListOptions? options,
   }) {
-    return _plugin.list(
+    return defaultPlugin.list(
       path: path,
       options: options,
     );
@@ -140,11 +50,11 @@ class StorageCategory<
   /// The result may include the metadata (if any) specified when the object
   /// was uploaded.
   /// {@endtemplate}
-  PluginStorageGetPropertiesOperation getProperties({
+  StorageGetPropertiesOperation getProperties({
     required String key,
     StorageGetPropertiesOptions? options,
   }) {
-    return _plugin.getProperties(
+    return defaultPlugin.getProperties(
       key: key,
       options: options,
     );
@@ -157,11 +67,11 @@ class StorageCategory<
   /// The url is presigned by the aws_signature_v4, and is enforced with scheme
   /// `https`.
   /// {@endtemplate}
-  PluginStorageGetUrlOperation getUrl({
+  StorageGetUrlOperation getUrl({
     required String key,
     StorageGetUrlOptions? options,
   }) {
-    return _plugin.getUrl(
+    return defaultPlugin.getUrl(
       key: key,
       options: options,
     );
@@ -175,12 +85,12 @@ class StorageCategory<
   /// Ensure you are managing the data in memory properly to avoid unexpected
   /// memory leaks.
   /// {@endtemplate}
-  PluginStorageDownloadDataOperation downloadData({
+  StorageDownloadDataOperation downloadData({
     required String key,
-    void Function(PluginTransferProgress)? onProgress,
+    void Function(StorageTransferProgress)? onProgress,
     StorageDownloadDataOptions? options,
   }) {
-    return _plugin.downloadData(
+    return defaultPlugin.downloadData(
       key: key,
       onProgress: onProgress,
       options: options,
@@ -192,13 +102,13 @@ class StorageCategory<
   /// [onProgress] and [StorageDownloadFileOptions], and returns a
   /// [StorageDownloadFileOperation].
   /// {@endtemplate}
-  PluginStorageDownloadFileOperation downloadFile({
+  StorageDownloadFileOperation downloadFile({
     required String key,
     required AWSFile localFile,
-    void Function(PluginTransferProgress)? onProgress,
+    void Function(StorageTransferProgress)? onProgress,
     StorageDownloadFileOptions? options,
   }) {
-    return _plugin.downloadFile(
+    return defaultPlugin.downloadFile(
       key: key,
       localFile: localFile,
       onProgress: onProgress,
@@ -213,13 +123,13 @@ class StorageCategory<
   ///
   /// See [StorageDataPayload] for supported data formats.
   /// {@endtemplate}
-  PluginStorageUploadDataOperation uploadData({
+  StorageUploadDataOperation uploadData({
     required StorageDataPayload data,
     required String key,
-    void Function(PluginTransferProgress)? onProgress,
+    void Function(StorageTransferProgress)? onProgress,
     StorageUploadDataOptions? options,
   }) {
-    return _plugin.uploadData(
+    return defaultPlugin.uploadData(
       key: key,
       data: data,
       onProgress: onProgress,
@@ -235,13 +145,13 @@ class StorageCategory<
   /// [AWSFile] provides various adapters to read file content from file
   /// abstractions, such as `XFile`, `PlatformFile`, `io.File` or `html.File`.
   /// {@endtemplate}
-  PluginStorageUploadFileOperation uploadFile({
+  StorageUploadFileOperation uploadFile({
     required AWSFile localFile,
     required String key,
-    void Function(PluginTransferProgress)? onProgress,
+    void Function(StorageTransferProgress)? onProgress,
     StorageUploadFileOptions? options,
   }) {
-    return _plugin.uploadFile(
+    return defaultPlugin.uploadFile(
       key: key,
       localFile: localFile,
       onProgress: onProgress,
@@ -258,12 +168,12 @@ class StorageCategory<
   /// The `source` should be readable to the API call originator following
   /// corresponding [StorageAccessLevel].
   /// {@endtemplate}
-  PluginStorageCopyOperation copy({
-    required StorageItemWithAccessLevel<PluginStorageItem> source,
-    required StorageItemWithAccessLevel<PluginStorageItem> destination,
+  StorageCopyOperation copy({
+    required StorageItemWithAccessLevel<StorageItem> source,
+    required StorageItemWithAccessLevel<StorageItem> destination,
     StorageCopyOptions? options,
   }) {
-    return _plugin.copy(
+    return defaultPlugin.copy(
       source: source,
       destination: destination,
       options: options,
@@ -280,12 +190,12 @@ class StorageCategory<
   ///
   /// {@macro amplify_core.amplify_storage_category.copy_source}
   /// {@endtemplate}
-  PluginStorageMoveOperation move({
-    required StorageItemWithAccessLevel<PluginStorageItem> source,
-    required StorageItemWithAccessLevel<PluginStorageItem> destination,
+  StorageMoveOperation move({
+    required StorageItemWithAccessLevel<StorageItem> source,
+    required StorageItemWithAccessLevel<StorageItem> destination,
     StorageMoveOptions? options,
   }) {
-    return _plugin.move(
+    return defaultPlugin.move(
       source: source,
       destination: destination,
       options: options,
@@ -296,22 +206,22 @@ class StorageCategory<
   /// Removes an object specified by [key] with optional [StorageRemoveOptions],
   /// and returns a [StorageRemoveOperation].
   /// {@endtemplate}
-  PluginStorageRemoveOperation remove({
+  StorageRemoveOperation remove({
     required String key,
     StorageRemoveOptions? options,
   }) {
-    return _plugin.remove(key: key, options: options);
+    return defaultPlugin.remove(key: key, options: options);
   }
 
   /// {@template amplify_core.amplify_storage_category.remove_many}
   /// Removes multiple objects specified by [keys] with optional
   /// [StorageRemoveManyOptions], and returns a [StorageRemoveManyOperation].
   /// {@endtemplate}
-  PluginStorageRemoveManyOperation removeMany({
+  StorageRemoveManyOperation removeMany({
     required List<String> keys,
     StorageRemoveManyOptions? options,
   }) {
-    return _plugin.removeMany(
+    return defaultPlugin.removeMany(
       keys: keys,
       options: options,
     );

--- a/packages/amplify_core/lib/src/plugin/amplify_plugin_key.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_plugin_key.dart
@@ -60,33 +60,7 @@ abstract class AuthPluginKey<
   const AuthPluginKey();
 }
 
-abstract class StoragePluginKey<
-    PluginStorageListOperation extends StorageListOperation,
-    PluginStorageGetPropertiesOperation extends StorageGetPropertiesOperation,
-    PluginStorageGetUrlOperation extends StorageGetUrlOperation,
-    PluginStorageUploadDataOperation extends StorageUploadDataOperation,
-    PluginStorageUploadFileOperation extends StorageUploadFileOperation,
-    PluginStorageDownloadDataOperation extends StorageDownloadDataOperation,
-    PluginStorageDownloadFileOperation extends StorageDownloadFileOperation,
-    PluginStorageCopyOperation extends StorageCopyOperation,
-    PluginStorageMoveOperation extends StorageMoveOperation,
-    PluginStorageRemoveOperation extends StorageRemoveOperation,
-    PluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
-    PluginStorageItem extends StorageItem,
-    PluginTransferProgress extends StorageTransferProgress,
-    P extends StoragePluginInterface<
-        PluginStorageListOperation,
-        PluginStorageGetPropertiesOperation,
-        PluginStorageGetUrlOperation,
-        PluginStorageUploadDataOperation,
-        PluginStorageUploadFileOperation,
-        PluginStorageDownloadDataOperation,
-        PluginStorageDownloadFileOperation,
-        PluginStorageCopyOperation,
-        PluginStorageMoveOperation,
-        PluginStorageRemoveOperation,
-        PluginStorageRemoveManyOperation,
-        PluginStorageItem,
-        PluginTransferProgress>> extends AmplifyPluginKey<P> {
+abstract class StoragePluginKey<P extends StoragePluginInterface>
+    extends AmplifyPluginKey<P> {
   const StoragePluginKey();
 }

--- a/packages/amplify_core/lib/src/plugin/amplify_storage_plugin_interface.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_storage_plugin_interface.dart
@@ -9,27 +9,13 @@ import 'package:meta/meta.dart';
 /// Defines Amplify Storage plugin interface.
 ///
 /// {@macro amplify_core.amplify_storage_category}
-abstract class StoragePluginInterface<
-        PluginStorageListOperation extends StorageListOperation,
-        PluginStorageGetPropertiesOperation extends StorageGetPropertiesOperation,
-        PluginStorageGetUrlOperation extends StorageGetUrlOperation,
-        PluginStorageUploadDataOperation extends StorageUploadDataOperation,
-        PluginStorageUploadFileOperation extends StorageUploadFileOperation,
-        PluginStorageDownloadDataOperation extends StorageDownloadDataOperation,
-        PluginStorageDownloadFileOperation extends StorageDownloadFileOperation,
-        PluginStorageCopyOperation extends StorageCopyOperation,
-        PluginStorageMoveOperation extends StorageMoveOperation,
-        PluginStorageRemoveOperation extends StorageRemoveOperation,
-        PluginStorageRemoveManyOperation extends StorageRemoveManyOperation,
-        PluginStorageItem extends StorageItem,
-        PluginTransferProgress extends StorageTransferProgress>
-    extends AmplifyPluginInterface {
+abstract class StoragePluginInterface extends AmplifyPluginInterface {
   @override
   @nonVirtual
   Category get category => Category.storage;
 
   /// {@macro amplify_core.amplify_storage_category.list}
-  PluginStorageListOperation list({
+  StorageListOperation list({
     String? path,
     StorageListOptions? options,
   }) {
@@ -37,7 +23,7 @@ abstract class StoragePluginInterface<
   }
 
   /// {@macro amplify_core.amplify_storage_category.get_properties}
-  PluginStorageGetPropertiesOperation getProperties({
+  StorageGetPropertiesOperation getProperties({
     required String key,
     StorageGetPropertiesOptions? options,
   }) {
@@ -45,7 +31,7 @@ abstract class StoragePluginInterface<
   }
 
   /// {@macro amplify_core.amplify_storage_category.get_url}
-  PluginStorageGetUrlOperation getUrl({
+  StorageGetUrlOperation getUrl({
     required String key,
     StorageGetUrlOptions? options,
   }) {
@@ -53,64 +39,64 @@ abstract class StoragePluginInterface<
   }
 
   /// {@macro amplify_core.amplify_storage_category.download_data}
-  PluginStorageDownloadDataOperation downloadData({
+  StorageDownloadDataOperation downloadData({
     required String key,
-    void Function(PluginTransferProgress)? onProgress,
+    void Function(StorageTransferProgress)? onProgress,
     StorageDownloadDataOptions? options,
   }) {
     throw UnimplementedError('downloadData() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.download_file}
-  PluginStorageDownloadFileOperation downloadFile({
+  StorageDownloadFileOperation downloadFile({
     required String key,
     required AWSFile localFile,
-    void Function(PluginTransferProgress)? onProgress,
+    void Function(StorageTransferProgress)? onProgress,
     StorageDownloadFileOptions? options,
   }) {
     throw UnimplementedError('downloadFile() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.upload_data}
-  PluginStorageUploadDataOperation uploadData({
+  StorageUploadDataOperation uploadData({
     required String key,
     required StorageDataPayload data,
-    void Function(PluginTransferProgress)? onProgress,
+    void Function(StorageTransferProgress)? onProgress,
     StorageUploadDataOptions? options,
   }) {
     throw UnimplementedError('uploadData() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.upload_file}
-  PluginStorageUploadFileOperation uploadFile({
+  StorageUploadFileOperation uploadFile({
     required String key,
     required AWSFile localFile,
-    void Function(PluginTransferProgress)? onProgress,
+    void Function(StorageTransferProgress)? onProgress,
     StorageUploadFileOptions? options,
   }) {
     throw UnimplementedError('uploadFile() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.copy}
-  PluginStorageCopyOperation copy({
-    required StorageItemWithAccessLevel<PluginStorageItem> source,
-    required StorageItemWithAccessLevel<PluginStorageItem> destination,
+  StorageCopyOperation copy({
+    required StorageItemWithAccessLevel<StorageItem> source,
+    required StorageItemWithAccessLevel<StorageItem> destination,
     StorageCopyOptions? options,
   }) {
     throw UnimplementedError('copy() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.move}
-  PluginStorageMoveOperation move({
-    required StorageItemWithAccessLevel<PluginStorageItem> source,
-    required StorageItemWithAccessLevel<PluginStorageItem> destination,
+  StorageMoveOperation move({
+    required StorageItemWithAccessLevel<StorageItem> source,
+    required StorageItemWithAccessLevel<StorageItem> destination,
     StorageMoveOptions? options,
   }) {
     throw UnimplementedError('move() has not been implemented.');
   }
 
   /// {@macro amplify_core.amplify_storage_category.remove}
-  PluginStorageRemoveOperation remove({
+  StorageRemoveOperation remove({
     required String key,
     StorageRemoveOptions? options,
   }) {
@@ -118,7 +104,7 @@ abstract class StoragePluginInterface<
   }
 
   /// {@macro amplify_core.amplify_storage_category.remove_many}
-  PluginStorageRemoveManyOperation removeMany({
+  StorageRemoveManyOperation removeMany({
     required List<String> keys,
     StorageRemoveManyOptions? options,
   }) {

--- a/packages/storage/amplify_storage_s3/lib/src/amplify_storage_s3_impl.dart
+++ b/packages/storage/amplify_storage_s3/lib/src/amplify_storage_s3_impl.dart
@@ -19,21 +19,8 @@ class AmplifyStorageS3 extends AmplifyStorageS3Dart {
 
   /// A plugin key which can be used with `Amplify.Storage.getPlugin` to retrieve
   /// a S3-specific Storage category interface.
-  static const StoragePluginKey<
-      S3ListOperation,
-      S3GetPropertiesOperation,
-      S3GetUrlOperation,
-      S3UploadDataOperation,
-      S3UploadFileOperation,
-      S3DownloadDataOperation,
-      S3DownloadFileOperation,
-      S3CopyOperation,
-      S3MoveOperation,
-      S3RemoveOperation,
-      S3RemoveManyOperation,
-      S3Item,
-      S3TransferProgress,
-      AmplifyStorageS3> pluginKey = _AmplifyStorageS3PluginKey();
+  static const StoragePluginKey<AmplifyStorageS3> pluginKey =
+      _AmplifyStorageS3PluginKey();
 
   @override
   Future<void> configure({
@@ -49,21 +36,7 @@ class AmplifyStorageS3 extends AmplifyStorageS3Dart {
   }
 }
 
-class _AmplifyStorageS3PluginKey extends StoragePluginKey<
-    S3ListOperation,
-    S3GetPropertiesOperation,
-    S3GetUrlOperation,
-    S3UploadDataOperation,
-    S3UploadFileOperation,
-    S3DownloadDataOperation,
-    S3DownloadFileOperation,
-    S3CopyOperation,
-    S3MoveOperation,
-    S3RemoveOperation,
-    S3RemoveManyOperation,
-    S3Item,
-    S3TransferProgress,
-    AmplifyStorageS3> {
+class _AmplifyStorageS3PluginKey extends StoragePluginKey<AmplifyStorageS3> {
   const _AmplifyStorageS3PluginKey();
 
   @override

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -26,20 +26,8 @@ bool get _zIsTest => Zone.current[zIsTest] as bool? ?? false;
 /// {@template amplify_storage_s3_dart.amplify_storage_s3_plugin_dart}
 /// The Dart Storage S3 plugin for the Amplify Storage Category.
 /// {@endtemplate}
-class AmplifyStorageS3Dart extends StoragePluginInterface<
-    S3ListOperation,
-    S3GetPropertiesOperation,
-    S3GetUrlOperation,
-    S3UploadDataOperation,
-    S3UploadFileOperation,
-    S3DownloadDataOperation,
-    S3DownloadFileOperation,
-    S3CopyOperation,
-    S3MoveOperation,
-    S3RemoveOperation,
-    S3RemoveManyOperation,
-    S3Item,
-    S3TransferProgress> with AWSDebuggable, AWSLoggerMixin {
+class AmplifyStorageS3Dart extends StoragePluginInterface
+    with AWSDebuggable, AWSLoggerMixin {
   /// {@macro amplify_storage_s3_dart.amplify_storage_s3_plugin_dart}
   AmplifyStorageS3Dart({
     String? delimiter,
@@ -53,21 +41,8 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
   /// A plugin key which can be used with `Amplify.Storage.getPlugin` to retrieve
   /// a S3-specific Storage category interface.
   /// {@endtemplate}
-  static const StoragePluginKey<
-      S3ListOperation,
-      S3GetPropertiesOperation,
-      S3GetUrlOperation,
-      S3UploadDataOperation,
-      S3UploadFileOperation,
-      S3DownloadDataOperation,
-      S3DownloadFileOperation,
-      S3CopyOperation,
-      S3MoveOperation,
-      S3RemoveOperation,
-      S3RemoveManyOperation,
-      S3Item,
-      S3TransferProgress,
-      AmplifyStorageS3Dart> pluginKey = _AmplifyStorageS3DartPluginKey();
+  static const StoragePluginKey<AmplifyStorageS3Dart> pluginKey =
+      _AmplifyStorageS3DartPluginKey();
 
   final String? _delimiter;
 
@@ -502,21 +477,8 @@ class AmplifyStorageS3Dart extends StoragePluginInterface<
   String get runtimeTypeName => 'AmplifyStorageS3Dart';
 }
 
-class _AmplifyStorageS3DartPluginKey extends StoragePluginKey<
-    S3ListOperation,
-    S3GetPropertiesOperation,
-    S3GetUrlOperation,
-    S3UploadDataOperation,
-    S3UploadFileOperation,
-    S3DownloadDataOperation,
-    S3DownloadFileOperation,
-    S3CopyOperation,
-    S3MoveOperation,
-    S3RemoveOperation,
-    S3RemoveManyOperation,
-    S3Item,
-    S3TransferProgress,
-    AmplifyStorageS3Dart> {
+class _AmplifyStorageS3DartPluginKey
+    extends StoragePluginKey<AmplifyStorageS3Dart> {
   const _AmplifyStorageS3DartPluginKey();
 
   @override


### PR DESCRIPTION
Removes generic types from public APIs and removes the category wrapper interface for `getPlugin`.