### PR TITLE
fix(storage): list options pageSize and nextToken params got lost

### DIFF
--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -143,6 +143,8 @@ class AmplifyStorageS3Dart extends StoragePluginInterface
     final s3Options = StorageListOptions(
       accessLevel: options?.accessLevel,
       pluginOptions: s3PluginOptions,
+      nextToken: options?.nextToken,
+      pageSize: options?.pageSize ?? 1000,
     );
 
     return S3ListOperation(

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -187,6 +187,8 @@ void main() {
         const testOptions = StorageListOptions(
           accessLevel: testAccessLevelProtected,
           pluginOptions: S3ListPluginOptions(excludeSubPaths: true),
+          nextToken: 'next-token-123',
+          pageSize: 2,
         );
 
         when(


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-flutter/issues/3275

*Description of changes:*

Ensure `pageSize` and `nextToken` options fields being forwarded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
