### PR TITLE
fix: wait for addPlugin prior to configuration

### DIFF
--- a/packages/amplify/amplify_flutter/lib/src/hybrid_impl.dart
+++ b/packages/amplify/amplify_flutter/lib/src/hybrid_impl.dart
@@ -14,11 +14,15 @@ class AmplifyHybridImpl extends AmplifyClassImpl {
   /// {@macro amplify_flutter.amplify_hybrid_impl}
   AmplifyHybridImpl() : super.protected();
 
+  final _addPluginFutures = <Future<void>>[];
+
   @override
   Future<void> configurePlatform(String config) async {
     final amplifyConfig = AmplifyConfig.fromJson(
       (jsonDecode(config) as Map<Object?, Object?>).cast(),
     );
+    await Future.wait(_addPluginFutures);
+    _addPluginFutures.clear();
     await Future.wait(
       [
         ...API.plugins,
@@ -38,7 +42,13 @@ class AmplifyHybridImpl extends AmplifyClassImpl {
   }
 
   @override
-  Future<void> addPlugin(AmplifyPluginInterface plugin) async {
+  Future<void> addPlugin(AmplifyPluginInterface plugin) {
+    final future = _addPlugin(plugin);
+    _addPluginFutures.add(future);
+    return future;
+  }
+
+  Future<void> _addPlugin(AmplifyPluginInterface plugin) async {
     if (isConfigured) {
       throw const AmplifyAlreadyConfiguredException(
         'Amplify has already been configured and adding plugins after configure is not supported.',

--- a/packages/amplify_core/lib/src/amplify_class_impl.dart
+++ b/packages/amplify_core/lib/src/amplify_class_impl.dart
@@ -21,8 +21,16 @@ class AmplifyClassImpl extends AmplifyClass {
   final AmplifyAuthProviderRepository authProviderRepo =
       AmplifyAuthProviderRepository();
 
+  final _addPluginFutures = <Future<void>>[];
+
   @override
   Future<void> addPlugin(AmplifyPluginInterface plugin) {
+    final future = _addPlugin(plugin);
+    _addPluginFutures.add(future);
+    return future;
+  }
+
+  Future<void> _addPlugin(AmplifyPluginInterface plugin) {
     switch (plugin.category) {
       case Category.analytics:
         return Analytics.addPlugin(
@@ -64,6 +72,8 @@ class AmplifyClassImpl extends AmplifyClass {
     final amplifyConfig = AmplifyConfig.fromJson(
       (jsonDecode(config) as Map<Object?, Object?>).cast(),
     );
+    await Future.wait(_addPluginFutures);
+    _addPluginFutures.clear();
     await Future.wait(
       [
         ...Analytics.plugins,
@@ -83,6 +93,7 @@ class AmplifyClassImpl extends AmplifyClass {
 
   @override
   Future<void> reset() async {
+    _addPluginFutures.clear();
     await Future.wait([
       Analytics.reset(),
       API.reset(),


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/2987

*Description of changes:*
- wait for `.addPlugin()` calls to complete prior to configuring plugins

While user should await calls to addPlugins, we should gracefully handle the scenario where they do not. Currently if the .addPlugin() call is not awaited, the plugin does not get configured because the plugin has not been added at the time of configuration. However, the plugin later does get added and Amplify does successfully configure (but without the plugin). This is a weird state that we shouldn't let users get into.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
