### PR TITLE
chore(repo): Fix publishing errors

### DIFF
--- a/packages/aft/lib/src/commands/publish_command.dart
+++ b/packages/aft/lib/src/commands/publish_command.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:aft/aft.dart';
 import 'package:aft/src/options/glob_options.dart';
 import 'package:aws_common/aws_common.dart';
+import 'package:collection/collection.dart';
 import 'package:graphs/graphs.dart';
 import 'package:path/path.dart' as p;
 
@@ -57,8 +58,14 @@ class PublishCommand extends AmplifyCommand with GlobOptions {
 
     try {
       final versionInfo = await resolveVersionInfo(package.name);
-      final publishedVersion =
-          versionInfo?.latestPrerelease ?? versionInfo?.latestVersion;
+      final publishedVersion = maxBy(
+        [
+          if (versionInfo?.latestPrerelease != null)
+            versionInfo?.latestPrerelease!,
+          if (versionInfo?.latestVersion != null) versionInfo?.latestVersion!,
+        ],
+        (v) => v,
+      );
       if (publishedVersion == null) {
         logger.info('No published info for package ${package.name}');
         return package;

--- a/packages/authenticator/amplify_authenticator_test/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator_test/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  amplify_authenticator: ">=1.0.0-next.5+1 <1.0.0-next.6"
-  amplify_flutter: ">=1.0.0-next.8 <1.0.0-next.9"
+  amplify_authenticator: any
+  amplify_flutter: any
   amplify_integration_test:
     path: ../../test/amplify_integration_test
   flutter:

--- a/packages/test/amplify_integration_test/pubspec.yaml
+++ b/packages/test/amplify_integration_test/pubspec.yaml
@@ -7,11 +7,11 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  amplify_auth_cognito_dart: ">=0.9.0+1 <0.10.0"
-  amplify_core: ">=1.0.0-next.8+1 <1.0.0-next.9"
+  amplify_auth_cognito_dart: any
+  amplify_core: any
   amplify_test:
     path: ../amplify_test
   stream_transform: ^2.0.0
 
 dev_dependencies:
-  amplify_lints: ^2.0.0
+  amplify_lints: any

--- a/packages/test/amplify_test/pubspec.yaml
+++ b/packages/test/amplify_test/pubspec.yaml
@@ -7,10 +7,10 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  amplify_core: ">=1.0.0-next.8 <1.0.0-next.9"
-  aws_common: ">=0.4.0 <0.5.0"
+  amplify_core: any
+  aws_common: any
   collection: ^1.15.0
   meta: ^1.8.0
 
 dev_dependencies:
-  amplify_lints: ^2.0.0
+  amplify_lints: any


### PR DESCRIPTION
- Since unpublished packages' constraints are not updated as part of `aft version-bump` set their constraints to `any` to not conflict with published packages' constraints
- Fix `aft publish` to look at the maximum of the pre-release and published version instead of assuming the pre-release is higher than the published
