### PR TITLE
fix: remove AndroidKeysetManager log, upgrade to google/tink 1.8.0

### DIFF
--- a/packages/secure_storage/amplify_secure_storage/android/build.gradle
+++ b/packages/secure_storage/amplify_secure_storage/android/build.gradle
@@ -50,6 +50,9 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.security:security-crypto:1.0.0'
+    // TODO(Jordan-Nelson): remove once security-crypto:1.1.0 is stable.
+    // See https://github.com/aws-amplify/amplify-flutter/issues/2640
+    implementation 'com.google.crypto.tink:tink-android:1.8.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.9'
     testImplementation 'androidx.test:core-ktx:1.5.0'

--- a/packages/secure_storage/amplify_secure_storage/android/src/main/kotlin/com/amazonaws/amplify/amplify_secure_storage/amplify_secure_storage/EncryptedKeyValueRepository.kt
+++ b/packages/secure_storage/amplify_secure_storage/android/src/main/kotlin/com/amazonaws/amplify/amplify_secure_storage/amplify_secure_storage/EncryptedKeyValueRepository.kt
@@ -5,7 +5,6 @@ package com.amazonaws.amplify.amplify_secure_storage.amplify_secure_storage
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV
@@ -25,9 +24,6 @@ open class EncryptedKeyValueRepository(
             removeSharedPreferencesFile()
             initializationFlagFile.createNewFile()
         }
-        // TODO(Jordan-Nelson): Remove when fix for https://github.com/google/tink/issues/534 is
-        // available in a stable version of androidx.security:security-crypto
-        if (!isInitialized) Log.i("AmplifySecureStorage", preInitMessage)
         val sharedPreferences = EncryptedSharedPreferences.create(
             sharedPreferencesName,
             MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
@@ -35,29 +31,8 @@ open class EncryptedKeyValueRepository(
             AES256_SIV,
             AES256_GCM
         )
-        // TODO(Jordan-Nelson): Remove when fix for https://github.com/google/tink/issues/534 is
-        // available in a stable version of androidx.security:security-crypto
-        if (!isInitialized) Log.i("AmplifySecureStorage", postInitMessage)
         sharedPreferences
     }
-
-    private val preInitMessage =
-        """    
-            Attempting to initialize EncryptedSharedPreferences file for scope: $sharedPreferencesName
-            *****************************************************************************************************
-            * NOTE: This will result in a FileNotFoundException log message from AndroidKeysetManager.
-            * This is expected when creating a new EncryptedSharedPreferences instance and can be safely ignored.
-            *****************************************************************************************************
-        """.trimIndent()
-
-    private val postInitMessage =
-        """
-            Successfully initialized EncryptedSharedPreferences for scope $sharedPreferencesName.
-            *****************************************************************************************************
-            * NOTE: You can safely ignore the FileNotFoundException log message from AndroidKeysetManager.
-            * This is expected when creating a new EncryptedSharedPreferences instance and can be safely ignored.
-            *****************************************************************************************************
-        """.trimIndent()
 
     private val editor: SharedPreferences.Editor by lazy {
         sharedPreferences.edit()


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/2640

*Description of changes:*
- Add dependency on google/tink v1.8.0. androidx.security v1.0 depends on google/tink v1.5.0+. 1.8.0 removes a confusing log message. See [google/tink/issues/534](https://github.com/google/tink/issues/534) for more info.
- Remove temp log message from secure_storage 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
