### PR TITLE
docs(auth): Add inline examples

### DIFF
--- a/aft.yaml
+++ b/aft.yaml
@@ -155,13 +155,18 @@ scripts:
       fi
       
       pushd doc
+      # All `doc` packages should allow `flutter` dependencies even if they 
+      # are subpackages of a Dart-only package. For example, we want to use 
+      # `amplify_flutter` in the `amplify_core` docs.
+      flutter pub get
+      flutter pub run build_runner build
+      popd
+
       if [ "{{ package.flavor }}" == "flutter" ]; then
         PUB="flutter pub"
       else
         PUB="dart"
       fi
-      $PUB run build_runner build
-      popd
 
       $PUB run code_excerpt_updater \
         --fragment-dir-path=doc/.dart_tool/build/generated \

--- a/aft.yaml
+++ b/aft.yaml
@@ -146,3 +146,25 @@ scripts:
       if [ -d android ]; then
         flutter build apk --debug
       fi
+  build:docs:
+    description: Builds the documentation examples
+    run: |
+      if [ ! -f doc/build.yaml ]; then
+        echo "No documentation examples for {{ package.name }}" >&2
+        exit 0
+      fi
+      
+      pushd doc
+      if [ "{{ package.flavor }}" == "flutter" ]; then
+        PUB="flutter pub"
+      else
+        PUB="dart"
+      fi
+      $PUB run build_runner build
+      popd
+
+      $PUB run code_excerpt_updater \
+        --fragment-dir-path=doc/.dart_tool/build/generated \
+        --yaml \
+        --write-in-place \
+        lib

--- a/packages/amplify_core/analysis_options.yaml
+++ b/packages/amplify_core/analysis_options.yaml
@@ -5,3 +5,4 @@ analyzer:
     public_member_api_docs: ignore
   exclude:
     - lib/**/*.g.dart
+    - doc/

--- a/packages/amplify_core/build.yaml
+++ b/packages/amplify_core/build.yaml
@@ -1,5 +1,8 @@
 targets:
   $default:
