### PR TITLE
test(auth): Fix e2e test

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_in_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_in_test.dart
@@ -91,7 +91,7 @@ void main() {
             username: username,
             password: password,
           );
-          expect(result.nextStep.additionalInfo, isNull);
+          expect(result.nextStep.additionalInfo, isEmpty);
         });
 
         asyncTest(


### PR DESCRIPTION
`additionalInfo` now returns and empty map instead of `null` by default.
