### PR TITLE
chore(core): Sealed exception types

### DIFF
--- a/packages/amplify_core/lib/src/types/analytics/analytics_types.dart
+++ b/packages/amplify_core/lib/src/types/analytics/analytics_types.dart
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Exception Types.
-export '../exception/analytics/analytics_exception.dart';
-export '../exception/analytics/invalid_event_exception.dart';
+export '../exception/amplify_exception.dart'
+    show
+        AnalyticsException,
+        InvalidEventException,
+        NetworkException,
+        UnknownException;
 
 /// API Types.
 export 'analytics/analytics_event.dart';

--- a/packages/amplify_core/lib/src/types/api/api_types.dart
+++ b/packages/amplify_core/lib/src/types/api/api_types.dart
@@ -4,10 +4,14 @@
 // Packages
 export 'package:retry/retry.dart' show RetryOptions;
 
-/// Exceptions
-export '../exception/api/api_exception.dart';
-export '../exception/api/http_status_exception.dart';
-export '../exception/api/operation_exception.dart';
+/// Exception Types.
+export '../exception/amplify_exception.dart'
+    show
+        ApiException,
+        ApiOperationException,
+        HttpStatusException,
+        NetworkException,
+        UnknownException;
 // API Authorization
 export 'auth/api_auth_provider.dart';
 export 'auth/api_authorization_type.dart';

--- a/packages/amplify_core/lib/src/types/auth/auth_types.dart
+++ b/packages/amplify_core/lib/src/types/auth/auth_types.dart
@@ -2,7 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Exceptions
-export '../exception/amplify_exception.dart';
+export '../exception/amplify_exception.dart'
+    show
+        AuthException,
+        InvalidStateException,
+        AuthNotAuthorizedException,
+        AuthServiceException,
+        SessionExpiredException,
+        SignedOutException,
+        UserCancelledException,
+        AuthValidationException,
+        NetworkException,
+        UnknownException;
 
 /// Attributes
 export 'attribute/auth_next_update_attribute_step.dart';

--- a/packages/amplify_core/lib/src/types/exception/amplify_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/amplify_exception.dart
@@ -4,6 +4,11 @@
 import 'package:amplify_core/amplify_core.dart';
 import 'package:meta/meta.dart';
 
+part 'analytics/analytics_exception.dart';
+part 'analytics/invalid_event_exception.dart';
+part 'api/api_exception.dart';
+part 'api/http_status_exception.dart';
+part 'api/operation_exception.dart';
 part 'auth/auth_exception.dart';
 part 'auth/invalid_state_exception.dart';
 part 'auth/not_authorized_exception.dart';
@@ -13,6 +18,13 @@ part 'auth/signed_out_exception.dart';
 part 'auth/user_cancelled_exception.dart';
 part 'auth/validation_exception.dart';
 part 'network_exception.dart';
+part 'push/push_notification_exception.dart';
+part 'storage/access_denied_exception.dart';
+part 'storage/http_status_exception.dart';
+part 'storage/key_not_found_exception.dart';
+part 'storage/local_file_not_found_exception.dart';
+part 'storage/operation_canceled_exception.dart';
+part 'storage/storage_exception.dart';
 part 'unknown_exception.dart';
 
 /// {@template amplify_core.amplify_exception}

--- a/packages/amplify_core/lib/src/types/exception/analytics/analytics_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/analytics/analytics_exception.dart
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
+part of '../amplify_exception.dart';
 
 /// Base Class for Analytics Exceptions.
