### PR TITLE
chore(core): Adjust log-level of state machine errors

### DIFF
--- a/packages/amplify_core/lib/src/state_machine/state_machine.dart
+++ b/packages/amplify_core/lib/src/state_machine/state_machine.dart
@@ -291,7 +291,7 @@ abstract class StateMachine<
     final stateMachineTrace = Trace.from(stackTrace);
     stackTrace = Chain([stateMachineTrace, eventTrace]);
 
-    logger.error('Emitted error', error, stackTrace);
+    logger.debug('Emitted error', error, stackTrace);
 
     final resolution = resolveError(error, stackTrace);
 


### PR DESCRIPTION
Errors generated by the state machine are being logged at `error ` level regardless of whether they are handled by the developer. This can be confusing (as seen in #3226) since they print similar to how an unhandled exception would be printed.

By adjusting the log level, these messages are still available if desired and will not affect how errors are surfaced via throwing.
