### PR TITLE
fix(secure_storage): Fallback for CFStringRef decoding

### DIFF
--- a/packages/secure_storage/amplify_secure_storage_dart/ffigen.cupertino.coreFoundation.config.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/ffigen.cupertino.coreFoundation.config.yaml
@@ -1,26 +1,29 @@
 # ffigen config for Apple's CoreFoundation Framework.
 # To regenerate, run: `make ffi_bindings_macos`
-# 
+#
 # This should be run on a Mac with XCode installed.
 #
 # NOTE: You may need to update the path to the `/Frameworks/` directory depending
 # which SDK versions you have installed
 
-output: 'lib/src/ffi/cupertino/core_foundation.bindings.g.dart'
-name: 'CoreFoundation'
-description: 'Bindings for the CoreFoundation Framework'
+output: "lib/src/ffi/cupertino/core_foundation.bindings.g.dart"
+name: "CoreFoundation"
+description: "Bindings for the CoreFoundation Framework"
 headers:
   entry-points:
-    - '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFDictionary.h'
-    - '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFString.h'
-    - '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFData.h'
+    - "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFDictionary.h"
+    - "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFString.h"
+    - "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFData.h"
 compiler-opts:
-  - '-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks'
+  - "-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks"
 functions:
   include:
     - CFDictionaryCreate
     - CFDataCreate
     - CFStringGetCStringPtr
+    - CFStringGetCString
+    - CFStringGetLength
+    - CFStringGetMaximumSizeForEncoding
     - CFStringCreateWithCString
     - CFDataGetBytePtr
     - CFRelease
@@ -28,10 +31,10 @@ structs:
   include:
     - NONE
   rename:
-    '__CFString': 'CFString'
-    '__CFType': 'CFType'
-    '__CFData': 'CFData'
-    '__CFDictionary': 'CFDictionary'
+    "__CFString": "CFString"
+    "__CFType": "CFType"
+    "__CFData": "CFData"
+    "__CFDictionary": "CFDictionary"
 enums:
   include:
     - NONE
@@ -49,5 +52,4 @@ unnamed-enums:
     - kCFStringEncodingUTF8
 comments: false
 preamble: |
-    // ignore_for_file: camel_case_types, non_constant_identifier_names, require_trailing_commas, sort_constructors_first
-
+  // ignore_for_file: camel_case_types, non_constant_identifier_names, require_trailing_commas, sort_constructors_first

--- a/packages/secure_storage/amplify_secure_storage_dart/ffigen.cupertino.security.config.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/ffigen.cupertino.security.config.yaml
@@ -62,6 +62,7 @@ unnamed-enums:
     - errSecAuthFailed
     - errSecInteractionRequired
     - errSecMissingEntitlement
+    - errSecInvalidOwnerEdit
 comments: false
 library-imports:
   coreFoundation: "./core_foundation.bindings.g.dart"
@@ -96,4 +97,4 @@ type-map:
       "c-type": "CFDictionaryRef"
       "dart-type": "CFDictionaryRef"
 preamble: |
