### PR TITLE
fix(auth): Fetch AWS credentials after Hosted UI login

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
@@ -38,6 +38,9 @@ class HostedUiStateMachine
   /// The platform-specific behavior.
   late final HostedUiPlatform _platform = getOrCreate();
 
+  /// The configured identity pool.
+  CognitoIdentityCredentialsProvider? get _identityPoolConfig => get();
+
   @override
   Future<void> resolve(HostedUiEvent event) async {
     switch (event.type) {
@@ -192,6 +195,16 @@ class HostedUiStateMachine
         signInDetails: signInDetails,
       ),
     );
+
+    // Clear anonymous credentials, if there were any, and fetch authenticated
+    // credentials.
+    if (_identityPoolConfig != null) {
+      await manager.clearCredentials(
+        CognitoIdentityPoolKeys(_identityPoolConfig!),
+      );
+
+      await manager.loadSession();
+    }
 
     final idToken = event.tokens.idToken;
     final userId = idToken.userId;


### PR DESCRIPTION
Fixes #2946.

Align logic with username/password login (https://github.com/aws-amplify/amplify-flutter/blob/a010c360376d062eba2c8ac4a01d04a88b555fec/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart#L539) and refresh AWS credentials upon succesful login.
