### PR TITLE
chore(authenticator): log a warning for duplicate fields

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/widgets/form_fields/sign_up_form_field.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/widgets/form_fields/sign_up_form_field.dart
@@ -33,7 +33,7 @@ abstract class SignUpFormField<FieldValue extends Object>
   ///
   /// The look and behavior of this widget will depend on your app's auth configuration.
   /// The `usernameAttributes` will be used to determine if the field is a standard
-  /// username field, and email field, or a phone number field.
+  /// username field, an email field, or a phone number field.
   /// {@endtemplate}
   ///
   /// If your app is configured to use email or phone, the value provided for this widget


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/3154

*Description of changes:*
- Log a warning when the use of a custom form and the sign in alias will cause a duplicate field to display. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
