### PR TITLE
feat(storage): using path style URLs when bucket name contains dots

### DIFF
--- a/infra/lib/stack.ts
+++ b/infra/lib/stack.ts
@@ -249,9 +249,13 @@ export class AmplifyFlutterIntegStack extends cdk.Stack {
 
     // The Storage stack
     const storage = new StorageIntegrationTestStack(this, [
-      { environmentName: "main" },
+      {
+        environmentName: "main",
+        enableTransferAcceleration: true,
+      },
       {
         environmentName: "custom-prefix",
+        enableTransferAcceleration: true,
         prefixResolver(accessLevel, identityId) {
           switch (accessLevel) {
             case StorageAccessLevel.public:
@@ -267,6 +271,11 @@ export class AmplifyFlutterIntegStack extends cdk.Stack {
           [StorageAccessLevel.protected]: "shared",
           [StorageAccessLevel.private]: "private",
         },
+      },
+      {
+        environmentName: "dots-in-name",
+        enableTransferAcceleration: false,
+        bucketName: "amplify.integ-test.stack.com",
       },
     ]);
 

--- a/infra/lib/storage/stack.ts
+++ b/infra/lib/storage/stack.ts
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import * as cognito_identity from "@aws-cdk/aws-cognito-identitypool-alpha";
 import * as cdk from "aws-cdk-lib";
 import { RemovalPolicy } from "aws-cdk-lib";
 import * as cognito from "aws-cdk-lib/aws-cognito";
-import * as cognito_identity from "@aws-cdk/aws-cognito-identitypool-alpha";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as lambda_nodejs from "aws-cdk-lib/aws-lambda-nodejs";
@@ -50,6 +50,13 @@ interface StorageIntegrationTestEnvironmentProps
   ) => string;
 
   prefixOverrides?: Record<StorageAccessLevel, String>;
+
+  /**
+   * The name of the bucket. If not provided, it will be auto-generated.
+   */
+  bucketName?: string;
+
+  enableTransferAcceleration?: boolean;
 }
 
 export class StorageIntegrationTestStack extends IntegrationTestStack<
@@ -90,7 +97,8 @@ class StorageIntegrationTestEnvironment extends IntegrationTestStackEnvironment<
     // Create the bucket
 
     const bucket = new s3.Bucket(this, "Bucket", {
-      transferAcceleration: true,
+      bucketName: props.bucketName,
+      transferAcceleration: props.enableTransferAcceleration,
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,

--- a/packages/smithy/smithy_aws/lib/src/s3/s3_client_config.dart
+++ b/packages/smithy/smithy_aws/lib/src/s3/s3_client_config.dart
@@ -44,7 +44,7 @@ class S3ClientConfig {
     S3ServiceConfiguration? signerConfiguration,
   }) {
     return S3ClientConfig(
-      usePathStyle: usePathStyle ?? this.useAcceleration,
+      usePathStyle: usePathStyle ?? this.usePathStyle,
       useDualStack: useDualStack ?? this.useDualStack,
       useAcceleration: useAcceleration ?? this.useAcceleration,
       signerConfiguration: signerConfiguration ?? this.signerConfiguration,

--- a/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
@@ -73,6 +73,7 @@ void main() {
       late String object1Etag;
       late String object2Etag;
       late String object3Etag;
+      final shouldTestTransferAcceleration = entry.key != 'dots-in-name';
 
       setUpAll(() async {
         if (entry.key == 'custom-prefix') {
@@ -455,31 +456,37 @@ void main() {
           expect(result.removedItem.key, testObject3CopyMoveKey);
         });
 
-        testContentTypeInferTest(
-          smallFileBytes: testBytes,
-          largeFileBytes: testLargeFileBytes,
-        );
+        group('content type infer', () {
+          testContentTypeInferTest(
+            smallFileBytes: testBytes,
+            largeFileBytes: testLargeFileBytes,
+          );
+        });
 
-        testTransferAcceleration(
-          dataPayloads: [
-            TestTransferAccelerationConfig(
-              targetKey: 'transfer-acceleration-datapayload-${uuid()}',
-              targetAccessLevel: StorageAccessLevel.guest,
-              uploadSource: S3DataPayload.bytes(
-                testBytes,
-              ),
-              referenceBytes: testBytes,
-            ),
-          ],
-          awsFiles: [
-            TestTransferAccelerationConfig(
-              targetKey: 'transfer-acceleration-awsfile-${uuid()}',
-              targetAccessLevel: StorageAccessLevel.private,
-              uploadSource: AWSFile.fromData(testLargeFileBytes),
-              referenceBytes: testLargeFileBytes,
-            )
-          ],
-        );
+        if (shouldTestTransferAcceleration) {
+          group('transfer acceleration', () {
+            testTransferAcceleration(
+              dataPayloads: [
+                TestTransferAccelerationConfig(
+                  targetKey: 'transfer-acceleration-datapayload-${uuid()}',
+                  targetAccessLevel: StorageAccessLevel.guest,
+                  uploadSource: S3DataPayload.bytes(
+                    testBytes,
+                  ),
+                  referenceBytes: testBytes,
+                ),
+              ],
+              awsFiles: [
+                TestTransferAccelerationConfig(
+                  targetKey: 'transfer-acceleration-awsfile-${uuid()}',
+                  targetAccessLevel: StorageAccessLevel.private,
+                  uploadSource: AWSFile.fromData(testLargeFileBytes),
+                  referenceBytes: testLargeFileBytes,
+                )
+              ],
+            );
+          });
+        }
 
         testWidgets(
             'multiple fields of user defined metadata with non-ascii string values',

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -78,7 +78,6 @@ class AmplifyStorageS3Dart extends StoragePluginInterface
     if (s3PluginConfig == null) {
       throw ConfigurationError('No Storage S3 plugin config detected.');
     }
-
     s3pluginConfig = s3PluginConfig;
 
     final identityProvider = authProviderRepo

--- a/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/exception/s3_storage_exception.dart
@@ -22,6 +22,12 @@ const s3ControllableOperationCanceledException =
       ' exception allows you to take further action when an operation is canceled.',
 );
 
+/// The exception thrown when attempt to use acceleration endpoint with a bucket
+/// that has dots in its name.
+final accelerateEndpointUnusable = ConfigurationError(
+  'S3 Transfer Acceleration is not supported for buckets with periods (.) in their names',
+);
+
 /// Extension of [s3.NoSuchKey] to add util methods.
 extension NoSuchKeyToStorageKeyNotFoundException on s3.NoSuchKey {
   /// Creates a [StorageKeyNotFoundException] with the [s3.NoSuchKey] as the

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -29,21 +29,58 @@ const testDateTimeNowOverride = #_testDateTimeNowOverride;
 /// {@endtemplate}
 class StorageS3Service {
   /// {@macro amplify_storage_s3.storage_s3_service}
-  StorageS3Service({
+  factory StorageS3Service({
     required S3PluginConfig s3PluginConfig,
     required S3PrefixResolver prefixResolver,
     required AWSIamAmplifyAuthProvider credentialsProvider,
     required AWSLogger logger,
-    String? delimiter,
     required DependencyManager dependencyManager,
+    String? delimiter,
+  }) {
+    final usePathStyle = s3PluginConfig.bucket.contains('.');
+
+    if (usePathStyle) {
+      logger.warn(
+          'Since your bucket name contains dots (`"."`), the StorageS3 plugin'
+          ' will use path style URLs to communicate with the S3 service. S3'
+          ' Transfer acceleration is not supported for path style URLs. For more'
+          ' information, refer to:'
+          ' https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html');
+    }
+
+    final s3ClientConfig = smithy_aws.S3ClientConfig(
+      signerConfiguration: _defaultS3SignerConfiguration,
+      usePathStyle: usePathStyle,
+    );
+
+    return StorageS3Service._(
+      s3PluginConfig: s3PluginConfig,
+      s3ClientConfig: s3ClientConfig,
+      prefixResolver: prefixResolver,
+      credentialsProvider: credentialsProvider,
+      logger: logger,
+      dependencyManager: dependencyManager,
+      delimiter: delimiter,
+    );
+  }
+
+  StorageS3Service._({
+    required S3PluginConfig s3PluginConfig,
+    required smithy_aws.S3ClientConfig s3ClientConfig,
+    required S3PrefixResolver prefixResolver,
+    required AWSIamAmplifyAuthProvider credentialsProvider,
+    required AWSLogger logger,
+    required DependencyManager dependencyManager,
+    String? delimiter,
   })  : _s3PluginConfig = s3PluginConfig,
         _delimiter = delimiter ?? '/',
+        _defaultS3ClientConfig = s3ClientConfig,
         // dependencyManager.get() => S3Client is used for unit tests
         _defaultS3Client = dependencyManager.get() ??
             s3.S3Client(
               region: s3PluginConfig.region,
               credentialsProvider: credentialsProvider,
-              s3ClientConfig: _defaultS3ClientConfig,
+              s3ClientConfig: s3ClientConfig,
               client: AmplifyHttpClient(dependencyManager)
                 ..supportedProtocols = SupportedProtocols.http1,
             ),
@@ -55,9 +92,6 @@ class StorageS3Service {
         _dependencyManager = dependencyManager,
         _serviceStartingTime = DateTime.now();
 
-  static final _defaultS3ClientConfig = smithy_aws.S3ClientConfig(
-    signerConfiguration: _defaultS3SignerConfiguration,
-  );
   // TODO(HuiSF): re-enable signPayload when the signer supports hashing on
   //  different threads.
   static final _defaultS3SignerConfiguration =
@@ -65,6 +99,7 @@ class StorageS3Service {
 
   final S3PluginConfig _s3PluginConfig;
   final String _delimiter;
+  final smithy_aws.S3ClientConfig _defaultS3ClientConfig;
   final s3.S3Client _defaultS3Client;
   final S3PrefixResolver _prefixResolver;
   final AWSLogger _logger;
@@ -210,6 +245,11 @@ class StorageS3Service {
     final s3PluginOptions = options.pluginOptions as S3GetUrlPluginOptions? ??
         const S3GetUrlPluginOptions();
 
+    if (s3PluginOptions.useAccelerateEndpoint &&
+        _defaultS3ClientConfig.usePathStyle) {
+      throw s3_exception.accelerateEndpointUnusable;
+    }
+
     if (s3PluginOptions.validateObjectExistence) {
       // make a HeadObject call for validating object existence
       // the validation may throw exceptions that are thrown from
@@ -244,7 +284,10 @@ class StorageS3Service {
     var host =
         '${_s3PluginConfig.bucket}.${_getS3EndpointHost(region: _s3PluginConfig.region)}';
 
-    if (s3PluginOptions.useAccelerateEndpoint) {
+    if (_defaultS3ClientConfig.usePathStyle) {
+      host = host.replaceFirst('${_s3PluginConfig.bucket}.', '');
+      keyToGetUrl = '/${_s3PluginConfig.bucket}$keyToGetUrl';
+    } else if (s3PluginOptions.useAccelerateEndpoint) {
       // https: //docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration-getting-started.html
       host = host
           .replaceFirst(RegExp('${_s3PluginConfig.region}\\.'), '')

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_download_task.dart
@@ -132,6 +132,12 @@ class S3DownloadTask {
 
     _state = StorageTransferState.inProgress;
 
+    if (_s3PluginOptions.useAccelerateEndpoint &&
+        _defaultS3ClientConfig.usePathStyle) {
+      await _completeDownloadWithError(s3_exception.accelerateEndpointUnusable);
+      return;
+    }
+
     try {
       await _preStart?.call();
     } on Exception catch (error, stackTrace) {

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -199,6 +199,12 @@ class S3UploadTask {
   ///
   /// Should be used only internally.
   Future<void> start() async {
+    if (_s3PluginOptions.useAccelerateEndpoint &&
+        _defaultS3ClientConfig.usePathStyle) {
+      _completeUploadWithError(s3_exception.accelerateEndpointUnusable);
+      return;
+    }
+
     try {
       await _setResolvedKey();
     } on Exception catch (error, stackTrace) {

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:amplify_core/amplify_core.dart' hide PaginatedResult;
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/exception/s3_storage_exception.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';
 import 'package:aws_signature_v4/aws_signature_v4.dart';
@@ -60,6 +61,23 @@ void main() {
         logger: logger,
         dependencyManager: dependencyManager,
       );
+    });
+
+    test('log a warning when should use path style URLs', () {
+      StorageS3Service(
+        s3PluginConfig: const S3PluginConfig(
+          bucket: 'bucket.name.has.dots.com',
+          region: 'us-west-2',
+        ),
+        prefixResolver: testPrefixResolver,
+        credentialsProvider: TestIamAuthProvider(),
+        logger: logger,
+        dependencyManager: dependencyManager,
+      );
+
+      final message = verify(() => logger.warn(captureAny())).captured.last;
+
+      expect(message, contains('Since your bucket name contains dots'));
     });
 
     group('_getResolvedPrefix()', () {
@@ -826,6 +844,106 @@ void main() {
             'AWSHttpRequest URI',
             contains('.s3-accelerate.'),
           ),
+        );
+      });
+
+      group('bucket name has dots (".")', () {
+        late AWSSigV4Signer pathStyleAwsSigV4Signer;
+        late StorageS3Service pathStyleStorageS3Service;
+        const pathStyleBucket = 'bucket.name.has.dots.com';
+        const pathStyleRegion = 'west-2';
+        const pathStyleS3PluginConfig =
+            S3PluginConfig(bucket: pathStyleBucket, region: pathStyleRegion);
+        final pathStyleURL = Uri(
+          host: 's3.amazonaws.com',
+          path: '/bucket.name.has.dots.com/album/1.jpg',
+          scheme: 'https',
+        );
+
+        setUpAll(() {
+          pathStyleAwsSigV4Signer = MockAWSSigV4Signer();
+          dependencyManager = DependencyManager()
+            ..addInstance<S3Client>(MockS3Client())
+            ..addInstance<AWSSigV4Signer>(pathStyleAwsSigV4Signer);
+          pathStyleStorageS3Service = StorageS3Service(
+            s3PluginConfig: pathStyleS3PluginConfig,
+            prefixResolver: testPrefixResolver,
+            credentialsProvider: TestIamAuthProvider(),
+            logger: MockAWSLogger(),
+            dependencyManager: dependencyManager,
+          );
+        });
+
+        test(
+          'generate path style URL',
+          () async {
+            const testOptions = StorageGetUrlOptions();
+
+            when(
+              () => pathStyleAwsSigV4Signer.presign(
+                any(),
+                credentialScope: any(named: 'credentialScope'),
+                serviceConfiguration: any(named: 'serviceConfiguration'),
+                expiresIn: any(named: 'expiresIn'),
+              ),
+            ).thenAnswer((_) async => pathStyleURL);
+
+            getUrlResult = await pathStyleStorageS3Service.getUrl(
+              key: testKey,
+              options: testOptions,
+            );
+
+            final capturedRequest = verify(
+              () => pathStyleAwsSigV4Signer.presign(
+                captureAny<AWSHttpRequest>(),
+                credentialScope: any(named: 'credentialScope'),
+                expiresIn: any(named: 'expiresIn'),
+                serviceConfiguration: any(
+                  named: 'serviceConfiguration',
+                ),
+              ),
+            ).captured.first;
+
+            expect(
+              capturedRequest,
+              isA<AWSHttpRequest>()
+                  .having(
+                    (o) => o.host,
+                    'host',
+                    's3.${pathStyleS3PluginConfig.region}.amazonaws.com',
+                  )
+                  .having(
+                    (o) => o.path,
+                    'path',
+                    '/bucket.name.has.dots.com/public#some-object',
+                  ),
+            );
+          },
+        );
+
+        test(
+          'throw exception when attempt to use accelerate endpoint with path style URL',
+          () {
+            const testOptions = StorageGetUrlOptions(
+              pluginOptions: S3GetUrlPluginOptions(
+                useAccelerateEndpoint: true,
+              ),
+            );
+
+            expect(
+              pathStyleStorageS3Service.getUrl(
+                key: testKey,
+                options: testOptions,
+              ),
+              throwsA(
+                isA<ConfigurationError>().having(
+                  (o) => o.message,
+                  'message',
+                  equals(accelerateEndpointUnusable.message),
+                ),
+              ),
+            );
+          },
         );
       });
     });

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_download_task_test.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/exception/s3_storage_exception.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart';
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/service/task/s3_download_task.dart';
 import 'package:mocktail/mocktail.dart';
@@ -236,6 +237,32 @@ void main() {
           throwsA(isA<StorageException>()),
         );
         expect(onErrorHasBeenCalled, isTrue);
+      });
+
+      test(
+          'throw exception when attempt to use accelerate endpoint with path style URL',
+          () {
+        final downloadTask = S3DownloadTask(
+          s3Client: s3Client,
+          defaultS3ClientConfig: const S3ClientConfig(usePathStyle: true),
+          prefixResolver: testPrefixResolver,
+          bucket: 'bucket.name.has.dots.com',
+          defaultAccessLevel: testDefaultAccessLevel,
+          key: testKey,
+          options: const StorageDownloadDataOptions(
+            pluginOptions: S3DownloadDataPluginOptions(
+              useAccelerateEndpoint: true,
+            ),
+          ),
+          logger: logger,
+        );
+
+        unawaited(downloadTask.start());
+
+        expect(
+          downloadTask.result,
+          throwsA(accelerateEndpointUnusable),
+        );
       });
     });
 

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3_dart/amplify_storage_s3_dart.dart';
+import 'package:amplify_storage_s3_dart/src/exception/s3_storage_exception.dart';
 import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/storage_s3_service.dart';
 import 'package:amplify_storage_s3_dart/src/storage_s3_service/transfer/database/transfer_record.dart';
@@ -2052,6 +2053,35 @@ void main() {
           verify(uploadPartSmithyOperation2.cancel).called(1);
           verify(uploadPartSmithyOperation3.cancel).called(1);
         });
+      });
+    });
+
+    group('path style URL', () {
+      test('throw exception when attempt to use accelerate endpoint', () {
+        final uploadTask = S3UploadTask.fromAWSFile(
+          AWSFile.fromPath('fake/file.jpg'),
+          s3Client: s3Client,
+          defaultS3ClientConfig:
+              const smithy_aws.S3ClientConfig(usePathStyle: true),
+          prefixResolver: testPrefixResolver,
+          bucket: testBucket,
+          defaultAccessLevel: testDefaultAccessLevel,
+          key: 'fake-key',
+          options: const StorageUploadDataOptions(
+            pluginOptions: S3UploadDataPluginOptions(
+              useAccelerateEndpoint: true,
+            ),
+          ),
+          logger: logger,
+          transferDatabase: transferDatabase,
+        );
+
+        unawaited(uploadTask.start());
+
+        expect(
+          uploadTask.result,
+          throwsA(accelerateEndpointUnusable),
+        );
       });
     });
   });


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-flutter/issues/3147

*Description of changes:*

* Update the infra stack to add a bucket that has dots in its name for integration tests
* Add support of using path style URLs when need to
* throwing exceptions when attempt to use acceleration endpoint when use path style URLs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
