### PR TITLE
chore(aws_common): Prevent build errors in Dart 3

### DIFF
--- a/packages/aws_common/lib/src/http/http_payload.dart
+++ b/packages/aws_common/lib/src/http/http_payload.dart
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO(dnys1): Remove when migrated to Dart 3
+// @dart=2.18
+
 import 'dart:async';
 import 'dart:convert';
 


### PR DESCRIPTION
Temporary workaround until codebase is migrated to Dart 3