### PR TITLE
chore(deps): Allow `http: ^1.0.0`

### DIFF
--- a/aft.yaml
+++ b/aft.yaml
@@ -18,6 +18,7 @@ dependencies:
   flutter_plugin_android_lifecycle: ^2.0.9
   json_annotation: ">=4.8.1 <4.9.0"
   json_serializable: 6.7.0
+  http: ">=0.13.6 <2.0.0"
   intl: ">=0.18.0 <1.0.0"
   mime: ^1.0.0
   package_info_plus: ^4.0.1

--- a/packages/aft/pubspec.yaml
+++ b/packages/aft/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   git: ^2.0.0
   glob: ^2.1.0
   graphs: ^2.1.0
-  http: ^0.13.0
+  http: ">=0.13.6 <2.0.0"
   json_annotation: ">=4.8.1 <4.9.0"
   libgit2dart:
     path: external/libgit2dart

--- a/packages/auth/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec.yaml
@@ -38,7 +38,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  http: ^0.13.5
+  http: ">=0.13.6 <2.0.0"
   integration_test:
     sdk: flutter
   io: ^1.0.0

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   convert: ^3.0.1
   crypto: ^3.0.1
   fixnum: ^1.0.0
-  http: ^0.13.4
+  http: ">=0.13.6 <2.0.0"
   intl: ">=0.18.0 <1.0.0"
   js: ^0.6.4
   json_annotation: ">=4.8.1 <4.9.0"

--- a/packages/auth/amplify_auth_cognito_test/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_test/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   built_value: ">=8.5.0 <8.6.0"
   collection: ^1.15.0
   convert: ^3.0.0
-  http: ^0.13.0
+  http: ">=0.13.6 <2.0.0"
   io: ^1.0.0
   json_rpc_2: ^3.0.0
   shelf: ^1.4.0

--- a/packages/storage/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/example/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  http: ^0.13.0
+  http: ">=0.13.6 <2.0.0"
   integration_test:
     sdk: flutter
   path: any


### PR DESCRIPTION
Ideally, we could just remove this dependency but it is required by `package:oauth2` and is needed for testing still.