### PR TITLE
chore: bump build_value_generator

### DIFF
--- a/aft.yaml
+++ b/aft.yaml
@@ -10,7 +10,7 @@ dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   built_value: ">=8.6.0 <8.7.0"
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   code_builder: 4.5.0
   connectivity_plus: ^4.0.1
   dart_style: 2.3.1

--- a/packages/aft/pubspec.yaml
+++ b/packages/aft/pubspec.yaml
@@ -54,7 +54,7 @@ dependency_overrides:
 dev_dependencies:
   amplify_lints: ">=2.0.2 <2.1.0"
   build_runner: ^2.4.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   json_serializable: 6.7.0
   test: ^1.22.1
 

--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -32,7 +32,7 @@ dev_dependencies:
   build_verify: ^3.0.0
   build_version: ^2.0.0
   build_web_compilers: ^4.0.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   drift_dev: ^2.2.0+1
   mocktail: ^0.3.0
   test: ^1.22.1

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -44,7 +44,7 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_verify: ^3.0.0
   build_web_compilers: ^4.0.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   ffigen: ^8.0.1
   json_serializable: 6.7.0
   mockito: ^5.0.0

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_test: ^2.1.5
   build_web_compilers: ^4.0.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   json_serializable: 6.7.0
   stream_channel: ^2.1.0
   test: ^1.22.1

--- a/packages/aws_sdk/smoke_test/pubspec.yaml
+++ b/packages/aws_sdk/smoke_test/pubspec.yaml
@@ -19,6 +19,6 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.0
   build_verify: ^3.1.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.0.0
   test: ^1.22.1

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
@@ -33,7 +33,7 @@ dev_dependencies:
   aws_common: ">=0.5.0 <0.6.0"
   aws_signature_v4: ">=0.4.0 <0.5.0"
   build_runner: ^2.4.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
@@ -39,7 +39,7 @@ dev_dependencies:
   build: ^2.3.0
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   ffigen: ^8.0.0
   test: ^1.22.1
   worker_bee_builder: ">=0.2.0 <0.3.0"

--- a/packages/smithy/goldens/lib/awsJson1_0/pubspec.yaml
+++ b/packages/smithy/goldens/lib/awsJson1_0/pubspec.yaml
@@ -39,6 +39,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib/awsJson1_1/pubspec.yaml
+++ b/packages/smithy/goldens/lib/awsJson1_1/pubspec.yaml
@@ -42,6 +42,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib/awsQuery/pubspec.yaml
+++ b/packages/smithy/goldens/lib/awsQuery/pubspec.yaml
@@ -38,6 +38,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib/custom/pubspec.yaml
+++ b/packages/smithy/goldens/lib/custom/pubspec.yaml
@@ -41,6 +41,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib/restJson1/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restJson1/pubspec.yaml
@@ -42,6 +42,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXml/pubspec.yaml
@@ -43,6 +43,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
@@ -41,6 +41,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib2/awsJson1_0/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/awsJson1_0/pubspec.yaml
@@ -39,6 +39,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib2/awsJson1_1/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/awsJson1_1/pubspec.yaml
@@ -42,6 +42,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib2/awsQuery/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/awsQuery/pubspec.yaml
@@ -38,6 +38,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib2/custom/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/custom/pubspec.yaml
@@ -41,6 +41,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib2/restJson1/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restJson1/pubspec.yaml
@@ -42,6 +42,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib2/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXml/pubspec.yaml
@@ -43,6 +43,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
@@ -41,6 +41,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   build_test: ^2.1.5
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   lints: ^2.1.0
   test: ^1.22.1

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
 dev_dependencies:
   amplify_lints: ">=3.0.0 <3.1.0"
   build_runner: ^2.4.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   json_serializable: 6.7.0
   stack_trace: ^1.10.0
   test: ^1.22.1

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
 dev_dependencies:
   amplify_lints: ">=3.0.0 <3.1.0"
   build_runner: ^2.4.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   file: ^6.1.2
   glob: ^2.0.2
   json_serializable: 6.7.0

--- a/packages/smithy/smithy_codegen/pubspec.yaml
+++ b/packages/smithy/smithy_codegen/pubspec.yaml
@@ -42,7 +42,7 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_verify: ^3.0.0
   build_version: ^2.1.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   json_serializable: 6.7.0
   smithy_test:
     path: ../smithy_test

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   amplify_lints: ">=3.0.0 <3.1.0"
   build_runner: ^2.4.0
   build_verify: ^3.0.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   drift_dev: ^2.2.0+1
   json_serializable: 6.7.0
   mocktail: ^0.3.0

--- a/packages/test/amplify_integration_test/pubspec.yaml
+++ b/packages/test/amplify_integration_test/pubspec.yaml
@@ -26,4 +26,4 @@ dependencies:
 dev_dependencies:
   amplify_lints: ^2.0.0
   build_runner: ^2.4.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1

--- a/packages/worker_bee/e2e/pubspec.yaml
+++ b/packages/worker_bee/e2e/pubspec.yaml
@@ -26,6 +26,6 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_verify: ^3.0.0
   build_web_compilers: ^4.0.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   worker_bee_builder:
     path: ../worker_bee_builder

--- a/packages/worker_bee/e2e_test/pubspec.yaml
+++ b/packages/worker_bee/e2e_test/pubspec.yaml
@@ -20,7 +20,7 @@ dev_dependencies:
   build_web_compilers: ^4.0.0
   built_collection: ^5.0.0
   built_value: ">=8.6.0 <8.7.0"
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   e2e:
     path: ../e2e
   meta: ^1.7.0

--- a/packages/worker_bee/worker_bee/pubspec.yaml
+++ b/packages/worker_bee/worker_bee/pubspec.yaml
@@ -24,5 +24,5 @@ dependencies:
 dev_dependencies:
   amplify_lints: ">=3.0.0 <3.1.0"
   build_runner: ^2.4.0
-  built_value_generator: 8.6.0
+  built_value_generator: 8.6.1
   test: ^1.22.1


### PR DESCRIPTION
Bumps `build_value_generator` to 8.6.1 in `aft.yaml` and includes result of `aft constraints udpate`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
