### PR TITLE
chore(version): bump version

### DIFF
--- a/infra/pubspec.yaml
+++ b/infra/pubspec.yaml
@@ -5,5 +5,5 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
   path: any

--- a/packages/aft/pubspec.yaml
+++ b/packages/aft/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies: 
   args: ^2.3.0
   async: ^2.10.0
-  aws_common: ">=0.4.0+1 <0.5.0"
+  aws_common: ">=0.4.2+2 <0.5.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
   checked_yaml: ^2.0.0
@@ -29,7 +29,7 @@ dependencies:
   path: any
   pub_semver: ^2.1.1
   pubspec_parse: ^1.2.0
-  smithy: ">=0.4.0+4 <0.5.0"
+  smithy: ">=0.4.0+5 <0.5.0"
   smithy_codegen:
     path: ../smithy/smithy_codegen
   stream_transform: ^2.0.0

--- a/packages/amplify/amplify_flutter/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter/CHANGELOG.md
@@ -1,3 +1,30 @@
+## 1.0.0-next.8
+
+### Breaking Changes
+- chore(analytics)!: Remove Analytics Prefix ([#2753](https://github.com/aws-amplify/amplify-flutter/pull/2753))
+- chore(analytics)!: export endpointManager, redo exports
+- chore(auth)!: send Pinpoint Endpoint id to Cognito
+- feat(storage)!: update upload APIs options to add metadata field ([#2815](https://github.com/aws-amplify/amplify-flutter/pull/2815))
+- refactor(auth)!: Remove generic types ([#2804](https://github.com/aws-amplify/amplify-flutter/pull/2804))
+- refactor(core)!: Dependency management
+- refactor(storage)!: rename checkObjectExistence to validateObjectExistence
+- refactor(storage)!: storage category APIs to use category level plugin options ([#2754](https://github.com/aws-amplify/amplify-flutter/pull/2754))
+- chore(secure_storage)!: add factory constructor, mark AmplifySecureStorage as internal ([#2607](https://github.com/aws-amplify/amplify-flutter/pull/2607))
+
+### Fixes
+- fix(api): Auth provider registration
+- fix(api): Include owner field in selection set ([#2795](https://github.com/aws-amplify/amplify-flutter/pull/2795))
+- fix(api): Support model definition target name ([#2814](https://github.com/aws-amplify/amplify-flutter/pull/2814))
+- fix(auth): Always allow repeated `confirmSignIn` attempts
+- fix(auth): Process sign-in events once
+- fix(secure_storage): resolve conflict with win32 package ([#2829](https://github.com/aws-amplify/amplify-flutter/pull/2829))
+
+### Features
+- feat(storage): add generic StorageOperationCanceledException in core
+- feat(storage): add handling of non-ascii object metadata values
+- feat(storage): make access level optional for storage APIs ([#2793](https://github.com/aws-amplify/amplify-flutter/pull/2793))
+- feat(storage): promote StorageTransferState to amplify_core
+
 ## 1.0.0-next.7
 
 ### Breaking Changes

--- a/packages/amplify/amplify_flutter/example/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/example/pubspec.yaml
@@ -6,12 +6,12 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_analytics_pinpoint: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_api: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_auth_cognito: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_datastore: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_storage_s3: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_analytics_pinpoint: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_datastore: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_storage_s3: ">=1.0.0-next.8 <1.0.0-next.9"
   flutter:
     sdk: flutter
 

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter
 description: The top level Flutter package for the AWS Amplify libraries.
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,10 +19,10 @@ platforms:
   web:
 
 dependencies:
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_datastore_plugin_interface: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter_android: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter_ios: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_datastore_plugin_interface: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter_android: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter_ios: ">=1.0.0-next.8 <1.0.0-next.9"
   amplify_secure_storage: ">=0.3.0 <0.4.0"
   aws_common: ">=0.4.0+1 <0.5.0"
   collection: ^1.15.0
@@ -32,12 +32,12 @@ dependencies:
   plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
-  amplify_analytics_pinpoint: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_api: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_auth_cognito: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_datastore: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_analytics_pinpoint: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_datastore: ">=1.0.0-next.8 <1.0.0-next.9"
   amplify_lints: ">=2.0.2 <2.1.0"
-  amplify_storage_s3: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_storage_s3: ">=1.0.0-next.8 <1.0.0-next.9"
   amplify_test:
     path: ../../amplify_test
   build_runner: ^2.0.0

--- a/packages/amplify/amplify_flutter_android/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.8
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.7
 
 ### Fixes

--- a/packages/amplify/amplify_flutter_android/pubspec.yaml
+++ b/packages/amplify/amplify_flutter_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter_android
 description: The method channel implementation for amplify_flutter on Android
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter_android
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/amplify/amplify_flutter_ios/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.8
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.7
 
 ### Fixes

--- a/packages/amplify/amplify_flutter_ios/example/pubspec.yaml
+++ b/packages/amplify/amplify_flutter_ios/example/pubspec.yaml
@@ -8,19 +8,19 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_flutter_ios: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_flutter_ios: ">=1.0.0-next.8 <1.0.0-next.9"
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  amplify_analytics_pinpoint: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_api: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_auth_cognito: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_datastore: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_analytics_pinpoint: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_datastore: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
   amplify_lints: ^2.0.0
-  amplify_storage_s3: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_storage_s3: ">=1.0.0-next.8 <1.0.0-next.9"
   amplify_test:
     path: ../../../amplify_test
   flutter_test:

--- a/packages/amplify/amplify_flutter_ios/pubspec.yaml
+++ b/packages/amplify/amplify_flutter_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter_ios
 description: The method channel implementation for amplify_flutter on iOS
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify/amplify_flutter_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
   flutter:
     sdk: flutter
 

--- a/packages/amplify_core/CHANGELOG.md
+++ b/packages/amplify_core/CHANGELOG.md
@@ -1,3 +1,37 @@
+## 1.0.0-next.8
+
+### Breaking Changes
+- chore(analytics)!: Remove Analytics Prefix ([#2753](https://github.com/aws-amplify/amplify-flutter/pull/2753))
+- chore(analytics)!: export endpointManager, redo exports
+- chore(auth)!: send Pinpoint Endpoint id to Cognito
+- feat(storage)!: update upload APIs options to add metadata field ([#2815](https://github.com/aws-amplify/amplify-flutter/pull/2815))
+- fix(storage)!: make S3Exception internal
+- refactor(auth)!: Remove generic types ([#2804](https://github.com/aws-amplify/amplify-flutter/pull/2804))
+- refactor(core)!: Dependency management
+- refactor(storage)!: rename checkObjectExistence to validateObjectExistence
+- refactor(storage)!: simplify storage s3 exceptions throwing
+- refactor(storage)!: storage category APIs to use category level plugin options ([#2754](https://github.com/aws-amplify/amplify-flutter/pull/2754))
+
+### Fixes
+- fix(api): Auth provider registration
+- fix(api): Include owner field in selection set ([#2795](https://github.com/aws-amplify/amplify-flutter/pull/2795))
+- fix(api): Support model definition target name ([#2814](https://github.com/aws-amplify/amplify-flutter/pull/2814))
+- fix(api): Supported protocols should be set on base client only
+- fix(auth): Always allow repeated `confirmSignIn` attempts
+- fix(auth): Client secret support
+- fix(auth): Process sign-in events once
+- fix(auth): User pool-only support
+- fix(smithy): Add missing `@optionalAuth` traits
+- fix(storage): Use `reifyPluginOptions` as instance method
+- fix(storage): add handling of AWSHttpException
+- fix(storage): remove unnecessary exception for resuming a canceled task
+
+### Features
+- feat(storage): add generic StorageOperationCanceledException in core
+- feat(storage): add handling of non-ascii object metadata values
+- feat(storage): make access level optional for storage APIs ([#2793](https://github.com/aws-amplify/amplify-flutter/pull/2793))
+- feat(storage): promote StorageTransferState to amplify_core
+
 ## 1.0.0-next.7
 
 ### Breaking Changes

--- a/packages/amplify_core/lib/src/version.dart
+++ b/packages/amplify_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.0.0-next.7';
+const packageVersion = '1.0.0-next.8';

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_core
 description: The base package containing common types and utilities that are shared across the Amplify Flutter packages.
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_core
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   async: ^2.10.0
-  aws_common: ">=0.4.2+1 <0.5.0"
-  aws_signature_v4: ">=0.3.1+3 <0.4.0"
+  aws_common: ">=0.4.2+2 <0.5.0"
+  aws_signature_v4: ">=0.3.1+5 <0.4.0"
   collection: ^1.15.0
   intl: ">=0.17.0 <1.0.0"
   json_annotation: ">=4.8.0 <4.9.0"

--- a/packages/amplify_datastore/CHANGELOG.md
+++ b/packages/amplify_datastore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.8
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.7
 
 ### Fixes

--- a/packages/amplify_datastore/example/pubspec.yaml
+++ b/packages/amplify_datastore/example/pubspec.yaml
@@ -12,9 +12,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_api: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_datastore: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_datastore: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
   flutter_driver:
     sdk: flutter
   integration_test:

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore
 description: The Amplify Flutter DataStore category plugin, providing a queryable, on-device data store.
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_datastore
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_datastore_plugin_interface: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_datastore_plugin_interface: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
   plugin_platform_interface: ^2.0.0
   meta: ^1.7.0
   collection: ^1.14.13

--- a/packages/amplify_datastore_plugin_interface/CHANGELOG.md
+++ b/packages/amplify_datastore_plugin_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.8
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.7
 
 - Minor bug fixes and improvements

--- a/packages/amplify_datastore_plugin_interface/pubspec.yaml
+++ b/packages/amplify_datastore_plugin_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore_plugin_interface
 description: The platform interface for the DataStore module of Amplify Flutter.
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/amplify_datastore_plugin_interface
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
   collection: ^1.15.0
   flutter:
     sdk: flutter

--- a/packages/amplify_test/pubspec.yaml
+++ b/packages/amplify_test/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_auth_cognito_dart: ">=0.8.0 <0.9.0"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_auth_cognito_dart: ">=0.9.0 <0.10.0"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
   aws_common: ">=0.4.0 <0.5.0"
   collection: ^1.15.0
   meta: ^1.8.0

--- a/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0-next.8
+
+### Breaking Changes
+- chore(analytics)!: Remove Analytics Prefix ([#2753](https://github.com/aws-amplify/amplify-flutter/pull/2753))
+- chore(analytics)!: export endpointManager, redo exports
+
 ## 1.0.0-next.7
 
 - Minor bug fixes and improvements

--- a/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_analytics_pinpoint: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_api: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_auth_cognito: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_analytics_pinpoint: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
 
   flutter:
     sdk: flutter
@@ -24,7 +24,7 @@ dependency_overrides:
   async: ^2.10.0
 
 dev_dependencies:
-  amplify_analytics_pinpoint_dart: ">=0.1.4+3 <0.2.0"
+  amplify_analytics_pinpoint_dart: ">=0.2.0 <0.3.0"
   amplify_lints:
     path: ../../../amplify_lints
   amplify_test:

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint
 description: The Amplify Flutter Analytics category plugin using the AWS Pinpoint provider.
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/analytics/amplify_analytics_pinpoint
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,10 +19,10 @@ platforms:
   web:
 
 dependencies:
-  amplify_analytics_pinpoint_dart: ">=0.1.4+3 <0.2.0"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_db_common: ">=0.1.2+4 <0.2.0"
-  amplify_secure_storage: ">=0.3.0 <0.4.0"
+  amplify_analytics_pinpoint_dart: ">=0.2.0 <0.3.0"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_db_common: ">=0.1.2+5 <0.2.0"
+  amplify_secure_storage: ">=0.3.0+1 <0.4.0"
   aws_common: ">=0.4.2 <0.5.0"
   device_info_plus: ^8.0.0
   flutter:

--- a/packages/analytics/amplify_analytics_pinpoint_dart/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0
+
+### Breaking Changes
+- chore(analytics)!: Remove Analytics Prefix ([#2753](https://github.com/aws-amplify/amplify-flutter/pull/2753))
+- chore(analytics)!: export endpointManager, redo exports
+
 ## 0.1.4+3
 
 ### Fixes

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/version.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.1.4+3';
+const packageVersion = '0.2.0';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint_dart
 description: A Dart-only implementation of the Amplify Analytics plugin for Pinpoint.
-version: 0.1.4+3
+version: 0.2.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/analytics/amplify_analytics_pinpoint_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,9 +9,9 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_db_common_dart: ">=0.2.0+4 <0.3.0"
-  amplify_secure_storage_dart: ">=0.3.0 <0.4.0"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_db_common_dart: ">=0.2.0+5 <0.3.0"
+  amplify_secure_storage_dart: ">=0.3.0+1 <0.4.0"
   aws_common: ">=0.4.2 <0.5.0"
   aws_signature_v4: ">=0.3.1+3 <0.4.0"
   built_collection: ^5.0.0

--- a/packages/api/amplify_api/CHANGELOG.md
+++ b/packages/api/amplify_api/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0-next.8
+
+### Fixes
+- fix(api): Auth provider registration
+- fix(api): Include owner field in selection set ([#2795](https://github.com/aws-amplify/amplify-flutter/pull/2795))
+
 ## 1.0.0-next.7
 
 - Minor bug fixes and improvements

--- a/packages/api/amplify_api/example/pubspec.yaml
+++ b/packages/api/amplify_api/example/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_api: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_auth_cognito: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_authenticator: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_authenticator: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
   async: ^2.10.0
   aws_common: ">=0.4.0 <0.5.0"
 

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api
 description: The Amplify Flutter API category plugin, supporting GraphQL and REST operations.
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,11 +19,11 @@ platforms:
   web:
 
 dependencies:
-  amplify_api_android: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_api_dart: ">=0.2.0+1 <0.3.0"
-  amplify_api_ios: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_api_android: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_api_dart: ">=0.2.0+2 <0.3.0"
+  amplify_api_ios: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
   connectivity_plus: ^3.0.2
   flutter:
     sdk: flutter

--- a/packages/api/amplify_api_android/CHANGELOG.md
+++ b/packages/api/amplify_api_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.8
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.7
 
 ### Fixes

--- a/packages/api/amplify_api_android/example/pubspec.yaml
+++ b/packages/api/amplify_api_android/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_api: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
   flutter:
     sdk: flutter
 

--- a/packages/api/amplify_api_android/pubspec.yaml
+++ b/packages/api/amplify_api_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_android
 description: The method channel implementation for amplify_api on Android
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api_android
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/api/amplify_api_dart/CHANGELOG.md
+++ b/packages/api/amplify_api_dart/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.0+2
+
+### Fixes
+- fix(api): Auth provider registration
+- fix(api): Include owner field in selection set ([#2795](https://github.com/aws-amplify/amplify-flutter/pull/2795))
+- fix(api): Support model definition target name ([#2814](https://github.com/aws-amplify/amplify-flutter/pull/2814))
+- fix(api): Supported protocols should be set on base client only
+
 ## 0.2.0+1
 
 - Minor bug fixes and improvements

--- a/packages/api/amplify_api_dart/pubspec.yaml
+++ b/packages/api/amplify_api_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_dart
 description: The Amplify API category plugin in Dart-only, supporting GraphQL and REST operations.
-version: 0.2.0+1
+version: 0.2.0+2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,9 +9,9 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
   async: ^2.10.0
-  aws_common: ">=0.4.0+1 <0.5.0"
+  aws_common: ">=0.4.2+2 <0.5.0"
   collection: ^1.15.0
   json_annotation: ">=4.8.0 <4.9.0"
   meta: ^1.7.0
@@ -21,7 +21,7 @@ dependencies:
 
 dev_dependencies:
   amplify_lints: ">=2.0.2 <2.1.0"
-  aws_signature_v4: ">=0.3.1+3 <0.4.0"
+  aws_signature_v4: ">=0.3.1+5 <0.4.0"
   build_runner: ^2.0.0
   build_test: ^2.1.5
   build_web_compilers: ^3.2.4

--- a/packages/api/amplify_api_ios/CHANGELOG.md
+++ b/packages/api/amplify_api_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.8
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.7
 
 ### Fixes

--- a/packages/api/amplify_api_ios/example/pubspec.yaml
+++ b/packages/api/amplify_api_ios/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_api: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
   flutter:
     sdk: flutter
 

--- a/packages/api/amplify_api_ios/pubspec.yaml
+++ b/packages/api/amplify_api_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_ios
 description: The package containing the method channel implementation for amplify_api on iOS
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/api/amplify_api_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
   flutter:
     sdk: flutter
 

--- a/packages/auth/amplify_auth_cognito/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.0-next.8
+
+### Breaking Changes
+- chore(auth)!: send Pinpoint Endpoint id to Cognito
+- refactor(auth)!: Remove generic types ([#2804](https://github.com/aws-amplify/amplify-flutter/pull/2804))
+
+### Fixes
+- fix(auth): Always allow repeated `confirmSignIn` attempts
+- fix(auth): Process sign-in events once
+
 ## 1.0.0-next.7
 
 ### Breaking Changes

--- a/packages/auth/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_api: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_auth_cognito: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_authenticator: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_authenticator: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
   flutter:
     sdk: flutter
   go_router: ^3.0.0
@@ -25,7 +25,7 @@ dependency_overrides:
   test_api: ^0.4.0
 
 dev_dependencies:
-  amplify_auth_cognito_dart: ">=0.8.0 <0.9.0"
+  amplify_auth_cognito_dart: ">=0.9.0 <0.10.0"
   amplify_auth_cognito_test: any
   amplify_lints:
     path: ../../../amplify_lints

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito
 description: The Amplify Flutter Auth category plugin using the AWS Cognito provider.
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,14 +19,14 @@ platforms:
   web:
 
 dependencies:
-  amplify_analytics_pinpoint: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_analytics_pinpoint_dart: ">=0.1.4+3 <0.2.0"
-  amplify_auth_cognito_android: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_auth_cognito_dart: ">=0.8.0 <0.9.0"
-  amplify_auth_cognito_ios: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_secure_storage: ">=0.3.0 <0.4.0"
+  amplify_analytics_pinpoint: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_analytics_pinpoint_dart: ">=0.2.0 <0.3.0"
+  amplify_auth_cognito_android: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_auth_cognito_dart: ">=0.9.0 <0.10.0"
+  amplify_auth_cognito_ios: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_secure_storage: ">=0.3.0+1 <0.4.0"
   async: ^2.10.0
   flutter:
     sdk: flutter

--- a/packages/auth/amplify_auth_cognito_android/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.8
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.7
 
 ### Fixes

--- a/packages/auth/amplify_auth_cognito_android/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_android
 description: The method channel implementation for amplify_auth_cognito on Android
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_android
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.9.0
+
+### Breaking Changes
+- chore(auth)!: send Pinpoint Endpoint id to Cognito
+- refactor(auth)!: Remove generic types ([#2804](https://github.com/aws-amplify/amplify-flutter/pull/2804))
+
+### Fixes
+- fix(auth): Always allow repeated `confirmSignIn` attempts
+- fix(auth): Client secret support
+- fix(auth): Process sign-in events once
+- fix(auth): User pool-only support
+- fix(smithy): Add missing `@optionalAuth` traits
+
 ## 0.8.0
 
 ### Breaking Changes

--- a/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
@@ -7,14 +7,14 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_auth_cognito_dart: ">=0.8.0 <0.9.0"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_auth_cognito_dart: ">=0.9.0 <0.10.0"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
   amplify_secure_storage_dart: ">=0.3.0 <0.4.0"
   example_common:
     path: ../../../example_common
 
 dev_dependencies:
-  amplify_api_dart: ">=0.2.0+1 <0.3.0"
+  amplify_api_dart: ">=0.2.0+2 <0.3.0"
   amplify_auth_cognito_test: any
   amplify_lints:
     path: ../../../amplify_lints

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_dart
 description: A Dart-only implementation of the Amplify Auth plugin for Cognito.
-version: 0.8.0
+version: 0.9.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,12 +9,12 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_analytics_pinpoint_dart: ">=0.1.4+3 <0.2.0"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_secure_storage_dart: ">=0.3.0 <0.4.0"
+  amplify_analytics_pinpoint_dart: ">=0.2.0 <0.3.0"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_secure_storage_dart: ">=0.3.0+1 <0.4.0"
   async: ^2.10.0
-  aws_common: ">=0.4.1+1 <0.5.0"
-  aws_signature_v4: ">=0.3.1+3 <0.4.0"
+  aws_common: ">=0.4.2+2 <0.5.0"
+  aws_signature_v4: ">=0.3.1+5 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
   collection: ^1.15.0
@@ -28,7 +28,7 @@ dependencies:
   meta: ^1.7.0
   oauth2: ^2.0.0
   path: ^1.8.0
-  smithy: ">=0.4.0+4 <0.5.0"
+  smithy: ">=0.4.0+5 <0.5.0"
   smithy_aws: ">=0.4.1+2 <0.5.0"
   stream_transform: ^2.0.0
   uuid: ">=3.0.6 <=3.0.7"

--- a/packages/auth/amplify_auth_cognito_ios/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-next.8
+
+- Minor bug fixes and improvements
+
 ## 1.0.0-next.7
 
 ### Fixes

--- a/packages/auth/amplify_auth_cognito_ios/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_ios
 description: The method channel implementation for amplify_auth_cognito on iOS
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_ios
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
   flutter:
     sdk: flutter
 

--- a/packages/auth/amplify_auth_cognito_test/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_test/pubspec.yaml
@@ -6,9 +6,9 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  amplify_analytics_pinpoint_dart: ">=0.1.4+3 <0.2.0"
-  amplify_auth_cognito_dart: ">=0.8.0 <0.9.0"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_analytics_pinpoint_dart: ">=0.2.0 <0.3.0"
+  amplify_auth_cognito_dart: ">=0.9.0 <0.10.0"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
   amplify_secure_storage_dart: ">=0.3.0 <0.4.0"
   aws_common: ">=0.4.0 <0.5.0"
   built_collection: ^5.0.0

--- a/packages/authenticator/amplify_authenticator/CHANGELOG.md
+++ b/packages/authenticator/amplify_authenticator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-next.5+1
+
+### Fixes
+- fix: prevent duplicate calls to onFieldSubmitted ([#2828](https://github.com/aws-amplify/amplify-flutter/pull/2828))
+
 ## 1.0.0-next.5
 
 ### Fixes

--- a/packages/authenticator/amplify_authenticator/example/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/example/pubspec.yaml
@@ -22,9 +22,9 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_auth_cognito: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_authenticator: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_authenticator: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
 
   flutter:
     sdk: flutter
@@ -42,7 +42,7 @@ dependency_overrides:
   async: ^2.10.0
 
 dev_dependencies:
-  amplify_api: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"
   amplify_authenticator_test:
     path: ../../amplify_authenticator_test
   amplify_lints:

--- a/packages/authenticator/amplify_authenticator/lib/src/version.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.0.0-next.4+2';
+const packageVersion = '1.0.0-next.5+1';

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_authenticator
 description: A prebuilt Sign In and Sign Up experience for the Amplify Auth category
-version: 1.0.0-next.5
+version: 1.0.0-next.5+1
 homepage: https://ui.docs.amplify.aws/flutter/connected-components/authenticator
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/authenticator/amplify_authenticator
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,11 +10,11 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_auth_cognito: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
   async: ^2.10.0
-  aws_common: ">=0.4.0+1 <0.5.0"
+  aws_common: ">=0.4.2+2 <0.5.0"
   collection: ^1.15.0
   flutter:
     sdk: flutter
@@ -22,7 +22,7 @@ dependencies:
     sdk: flutter
   intl: ">=0.17.0 <1.0.0"
   meta: ^1.7.0
-  smithy: ">=0.4.0+4 <0.5.0"
+  smithy: ">=0.4.0+5 <0.5.0"
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/authenticator/amplify_authenticator_test/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator_test/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_authenticator: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_authenticator: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
   amplify_test:
     path: ../../amplify_test
   flutter:

--- a/packages/aws_common/CHANGELOG.md
+++ b/packages/aws_common/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.2+2
+
+### Fixes
+- fix(http): Header casing in HTTP/2
+- fix(sigv4): Query parameter encoding
+
 ## 0.4.2+1
 
 ### Fixes

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aws_common
 description: Common types and utilities used across AWS and Amplify packages.
-version: 0.4.2+1
+version: 0.4.2+2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/aws_common
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/aws_signature_v4/CHANGELOG.md
+++ b/packages/aws_signature_v4/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1+5
+
+### Fixes
+- fix(sigv4): Query parameter encoding
+
 ## 0.3.1+4
 
 - Minor bug fixes and improvements

--- a/packages/aws_signature_v4/lib/src/version.dart
+++ b/packages/aws_signature_v4/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.3.1+4';
+const packageVersion = '0.3.1+5';

--- a/packages/aws_signature_v4/pubspec.yaml
+++ b/packages/aws_signature_v4/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aws_signature_v4
 description: Dart implementation of the AWS Signature Version 4 algorithm, for communication with AWS services.
-version: 0.3.1+4
+version: 0.3.1+5
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/aws_signature_v4
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.10.0
-  aws_common: ">=0.4.0+1 <0.5.0"
+  aws_common: ">=0.4.2+2 <0.5.0"
   collection: ^1.15.0
   convert: ^3.0.0
   crypto: ^3.0.0

--- a/packages/common/amplify_db_common/CHANGELOG.md
+++ b/packages/common/amplify_db_common/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2+5
+
+- Minor bug fixes and improvements
+
 ## 0.1.2+4
 
 ### Fixes

--- a/packages/common/amplify_db_common/example/pubspec.yaml
+++ b/packages/common/amplify_db_common/example/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_db_common: ">=0.1.2+4 <0.2.0"
+  amplify_db_common: ">=0.1.2+5 <0.2.0"
   drift: ">=2.4.0 <2.6.0"
   flutter:
     sdk: flutter

--- a/packages/common/amplify_db_common/pubspec.yaml
+++ b/packages/common/amplify_db_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_db_common
 description: Common utilities for working with databases such as SQLite.
-version: 0.1.2+4
+version: 0.1.2+5
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/common/amplify_db_common
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_db_common_dart: ">=0.2.0+4 <0.3.0"
+  amplify_db_common_dart: ">=0.2.0+5 <0.3.0"
   drift: ">=2.4.0 <2.6.0"
   flutter:
     sdk: flutter

--- a/packages/common/amplify_db_common_dart/CHANGELOG.md
+++ b/packages/common/amplify_db_common_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+5
+
+- Minor bug fixes and improvements
+
 ## 0.2.0+4
 
 - Minor bug fixes and improvements

--- a/packages/common/amplify_db_common_dart/example/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/example/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_db_common_dart: ">=0.2.0+4 <0.3.0"
+  amplify_db_common_dart: ">=0.2.0+5 <0.3.0"
   drift: ">=2.4.0 <2.6.0"
   example_common:
     path: ../../../example_common

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_db_common_dart
 description: Common utilities for working with databases such as sqlite. Used throughout Amplify packages.
-version: 0.2.0+4
+version: 0.2.0+5
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/common/amplify_db_common_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
   async: ^2.10.0
   aws_common: ">=0.4.0+1 <0.5.0"
   drift: ">=2.4.0 <2.6.0"

--- a/packages/secure_storage/amplify_secure_storage/CHANGELOG.md
+++ b/packages/secure_storage/amplify_secure_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+1
+
+- Minor bug fixes and improvements
+
 ## 0.3.0
 
 ### Breaking Changes

--- a/packages/secure_storage/amplify_secure_storage/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_secure_storage
 description: A package for storing secrets, intended for use in Amplify libraries.
-version: 0.3.0
+version: 0.3.0+1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/secure_storage/amplify_secure_storage
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_secure_storage_dart: ">=0.3.0 <0.4.0"
+  amplify_secure_storage_dart: ">=0.3.0+1 <0.4.0"
   async: ^2.10.0
   file: ^6.0.0
   flutter:

--- a/packages/secure_storage/amplify_secure_storage_dart/CHANGELOG.md
+++ b/packages/secure_storage/amplify_secure_storage_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+1
+
+- Minor bug fixes and improvements
+
 ## 0.3.0
 
 - Minor bug fixes and improvements

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_secure_storage_dart
 description: A Dart-only implementation of `amplify_secure_storage`, using `dart:ffi` for Desktop and `dart:html` for Web.
-version: 0.3.0
+version: 0.3.0+1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/secure_storage/amplify_secure_storage_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/smithy/smithy/CHANGELOG.md
+++ b/packages/smithy/smithy/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+5
+
+- Minor bug fixes and improvements
+
 ## 0.4.0+4
 
 ### Fixes

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smithy
 description: Smithy client runtime for Dart with common utilities for I/O and serialization.
-version: 0.4.0+4
+version: 0.4.0+5
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/next
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/smithy/smithy
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.10.0
-  aws_common: ">=0.4.0+1 <0.5.0"
+  aws_common: ">=0.4.2+2 <0.5.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
   collection: ^1.15.0

--- a/packages/storage/amplify_storage_s3/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.0-next.8
+
+### Breaking Changes
+- feat(storage)!: update upload APIs options to add metadata field ([#2815](https://github.com/aws-amplify/amplify-flutter/pull/2815))
+- refactor(storage)!: rename checkObjectExistence to validateObjectExistence
+- refactor(storage)!: storage category APIs to use category level plugin options ([#2754](https://github.com/aws-amplify/amplify-flutter/pull/2754))
+
+### Features
+- feat(storage): add handling of non-ascii object metadata values
+
 ## 1.0.0-next.7
 
 - Minor bug fixes and improvements

--- a/packages/storage/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/example/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_auth_cognito: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_authenticator: ">=1.0.0-next.5 <1.0.0-next.6"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_flutter: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_authenticator: ">=1.0.0-next.5+1 <1.0.0-next.6"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
   amplify_secure_storage: ">=0.3.0 <0.4.0"
-  amplify_storage_s3: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_storage_s3: ">=1.0.0-next.8 <1.0.0-next.9"
   flutter:
     sdk: flutter
   go_router: ^5.0.5
@@ -26,7 +26,7 @@ dependency_overrides:
 dev_dependencies:
   amplify_lints:
     path: ../../../amplify_lints
-  amplify_storage_s3_dart: ">=0.1.7+1 <0.2.0"
+  amplify_storage_s3_dart: ">=0.2.0 <0.3.0"
   amplify_test:
     path: ../../../amplify_test
   aws_common: ">=0.4.0 <0.5.0"

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3
 description: The Amplify Flutter Storage category plugin using the AWS S3 provider.
-version: 1.0.0-next.7
+version: 1.0.0-next.8
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/storage/amplify_storage_s3
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,10 +19,10 @@ platforms:
   web:
 
 dependencies:
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_db_common: ">=0.1.2+4 <0.2.0"
-  amplify_storage_s3_dart: ">=0.1.7+1 <0.2.0"
-  aws_common: ">=0.4.0+1 <0.5.0"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_db_common: ">=0.1.2+5 <0.2.0"
+  amplify_storage_s3_dart: ">=0.2.0 <0.3.0"
+  aws_common: ">=0.4.2+2 <0.5.0"
   flutter:
     sdk: flutter
   meta: ^1.7.0
@@ -32,7 +32,7 @@ dev_dependencies:
   amplify_lints: ">=2.0.2 <2.1.0"
   amplify_test:
     path: ../../amplify_test
-  aws_signature_v4: ">=0.3.1+3 <0.4.0"
+  aws_signature_v4: ">=0.3.1+5 <0.4.0"
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/storage/amplify_storage_s3_dart/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3_dart/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 0.2.0
+
+### Breaking Changes
+- feat(storage)!: update upload APIs options to add metadata field ([#2815](https://github.com/aws-amplify/amplify-flutter/pull/2815))
+- fix(storage)!: make S3Exception internal
+- refactor(storage)!: rename checkObjectExistence to validateObjectExistence
+- refactor(storage)!: simplify storage s3 exceptions throwing
+- refactor(storage)!: storage category APIs to use category level plugin options ([#2754](https://github.com/aws-amplify/amplify-flutter/pull/2754))
+
+### Fixes
+- fix(storage): Use `reifyPluginOptions` as instance method
+- fix(storage): add handling of AWSHttpException
+- fix(storage): remove unnecessary exception for resuming a canceled task
+
+### Features
+- feat(storage): add generic StorageOperationCanceledException in core
+- feat(storage): add handling of non-ascii object metadata values
+- feat(storage): make access level optional for storage APIs ([#2793](https://github.com/aws-amplify/amplify-flutter/pull/2793))
+- feat(storage): promote StorageTransferState to amplify_core
+
 ## 0.1.7+1
 
 - Minor bug fixes and improvements

--- a/packages/storage/amplify_storage_s3_dart/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/example/pubspec.yaml
@@ -7,10 +7,10 @@ environment:
   sdk: '>=2.17.6 <3.0.0'
 
 dependencies:
-  amplify_auth_cognito_dart: ">=0.8.0 <0.9.0"
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
+  amplify_auth_cognito_dart: ">=0.9.0 <0.10.0"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
   amplify_secure_storage_dart: ">=0.3.0 <0.4.0"
-  amplify_storage_s3_dart: ">=0.1.7+1 <0.2.0"
+  amplify_storage_s3_dart: ">=0.2.0 <0.3.0"
   example_common:
     path: ../../../example_common
 

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3_dart
 description: A Dart-only implementation of the Amplify Storage plugin for S3.
-version: 0.1.7+1
+version: 0.2.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/storage/amplify_storage_s3_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,11 +9,11 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  amplify_core: ">=1.0.0-next.7 <1.0.0-next.8"
-  amplify_db_common_dart: ">=0.2.0+4 <0.3.0"
+  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_db_common_dart: ">=0.2.0+5 <0.3.0"
   async: ^2.10.0
-  aws_common: ">=0.4.2 <0.5.0"
-  aws_signature_v4: ">=0.3.1+3 <0.4.0"
+  aws_common: ">=0.4.2+2 <0.5.0"
+  aws_signature_v4: ">=0.3.1+5 <0.4.0"
   built_collection: ^5.0.0
   built_value: ">=8.4.0 <8.5.0"
   drift: ">=2.4.0 <2.6.0"
@@ -21,7 +21,7 @@ dependencies:
   json_annotation: ">=4.8.0 <4.9.0"
   meta: ^1.7.0
   path: ^1.8.0
-  smithy: ">=0.4.0+4 <0.5.0"
+  smithy: ">=0.4.0+5 <0.5.0"
   smithy_aws: ">=0.4.1+1 <0.5.0"
 
 dev_dependencies:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

### Breaking Changes
- chore(analytics)!: Remove Analytics Prefix ([#2753](https://github.com/aws-amplify/amplify-flutter/pull/2753))
- chore(analytics)!: export endpointManager, redo exports
- chore(auth)!: send Pinpoint Endpoint id to Cognito
- feat(storage)!: update upload APIs options to add metadata field ([#2815](https://github.com/aws-amplify/amplify-flutter/pull/2815))
- refactor(auth)!: Remove generic types ([#2804](https://github.com/aws-amplify/amplify-flutter/pull/2804))
- refactor(core)!: Dependency management
- refactor(storage)!: rename checkObjectExistence to validateObjectExistence
- refactor(storage)!: storage category APIs to use category level plugin options ([#2754](https://github.com/aws-amplify/amplify-flutter/pull/2754))

### Fixes
- fix(api): Auth provider registration
- fix(api): Include owner field in selection set ([#2795](https://github.com/aws-amplify/amplify-flutter/pull/2795))
- fix(api): Support model definition target name ([#2814](https://github.com/aws-amplify/amplify-flutter/pull/2814))
- fix(auth): Always allow repeated `confirmSignIn` attempts
- fix(auth): Process sign-in events once
- fix(secure_storage): resolve conflict with win32 package ([#2829](https://github.com/aws-amplify/amplify-flutter/pull/2829))

### Features
- feat(storage): add generic StorageOperationCanceledException in core
- feat(storage): add handling of non-ascii object metadata values
- feat(storage): make access level optional for storage APIs ([#2793](https://github.com/aws-amplify/amplify-flutter/pull/2793))
- feat(storage): promote StorageTransferState to amplify_core


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