-abstract class AnalyticsException extends AmplifyException {
+sealed class AnalyticsException extends AmplifyException {
   const AnalyticsException(
     super.message, {
     super.recoverySuggestion,

--- a/packages/amplify_core/lib/src/types/exception/analytics/invalid_event_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/analytics/invalid_event_exception.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
+part of '../amplify_exception.dart';
 
 /// {@template amplify_core.analytics.invalid_event_exception}
 /// Exception when event data is invalid and

--- a/packages/amplify_core/lib/src/types/exception/api/api_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/api/api_exception.dart
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
+part of '../amplify_exception.dart';
 
 /// {@template amplify_core.api.api_exception}
 /// Exception thrown from the API Category.
 /// {@endtemplate}
-abstract class ApiException extends AmplifyException {
+sealed class ApiException extends AmplifyException {
   /// {@macro api_exception}
   const ApiException(
     super.message, {

--- a/packages/amplify_core/lib/src/types/exception/api/http_status_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/api/http_status_exception.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
+part of '../amplify_exception.dart';
 
 @Deprecated('Use HttpStatusException instead')
 typedef RestException = HttpStatusException;

--- a/packages/amplify_core/lib/src/types/exception/api/operation_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/api/operation_exception.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/src/types/exception/api/api_exception.dart';
+part of '../amplify_exception.dart';
 
 /// {@template amplify_core.api.api_operation_error}
 /// An in-process operation encountered a processing error

--- a/packages/amplify_core/lib/src/types/exception/push/push_notification_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/push/push_notification_exception.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
+part of '../amplify_exception.dart';
 
 /// {@template amplify_core.push.push_notifications_exception}
 /// Base Class for Push Notification Exceptions

--- a/packages/amplify_core/lib/src/types/exception/storage/access_denied_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/storage/access_denied_exception.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
+part of '../amplify_exception.dart';
 
 /// {@template amplify_core.storage.access_denied_exception}
 /// Exception thrown when the service request receives access denied error.

--- a/packages/amplify_core/lib/src/types/exception/storage/http_status_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/storage/http_status_exception.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
+part of '../amplify_exception.dart';
 
 /// {@template amplify_core.storage.http_status_exception}
 /// Exception thrown when the service returned unsuccessful response.

--- a/packages/amplify_core/lib/src/types/exception/storage/key_not_found_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/storage/key_not_found_exception.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
+part of '../amplify_exception.dart';
 
 /// {@template amplify_core.storage.key_not_found_exception}
 /// Exception thrown when the key is not found in the storage service.

--- a/packages/amplify_core/lib/src/types/exception/storage/local_file_not_found_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/storage/local_file_not_found_exception.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
+part of '../amplify_exception.dart';
 
 /// {@template amplify_core.storage.local_file_not_found_exception}
 /// Exception thrown when a file in the local file system is not found.

--- a/packages/amplify_core/lib/src/types/exception/storage/operation_canceled_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/storage/operation_canceled_exception.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
+part of '../amplify_exception.dart';
 
 /// {@template amplify_core.storage.operation_canceled_exception}
 /// Exception thrown when a storage operation is canceled.

--- a/packages/amplify_core/lib/src/types/exception/storage/storage_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/storage/storage_exception.dart
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
+part of '../amplify_exception.dart';
 
 /// {@template amplify_core.storage.exception}
 /// The base class for Storage category exceptions.
 /// {@endtemplate}
-abstract class StorageException extends AmplifyException with AWSDebuggable {
+sealed class StorageException extends AmplifyException with AWSDebuggable {
   /// {@macro amplify_core.storage.exception}
   const StorageException(
     super.message, {

--- a/packages/amplify_core/lib/src/types/notifications/notification_types.dart
+++ b/packages/amplify_core/lib/src/types/notifications/notification_types.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export '../exception/push/push_notification_exception.dart';
+export '../exception/amplify_exception.dart' show PushNotificationException;
 export 'push/apns_platform_options.dart';
 export 'push/fcm_platform_options.dart';
 export 'push/on_remote_message_callback.dart';

--- a/packages/amplify_core/lib/src/types/storage/storage_types.dart
+++ b/packages/amplify_core/lib/src/types/storage/storage_types.dart
@@ -1,12 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export '../exception/storage/access_denied_exception.dart';
-export '../exception/storage/http_status_exception.dart';
-export '../exception/storage/key_not_found_exception.dart';
-export '../exception/storage/local_file_not_found_exception.dart';
-export '../exception/storage/operation_canceled_exception.dart';
-export '../exception/storage/storage_exception.dart';
+export '../exception/amplify_exception.dart'
+    show
+        StorageException,
+        StorageAccessDeniedException,
+        StorageHttpStatusException,
+        StorageKeyNotFoundException,
+        StorageLocalFileNotFoundException,
+        StorageOperationCanceledException,
+        NetworkException,
+        UnknownException;
 export 'access_level.dart';
 export 'copy_operation.dart';
 export 'copy_options.dart';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/workers/workers.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/workers/workers.dart
@@ -7,6 +7,7 @@
   SrpDevicePasswordVerifierWorker,
   ConfirmDeviceWorker,
 ])
+library;
 
 import 'package:amplify_auth_cognito_dart/src/flows/device/confirm_device_worker.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/srp/srp_device_password_verifier_worker.dart';

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/worker/workers.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/worker/workers.dart
@@ -4,7 +4,7 @@
 @WorkerHive([
   SecureStorageWorker,
 ])
-library amplify_secure_storage_dart.workers;
+library;
 
 import 'package:amplify_secure_storage_dart/src/worker/secure_storage_worker.dart';
 import 'package:worker_bee/worker_bee.dart';

--- a/packages/worker_bee/e2e/lib/no_workers.dart
+++ b/packages/worker_bee/e2e/lib/no_workers.dart
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 @WorkerHive([])
+library;
 
 import 'package:worker_bee/worker_bee.dart';

--- a/packages/worker_bee/e2e/lib/workers.dart
+++ b/packages/worker_bee/e2e/lib/workers.dart
@@ -8,6 +8,7 @@
   E2EWorkerNullResult,
   E2EWorkerThrows,
 ])
+library;
 
 import 'package:worker_bee/worker_bee.dart';
 


### PR DESCRIPTION
Makes all `AmplifyException` category subtypes sealed.