+    sources:
+      exclude:
+        - doc/**
     builders:
       build_web_compilers:entrypoint:
         release_options:

--- a/packages/amplify_core/doc/.gitignore
+++ b/packages/amplify_core/doc/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/amplify_core/doc/README.md
+++ b/packages/amplify_core/doc/README.md
@@ -1,0 +1,1 @@
+Code excerpts for the `amplify_core` package, used in inline documentation.

--- a/packages/amplify_core/doc/analysis_options.yaml
+++ b/packages/amplify_core/doc/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:amplify_lints/library.yaml
+
+analyzer:
+  errors:
+    public_member_api_docs: ignore
+    unused_local_variable: ignore

--- a/packages/amplify_core/doc/build.yaml
+++ b/packages/amplify_core/doc/build.yaml
@@ -1,0 +1,5 @@
+targets:
+  $default:
+    builders:
+      code_excerpter|code_excerpter:
+        enabled: true

--- a/packages/amplify_core/doc/lib/auth.dart
+++ b/packages/amplify_core/doc/lib/auth.dart
@@ -47,6 +47,8 @@ Future<void> _handleSignUpResult(SignUpResult result) async {
 // #enddocregion handle-signup
 
 // #docregion signup
+/// Signs a user up with a username, password, and email. The required
+/// attributes may be different depending on your app's configuration.
 Future<void> signUpUser({
   required String username,
   required String password,

--- a/packages/amplify_core/doc/lib/auth.dart
+++ b/packages/amplify_core/doc/lib/auth.dart
@@ -1,0 +1,483 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Code excerpts for the Auth category.
+library auth;
+
+// #docregion imports
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
+// #enddocregion imports
+
+const username = '';
+
+// #docregion get-plugin
+Future<CognitoSignInResult> signInWithCognito(
+  String username,
+  String password,
+) async {
+  final cognitoPlugin = Amplify.Auth.getPlugin(
+    AmplifyAuthCognito.pluginKey,
+  );
+  return cognitoPlugin.signIn(username: username, password: password);
+}
+// #enddocregion get-plugin
+
+// #docregion handle-code
+void _handleCodeDelivery(AuthCodeDeliveryDetails codeDeliveryDetails) {
+  safePrint(
+    'A confirmation code has been sent to ${codeDeliveryDetails.destination}. '
+    'Please check your ${codeDeliveryDetails.deliveryMedium.name} for the code.',
+  );
+}
+// #enddocregion handle-code
+
+// #docregion handle-signup
+Future<void> _handleSignUpResult(SignUpResult result) async {
+  switch (result.nextStep.signUpStep) {
+    case AuthSignUpStep.confirmSignUp:
+      final codeDeliveryDetails = result.nextStep.codeDeliveryDetails!;
+      _handleCodeDelivery(codeDeliveryDetails);
+      break;
+    case AuthSignUpStep.done:
+      safePrint('Sign up is complete');
+      break;
+  }
+}
+// #enddocregion handle-signup
+
+// #docregion signup
+Future<void> signUpUser({
+  required String username,
+  required String password,
+  required String email,
+  String? phoneNumber,
+}) async {
+  try {
+    final userAttributes = {
+      AuthUserAttributeKey.email: email,
+      if (phoneNumber != null) AuthUserAttributeKey.phoneNumber: phoneNumber,
+      // additional attributes as needed
+    };
+    final result = await Amplify.Auth.signUp(
+      username: username,
+      password: password,
+      options: SignUpOptions(
+        userAttributes: userAttributes,
+      ),
+    );
+    return _handleSignUpResult(result);
+  } on AuthException catch (e) {
+    safePrint('Error signing up user: ${e.message}');
+  }
+}
+// #enddocregion signup
+
+// #docregion confirm-signup
+Future<void> confirmUser({
+  required String username,
+  required String confirmationCode,
+}) async {
+  try {
+    final result = await Amplify.Auth.confirmSignUp(
+      username: username,
+      confirmationCode: confirmationCode,
+    );
+    return _handleSignUpResult(result);
+  } on AuthException catch (e) {
+    safePrint('Error confirming user: ${e.message}');
+  }
+}
+// #enddocregion confirm-signup
+
+// #docregion resend-signup-code
+Future<void> resendSignUpCode(String username) async {
+  try {
+    final result = await Amplify.Auth.resendSignUpCode(
+      username: username,
+    );
+    final codeDeliveryDetails = result.codeDeliveryDetails;
+    _handleCodeDelivery(codeDeliveryDetails);
+  } on AuthException catch (e) {
+    safePrint('Error resending code: ${e.message}');
+  }
+}
+// #enddocregion resend-signup-code
+
+// #docregion handle-signin, handle-confirm-signin-sms, handle-confirm-signin-new-password, handle-confirm-signin-custom-challenge, handle-confirm-signin-reset-password, handle-confirm-signin-confirm-signup, handle-confirm-signin-done
+Future<void> _handleSignInResult(SignInResult result) async {
+  switch (result.nextStep.signInStep) {
+    // #enddocregion handle-signin, handle-confirm-signin-sms, handle-confirm-signin-new-password, handle-confirm-signin-custom-challenge, handle-confirm-signin-reset-password, handle-confirm-signin-confirm-signup, handle-confirm-signin-done
+    // #docregion handle-confirm-signin-sms
+    case AuthSignInStep.confirmSignInWithSmsMfaCode:
+      final codeDeliveryDetails = result.nextStep.codeDeliveryDetails!;
+      _handleCodeDelivery(codeDeliveryDetails);
+      break;
+    // #enddocregion handle-confirm-signin-sms
+    // #docregion handle-confirm-signin-new-password
+    case AuthSignInStep.confirmSignInWithNewPassword:
+      safePrint('Enter a new password to continue signing in');
+      break;
+    // #enddocregion handle-confirm-signin-new-password
+    // #docregion handle-confirm-signin-custom-challenge
+    case AuthSignInStep.confirmSignInWithCustomChallenge:
+      final parameters = result.nextStep.additionalInfo;
+      final prompt = parameters['prompt']!;
+      safePrint(prompt);
+      break;
+    // #enddocregion handle-confirm-signin-custom-challenge
+    // #docregion handle-confirm-signin-reset-password
+    case AuthSignInStep.resetPassword:
+      final resetResult = await Amplify.Auth.resetPassword(
+        username: username,
+      );
+      await _handleResetPasswordResult(resetResult);
+      break;
+    // #enddocregion handle-confirm-signin-reset-password
+    // #docregion handle-confirm-signin-confirm-signup
+    case AuthSignInStep.confirmSignUp:
+      // Resend the sign up code to the registered device.
+      final resendResult = await Amplify.Auth.resendSignUpCode(
+        username: username,
+      );
+      _handleCodeDelivery(resendResult.codeDeliveryDetails);
+      break;
+    // #enddocregion handle-confirm-signin-confirm-signup
+    // #docregion handle-confirm-signin-done
+    case AuthSignInStep.done:
+      safePrint('Sign in is complete');
+      break;
+    // #enddocregion handle-confirm-signin-done
+    // #docregion handle-signin, handle-confirm-signin-sms, handle-confirm-signin-new-password, handle-confirm-signin-custom-challenge, handle-confirm-signin-reset-password, handle-confirm-signin-confirm-signup, handle-confirm-signin-done
+  }
+}
+// #enddocregion handle-signin, handle-confirm-signin-sms, handle-confirm-signin-new-password, handle-confirm-signin-custom-challenge, handle-confirm-signin-reset-password, handle-confirm-signin-confirm-signup, handle-confirm-signin-done
+
+// #docregion signin
+Future<void> signInUser(String username, String password) async {
+  try {
+    final result = await Amplify.Auth.signIn(
+      username: username,
+      password: password,
+    );
+    return _handleSignInResult(result);
+  } on AuthException catch (e) {
+    safePrint('Error signing in: ${e.message}');
+  }
+}
+// #enddocregion signin
+
+// #docregion signin-webui
+Future<void> socialSignIn() async {
+  try {
+    final result = await Amplify.Auth.signInWithWebUI(
+      provider: AuthProvider.google,
+    );
+    return _handleSignInResult(result);
+  } on AuthException catch (e) {
+    safePrint('Error signing in: ${e.message}');
+  }
+}
+// #enddocregion signin-webui
+
+// #docregion handle-reset-password
+Future<void> _handleResetPasswordResult(ResetPasswordResult result) async {
+  switch (result.nextStep.updateStep) {
+    case AuthResetPasswordStep.confirmResetPasswordWithCode:
+      final codeDeliveryDetails = result.nextStep.codeDeliveryDetails!;
+      _handleCodeDelivery(codeDeliveryDetails);
+      break;
+    case AuthResetPasswordStep.done:
+      safePrint('Successfully reset password');
+      break;
+  }
+}
+// #enddocregion handle-reset-password
+
+// #docregion confirm-signin
+Future<void> confirmMfaUser(String mfaCode) async {
+  try {
+    final result = await Amplify.Auth.confirmSignIn(
+      confirmationValue: mfaCode,
+    );
+    return _handleSignInResult(result);
+  } on AuthException catch (e) {
+    safePrint('Error confirming MFA code: ${e.message}');
+  }
+}
+// #enddocregion confirm-signin
+
+// #docregion signout
+Future<void> signOutCurrentUser() async {
+  final result = await Amplify.Auth.signOut();
+  if (result is CognitoCompleteSignOut) {
+    safePrint('Sign out completed successfully');
+  } else if (result is CognitoFailedSignOut) {
+    safePrint('Error signing user out: ${result.exception.message}');
+  }
+}
+// #enddocregion signout
+
+// #docregion signout-globally
+Future<void> signOutGlobally() async {
+  final result = await Amplify.Auth.signOut(
+    options: const SignOutOptions(globalSignOut: true),
+  );
+  if (result is CognitoCompleteSignOut) {
+    safePrint('Sign out completed successfully');
+  } else if (result is CognitoPartialSignOut) {
+    final globalSignOutException = result.globalSignOutException!;
+    final accessToken = globalSignOutException.accessToken;
+    // Retry the global sign out using the access token, if desired
+    // ...
+    safePrint('Error signing user out: ${globalSignOutException.message}');
+  } else if (result is CognitoFailedSignOut) {
+    safePrint('Error signing user out: ${result.exception.message}');
+  }
+}
+// #enddocregion signout-globally
+
+// #docregion update-password
+Future<void> updatePassword({
+  required String oldPassword,
+  required String newPassword,
+}) async {
+  try {
+    await Amplify.Auth.updatePassword(
+      oldPassword: oldPassword,
+      newPassword: newPassword,
+    );
+  } on AmplifyException catch (e) {
+    safePrint('Error updating password: ${e.message}');
+  }
+}
+// #enddocregion update-password
+
+// #docregion reset-password
+Future<void> resetPassword(String username) async {
+  try {
+    final result = await Amplify.Auth.resetPassword(
+      username: username,
+    );
+    return _handleResetPasswordResult(result);
+  } on AuthException catch (e) {
+    safePrint('Error resetting password: ${e.message}');
+  }
+}
+// #enddocregion reset-password
+
+// #docregion confirm-reset-password
+Future<void> confirmResetPassword({
+  required String username,
+  required String newPassword,
+  required String confirmationCode,
+}) async {
+  try {
+    final result = await Amplify.Auth.confirmResetPassword(
+      username: username,
+      newPassword: newPassword,
+      confirmationCode: confirmationCode,
+    );
+    safePrint('Password reset complete: ${result.isPasswordReset}');
+  } on AuthException catch (e) {
+    safePrint('Error resetting password: ${e.message}');
+  }
+}
+// #enddocregion confirm-reset-password
+
+// #docregion get-current-user
+Future<String?> getCurrentUserId() async {
+  try {
+    final user = await Amplify.Auth.getCurrentUser();
+    return user.userId;
+  } on AuthException catch (e) {
+    safePrint('Could not retrieve current user: ${e.message}');
+    return null;
+  }
+}
+// #enddocregion get-current-user
+
+// #docregion fetch-auth-session
+Future<void> fetchAuthSession() async {
+  try {
+    final result = await Amplify.Auth.fetchAuthSession();
+    safePrint('User is signed in: ${result.isSignedIn}');
+  } on AuthException catch (e) {
+    safePrint('Error retrieving auth session: ${e.message}');
+  }
+}
+// #enddocregion fetch-auth-session
+
+// #docregion fetch-cognito-auth-session
+Future<void> fetchCognitoAuthSession() async {
+  try {
+    final cognitoPlugin = Amplify.Auth.getPlugin(AmplifyAuthCognito.pluginKey);
+    final result = await cognitoPlugin.fetchAuthSession();
+    final identityId = result.identityIdResult.value;
+    safePrint("Current user's identity ID: $identityId");
+  } on AuthException catch (e) {
+    safePrint('Error retrieving auth session: ${e.message}');
+  }
+}
+// #enddocregion fetch-cognito-auth-session
+
+// #docregion fetch-user-attributes
+Future<void> fetchCurrentUserAttributes() async {
+  try {
+    final result = await Amplify.Auth.fetchUserAttributes();
+    for (final element in result) {
+      safePrint('key: ${element.userAttributeKey}; value: ${element.value}');
+    }
+  } on AuthException catch (e) {
+    safePrint('Error fetching user attributes: ${e.message}');
+  }
+}
+// #enddocregion fetch-user-attributes
+
+// #docregion handle-update-user-attribute
+void _handleUpdateUserAttributeResult(
+  UpdateUserAttributeResult result,
+) {
+  switch (result.nextStep.updateAttributeStep) {
+    case AuthUpdateAttributeStep.confirmAttributeWithCode:
+      final codeDeliveryDetails = result.nextStep.codeDeliveryDetails!;
+      _handleCodeDelivery(codeDeliveryDetails);
+      break;
+    case AuthUpdateAttributeStep.done:
+      safePrint('Successfully updated attribute');
+      break;
+  }
+}
+// #enddocregion handle-update-user-attribute
+
+// #docregion update-user-attribute
+Future<void> updateUserEmail({
+  required String newEmail,
+}) async {
+  try {
+    final result = await Amplify.Auth.updateUserAttribute(
+      userAttributeKey: AuthUserAttributeKey.email,
+      value: newEmail,
+    );
+    return _handleUpdateUserAttributeResult(result);
+  } on AuthException catch (e) {
+    safePrint('Error updating user attribute: ${e.message}');
+  }
+}
+// #enddocregion update-user-attribute
+
+// #docregion update-user-attributes
+Future<void> updateUserAttributes() async {
+  const attributes = [
+    AuthUserAttribute(
+      userAttributeKey: AuthUserAttributeKey.email,
+      value: 'email@email.com',
+    ),
+    AuthUserAttribute(
+      userAttributeKey: AuthUserAttributeKey.familyName,
+      value: 'MyFamilyName',
+    ),
+  ];
+  try {
+    final result = await Amplify.Auth.updateUserAttributes(
+      attributes: attributes,
+    );
+    result.forEach((key, value) {
+      switch (value.nextStep.updateAttributeStep) {
+        case AuthUpdateAttributeStep.confirmAttributeWithCode:
+          final destination = value.nextStep.codeDeliveryDetails?.destination;
+          safePrint('Confirmation code sent to $destination for $key');
+          break;
+        case AuthUpdateAttributeStep.done:
+          safePrint('Update completed for $key');
+          break;
+      }
+    });
+  } on AuthException catch (e) {
+    safePrint('Error updating user attributes: ${e.message}');
+  }
+}
+// #enddocregion update-user-attributes
+
+// #docregion confirm-user-attribute
+Future<void> verifyAttributeUpdate() async {
+  try {
+    await Amplify.Auth.confirmUserAttribute(
+      userAttributeKey: AuthUserAttributeKey.email,
+      confirmationCode: '390739',
+    );
+  } on AuthException catch (e) {
+    safePrint('Error confirming attribute update: ${e.message}');
+  }
+}
+// #enddocregion confirm-user-attribute
+
+// #docregion resend-user-attribute-code
+Future<void> resendVerificationCode() async {
+  try {
+    final result = await Amplify.Auth.resendUserAttributeConfirmationCode(
+      userAttributeKey: AuthUserAttributeKey.email,
+    );
+    _handleCodeDelivery(result.codeDeliveryDetails);
+  } on AuthException catch (e) {
+    safePrint('Error resending code: ${e.message}');
+  }
+}
+// #enddocregion resend-user-attribute-code
+
+// #docregion remember-device
+Future<void> rememberCurrentDevice() async {
+  try {
+    await Amplify.Auth.rememberDevice();
+    safePrint('Remember device succeeded');
+  } on AuthException catch (e) {
+    safePrint('Remember device failed with error: $e');
+  }
+}
+// #enddocregion remember-device
+
+// #docregion forget-device
+Future<void> forgetCurrentDevice() async {
+  try {
+    await Amplify.Auth.forgetDevice();
+    safePrint('Forget device succeeded');
+  } on AuthException catch (e) {
+    safePrint('Forget device failed with error: $e');
+  }
+}
+// #enddocregion forget-device
+
+// #docregion forget-specific-device
+Future<void> forgetSpecificDevice(AuthDevice myDevice) async {
+  try {
+    await Amplify.Auth.forgetDevice(myDevice);
+    safePrint('Forget device succeeded');
+  } on AuthException catch (e) {
+    safePrint('Forget device failed with error: $e');
+  }
+}
+// #enddocregion forget-specific-device
+
+// #docregion fetch-devices
+Future<void> fetchAllDevices() async {
+  try {
+    final devices = await Amplify.Auth.fetchDevices();
+    for (final device in devices) {
+      safePrint('Device: $device');
+    }
+  } on AuthException catch (e) {
+    safePrint('Fetch devices failed with error: $e');
+  }
+}
+// #enddocregion fetch-devices
+
+// #docregion delete-user
+Future<void> deleteUser() async {
+  try {
+    await Amplify.Auth.deleteUser();
+    safePrint('Delete user succeeded');
+  } on AuthException catch (e) {
+    safePrint('Delete user failed with error: $e');
+  }
+}
+// #enddocregion delete-user

--- a/packages/amplify_core/doc/pubspec.yaml
+++ b/packages/amplify_core/doc/pubspec.yaml
@@ -1,0 +1,28 @@
+name: doc
+description: Docs examples for the `amplify_core` package.
+version: 0.1.0
+homepage: https://docs.amplify.aws/lib/q/platform/flutter/
+repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_core/doc
+issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
+
+environment:
+  sdk: '>=2.18.0 <4.0.0'
+
+dependencies:
+  amplify_analytics_pinpoint: any
+  amplify_api: any
+  amplify_auth_cognito: any
+  amplify_datastore: any
+  amplify_flutter: any
+  amplify_storage_s3: any
+
+dev_dependencies:
+  amplify_lints: ^2.0.0
+  build_runner: ^2.0.0
+  code_excerpter:
+    git:
+      url: https://github.com/dart-lang/site-shared
+      # TODO(dnys1): Remove when Dart is bumped to >=2.19
+      ref: 0fe3c62c70c0e8c4f1a051a5dec3bbc4eb6c8e57
+      path: packages/code_excerpter
+  test: ^1.16.0

--- a/packages/amplify_core/lib/src/category/amplify_auth_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_auth_category.dart
@@ -49,6 +49,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// {@template amplify_core.amplify_auth_category.sign_up}
   /// Create a new user with the given [username] and [password].
   ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signin/q/platform/flutter/#register-a-user).
+  ///
+  /// ## Examples
+  ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
   /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
@@ -57,6 +65,8 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="signup"?>
   /// ```dart
+  /// /// Signs a user up with a username, password, and email. The required
+  /// /// attributes may be different depending on your app's configuration.
   /// Future<void> signUpUser({
   ///   required String username,
   ///   required String password,
@@ -102,14 +112,18 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// }
   /// ```
   ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-code"?>
+  /// ```dart
+  /// void _handleCodeDelivery(AuthCodeDeliveryDetails codeDeliveryDetails) {
+  ///   safePrint(
+  ///     'A confirmation code has been sent to ${codeDeliveryDetails.destination}. '
+  ///     'Please check your ${codeDeliveryDetails.deliveryMedium.name} for the code.',
+  ///   );
+  /// }
+  /// ```
+  ///
   /// If you need to resend the sign up code at any point in the sign up process,
   /// call [resendSignUpCode].
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signin/q/platform/flutter/#register-a-user).
   /// {@endtemplate}
   Future<SignUpResult> signUp({
     required String username,
@@ -125,6 +139,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// {@template amplify_core.amplify_auth_category.confirm_sign_up}
   /// Confirm the current sign up for [username] with the [confirmationCode]
   /// provided by the user.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signin/q/platform/flutter/#register-a-user).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -180,12 +202,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   );
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signin/q/platform/flutter/#register-a-user).
   /// {@endtemplate}
   Future<SignUpResult> confirmSignUp({
     required String username,
@@ -204,6 +220,11 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// [username] must be the same as the value passed to [signUp] and is either an
   /// identifier chosen by the user or their email/phone number, depending on the
   /// configuration.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -238,9 +259,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   );
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
   /// {@endtemplate}
   Future<ResendSignUpCodeResult> resendSignUpCode({
     required String username,
@@ -253,6 +271,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
 
   /// {@template amplify_core.amplify_auth_category.sign_in}
   /// Initiate sign in for user with [username] and optional [password].
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signin/q/platform/flutter/).
+  ///
+  /// ## Examples
   ///
   /// For Cognito flows, including a [password] will initiate an SRP sign-in,
   /// while excluding the [password] will initiate a custom auth sign-in.
@@ -430,12 +456,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signin/q/platform/flutter/).
   /// {@endtemplate}
   Future<SignInResult> signIn({
     required String username,
@@ -451,6 +471,11 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// {@template amplify_core.amplify_auth_category.confirm_sign_in}
   /// Confirm the current sign in with the [confirmationValue] provided by the
   /// user.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// ## Examples
   ///
   /// For example, to confirm a sign in requring MFA:
   ///
@@ -486,13 +511,7 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// }
   /// ```
   ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
   /// See [signIn] for examples of all confirmation flows.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signin/q/platform/flutter/).
   /// {@endtemplate}
   Future<SignInResult> confirmSignIn({
     required String confirmationValue,
@@ -505,6 +524,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
 
   /// {@template amplify_core.amplify_auth_category.sign_out}
   /// Sign the user out of the current device.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signOut/q/platform/flutter/).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -553,12 +580,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signOut/q/platform/flutter/).
   /// {@endtemplate}
   Future<SignOutResult> signOut({
     SignOutOptions? options,
@@ -569,6 +590,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// Update the password of the current user.
   ///
   /// **NOTE**: There must be a user signed in to perform this action.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/password_management/q/platform/flutter/#change-password).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -592,12 +621,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/password_management/q/platform/flutter/#change-password).
   /// {@endtemplate}
   Future<UpdatePasswordResult> updatePassword({
     required String oldPassword,
@@ -616,6 +639,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// [username] must be the same as the value used when signing in and is either an
   /// identifier chosen by the user or their email/phone number, depending on the
   /// configuration.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/password_management/q/platform/flutter/#reset-password).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -688,12 +719,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/password_management/q/platform/flutter/#reset-password).
   /// {@endtemplate}
   Future<ResetPasswordResult> resetPassword({
     required String username,
@@ -711,6 +736,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// [username] must be the same as the value used when signing in and is either an
   /// identifier chosen by the user or their email/phone number, depending on the
   /// configuration.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/password_management/q/platform/flutter/#reset-password).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -737,12 +770,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/password_management/q/platform/flutter/#reset-password).
   /// {@endtemplate}
   Future<ResetPasswordResult> confirmResetPassword({
     required String username,
@@ -759,6 +786,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
 
   /// {@template amplify_core.amplify_auth_category.get_current_user}
   /// Retrieves the current active user.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/getting-started/q/platform/flutter/#check-the-current-auth-session).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -778,12 +813,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/getting-started/q/platform/flutter/#check-the-current-auth-session).
   /// {@endtemplate}
   Future<AuthUser> getCurrentUser({
     GetCurrentUserOptions? options,
@@ -792,6 +821,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
 
   /// {@template amplify_core.amplify_auth_category.fetch_user_attributes}
   /// Fetch all user attributes associated with the current user.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#fetch-the-current-users-attributes).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -812,12 +849,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#fetch-the-current-users-attributes).
   /// {@endtemplate}
   Future<List<AuthUserAttribute>> fetchUserAttributes({
     FetchUserAttributesOptions? options,
@@ -826,6 +857,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
 
   /// {@template amplify_core.amplify_auth_category.fetch_auth_session}
   /// Fetch the current auth session.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/access_credentials/q/platform/flutter/).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -863,12 +902,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/access_credentials/q/platform/flutter/).
   /// {@endtemplate}
   Future<AuthSession> fetchAuthSession({
     FetchAuthSessionOptions? options,
@@ -882,6 +915,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// If no [provider] is supplied, the default login page will be shown. By
   /// specifying a [provider], the webpage will open directly to the provider's
   /// login page.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/social/q/platform/flutter/).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -902,12 +943,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/social/q/platform/flutter/).
   /// {@endtemplate}
   Future<SignInResult> signInWithWebUI({
     AuthProvider? provider,
@@ -922,6 +957,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// Updates a single user attribute.
   ///
   /// > To update multiple attributes, use [updateUserAttributes] instead.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#update-user-attribute).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -967,12 +1010,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// ```
   ///
   /// Then call [confirmUserAttribute] with the delivered confirmation code.
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#update-user-attribute).
   /// {@endtemplate}
   Future<UpdateUserAttributeResult> updateUserAttribute({
     required AuthUserAttributeKey userAttributeKey,
@@ -987,6 +1024,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
 
   /// {@template amplify_core.amplify_auth_category.update_user_attributes}
   /// Updates multiple user attributes at once.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#update-user-attribute).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -1027,12 +1072,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#update-user-attribute).
   /// {@endtemplate}
   Future<Map<AuthUserAttributeKey, UpdateUserAttributeResult>>
       updateUserAttributes({
@@ -1047,6 +1086,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// {@template amplify_core.amplify_auth_category.confirm_user_attribute}
   /// Confirms a user attribute update initiated with either [updateUserAttribute]
   /// or [updateUserAttributes].
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#verify-user-attribute).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -1067,12 +1114,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#verify-user-attribute).
   /// {@endtemplate}
   Future<ConfirmUserAttributeResult> confirmUserAttribute({
     required AuthUserAttributeKey userAttributeKey,
@@ -1091,6 +1132,14 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///
   /// If a confirmation code sent as the result of a [updateUserAttribute] or [updateUserAttributes]
   /// call expires, you can use this API to request a new one.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#resend-verification-code).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -1125,12 +1174,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   );
   /// }
   /// ```
-  ///
-  /// Optionally accepts plugin [options] which allow customizing provider-specific
-  /// behavior, e.g. the Cognito User Pool.
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#resend-verification-code).
   /// {@endtemplate}
   Future<ResendUserAttributeConfirmationCodeResult>
       resendUserAttributeConfirmationCode({
@@ -1144,6 +1187,11 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
 
   /// {@template amplify_core.amplify_auth_category.remember_device}
   /// Remembers the current device.
+  ///
+  /// For more information about device tracking, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/device_features/q/platform/flutter/).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -1162,14 +1210,16 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// For more information about device tracking, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/device_features/q/platform/flutter/).
   /// {@endtemplate}
   Future<void> rememberDevice() => defaultPlugin.rememberDevice();
 
   /// {@template amplify_core.amplify_auth_category.forget_device}
   /// Forgets the current device.
+  ///
+  /// For more information about device tracking, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/device_features/q/platform/flutter/).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -1203,15 +1253,17 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// For more information about device tracking, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/device_features/q/platform/flutter/).
   /// {@endtemplate}
   Future<void> forgetDevice([AuthDevice? device]) =>
       defaultPlugin.forgetDevice(device);
 
   /// {@template amplify_core.amplify_auth_category.fetch_devices}
   /// Retrieves all tracked devices for the current user.
+  ///
+  /// For more information about device tracking, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/device_features/q/platform/flutter/).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -1232,14 +1284,16 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// For more information about device tracking, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/device_features/q/platform/flutter/).
   /// {@endtemplate}
   Future<List<AuthDevice>> fetchDevices() => defaultPlugin.fetchDevices();
 
   /// {@template amplify_core.amplify_auth_category.delete_user}
   /// Deletes the current authenticated user.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/delete_user/q/platform/flutter/).
+  ///
+  /// ## Examples
   ///
   /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
   /// ```dart
@@ -1258,9 +1312,6 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///   }
   /// }
   /// ```
-  ///
-  /// For more information, see the
-  /// [Amplify docs](https://docs.amplify.aws/lib/auth/delete_user/q/platform/flutter/).
   /// {@endtemplate}
   Future<void> deleteUser() => defaultPlugin.deleteUser();
 }

--- a/packages/amplify_core/lib/src/category/amplify_auth_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_auth_category.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:meta/meta.dart';
 
+/// {@category Auth}
 /// {@template amplify_core.amplify_auth_category}
 /// The Amplify Auth category provides an interface for authenticating a user.
 ///
@@ -23,6 +24,7 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
 
   /// Gets the registered plugin of type [Plugin] as provided by a [pluginKey], e.g.
   ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="get-plugin"?>
   /// ```dart
   /// Future<CognitoSignInResult> signInWithCognito(
   ///   String username,
@@ -46,6 +48,68 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
 
   /// {@template amplify_core.amplify_auth_category.sign_up}
   /// Create a new user with the given [username] and [password].
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="signup"?>
+  /// ```dart
+  /// Future<void> signUpUser({
+  ///   required String username,
+  ///   required String password,
+  ///   required String email,
+  ///   String? phoneNumber,
+  /// }) async {
+  ///   try {
+  ///     final userAttributes = {
+  ///       AuthUserAttributeKey.email: email,
+  ///       if (phoneNumber != null) AuthUserAttributeKey.phoneNumber: phoneNumber,
+  ///       // additional attributes as needed
+  ///     };
+  ///     final result = await Amplify.Auth.signUp(
+  ///       username: username,
+  ///       password: password,
+  ///       options: SignUpOptions(
+  ///         userAttributes: userAttributes,
+  ///       ),
+  ///     );
+  ///     return _handleSignUpResult(result);
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error signing up user: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// The next step in the sign up flow is to confirm the user. A confirmation code
+  /// will be sent to the email or phone number provided during sign up. Prompt the
+  /// user to check their device for the code sent by Cognito.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-signup"?>
+  /// ```dart
+  /// Future<void> _handleSignUpResult(SignUpResult result) async {
+  ///   switch (result.nextStep.signUpStep) {
+  ///     case AuthSignUpStep.confirmSignUp:
+  ///       final codeDeliveryDetails = result.nextStep.codeDeliveryDetails!;
+  ///       _handleCodeDelivery(codeDeliveryDetails);
+  ///       break;
+  ///     case AuthSignUpStep.done:
+  ///       safePrint('Sign up is complete');
+  ///       break;
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// If you need to resend the sign up code at any point in the sign up process,
+  /// call [resendSignUpCode].
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signin/q/platform/flutter/#register-a-user).
   /// {@endtemplate}
   Future<SignUpResult> signUp({
     required String username,
@@ -61,6 +125,67 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// {@template amplify_core.amplify_auth_category.confirm_sign_up}
   /// Confirm the current sign up for [username] with the [confirmationCode]
   /// provided by the user.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="confirm-signup"?>
+  /// ```dart
+  /// Future<void> confirmUser({
+  ///   required String username,
+  ///   required String confirmationCode,
+  /// }) async {
+  ///   try {
+  ///     final result = await Amplify.Auth.confirmSignUp(
+  ///       username: username,
+  ///       confirmationCode: confirmationCode,
+  ///     );
+  ///     return _handleSignUpResult(result);
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error confirming user: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// After confirming the sign up, check the [SignUpResult] object to check if
+  /// further confirmations are needed or if the sign up is complete.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-signup"?>
+  /// ```dart
+  /// Future<void> _handleSignUpResult(SignUpResult result) async {
+  ///   switch (result.nextStep.signUpStep) {
+  ///     case AuthSignUpStep.confirmSignUp:
+  ///       final codeDeliveryDetails = result.nextStep.codeDeliveryDetails!;
+  ///       _handleCodeDelivery(codeDeliveryDetails);
+  ///       break;
+  ///     case AuthSignUpStep.done:
+  ///       safePrint('Sign up is complete');
+  ///       break;
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Prompt the user to check the destination of the delivered code by examining
+  /// the returned [AuthCodeDeliveryDetails] object.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-code"?>
+  /// ```dart
+  /// void _handleCodeDelivery(AuthCodeDeliveryDetails codeDeliveryDetails) {
+  ///   safePrint(
+  ///     'A confirmation code has been sent to ${codeDeliveryDetails.destination}. '
+  ///     'Please check your ${codeDeliveryDetails.deliveryMedium.name} for the code.',
+  ///   );
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signin/q/platform/flutter/#register-a-user).
   /// {@endtemplate}
   Future<SignUpResult> confirmSignUp({
     required String username,
@@ -74,12 +199,48 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
       );
 
   /// {@template amplify_core.amplify_auth_category.resend_sign_up_code}
-  /// Resends the code that is used to confirm the user's account after sign up
+  /// Resends the code that is used to confirm the user's account after sign up.
   ///
-  /// Resends the code to the user with the given [username], where [username]
-  /// is a login identifier or an email/phone number, depending on the configuration
+  /// [username] must be the same as the value passed to [signUp] and is either an
+  /// identifier chosen by the user or their email/phone number, depending on the
+  /// configuration.
   ///
-  /// Accepts plugin-specific, advanced [options] for the request
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="resend-signup-code"?>
+  /// ```dart
+  /// Future<void> resendSignUpCode(String username) async {
+  ///   try {
+  ///     final result = await Amplify.Auth.resendSignUpCode(
+  ///       username: username,
+  ///     );
+  ///     final codeDeliveryDetails = result.codeDeliveryDetails;
+  ///     _handleCodeDelivery(codeDeliveryDetails);
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error resending code: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Prompt the user to check the destination of the delivered code by examining
+  /// the returned [AuthCodeDeliveryDetails] object.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-code"?>
+  /// ```dart
+  /// void _handleCodeDelivery(AuthCodeDeliveryDetails codeDeliveryDetails) {
+  ///   safePrint(
+  ///     'A confirmation code has been sent to ${codeDeliveryDetails.destination}. '
+  ///     'Please check your ${codeDeliveryDetails.deliveryMedium.name} for the code.',
+  ///   );
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
   /// {@endtemplate}
   Future<ResendSignUpCodeResult> resendSignUpCode({
     required String username,
@@ -95,6 +256,186 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   ///
   /// For Cognito flows, including a [password] will initiate an SRP sign-in,
   /// while excluding the [password] will initiate a custom auth sign-in.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="signin"?>
+  /// ```dart
+  /// Future<void> signInUser(String username, String password) async {
+  ///   try {
+  ///     final result = await Amplify.Auth.signIn(
+  ///       username: username,
+  ///       password: password,
+  ///     );
+  ///     return _handleSignInResult(result);
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error signing in: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-signin"?>
+  /// ```dart
+  /// Future<void> _handleSignInResult(SignInResult result) async {
+  ///   switch (result.nextStep.signInStep) {
+  ///     // ···
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// If SMS MFA is enabled, prompt the user to check their phone for a code.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-confirm-signin-sms"?>
+  /// ```dart
+  /// Future<void> _handleSignInResult(SignInResult result) async {
+  ///   switch (result.nextStep.signInStep) {
+  ///     // ···
+  ///     case AuthSignInStep.confirmSignInWithSmsMfaCode:
+  ///       final codeDeliveryDetails = result.nextStep.codeDeliveryDetails!;
+  ///       _handleCodeDelivery(codeDeliveryDetails);
+  ///       break;
+  ///     // ···
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-code"?>
+  /// ```dart
+  /// void _handleCodeDelivery(AuthCodeDeliveryDetails codeDeliveryDetails) {
+  ///   safePrint(
+  ///     'A confirmation code has been sent to ${codeDeliveryDetails.destination}. '
+  ///     'Please check your ${codeDeliveryDetails.deliveryMedium.name} for the code.',
+  ///   );
+  /// }
+  /// ```
+  ///
+  /// If the user was created by an administrator, a new password will be required.
+  /// Prompt the user to choose a new password and pass the value to [confirmSignIn].
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-confirm-signin-new-password"?>
+  /// ```dart
+  /// Future<void> _handleSignInResult(SignInResult result) async {
+  ///   switch (result.nextStep.signInStep) {
+  ///     // ···
+  ///     case AuthSignInStep.confirmSignInWithNewPassword:
+  ///       safePrint('Enter a new password to continue signing in');
+  ///       break;
+  ///     // ···
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// If you've implemented a custom auth flow, the [SignInResult] will include the parameters
+  /// of your challenge in the `additionalInfo` field. These parameters can be used to relay
+  /// any information from your backend code which can be used to customize the flow however
+  /// you'd like.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-confirm-signin-custom-challenge"?>
+  /// ```dart
+  /// Future<void> _handleSignInResult(SignInResult result) async {
+  ///   switch (result.nextStep.signInStep) {
+  ///     // ···
+  ///     case AuthSignInStep.confirmSignInWithCustomChallenge:
+  ///       final parameters = result.nextStep.additionalInfo;
+  ///       final prompt = parameters['prompt']!;
+  ///       safePrint(prompt);
+  ///       break;
+  ///     // ···
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// If the user is required to reset their password before continuing, use the [resetPassword]
+  /// API to initiate a password and follow the instructions to confirm the reset if
+  /// necessary.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-confirm-signin-reset-password"?>
+  /// ```dart
+  /// Future<void> _handleSignInResult(SignInResult result) async {
+  ///   switch (result.nextStep.signInStep) {
+  ///     // ···
+  ///     case AuthSignInStep.resetPassword:
+  ///       final resetResult = await Amplify.Auth.resetPassword(
+  ///         username: username,
+  ///       );
+  ///       await _handleResetPasswordResult(resetResult);
+  ///       break;
+  ///     // ···
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-reset-password"?>
+  /// ```dart
+  /// Future<void> _handleResetPasswordResult(ResetPasswordResult result) async {
+  ///   switch (result.nextStep.updateStep) {
+  ///     case AuthResetPasswordStep.confirmResetPasswordWithCode:
+  ///       final codeDeliveryDetails = result.nextStep.codeDeliveryDetails!;
+  ///       _handleCodeDelivery(codeDeliveryDetails);
+  ///       break;
+  ///     case AuthResetPasswordStep.done:
+  ///       safePrint('Successfully reset password');
+  ///       break;
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// If a user tries to sign in before completing their sign up, the [AuthSignInStep.confirmSignUp]
+  /// step will be returned. This is the same step returned from [signUp] and requires a
+  /// call to [confirmSignUp] before re-initiating the sign in flow.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-confirm-signin-confirm-signup"?>
+  /// ```dart
+  /// Future<void> _handleSignInResult(SignInResult result) async {
+  ///   switch (result.nextStep.signInStep) {
+  ///     // ···
+  ///     case AuthSignInStep.confirmSignUp:
+  ///       // Resend the sign up code to the registered device.
+  ///       final resendResult = await Amplify.Auth.resendSignUpCode(
+  ///         username: username,
+  ///       );
+  ///       _handleCodeDelivery(resendResult.codeDeliveryDetails);
+  ///       break;
+  ///     // ···
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-code"?>
+  /// ```dart
+  /// void _handleCodeDelivery(AuthCodeDeliveryDetails codeDeliveryDetails) {
+  ///   safePrint(
+  ///     'A confirmation code has been sent to ${codeDeliveryDetails.destination}. '
+  ///     'Please check your ${codeDeliveryDetails.deliveryMedium.name} for the code.',
+  ///   );
+  /// }
+  /// ```
+  ///
+  /// When there are no more challenges and the sign in is complete, the next step will
+  /// be [AuthSignInStep.done].
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-confirm-signin-done"?>
+  /// ```dart
+  /// Future<void> _handleSignInResult(SignInResult result) async {
+  ///   switch (result.nextStep.signInStep) {
+  ///     // ···
+  ///     case AuthSignInStep.done:
+  ///       safePrint('Sign in is complete');
+  ///       break;
+  ///     // ···
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signin/q/platform/flutter/).
   /// {@endtemplate}
   Future<SignInResult> signIn({
     required String username,
@@ -110,6 +451,48 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// {@template amplify_core.amplify_auth_category.confirm_sign_in}
   /// Confirm the current sign in with the [confirmationValue] provided by the
   /// user.
+  ///
+  /// For example, to confirm a sign in requring MFA:
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="confirm-signin"?>
+  /// ```dart
+  /// Future<void> confirmMfaUser(String mfaCode) async {
+  ///   try {
+  ///     final result = await Amplify.Auth.confirmSignIn(
+  ///       confirmationValue: mfaCode,
+  ///     );
+  ///     return _handleSignInResult(result);
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error confirming MFA code: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Confirming a sign in can still require additional confirmations which
+  /// should be handled accordingly.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-signin"?>
+  /// ```dart
+  /// Future<void> _handleSignInResult(SignInResult result) async {
+  ///   switch (result.nextStep.signInStep) {
+  ///     // ···
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// See [signIn] for examples of all confirmation flows.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signin/q/platform/flutter/).
   /// {@endtemplate}
   Future<SignInResult> confirmSignIn({
     required String confirmationValue,
@@ -123,8 +506,59 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// {@template amplify_core.amplify_auth_category.sign_out}
   /// Sign the user out of the current device.
   ///
-  /// Accepts advanced [options] for the request, which can be used for
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="signout"?>
+  /// ```dart
+  /// Future<void> signOutCurrentUser() async {
+  ///   final result = await Amplify.Auth.signOut();
+  ///   if (result is CognitoCompleteSignOut) {
+  ///     safePrint('Sign out completed successfully');
+  ///   } else if (result is CognitoFailedSignOut) {
+  ///     safePrint('Error signing user out: ${result.exception.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// You can pass [options] for the request, which can be used for
   /// global sign out as well as other plugin-specific options.
+  ///
+  /// In the case of the Cognito plugin, passing `globalSignOut: true`
+  /// to the API can result in instances of partial sign out, where
+  /// the user's session is cleared locally, but an error occurred
+  /// performing global sign out. In this case, the exception is returned
+  /// along with the token which can be used to manually retry the
+  /// global sign out if desired.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="signout-globally"?>
+  /// ```dart
+  /// Future<void> signOutGlobally() async {
+  ///   final result = await Amplify.Auth.signOut(
+  ///     options: const SignOutOptions(globalSignOut: true),
+  ///   );
+  ///   if (result is CognitoCompleteSignOut) {
+  ///     safePrint('Sign out completed successfully');
+  ///   } else if (result is CognitoPartialSignOut) {
+  ///     final globalSignOutException = result.globalSignOutException!;
+  ///     final accessToken = globalSignOutException.accessToken;
+  ///     // Retry the global sign out using the access token, if desired
+  ///     // ...
+  ///     safePrint('Error signing user out: ${globalSignOutException.message}');
+  ///   } else if (result is CognitoFailedSignOut) {
+  ///     safePrint('Error signing user out: ${result.exception.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/signOut/q/platform/flutter/).
   /// {@endtemplate}
   Future<SignOutResult> signOut({
     SignOutOptions? options,
@@ -134,9 +568,36 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// {@template amplify_core.amplify_auth_category.update_password}
   /// Update the password of the current user.
   ///
-  /// There must be a user signed in to perform this action.
+  /// **NOTE**: There must be a user signed in to perform this action.
   ///
-  /// Optionally accepts plugin-specific, advanced [options] for the request.
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="update-password"?>
+  /// ```dart
+  /// Future<void> updatePassword({
+  ///   required String oldPassword,
+  ///   required String newPassword,
+  /// }) async {
+  ///   try {
+  ///     await Amplify.Auth.updatePassword(
+  ///       oldPassword: oldPassword,
+  ///       newPassword: newPassword,
+  ///     );
+  ///   } on AmplifyException catch (e) {
+  ///     safePrint('Error updating password: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/password_management/q/platform/flutter/#change-password).
   /// {@endtemplate}
   Future<UpdatePasswordResult> updatePassword({
     required String oldPassword,
@@ -152,10 +613,87 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// {@template amplify_core.amplify_auth_category.reset_password}
   /// Initiates a password reset for the user with the given username.
   ///
-  /// The [username] is a login identifier or an email/phone number, depending on
-  /// the configuration.
+  /// [username] must be the same as the value used when signing in and is either an
+  /// identifier chosen by the user or their email/phone number, depending on the
+  /// configuration.
   ///
-  /// Optionally accepts plugin-specific, advanced [options] for the request.
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="reset-password"?>
+  /// ```dart
+  /// Future<void> resetPassword(String username) async {
+  ///   try {
+  ///     final result = await Amplify.Auth.resetPassword(
+  ///       username: username,
+  ///     );
+  ///     return _handleResetPasswordResult(result);
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error resetting password: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// If further confirmation is required before the reset is complete, the next
+  /// step will be returned as part of the [ResetPasswordResult].
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-reset-password"?>
+  /// ```dart
+  /// Future<void> _handleResetPasswordResult(ResetPasswordResult result) async {
+  ///   switch (result.nextStep.updateStep) {
+  ///     case AuthResetPasswordStep.confirmResetPasswordWithCode:
+  ///       final codeDeliveryDetails = result.nextStep.codeDeliveryDetails!;
+  ///       _handleCodeDelivery(codeDeliveryDetails);
+  ///       break;
+  ///     case AuthResetPasswordStep.done:
+  ///       safePrint('Successfully reset password');
+  ///       break;
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-code"?>
+  /// ```dart
+  /// void _handleCodeDelivery(AuthCodeDeliveryDetails codeDeliveryDetails) {
+  ///   safePrint(
+  ///     'A confirmation code has been sent to ${codeDeliveryDetails.destination}. '
+  ///     'Please check your ${codeDeliveryDetails.deliveryMedium.name} for the code.',
+  ///   );
+  /// }
+  /// ```
+  ///
+  /// In order to complete the password reset, check the returned [ResetPasswordResult]
+  /// for details on where the confirmation code was sent, then call [confirmResetPassword]
+  /// with the confirmation code and the new password.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="confirm-reset-password"?>
+  /// ```dart
+  /// Future<void> confirmResetPassword({
+  ///   required String username,
+  ///   required String newPassword,
+  ///   required String confirmationCode,
+  /// }) async {
+  ///   try {
+  ///     final result = await Amplify.Auth.confirmResetPassword(
+  ///       username: username,
+  ///       newPassword: newPassword,
+  ///       confirmationCode: confirmationCode,
+  ///     );
+  ///     safePrint('Password reset complete: ${result.isPasswordReset}');
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error resetting password: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/password_management/q/platform/flutter/#reset-password).
   /// {@endtemplate}
   Future<ResetPasswordResult> resetPassword({
     required String username,
@@ -168,12 +706,43 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
 
   /// {@template amplify_core.amplify_auth_category.confirm_reset_password}
   /// Completes the password reset process given a username, new password,
-  /// and confirmation code.
+  /// and the confirmation code which was sent calling [resetPassword].
   ///
-  /// The [username] is a login identifier or an email/phone number, depending on
-  /// the configuration.
+  /// [username] must be the same as the value used when signing in and is either an
+  /// identifier chosen by the user or their email/phone number, depending on the
+  /// configuration.
   ///
-  /// Optionally accepts plugin-specific, advanced [options] for the request.
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="confirm-reset-password"?>
+  /// ```dart
+  /// Future<void> confirmResetPassword({
+  ///   required String username,
+  ///   required String newPassword,
+  ///   required String confirmationCode,
+  /// }) async {
+  ///   try {
+  ///     final result = await Amplify.Auth.confirmResetPassword(
+  ///       username: username,
+  ///       newPassword: newPassword,
+  ///       confirmationCode: confirmationCode,
+  ///     );
+  ///     safePrint('Password reset complete: ${result.isPasswordReset}');
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error resetting password: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/password_management/q/platform/flutter/#reset-password).
   /// {@endtemplate}
   Future<ResetPasswordResult> confirmResetPassword({
     required String username,
@@ -189,7 +758,32 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
       );
 
   /// {@template amplify_core.amplify_auth_category.get_current_user}
-  /// Retrieve the current active user.
+  /// Retrieves the current active user.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="get-current-user"?>
+  /// ```dart
+  /// Future<String?> getCurrentUserId() async {
+  ///   try {
+  ///     final user = await Amplify.Auth.getCurrentUser();
+  ///     return user.userId;
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Could not retrieve current user: ${e.message}');
+  ///     return null;
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/getting-started/q/platform/flutter/#check-the-current-auth-session).
   /// {@endtemplate}
   Future<AuthUser> getCurrentUser({
     GetCurrentUserOptions? options,
@@ -198,6 +792,32 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
 
   /// {@template amplify_core.amplify_auth_category.fetch_user_attributes}
   /// Fetch all user attributes associated with the current user.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="fetch-user-attributes"?>
+  /// ```dart
+  /// Future<void> fetchCurrentUserAttributes() async {
+  ///   try {
+  ///     final result = await Amplify.Auth.fetchUserAttributes();
+  ///     for (final element in result) {
+  ///       safePrint('key: ${element.userAttributeKey}; value: ${element.value}');
+  ///     }
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error fetching user attributes: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#fetch-the-current-users-attributes).
   /// {@endtemplate}
   Future<List<AuthUserAttribute>> fetchUserAttributes({
     FetchUserAttributesOptions? options,
@@ -207,9 +827,48 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// {@template amplify_core.amplify_auth_category.fetch_auth_session}
   /// Fetch the current auth session.
   ///
-  /// For Cognito flows, this returns the User Pool tokens. AWS credentials
-  /// can be returned as well by providing a `CognitoSessionOptions` value
-  /// for [options].
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="fetch-auth-session"?>
+  /// ```dart
+  /// Future<void> fetchAuthSession() async {
+  ///   try {
+  ///     final result = await Amplify.Auth.fetchAuthSession();
+  ///     safePrint('User is signed in: ${result.isSignedIn}');
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error retrieving auth session: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Sometimes it can be helpful to retrieve the instance of the underlying plugin
+  /// which has more specific typing. In the case of Cognito, calling [fetchAuthSession]
+  /// on the Cognito plugin returns AWS-specific values such as the identity ID,
+  /// AWS credentials, and Cognito User Pool tokens.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="fetch-cognito-auth-session"?>
+  /// ```dart
+  /// Future<void> fetchCognitoAuthSession() async {
+  ///   try {
+  ///     final cognitoPlugin = Amplify.Auth.getPlugin(AmplifyAuthCognito.pluginKey);
+  ///     final result = await cognitoPlugin.fetchAuthSession();
+  ///     final identityId = result.identityIdResult.value;
+  ///     safePrint("Current user's identity ID: $identityId");
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error retrieving auth session: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/access_credentials/q/platform/flutter/).
   /// {@endtemplate}
   Future<AuthSession> fetchAuthSession({
     FetchAuthSessionOptions? options,
@@ -217,7 +876,38 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
       defaultPlugin.fetchAuthSession(options: options);
 
   /// {@template amplify_core.amplify_auth_category.sign_in_with_web_ui}
-  /// Initiate sign in for a web-based flow, e.g. a social provider.
+  /// Initiate sign in for a web-based flow, e.g. a social provider like Facebook,
+  /// Google, or Apple.
+  ///
+  /// If no [provider] is supplied, the default login page will be shown. By
+  /// specifying a [provider], the webpage will open directly to the provider's
+  /// login page.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="signin-webui"?>
+  /// ```dart
+  /// Future<void> socialSignIn() async {
+  ///   try {
+  ///     final result = await Amplify.Auth.signInWithWebUI(
+  ///       provider: AuthProvider.google,
+  ///     );
+  ///     return _handleSignInResult(result);
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error signing in: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/social/q/platform/flutter/).
   /// {@endtemplate}
   Future<SignInResult> signInWithWebUI({
     AuthProvider? provider,
@@ -229,9 +919,60 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
       );
 
   /// {@template amplify_core.amplify_auth_category.update_user_attribute}
-  /// Updates a single user attribute and returns a [UpdateUserAttributeResult].
+  /// Updates a single user attribute.
   ///
-  /// Accepts plugin-specific, advanced [options] for the request.
+  /// > To update multiple attributes, use [updateUserAttributes] instead.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="update-user-attribute"?>
+  /// ```dart
+  /// Future<void> updateUserEmail({
+  ///   required String newEmail,
+  /// }) async {
+  ///   try {
+  ///     final result = await Amplify.Auth.updateUserAttribute(
+  ///       userAttributeKey: AuthUserAttributeKey.email,
+  ///       value: newEmail,
+  ///     );
+  ///     return _handleUpdateUserAttributeResult(result);
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error updating user attribute: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// If the update requires further confirmation, follow the next step returned
+  /// in the [UpdateUserAttributeResult].
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-update-user-attribute"?>
+  /// ```dart
+  /// void _handleUpdateUserAttributeResult(
+  ///   UpdateUserAttributeResult result,
+  /// ) {
+  ///   switch (result.nextStep.updateAttributeStep) {
+  ///     case AuthUpdateAttributeStep.confirmAttributeWithCode:
+  ///       final codeDeliveryDetails = result.nextStep.codeDeliveryDetails!;
+  ///       _handleCodeDelivery(codeDeliveryDetails);
+  ///       break;
+  ///     case AuthUpdateAttributeStep.done:
+  ///       safePrint('Successfully updated attribute');
+  ///       break;
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Then call [confirmUserAttribute] with the delivered confirmation code.
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#update-user-attribute).
   /// {@endtemplate}
   Future<UpdateUserAttributeResult> updateUserAttribute({
     required AuthUserAttributeKey userAttributeKey,
@@ -245,10 +986,53 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
       );
 
   /// {@template amplify_core.amplify_auth_category.update_user_attributes}
-  /// Updates multiple user attributes and returns a map of
-  /// [UpdateUserAttributeResult].
+  /// Updates multiple user attributes at once.
   ///
-  /// Accepts plugin-specific, advanced [options] for the request.
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="update-user-attributes"?>
+  /// ```dart
+  /// Future<void> updateUserAttributes() async {
+  ///   const attributes = [
+  ///     AuthUserAttribute(
+  ///       userAttributeKey: AuthUserAttributeKey.email,
+  ///       value: 'email@email.com',
+  ///     ),
+  ///     AuthUserAttribute(
+  ///       userAttributeKey: AuthUserAttributeKey.familyName,
+  ///       value: 'MyFamilyName',
+  ///     ),
+  ///   ];
+  ///   try {
+  ///     final result = await Amplify.Auth.updateUserAttributes(
+  ///       attributes: attributes,
+  ///     );
+  ///     result.forEach((key, value) {
+  ///       switch (value.nextStep.updateAttributeStep) {
+  ///         case AuthUpdateAttributeStep.confirmAttributeWithCode:
+  ///           final destination = value.nextStep.codeDeliveryDetails?.destination;
+  ///           safePrint('Confirmation code sent to $destination for $key');
+  ///           break;
+  ///         case AuthUpdateAttributeStep.done:
+  ///           safePrint('Update completed for $key');
+  ///           break;
+  ///       }
+  ///     });
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error updating user attributes: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#update-user-attribute).
   /// {@endtemplate}
   Future<Map<AuthUserAttributeKey, UpdateUserAttributeResult>>
       updateUserAttributes({
@@ -261,8 +1045,34 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
           );
 
   /// {@template amplify_core.amplify_auth_category.confirm_user_attribute}
-  /// Confirms a user attribute update and returns a
-  /// [ConfirmUserAttributeResult].
+  /// Confirms a user attribute update initiated with either [updateUserAttribute]
+  /// or [updateUserAttributes].
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="confirm-user-attribute"?>
+  /// ```dart
+  /// Future<void> verifyAttributeUpdate() async {
+  ///   try {
+  ///     await Amplify.Auth.confirmUserAttribute(
+  ///       userAttributeKey: AuthUserAttributeKey.email,
+  ///       confirmationCode: '390739',
+  ///     );
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error confirming attribute update: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#verify-user-attribute).
   /// {@endtemplate}
   Future<ConfirmUserAttributeResult> confirmUserAttribute({
     required AuthUserAttributeKey userAttributeKey,
@@ -276,10 +1086,51 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
       );
 
   /// {@template amplify_core.amplify_auth_category.resend_user_attribute_confirmation_code}
-  /// Resends a confirmation code for the given attribute and returns a
-  /// [ResendUserAttributeConfirmationCodeResult].
+  /// Resends a confirmation code for the given [userAttributeKey], if required, while
+  /// updating the attribute.
   ///
-  /// Accepts plugin-specific, advanced [options] for the request.
+  /// If a confirmation code sent as the result of a [updateUserAttribute] or [updateUserAttributes]
+  /// call expires, you can use this API to request a new one.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="resend-user-attribute-code"?>
+  /// ```dart
+  /// Future<void> resendVerificationCode() async {
+  ///   try {
+  ///     final result = await Amplify.Auth.resendUserAttributeConfirmationCode(
+  ///       userAttributeKey: AuthUserAttributeKey.email,
+  ///     );
+  ///     _handleCodeDelivery(result.codeDeliveryDetails);
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Error resending code: ${e.message}');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// The details of where the code will be delivered are returned in the result's
+  /// [ResendUserAttributeConfirmationCodeResult.codeDeliveryDetails] property
+  /// and should be used to prompt the user on where to look for the code.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="handle-code"?>
+  /// ```dart
+  /// void _handleCodeDelivery(AuthCodeDeliveryDetails codeDeliveryDetails) {
+  ///   safePrint(
+  ///     'A confirmation code has been sent to ${codeDeliveryDetails.destination}. '
+  ///     'Please check your ${codeDeliveryDetails.deliveryMedium.name} for the code.',
+  ///   );
+  /// }
+  /// ```
+  ///
+  /// Optionally accepts plugin [options] which allow customizing provider-specific
+  /// behavior, e.g. the Cognito User Pool.
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/user-attributes/q/platform/flutter/#resend-verification-code).
   /// {@endtemplate}
   Future<ResendUserAttributeConfirmationCodeResult>
       resendUserAttributeConfirmationCode({
@@ -293,22 +1144,123 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
 
   /// {@template amplify_core.amplify_auth_category.remember_device}
   /// Remembers the current device.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="remember-device"?>
+  /// ```dart
+  /// Future<void> rememberCurrentDevice() async {
+  ///   try {
+  ///     await Amplify.Auth.rememberDevice();
+  ///     safePrint('Remember device succeeded');
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Remember device failed with error: $e');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// For more information about device tracking, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/device_features/q/platform/flutter/).
   /// {@endtemplate}
   Future<void> rememberDevice() => defaultPlugin.rememberDevice();
 
   /// {@template amplify_core.amplify_auth_category.forget_device}
-  /// Forgets [device], or the current device, if no parameters are given.
+  /// Forgets the current device.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="forget-device"?>
+  /// ```dart
+  /// Future<void> forgetCurrentDevice() async {
+  ///   try {
+  ///     await Amplify.Auth.forgetDevice();
+  ///     safePrint('Forget device succeeded');
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Forget device failed with error: $e');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Optionally, to forget a specific device, i.e. one retrieved from [fetchDevices],
+  /// pass the [AuthDevice] when making the API call.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="forget-specific-device"?>
+  /// ```dart
+  /// Future<void> forgetSpecificDevice(AuthDevice myDevice) async {
+  ///   try {
+  ///     await Amplify.Auth.forgetDevice(myDevice);
+  ///     safePrint('Forget device succeeded');
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Forget device failed with error: $e');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// For more information about device tracking, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/device_features/q/platform/flutter/).
   /// {@endtemplate}
   Future<void> forgetDevice([AuthDevice? device]) =>
       defaultPlugin.forgetDevice(device);
 
   /// {@template amplify_core.amplify_auth_category.fetch_devices}
   /// Retrieves all tracked devices for the current user.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="fetch-devices"?>
+  /// ```dart
+  /// Future<void> fetchAllDevices() async {
+  ///   try {
+  ///     final devices = await Amplify.Auth.fetchDevices();
+  ///     for (final device in devices) {
+  ///       safePrint('Device: $device');
+  ///     }
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Fetch devices failed with error: $e');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// For more information about device tracking, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/device_features/q/platform/flutter/).
   /// {@endtemplate}
   Future<List<AuthDevice>> fetchDevices() => defaultPlugin.fetchDevices();
 
   /// {@template amplify_core.amplify_auth_category.delete_user}
   /// Deletes the current authenticated user.
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="delete-user"?>
+  /// ```dart
+  /// Future<void> deleteUser() async {
+  ///   try {
+  ///     await Amplify.Auth.deleteUser();
+  ///     safePrint('Delete user succeeded');
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Delete user failed with error: $e');
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// For more information, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/delete_user/q/platform/flutter/).
   /// {@endtemplate}
   Future<void> deleteUser() => defaultPlugin.deleteUser();
 }

--- a/packages/amplify_core/lib/src/types/auth/attribute/auth_next_update_attribute_step.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/auth_next_update_attribute_step.g.dart
@@ -24,7 +24,9 @@ AuthNextUpdateAttributeStep _$AuthNextUpdateAttributeStepFromJson(
 
 Map<String, dynamic> _$AuthNextUpdateAttributeStepToJson(
     AuthNextUpdateAttributeStep instance) {
-  final val = <String, dynamic>{};
+  final val = <String, dynamic>{
+    'additionalInfo': instance.additionalInfo,
+  };
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -32,7 +34,6 @@ Map<String, dynamic> _$AuthNextUpdateAttributeStepToJson(
     }
   }
 
-  writeNotNull('additionalInfo', instance.additionalInfo);
   writeNotNull('codeDeliveryDetails', instance.codeDeliveryDetails?.toJson());
   val['updateAttributeStep'] =
       _$AuthUpdateAttributeStepEnumMap[instance.updateAttributeStep]!;

--- a/packages/amplify_core/lib/src/types/auth/auth_next_step.dart
+++ b/packages/amplify_core/lib/src/types/auth/auth_next_step.dart
@@ -4,8 +4,11 @@
 import 'package:amplify_core/amplify_core.dart';
 
 abstract class AuthNextStep with AWSSerializable<Map<String, Object?>> {
-  const AuthNextStep({this.codeDeliveryDetails, this.additionalInfo});
+  const AuthNextStep({
+    this.codeDeliveryDetails,
+    Map<String, String>? additionalInfo,
+  }) : additionalInfo = additionalInfo ?? const {};
 
-  final Map<String, String>? additionalInfo;
+  final Map<String, String> additionalInfo;
   final AuthCodeDeliveryDetails? codeDeliveryDetails;
 }

--- a/packages/amplify_core/lib/src/types/auth/password/reset_password_step.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/reset_password_step.g.dart
@@ -22,7 +22,9 @@ ResetPasswordStep _$ResetPasswordStepFromJson(Map<String, dynamic> json) =>
     );
 
 Map<String, dynamic> _$ResetPasswordStepToJson(ResetPasswordStep instance) {
-  final val = <String, dynamic>{};
+  final val = <String, dynamic>{
+    'additionalInfo': instance.additionalInfo,
+  };
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -30,7 +32,6 @@ Map<String, dynamic> _$ResetPasswordStepToJson(ResetPasswordStep instance) {
     }
   }
 
-  writeNotNull('additionalInfo', instance.additionalInfo);
   writeNotNull('codeDeliveryDetails', instance.codeDeliveryDetails?.toJson());
   val['updateStep'] = _$AuthResetPasswordStepEnumMap[instance.updateStep]!;
   return val;

--- a/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.g.dart
@@ -26,7 +26,9 @@ AuthNextSignInStep _$AuthNextSignInStepFromJson(Map<String, dynamic> json) =>
     );
 
 Map<String, dynamic> _$AuthNextSignInStepToJson(AuthNextSignInStep instance) {
-  final val = <String, dynamic>{};
+  final val = <String, dynamic>{
+    'additionalInfo': instance.additionalInfo,
+  };
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -34,7 +36,6 @@ Map<String, dynamic> _$AuthNextSignInStepToJson(AuthNextSignInStep instance) {
     }
   }
 
-  writeNotNull('additionalInfo', instance.additionalInfo);
   writeNotNull('codeDeliveryDetails', instance.codeDeliveryDetails?.toJson());
   val['signInStep'] = _$AuthSignInStepEnumMap[instance.signInStep]!;
   val['missingAttributes'] = instance.missingAttributes

--- a/packages/amplify_core/lib/src/types/auth/sign_up/auth_next_sign_up_step.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/auth_next_sign_up_step.g.dart
@@ -21,7 +21,9 @@ AuthNextSignUpStep _$AuthNextSignUpStepFromJson(Map<String, dynamic> json) =>
     );
 
 Map<String, dynamic> _$AuthNextSignUpStepToJson(AuthNextSignUpStep instance) {
-  final val = <String, dynamic>{};
+  final val = <String, dynamic>{
+    'additionalInfo': instance.additionalInfo,
+  };
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -29,7 +31,6 @@ Map<String, dynamic> _$AuthNextSignUpStepToJson(AuthNextSignUpStep instance) {
     }
   }
 
-  writeNotNull('additionalInfo', instance.additionalInfo);
   writeNotNull('codeDeliveryDetails', instance.codeDeliveryDetails?.toJson());
   val['signUpStep'] = _$AuthSignUpStepEnumMap[instance.signUpStep]!;
   return val;

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -27,6 +27,12 @@ dev_dependencies:
   build_test: ^2.1.5
   build_version: ^2.1.1
   build_web_compilers: ^3.2.4
+  code_excerpt_updater:
+    git:
+      url: https://github.com/dart-lang/site-shared
+      # TODO(dnys1): Remove when Dart is bumped to >=2.19
+      ref: 0fe3c62c70c0e8c4f1a051a5dec3bbc4eb6c8e57
+      path: packages/code_excerpt_updater
   json_serializable: 6.6.1
   path: any
   test: ^1.17.0

--- a/packages/amplify_core/tool/setup.sh
+++ b/packages/amplify_core/tool/setup.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-set -e
-
-aft run build:docs --include=current

--- a/packages/amplify_core/tool/setup.sh
+++ b/packages/amplify_core/tool/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+aft run build:docs --include=current

--- a/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -211,8 +211,7 @@ class StateMachineBloc
           break;
         case AuthSignInStep.confirmSignInWithCustomChallenge:
           yield ConfirmSignInCustom(
-            publicParameters:
-                result.nextStep.additionalInfo ?? <String, String>{},
+            publicParameters: result.nextStep.additionalInfo,
           );
           break;
         case AuthSignInStep.confirmSignInWithNewPassword:
@@ -301,8 +300,7 @@ class StateMachineBloc
       case AuthSignInStep.confirmSignInWithCustomChallenge:
         _emit(
           ConfirmSignInCustom(
-            publicParameters:
-                result.nextStep.additionalInfo ?? <String, String>{},
+            publicParameters: result.nextStep.additionalInfo,
           ),
         );
         break;


### PR DESCRIPTION
- Adds a mechanism for incorporating examples from Dart code inline in docs. Uses the [code_excerpter](https://github.com/dart-lang/site-shared/tree/main/packages/code_excerpter) library which is used internally by the Dart+Flutter teams and provides a very simple mechanism for orchestrating this flow.
- Adds inline code examples to the Auth category docs. To regenerate: `aft run build:docs --include=amplify_core`.