### PR TITLE
ci(repo): Remove CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,245 +1,224 @@
 version: 2.1
 
-executors:
-  docker-executor:
-    docker:
-      - image: circleci/android:api-30
-    working_directory: ~/amplify-flutter
+orbs:
+  # Using inline orb for now
+  getting-started-smoke-test:
+    orbs:
+      macos: circleci/macos@2.2.0
+      android: circleci/android@2.0.3
+      flutter-orb: circleci/flutter@1.1.0
+      aws-cli: circleci/aws-cli@3.1.1
 
-  macos-executor:
-    macos:
-      xcode: 14.2.0
-    working_directory: ~/amplify-flutter
+    executors:
+      mac-executor:
+        macos:
+          xcode: 13.2.1
+        resource_class: large
 
-commands:
-  install_flutter:
-    description: Install Flutter and set up paths.
-    parameters:
-      flutter_branch:
-        description: Flutter branch or version tag.
-        type: string
-        default: stable
-    steps:
-      - run:
-          name: Set up Flutter
-          command: |
-            echo 'export FLUTTER_HOME=${HOME}/sdks/flutter' >> $BASH_ENV
-            echo 'export FLUTTER_BRANCH=<< parameters.flutter_branch >>' >> $BASH_ENV
-            echo 'export FLUTTER_ROOT=${FLUTTER_HOME}' >> $BASH_ENV
-            echo 'export PATH=${PATH}:${FLUTTER_HOME}/bin:${FLUTTER_HOME}/bin/cache/dart-sdk/bin:${HOME}/.pub-cache/bin:${FLUTTER_HOME}/.pub-cache/bin' >> $BASH_ENV
-            source $BASH_ENV
-            git clone --branch ${FLUTTER_BRANCH} https://github.com/flutter/flutter.git ${FLUTTER_HOME}
-            (yes || true) | flutter doctor --android-licenses && flutter doctor
-            flutter precache
-  install_melos:
-    steps:
-      - run:
-          name: Install and set up melos
-          command: |
-            flutter pub global activate melos 2.9.0
-  install_aft:
-    steps:
-      - run:
-          name: Install and set up aft
-          command: |
-            git submodule update --init
-            flutter pub global activate -spath packages/aft
-            aft bootstrap
-  activate_pana:
-    steps:
-      - run:
-          name: Install and set up pana
-          command: |
-            flutter pub global activate pana
-  install_tuneup:
-    steps:
-      - run:
-          name: Install tuneup
-          command: |
-            flutter pub global activate tuneup
-jobs:
-  format_flutter:
-    executor: docker-executor
-    steps:
-      - install_flutter
-      - checkout
-      - install_aft
-      - run: aft run format
+      android-executor:
+        machine:
+          image: android:202102-01
+        resource_class: large
 
