### PR TITLE
chore(storage): integ test for pageSize/nextToken in list()

### DIFF
--- a/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
@@ -726,6 +726,99 @@ void main() {
             expect(result.copiedItem.eTag, isNotEmpty);
           });
 
+          testWidgets('list respects pageSize', (WidgetTester tester) async {
+            const filesToUpload = 2;
+            const filesToList = 1;
+            const accessLevel = StorageAccessLevel.private;
+            final uploadedKeys = <String>[];
+            // Upload some files to test.
+            for (var i = filesToUpload; i > 0; i--) {
+              final fileKey = 'testObjectKey${uuid()}';
+              uploadedKeys.add(fileKey);
+              final fileNameTemp = 'userPrivate${uuid()}.txt';
+              await Amplify.Storage.uploadData(
+                data: S3DataPayload.bytes(
+                  testBytes,
+                  contentType: 'text/plain',
+                ),
+                key: fileKey,
+                options: StorageUploadDataOptions(
+                  accessLevel: accessLevel,
+                  metadata: {
+                    'filename': fileNameTemp,
+                  },
+                ),
+              ).result;
+            }
+
+            // Call list() and ensure length of result matches pageSize.
+            final listResult = await Amplify.Storage.list(
+              options: const StorageListOptions(
+                accessLevel: accessLevel,
+                pageSize: filesToList,
+              ),
+            ).result;
+            expect(listResult.nextToken?.isNotEmpty, isTrue);
+            expect(listResult.items.length, filesToList);
+            // Clean up files from this test.
+            await Amplify.Storage.removeMany(
+              keys: uploadedKeys,
+              options: const StorageRemoveManyOptions(
+                accessLevel: accessLevel,
+              ),
+            ).result;
+          });
+
+          testWidgets('list uses nextToken for pagination',
+              (WidgetTester tester) async {
+            const filesToUpload = 2;
+            const filesToList = 1;
+            const accessLevel = StorageAccessLevel.private;
+            final uploadedKeys = <String>[];
+            // Upload some files to test.
+            for (var i = filesToUpload; i > 0; i--) {
+              final fileKey = 'testObjectKey${uuid()}';
+              uploadedKeys.add(fileKey);
+              final fileNameTemp = 'userPrivate${uuid()}.txt';
+              await Amplify.Storage.uploadData(
+                data: S3DataPayload.bytes(
+                  testBytes,
+                  contentType: 'text/plain',
+                ),
+                key: fileKey,
+                options: StorageUploadDataOptions(
+                  accessLevel: accessLevel,
+                  metadata: {
+                    'filename': fileNameTemp,
+                  },
+                ),
+              ).result;
+            }
+
+            String? lastNextToken;
+            var timesCalled = 0;
+            while (lastNextToken != null || timesCalled == 0) {
+              // Call list() until nextToken is null and ensure we paginated expected times.
+              final listResult = await Amplify.Storage.list(
+                options: StorageListOptions(
+                  accessLevel: accessLevel,
+                  pageSize: filesToList,
+                  nextToken: lastNextToken,
+                ),
+              ).result;
+              lastNextToken = listResult.nextToken;
+              timesCalled++;
+            }
+            expect(timesCalled, greaterThanOrEqualTo(filesToUpload));
+            // Clean up files from this test.
+            await Amplify.Storage.removeMany(
+              keys: uploadedKeys,
+              options: const StorageRemoveManyOptions(
+                accessLevel: accessLevel,
+              ),
+            ).result;
+          });
+
           testWidgets(
               'remove many objects belongs to the currently signed user',
               (WidgetTester tester) async {

--- a/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
@@ -774,10 +774,11 @@ void main() {
             const filesToUpload = 2;
             const filesToList = 1;
             const accessLevel = StorageAccessLevel.private;
+            final keyPrefix = 'testObjectList${uuid()}';
             final uploadedKeys = <String>[];
             // Upload some files to test.
             for (var i = filesToUpload; i > 0; i--) {
-              final fileKey = 'testObjectKey${uuid()}';
+              final fileKey = '$keyPrefix/uploadToList${uuid()}';
               uploadedKeys.add(fileKey);
               final fileNameTemp = 'userPrivate${uuid()}.txt';
               await Amplify.Storage.uploadData(
@@ -797,7 +798,7 @@ void main() {
 
             String? lastNextToken;
             var timesCalled = 0;
-            while (lastNextToken != null || timesCalled == 0) {
+            do {
               // Call list() until nextToken is null and ensure we paginated expected times.
               final listResult = await Amplify.Storage.list(
                 options: StorageListOptions(
@@ -805,11 +806,12 @@ void main() {
                   pageSize: filesToList,
                   nextToken: lastNextToken,
                 ),
+                path: keyPrefix,
               ).result;
               lastNextToken = listResult.nextToken;
               timesCalled++;
-            }
-            expect(timesCalled, greaterThanOrEqualTo(filesToUpload));
+            } while (lastNextToken != null);
+            expect(timesCalled, equals(filesToUpload));
             // Clean up files from this test.
             await Amplify.Storage.removeMany(
               keys: uploadedKeys,


### PR DESCRIPTION
Adds some integ tests for s3 list() API.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
