### PR TITLE
chore: add CI check for workflows

### DIFF
--- a/.github/workflows/generate_workflows.yaml
+++ b/.github/workflows/generate_workflows.yaml
@@ -1,0 +1,35 @@
+name: Generate Workflows
+on:
+  push:
+    branches:
+      - main
+      - stable
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at 00:00
+
+jobs:
+  test:
+    name: Generate Workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+        with:
+          submodules: true
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@196f54580e9eee2797c57e85e289339f85e6779d # main
+        with:
+          sdk: stable
+
+      - name: Setup aft
+        shell: bash # Run in bash regardless of platform
+        run: |
+          # Patch libgit2dart (see https://github.com/dart-lang/pub/issues/3563)
+          ( cd packages/aft/external/libgit2dart; git apply ../libgit2dart.patch )
+          dart pub global activate -spath packages/aft
+          ( cd packages/aft/external/libgit2dart; git reset --hard HEAD )
+
+      - name: Generate Workflows
+        run: aft generate workflows --set-exit-if-changed 

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -169,11 +169,7 @@ jobs:
         }
       }
 
-      if (setExitIfChanged) {
-        exitIfChanged(workflowFile, workflowContents.toString());
-      }
-
-      workflowFile.writeAsStringSync(workflowContents.toString());
+      writeWorkflowFile(workflowFile, workflowContents.toString());
 
       await generateAndroidUnitTestWorkflow(
         package: package,
@@ -265,11 +261,7 @@ jobs:
       package-name: ${package.name}
 ''';
 
-    if (setExitIfChanged) {
-      exitIfChanged(androidWorkflowFile, androidWorkflowContents);
-    }
-
-    androidWorkflowFile.writeAsStringSync(androidWorkflowContents);
+    writeWorkflowFile(androidWorkflowFile, androidWorkflowContents);
   }
 
   /// If a package has iOS unit tests, generate a separate workflow for them.
@@ -354,20 +346,20 @@ jobs:
       package-name: $packageNameToTest
 ''';
 
-    if (setExitIfChanged) {
-      exitIfChanged(iosWorkflowFile, iosWorkflowContents);
-    }
-
-    iosWorkflowFile.writeAsStringSync(iosWorkflowContents);
+    writeWorkflowFile(iosWorkflowFile, iosWorkflowContents);
   }
 
-  void exitIfChanged(File workflowFile, String content) {
+  void writeWorkflowFile(File workflowFile, String content) {
+    if (!workflowFile.existsSync()) {
+      workflowFile.createSync();
+    }
     final currentContent = workflowFile.readAsStringSync();
-    if (currentContent != content) {
+    if (currentContent != content && setExitIfChanged) {
       logger
         ..error('Workflows are not up to date.')
         ..error('Run `aft generate workflows` to regenerate them.');
       exit(1);
     }
+    workflowFile.writeAsStringSync(content);
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add `--set-exit-if-changed` flag to `aft generate workflows`
- Add CI workflow to run `aft generate workflows --set-exit-if-changed`

Example of failing CI: https://github.com/aws-amplify/amplify-flutter/actions/runs/4702723385/jobs/8340333238?pr=2873


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
