### PR TITLE
fix(api): GraphQL subscription with custom domain formats URI correctly

### DIFF
--- a/packages/api/amplify_api_dart/lib/src/decorators/web_socket_auth_utils.dart
+++ b/packages/api/amplify_api_dart/lib/src/decorators/web_socket_auth_utils.dart
@@ -13,6 +13,9 @@ import 'package:meta/meta.dart';
 
 const _appSyncHostPortion = 'appsync-api';
 const _appSyncRealtimeHostPortion = 'appsync-realtime-api';
+const _appSyncHostSuffix = 'amazonaws.com';
+const _appSyncPath = 'graphql';
+const _customDomainPath = 'graphql/realtime';
 
 // Constants for header values as noted in https://docs.aws.amazon.com/appsync/latest/devguide/real-time-websocket-client.html.
 const _requiredHeaders = {
@@ -48,17 +51,17 @@ Future<Uri> generateConnectionUri(
   var endpointUriHost = Uri.parse(config.endpoint).host;
   String path;
   if (endpointUriHost.contains(_appSyncHostPortion) &&
-      endpointUriHost.endsWith('amazonaws.com')) {
+      endpointUriHost.endsWith(_appSyncHostSuffix)) {
     // AppSync domain that contains "appsync-api" and ends with "amazonaws.com."
     // Replace "appsync-api" with "appsync-realtime-api," append "/graphql."
     endpointUriHost = endpointUriHost.replaceFirst(
       _appSyncHostPortion,
       _appSyncRealtimeHostPortion,
     );
-    path = 'graphql';
+    path = _appSyncPath;
   } else {
     // Custom domain, append "graphql/realtime" to the path like on https://docs.aws.amazon.com/appsync/latest/devguide/custom-domain-name.html.
-    path = 'graphql/realtime';
+    path = _customDomainPath;
   }
   // Return wss URI with auth query parameters.
   return Uri(

--- a/packages/api/amplify_api_dart/test/util.dart
+++ b/packages/api/amplify_api_dart/test/util.dart
@@ -75,9 +75,18 @@ const testApiKeyConfig = AWSApiConfig(
   authorizationType: APIAuthorizationType.apiKey,
   apiKey: 'abc-123',
 );
+const testApiKeyConfigCustomDomain = AWSApiConfig(
+  endpointType: EndpointType.graphQL,
+  endpoint: 'https://foo.bar.aws.dev/graphql ',
+  region: 'us-east-1',
+  authorizationType: APIAuthorizationType.apiKey,
+  apiKey: 'abc-123',
+);
 
 const expectedApiKeyWebSocketConnectionUrl =
     'wss://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql?header=eyJBY2NlcHQiOiJhcHBsaWNhdGlvbi9qc29uLCB0ZXh0L2phdmFzY3JpcHQiLCJDb250ZW50LUVuY29kaW5nIjoiYW16LTEuMCIsIkNvbnRlbnQtVHlwZSI6ImFwcGxpY2F0aW9uL2pzb247IGNoYXJzZXQ9dXRmLTgiLCJYLUFwaS1LZXkiOiJhYmMtMTIzIiwiSG9zdCI6ImFiYzEyMy5hcHBzeW5jLWFwaS51cy1lYXN0LTEuYW1hem9uYXdzLmNvbSJ9&payload=e30%3D';
+const expectedApiKeyWebSocketConnectionUrlCustomDomain =
+    'wss://foo.bar.aws.dev/graphql/realtime?header=eyJBY2NlcHQiOiJhcHBsaWNhdGlvbi9qc29uLCB0ZXh0L2phdmFzY3JpcHQiLCJDb250ZW50LUVuY29kaW5nIjoiYW16LTEuMCIsIkNvbnRlbnQtVHlwZSI6ImFwcGxpY2F0aW9uL2pzb247IGNoYXJzZXQ9dXRmLTgiLCJYLUFwaS1LZXkiOiJhYmMtMTIzIiwiSG9zdCI6ImZvby5iYXIuYXdzLmRldiJ9&payload=e30%3D';
 
 AmplifyAuthProviderRepository getTestAuthProviderRepo() {
   final testAuthProviderRepo = AmplifyAuthProviderRepository()

--- a/packages/api/amplify_api_dart/test/web_socket/web_socket_auth_utils_test.dart
+++ b/packages/api/amplify_api_dart/test/web_socket/web_socket_auth_utils_test.dart
@@ -55,6 +55,18 @@ void main() {
         expectedApiKeyWebSocketConnectionUrl,
       );
     });
+
+    test('should generate authorized connection URI with a custom domain',
+        () async {
+      final actualConnectionUri = await generateConnectionUri(
+        testApiKeyConfigCustomDomain,
+        authProviderRepo,
+      );
+      expect(
+        actualConnectionUri.toString(),
+        expectedApiKeyWebSocketConnectionUrlCustomDomain,
+      );
+    });
   });
 
   group('generateSubscriptionRegistrationMessage', () {


### PR DESCRIPTION
Fixes https://github.com/aws-amplify/amplify-flutter/issues/3028

There is a bug where GraphQL subscriptions do not work with custom domains. As documented on https://docs.aws.amazon.com/appsync/latest/devguide/custom-domain-name.html., AppSync custom domains require some runtime changes to the way the connection URI is formatted. This is automatically handled in Android and users reported this as a regression with version 1.

I tested this fix manually in Android with a real endpoint w custom domain

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
