### PR TITLE
fix: convert `AuthUserAttribute` to `CognitoUserAttribute` in `updateUserAttributes()`

### DIFF
--- a/packages/amplify_core/lib/src/types/auth/attribute/cognito_user_attribute_key.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/cognito_user_attribute_key.dart
@@ -216,3 +216,13 @@ class CognitoUserAttributeKey extends AuthUserAttributeKey
   @override
   String get runtimeTypeName => 'CognitoUserAttributeKey';
 }
+
+extension ToCognitoUserAttributeKey on AuthUserAttributeKey {
+  CognitoUserAttributeKey toCognitoUserAttributeKey() {
+    if (this is CognitoUserAttributeKey) {
+      return this as CognitoUserAttributeKey;
+    } else {
+      return CognitoUserAttributeKey.parse(key);
+    }
+  }
+}

--- a/packages/api/amplify_api/example/integration_test/util.dart
+++ b/packages/api/amplify_api/example/integration_test/util.dart
@@ -40,7 +40,7 @@ class TestUser {
       username: _username,
       password: _password,
       options: SignUpOptions(
-        userAttributes: {CognitoUserAttributeKey.email: testEmail},
+        userAttributes: {AuthUserAttributeKey.email: testEmail},
       ),
     );
     if (!result.isSignUpComplete) {

--- a/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_up_test.dart
@@ -35,8 +35,8 @@ void main() {
               password: password,
               options: SignUpOptions(
                 userAttributes: {
-                  CognitoUserAttributeKey.email: generateEmail(),
-                  CognitoUserAttributeKey.phoneNumber: generatePhoneNumber(),
+                  AuthUserAttributeKey.email: generateEmail(),
+                  AuthUserAttributeKey.phoneNumber: generatePhoneNumber(),
                 },
               ),
             ) as CognitoSignUpResult;

--- a/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/device_tracking_test.dart
@@ -72,7 +72,7 @@ void main() {
           attributes: [
             if (emailAlias)
               AuthUserAttribute(
-                userAttributeKey: CognitoUserAttributeKey.email,
+                userAttributeKey: AuthUserAttributeKey.email,
                 value: username!,
               ),
           ],

--- a/packages/auth/amplify_auth_cognito/example/integration_test/fetch_auth_session_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/fetch_auth_session_test.dart
@@ -315,7 +315,7 @@ void main() {
           );
 
           await Amplify.Auth.updateUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.address,
+            userAttributeKey: AuthUserAttributeKey.address,
             value: '1 Main St',
           );
 

--- a/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/get_current_user_test.dart
@@ -97,7 +97,7 @@ void main() {
             enableMfa: true,
             attributes: [
               AuthUserAttribute(
-                userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+                userAttributeKey: AuthUserAttributeKey.phoneNumber,
                 value: username,
               ),
             ],

--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_up_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_up_test.dart
@@ -31,8 +31,8 @@ void main() {
             password: password,
             options: SignUpOptions(
               userAttributes: {
-                CognitoUserAttributeKey.email: generateEmail(),
-                CognitoUserAttributeKey.phoneNumber: generatePhoneNumber(),
+                AuthUserAttributeKey.email: generateEmail(),
+                AuthUserAttributeKey.phoneNumber: generatePhoneNumber(),
               },
             ),
           ) as CognitoSignUpResult;
@@ -64,8 +64,8 @@ void main() {
             const invalidPassword = '123';
             final options = SignUpOptions(
               userAttributes: {
-                CognitoUserAttributeKey.email: generateEmail(),
-                CognitoUserAttributeKey.phoneNumber: generatePhoneNumber(),
+                AuthUserAttributeKey.email: generateEmail(),
+                AuthUserAttributeKey.phoneNumber: generatePhoneNumber(),
               },
             );
             await expectLater(
@@ -90,8 +90,8 @@ void main() {
             final userOnePassword = generatePassword();
             final userOneOptions = SignUpOptions(
               userAttributes: {
-                CognitoUserAttributeKey.email: generateEmail(),
-                CognitoUserAttributeKey.phoneNumber: generatePhoneNumber(),
+                AuthUserAttributeKey.email: generateEmail(),
+                AuthUserAttributeKey.phoneNumber: generatePhoneNumber(),
               },
             );
             await Amplify.Auth.signUp(
@@ -104,8 +104,8 @@ void main() {
             final userTwoPassword = generatePassword();
             final userTwoOptions = SignUpOptions(
               userAttributes: {
-                CognitoUserAttributeKey.email: generateEmail(),
-                CognitoUserAttributeKey.phoneNumber: generatePhoneNumber(),
+                AuthUserAttributeKey.email: generateEmail(),
+                AuthUserAttributeKey.phoneNumber: generatePhoneNumber(),
               },
             );
             await expectLater(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/user_attributes_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/user_attributes_test.dart
@@ -12,8 +12,10 @@ import 'utils/setup_utils.dart';
 import 'utils/test_utils.dart';
 
 extension on List<AuthUserAttribute> {
-  String? valueOf(AuthUserAttributeKey key) =>
-      singleWhereOrNull((el) => el.userAttributeKey == key)?.value;
+  String? valueOf(AuthUserAttributeKey authUserAttributeKey) =>
+      singleWhereOrNull(
+        (el) => el.userAttributeKey.key == authUserAttributeKey.key,
+      )?.value;
 }
 
 void main() {
@@ -46,15 +48,15 @@ void main() {
             verifyAttributes: true,
             attributes: [
               AuthUserAttribute(
-                userAttributeKey: CognitoUserAttributeKey.name,
+                userAttributeKey: AuthUserAttributeKey.name,
                 value: name,
               ),
               AuthUserAttribute(
-                userAttributeKey: CognitoUserAttributeKey.email,
+                userAttributeKey: AuthUserAttributeKey.email,
                 value: email,
               ),
               AuthUserAttribute(
-                userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+                userAttributeKey: AuthUserAttributeKey.phoneNumber,
                 value: phoneNumber,
               )
             ],
@@ -77,15 +79,15 @@ void main() {
             final userAttributes = await Amplify.Auth.fetchUserAttributes();
 
             expect(
-              userAttributes.valueOf(CognitoUserAttributeKey.email),
+              userAttributes.valueOf(AuthUserAttributeKey.email),
               email,
             );
             expect(
-              userAttributes.valueOf(CognitoUserAttributeKey.phoneNumber),
+              userAttributes.valueOf(AuthUserAttributeKey.phoneNumber),
               phoneNumber,
             );
             expect(
-              userAttributes.valueOf(CognitoUserAttributeKey.name),
+              userAttributes.valueOf(AuthUserAttributeKey.name),
               name,
             );
           });
@@ -95,7 +97,7 @@ void main() {
           asyncTest('should update a single users attribute', (_) async {
             final updatedName = generateNameAttribute();
             final res = await Amplify.Auth.updateUserAttribute(
-              userAttributeKey: CognitoUserAttributeKey.name,
+              userAttributeKey: AuthUserAttributeKey.name,
               value: updatedName,
             );
             expect(
@@ -105,9 +107,9 @@ void main() {
 
             final userAttributes = await Amplify.Auth.fetchUserAttributes();
             expect(
-              userAttributes.valueOf(CognitoUserAttributeKey.name),
+              userAttributes.valueOf(AuthUserAttributeKey.name),
               updatedName,
-              reason: 'Attribute shoud be updated',
+              reason: 'Attribute should be updated',
             );
           });
 
@@ -133,7 +135,7 @@ void main() {
               const invalidEmailAddress = 'invalidEmailFormat.com';
               await expectLater(
                 Amplify.Auth.updateUserAttribute(
-                  userAttributeKey: CognitoUserAttributeKey.email,
+                  userAttributeKey: AuthUserAttributeKey.email,
                   value: invalidEmailAddress,
                 ),
                 throwsA(isA<InvalidParameterException>()),
@@ -149,11 +151,11 @@ void main() {
             await Amplify.Auth.updateUserAttributes(
               attributes: [
                 AuthUserAttribute(
-                  userAttributeKey: CognitoUserAttributeKey.name,
+                  userAttributeKey: AuthUserAttributeKey.name,
                   value: updatedName,
                 ),
                 AuthUserAttribute(
-                  userAttributeKey: CognitoUserAttributeKey.givenName,
+                  userAttributeKey: AuthUserAttributeKey.givenName,
                   value: updatedGivenName,
                 ),
               ],
@@ -161,14 +163,14 @@ void main() {
 
             final userAttributes = await Amplify.Auth.fetchUserAttributes();
             expect(
-              userAttributes.valueOf(CognitoUserAttributeKey.name),
+              userAttributes.valueOf(AuthUserAttributeKey.name),
               updatedName,
-              reason: 'Attribute shoud be updated',
+              reason: 'Attribute should be updated',
             );
             expect(
-              userAttributes.valueOf(CognitoUserAttributeKey.givenName),
+              userAttributes.valueOf(AuthUserAttributeKey.givenName),
               updatedGivenName,
-              reason: 'Attribute shoud be updated',
+              reason: 'Attribute should be updated',
             );
           });
 
@@ -178,7 +180,7 @@ void main() {
             (_) async {
               // set initial state
               await Amplify.Auth.updateUserAttribute(
-                userAttributeKey: CognitoUserAttributeKey.name,
+                userAttributeKey: AuthUserAttributeKey.name,
                 value: name,
               );
 
@@ -188,7 +190,7 @@ void main() {
                 Amplify.Auth.updateUserAttributes(
                   attributes: [
                     AuthUserAttribute(
-                      userAttributeKey: CognitoUserAttributeKey.name,
+                      userAttributeKey: AuthUserAttributeKey.name,
                       value: updatedName,
                     ),
                     AuthUserAttribute(
@@ -204,9 +206,9 @@ void main() {
 
               final userAttributes = await Amplify.Auth.fetchUserAttributes();
               expect(
-                userAttributes.valueOf(CognitoUserAttributeKey.name),
+                userAttributes.valueOf(AuthUserAttributeKey.name),
                 name,
-                reason: 'Attribute shoud not be updated',
+                reason: 'Attribute should not be updated',
               );
             },
           );

--- a/packages/auth/amplify_auth_cognito/example/lib/screens/view_user_attributes.dart
+++ b/packages/auth/amplify_auth_cognito/example/lib/screens/view_user_attributes.dart
@@ -94,7 +94,7 @@ class _ViewUserAttributesScreenState extends State<ViewUserAttributesScreen> {
                 itemBuilder: (context, index) {
                   final attribute = _userAttributes[index];
                   final userAttributeKey =
-                      attribute.userAttributeKey as CognitoUserAttributeKey;
+                      attribute.userAttributeKey.toCognitoUserAttributeKey();
                   final value = attribute.value;
                   return ListTile(
                     title: Text(userAttributeKey.key),

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/attribute_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/attribute_component.dart
@@ -38,8 +38,8 @@ class UserAttributeComponent extends StatefulComponent {
           id: attr.userAttributeKey.toString(),
           labelText: attr.userAttributeKey.toString(),
           onChanged: (value) {
-            _modifiedAttributes[
-                attr.userAttributeKey as CognitoUserAttributeKey] = value ?? '';
+            _modifiedAttributes[attr.userAttributeKey
+                .toCognitoUserAttributeKey()] = value ?? '';
           },
         ),
       );

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -725,7 +725,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
       final nextStep = isUpdated
           ? AuthUpdateAttributeStep.done
           : AuthUpdateAttributeStep.confirmAttributeWithCode;
-      result[attribute.userAttributeKey as CognitoUserAttributeKey] =
+      result[attribute.userAttributeKey.toCognitoUserAttributeKey()] =
           UpdateUserAttributeResult(
         isUpdated: isUpdated,
         nextStep: AuthNextUpdateAttributeStep(

--- a/packages/authenticator/amplify_authenticator/example/integration_test/custom_ui_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/custom_ui_test.dart
@@ -75,7 +75,7 @@ void main() {
         verifyAttributes: true,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.email,
+            userAttributeKey: AuthUserAttributeKey.email,
             value: username,
           ),
         ],

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_force_new_password_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_force_new_password_test.dart
@@ -43,7 +43,7 @@ void main() {
         verifyAttributes: true,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+            userAttributeKey: AuthUserAttributeKey.phoneNumber,
             value: phoneNumber.toE164(),
           ),
         ],

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_mfa_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_mfa_test.dart
@@ -41,7 +41,7 @@ void main() {
         verifyAttributes: true,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+            userAttributeKey: AuthUserAttributeKey.phoneNumber,
             value: phoneNumber.toE164(),
           ),
         ],

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_with_email_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_with_email_test.dart
@@ -87,7 +87,7 @@ void main() {
         username: email,
         password: password,
         options: SignUpOptions(
-          userAttributes: {CognitoUserAttributeKey.email: email},
+          userAttributes: {AuthUserAttributeKey.email: email},
         ),
       );
 
@@ -128,7 +128,7 @@ void main() {
         verifyAttributes: true,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.email,
+            userAttributeKey: AuthUserAttributeKey.email,
             value: username,
           ),
         ],
@@ -176,7 +176,7 @@ void main() {
         verifyAttributes: true,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.email,
+            userAttributeKey: AuthUserAttributeKey.email,
             value: username,
           ),
         ],
@@ -229,7 +229,7 @@ void main() {
         password,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.email,
+            userAttributeKey: AuthUserAttributeKey.email,
             value: username,
           ),
         ],

--- a/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_with_phone_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/sign_in_with_phone_test.dart
@@ -80,7 +80,7 @@ void main() {
         password: password,
         options: SignUpOptions(
           userAttributes: {
-            CognitoUserAttributeKey.email: email,
+            AuthUserAttributeKey.email: email,
           },
         ),
       );
@@ -128,7 +128,7 @@ void main() {
         verifyAttributes: true,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+            userAttributeKey: AuthUserAttributeKey.phoneNumber,
             value: phoneNumber.toE164(),
           ),
         ],
@@ -179,7 +179,7 @@ void main() {
         password,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+            userAttributeKey: AuthUserAttributeKey.phoneNumber,
             value: phoneNumber.toE164(),
           ),
         ],

--- a/packages/authenticator/amplify_authenticator/example/integration_test/verify_user_test.dart
+++ b/packages/authenticator/amplify_authenticator/example/integration_test/verify_user_test.dart
@@ -50,7 +50,7 @@ void main() {
         autoConfirm: true,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.email,
+            userAttributeKey: AuthUserAttributeKey.email,
             value: username,
           ),
         ],
@@ -86,8 +86,8 @@ void main() {
             (state) => state.unverifiedAttributeKeys,
             'unverifiedAttributeKeys',
             unorderedEquals([
-              CognitoUserAttributeKey.email,
-              CognitoUserAttributeKey.phoneNumber,
+              AuthUserAttributeKey.email,
+              AuthUserAttributeKey.phoneNumber,
             ]),
           ),
           isA<AuthenticatedState>(),
@@ -104,7 +104,7 @@ void main() {
         autoConfirm: true,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.email,
+            userAttributeKey: AuthUserAttributeKey.email,
             value: username,
           ),
         ],
@@ -146,14 +146,14 @@ void main() {
             (state) => state.unverifiedAttributeKeys,
             'unverifiedAttributeKeys',
             unorderedEquals([
-              CognitoUserAttributeKey.email,
-              CognitoUserAttributeKey.phoneNumber,
+              AuthUserAttributeKey.email,
+              AuthUserAttributeKey.phoneNumber,
             ]),
           ),
           isA<AttributeVerificationSent>().having(
             (state) => state.userAttributeKey,
             'userAttributeKey',
-            CognitoUserAttributeKey.email,
+            AuthUserAttributeKey.email,
           ),
           isA<AuthenticatedState>(),
           emitsDone,
@@ -169,7 +169,7 @@ void main() {
         autoConfirm: true,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.email,
+            userAttributeKey: AuthUserAttributeKey.email,
             value: username,
           ),
         ],
@@ -226,14 +226,14 @@ void main() {
             (state) => state.unverifiedAttributeKeys,
             'unverifiedAttributeKeys',
             unorderedEquals([
-              CognitoUserAttributeKey.email,
-              CognitoUserAttributeKey.phoneNumber,
+              AuthUserAttributeKey.email,
+              AuthUserAttributeKey.phoneNumber,
             ]),
           ),
           isA<AttributeVerificationSent>().having(
             (state) => state.userAttributeKey,
             'userAttributeKey',
-            CognitoUserAttributeKey.phoneNumber,
+            AuthUserAttributeKey.phoneNumber,
           ),
           isA<AuthenticatedState>(),
           emitsDone,
@@ -250,11 +250,11 @@ void main() {
         autoConfirm: true,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.email,
+            userAttributeKey: AuthUserAttributeKey.email,
             value: username,
           ),
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+            userAttributeKey: AuthUserAttributeKey.phoneNumber,
             value: phoneNumber.toE164(),
           ),
         ],
@@ -320,7 +320,7 @@ void main() {
         autoConfirm: true,
         attributes: [
           AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.email,
+            userAttributeKey: AuthUserAttributeKey.email,
             value: username,
           ),
         ],

--- a/packages/authenticator/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -278,8 +278,7 @@ class AmplifyAuthService implements AuthService {
       final userAttributes = await Amplify.Auth.fetchUserAttributes();
 
       final verifiableAttributes = userAttributes
-          .map((e) => e.userAttributeKey)
-          .cast<CognitoUserAttributeKey>()
+          .map((e) => e.userAttributeKey.toCognitoUserAttributeKey())
           .where(
             (element) =>
                 element == CognitoUserAttributeKey.email ||

--- a/packages/test/amplify_integration_test/lib/src/integration_test_utils/auth_cognito/integration_test_auth_utils.dart
+++ b/packages/test/amplify_integration_test/lib/src/integration_test_utils/auth_cognito/integration_test_auth_utils.dart
@@ -104,7 +104,7 @@ Future<String> adminCreateUser(
     'autoConfirm': autoConfirm,
     'email': attributes
         .firstWhere(
-          (el) => el.userAttributeKey == AuthUserAttributeKey.email,
+          (el) => el.userAttributeKey.key == AuthUserAttributeKey.email.key,
           orElse: () => AuthUserAttribute(
             userAttributeKey: AuthUserAttributeKey.email,
             value: generateEmail(),
@@ -114,7 +114,7 @@ Future<String> adminCreateUser(
     'enableMFA': enableMfa,
     'givenName': attributes
         .firstWhere(
-          (el) => el.userAttributeKey == AuthUserAttributeKey.givenName,
+          (el) => el.userAttributeKey.key == AuthUserAttributeKey.givenName.key,
           orElse: () => const AuthUserAttribute(
             userAttributeKey: AuthUserAttributeKey.givenName,
             value: 'default_given_name',
@@ -123,7 +123,7 @@ Future<String> adminCreateUser(
         .value,
     'name': attributes
         .firstWhere(
-          (el) => el.userAttributeKey == AuthUserAttributeKey.name,
+          (el) => el.userAttributeKey.key == AuthUserAttributeKey.name.key,
           orElse: () => const AuthUserAttribute(
             userAttributeKey: AuthUserAttributeKey.name,
             value: 'default_name',
@@ -132,7 +132,8 @@ Future<String> adminCreateUser(
         .value,
     'phoneNumber': attributes
         .firstWhere(
-          (el) => el.userAttributeKey == AuthUserAttributeKey.phoneNumber,
+          (el) =>
+              el.userAttributeKey.key == AuthUserAttributeKey.phoneNumber.key,
           orElse: () => AuthUserAttribute(
             userAttributeKey: AuthUserAttributeKey.phoneNumber,
             value: generatePhoneNumber(),
@@ -211,10 +212,10 @@ Future<OtpResult> getOtpCode(UserAttribute userAttribute) async {
           case UserAttributeType.username:
             return event.username == userAttribute.value;
           case UserAttributeType.email:
-            return event.userAttributes[AuthUserAttributeKey.email] ==
+            return event.userAttributes[CognitoUserAttributeKey.email] ==
                 userAttribute.value;
           case UserAttributeType.phone:
-            return event.userAttributes[AuthUserAttributeKey.phoneNumber] ==
+            return event.userAttributes[CognitoUserAttributeKey.phoneNumber] ==
                 userAttribute.value;
         }
       })

--- a/packages/test/amplify_integration_test/lib/src/integration_test_utils/auth_cognito/integration_test_auth_utils.dart
+++ b/packages/test/amplify_integration_test/lib/src/integration_test_utils/auth_cognito/integration_test_auth_utils.dart
@@ -104,9 +104,9 @@ Future<String> adminCreateUser(
     'autoConfirm': autoConfirm,
     'email': attributes
         .firstWhere(
-          (el) => el.userAttributeKey == CognitoUserAttributeKey.email,
+          (el) => el.userAttributeKey == AuthUserAttributeKey.email,
           orElse: () => AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.email,
+            userAttributeKey: AuthUserAttributeKey.email,
             value: generateEmail(),
           ),
         )
@@ -114,27 +114,27 @@ Future<String> adminCreateUser(
     'enableMFA': enableMfa,
     'givenName': attributes
         .firstWhere(
-          (el) => el.userAttributeKey == CognitoUserAttributeKey.givenName,
+          (el) => el.userAttributeKey == AuthUserAttributeKey.givenName,
           orElse: () => const AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.givenName,
+            userAttributeKey: AuthUserAttributeKey.givenName,
             value: 'default_given_name',
           ),
         )
         .value,
     'name': attributes
         .firstWhere(
-          (el) => el.userAttributeKey == CognitoUserAttributeKey.name,
+          (el) => el.userAttributeKey == AuthUserAttributeKey.name,
           orElse: () => const AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.name,
+            userAttributeKey: AuthUserAttributeKey.name,
             value: 'default_name',
           ),
         )
         .value,
     'phoneNumber': attributes
         .firstWhere(
-          (el) => el.userAttributeKey == CognitoUserAttributeKey.phoneNumber,
+          (el) => el.userAttributeKey == AuthUserAttributeKey.phoneNumber,
           orElse: () => AuthUserAttribute(
-            userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+            userAttributeKey: AuthUserAttributeKey.phoneNumber,
             value: generatePhoneNumber(),
           ),
         )
@@ -211,10 +211,10 @@ Future<OtpResult> getOtpCode(UserAttribute userAttribute) async {
           case UserAttributeType.username:
             return event.username == userAttribute.value;
           case UserAttributeType.email:
-            return event.userAttributes[CognitoUserAttributeKey.email] ==
+            return event.userAttributes[AuthUserAttributeKey.email] ==
                 userAttribute.value;
           case UserAttributeType.phone:
-            return event.userAttributes[CognitoUserAttributeKey.phoneNumber] ==
+            return event.userAttributes[AuthUserAttributeKey.phoneNumber] ==
                 userAttribute.value;
         }
       })

--- a/packages/test/amplify_integration_test/lib/src/stubs/amplify_auth_cognito_stub.dart
+++ b/packages/test/amplify_integration_test/lib/src/stubs/amplify_auth_cognito_stub.dart
@@ -67,11 +67,11 @@ class AmplifyAuthCognitoStub extends AuthPluginInterface
     SignUpOptions? options,
   }) async {
     await Future<void>.delayed(delay);
-    MockCognitoUser? user = _users[username];
+    var user = _users[username];
     if (user != null) {
       throw usernameExistsException;
     } else {
-      MockCognitoUser newUser = MockCognitoUser(
+      var newUser = MockCognitoUser(
         username: username,
         password: password,
         email: options?.userAttributes['email'],
@@ -111,7 +111,7 @@ class AmplifyAuthCognitoStub extends AuthPluginInterface
     ResendSignUpCodeOptions? options,
   }) async {
     await Future<void>.delayed(delay);
-    MockCognitoUser? user = _users[username];
+    var user = _users[username];
     if (user == null) {
       throw userNotFoundException;
     }
@@ -125,7 +125,7 @@ class AmplifyAuthCognitoStub extends AuthPluginInterface
     SignInOptions? options,
   }) async {
     await Future<void>.delayed(delay);
-    MockCognitoUser? user = _users[username];
+    var user = _users[username];
     if (user == null) {
       throw userNotFoundException;
     }
@@ -174,7 +174,7 @@ class AmplifyAuthCognitoStub extends AuthPluginInterface
     ResetPasswordOptions? options,
   }) async {
     await Future<void>.delayed(delay);
-    MockCognitoUser? user = _users[username];
+    var user = _users[username];
     if (user == null) {
       throw userNotFoundException;
     }
@@ -195,14 +195,14 @@ class AmplifyAuthCognitoStub extends AuthPluginInterface
     ConfirmResetPasswordOptions? options,
   }) async {
     await Future<void>.delayed(delay);
-    MockCognitoUser? user = _users[username];
+    var user = _users[username];
     if (user == null) {
       throw userNotFoundException;
     }
     if (confirmationCode != verificationCode) {
       throw codeMismatchException;
     }
-    MockCognitoUser updatedUser = user.copyWith(password: newPassword);
+    var updatedUser = user.copyWith(password: newPassword);
     _users[username] = updatedUser;
     _currentUser = updatedUser;
     return const CognitoResetPasswordResult(
@@ -276,26 +276,26 @@ class AmplifyAuthCognitoStub extends AuthPluginInterface
     return [
       if (_currentUser!.email != null) ...[
         AuthUserAttribute(
-          userAttributeKey: CognitoUserAttributeKey.email,
+          userAttributeKey: AuthUserAttributeKey.email,
           value: _currentUser!.email!,
         ),
         const AuthUserAttribute(
-          userAttributeKey: CognitoUserAttributeKey.emailVerified,
+          userAttributeKey: AuthUserAttributeKey.emailVerified,
           value: 'true',
         ),
       ],
       if (_currentUser!.phoneNumber != null) ...[
         AuthUserAttribute(
-          userAttributeKey: CognitoUserAttributeKey.phoneNumber,
+          userAttributeKey: AuthUserAttributeKey.phoneNumber,
           value: _currentUser!.phoneNumber!,
         ),
         const AuthUserAttribute(
-          userAttributeKey: CognitoUserAttributeKey.phoneNumberVerified,
+          userAttributeKey: AuthUserAttributeKey.phoneNumberVerified,
           value: 'true',
         ),
       ],
       AuthUserAttribute(
-        userAttributeKey: const CognitoUserAttributeKey.custom('sub'),
+        userAttributeKey: AuthUserAttributeKey.sub,
         value: _currentUser!.sub,
       ),
     ];
@@ -391,11 +391,13 @@ class AmplifyAuthCognitoStub extends AuthPluginInterface
 }
 
 class MockCognitoUser {
-  final String sub;
-  final String username;
-  final String password;
-  final String? email;
-  final String? phoneNumber;
+  const MockCognitoUser._({
+    required this.sub,
+    required this.username,
+    required this.password,
+    required this.phoneNumber,
+    required this.email,
+  });
 
   factory MockCognitoUser({
     required String username,
@@ -411,14 +413,11 @@ class MockCognitoUser {
       phoneNumber: phoneNumber,
     );
   }
-
-  const MockCognitoUser._({
-    required this.sub,
-    required this.username,
-    required this.password,
-    required this.phoneNumber,
-    required this.email,
-  });
+  final String sub;
+  final String username;
+  final String password;
+  final String? email;
+  final String? phoneNumber;
 
   CognitoUserPoolTokens get userPoolTokens {
     final accessToken = JsonWebToken(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Properly convert `AuthUserAttribute` to `CognitoUserAttribute` in `updateUserAttributes()`
- Update example apps to use `AuthUserAttribute` by default to match docs
- Update integ tests to use `AuthUserAttribute` by default to match docs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
