### PR TITLE
chore(repo): Fix circular dependencies when publishing

### DIFF
--- a/packages/aft/lib/src/util.dart
+++ b/packages/aft/lib/src/util.dart
@@ -90,8 +90,10 @@ void sortPackagesTopologically<T>(
   final packageNames = pubspecs.map((el) => el.name).toList();
   final directGraph = <String, List<String>>{
     for (final package in pubspecs)
-      package.name:
-          package.dependencies.keys.where(packageNames.contains).toList(),
+      package.name: [
+        ...package.dependencies.keys.where(packageNames.contains),
+        ...package.devDependencies.keys.where(packageNames.contains),
+      ],
   };
   final transitiveGraph = <String, Set<String>>{
     for (final package in pubspecs) package.name: {},

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -32,7 +32,8 @@ dependencies:
 
 dev_dependencies:
   amplify_lints: ">=2.0.2 <2.1.0"
-  amplify_test: any
+  amplify_test:
+    path: ../../test/amplify_test
   build_runner: ^2.0.0
   flutter_test:
     sdk: flutter

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -29,15 +29,9 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
-  amplify_analytics_pinpoint: ">=1.0.0-next.8+1 <1.0.0-next.9"
-  amplify_api: ">=1.0.0-next.8+1 <1.0.0-next.9"
-  amplify_auth_cognito: ">=1.0.0-next.8+1 <1.0.0-next.9"
-  amplify_datastore: ">=1.0.0-next.8+1 <1.0.0-next.9"
   amplify_lints: ">=2.0.2 <2.1.0"
-  amplify_storage_s3: ">=1.0.0-next.8+1 <1.0.0-next.9"
   amplify_test: any
   build_runner: ^2.0.0
   flutter_test:

--- a/packages/amplify/amplify_flutter/test/amplify_test.dart
+++ b/packages/amplify/amplify_flutter/test/amplify_test.dart
@@ -1,10 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_datastore/amplify_datastore.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_flutter/src/amplify_impl.dart';
-import 'package:amplify_test/test_models/ModelProvider.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -17,6 +15,8 @@ final throwsPluginNotAddedError = throwsA(
     contains('plugin has not been added to Amplify'),
   ),
 );