-  analyze_flutter:
-    executor: docker-executor
-    steps:
-      - install_flutter
-      - checkout
-      - install_aft
-      - run:
-          name: Analyze Dart/Flutter Code
-          command: aft run analyze --include=flutter -- --no-fatal-infos
+    commands:
+      send-metric-on-fail:
+        description: Send failure datapoint to cloudwatch
+        steps:
+          - run:
+              name: Send failure datapoint to cloudwatch
+              command: |
+                payload="{\"jobName\": \"${CIRCLE_JOB}\", \"projectRepoName\": \"${CIRCLE_PROJECT_REPONAME}\"}"
+                echo $payload
+                aws lambda invoke --function-name CircleCIWorkflowFailureHandler --payload "$payload" --cli-binary-format raw-in-base64-out response.json
+              when: on_fail
+      run-with-retry:
+        description: Run command with retry
+        parameters:
+          label:
+            description: Display name
+            type: string
+          command:
+            description: Command to run
+            type: string
+          retry-count:
+            description: Number of retry
+            type: integer
+            default: 3
+          sleep:
+            description: Wait duration until next retry
+            type: integer
+            default: 5
+          no_output_timeout:
+            description: Elapsed time the command can run without output
+            type: string
+            default: 10m
+        steps:
+          - run:
+              name: << parameters.label >>
+              command: |
+                retry() {
+                  MAX_RETRY=<< parameters.retry-count >>
+                  n=0
+                  until [ $n -ge $MAX_RETRY ]
+                  do
+                      << parameters.command >> && break
+                      n=$[$n+1]
+                      sleep << parameters.sleep >>
+                  done
+                  if [ $n -ge $MAX_RETRY ]; then
+                    echo "failed: ${@}" >&2
+                    exit 1
+                  fi
+                }
+                retry
+              no_output_timeout: << parameters.no_output_timeout >>
+      install-flutter:
+        description: Install Flutter and set up paths.
+        parameters:
+          flutter_branch:
+            description: Flutter branch or version tag.
+            type: string
+            default: stable
+        steps:
+          - run:
+              name: Set up Flutter
+              command: |
+                echo 'export FLUTTER_HOME=${HOME}/sdks/flutter' >> $BASH_ENV
+                echo 'export FLUTTER_BRANCH=<< parameters.flutter_branch >>' >> $BASH_ENV
+                echo 'export FLUTTER_ROOT=${FLUTTER_HOME}' >> $BASH_ENV
+                echo 'export PATH=${PATH}:${FLUTTER_HOME}/bin:${FLUTTER_HOME}/bin/cache/dart-sdk/bin:${HOME}/.pub-cache/bin:${FLUTTER_HOME}/.pub-cache/bin' >> $BASH_ENV
+                source $BASH_ENV
+                git clone --branch ${FLUTTER_BRANCH} https://github.com/flutter/flutter.git ${FLUTTER_HOME}
+                (yes || true) | flutter doctor --android-licenses && flutter doctor
+                flutter precache
+      setup-amplify-flutter-project:
+        description: Setup Amplify project
+        steps:
+          - run-with-retry:
+              label: Setting up dependences
+              command: flutter pub add amplify_flutter && flutter pub add amplify_datastore && flutter pub add amplify_storage_s3 && flutter pub add amplify_analytics_pinpoint && flutter pub add amplify_auth_cognito && flutter pub add amplify_api
+              no_output_timeout: 5m
+          - run:
+              name: Adding integration_test package
+              command: 'sed -i -e "s/dev_dependencies:/dev_dependencies:\n  integration_test:\n    sdk: flutter/" ./pubspec.yaml && cat ./pubspec.yaml'
+          - run:
+              name: Update outdated dependences
+              command: flutter pub upgrade --major-versions
+          - run:
+              name: Adding amplifyconfig file
+              command: mv canaries/dummy_amplifyconfiguration.dart canaries/amplifyconfiguration.dart && cp canaries/amplifyconfiguration.dart amplified_todo/lib
+              working_directory: ~/flutter-canaries/
+          - run:
+              name: Adding test code
+              command: cp canaries/main.dart amplified_todo/lib && cp -r canaries/integration_test amplified_todo/integration_test && cp -r canaries/models amplified_todo/lib/models
+              working_directory: ~/flutter-canaries/
 
