### PR TITLE
chore(infra): Bump rate limit threshold

### DIFF
--- a/infra/lib/stack.ts
+++ b/infra/lib/stack.ts
@@ -42,7 +42,7 @@ export class AmplifyFlutterIntegStack extends cdk.Stack {
               aggregateKeyType: "IP",
               // The number of requests which can be performed by
               // a single IP in a 5-minute window.
-              limit: 1000,
+              limit: 3000,
             },
           },
           visibilityConfig: {


### PR DESCRIPTION
Some integ tests seem to be failing due to this reason. When multiple e2e tests are run in parallel, especially Auth/API ones, we can hit this limit.
