### PR TITLE
fix(auth): Attribute key equality

### DIFF
--- a/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute_key.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute_key.dart
@@ -13,7 +13,10 @@ typedef UserAttributeKey = AuthUserAttributeKey;
 /// {@endtemplate}
 @immutable
 abstract class AuthUserAttributeKey
-    with AWSSerializable<String>
+    with
+        AWSSerializable<String>,
+        AWSEquatable<AuthUserAttributeKey>,
+        AWSDebuggable
     implements Comparable<AuthUserAttributeKey> {
   /// {@macro amplify_core.auth_user_attribute_key}
   const AuthUserAttributeKey();
@@ -140,18 +143,17 @@ abstract class AuthUserAttributeKey
   String toJson() => key;
 
   @override
-  int compareTo(AuthUserAttributeKey other) => key.compareTo(other.key);
+  int compareTo(AuthUserAttributeKey other) =>
+      key.toLowerCase().compareTo(other.key.toLowerCase());
 
   @override
   String toString() => key;
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is AuthUserAttributeKey && key == other.key;
+  List<Object?> get props => [key.toLowerCase()];
 
   @override
-  int get hashCode => key.hashCode;
+  String get runtimeTypeName => 'AuthUserAttributeKey';
 }
 
 class _AuthUserAttributeKey extends AuthUserAttributeKey {

--- a/packages/amplify_core/lib/src/types/auth/attribute/cognito_user_attribute_key.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/cognito_user_attribute_key.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:meta/meta.dart';
 
 /// User attributes available for configuring via `Amplify.Auth.signUp`,
 /// or updating via `Amplify.Auth.updateUserAttribute` and
@@ -12,9 +11,7 @@ import 'package:meta/meta.dart';
 /// [here](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html).
 ///
 /// Use [CognitoUserAttributeKey.custom] to create a custom Cognito attribute.
-@immutable
-class CognitoUserAttributeKey extends AuthUserAttributeKey
-    with AWSEquatable<CognitoUserAttributeKey>, AWSDebuggable {
+class CognitoUserAttributeKey extends AuthUserAttributeKey {
   const CognitoUserAttributeKey._(this._key, {this.readOnly = false})
       : isCustom = false;
 
@@ -68,12 +65,6 @@ class CognitoUserAttributeKey extends AuthUserAttributeKey
 
   /// Whether this is a custom key.
   final bool isCustom;
-
-  @override
-  List<Object?> get props => [
-        // Cognito will lowercase these in API calls
-        key.toLowerCase(),
-      ];
 
   /// {@macro amplify_core.user_attribute.address}
   ///

--- a/packages/amplify_core/test/types/auth/auth_user_attribute_key_test.dart
+++ b/packages/amplify_core/test/types/auth/auth_user_attribute_key_test.dart
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AuthUserAttributeKey', () {
+    test('equality', () {
+      expect(
+        AuthUserAttributeKey.email,
+        CognitoUserAttributeKey.email,
+        reason: 'Two keys are equal if the value of their keys are equal',
+      );
+      expect(
+        AuthUserAttributeKey.email,
+        CognitoUserAttributeKey.parse('email'),
+      );
+      expect(
+        CognitoUserAttributeKey.email,
+        CognitoUserAttributeKey.parse('email'),
+      );
+
+      expect(
+        AuthUserAttributeKey.email,
+        // ignore: prefer_const_constructors
+        CustomUserAttributeKey('email'),
+        reason: 'Any class which inherits from AuthUserAttibuteKey '
+            'inherits equality rules',
+      );
+
+      expect(
+        const CognitoUserAttributeKey.custom('myattr'),
+        const CustomUserAttributeKey('custom:MYATTR'),
+        reason: 'Two keys are equal if the lower-case value of their '
+            'keys are equal',
+      );
+    });
+
+    test('hashCode', () {
+      expect(
+        AuthUserAttributeKey.email.hashCode,
+        CognitoUserAttributeKey.email.hashCode,
+      );
+      expect(
+        AuthUserAttributeKey.email.hashCode,
+        CognitoUserAttributeKey.parse('email').hashCode,
+      );
+      expect(
+        CognitoUserAttributeKey.email.hashCode,
+        CognitoUserAttributeKey.parse('email').hashCode,
+      );
+      expect(
+        AuthUserAttributeKey.email.hashCode,
+        // ignore: prefer_const_constructors
+        CustomUserAttributeKey('email').hashCode,
+      );
+      expect(
+        const CognitoUserAttributeKey.custom('myattr').hashCode,
+        const CustomUserAttributeKey('custom:MYATTR').hashCode,
+      );
+    });
+  });
+}
+
+class CustomUserAttributeKey extends AuthUserAttributeKey {
+  const CustomUserAttributeKey(this.key);
+
+  @override
+  final String key;
+}

