### PR TITLE
fix(auth): remove duplicate continuation call for hosted UI

### DIFF
--- a/packages/auth/amplify_auth_cognito/darwin/Classes/HostedUIFlow.swift
+++ b/packages/auth/amplify_auth_cognito/darwin/Classes/HostedUIFlow.swift
@@ -20,27 +20,24 @@ class HostedUIFlow: NSObject, ASWebAuthenticationPresentationContextProviding {
         guard let uri = URL(string: url) else {
             throw HostedUIError.unknown("Invalid URL: \(url)")
         }
-        return try await withCheckedThrowingContinuation { continutation in
+        return try await withCheckedThrowingContinuation { continuation in
             let session = ASWebAuthenticationSession(url: uri, callbackURLScheme: callbackURLScheme) {
                 callbackURL, error in
                 if let error = error {
-                    continutation.resume(throwing: HostedUIError.fromError(error))
+                    continuation.resume(throwing: HostedUIError.fromError(error))
                     return
                 }
                 guard let callbackURL = callbackURL else {
-                    continutation.resume(throwing: HostedUIError.unknown("Nil callback URL"))
+                    continuation.resume(throwing: HostedUIError.unknown("Nil callback URL"))
                     return
                 }
                 let queryParameters = HostedUIFlow.processParameters(callbackURL)
-                continutation.resume(returning: queryParameters)
+                continuation.resume(returning: queryParameters)
             }
 
             session.presentationContextProvider = self
             session.prefersEphemeralWebBrowserSession = preferPrivateSession
-            guard session.start() else {
-                continutation.resume(throwing: HostedUIError.unknown("Could not start ASWebAuthenticationSession"))
-                return
-            }
+            session.start()
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/3089

*Description of changes:*
- remove unnecessary guard for `session.start()`

While there is no apple documentation stating this, it seems that the completion handler passed into ASWebAuthenticationSession will always be called upon start, which means that handling the case that start returns false is not needed. The removes the possibility of the continuation being resumed multiple times, which will cause the app to crash when in release mode.

This is consistent with Amplify-Swift as can be seen [here](https://github.com/aws-amplify/amplify-swift/blob/758119b568aff5215997217909c68988326d7582/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIASWebAuthenticationSession.swift#L47).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
