### PR TITLE
fix(auth, authenticator): prevent fetch session during sign up

### DIFF
--- a/packages/auth/amplify_auth_cognito_test/test/state/sign_in_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/sign_in_state_machine_test.dart
@@ -136,6 +136,15 @@ void main() {
         ).ignore();
 
       final signInStateMachine = stateMachine.expect(SignInStateMachine.type);
+
+      final fetchAuthSessionStateMachine = stateMachine.getOrCreate(
+        FetchAuthSessionStateMachine.type,
+      );
+
+      fetchAuthSessionStateMachine.stream.listen(
+        (_) => throw StateError('.signIn() should not fetch auth session.'),
+      );
+
       expect(
         signInStateMachine.stream,
         emitsInOrder([

--- a/packages/authenticator/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -28,8 +28,18 @@ abstract class AuthService {
 
   Future<AuthUser?> get currentUser;
 
+  /// Checks to see if a user has a valid session.
+  ///
+  /// A valid session is a session in which the tokens are not expired, OR
+  /// the access/id tokens have expired but the state of the refresh token is
+  /// unknown due to network unavailability.
   Future<bool> isValidSession();
 
+  /// Checks if a user is logged in based on whether or not there are
+  /// tokens on the device.
+  ///
+  /// This will not check whether or not those tokens are valid. To check
+  /// if tokens are valid, see [isValidSession].
   Future<bool> get isLoggedIn;
 
   Future<ResetPasswordResult> resetPassword(String username);
@@ -191,9 +201,8 @@ class AmplifyAuthService
   Future<bool> get isLoggedIn async {
     return _withUserAgent(() async {
       try {
-        final result = await Amplify.Auth.fetchAuthSession();
-
-        return result.isSignedIn;
+        await Amplify.Auth.getCurrentUser();
+        return true;
       } on SignedOutException {
         return false;
       }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/3122

*Description of changes:*
- prevent `Auth.signIn()` from fetching the session by using `loadCredentials()` insead of `getUserPoolTokens()` and by using an AnonymousCredentialsProvider on sign in calls.
- Update the Authenticator to use getCurrentUser to check the sign in state prior to calling sign in. This aligns with the updated behavior in the auth library and will prevent unnecessary network calls to fetch the session.

*Background:*
- The sign in flow can result in unnecessary network calls. At multiple points in the sign in flow there is an attempt to retrieve credentials. If there is no unauthenticated identity at this point, the auth lib attempts to create an unauthenticated identity. This results in 2 extra calls in the case where unuathenticated identities are allowed (one to get ID and one to get credentials) and results in several additional calls in the case that unuathenticated identities are not allowed (each attempt will call get ID which will fail).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
