### PR TITLE
chore(analytics): Bump package_info_plus to ^4.0.0

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  package_info_plus: ^3.0.2
+  package_info_plus: ^4.0.0
   path_provider: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Major version because of

Android Gradle Plugin (AGP) 8 update drops support for AGP < 4.2
and also updated min Android to 4.4 (API 19) and iOS to 11.
https://pub.dev/packages/package_info_plus/changelog#400

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
