### PR TITLE
chore(smithy): Fix switch lint

### DIFF
--- a/packages/smithy/smithy/lib/src/serialization/xml/xml_num_serializer.dart
+++ b/packages/smithy/smithy/lib/src/serialization/xml/xml_num_serializer.dart
@@ -30,9 +30,9 @@ class XmlNumSerializer extends PrimitiveSmithySerializer<num> {
     }
     serialized as String;
     switch (specifiedType.root) {
-      case int:
+      case const (int):
         return int.parse(serialized);
-      case double:
+      case const (double):
         if (serialized == nan) {
           return double.nan;
         } else if (serialized == negativeInfinity) {


### PR DESCRIPTION
Fixes a lint introduced in latest Dart stable for switching on a `Type`