-    // ignore_for_file: camel_case_types, non_constant_identifier_names, require_trailing_commas, sort_constructors_first
+  // ignore_for_file: camel_case_types, non_constant_identifier_names, require_trailing_commas, sort_constructors_first

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/cupertino/core_foundation.bindings.g.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/cupertino/core_foundation.bindings.g.dart
@@ -123,11 +123,46 @@ class CoreFoundation {
       _CFStringCreateWithCStringPtr.asFunction<
           CFStringRef Function(CFAllocatorRef, ffi.Pointer<ffi.Char>, int)>();
 
+  int CFStringGetLength(
+    CFStringRef theString,
+  ) {
+    return _CFStringGetLength(
+      theString,
+    );
+  }
+
+  late final _CFStringGetLengthPtr =
+      _lookup<ffi.NativeFunction<CFIndex Function(CFStringRef)>>(
+          'CFStringGetLength');
+  late final _CFStringGetLength =
+      _CFStringGetLengthPtr.asFunction<int Function(CFStringRef)>();
+
+  int CFStringGetCString(
+    CFStringRef theString,
+    ffi.Pointer<ffi.Char> buffer,
+    int bufferSize,
+    int encoding,
+  ) {
+    return _CFStringGetCString(
+      theString,
+      buffer,
+      bufferSize,
+      encoding,
+    );
+  }
+
+  late final _CFStringGetCStringPtr = _lookup<
+      ffi.NativeFunction<
+          Boolean Function(CFStringRef, ffi.Pointer<ffi.Char>, CFIndex,
+              CFStringEncoding)>>('CFStringGetCString');
+  late final _CFStringGetCString = _CFStringGetCStringPtr.asFunction<
+      int Function(CFStringRef, ffi.Pointer<ffi.Char>, int, int)>();
+
   ffi.Pointer<ffi.Char> CFStringGetCStringPtr(
     CFStringRef theString,
     int encoding,
   ) {
-    return _CFStringGetCStringPtr(
+    return _CFStringGetCStringPtr1(
       theString,
       encoding,
     );
@@ -137,8 +172,25 @@ class CoreFoundation {
       ffi.NativeFunction<
           ffi.Pointer<ffi.Char> Function(
               CFStringRef, CFStringEncoding)>>('CFStringGetCStringPtr');
-  late final _CFStringGetCStringPtr = _CFStringGetCStringPtrPtr.asFunction<
+  late final _CFStringGetCStringPtr1 = _CFStringGetCStringPtrPtr.asFunction<
       ffi.Pointer<ffi.Char> Function(CFStringRef, int)>();
+
+  int CFStringGetMaximumSizeForEncoding(
+    int length,
+    int encoding,
+  ) {
+    return _CFStringGetMaximumSizeForEncoding(
+      length,
+      encoding,
+    );
+  }
+
+  late final _CFStringGetMaximumSizeForEncodingPtr =
+      _lookup<ffi.NativeFunction<CFIndex Function(CFIndex, CFStringEncoding)>>(
+          'CFStringGetMaximumSizeForEncoding');
+  late final _CFStringGetMaximumSizeForEncoding =
+      _CFStringGetMaximumSizeForEncodingPtr.asFunction<
+          int Function(int, int)>();
 }
 
 typedef CFTypeRef = ffi.Pointer<ffi.Void>;

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/cupertino/security.bindings.g.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/cupertino/security.bindings.g.dart
@@ -293,3 +293,5 @@ const int errSecDuplicateItem = -25299;
 const int errSecItemNotFound = -25300;
 
 const int errSecInteractionRequired = -25315;
+
+const int errSecInvalidOwnerEdit = -25244;

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_cupertino.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_cupertino.dart
@@ -14,6 +14,7 @@ import 'package:amplify_secure_storage_dart/src/exception/secure_storage_excepti
 import 'package:amplify_secure_storage_dart/src/exception/unknown_exception.dart';
 import 'package:amplify_secure_storage_dart/src/ffi/cupertino/cupertino.dart';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 
 /// {@template amplify_secure_storage_dart.amplify_secure_storage_cupertino}
 /// The implementation of [SecureStorageInterface] for iOS and MacOS.
@@ -313,29 +314,30 @@ class AmplifySecureStorageCupertino extends AmplifySecureStorageInterface {
 
   /// Maps the result code to a [SecureStorageException].
   SecureStorageException _getExceptionFromResultCode(int code) {
-    final securityFrameworkError = _SecurityFrameworkError.fromCode(code);
+    final securityFrameworkError = SecurityFrameworkError.fromCode(code);
     return securityFrameworkError.toSecureStorageException();
   }
 }
 
 /// An error from the Security Framework.
-class _SecurityFrameworkError {
-  _SecurityFrameworkError({required this.code, required this.message});
+@visibleForTesting
+class SecurityFrameworkError {
+  SecurityFrameworkError({required this.code, required this.message});
 
   /// Creates an error from the given result code.
-  factory _SecurityFrameworkError.fromCode(int code) {
+  factory SecurityFrameworkError.fromCode(int code) {
     final cfString = security.SecCopyErrorMessageString(code, nullptr);
     if (cfString == nullptr) {
-      return _SecurityFrameworkError(
+      return SecurityFrameworkError(
         code: code,
         message: _noErrorStringMessage,
       );
     }
     try {
       final message = cfString.toDartString() ?? _noErrorStringMessage;
-      return _SecurityFrameworkError(code: code, message: message);
+      return SecurityFrameworkError(code: code, message: message);
     } on Exception {
-      return _SecurityFrameworkError(
+      return SecurityFrameworkError(
         code: code,
         message: 'The error string could not be parsed.',
       );

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
@@ -40,7 +40,7 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   built_value_generator: 8.5.0
-  ffigen: ^8.0.0-0
+  ffigen: ^8.0.0
   test: ^1.22.1
   worker_bee_builder: ">=0.2.0 <0.3.0"
 

--- a/packages/secure_storage/amplify_secure_storage_test/test/mac_os_test.dart
+++ b/packages/secure_storage/amplify_secure_storage_test/test/mac_os_test.dart
@@ -5,6 +5,7 @@
 
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 import 'package:amplify_secure_storage_dart/src/platforms/amplify_secure_storage_cupertino.dart';
+import 'package:amplify_secure_storage_dart/src/ffi/cupertino/security.bindings.g.dart';
 import 'package:test/test.dart';
 
 const key1 = 'key_1';
@@ -80,5 +81,20 @@ void main() {
         expect(() => storage.removeAll(), returnsNormally);
       },
     );
+  });
+
+  group('SecurityError', () {
+    test('errSecInvalidOwnerEdit', () {
+      final error = SecurityFrameworkError.fromCode(errSecInvalidOwnerEdit);
+      expect(
+        error.message,
+        'Invalid attempt to change the owner of this item.',
+      );
+    });
+
+    test('invalid code', () {
+      final error = SecurityFrameworkError.fromCode(1 >> 10);
+      expect(error.message, 'No error.');
+    });
   });
 }

--- a/packages/secure_storage/amplify_secure_storage_test/test/mac_os_test.dart
+++ b/packages/secure_storage/amplify_secure_storage_test/test/mac_os_test.dart
@@ -92,9 +92,15 @@ void main() {
       );
     });
 
-    test('invalid code', () {
-      final error = SecurityFrameworkError.fromCode(1 >> 10);
+    test('no error', () {
+      final error = SecurityFrameworkError.fromCode(0);
       expect(error.message, 'No error.');
+    });
+
+    test('invalid code', () {
+      const invalidCode = 1 << 20;
+      final error = SecurityFrameworkError.fromCode(invalidCode);
+      expect(error.message, 'OSStatus $invalidCode');
     });
   });
 }


### PR DESCRIPTION
In the Apple [docs](https://developer.apple.com/documentation/corefoundation/1542133-cfstringgetcstringptr), they suggest using `CFStringGetCString` as a fallback for `CFStringGetCStringPtr` which is failing in some instances.