--- a/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_in_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/confirm_sign_in_test.dart
@@ -164,12 +164,13 @@ void main() {
           AuthSignInStep.confirmSignInWithNewPassword,
         );
         expect(
-          signInRes.nextStep.missingAttributes.map((key) => key.key),
-          contains('email'),
+          signInRes.nextStep.missingAttributes,
+          equals([CognitoUserAttributeKey.email]),
         );
 
         final newPassword = generatePassword();
         final email = generateEmail();
+        const name = 'Test User';
         final confirmSignInRes = await Amplify.Auth.confirmSignIn(
           confirmationValue: newPassword,
           options: ConfirmSignInOptions(
@@ -179,7 +180,7 @@ void main() {
                 CognitoUserAttributeKey.email: email,
 
                 // Code path 2: a missing non-required attribute
-                CognitoUserAttributeKey.name: 'Test User',
+                CognitoUserAttributeKey.name: name,
               },
             ),
           ),
@@ -192,13 +193,17 @@ void main() {
         final userAttributes = await Amplify.Auth.fetchUserAttributes();
         expect(
           userAttributes
-              .firstWhereOrNull((attr) => attr.userAttributeKey.key == 'name')
+              .firstWhereOrNull(
+                (attr) => attr.userAttributeKey == AuthUserAttributeKey.name,
+              )
               ?.value,
-          'Test User',
+          name,
         );
         expect(
           userAttributes
-              .firstWhereOrNull((attr) => attr.userAttributeKey.key == 'email')
+              .firstWhereOrNull(
+                (attr) => attr.userAttributeKey == AuthUserAttributeKey.email,
+              )
               ?.value,
           email,
         );

--- a/packages/auth/amplify_auth_cognito/example/integration_test/user_attributes_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/user_attributes_test.dart
@@ -13,7 +13,7 @@ import 'test_runner.dart';
 extension on List<AuthUserAttribute> {
   String? valueOf(AuthUserAttributeKey authUserAttributeKey) =>
       singleWhereOrNull(
-        (el) => el.userAttributeKey.key == authUserAttributeKey.key,
+        (el) => el.userAttributeKey == authUserAttributeKey,
       )?.value;
 }
 

--- a/packages/test/amplify_integration_test/lib/src/integration_test_utils/auth_cognito/integration_test_auth_utils.dart
+++ b/packages/test/amplify_integration_test/lib/src/integration_test_utils/auth_cognito/integration_test_auth_utils.dart
@@ -107,29 +107,26 @@ Future<String> adminCreateUser(
     'autoConfirm': autoConfirm,
     'email': attributes
             .firstWhereOrNull(
-              (el) => el.userAttributeKey.key == AuthUserAttributeKey.email.key,
+              (el) => el.userAttributeKey == AuthUserAttributeKey.email,
             )
             ?.value ??
         (autoFillAttributes ? generateEmail() : null),
     'enableMFA': enableMfa,
     'givenName': attributes
             .firstWhereOrNull(
-              (el) =>
-                  el.userAttributeKey.key == AuthUserAttributeKey.givenName.key,
+              (el) => el.userAttributeKey == AuthUserAttributeKey.givenName,
             )
             ?.value ??
         (autoFillAttributes ? 'default_given_name' : null),
     'name': attributes
             .firstWhereOrNull(
-              (el) => el.userAttributeKey.key == AuthUserAttributeKey.name.key,
+              (el) => el.userAttributeKey == AuthUserAttributeKey.name,
             )
             ?.value ??
         (autoFillAttributes ? 'default_name' : null),
     'phoneNumber': attributes
             .firstWhereOrNull(
-              (el) =>
-                  el.userAttributeKey.key ==
-                  AuthUserAttributeKey.phoneNumber.key,
+              (el) => el.userAttributeKey == AuthUserAttributeKey.phoneNumber,
             )
             ?.value ??
         (autoFillAttributes ? generatePhoneNumber() : null),


### PR DESCRIPTION
Two keys should be equal if the lower-case value of their keys are equal regardless of their class.
