### PR TITLE
chore(canaries): Use `xcodes`

### DIFF
--- a/.github/composite_actions/launch_ios_simulator/action.yaml
+++ b/.github/composite_actions/launch_ios_simulator/action.yaml
@@ -25,7 +25,7 @@ runs:
         }
         if [[ -z "$(get_runtime)" ]]; then
           echo "No runtime found for iOS ${{ inputs.ios-version }}" >&2
-          sudo xcodes runtime install 'iOS ${{ inputs.ios-version }}'
+          sudo xcodes runtimes install 'iOS ${{ inputs.ios-version }}'
         fi
         xcrun simctl create test "iPhone 11" "$(get_runtime)"
         xcrun simctl boot test

--- a/.github/composite_actions/launch_ios_simulator/action.yaml
+++ b/.github/composite_actions/launch_ios_simulator/action.yaml
@@ -12,7 +12,10 @@ runs:
       shell: bash
       run: |
         xcrun simctl list runtimes -j
-        xcversion simulators --verbose
+
+        # Use xcodes (https://github.com/XcodesOrg/xcodes) to list runtimes for all Xcode versions
+        brew install xcodesorg/made/xcodes
+        xcodes runtimes
 
     - name: Create Simulator
       shell: bash
@@ -22,7 +25,7 @@ runs:
         }
         if [[ -z "$(get_runtime)" ]]; then
           echo "No runtime found for iOS ${{ inputs.ios-version }}" >&2
-          xcversion simulators --install='iOS ${{ inputs.ios-version }}' --verbose
+          sudo xcodes runtime install 'iOS ${{ inputs.ios-version }}'
         fi
         xcrun simctl create test "iPhone 11" "$(get_runtime)"
         xcrun simctl boot test

--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -3,6 +3,7 @@ on:
   schedule:
     # 6am pacific time daily, only runs on default branch
     - cron: "0 13 * * *"
+  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -3,7 +3,6 @@ on:
   schedule:
     # 6am pacific time daily, only runs on default branch
     - cron: "0 13 * * *"
-  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The `xcversion` command, which is preinstalled on GH runners, is being deprecated: https://github.com/xcpretty/xcode-install and no longer works on `macos-latest` which recently moved to macOS 13. This migrates to the recommended replacement `xcodes`.
