### PR TITLE
fix(aft): Minor fixes

### DIFF
--- a/packages/aft/lib/src/commands/constraints_command.dart
+++ b/packages/aft/lib/src/commands/constraints_command.dart
@@ -294,7 +294,6 @@ class _ConstraintsUpdateCommand extends _ConstraintsSubcommand {
             );
             continue;
           }
-          // ">=1.1.0 <1.4.3"
           if (latestVersion >= lowerBound.nextBreaking) {
             logger.warn(
               'Breaking change detected for $package: $latestVersion '
@@ -302,6 +301,7 @@ class _ConstraintsUpdateCommand extends _ConstraintsSubcommand {
             );
             continue;
           }
+          // ">=1.1.0 <1.4.3"
           updateConstraint(
             VersionRange(
               min: lowerBound,
@@ -327,12 +327,14 @@ class _ConstraintsUpdateCommand extends _ConstraintsSubcommand {
       logger.info('No dependencies updated');
     }
 
-    for (final failedUpdate in failedUpdates) {
-      logger.error('Could not update $failedUpdate');
-      exitCode = 1;
+    if (failedUpdates.isNotEmpty) {
+      for (final failedUpdate in failedUpdates) {
+        logger.error('Could not update $failedUpdate');
+      }
+      exit(1);
     }
 
-    if (hasUpdates && failedUpdates.isEmpty) {
+    if (hasUpdates) {
       await _run(_ConstraintsAction.apply);
     }
   }

--- a/packages/aft/lib/src/commands/publish_command.dart
+++ b/packages/aft/lib/src/commands/publish_command.dart
@@ -268,6 +268,10 @@ Future<void> runBuildRunner(
   if (!package.needsBuildRunner) {
     return;
   }
+  final dartTool = Directory(p.join(package.path, '.dart_tool'));
+  if (!dartTool.existsSync()) {
+    await runPub(package.flavor, ['get'], package);
+  }
   logger.info('Running build_runner for ${package.name}...');
   final buildRunnerCmd = await Process.start(
     package.flavor.entrypoint,


### PR DESCRIPTION
**fix(aft): Run pub get before build_runner if necessary**
If running in a fresh repo/worktree, pub get may not have been run yet which can cause errors. 

**fix(aft): Bump constraints on non-breaking change**
For non-breaking changes, we still need to update all constraints since we "pin" to minor versions. Before, this was leaving some outdated constraints in the repo.