### PR TITLE
feat(logging): logger can register one plugin per type in a logger hierarchy

### DIFF
--- a/packages/amplify_core/lib/src/logger/amplify_logger.dart
+++ b/packages/amplify_core/lib/src/logger/amplify_logger.dart
@@ -37,6 +37,9 @@ class AmplifyLogger extends AWSLogger {
     assert(name.isNotEmpty, 'Name should not be empty');
     return AmplifyLogger('$namespace.$name');
   }
+
+  @override
+  String get runtimeTypeName => 'AmplifyLogger';
 }
 
 /// {@template amplify_core.logger.amplify_logger_plugin}

--- a/packages/aws_common/lib/src/logging/aws_logger.dart
+++ b/packages/aws_common/lib/src/logging/aws_logger.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:aws_common/aws_common.dart';
 import 'package:aws_common/src/logging/logging_ext.dart';
+import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 
@@ -22,7 +23,7 @@ const zDefaultLogLevel = LogLevel.info;
 ///
 /// By default, a [SimpleLogPrinter] is registered on the root [AWSLogger]
 /// which impacts all child loggers.
-class AWSLogger implements Closeable {
+class AWSLogger with AWSDebuggable implements Closeable {
   /// Creates a top-level [AWSLogger].
   ///
   /// {@macro aws_common.logging.aws_logger}
@@ -40,6 +41,7 @@ class AWSLogger implements Closeable {
   @protected
   AWSLogger.protected(String namespace) : _logger = Logger(namespace) {
     _init(this);
+    _parent?._children.add(this);
   }
 
   static bool _initialized = false;
@@ -63,6 +65,24 @@ class AWSLogger implements Closeable {
 
   final Logger _logger;
 
+  /// Parent of this logger in the logger hierarchy.
+  AWSLogger? get _parent {
+    return activeLoggers[_logger.parent?.fullName];
+  }
+
+  /// Children of this logger in the logger hierarchy.
+  final List<AWSLogger> _children = [];
+
+  Never _pluginAlreadyRegistered(String pluginType) {
+    final loggerInstance = '$runtimeTypeName($namespace)';
+    throw StateError(
+      'A plugin of type "$pluginType" is already registered to'
+      ' "$loggerInstance" in the same logging hierarchy. Unregister the'
+      ' existing plugin from "$loggerInstance" first and then register the'
+      ' new plugin.',
+    );
+  }
+
   /// The namespace of this logger.
   String get namespace => _logger.fullName;
 
@@ -72,10 +92,31 @@ class AWSLogger implements Closeable {
     return AWSLogger('$namespace.$name');
   }
 
+  /// Returns a plugin of type [Plugin] registered to this
+  /// logger hierarchy or `null`.
+  Plugin? getPlugin<Plugin extends AWSLoggerPlugin>() {
+    final registeredPlugin = _subscriptions.keys
+            .firstWhereOrNull((element) => element.runtimeType == Plugin)
+        as Plugin?;
+    return registeredPlugin ?? _parent?.getPlugin<Plugin>();
+  }
+
   /// Registers an [AWSLoggerPlugin] to handle logs emitted by this logger
   /// instance.
-  void registerPlugin(AWSLoggerPlugin plugin) {
-    unregisterPlugin(plugin);
+  ///
+  /// Throws [StateError] if a plugin with same type is registered to this
+  /// logger hierarchy.
+  void registerPlugin<T extends AWSLoggerPlugin>(
+    T plugin,
+  ) {
+    bool hasPlugin(AWSLogger logger) =>
+        logger._subscriptions.keys.any((element) => element.runtimeType == T) ||
+        logger._children.any(hasPlugin);
+
+    if (getPlugin<T>() != null || _children.any(hasPlugin)) {
+      _pluginAlreadyRegistered(T.toString());
+    }
+
     _subscriptions[plugin] = _logger.onRecord
         .map((record) => record.toLogEntry())
         .listen(plugin.handleLogEntry);
@@ -141,6 +182,10 @@ class AWSLogger implements Closeable {
 
   @override
   void close() => unregisterAllPlugins();
+
+  @override
+  @mustBeOverridden
+  String get runtimeTypeName => 'AWSLogger';
 }
 
 /// {@template aws_common.logging.aws_logger_plugin}

--- a/packages/notifications/push/amplify_push_notifications/test/amplify_push_noitfications_impl_test.mocks.dart
+++ b/packages/notifications/push/amplify_push_notifications/test/amplify_push_noitfications_impl_test.mocks.dart
@@ -57,6 +57,9 @@ class _FakeAWSLogger_2 extends _i1.SmartFake implements _i4.AWSLogger {
           parent,
           parentInvocation,
         );
+
+  @override
+  String get runtimeTypeName => '_FakeAWSLogger_2';
 }
 
 /// A class which mocks [PushNotificationsHostApi].

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/test/push_notifications_background_processing_test.mocks.dart
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/test/push_notifications_background_processing_test.mocks.dart
@@ -45,6 +45,9 @@ class _FakeAWSLogger_1 extends _i1.SmartFake implements _i3.AWSLogger {
           parent,
           parentInvocation,
         );
+
+  @override
+  String get runtimeTypeName => '_FakeAWSLogger_1';
 }
 
 class _FakeAuthCategory_2 extends _i1.SmartFake implements _i4.AuthCategory {

--- a/packages/storage/amplify_storage_s3_dart/test/test_utils/mocks.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/test_utils/mocks.dart
@@ -13,7 +13,10 @@ class MockStorageS3Service extends Mock implements StorageS3Service {}
 
 class MockS3Client extends Mock implements S3Client {}
 
-class MockAWSLogger extends Mock implements AWSLogger {}
+class MockAWSLogger extends Mock implements AWSLogger {
+  @override
+  String get runtimeTypeName => 'MockAWSLogger';
+}
 
 class MockAWSSigV4Signer extends Mock implements AWSSigV4Signer {}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


- Update registerPlugin API to allow registering one plugin per type in a logger hierarchy.
- Add getPlugin API to get plugin of an specified type registered in a logger hierarchy.
