### PR TITLE
fix(auth): Transform network exceptions

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_exception.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_exception.dart
@@ -598,7 +598,7 @@ class ResourceConflictException extends core.AuthServiceException {
 @internal
 Object transformSdkException(Object e) {
   if (e is! SmithyException) {
-    return e;
+    return e is Exception ? core.AuthException.fromException(e) : e;
   }
   final message = e.message ?? e.toString();
   final shapeId = e.shapeId;

--- a/packages/auth/amplify_auth_cognito_dart/test/sdk/sdk_exception_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/sdk/sdk_exception_test.dart
@@ -1,29 +1,42 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_auth_cognito_dart/src/sdk/sdk_exception.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('LambdaException', () {
-    const error = 'something bad happened';
-    const message = 'PreConfirmation failed with error $error.';
+  group('SDK exception', () {
+    group('LambdaException', () {
+      const error = 'something bad happened';
+      const message = 'PreConfirmation failed with error $error.';
 
-    test('matches string', () {
-      expect(LambdaException.isLambdaException(message), isTrue);
+      test('matches string', () {
+        expect(LambdaException.isLambdaException(message), isTrue);
 
-      final exception = LambdaException(message);
-      expect(exception.message, error);
-      expect(exception.lambdaName, 'PreConfirmation');
+        final exception = LambdaException(message);
+        expect(exception.message, error);
+        expect(exception.lambdaName, 'PreConfirmation');
+      });
+
+      test('matches exception', () {
+        const wrapped = UserNotConfirmedException(message);
+        expect(LambdaException.isLambdaException(wrapped.toString()), isTrue);
+
+        final exception = LambdaException(wrapped.toString());
+        expect(exception.message, error);
+        expect(exception.lambdaName, 'PreConfirmation');
+      });
     });
 
-    test('matches exception', () {
-      const wrapped = UserNotConfirmedException(message);
-      expect(LambdaException.isLambdaException(wrapped.toString()), isTrue);
-
-      final exception = LambdaException(wrapped.toString());
-      expect(exception.message, error);
-      expect(exception.lambdaName, 'PreConfirmation');
+    test('transforms network exceptions', () {
+      final networkException = AWSHttpException(
+        AWSHttpRequest.get(Uri.parse('https://example.com')),
+      );
+      expect(
+        transformSdkException(networkException),
+        isA<NetworkException>(),
+      );
     });
   });
 }

--- a/packages/auth/amplify_auth_cognito_dart/tool/generate_sdk_exceptions.dart
+++ b/packages/auth/amplify_auth_cognito_dart/tool/generate_sdk_exceptions.dart
@@ -181,7 +181,7 @@ class $shapeName extends core.AuthServiceException {
 @internal
 Object transformSdkException(Object e) {
   if (e is! SmithyException) {
-    return e;
+    return e is Exception ? core.AuthException.fromException(e) : e;
   }
   final message = e.message ?? e.toString();
   final shapeId = e.shapeId;


### PR DESCRIPTION
Transform network exceptions in the SDK layer so that individual plugin methods do not need to be wrapped.