-  pub_analysis:
-    executor: docker-executor
-    parameters:
-      plugin_threshold:
-        type: string
-        description: the plugin name and the pub analysis threshold in the format <plugin_name>:<threshold>
-    steps:
-      - install_flutter
-      - checkout
-      - install_aft
-      - install_melos
-      - activate_pana
-      - run:
-          name: Run pub analysis and fail if the score is below the max score
-          command: param=<< parameters.plugin_threshold >> && plugin=${param%:*} && threshold=${param#*:} && melos exec -c 1 --fail-fast --scope="$plugin" -- pana --no-warning --exit-code-threshold $threshold .
+    jobs:
+      flutter-android:
+        parameters:
+          flutter-version:
+            type: string
+        executor:
+          name: android/android-machine
+          resource-class: large
+          tag: 2022.07.1
+        working_directory: ~/flutter-canaries/amplified_todo
+        steps:
+          - checkout:
+              path: ~/flutter-canaries
+          - aws-cli/setup:
+              role-session-name: ${CIRCLE_WORKFLOW_JOB_ID}
+              role-arn: ${AWS_ROLE_ARN}
+              session-duration: '2000'
+          - install-flutter:
+              flutter_branch: << parameters.flutter-version >>
+          - run:
+              name: Setting up project
+              command: cd ../ && flutter create amplified_todo
+          - run:
+              name: Update Android version
+              command: sed -i -e "s/minSdkVersion .*/minSdkVersion 21/" ./android/app/build.gradle && cat ./android/app/build.gradle
+          - setup-amplify-flutter-project
+          - flutter-orb/install_android_gradle:
+              app-dir: ./
+          - android/create-avd:
+              avd-name: flutter
+              install: true
+              system-image: system-images;android-29;default;x86
+          - android/start-emulator:
+              avd-name: flutter
+              post-emulator-launch-assemble-command: ls -lrt
+              restore-gradle-cache-find-args: ./android -name 'build.gradle'
+          - run-with-retry:
+              label: Run Flutter Build
+              command: flutter build apk --debug
+              no_output_timeout: 20m
+          - run-with-retry:
+              label: Run Flutter Tests
+              command: flutter test integration_test
+              no_output_timeout: 1h
+              retry-count: 5
+          - send-metric-on-fail
 
-  unit_test_flutter:
-    executor: docker-executor
-    parameters:
-      plugin:
-        type: string
-    steps:
-      - install_flutter
-      - checkout
-      - install_aft
-      - run:
-          name: Install junitreport for JUnit XML reports
-          command: flutter pub global activate junitreport
-      - run:
-          name: Run Flutter Unit Tests
-          command: aft run test:unit:flutter --include=<< parameters.plugin >>
-      - run:
-          name: Save test results
-          command: |
-            mkdir -p ~/test-results/junit/
-            mkdir -p ~/test-results/failures/
-            find . -type f -regex "\./packages/.*/test-results/.*-flutter-test\.xml" -exec cp {} ~/test-results/junit/ \;
-            find . -type f -regex "\./packages/.*/failures/.*\.png" -exec cp {} ~/test-results/failures/ \;
-          when: always
-      - store_test_results:
-          path: ~/test-results
-      - store_artifacts:
-          path: ~/test-results/junit
-      - store_artifacts:
-          path: ~/test-results/failures
-
-  unit_test_ios:
-    executor: macos-executor
-    parameters:
-      plugin:
-        type: string
-    steps:
-      - install_flutter
-      - checkout
-      - install_aft
-      - run:
-          name: Pre-start iOS simulator
-          command: xcrun simctl boot "iPhone 14 Pro Max" || true
-      - run:
-          name: Build example iOS apps
-          command: aft run build:example:ios --include='**<< parameters.plugin >>**'
-      - run:
-          name: Run iOS Unit Tests
-          command: aft run test:unit:ios --include=<< parameters.plugin >>
-      - run:
-          name: Save test results
-          command: |
-            mkdir -p ~/test-results/junit/
-            find . -type f -regex "\./packages/.*/example/ios/test-results/.*-xcodebuild-test\.xml" -exec cp {} ~/test-results/junit/ \;
-          when: always
-      - store_test_results:
-          path: ~/test-results
-      - store_artifacts:
-          path: ~/test-results/junit
-
-  unit_test_android:
-    executor: docker-executor
-    parameters:
-      plugin:
-        type: string
-    environment:
-      _JAVA_OPTIONS: -XX:MaxRAMPercentage=80.0
-      GRADLE_OPTS: -Xmx1536m -Xms768m -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.daemon=false
-    steps:
-      - install_flutter
-      - checkout
-      - install_aft
-      - run:
-          name: Build example APKs
-          command: aft run build:example:android --include='**<< parameters.plugin >>**'
-          no_output_timeout: 20m
-      # - run:
-      #     name: Run lint checks
-      #     command: melos run lint:android:<< parameters.plugin >>
-      - run:
-          name: Run Android Unit Tests
-          command: aft run test:unit:android --include=<< parameters.plugin >>
-      - run:
-          name: Save test results
-          command: |
-            mkdir -p ~/test-results/junit/
-            find . -type f -regex "\./packages/.*/example/build/.*/test-results/.*\.xml" -exec cp {} ~/test-results/junit/ \;
-          when: always
-      - store_test_results:
-          path: ~/test-results
-      - store_artifacts:
-          path: ~/test-results/junit
-
-releasable_branches: &releasable_branches
-  branches:
-    only:
-      - release
-      - main
+      flutter-ios:
+        parameters:
+          flutter-version:
+            type: string
+        executor: mac-executor
+        working_directory: ~/flutter-canaries/amplified_todo
+        steps:
+          - checkout:
+              path: ~/flutter-canaries
+          - aws-cli/setup:
+              role-session-name: ${CIRCLE_WORKFLOW_JOB_ID}
+              role-arn: ${AWS_ROLE_ARN}
+              session-duration: '2000'
+          - run:
+              name: Install gnu-sed
+              command: brew install gnu-sed
+          - macos/preboot-simulator:
+              device: iPhone 13
+              version: "15.2"
+          - install-flutter:
+              flutter_branch: << parameters.flutter-version >>
+          - run:
+              name: Setting up project
+              command: cd ../ && flutter create amplified_todo
+          - setup-amplify-flutter-project
+          - run:
+              name: Removing IPHONEOS_DEPLOYMENT_TARGET from build_settings
+              command: cd ios && gsed -i "/flutter_additional_ios_build_settings(target)/ a \    target.build_configurations.each do |config|\n      config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'\n    end" Podfile
+          - run:
+              name: Update ios version
+              command: sed -i -e "s/# platform .*/platform :ios, '13.0'/" ./ios/Podfile && cat ./ios/Podfile
+          - run-with-retry:
+              label: Run Flutter Build
+              command: flutter build ios --debug --simulator
+              no_output_timeout: 20m
+          - run-with-retry:
+              label: Run Flutter Tests
+              command: flutter test integration_test
+              no_output_timeout: 20m
+          - send-metric-on-fail
 
 workflows:
-  test_deploy:
+  # Scheduled smoke test workflow
+  # Jobs are pulled from the getting-started-smoke-test inline orb defined above
+  canaries:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "Canaries", << pipeline.schedule.name >> ]
     jobs:
