### PR TITLE
test(auth): Consolidate initialization code

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_in_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_in_test.dart
@@ -6,14 +6,12 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 void main() {
-  AWSLogger().logLevel = LogLevel.verbose;
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('confirmSignIn', () {
     for (final environmentName in userPoolEnvironments) {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
@@ -6,14 +6,12 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 void main() {
-  AWSLogger().logLevel = LogLevel.verbose;
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group(
     'confirmSignUp',

--- a/packages/auth/amplify_auth_cognito/example/integration_test/custom_auth_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/custom_auth_test.dart
@@ -6,14 +6,13 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 void main() {
-  AWSLogger().logLevel = LogLevel.verbose;
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
+
   final logger = AWSLogger().createChild('CustomAuth');
 
   group('custom auth', () {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/custom_authorizer_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/custom_authorizer_test.dart
@@ -9,7 +9,6 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:aws_signature_v4/aws_signature_v4.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
@@ -25,8 +24,7 @@ class CognitoUserPoolsAuthorizer extends OIDCAuthProvider {
 }
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  AWSLogger().logLevel = LogLevel.verbose;
+  initTests();
 
   group('Custom Authorizer', () {
     const customHeaders = {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/delete_user_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/delete_user_test.dart
@@ -5,14 +5,12 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 void main() {
-  AWSLogger().logLevel = LogLevel.verbose;
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('deleteUser', () {
     for (final environmentName in userPoolEnvironments) {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
@@ -8,7 +8,6 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
@@ -22,8 +21,7 @@ DeviceMetadataRepository get deviceRepo =>
         .getOrCreate<DeviceMetadataRepository>();
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  AmplifyLogger().logLevel = LogLevel.debug;
+  initTests();
 
   group('Device Tracking', () {
     // The username selected by the user.

--- a/packages/auth/amplify_auth_cognito/example/integration_test/federated_sign_in_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/federated_sign_in_test.dart
@@ -16,13 +16,12 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('federateToIdentityPool', () {
     late final cognitoPlugin = Amplify.Auth.getPlugin(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/fetch_auth_session_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/fetch_auth_session_test.dart
@@ -6,15 +6,13 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 import 'utils/validation_utils.dart';
 
 void main() {
-  AWSLogger().logLevel = LogLevel.verbose;
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('fetchAuthSession', () {
     group('unauthenticated access enabled', () {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
@@ -6,15 +6,13 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 import 'utils/validation_utils.dart';
 
 void main() {
-  AWSLogger().logLevel = LogLevel.verbose;
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('getCurrentUser', () {
     for (final environmentName in userPoolEnvironments) {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/hosted_ui_webview_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/hosted_ui_webview_test.dart
@@ -20,7 +20,6 @@ import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 // ignore: implementation_imports
 import 'package:webview_flutter_wkwebview/src/foundation/foundation.dart';
@@ -32,8 +31,7 @@ final AWSLogger _logger = AWSLogger().createChild('HostedUI');
 // This test verifies the non-native logic of the Hosted UI flow on iOS and
 // Android using an embedded WebView.
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  AWSLogger().logLevel = LogLevel.verbose;
+  initTests();
 
   group(
     'Hosted UI',

--- a/packages/auth/amplify_auth_cognito/example/integration_test/hub_events_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/hub_events_test.dart
@@ -4,13 +4,12 @@
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('Auth Hub', () {
     final authEventStream =

--- a/packages/auth/amplify_auth_cognito/example/integration_test/main_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/main_test.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'confirm_sign_in_test.dart' as confirm_sign_in_tests;
 import 'confirm_sign_up_test.dart' as confirm_sign_up_tests;
@@ -24,9 +23,10 @@ import 'sign_out_test.dart' as sign_out_tests;
 import 'sign_up_test.dart' as sign_up_tests;
 import 'update_password_test.dart' as update_password_tests;
 import 'user_attributes_test.dart' as user_attributes_tests;
+import 'utils/setup_utils.dart';
 
 void main() async {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('amplify_auth_cognito', () {
     confirm_sign_in_tests.main();

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_test.dart
@@ -4,13 +4,12 @@
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group(
     'MFA (SMS)',

--- a/packages/auth/amplify_auth_cognito/example/integration_test/native_auth_bridge_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/native_auth_bridge_test.dart
@@ -15,7 +15,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 
+import 'utils/setup_utils.dart';
+
 void main() {
+  initTests();
+
   group(
     'NativeAuthBridge',
     skip: zIsWeb || !(Platform.isIOS || Platform.isAndroid),

--- a/packages/auth/amplify_auth_cognito/example/integration_test/reset_password_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/reset_password_test.dart
@@ -5,14 +5,12 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 void main() {
-  AWSLogger().logLevel = LogLevel.verbose;
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('resetPassword', () {
     for (final environmentName in userPoolEnvironments) {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/security_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/security_test.dart
@@ -9,7 +9,6 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
@@ -35,7 +34,7 @@ class InlineHttpClient extends AWSCustomHttpClient {
 }
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('security', () {
     tearDown(() async {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_in_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_in_test.dart
@@ -6,14 +6,12 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 void main() {
-  AWSLogger().logLevel = LogLevel.verbose;
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('signIn (SRP)', () {
     for (final environmentName in userPoolEnvironments) {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_out_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_out_test.dart
@@ -9,14 +9,12 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 void main() {
-  AWSLogger().logLevel = LogLevel.verbose;
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('signOut', () {
     for (final environmentName in userPoolEnvironments) {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_up_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_up_test.dart
@@ -6,14 +6,12 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 void main() {
-  AWSLogger().logLevel = LogLevel.verbose;
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('signUp', () {
     for (final environmentName in userPoolEnvironments) {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/update_password_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/update_password_test.dart
@@ -6,14 +6,12 @@ import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 void main() {
-  AWSLogger().logLevel = LogLevel.verbose;
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('updatePassword', () {
     for (final environmentName in userPoolEnvironments) {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/user_attributes_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/user_attributes_test.dart
@@ -7,7 +7,6 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_test/amplify_test.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 
 import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
@@ -18,8 +17,7 @@ extension on List<AuthUserAttribute> {
 }
 
 void main() {
-  AWSLogger().logLevel = LogLevel.verbose;
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  initTests();
 
   group('User Attributes', () {
     for (final environmentName in userPoolEnvironments) {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/utils/setup_utils.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/utils/setup_utils.dart
@@ -7,7 +7,10 @@ import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:stack_trace/stack_trace.dart';
 
 /// Environments with a user pool and username-based sign in.
 const userPoolEnvironments = ['main', 'user-pool-only', 'with-client-secret'];
@@ -18,6 +21,23 @@ const deviceOptInEnvironments = [
   'user-pool-only',
   'with-client-secret'
 ];
+
+/// Initializes the testing framework.
+void initTests() {
+  AWSLogger().logLevel = LogLevel.verbose;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  // Required demangler since we use `package:stack_trace` in Auth code
+  // but flutter_test expects normal stack traces.
+  FlutterError.demangleStackTrace = (StackTrace stack) {
+    if (stack is Trace) {
+      return stack.vmTrace;
+    }
+    if (stack is Chain) {
+      return stack.toTrace().vmTrace;
+    }
+    return stack;
+  };
+}
 
 Future<void> configureAuth({
   String config = amplifyconfig,

--- a/packages/auth/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec.yaml
@@ -43,6 +43,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   io: ^1.0.0
+  stack_trace: ^1.10.0
   test: ^1.22.0
   webdriver: ^3.0.0
   webview_flutter: ^4.0.0


### PR DESCRIPTION
And add stack trace demangler since we use `package:stack_trace` in Auth and `package:integration_test` expects VM-style stack traces.
