### PR TITLE
Revert "fix(android): Bump Amplify Android to 2.8.3 (#3023)"

### DIFF
--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -72,10 +72,10 @@ dependencies {
     // Support for Java 8 features
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
-    implementation 'com.amplifyframework:aws-auth-cognito:2.8.3'
-    implementation 'com.amplifyframework:aws-api:2.8.3'
-    implementation 'com.amplifyframework:aws-datastore:2.8.3'
-    implementation 'com.amplifyframework:aws-api-appsync:2.8.3'
+    implementation 'com.amplifyframework:aws-auth-cognito:2.4.1'
+    implementation "com.amplifyframework:aws-api:2.4.1"
+    implementation "com.amplifyframework:aws-datastore:2.4.1"
+    implementation "com.amplifyframework:aws-api-appsync:2.4.1"
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
 

--- a/packages/notifications/push/amplify_push_notifications/android/build.gradle
+++ b/packages/notifications/push/amplify_push_notifications/android/build.gradle
@@ -65,7 +65,7 @@ android {
 dependencies {
     api "com.google.firebase:firebase-messaging:23.1.0"
     // Import support library for Amplify push utils
-    implementation 'com.amplifyframework:aws-push-notifications-pinpoint-common:2.8.3'
+    implementation 'com.amplifyframework:aws-push-notifications-pinpoint-common:2.5.0'
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
     implementation project(path: ':flutter_plugin_android_lifecycle')
     implementation 'androidx.test:core-ktx:1.5.0'


### PR DESCRIPTION
This reverts commit 8ab7f12cf7695103b57d4f473ff7782c5a2a712c.

*Issue #, if available:*

*Description of changes:*
reverting because some android integration tests fails after this change. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
