### PR TITLE
chore: update win32 version, use show in win32 imports

### DIFF
--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/data_protection.bindings.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/data_protection.bindings.dart
@@ -6,6 +6,8 @@ import 'package:ffi/ffi.dart';
 
 final _crypt32 = DynamicLibrary.open('crypt32.dll');
 
+// TODO(Jordan-Nelson): remove when win32 version constraint is bumped to 4.1.2
+
 /// Performs encryption on the data in a DATA_BLOB structure.
 ///
 /// Typically, only a user with the same logon credential as the

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/data_protection.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/data_protection.dart
@@ -5,7 +5,7 @@ import 'dart:typed_data';
 import 'package:amplify_secure_storage_dart/src/ffi/win32/data_protection.bindings.dart';
 import 'package:amplify_secure_storage_dart/src/ffi/win32/utils.dart';
 import 'package:ffi/ffi.dart';
-import 'package:win32/win32.dart';
+import 'package:win32/win32.dart' show GetLastError, ERROR_SUCCESS;
 
 /// Encrypts the provided string as a [Uint8List].
 Uint8List encryptString(String value) {
@@ -13,7 +13,7 @@ Uint8List encryptString(String value) {
   return encrypt(encodedValue);
 }
 
-/// Decrypts the providued [Uint8List] as a String.
+/// Decrypts the provided [Uint8List] as a String.
 String decryptString(Uint8List data) {
   final decryptedData = decrypt(data);
   return utf8.decode(decryptedData);

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/utils.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/utils.dart
@@ -6,9 +6,10 @@ import 'dart:typed_data';
 
 import 'package:amplify_secure_storage_dart/src/exception/secure_storage_exception.dart';
 import 'package:amplify_secure_storage_dart/src/exception/unknown_exception.dart';
-import 'package:win32/win32.dart';
+import 'package:win32/win32.dart'
+    show Uint8ListBlobConversion, WindowsException, HRESULT_FROM_WIN32;
 
-extension Uint8ListBlobConversion on Uint8List {
+extension Uint8ListBlobConversionX on Uint8List {
   /// Alternative to [allocatePointer] from win32, which accepts an allocator
   Pointer<Uint8> allocatePointerWith(Allocator allocator) {
     final blob = allocator<Uint8>(length);

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   js: ^0.6.4
   meta: ^1.7.0
   path: ^1.8.0
-  win32: ^3.0.0
+  win32: ">=3.0.0 <5.0.0"
   worker_bee: ">=0.1.3+3 <0.2.0"
 
 dev_dependencies:


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/2827

*Description of changes:*
- Update win32 version constraint to versions that export data protection APIs (3.1.4 and up)
- Use win32 data protection APIs, remove hand written bindings in secure_storage
- Update win32 imports to use `show`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
