### PR TITLE
chore(canaries): Use 3.3 compatible flutter pub add command

### DIFF
--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -3,6 +3,7 @@ on:
   schedule:
     # 6am pacific time daily, only runs on default branch
     - cron: "0 13 * * *"
+  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -3,7 +3,6 @@ on:
   schedule:
     # 6am pacific time daily, only runs on default branch
     - cron: "0 13 * * *"
-  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/build-support/build_canary.sh
+++ b/build-support/build_canary.sh
@@ -16,8 +16,7 @@ flutter pub add amplify_flutter \
   amplify_authenticator \
   amplify_api
 # add test packages
-flutter pub add dev:integration_test:'{"sdk":"flutter"}' dev:flutter_test:'{"sdk":"flutter"}'
-flutter pub upgrade --major-versions
+flutter pub add --dev --sdk=flutter integration_test
 
 # copy template files to newly generated app
 cp -r $ROOT_DIR/canaries/lib .

--- a/build-support/build_canary.sh
+++ b/build-support/build_canary.sh
@@ -23,7 +23,9 @@ cp -r $ROOT_DIR/canaries/lib .
 cp $ROOT_DIR/.circleci/dummy_amplifyconfiguration.dart lib/amplifyconfiguration.dart
 
 # Android
-sed -i'' -e "s/minSdkVersion .*/minSdkVersion 24/" ./android/app/build.gradle && cat ./android/app/build.gradle
+sed -i'' -e "s/minSdkVersion .*/minSdkVersion 24/" ./android/app/build.gradle
+sed -i'' -e "s/compileSdkVersion .*/compileSdkVersion 33/" ./android/app/build.gradle
+cat ./android/app/build.gradle
 # iOS
 sed -i'' -e "s/# platform .*/platform :ios, '13.0'/" ./ios/Podfile && cat ./ios/Podfile
 

--- a/build-support/build_canary.sh
+++ b/build-support/build_canary.sh
@@ -23,6 +23,7 @@ cp -r $ROOT_DIR/canaries/lib .
 cp $ROOT_DIR/.circleci/dummy_amplifyconfiguration.dart lib/amplifyconfiguration.dart
 
 # Android
+sed -i'' -e "s/ext.kotlin_version = .*/ext.kotlin_version = \"1.8.21\"/" ./android/build.gradle
 sed -i'' -e "s/minSdkVersion .*/minSdkVersion 24/" ./android/app/build.gradle
 sed -i'' -e "s/compileSdkVersion .*/compileSdkVersion 33/" ./android/app/build.gradle
 cat ./android/app/build.gradle

--- a/packages/aft/lib/src/models/config.dart
+++ b/packages/aft/lib/src/models/config.dart
@@ -206,7 +206,9 @@ class PackageInfo
 
   /// Whether the package is an example package.
   bool get isExample {
-    return p.basename(path) == 'example' || name == 'doc';
+    return p.basename(path) == 'example' ||
+        name == 'doc' ||
+        p.basename(path) == 'canaries';
   }
 
   /// Whether the package is a test package.

--- a/packages/aft/test/models/package_selector_test.dart
+++ b/packages/aft/test/models/package_selector_test.dart
@@ -127,6 +127,7 @@ void main() {
       expect(
         selector.allPaths(repoState),
         matchesPackagePaths([
+          'canaries',
           'packages/amplify/amplify_flutter/example',
           'packages/amplify/amplify_flutter_ios/example',
           'packages/amplify_core/doc',


### PR DESCRIPTION
Flutter 3.3 does not support the current syntax, which is causing tests to fail. It also fails when adding dependencies already present, so remove `flutter_test` cmd since it's already included in new flutter projects.

Updates `compileSdkVersion` and Kotlin version since Flutter 3.3 defaults do not work.