### PR TITLE
fix(auth): `signOut` after user deletion

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/integration_test/delete_user_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/delete_user_test.dart
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_auth_integration_test/amplify_auth_integration_test.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';

--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_out_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_out_test.dart
@@ -5,9 +5,12 @@ import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 // ignore: implementation_imports
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart'
     as cognito_idp;
+// ignore: invalid_use_of_internal_member
+import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_auth_integration_test/amplify_auth_integration_test.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_integration_test/amplify_integration_test.dart';
+import 'package:checks/checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_runner.dart';
@@ -27,7 +30,10 @@ void main() {
         late AWSHttpClient client;
         late cognito_idp.CognitoIdentityProviderClient cognitoClient;
 
-        Future<void> check(String accessToken, {required bool isValid}) async {
+        Future<void> checkToken(
+          String accessToken, {
+          required bool isValid,
+        }) async {
           await expectLater(
             cognitoClient
                 .getUser(cognito_idp.GetUserRequest(accessToken: accessToken))
@@ -103,16 +109,78 @@ void main() {
             isNot(session2Tokens.accessToken.raw),
           );
 
-          await check(session1Tokens.accessToken.raw, isValid: true);
-          await check(session2Tokens.accessToken.raw, isValid: true);
+          await checkToken(session1Tokens.accessToken.raw, isValid: true);
+          await checkToken(session2Tokens.accessToken.raw, isValid: true);
 
           final signOutResult = await cognitoPlugin.signOut(
             options: const SignOutOptions(globalSignOut: true),
           );
           expect(signOutResult, isA<CognitoCompleteSignOut>());
 
-          await check(session1Tokens.accessToken.raw, isValid: false);
-          await check(session2Tokens.accessToken.raw, isValid: false);
+          await checkToken(session1Tokens.accessToken.raw, isValid: false);
+          await checkToken(session2Tokens.accessToken.raw, isValid: false);
+        });
+
+        asyncTest('can call sign out after admin delete', (_) async {
+          final username = generateUsername();
+          final password = generatePassword();
+
+          await adminCreateUser(
+            username,
+            password,
+            autoConfirm: true,
+            verifyAttributes: true,
+          );
+
+          final res = await Amplify.Auth.signIn(
+            username: username,
+            password: password,
+          );
+          check(res.isSignedIn).isTrue();
+
+          await adminDeleteUser(username);
+
+          await check(
+            because: 'Sign out should succeed even if user is deleted',
+            cognitoPlugin.signOut(),
+          ).completes(
+            it()
+              ..has((res) => res.signedOutLocally, 'signedOutLocally').isTrue(),
+          );
+        });
+
+        asyncTest('can call sign out after admin delete and session expiration',
+            (_) async {
+          final username = generateUsername();
+          final password = generatePassword();
+
+          await adminCreateUser(
+            username,
+            password,
+            autoConfirm: true,
+            verifyAttributes: true,
+          );
+
+          final res = await Amplify.Auth.signIn(
+            username: username,
+            password: password,
+          );
+          check(res.isSignedIn).isTrue();
+
+          await adminDeleteUser(username);
+
+          cognitoPlugin.stateMachine
+              .expect(FetchAuthSessionStateMachine.type)
+              .invalidate();
+
+          await check(
+            because: 'Sign out should succeed even if user is deleted and '
+                'credentials are expired',
+            cognitoPlugin.signOut(),
+          ).completes(
+            it()
+              ..has((res) => res.signedOutLocally, 'signedOutLocally').isTrue(),
+          );
         });
       });
     }

--- a/packages/auth/amplify_auth_cognito/example/integration_test/test_runner.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/test_runner.dart
@@ -1,8 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_auth_cognito_example/amplifyconfiguration.dart';
 import 'package:amplify_auth_integration_test/amplify_auth_integration_test.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
 
 /// The global test runner.
 const AuthTestRunner testRunner = AuthTestRunner(amplifyEnvironments);
+
+/// The registered [AmplifyAuthCognito] plugin.
+AmplifyAuthCognito get cognitoPlugin =>
+    Amplify.Auth.getPlugin(AmplifyAuthCognito.pluginKey);

--- a/packages/auth/amplify_auth_cognito/example/test_driver/hosted_ui_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/test_driver/hosted_ui_test.dart
@@ -52,7 +52,7 @@ void main() {
 
       logger.debug('Creating user $username...');
       await adminCreateUser(username, password, autoConfirm: true);
-      addTearDown(() => deleteUser(username));
+      addTearDown(() => adminDeleteUser(username));
 
       webDriver = await createWebDriver();
       addTearDown(webDriver.quit);

--- a/packages/auth/amplify_auth_cognito_dart/example/integration_test/hosted_ui_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/integration_test/hosted_ui_test.dart
@@ -63,7 +63,7 @@ void main() {
 
           logger.debug('Creating user $username...');
           await adminCreateUser(username, password, autoConfirm: true);
-          addTearDown(() => deleteUser(username));
+          addTearDown(() => adminDeleteUser(username));
 
           driver = await createWebDriver();
           addTearDown(driver.quit);

--- a/packages/auth/amplify_auth_cognito_dart/example/integration_test/hosted_ui_web_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/integration_test/hosted_ui_web_test.dart
@@ -173,7 +173,7 @@ Future<void> main() async {
 
             logger.debug('Creating user $username...');
             await adminCreateUser(username, password, autoConfirm: true);
-            addTearDown(() => deleteUser(username));
+            addTearDown(() => adminDeleteUser(username));
 
             logger.info('Launching Chrome...');
             driver = await createWebDriver();

--- a/packages/test/amplify_auth_integration_test/lib/src/test_auth_plugin.dart
+++ b/packages/test/amplify_auth_integration_test/lib/src/test_auth_plugin.dart
@@ -30,7 +30,7 @@ class AmplifyAuthTestPlugin extends AmplifyAuthCognito {
     SignUpOptions? options,
   }) {
     addTearDown(
-      () => integ.deleteUser(username).onError(
+      () => integ.adminDeleteUser(username).onError(
             // This is expected in environments which do not have an admin GraphQL API.
             (e, st) => logger.debug('Error deleting user ($username):', e, st),
           ),

--- a/packages/test/amplify_integration_test/lib/src/integration_test_utils/auth_cognito/integration_test_auth_utils.dart
+++ b/packages/test/amplify_integration_test/lib/src/integration_test_utils/auth_cognito/integration_test_auth_utils.dart
@@ -36,7 +36,7 @@ Future<Map<String, Object?>> _graphQL(
 ///
 /// This method differs from the Auth.deleteUser API in that
 /// an access token is not required.
-Future<void> deleteUser(String username) async {
+Future<void> adminDeleteUser(String username) async {
   final result = await _graphQL(
     r'''
 mutation DeleteUser($username: String!) {
@@ -166,8 +166,8 @@ Future<String> adminCreateUser(
     try {
       await _oneOf([
         // TODO(dnys1): Cognito cannot always delete a user by `cognitoUsername`. Why?
-        deleteUser(username),
-        deleteUser(cognitoUsername),
+        adminDeleteUser(username),
+        adminDeleteUser(cognitoUsername),
       ]);
     } on Exception catch (e) {
       _logger.debug('Error deleting user ($username / $cognitoUsername):', e);


### PR DESCRIPTION
If a user is deleted by an administrator while logged into a device, calling `signOut` can fail when tokens have also expired. The library gets stuck because credentials are not cleared but they are also invalid and cannot be refreshed.

Fixes:  https://github.com/aws-amplify/amplify-flutter/issues/3160
