### PR TITLE
chore: remove amplify_datastore_plugin_interface dependency

### DIFF
--- a/.github/workflows/amplify_api.yaml
+++ b/.github/workflows/amplify_api.yaml
@@ -13,8 +13,6 @@ on:
       - 'packages/amplify/amplify_flutter/pubspec.yaml'
       - 'packages/amplify_core/lib/**/*.dart'
       - 'packages/amplify_core/pubspec.yaml'
-      - 'packages/amplify_datastore_plugin_interface/lib/**/*.dart'
-      - 'packages/amplify_datastore_plugin_interface/pubspec.yaml'
       - 'packages/amplify_lints/lib/**/*.yaml'
       - 'packages/amplify_lints/pubspec.yaml'
       - 'packages/api/amplify_api/**/*.dart'

--- a/.github/workflows/amplify_auth_cognito.yaml
+++ b/.github/workflows/amplify_auth_cognito.yaml
@@ -13,8 +13,6 @@ on:
       - 'packages/amplify/amplify_flutter/pubspec.yaml'
       - 'packages/amplify_core/lib/**/*.dart'
       - 'packages/amplify_core/pubspec.yaml'
-      - 'packages/amplify_datastore_plugin_interface/lib/**/*.dart'
-      - 'packages/amplify_datastore_plugin_interface/pubspec.yaml'
       - 'packages/amplify_lints/lib/**/*.yaml'
       - 'packages/amplify_lints/pubspec.yaml'
       - 'packages/analytics/amplify_analytics_pinpoint/lib/**/*.dart'

--- a/.github/workflows/amplify_authenticator.yaml
+++ b/.github/workflows/amplify_authenticator.yaml
@@ -13,8 +13,6 @@ on:
       - 'packages/amplify/amplify_flutter/pubspec.yaml'
       - 'packages/amplify_core/lib/**/*.dart'
       - 'packages/amplify_core/pubspec.yaml'
-      - 'packages/amplify_datastore_plugin_interface/lib/**/*.dart'
-      - 'packages/amplify_datastore_plugin_interface/pubspec.yaml'
       - 'packages/amplify_lints/lib/**/*.yaml'
       - 'packages/amplify_lints/pubspec.yaml'
       - 'packages/analytics/amplify_analytics_pinpoint/lib/**/*.dart'

--- a/.github/workflows/amplify_flutter.yaml
+++ b/.github/workflows/amplify_flutter.yaml
@@ -15,8 +15,6 @@ on:
       - 'packages/amplify/amplify_flutter/test/**/*'
       - 'packages/amplify_core/lib/**/*.dart'
       - 'packages/amplify_core/pubspec.yaml'
-      - 'packages/amplify_datastore_plugin_interface/lib/**/*.dart'
-      - 'packages/amplify_datastore_plugin_interface/pubspec.yaml'
       - 'packages/amplify_lints/lib/**/*.yaml'
       - 'packages/amplify_lints/pubspec.yaml'
       - 'packages/aws_common/lib/**/*.dart'

--- a/.github/workflows/amplify_push_notifications_pinpoint.yaml
+++ b/.github/workflows/amplify_push_notifications_pinpoint.yaml
@@ -13,8 +13,6 @@ on:
       - 'packages/amplify/amplify_flutter/pubspec.yaml'
       - 'packages/amplify_core/lib/**/*.dart'
       - 'packages/amplify_core/pubspec.yaml'
-      - 'packages/amplify_datastore_plugin_interface/lib/**/*.dart'
-      - 'packages/amplify_datastore_plugin_interface/pubspec.yaml'
       - 'packages/amplify_lints/lib/**/*.yaml'
       - 'packages/amplify_lints/pubspec.yaml'
       - 'packages/analytics/amplify_analytics_pinpoint/lib/**/*.dart'

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -20,7 +20,6 @@ platforms:
 
 dependencies:
   amplify_core: ">=1.0.0 <1.1.0"
-  amplify_datastore_plugin_interface: ">=1.0.0 <1.1.0"
   amplify_secure_storage: ">=0.3.0+3 <0.4.0"
   aws_common: ">=0.4.2+4 <0.5.0"
   collection: ^1.15.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- remove amplify_datastore_plugin_interface dependency from amplify_flutter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
