### PR TITLE
chore(api): material 3 example app overflow fix

### DIFF
--- a/packages/api/amplify_api/example/lib/util/util.dart
+++ b/packages/api/amplify_api/example/lib/util/util.dart
@@ -43,7 +43,13 @@ Widget apiButton({
     onPressed: Amplify.isConfigured ? onPressed : null,
     style: ElevatedButton.styleFrom(
       backgroundColor: btnColor,
+      padding: const EdgeInsets.fromLTRB(15, 5, 15, 5),
     ),
-    child: Text(text),
+    child: Text(
+      text,
+      style: TextStyle(
+        color: onPressed != null ? Colors.white : Colors.black45,
+      ),
+    ),
   );
 }

--- a/packages/api/amplify_api/example/lib/widgets/create.dart
+++ b/packages/api/amplify_api/example/lib/widgets/create.dart
@@ -88,8 +88,10 @@ class GraphQLCreateExamples extends StatelessWidget {
           'Create',
           textAlign: TextAlign.left,
         ),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        Wrap(
+          alignment: WrapAlignment.spaceBetween,
+          spacing: 12,
+          runSpacing: 12,
           children: [
             apiButton(
               onPressed: createBlog,

--- a/packages/api/amplify_api/example/lib/widgets/query.dart
+++ b/packages/api/amplify_api/example/lib/widgets/query.dart
@@ -96,8 +96,10 @@ class GraphQLQueryExamples extends StatelessWidget {
           'List',
           textAlign: TextAlign.left,
         ),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        Wrap(
+          alignment: WrapAlignment.spaceBetween,
+          spacing: 12,
+          runSpacing: 12,
           children: [
             apiButton(
               onPressed: queryBlogs,

--- a/packages/api/amplify_api/example/lib/widgets/subscribe.dart
+++ b/packages/api/amplify_api/example/lib/widgets/subscribe.dart
@@ -102,8 +102,10 @@ class GraphQLSubscriptionsExamples extends StatelessWidget {
           'Subscriptions',
           textAlign: TextAlign.left,
         ),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        Wrap(
+          alignment: WrapAlignment.spaceBetween,
+          spacing: 12,
+          runSpacing: 12,
           children: [
             apiButton(
               onPressed: subscription == null ? subscribe : null,


### PR DESCRIPTION
*Description of changes:*
Fixes an overflow caused by the default button size increasing. Also adjusts the button text colors so they are more readable.

Before:
![image](https://github.com/aws-amplify/amplify-flutter/assets/6456935/45b46f08-f06f-4959-be4a-44a359a9f6cb)


After:
![Screenshot 2023-05-25 at 2 33 11 PM](https://github.com/aws-amplify/amplify-flutter/assets/6456935/07d24350-a8bf-466f-8d18-eb72a10ca719)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