+
+class MockPlugin extends AuthPluginInterface {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -120,44 +120,24 @@ void main() {
   test('adding multiple plugins using addPlugins method doesn\'t throw',
       () async {
     await amplify.addPlugins([
-      AmplifyDataStore(modelProvider: ModelProvider.instance),
-      AmplifyDataStore(modelProvider: ModelProvider.instance),
+      MockPlugin(),
+      MockPlugin(),
     ]);
     await amplify.configure(validJsonConfiguration);
     expect(amplify.isConfigured, true);
   });
 
   test('adding single plugins using addPlugin method doesn\'t throw', () async {
-    await amplify
-        .addPlugin(AmplifyDataStore(modelProvider: ModelProvider.instance));
+    await amplify.addPlugin(MockPlugin());
     await amplify.configure(validJsonConfiguration);
     expect(amplify.isConfigured, true);
   });
 
-  test('adding multiple plugins from same Analytic category throws exception',
-      () async {
-    await amplify
-        .addPlugin(AmplifyDataStore(modelProvider: ModelProvider.instance));
-    expect(
-      amplify
-          .addPlugin(AmplifyDataStore(modelProvider: ModelProvider.instance)),
-      throwsA(
-        isA<PluginError>().having(
-          (e) => e.toString(),
-          'toString',
-          contains('DataStore plugin has already been added'),
-        ),
-      ),
-    );
-  });
-
   test('adding plugins after configure throws an exception', () async {
-    await amplify
-        .addPlugin(AmplifyDataStore(modelProvider: ModelProvider.instance));
+    await amplify.addPlugin(MockPlugin());
     await amplify.configure(validJsonConfiguration);
     try {
-      await amplify
-          .addPlugin(AmplifyDataStore(modelProvider: ModelProvider.instance));
+      await amplify.addPlugin(MockPlugin());
     } catch (e) {
       expect(e, amplifyAlreadyConfiguredForAddPluginException);
       expect(amplify.isConfigured, true);

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -20,7 +20,8 @@ dependencies:
   async: ^2.10.0
 
 dev_dependencies:
-  amplify_test: any
+  amplify_test:
+    path: ../test/amplify_test
   flutter_test:
     sdk: flutter
   fake_async: ^1.2.0

--- a/packages/amplify_datastore_plugin_interface/pubspec.yaml
+++ b/packages/amplify_datastore_plugin_interface/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   meta: ^1.7.0
 
 dev_dependencies:
-  amplify_test: any
+  amplify_test:
+    path: ../test/amplify_test
   flutter_test:
     sdk: flutter

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -32,7 +32,8 @@ dependencies:
 
 dev_dependencies:
   amplify_lints: ">=2.0.2 <2.1.0"
-  amplify_test: any
+  amplify_test:
+    path: ../../test/amplify_test
   build_runner: ^2.0.0
   connectivity_plus_platform_interface: any
   flutter_test:

--- a/packages/authenticator/amplify_authenticator/example/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/example/pubspec.yaml
@@ -45,10 +45,12 @@ dev_dependencies:
   amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"
   amplify_authenticator_test:
     path: ../../amplify_authenticator_test
-  amplify_integration_test: any
+  amplify_integration_test:
+    path: ../../../test/amplify_integration_test
   amplify_lints:
     path: ../../../amplify_lints
-  amplify_test: any
+  amplify_test:
+    path: ../../../test/amplify_test
   aws_common: any
   flutter_driver:
     sdk: flutter

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -28,7 +28,8 @@ dependencies:
 dev_dependencies:
   amplify_authenticator_test:
     path: ../amplify_authenticator_test
-  amplify_integration_test: any
+  amplify_integration_test:
+    path: ../../test/amplify_integration_test
   amplify_lints: ">=2.0.2 <2.1.0"
   build_runner: ^2.3.3
   build_version: ^2.1.1

--- a/packages/authenticator/amplify_authenticator_test/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator_test/pubspec.yaml
@@ -10,7 +10,8 @@ environment:
 dependencies:
   amplify_authenticator: ">=1.0.0-next.5+1 <1.0.0-next.6"
   amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
-  amplify_integration_test: any
+  amplify_integration_test:
+    path: ../../test/amplify_integration_test
   flutter:
     sdk: flutter
   flutter_test:

--- a/packages/notifications/push/amplify_push_notifications/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications/pubspec.yaml
@@ -19,7 +19,8 @@ dependencies:
 
 dev_dependencies:
   amplify_lints: ^2.0.0
-  amplify_test: any
+  amplify_test:
+    path: ../../../test/amplify_test
   aws_signature_v4: ">=0.3.1+5 <0.4.0"
   build_runner: ^2.0.0
   build_test: ^2.1.5

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
@@ -22,7 +22,8 @@ dependencies:
 
 dev_dependencies:
   amplify_lints: ^2.0.0
-  amplify_test: any
+  amplify_test:
+    path: ../../../test/amplify_test
   build_runner: ^2.0.0
   built_value_generator: 8.4.4
   flutter_test:

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -30,7 +30,8 @@ dependencies:
 
 dev_dependencies:
   amplify_lints: ">=2.0.2 <2.1.0"
-  amplify_test: any
+  amplify_test:
+    path: ../../test/amplify_test
   aws_signature_v4: ">=0.3.1+5 <0.4.0"
   flutter_test:
     sdk: flutter

--- a/packages/test/amplify_integration_test/CHANGELOG.md
+++ b/packages/test/amplify_integration_test/CHANGELOG.md
@@ -1,3 +1,0 @@
-## 0.1.0
-
-- Initial version.

--- a/packages/test/amplify_integration_test/pubspec.yaml
+++ b/packages/test/amplify_integration_test/pubspec.yaml
@@ -1,6 +1,5 @@
 name: amplify_integration_test
 description: Utilities for running Amplify integration tests.
-version: 0.1.0
 homepage: https://github.com/aws-amplify/amplify-flutter
 publish_to: none
 
@@ -8,9 +7,10 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  amplify_auth_cognito_dart: ">=0.7.0 <0.8.0"
-  amplify_core: '>=1.0.0-next.6 <1.0.0-next.7'
-  amplify_test: any
+  amplify_auth_cognito_dart: ">=0.9.0+1 <0.10.0"
+  amplify_core: ">=1.0.0-next.8+1 <1.0.0-next.9"
+  amplify_test:
+    path: ../amplify_test
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/test/amplify_test/CHANGELOG.md
+++ b/packages/test/amplify_test/CHANGELOG.md
@@ -1,3 +1,0 @@
-## 0.0.1
-
-* TODO: Describe initial release.

--- a/packages/test/amplify_test/pubspec.yaml
+++ b/packages/test/amplify_test/pubspec.yaml
@@ -1,6 +1,5 @@
 name: amplify_test
 description: Test utilities for Amplify packages
-version: 0.0.1
 homepage: https://github.com/aws-amplify/amplify-flutter
 publish_to: none
 


### PR DESCRIPTION
When publishing, the `pub` tool uses (roughly) the following logic:

1. For all packages listed in `dependencies` and `dev_dependencies`:
    a. If it's a hosted dependency (meaning a version is specified), check if the version is published and throw an error if not
    b.If it's a path dependency (only applies to `dev_dependencies`), do nothing
2. Traverse into each dependency and dev_dependency and repeat

However, there's a catch in that a `dev_dependency` cannot also conflict with a regular `dependency` (either direct or transitive). Meaning the following is not allowed:

```yaml
name: amplify_auth_cognito

dependencies:
  amplify_flutter: ^1.0.0

dev_dependencies:
  amplify_flutter:
    path: ../../amplify/amplify_flutter
```

To get around these issues, we can use the following simple heuristics:
1. Dependencies must never be circular. Thinking of the repo's packages like a graph/tree can help with this. If you imagine `amplify_flutter` as a node in the graph, all of its children would be the packages which it depends on, for example `amplify_core`. Then, `amplify_core`'s children would include `aws_common`.

  In fact the whole dependency tree for `amplify_flutter` looks like this (generated with [pubviz](https://pub.dev/packages/pubviz)):
  ![dependencies](https://user-images.githubusercontent.com/24740863/231895460-d154ead6-ee66-440f-9207-6573061046cd.png)

  The trick to preventing circular dependencies is to only add dependencies down in the dependency tree.

2. Unpublished packages must be `path` dependencies, e.g. `amplify_test` (must be done manually for now)
3. Published packages must be `hosted` dependencies and have an appropriate range (automatically handled by `aft version-bump`)
