### PR TITLE
chore(secure_storage): remove enableUnitTestBinaryResources

### DIFF
--- a/packages/secure_storage/amplify_secure_storage/android/gradle.properties
+++ b/packages/secure_storage/amplify_secure_storage/android/gradle.properties
@@ -1,1 +1,0 @@
-android.enableUnitTestBinaryResources=true


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/2962

*Description of changes:*
- Remove `android.enableUnitTestBinaryResources=true` from gradle.properties. This was required prior to Android Studio 3.3 (released in 2019). I had added this as part of https://github.com/aws-amplify/amplify-flutter/pull/2637 as that PR uses roboelectric and [setup docs](https://robolectric.org/getting-started/) include adding this. However, the setup docs note this is not required as of v3.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
