### PR TITLE
chore(auth): Remove `package:oauth2` dependency

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/integration_test/native_auth_bridge_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/native_auth_bridge_test.dart
@@ -12,9 +12,8 @@ import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_auth_cognito_test/amplify_auth_cognito_test.dart';
 import 'package:amplify_auth_integration_test/amplify_auth_integration_test.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
+import 'package:aws_common/testing.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:http/http.dart' as http;
-import 'package:http/testing.dart';
 
 import 'test_runner.dart';
 
@@ -34,8 +33,8 @@ void main() {
         dependencyManager = DependencyManager()
           ..addInstance<CognitoOAuthConfig>(hostedUiConfig)
           ..addInstance<SecureStorageInterface>(MockSecureStorage())
-          ..addInstance<http.Client>(
-            MockClient((request) {
+          ..addInstance<AWSHttpClient>(
+            MockAWSHttpClient((request, isCancelled) {
               throw UnimplementedError();
             }),
           );

--- a/packages/auth/amplify_auth_cognito/example/integration_test/native_auth_bridge_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/native_auth_bridge_test.dart
@@ -43,7 +43,7 @@ void main() {
 
       asyncTest('signInWithUrl', (_) async {
         const options = CognitoSignInWithWebUIPluginOptions(
-          isPreferPrivateSession: true,
+          isPreferPrivateSession: false,
           browserPackageName: browserPackage,
         );
         dependencyManager
@@ -57,7 +57,7 @@ void main() {
               ) async {
                 expect(argUrl, contains(hostedUiConfig.webDomain));
                 expect(argCallbackurlscheme, testUrlScheme);
-                expect(argPreferprivatesession, isTrue);
+                expect(argPreferprivatesession, isFalse);
                 expect(argBrowserpackagename, browserPackage);
                 return {'code': 'code', 'state': 'state'};
               }),
@@ -71,7 +71,7 @@ void main() {
 
       asyncTest('signOutWithUrl', (_) async {
         const options = CognitoSignInWithWebUIPluginOptions(
-          isPreferPrivateSession: true,
+          isPreferPrivateSession: false,
           browserPackageName: browserPackage,
         );
         dependencyManager
@@ -85,7 +85,7 @@ void main() {
               ) async {
                 expect(argUrl, contains(hostedUiConfig.webDomain));
                 expect(argCallbackurlscheme, testUrlScheme);
-                expect(argPreferprivatesession, isTrue);
+                expect(argPreferprivatesession, isFalse);
                 expect(argBrowserpackagename, browserPackage);
               }),
             ),

--- a/packages/auth/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec.yaml
@@ -31,6 +31,7 @@ dev_dependencies:
   amplify_lints:
     path: ../../../amplify_lints
   async: ^2.10.0
+  aws_common: any
   aws_signature_v4: any
   checks: ^0.2.0
   collection: any
@@ -38,7 +39,6 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  http: ^0.13.5
   integration_test:
     sdk: flutter
   io: ^1.0.0

--- a/packages/auth/amplify_auth_cognito_dart/analysis_options.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/analysis_options.yaml
@@ -2,5 +2,5 @@ include: package:amplify_lints/library.yaml
 
 analyzer:
   exclude:
-    - '**/*.g.dart'
+    - "**/*.g.dart"
     - lib/src/sdk/src/**

--- a/packages/auth/amplify_auth_cognito_dart/example/analysis_options.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/example/analysis_options.yaml
@@ -2,4 +2,5 @@ include: package:amplify_lints/app.yaml
 
 analyzer:
   exclude:
+    - build
     - lib/**/*.g.dart

--- a/packages/auth/amplify_auth_cognito_dart/example/integration_test/hosted_ui_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/integration_test/hosted_ui_test.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:amplify_api_dart/amplify_api_dart.dart';
 import 'package:amplify_auth_cognito_test/amplify_auth_cognito_test.dart';
 import 'package:amplify_auth_cognito_test/hosted_ui/hosted_ui_client.dart';
 import 'package:amplify_auth_cognito_test/hosted_ui/hosted_ui_common.dart';
@@ -55,6 +56,7 @@ void main() {
           application = await runApp();
           addTearDown(application.close);
 
+          await Amplify.addPlugin(AmplifyAPIDart());
           await Amplify.configure(jsonEncode(config));
           addTearDown(Amplify.reset);
 

--- a/packages/auth/amplify_auth_cognito_dart/example/lib/common.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/lib/common.dart
@@ -4,6 +4,8 @@
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 // ignore: implementation_imports
 import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/hosted_ui_platform.dart';
+import 'package:amplify_auth_cognito_test/amplify_auth_cognito_test.dart'
+    show webDatabaseName;
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
 
@@ -18,9 +20,15 @@ Future<void> configure({
   }
   await Amplify.addPlugin(
     AmplifyAuthCognitoDart(
-      secureStorageFactory: AmplifySecureStorageWorker.factoryFrom(
-        // ignore: invalid_use_of_visible_for_testing_member
-        macOSOptions: MacOSSecureStorageOptions(useDataProtection: false),
+      // ignore: invalid_use_of_visible_for_testing_member, invalid_use_of_internal_member
+      secureStorageFactory: (scope) => AmplifySecureStorageWorker(
+        config: AmplifySecureStorageConfig.byNamespace(
+          namespace: webDatabaseName,
+        ).rebuild((config) {
+          // enabling useDataProtection requires adding the app to an
+          // app group, which requires setting a development team
+          config.macOSOptions.useDataProtection = false;
+        }),
       ),
       hostedUiPlatformFactory: hostedUiPlatformFactory,
     ),

--- a/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   amplify_auth_cognito_dart: any
+  amplify_auth_cognito_test: any
   amplify_core: any
   amplify_secure_storage_dart: any
   example_common:
@@ -15,7 +16,6 @@ dependencies:
 
 dev_dependencies:
   amplify_api_dart: any
-  amplify_auth_cognito_test: any
   amplify_integration_test: any
   amplify_lints:
     path: ../../../amplify_lints
@@ -29,4 +29,5 @@ dev_dependencies:
   path: ^1.8.0
   shelf: ^1.4.0
   test: ^1.22.1
+  webdev: ^3.0.4
   webdriver: ^3.0.0

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/crypto/oauth.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/crypto/oauth.dart
@@ -40,5 +40,7 @@ String createCodeVerifier() {
 /// Creates a `Basic` authorization header for identifiying clients.
 String createBasicAuthorization(String clientId, [String? clientSecret]) {
   clientSecret ??= '';
-  return 'Basic ${base64Encode('$clientId:$clientSecret'.codeUnits)}';
+  final userPass =
+      '${Uri.encodeFull(clientId)}:${Uri.encodeFull(clientSecret)}';
+  return 'Basic ${base64Encode(ascii.encode(userPass))}';
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/LICENSE
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2014, the Dart project authors. 
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/README.md
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/README.md
@@ -1,0 +1,3 @@
+# OAuth2 Utilities
+
+Modified version of [package:oauth2](https://github.com/dart-lang/oauth2).

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/authorization_code_grant.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/authorization_code_grant.dart
@@ -1,0 +1,353 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:amplify_auth_cognito_dart/src/crypto/oauth.dart';
+import 'package:amplify_auth_cognito_dart/src/model/session/cognito_user_pool_tokens.dart';
+import 'package:amplify_auth_cognito_dart/src/oauth/authorization_exception.dart';
+import 'package:amplify_auth_cognito_dart/src/oauth/handle_access_token_response.dart';
+import 'package:amplify_auth_cognito_dart/src/oauth/parameters.dart';
+import 'package:amplify_auth_cognito_dart/src/oauth/utils.dart';
+import 'package:aws_common/aws_common.dart';
+import 'package:crypto/crypto.dart';
+import 'package:http_parser/http_parser.dart';
+
+/// A class for obtaining credentials via an [authorization code grant][].
+///
+/// This method of authorization involves sending the resource owner to the
+/// authorization server where they will authorize the client. They're then
+/// redirected back to your server, along with an authorization code. This is
+/// used to obtain [CognitoUserPoolTokens].
+///
+/// To use this class, you must first call [getAuthorizationUrl] to get the URL
+/// to which to redirect the resource owner. Then once they've been redirected
+/// back to your application, call [handleAuthorizationResponse] or
+/// [handleAuthorizationCode] to process the authorization server's response.
+///
+/// [authorization code grant]: http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.1
+class AuthorizationCodeGrant {
+  /// Creates a new grant.
+  ///
+  /// If [basicAuth] is `true` (the default), the client credentials are sent to
+  /// the server using using HTTP Basic authentication as defined in [RFC 2617].
+  /// Otherwise, they're included in the request body. Note that the latter form
+  /// is not recommended by the OAuth 2.0 spec, and should only be used if the
+  /// server doesn't support Basic authentication.
+  ///
+  /// [RFC 2617]: https://tools.ietf.org/html/rfc2617
+  ///
+  /// [httpClient] is used for all HTTP requests made by this grant.
+  ///
+  /// [codeVerifier] String to be used as PKCE code verifier. If none is
+  /// provided a random codeVerifier will be generated.
+  /// The codeVerifier must meet requirements specified in [RFC 7636].
+  ///
+  /// [RFC 7636]: https://tools.ietf.org/html/rfc7636#section-4.1
+  ///
+  /// The scope strings will be separated by the provided [delimiter]. This
+  /// defaults to `" "`, the OAuth2 standard, but some APIs (such as Facebook's)
+  /// use non-standard delimiters.
+  ///
+  /// By default, this follows the OAuth2 spec and requires the server's
+  /// responses to be in JSON format. However, some servers return non-standard
+  /// response formats, which can be parsed using the [getParameters] function.
+  ///
+  /// This function is passed the `Content-Type` header of the response as well
+  /// as its body as a UTF-8-decoded string. It should return a map in the same
+  /// format as the [standard JSON response][].
+  ///
+  /// [standard JSON response]: https://tools.ietf.org/html/rfc6749#section-5.1
+  AuthorizationCodeGrant(
+    this.identifier,
+    this.authorizationEndpoint,
+    this.tokenEndpoint, {
+    this.secret,
+    String? delimiter,
+    bool basicAuth = true,
+    required AWSHttpClient httpClient,
+    Map<String, dynamic> Function(MediaType? contentType, String body)?
+        getParameters,
+    String? codeVerifier,
+  })  : _basicAuth = basicAuth,
+        _httpClient = httpClient,
+        _delimiter = delimiter ?? ' ',
+        _getParameters = getParameters ?? parseJsonParameters,
+        _codeVerifier = codeVerifier ?? _createCodeVerifier();
+
+  /// The function used to parse parameters from a host's response.
+  final GetParameters _getParameters;
+
+  /// The client identifier for this client.
+  ///
+  /// The authorization server will issue each client a separate client
+  /// identifier and secret, which allows the server to tell which client is
+  /// accessing it. Some servers may also have an anonymous identifier/secret
+  /// pair that any client may use.
+  ///
+  /// This is usually global to the program using this library.
+  final String identifier;
+
+  /// The client secret for this client.
+  ///
+  /// The authorization server will issue each client a separate client
+  /// identifier and secret, which allows the server to tell which client is
+  /// accessing it. Some servers may also have an anonymous identifier/secret
+  /// pair that any client may use.
+  ///
+  /// This is usually global to the program using this library.
+  ///
+  /// Note that clients whose source code or binary executable is readily
+  /// available may not be able to make sure the client secret is kept a secret.
+  /// This is fine; OAuth2 servers generally won't rely on knowing with
+  /// certainty that a client is who it claims to be.
+  final String? secret;
+
+  /// A URL provided by the authorization server that serves as the base for the
+  /// URL that the resource owner will be redirected to to authorize this
+  /// client.
+  ///
+  /// This will usually be listed in the authorization server's OAuth2 API
+  /// documentation.
+  final Uri authorizationEndpoint;
+
+  /// A URL provided by the authorization server that this library uses to
+  /// obtain long-lasting credentials.
+  ///
+  /// This will usually be listed in the authorization server's OAuth2 API
+  /// documentation.
+  final Uri tokenEndpoint;
+
+  /// Whether to use HTTP Basic authentication for authorizing the client.
+  final bool _basicAuth;
+
+  /// A [String] used to separate scopes; defaults to `" "`.
+  final String _delimiter;
+
+  /// The HTTP client used to make HTTP requests.
+  final AWSHttpClient _httpClient;
+
+  /// The URL to which the resource owner will be redirected after they
+  /// authorize this client with the authorization server.
+  Uri? _redirectEndpoint;
+
+  /// The scopes that the client is requesting access to.
+  List<String>? _scopes;
+
+  /// An opaque string that users of this library may specify that will be
+  /// included in the response query parameters.
+  String? _stateString;
+
+  /// The current state of the grant object.
+  _State _state = _State.initial;
+
+  /// Allowed characters for generating the _codeVerifier
+  static const String _charset =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+
+  /// The PKCE code verifier. Will be generated if one is not provided in the
+  /// constructor.
+  final String _codeVerifier;
+
+  /// Returns the URL to which the resource owner should be redirected to
+  /// authorize this client.
+  ///
+  /// The resource owner will then be redirected to [redirect], which should
+  /// point to a server controlled by the client. This redirect will have
+  /// additional query parameters that should be passed to
+  /// [handleAuthorizationResponse].
+  ///
+  /// The specific permissions being requested from the authorization server may
+  /// be specified via [scopes]. The scope strings are specific to the
+  /// authorization server and may be found in its documentation.
+  ///
+  /// An opaque [state] string may also be passed that will be present in the
+  /// query parameters provided to the redirect URL.
+  ///
+  /// It is a [StateError] to call this more than once.
+  Uri getAuthorizationUrl(
+    Uri redirect, {
+    Iterable<String>? scopes,
+    String? state,
+  }) {
+    if (_state != _State.initial) {
+      throw StateError('The authorization URL has already been generated.');
+    }
+    _state = _State.awaitingResponse;
+
+    final scopeList = scopes?.toList() ?? <String>[];
+    final codeChallenge = base64Url
+        .encode(sha256.convert(ascii.encode(_codeVerifier)).bytes)
+        .replaceAll('=', '');
+
+    _redirectEndpoint = redirect;
+    _scopes = scopeList;
+    _stateString = state;
+    final parameters = {
+      'response_type': 'code',
+      'client_id': identifier,
+      'redirect_uri': redirect.toString(),
+      'code_challenge': codeChallenge,
+      'code_challenge_method': 'S256'
+    };
+
+    if (state != null) parameters['state'] = state;
+    if (scopeList.isNotEmpty) parameters['scope'] = scopeList.join(_delimiter);
+
+    return addQueryParameters(authorizationEndpoint, parameters);
+  }
+
+  /// Processes the query parameters added to a redirect from the authorization
+  /// server.
+  ///
+  /// Note that this "response" is not an HTTP response, but rather the data
+  /// passed to a server controlled by the client as query parameters on the
+  /// redirect URL.
+  ///
+  /// It is a [StateError] to call this more than once, to call it before
+  /// [getAuthorizationUrl] is called, or to call it after
+  /// [handleAuthorizationCode] is called.
+  ///
+  /// Throws [FormatException] if [parameters] is invalid according to the
+  /// OAuth2 spec or if the authorization server otherwise provides invalid
+  /// responses. If `state` was passed to [getAuthorizationUrl], this will throw
+  /// a [FormatException] if the `state` parameter doesn't match the original
+  /// value.
+  ///
+  /// Throws [AuthorizationException] if the authorization fails.
+  Future<CognitoUserPoolTokens> handleAuthorizationResponse(
+    Map<String, String> parameters,
+  ) async {
+    if (_state == _State.initial) {
+      throw StateError('The authorization URL has not yet been generated.');
+    } else if (_state == _State.finished) {
+      throw StateError('The authorization code has already been received.');
+    }
+    _state = _State.finished;
+
+    if (_stateString != null) {
+      if (!parameters.containsKey('state')) {
+        throw FormatException('Invalid OAuth response for '
+            '"$authorizationEndpoint": parameter "state" expected to be '
+            '"$_stateString", was missing.');
+      } else if (parameters['state'] != _stateString) {
+        throw FormatException('Invalid OAuth response for '
+            '"$authorizationEndpoint": parameter "state" expected to be '
+            '"$_stateString", was "${parameters['state']}".');
+      }
+    }
+
+    if (parameters.containsKey('error')) {
+      final description = parameters['error_description'];
+      final uriString = parameters['error_uri'];
+      final uri = uriString == null ? null : Uri.parse(uriString);
+      throw AuthorizationException(parameters['error']!, description, uri);
+    } else if (!parameters.containsKey('code')) {
+      throw FormatException('Invalid OAuth response for '
+          '"$authorizationEndpoint": did not contain required parameter '
+          '"code".');
+    }
+
+    return _handleAuthorizationCode(parameters['code']!);
+  }
+
+  /// Processes an authorization code directly.
+  ///
+  /// Usually [handleAuthorizationResponse] is preferable to this method, since
+  /// it validates all of the query parameters. However, some authorization
+  /// servers allow the user to copy and paste an authorization code into a
+  /// command-line application, in which case this method must be used.
+  ///
+  /// It is a [StateError] to call this more than once, to call it before
+  /// [getAuthorizationUrl] is called, or to call it after
+  /// [handleAuthorizationCode] is called.
+  ///
+  /// Throws [FormatException] if the authorization server provides invalid
+  /// responses while retrieving credentials.
+  ///
+  /// Throws [AuthorizationException] if the authorization fails.
+  Future<CognitoUserPoolTokens> handleAuthorizationCode(
+    String authorizationCode,
+  ) async {
+    if (_state == _State.initial) {
+      throw StateError('The authorization URL has not yet been generated.');
+    } else if (_state == _State.finished) {
+      throw StateError('The authorization code has already been received.');
+    }
+    _state = _State.finished;
+
+    return _handleAuthorizationCode(authorizationCode);
+  }
+
+  /// This works just like [handleAuthorizationCode], except it doesn't validate
+  /// the state beforehand.
+  Future<CognitoUserPoolTokens> _handleAuthorizationCode(
+    String authorizationCode,
+  ) async {
+    final startTime = DateTime.now();
+
+    final headers = <String, String>{};
+
+    final body = {
+      'grant_type': 'authorization_code',
+      'code': authorizationCode,
+      'redirect_uri': _redirectEndpoint.toString(),
+      'code_verifier': _codeVerifier
+    };
+
+    final secret = this.secret;
+    if (_basicAuth && secret != null) {
+      headers['Authorization'] = createBasicAuthorization(identifier, secret);
+    } else {
+      // The ID is required for this request any time basic auth isn't being
+      // used, even if there's no actual client authentication to be done.
+      body['client_id'] = identifier;
+      if (secret != null) body['client_secret'] = secret;
+    }
+
+    final response = await _httpClient
+        .send(
+          AWSStreamedHttpRequest.post(
+            tokenEndpoint,
+            headers: headers,
+            body: HttpPayload.formFields(body),
+          ),
+        )
+        .response;
+
+    return handleAccessTokenResponse(
+      switch (response) {
+        AWSHttpResponse _ => response,
+        AWSStreamedHttpResponse _ => await response.read(),
+      },
+      tokenEndpoint,
+      startTime,
+      _scopes,
+      _delimiter,
+      getParameters: _getParameters,
+    );
+  }
+
+  // Randomly generate a 128 character string to be used as the PKCE code
+  // verifier.
+  static String _createCodeVerifier() => List.generate(
+        128,
+        (i) => _charset[Random.secure().nextInt(_charset.length)],
+      ).join();
+}
+
+/// States that [AuthorizationCodeGrant] can be in.
+enum _State {
+  initial('initial'),
+  awaitingResponse('awaiting response'),
+  finished('finished');
+
+  const _State(this._name);
+  final String _name;
+
+  @override
+  String toString() => _name;
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/authorization_exception.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/authorization_exception.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// An exception raised when OAuth2 authorization fails.
+class AuthorizationException implements Exception {
+  /// Creates an AuthorizationException.
+  const AuthorizationException(this.error, this.description, this.uri);
+
+  /// The name of the error.
+  ///
+  /// Possible names are enumerated in [the spec][].
+  ///
+  /// [the spec]: http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-5.2
+  final String error;
+
+  /// The description of the error, provided by the server.
+  ///
+  /// May be `null` if the server provided no description.
+  final String? description;
+
+  /// A URL for a page that describes the error in more detail, provided by the
+  /// server.
+  ///
+  /// May be `null` if the server provided no URL.
+  final Uri? uri;
+
+  /// Provides a string description of the AuthorizationException.
+  @override
+  String toString() {
+    var header = 'OAuth authorization error ($error)';
+    if (description != null) {
+      header = '$header: $description';
+    } else if (uri != null) {
+      header = '$header: $uri';
+    }
+    return '$header.';
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/handle_access_token_response.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/handle_access_token_response.dart
@@ -1,0 +1,155 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:amplify_auth_cognito_dart/src/jwt/jwt.dart';
+import 'package:amplify_auth_cognito_dart/src/model/session/cognito_sign_in_details.dart';
+import 'package:amplify_auth_cognito_dart/src/model/session/cognito_user_pool_tokens.dart';
+import 'package:amplify_auth_cognito_dart/src/oauth/authorization_exception.dart';
+import 'package:amplify_auth_cognito_dart/src/oauth/parameters.dart';
+import 'package:aws_common/aws_common.dart';
+import 'package:http_parser/http_parser.dart';
+
+/// Handles a response from the authorization server that contains an access
+/// token.
+///
+/// This response format is common across several different components of the
+/// OAuth2 flow.
+///
+/// By default, this follows the OAuth2 spec and requires the server's responses
+/// to be in JSON format. However, some servers return non-standard response
+/// formats, which can be parsed using the [getParameters] function.
+///
+/// This function is passed the `Content-Type` header of the response as well as
+/// its body as a UTF-8-decoded string. It should return a map in the same
+/// format as the [standard JSON response][].
+///
+/// [standard JSON response]: https://tools.ietf.org/html/rfc6749#section-5.1
+CognitoUserPoolTokens handleAccessTokenResponse(
+  AWSHttpResponse response,
+  Uri tokenEndpoint,
+  DateTime startTime,
+  List<String>? scopes,
+  String delimiter, {
+  Map<String, dynamic> Function(MediaType? contentType, String body)?
+      getParameters,
+}) {
+  getParameters ??= parseJsonParameters;
+
+  try {
+    if (response.statusCode != 200) {
+      _handleErrorResponse(response, tokenEndpoint, getParameters);
+    }
+
+    final contentTypeString = response.headers['content-type'];
+    if (contentTypeString == null) {
+      throw const FormatException('Missing Content-Type string.');
+    }
+
+    final parameters = getParameters(
+      MediaType.parse(contentTypeString),
+      response.decodeBody(),
+    );
+
+    for (final requiredParameter in ['access_token', 'token_type']) {
+      if (!parameters.containsKey(requiredParameter)) {
+        throw FormatException(
+          'did not contain required parameter "$requiredParameter"',
+        );
+      } else if (parameters[requiredParameter] is! String) {
+        throw FormatException(
+            'required parameter "$requiredParameter" was not a string, was '
+            '"${parameters[requiredParameter]}"');
+      }
+    }
+
+    // TODO(nweiz): support the "mac" token type
+    // (http://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01)
+    if ((parameters['token_type'] as String).toLowerCase() != 'bearer') {
+      throw FormatException(
+        '"$tokenEndpoint": unknown token type "${parameters['token_type']}"',
+      );
+    }
+
+    var expiresIn = parameters['expires_in'];
+    if (expiresIn != null) {
+      if (expiresIn is String) {
+        try {
+          expiresIn = double.parse(expiresIn).toInt();
+        } on FormatException {
+          throw FormatException(
+            'parameter "expires_in" could not be parsed as in, was: "$expiresIn"',
+          );
+        }
+      } else if (expiresIn is! int) {
+        throw FormatException(
+          'parameter "expires_in" was not an int, was: "$expiresIn"',
+        );
+      }
+    }
+
+    for (final name in ['refresh_token', 'id_token', 'scope']) {
+      final value = parameters[name];
+      if (value != null && value is! String) {
+        throw FormatException(
+          'parameter "$name" was not a string, was "$value"',
+        );
+      }
+    }
+
+    final scope = parameters['scope'] as String?;
+    if (scope != null) scopes = scope.split(delimiter);
+
+    return CognitoUserPoolTokens(
+      signInMethod: CognitoSignInMethod.hostedUi,
+      accessToken: JsonWebToken.parse(parameters['access_token'] as String),
+      refreshToken: parameters['refresh_token'] as String,
+      idToken: JsonWebToken.parse(parameters['id_token'] as String),
+    );
+  } on FormatException catch (e) {
+    throw FormatException('Invalid OAuth response for "$tokenEndpoint": '
+        '${e.message}.\n\n${response.body}');
+  }
+}
+
+/// Throws the appropriate exception for an error response from the
+/// authorization server.
+void _handleErrorResponse(
+  AWSHttpResponse response,
+  Uri tokenEndpoint,
+  GetParameters getParameters,
+) {
+  // OAuth2 mandates a 400 or 401 response code for access token error
+  // responses. If it's not a 400 reponse, the server is either broken or
+  // off-spec.
+  if (response.statusCode != 400 && response.statusCode != 401) {
+    throw FormatException('OAuth request for "$tokenEndpoint" failed '
+        'with status ${response.statusCode}.\n\n${response.body}');
+  }
+
+  final contentTypeString = response.headers['content-type'];
+  final contentType =
+      contentTypeString == null ? null : MediaType.parse(contentTypeString);
+
+  final parameters = getParameters(contentType, response.decodeBody());
+
+  if (!parameters.containsKey('error')) {
+    throw const FormatException('did not contain required parameter "error"');
+  } else if (parameters['error'] is! String) {
+    throw FormatException('required parameter "error" was not a string, was '
+        '"${parameters["error"]}"');
+  }
+
+  for (final name in ['error_description', 'error_uri']) {
+    final value = parameters[name];
+
+    if (value != null && value is! String) {
+      throw FormatException('parameter "$name" was not a string, was "$value"');
+    }
+  }
+
+  final uriString = parameters['error_uri'] as String?;
+  final uri = uriString == null ? null : Uri.parse(uriString);
+  final description = parameters['error_description'] as String?;
+  throw AuthorizationException(parameters['error'] as String, description, uri);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/oauth.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/oauth.dart
@@ -1,0 +1,13 @@
+/// OAuth2 client implementation.
+///
+/// Forked from Dart team's `package:oauth2` which has been [deprecated](https://github.com/dart-lang/oauth2/issues/137).
+@internal
+library;
+
+import 'package:meta/meta.dart';
+
+export 'authorization_code_grant.dart';
+export 'authorization_exception.dart';
+export 'handle_access_token_response.dart';
+export 'parameters.dart';
+export 'utils.dart';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/oauth.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/oauth.dart
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /// OAuth2 client implementation.
 ///
 /// Forked from Dart team's `package:oauth2` which has been [deprecated](https://github.com/dart-lang/oauth2/issues/137).

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/parameters.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/parameters.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:http_parser/http_parser.dart';
+
+/// The type of a callback that parses parameters from an HTTP response.
+typedef GetParameters = Map<String, dynamic> Function(
+  MediaType? contentType,
+  String body,
+);
+
+/// Parses parameters from a response with a JSON body, as per the
+/// [OAuth2 spec][].
+///
+/// [OAuth2 spec]: https://tools.ietf.org/html/rfc6749#section-5.1
+Map<String, dynamic> parseJsonParameters(MediaType? contentType, String body) {
+  // The spec requires a content-type of application/json, but some endpoints
+  // (e.g. Dropbox) serve it as text/javascript instead.
+  if (contentType == null ||
+      (contentType.mimeType != 'application/json' &&
+          contentType.mimeType != 'text/javascript')) {
+    throw FormatException(
+      'Content-Type was "$contentType", expected "application/json"',
+    );
+  }
+
+  final untypedParameters = jsonDecode(body);
+  if (untypedParameters is Map<String, dynamic>) {
+    return untypedParameters;
+  }
+
+  throw FormatException('Parameters must be a map, was "$untypedParameters"');
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/utils.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/oauth/utils.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Adds additional query parameters to [url], overwriting the original
+/// parameters if a name conflict occurs.
+Uri addQueryParameters(Uri url, Map<String, String> parameters) => url.replace(
+      queryParameters: Map.from(url.queryParameters)..addAll(parameters),
+    );

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/cognito_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/cognito_state_machine.dart
@@ -10,7 +10,6 @@ import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/hosted_ui_platform
 import 'package:amplify_auth_cognito_dart/src/model/session/cognito_sign_in_details.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
-import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
 /// Default state machine builders for [CognitoAuthStateMachine].
@@ -30,7 +29,6 @@ final stateMachineBuilders = <StateMachineToken,
 @visibleForTesting
 final defaultDependencies = <Token, DependencyBuilder>{
   const Token<HostedUiPlatform>(): HostedUiPlatform.new,
-  const Token<http.Client>(): (_) => http.Client(),
   const Token<AuthPluginCredentialsProvider>():
       AuthPluginCredentialsProviderImpl.new,
   const Token<DeviceMetadataRepository>():

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -21,12 +21,11 @@ dependencies:
   convert: ^3.0.1
   crypto: ^3.0.1
   fixnum: ^1.0.0
-  http: ^0.13.4
+  http_parser: ^4.0.2
   intl: ">=0.18.0 <1.0.0"
   js: ^0.6.4
   json_annotation: ">=4.8.1 <4.9.0"
   meta: ^1.7.0
-  oauth2: ^2.0.0
   path: ^1.8.0
   smithy: ">=0.5.0 <0.6.0"
   smithy_aws: ">=0.5.0 <0.6.0"

--- a/packages/auth/amplify_auth_cognito_test/lib/common/mock_config.dart
+++ b/packages/auth/amplify_auth_cognito_test/lib/common/mock_config.dart
@@ -7,6 +7,9 @@ import 'package:amplify_auth_cognito_dart/src/jwt/jwt.dart';
 import 'package:amplify_auth_cognito_dart/src/model/auth_configuration.dart';
 import 'package:amplify_core/amplify_core.dart';
 
+/// The name of the database to use in Web tests.
+const String webDatabaseName = 'dart-auth-test';
+
 const testUserPoolId = 'us-east-1_userPoolId';
 const testAppClientId = 'appClientId';
 const testIdentityPoolId = 'identityPoolId';

--- a/packages/auth/amplify_auth_cognito_test/lib/hosted_ui/hosted_ui_common.dart
+++ b/packages/auth/amplify_auth_cognito_test/lib/hosted_ui/hosted_ui_common.dart
@@ -9,9 +9,6 @@ import 'package:io/io.dart';
 import 'package:test/test.dart';
 import 'package:webdriver/async_io.dart';
 
-/// The name of the database to use in Web.
-const String webDatabaseName = 'dart-auth-test';
-
 /// The URI for the RPC server, used to drive VM tests.
 final Uri rpcUri = Uri.parse('ws://localhost:4321');
 

--- a/packages/auth/amplify_auth_cognito_test/lib/hosted_ui/hosted_ui_server.dart
+++ b/packages/auth/amplify_auth_cognito_test/lib/hosted_ui/hosted_ui_server.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 // ignore: implementation_imports
 import 'package:amplify_auth_cognito_dart/src/flows/hosted_ui/hosted_ui_platform_io.dart';
+import 'package:amplify_auth_cognito_test/common/mock_config.dart';
 import 'package:amplify_auth_cognito_test/hosted_ui/hosted_ui_common.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';

--- a/packages/auth/amplify_auth_cognito_test/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_test/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   built_value: ">=8.5.0 <8.6.0"
   collection: ^1.15.0
   convert: ^3.0.0
-  http: ^0.13.0
   io: ^1.0.0
   json_rpc_2: ^3.0.0
   shelf: ^1.4.0

--- a/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_io_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_io_test.dart
@@ -15,7 +15,6 @@ import 'package:amplify_auth_cognito_test/common/mock_hosted_ui.dart';
 import 'package:amplify_auth_cognito_test/common/mock_secure_storage.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
-import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 
 class MockHostedUiPlatform extends HostedUiPlatformImpl {
@@ -133,7 +132,7 @@ void main() {
 
     group('signIn', () {
       test('completes', () async {
-        final client = http.Client();
+        final client = AWSHttpClient();
         final dispatcher = MockDispatcher(
           onDispatch: expectAsync1((event) {
             expect(event, isA<HostedUiExchange>());
@@ -159,7 +158,10 @@ void main() {
           ),
         );
 
-        await expectLater(client.get(redirect), completes);
+        await expectLater(
+          client.send(AWSHttpRequest.get(redirect)).response,
+          completes,
+        );
         expect(
           hostedUiPlatform._localServer,
           isNotNull,
@@ -167,11 +169,15 @@ void main() {
         );
 
         await expectLater(
-          client.get(
-            redirect.replace(
-              queryParameters: {'state': 'state', 'code': 'code'},
-            ),
-          ),
+          client
+              .send(
+                AWSHttpRequest.get(
+                  redirect.replace(
+                    queryParameters: {'state': 'state', 'code': 'code'},
+                  ),
+                ),
+              )
+              .response,
           completes,
         );
         await Future<void>.delayed(Duration.zero);

--- a/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_test.dart
@@ -11,7 +11,6 @@ import 'package:amplify_auth_cognito_test/common/mock_oauth_server.dart';
 import 'package:amplify_auth_cognito_test/common/mock_secure_storage.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
-import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 
 final throwsInvalidStateException = throwsA(isA<InvalidStateException>());
@@ -30,7 +29,7 @@ void main() {
       dependencyManager = DependencyManager()
         ..addInstance(hostedUiConfig)
         ..addInstance<SecureStorageInterface>(secureStorage)
-        ..addInstance<http.Client>(server.httpClient)
+        ..addInstance<AWSHttpClient>(server.httpClient)
         ..addInstance<Dispatcher<AuthEvent, AuthState>>(const MockDispatcher());
 
       platform = HostedUiPlatform(dependencyManager);
@@ -103,7 +102,7 @@ void main() {
             includeNonce: false,
           ),
         );
-        dependencyManager.addInstance<http.Client>(server.httpClient);
+        dependencyManager.addInstance<AWSHttpClient>(server.httpClient);
         platform = HostedUiPlatform(dependencyManager);
         final parameters = await server.authorize(
           await platform.getSignInUri(

--- a/packages/auth/amplify_auth_cognito_test/test/state/hosted_ui_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/hosted_ui_state_machine_test.dart
@@ -13,7 +13,6 @@ import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_auth_cognito_test/amplify_auth_cognito_test.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';
-import 'package:http/http.dart' as http;
 import 'package:stream_transform/stream_transform.dart';
 import 'package:test/test.dart';
 
@@ -83,7 +82,7 @@ void main() {
       server = MockOAuthServer();
       secureStorage = MockSecureStorage();
       stateMachine = CognitoAuthStateMachine()
-        ..addInstance<http.Client>(server.httpClient)
+        ..addInstance<AWSHttpClient>(server.httpClient)
         ..addInstance(secureStorage)
         ..addBuilder<HostedUiPlatform>(MockHostedUiPlatform.new);
     });


### PR DESCRIPTION
The Dart authors are deprecating `package:oauth2` (https://github.com/dart-lang/oauth2/issues/137). This means we can likely not expect to receive further updates. Currently, their `package:http` constraint doesn't allow the latest version (`1.0.0`) and this is the only package we use which brings `http` into our dependency tree.

Rather than force our customers to work around this, this PR has the minimum lift-and-shift required to remove `package:oauth2` and by extension, `package:http`, dependency. It does this by copying over the subset of `package:oauth2` we use and updating it to use `AWSHttpClient` instead.

Accuracy verified through CI and local e2e tests for all platforms. 