### PR TITLE
chore(authenticator): add warning for delayed asyncConfig

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -159,7 +159,7 @@ class StateMachineBloc
 
   Stream<AuthState> _authLoad() async* {
     yield const LoadingState();
-    await Amplify.asyncConfig;
+    await _authService.waitForConfiguration();
     yield* _isValidSession();
     // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
     // TODO(dnys1): investigate broken event handling

--- a/packages/authenticator/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -316,13 +316,15 @@ class AmplifyAuthService
   Future<AmplifyConfig> waitForConfiguration() async {
     final timer = Timer.periodic(const Duration(seconds: 10), (timer) {
       logger.warn(
-        'Amplify is taking longer to configure than expected.'
+        'Amplify is taking longer than expected to configure.'
         ' Have you called `Amplify.configure()`?',
       );
     });
-    final config = await Amplify.asyncConfig;
-    timer.cancel();
-    return config;
+    try {
+      return await Amplify.asyncConfig;
+    } finally {
+      timer.cancel();
+    }
   }
 
   @override


### PR DESCRIPTION
*Issue #, if available:* Related to https://github.com/aws-amplify/amplify-flutter/issues/2989

*Description of changes:*
- Periodically log warnings from the authenticator while waiting on configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