-      - format_flutter
-      - analyze_flutter
-      # TODO: Enable pub_analysis after https://github.com/dart-lang/pana/issues/1020 is 
-      # resolved or these are updated to run against unpub
-      # - pub_analysis:
-      #     matrix:
-      #       parameters:
-      #         plugin_threshold: [
-      #             # should be in format <plugin_name>:<threshold>
-      #             "amplify_analytics_pinpoint:10",
-      #             "amplify_api:10",
-      #             "amplify_auth_cognito:10",
-      #             "amplify_authenticator:0",
-      #             "amplify_core:10",
-      #             "amplify_datastore:20",
-      #             "amplify_flutter:20",
-      #             "amplify_storage_s3:10",
-      #           ]
-      - unit_test_flutter:
+      - getting-started-smoke-test/flutter-android:
+          context:
+            - cloudwatch-monitoring
           matrix:
             parameters:
-              plugin:
-                [
-                  "amplify_api",
-                  "amplify_authenticator",
-                  "amplify_datastore",
-                  "amplify_flutter",
-                  "amplify_storage_s3"
-                ]
-      - unit_test_android:
+              flutter-version: [ "stable", "beta" ]
+      - getting-started-smoke-test/flutter-ios:
+          context:
+            - cloudwatch-monitoring
           matrix:
             parameters:
-              plugin:
-                [
-                  "amplify_api_android",
-                  "amplify_auth_cognito",
-                  "amplify_datastore",
-                  "amplify_flutter",
-                  "amplify_secure_storage",
-                ]
-      - unit_test_ios:
-          matrix:
-            parameters:
-              plugin:
-                [
-                  "amplify_api_ios",
-                  "amplify_auth_cognito",
-                  "amplify_datastore",
-                  "amplify_flutter",
-                ]
+              flutter-version: [ "stable", "beta" ]


### PR DESCRIPTION
Removes all but canaries from the CircleCI configuration. The canaries workflow hadn't been merged to `next`, so the diff includes the removal of unit tests + copying over the canaries from `main-v0`.