### PR TITLE
chore(repo): Clean up users in e2e tests

### DIFF
--- a/infra/lib/auth/stack.ts
+++ b/infra/lib/auth/stack.ts
@@ -108,7 +108,7 @@ export interface AuthFullEnvironmentProps {
    * @default true
    */
   allowUnauthenticatedIdentities?: boolean;
-  
+
   /**
    * Whether to issue a client secret to the user pool client.
    * 
@@ -365,6 +365,7 @@ class AuthIntegrationTestStackEnvironment extends IntegrationTestStackEnvironmen
       customSenderKmsKey,
       deviceTracking: props.deviceTracking,
     });
+    this.createUserCleanupJob(userPool);
 
     let oAuth: cognito.OAuthSettings | undefined;
     let webDomain: cognito.UserPoolDomain | undefined;

--- a/infra/lib/cleanup-users.ts
+++ b/infra/lib/cleanup-users.ts
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CognitoIdentityProvider, UserType } from '@aws-sdk/client-cognito-identity-provider';
+import type * as lambda from 'aws-lambda';
+
+const CLIENT = new CognitoIdentityProvider({});
+const { USER_POOL_ID } = process.env;
+
+export const handler: lambda.Handler = async (event) => {
+    console.log(`Got event: ${JSON.stringify(event, null, 2)}`);
+
+    const users: UserType[] = [];
+    try {
+        console.log('Listing users...');
+
+        let nextToken: string | undefined;
+        do {
+            const usersResp = await CLIENT.listUsers({
+                UserPoolId: USER_POOL_ID!,
+                PaginationToken: nextToken,
+            });
+            for (const user of usersResp.Users ?? []) {
+                users.push(user);
+            }
+            nextToken = usersResp.PaginationToken;
+        } while (nextToken);
+    } catch (e) {
+        console.error(`Error listing users: ${e}`);
+        return;
+    }
+
+    console.log(`Got users: ${JSON.stringify(users, null, 2)}`);
+
+    for (const user of users) {
+        console.log(`Deleting user: ${user.Username}`);
+        await CLIENT.adminDeleteUser({
+            UserPoolId: USER_POOL_ID!,
+            Username: user.Username!,
+        });
+    }
+};

--- a/infra/lib/storage/stack.ts
+++ b/infra/lib/storage/stack.ts
@@ -144,6 +144,7 @@ class StorageIntegrationTestEnvironment extends IntegrationTestStackEnvironment<
         preSignUp: autoConfirmTrigger,
       },
     });
+    this.createUserCleanupJob(userPool);
 
     const userPoolClient = userPool.addClient("UserPoolClient", {
       authFlows: {
@@ -212,13 +213,11 @@ class StorageIntegrationTestEnvironment extends IntegrationTestStackEnvironment<
                       `${prefixes[StorageAccessLevel.public]}*`,
                       `${prefixes[StorageAccessLevel.protected]}`,
                       `${prefixes[StorageAccessLevel.protected]}*`,
-                      `${
-                        prefixOverrides?.[StorageAccessLevel.protected] ??
-                        "protected"
+                      `${prefixOverrides?.[StorageAccessLevel.protected] ??
+                      "protected"
                       }/`,
-                      `${
-                        prefixOverrides?.[StorageAccessLevel.protected] ??
-                        "protected"
+                      `${prefixOverrides?.[StorageAccessLevel.protected] ??
+                      "protected"
                       }/*`,
                     ].filter((val) => val !== "")
                   )
@@ -256,8 +255,7 @@ class StorageIntegrationTestEnvironment extends IntegrationTestStackEnvironment<
           new iam.PolicyStatement({
             actions: ["s3:GetObject"],
             resources: [
-              `${bucket.bucketArn}/${
-                prefixOverrides?.[StorageAccessLevel.protected] ?? "protected"
+              `${bucket.bucketArn}/${prefixOverrides?.[StorageAccessLevel.protected] ?? "protected"
               }/*`,
             ],
           }),

--- a/packages/authenticator/amplify_authenticator/example/integration_test/confirm_sign_up_email_or_phone_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/confirm_sign_up_email_or_phone_test.dart
@@ -50,6 +50,8 @@ void main() {
         );
 
         final email = generateEmail();
+        addTearDown(() => deleteUser(email));
+
         final phoneNumber = generateUSPhoneNumber();
         final password = generatePassword();
 
@@ -124,6 +126,7 @@ void main() {
 
         // And I type my phone number as a username
         await signUpPage.enterUsername(phoneNumber.withOutCountryCode());
+        addTearDown(() => deleteUser(phoneNumber.toE164()));
 
         // And I type my password
         await signUpPage.enterPassword(password);

--- a/packages/authenticator/amplify_authenticator/example/integration_test/confirm_sign_up_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/confirm_sign_up_test.dart
@@ -50,6 +50,8 @@ void main() {
         );
 
         final username = generateEmail();
+        addTearDown(() => deleteUser(username));
+
         final password = generatePassword();
 
         await signInPage.navigateToSignUp();
@@ -103,6 +105,8 @@ void main() {
       );
 
       final username = generateEmail();
+      addTearDown(() => deleteUser(username));
+
       final password = generatePassword();
       final otpResult = await getOtpCode(UserAttribute.email(username));
 

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_with_email_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_with_email_test.dart
@@ -90,6 +90,7 @@ void main() {
           userAttributes: {CognitoUserAttributeKey.email: email},
         ),
       );
+      addTearDown(() => deleteUser(email));
 
       signInPage.expectUsername(label: 'Email');
 

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_with_phone_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_with_phone_test.dart
@@ -84,6 +84,8 @@ void main() {
           },
         ),
       );
+      addTearDown(() => deleteUser(phoneNumber.toE164()));
+
       await loadAuthenticator(tester: tester);
 
       expect(

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_email_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_email_test.dart
@@ -79,6 +79,8 @@ void main() {
       await signInPage.navigateToSignUp();
 
       final username = generateEmail();
+      addTearDown(() => deleteUser(username));
+
       final password = generatePassword();
 
       // When I type a new "email"

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_email_with_lambda_trigger_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_email_with_lambda_trigger_test.dart
@@ -84,6 +84,8 @@ void main() {
           final po = SignUpPage(tester: tester);
 
           final username = generateEmail();
+          addTearDown(() => deleteUser(username));
+
           final password = generatePassword();
 
           // When I type a new "email"
@@ -94,18 +96,6 @@ void main() {
 
           // And I confirm my password
           await po.enterPasswordConfirmation(password);
-
-          // And I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }'
-          // with fixture "sign-up-with-email-with-lambda-trigger"
-          noOp();
-
-          // And I mock 'Amplify.Auth.signIn' with fixture
-          // "Auth.signIn-verified-email"
-          noOp();
-
-          // And I mock 'Amplify.Auth.currentAuthenticatedUser' with fixture
-          // "Auth.currentAuthenticatedUser-verified-email"
-          noOp();
 
           // And I click the "Create Account" button
           await po.submitSignUp();

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_phone_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_phone_test.dart
@@ -100,6 +100,8 @@ void main() {
       await signInPage.navigateToSignUp();
 
       final phoneNumber = generateUSPhoneNumber();
+      addTearDown(() => deleteUser(phoneNumber.toE164()));
+
       final password = generatePassword();
       final email = generateEmail();
 
@@ -146,6 +148,8 @@ void main() {
       await signInPage.navigateToSignUp();
 
       final phoneNumber = generateFrenchPhoneNumber();
+      addTearDown(() => deleteUser(phoneNumber.toE164()));
+
       final password = generatePassword();
       final email = generateEmail();
 

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_username_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_up_with_username_test.dart
@@ -112,6 +112,8 @@ void main() {
       await signInPage.navigateToSignUp();
 
       final username = generateUsername();
+      addTearDown(() => deleteUser(username));
+
       final password = generatePassword();
       final email = generateEmail();
 


### PR DESCRIPTION
- Adds teardown calls to Authenticator e2e tests. Should resolve some flakiness with phone number tests.
- Adds a scheduled cron job to the e2e infra to delete all users every day.
