### PR TITLE
fix: suppress browser on sign out when preferPrivateSession is true

### DIFF
--- a/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_flutter.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/flows/hosted_ui/hosted_ui_platform_flutter.dart
@@ -123,6 +123,9 @@ class HostedUiPlatformImpl extends io.HostedUiPlatformImpl {
     if (!_isMobile) {
       return super.signOut(options: options);
     }
+    // Launching the sign out url is not needed on iOS if isPreferPrivateSession
+    // is true.
+    if (Platform.isIOS && options.isPreferPrivateSession) return;
     final signOutUri = getSignOutUri();
     await _nativeAuthBridge.signOutWithUrl(
       signOutUri.toString(),


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/3089

*Description of changes:*
- Do not show launch sign out URL on iOS when `preferPrivateSession` is true.

When `preferPrivateSession` is true, nothing needs to be cleared from the browser on sign out so there is no need to launch the browser. This behavior matches amplify-swift which can be seen [here](https://github.com/aws-amplify/amplify-swift/blob/f0bc8dfc0060f69bb081126ba751a087918e1194/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignOut/InitiateSignOut.swift#LL23C1-L23C1).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
