### PR TITLE
ci: Fix db_common tests on Windows

### DIFF
--- a/.github/workflows/amplify_analytics_pinpoint_dart.yaml
+++ b/.github/workflows/amplify_analytics_pinpoint_dart.yaml
@@ -50,7 +50,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/analytics/amplify_analytics_pinpoint_dart
-      skip-on-windows: true
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/amplify_api_dart.yaml
+++ b/.github/workflows/amplify_api_dart.yaml
@@ -40,7 +40,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/api/amplify_api_dart
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/amplify_auth_cognito_dart.yaml
+++ b/.github/workflows/amplify_auth_cognito_dart.yaml
@@ -49,4 +49,3 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/auth/amplify_auth_cognito_dart
-      skip-on-windows: false

--- a/.github/workflows/amplify_auth_cognito_test.yaml
+++ b/.github/workflows/amplify_auth_cognito_test.yaml
@@ -54,7 +54,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/auth/amplify_auth_cognito_test
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/amplify_core.yaml
+++ b/.github/workflows/amplify_core.yaml
@@ -38,7 +38,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/amplify_core
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/amplify_db_common_dart.yaml
+++ b/.github/workflows/amplify_db_common_dart.yaml
@@ -40,7 +40,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/common/amplify_db_common_dart
-      skip-on-windows: true
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/amplify_secure_storage_test.yaml
+++ b/.github/workflows/amplify_secure_storage_test.yaml
@@ -40,7 +40,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/secure_storage/amplify_secure_storage_test
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/amplify_storage_s3_dart.yaml
+++ b/.github/workflows/amplify_storage_s3_dart.yaml
@@ -43,4 +43,3 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/storage/amplify_storage_s3_dart
-      skip-on-windows: true

--- a/.github/workflows/aws_common.yaml
+++ b/.github/workflows/aws_common.yaml
@@ -34,7 +34,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/aws_common
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/aws_json1_0_v1.yaml
+++ b/.github/workflows/aws_json1_0_v1.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/awsJson1_0
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/aws_json1_0_v2.yaml
+++ b/.github/workflows/aws_json1_0_v2.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/awsJson1_0
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/aws_json1_1_v1.yaml
+++ b/.github/workflows/aws_json1_1_v1.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/awsJson1_1
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/aws_json1_1_v2.yaml
+++ b/.github/workflows/aws_json1_1_v2.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/awsJson1_1
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/aws_signature_v4.yaml
+++ b/.github/workflows/aws_signature_v4.yaml
@@ -36,7 +36,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/aws_signature_v4
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/custom_v1.yaml
+++ b/.github/workflows/custom_v1.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/custom
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/custom_v2.yaml
+++ b/.github/workflows/custom_v2.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/custom
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -59,12 +59,16 @@ jobs:
       # This is needed to support running tests which depend on db_common.
       - name: Install SQLite
         if: runner.os == 'Windows'
-        shell: bash
         run: |
           # Should match `packages/common/amplify_db_common/windows/CMakeLists.txt`
-          curl -sLo sqlite.zip https://www.sqlite.org/2022/sqlite-dll-win64-x64-3400000.zip
-          unzip sqlite.zip
-          echo "$PWD" >> "$GITHUB_PATH"
+          $uri = "https://www.sqlite.org/2022/sqlite-dll-win64-x64-3400000.zip"
+          $outFile = "sqlite.zip"
+          $out = ".\sqlite"
+          Invoke-WebRequest -Uri $uri -OutFile $outFile
+          Expand-Archive -LiteralPath $outFile -DestinationPath $out
+          $absoluteOut = Resolve-Path -Path $out
+          Add-Content $env:GITHUB_PATH $absoluteOut
+          Get-Content $env:GITHUB_PATH
 
       - name: Bootstrap
         id: bootstrap

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -7,10 +7,6 @@ on:
         description: The working directory relative to the repo root
         required: true
         type: string
-      skip-on-windows:
-        description: Whether the current package cannot be tested on Windows
-        required: true
-        type: boolean
 
 jobs:
   native_test:
@@ -60,6 +56,16 @@ jobs:
           dart pub global activate -spath packages/aft
           ( cd packages/aft/external/libgit2dart; git reset --hard HEAD )
 
+      # This is needed to support running tests which depend on db_common.
+      - name: Install SQLite
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          # Should match `packages/common/amplify_db_common/windows/CMakeLists.txt`
+          curl -sLo sqlite.zip https://www.sqlite.org/2022/sqlite-dll-win64-x64-3400000.zip
+          unzip sqlite.zip
+          echo "$PWD" >> "$GITHUB_PATH"
+
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
@@ -75,6 +81,6 @@ jobs:
           fi
 
       - name: Run Tests
-        if: "always() && steps.bootstrap.conclusion == 'success' && (runner.os != 'Windows' || !inputs.skip-on-windows)"
+        if: "always() && steps.bootstrap.conclusion == 'success'"
         run: dart test --exclude-tags=build
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/rest_json1_v1.yaml
+++ b/.github/workflows/rest_json1_v1.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/restJson1
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/rest_json1_v2.yaml
+++ b/.github/workflows/rest_json1_v2.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/restJson1
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/rest_xml_v1.yaml
+++ b/.github/workflows/rest_xml_v1.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/restXml
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/rest_xml_v2.yaml
+++ b/.github/workflows/rest_xml_v2.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/restXml
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/rest_xml_with_namespace_v1.yaml
+++ b/.github/workflows/rest_xml_with_namespace_v1.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib/restXmlWithNamespace
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/rest_xml_with_namespace_v2.yaml
+++ b/.github/workflows/rest_xml_with_namespace_v2.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/goldens/lib2/restXmlWithNamespace
-      skip-on-windows: false
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml

--- a/.github/workflows/smithy.yaml
+++ b/.github/workflows/smithy.yaml
@@ -33,4 +33,3 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/smithy
-      skip-on-windows: false

--- a/.github/workflows/smithy_aws.yaml
+++ b/.github/workflows/smithy_aws.yaml
@@ -37,4 +37,3 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/smithy_aws
-      skip-on-windows: false

--- a/.github/workflows/smithy_codegen.yaml
+++ b/.github/workflows/smithy_codegen.yaml
@@ -39,4 +39,3 @@ jobs:
     uses: ./.github/workflows/dart_native.yaml
     with:
       working-directory: packages/smithy/smithy_codegen
-      skip-on-windows: false

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -66,14 +66,6 @@ class GenerateWorkflowsCommand extends AmplifyCommand {
           isDartPackage ? 'dart_vm.yaml' : 'flutter_vm.yaml';
       final needsNativeTest =
           isDartPackage && package.unitTestDirectory != null;
-      // Packages which use DB Common (SQLite) will not work on Windows until
-      // native assets are supported.
-      // TODO(dnys1): https://github.com/dart-lang/sdk/issues/50565
-      final skipOnWindows = const [
-        'amplify_db_common_dart',
-        'amplify_analytics_pinpoint_dart',
-        'amplify_storage_s3_dart',
-      ].contains(package.name);
       final needsWebTest =
           package.pubspecInfo.pubspec.devDependencies.containsKey('build_test');
       final workflows = [
@@ -147,7 +139,6 @@ jobs:
     uses: ./.github/workflows/$nativeWorkflow
     with:
       working-directory: $repoRelativePath
-      skip-on-windows: $skipOnWindows
 ''',
         );
 


### PR DESCRIPTION
Downloads sqlite3 and adds it to the Windows PATH which is all that's needed for `package:sqlite3` to find it. Based off: https://github.com/simolus3/sqlite3.dart/blob/main/.github/workflows/main.yml