### PR TITLE
ci: Use Dart 3.0.1/Flutter 3.10.1

### DIFF
--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -22,7 +22,7 @@ jobs:
           - "any" # latest
         include:
           - channel: "stable"
-            flutter-version: "3.10.0"
+            flutter-version: "3.10.1"
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
         with:
@@ -62,7 +62,7 @@ jobs:
           - "any" # latest
         include:
           - channel: "stable"
-            flutter-version: "3.10.0"
+            flutter-version: "3.10.1"
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
         with:
@@ -112,7 +112,7 @@ jobs:
           - "any" # latest
         include:
           - channel: "stable"
-            flutter-version: "3.10.0"
+            flutter-version: "3.10.1"
         ios-version:
           - "13.7"
           - "16"

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         sdk:
           # Minimum supported Dart version
-          - "3.0.0"
+          - "3.0.1"
           - stable
           - beta
         browser:

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         sdk:
           # Minimum supported Dart version
-          - "3.0.0"
+          - "3.0.1"
           - stable
           - beta
         browser:

--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         sdk:
           # Minimum supported Dart version
-          - "3.0.0"
+          - "3.0.1"
           - stable
           - beta
     steps:

--- a/.github/workflows/flutter_vm.yaml
+++ b/.github/workflows/flutter_vm.yaml
@@ -23,7 +23,7 @@ jobs:
           - "any" # latest
         include:
           - channel: "stable"
-            flutter-version: "3.10.0"
+            flutter-version: "3.10.1"
     steps:
       - name: Git Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0

--- a/packages/amplify_core/lib/src/types/models/model_association.dart
+++ b/packages/amplify_core/lib/src/types/models/model_association.dart
@@ -15,8 +15,10 @@ class ModelAssociation with AWSEquatable<ModelAssociation>, AWSSerializable {
 
   const ModelAssociation({
     required this.associationType,
-    @Deprecated('Please use the latest version of Amplify CLI to regenerate models')
-        this.targetName,
+    @Deprecated(
+      'Please use the latest version of Amplify CLI to regenerate models',
+    )
+    this.targetName,
     this.targetNames,
     this.associatedName,
     this.associatedType,

--- a/packages/amplify_core/lib/src/types/models/model_field_definition.dart
+++ b/packages/amplify_core/lib/src/types/models/model_field_definition.dart
@@ -147,8 +147,10 @@ class ModelFieldDefinition {
     bool isRequired = true,
     required String ofModelName,
     QueryField<Object?>? associatedKey,
-    @Deprecated('Please use the latest version of Amplify CLI to regenerate models')
-        String? targetName,
+    @Deprecated(
+      'Please use the latest version of Amplify CLI to regenerate models',
+    )
+    String? targetName,
     List<String>? targetNames,
   }) {
     // Extra code needed due to lack of nullability support

--- a/packages/api/amplify_api/example/pubspec.yaml
+++ b/packages/api/amplify_api/example/pubspec.yaml
@@ -20,12 +20,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-# Needed to support both Flutter 3.3 + 3.7 in CI.
-# TODO(dnys1): Remove when Flutter 3.3 is no longer supported
-dependency_overrides:
-  async: ^2.9.0
-  test_api: any
-
 dev_dependencies:
   amplify_integration_test: any
   amplify_lints:


### PR DESCRIPTION
One of our dependencies `code_excerpter` bumped its min SDK to 3.0.1. We could just pin to an older version, but bumping CI maintains the same contract IMO.