### PR TITLE
chore(smithy): Improve union DX

### DIFF
--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/analytics_filter.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/analytics_filter.dart
@@ -16,10 +16,23 @@ sealed class AnalyticsFilter extends _i1.SmithyUnion<AnalyticsFilter> {
 
   const factory AnalyticsFilter.prefix(String prefix) = AnalyticsFilterPrefix;
 
-  const factory AnalyticsFilter.tag(_i2.Tag tag) = AnalyticsFilterTag;
+  factory AnalyticsFilter.tag({
+    required String key,
+    required String value,
+  }) =>
+      AnalyticsFilterTag(_i2.Tag(
+        key: key,
+        value: value,
+      ));
 
-  const factory AnalyticsFilter.and(_i3.AnalyticsAndOperator and) =
-      AnalyticsFilterAnd;
+  factory AnalyticsFilter.and({
+    String? prefix,
+    List<_i2.Tag>? tags,
+  }) =>
+      AnalyticsFilterAnd(_i3.AnalyticsAndOperator(
+        prefix: prefix,
+        tags: tags,
+      ));
 
   const factory AnalyticsFilter.sdkUnknown(
     String name,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/lifecycle_rule_filter.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/lifecycle_rule_filter.dart
@@ -18,7 +18,14 @@ sealed class LifecycleRuleFilter extends _i1.SmithyUnion<LifecycleRuleFilter> {
   const factory LifecycleRuleFilter.prefix(String prefix) =
       LifecycleRuleFilterPrefix;
 
-  const factory LifecycleRuleFilter.tag(_i2.Tag tag) = LifecycleRuleFilterTag;
+  factory LifecycleRuleFilter.tag({
+    required String key,
+    required String value,
+  }) =>
+      LifecycleRuleFilterTag(_i2.Tag(
+        key: key,
+        value: value,
+      ));
 
   const factory LifecycleRuleFilter.objectSizeGreaterThan(
           _i3.Int64 objectSizeGreaterThan) =
@@ -27,8 +34,18 @@ sealed class LifecycleRuleFilter extends _i1.SmithyUnion<LifecycleRuleFilter> {
   const factory LifecycleRuleFilter.objectSizeLessThan(
       _i3.Int64 objectSizeLessThan) = LifecycleRuleFilterObjectSizeLessThan;
 
-  const factory LifecycleRuleFilter.and(_i4.LifecycleRuleAndOperator and) =
-      LifecycleRuleFilterAnd;
+  factory LifecycleRuleFilter.and({
+    String? prefix,
+    List<_i2.Tag>? tags,
+    _i3.Int64? objectSizeGreaterThan,
+    _i3.Int64? objectSizeLessThan,
+  }) =>
+      LifecycleRuleFilterAnd(_i4.LifecycleRuleAndOperator(
+        prefix: prefix,
+        tags: tags,
+        objectSizeGreaterThan: objectSizeGreaterThan,
+        objectSizeLessThan: objectSizeLessThan,
+      ));
 
   const factory LifecycleRuleFilter.sdkUnknown(
     String name,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/metrics_filter.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/metrics_filter.dart
@@ -16,13 +16,28 @@ sealed class MetricsFilter extends _i1.SmithyUnion<MetricsFilter> {
 
   const factory MetricsFilter.prefix(String prefix) = MetricsFilterPrefix;
 
-  const factory MetricsFilter.tag(_i2.Tag tag) = MetricsFilterTag;
+  factory MetricsFilter.tag({
+    required String key,
+    required String value,
+  }) =>
+      MetricsFilterTag(_i2.Tag(
+        key: key,
+        value: value,
+      ));
 
   const factory MetricsFilter.accessPointArn(String accessPointArn) =
       MetricsFilterAccessPointArn;
 
-  const factory MetricsFilter.and(_i3.MetricsAndOperator and) =
-      MetricsFilterAnd;
+  factory MetricsFilter.and({
+    String? prefix,
+    List<_i2.Tag>? tags,
+    String? accessPointArn,
+  }) =>
+      MetricsFilterAnd(_i3.MetricsAndOperator(
+        prefix: prefix,
+        tags: tags,
+        accessPointArn: accessPointArn,
+      ));
 
   const factory MetricsFilter.sdkUnknown(
     String name,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/replication_rule_filter.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/replication_rule_filter.dart
@@ -18,11 +18,23 @@ sealed class ReplicationRuleFilter
   const factory ReplicationRuleFilter.prefix(String prefix) =
       ReplicationRuleFilterPrefix;
 
-  const factory ReplicationRuleFilter.tag(_i2.Tag tag) =
-      ReplicationRuleFilterTag;
+  factory ReplicationRuleFilter.tag({
+    required String key,
+    required String value,
+  }) =>
+      ReplicationRuleFilterTag(_i2.Tag(
+        key: key,
+        value: value,
+      ));
 
-  const factory ReplicationRuleFilter.and(_i3.ReplicationRuleAndOperator and) =
-      ReplicationRuleFilterAnd;
+  factory ReplicationRuleFilter.and({
+    String? prefix,
+    List<_i2.Tag>? tags,
+  }) =>
+      ReplicationRuleFilterAnd(_i3.ReplicationRuleAndOperator(
+        prefix: prefix,
+        tags: tags,
+      ));
 
   const factory ReplicationRuleFilter.sdkUnknown(
     String name,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/select_object_content_event_stream.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/select_object_content_event_stream.dart
@@ -3,34 +3,39 @@
 
 library smoke_test.s3.model.select_object_content_event_stream; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:typed_data' as _i2;
+
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i1;
-import 'package:smoke_test/src/sdk/src/s3/model/continuation_event.dart' as _i5;
-import 'package:smoke_test/src/sdk/src/s3/model/end_event.dart' as _i6;
-import 'package:smoke_test/src/sdk/src/s3/model/progress_event.dart' as _i4;
-import 'package:smoke_test/src/sdk/src/s3/model/records_event.dart' as _i2;
-import 'package:smoke_test/src/sdk/src/s3/model/stats_event.dart' as _i3;
+import 'package:smoke_test/src/sdk/src/s3/model/continuation_event.dart' as _i8;
+import 'package:smoke_test/src/sdk/src/s3/model/end_event.dart' as _i9;
+import 'package:smoke_test/src/sdk/src/s3/model/progress.dart' as _i6;
+import 'package:smoke_test/src/sdk/src/s3/model/progress_event.dart' as _i7;
+import 'package:smoke_test/src/sdk/src/s3/model/records_event.dart' as _i3;
+import 'package:smoke_test/src/sdk/src/s3/model/stats.dart' as _i4;
+import 'package:smoke_test/src/sdk/src/s3/model/stats_event.dart' as _i5;
 
 /// The container for selecting objects from a content event stream.
 sealed class SelectObjectContentEventStream
     extends _i1.SmithyUnion<SelectObjectContentEventStream> {
   const SelectObjectContentEventStream._();
 
-  const factory SelectObjectContentEventStream.records(
-      _i2.RecordsEvent records) = SelectObjectContentEventStreamRecords;
+  factory SelectObjectContentEventStream.records({_i2.Uint8List? payload}) =>
+      SelectObjectContentEventStreamRecords(_i3.RecordsEvent(payload: payload));
 
-  const factory SelectObjectContentEventStream.stats(_i3.StatsEvent stats) =
-      SelectObjectContentEventStreamStats;
+  factory SelectObjectContentEventStream.stats({_i4.Stats? details}) =>
+      SelectObjectContentEventStreamStats(_i5.StatsEvent(details: details));
 
-  const factory SelectObjectContentEventStream.progress(
-      _i4.ProgressEvent progress) = SelectObjectContentEventStreamProgress;
+  factory SelectObjectContentEventStream.progress({_i6.Progress? details}) =>
+      SelectObjectContentEventStreamProgress(
+          _i7.ProgressEvent(details: details));
 
-  const factory SelectObjectContentEventStream.cont(
-      _i5.ContinuationEvent cont) = SelectObjectContentEventStreamCont;
+  factory SelectObjectContentEventStream.cont() =>
+      SelectObjectContentEventStreamCont(_i8.ContinuationEvent());
 
-  const factory SelectObjectContentEventStream.end(_i6.EndEvent end) =
-      SelectObjectContentEventStreamEnd;
+  factory SelectObjectContentEventStream.end() =>
+      SelectObjectContentEventStreamEnd(_i9.EndEvent());
 
   const factory SelectObjectContentEventStream.sdkUnknown(
     String name,
@@ -41,19 +46,19 @@ sealed class SelectObjectContentEventStream
       serializers = [SelectObjectContentEventStreamRestXmlSerializer()];
 
   /// The Records Event.
-  _i2.RecordsEvent? get records => null;
+  _i3.RecordsEvent? get records => null;
 
   /// The Stats Event.
-  _i3.StatsEvent? get stats => null;
+  _i5.StatsEvent? get stats => null;
 
   /// The Progress Event.
-  _i4.ProgressEvent? get progress => null;
+  _i7.ProgressEvent? get progress => null;
 
   /// The Continuation Event.
-  _i5.ContinuationEvent? get cont => null;
+  _i8.ContinuationEvent? get cont => null;
 
   /// The End Event.
-  _i6.EndEvent? get end => null;
+  _i9.EndEvent? get end => null;
   @override
   Object get value => (records ?? stats ?? progress ?? cont ?? end)!;
   @override
@@ -99,7 +104,7 @@ final class SelectObjectContentEventStreamRecords
   const SelectObjectContentEventStreamRecords(this.records) : super._();
 
   @override
-  final _i2.RecordsEvent records;
+  final _i3.RecordsEvent records;
 
   @override
   String get name => 'Records';
@@ -110,7 +115,7 @@ final class SelectObjectContentEventStreamStats
   const SelectObjectContentEventStreamStats(this.stats) : super._();
 
   @override
-  final _i3.StatsEvent stats;
+  final _i5.StatsEvent stats;
 
   @override
   String get name => 'Stats';
@@ -121,7 +126,7 @@ final class SelectObjectContentEventStreamProgress
   const SelectObjectContentEventStreamProgress(this.progress) : super._();
 
   @override
-  final _i4.ProgressEvent progress;
+  final _i7.ProgressEvent progress;
 
   @override
   String get name => 'Progress';
@@ -132,7 +137,7 @@ final class SelectObjectContentEventStreamCont
   const SelectObjectContentEventStreamCont(this.cont) : super._();
 
   @override
-  final _i5.ContinuationEvent cont;
+  final _i8.ContinuationEvent cont;
 
   @override
   String get name => 'Cont';
@@ -143,7 +148,7 @@ final class SelectObjectContentEventStreamEnd
   const SelectObjectContentEventStreamEnd(this.end) : super._();
 
   @override
-  final _i6.EndEvent end;
+  final _i9.EndEvent end;
 
   @override
   String get name => 'End';
@@ -195,28 +200,28 @@ class SelectObjectContentEventStreamRestXmlSerializer
       case 'Records':
         return SelectObjectContentEventStreamRecords((serializers.deserialize(
           value,
-          specifiedType: const FullType(_i2.RecordsEvent),
-        ) as _i2.RecordsEvent));
+          specifiedType: const FullType(_i3.RecordsEvent),
+        ) as _i3.RecordsEvent));
       case 'Stats':
         return SelectObjectContentEventStreamStats((serializers.deserialize(
           value,
-          specifiedType: const FullType(_i3.StatsEvent),
-        ) as _i3.StatsEvent));
+          specifiedType: const FullType(_i5.StatsEvent),
+        ) as _i5.StatsEvent));
       case 'Progress':
         return SelectObjectContentEventStreamProgress((serializers.deserialize(
           value,
-          specifiedType: const FullType(_i4.ProgressEvent),
-        ) as _i4.ProgressEvent));
+          specifiedType: const FullType(_i7.ProgressEvent),
+        ) as _i7.ProgressEvent));
       case 'Cont':
         return SelectObjectContentEventStreamCont((serializers.deserialize(
           value,
-          specifiedType: const FullType(_i5.ContinuationEvent),
-        ) as _i5.ContinuationEvent));
+          specifiedType: const FullType(_i8.ContinuationEvent),
+        ) as _i8.ContinuationEvent));
       case 'End':
         return SelectObjectContentEventStreamEnd((serializers.deserialize(
           value,
-          specifiedType: const FullType(_i6.EndEvent),
-        ) as _i6.EndEvent));
+          specifiedType: const FullType(_i9.EndEvent),
+        ) as _i9.EndEvent));
     }
     return SelectObjectContentEventStream.sdkUnknown(
       key,
@@ -236,27 +241,27 @@ class SelectObjectContentEventStreamRestXmlSerializer
         SelectObjectContentEventStreamRecords(:final value) =>
           serializers.serialize(
             value,
-            specifiedType: const FullType(_i2.RecordsEvent),
+            specifiedType: const FullType(_i3.RecordsEvent),
           ),
         SelectObjectContentEventStreamStats(:final value) =>
           serializers.serialize(
             value,
-            specifiedType: const FullType(_i3.StatsEvent),
+            specifiedType: const FullType(_i5.StatsEvent),
           ),
         SelectObjectContentEventStreamProgress(:final value) =>
           serializers.serialize(
             value,
-            specifiedType: const FullType(_i4.ProgressEvent),
+            specifiedType: const FullType(_i7.ProgressEvent),
           ),
         SelectObjectContentEventStreamCont(:final value) =>
           serializers.serialize(
             value,
-            specifiedType: const FullType(_i5.ContinuationEvent),
+            specifiedType: const FullType(_i8.ContinuationEvent),
           ),
         SelectObjectContentEventStreamEnd(:final value) =>
           serializers.serialize(
             value,
-            specifiedType: const FullType(_i6.EndEvent),
+            specifiedType: const FullType(_i9.EndEvent),
           ),
         SelectObjectContentEventStreamSdkUnknown(:final value) => value,
       },

--- a/packages/smithy/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/my_union.dart
+++ b/packages/smithy/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/my_union.dart
@@ -36,8 +36,8 @@ sealed class MyUnion extends _i1.SmithyUnion<MyUnion> {
 
   factory MyUnion.mapValue(Map<String, String> mapValue) = MyUnionMapValue;
 
-  const factory MyUnion.structureValue(_i4.GreetingStruct structureValue) =
-      MyUnionStructureValue;
+  factory MyUnion.structureValue({String? hi}) =>
+      MyUnionStructureValue(_i4.GreetingStruct(hi: hi));
 
   const factory MyUnion.sdkUnknown(
     String name,

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/my_union.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/model/my_union.dart
@@ -34,8 +34,8 @@ sealed class MyUnion extends _i1.SmithyUnion<MyUnion> {
 
   factory MyUnion.mapValue(Map<String, String> mapValue) = MyUnionMapValue;
 
-  const factory MyUnion.structureValue(_i4.GreetingStruct structureValue) =
-      MyUnionStructureValue;
+  factory MyUnion.structureValue({String? hi}) =>
+      MyUnionStructureValue(_i4.GreetingStruct(hi: hi));
 
   const factory MyUnion.sdkUnknown(
     String name,

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/my_union.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/my_union.dart
@@ -37,11 +37,11 @@ sealed class MyUnion extends _i1.SmithyUnion<MyUnion> {
 
   factory MyUnion.mapValue(Map<String, String> mapValue) = MyUnionMapValue;
 
-  const factory MyUnion.structureValue(_i4.GreetingStruct structureValue) =
-      MyUnionStructureValue;
+  factory MyUnion.structureValue({String? hi}) =>
+      MyUnionStructureValue(_i4.GreetingStruct(hi: hi));
 
-  const factory MyUnion.renamedStructureValue(
-      _i5.RenamedGreeting renamedStructureValue) = MyUnionRenamedStructureValue;
+  factory MyUnion.renamedStructureValue({String? salutation}) =>
+      MyUnionRenamedStructureValue(_i5.RenamedGreeting(salutation: salutation));
 
   const factory MyUnion.sdkUnknown(
     String name,

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_union_shape.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_union_shape.dart
@@ -39,8 +39,26 @@ sealed class XmlUnionShape extends _i1.SmithyUnion<XmlUnionShape> {
   const factory XmlUnionShape.unionValue(XmlUnionShape unionValue) =
       XmlUnionShapeUnionValue;
 
-  const factory XmlUnionShape.structValue(
-      _i3.XmlNestedUnionStruct structValue) = XmlUnionShapeStructValue;
+  factory XmlUnionShape.structValue({
+    String? stringValue,
+    bool? booleanValue,
+    int? byteValue,
+    int? shortValue,
+    int? integerValue,
+    _i2.Int64? longValue,
+    double? floatValue,
+    double? doubleValue,
+  }) =>
+      XmlUnionShapeStructValue(_i3.XmlNestedUnionStruct(
+        stringValue: stringValue,
+        booleanValue: booleanValue,
+        byteValue: byteValue,
+        shortValue: shortValue,
+        integerValue: integerValue,
+        longValue: longValue,
+        floatValue: floatValue,
+        doubleValue: doubleValue,
+      ));
 
   const factory XmlUnionShape.sdkUnknown(
     String name,

--- a/packages/smithy/goldens/lib2/awsJson1_0/lib/src/json_rpc_10/model/my_union.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_0/lib/src/json_rpc_10/model/my_union.dart
@@ -38,8 +38,8 @@ sealed class MyUnion extends _i1.SmithyUnion<MyUnion> {
 
   factory MyUnion.mapValue(Map<String, String> mapValue) = MyUnionMapValue;
 
-  const factory MyUnion.structureValue(_i5.GreetingStruct structureValue) =
-      MyUnionStructureValue;
+  factory MyUnion.structureValue({String? hi}) =>
+      MyUnionStructureValue(_i5.GreetingStruct(hi: hi));
 
   const factory MyUnion.sdkUnknown(
     String name,

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/my_union.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/model/my_union.dart
@@ -34,8 +34,8 @@ sealed class MyUnion extends _i1.SmithyUnion<MyUnion> {
 
   factory MyUnion.mapValue(Map<String, String> mapValue) = MyUnionMapValue;
 
-  const factory MyUnion.structureValue(_i4.GreetingStruct structureValue) =
-      MyUnionStructureValue;
+  factory MyUnion.structureValue({String? hi}) =>
+      MyUnionStructureValue(_i4.GreetingStruct(hi: hi));
 
   const factory MyUnion.sdkUnknown(
     String name,

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/my_union.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/my_union.dart
@@ -37,11 +37,11 @@ sealed class MyUnion extends _i1.SmithyUnion<MyUnion> {
 
   factory MyUnion.mapValue(Map<String, String> mapValue) = MyUnionMapValue;
 
-  const factory MyUnion.structureValue(_i4.GreetingStruct structureValue) =
-      MyUnionStructureValue;
+  factory MyUnion.structureValue({String? hi}) =>
+      MyUnionStructureValue(_i4.GreetingStruct(hi: hi));
 
-  const factory MyUnion.renamedStructureValue(
-      _i5.RenamedGreeting renamedStructureValue) = MyUnionRenamedStructureValue;
+  factory MyUnion.renamedStructureValue({String? salutation}) =>
+      MyUnionRenamedStructureValue(_i5.RenamedGreeting(salutation: salutation));
 
   const factory MyUnion.sdkUnknown(
     String name,

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_union_shape.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_union_shape.dart
@@ -39,8 +39,26 @@ sealed class XmlUnionShape extends _i1.SmithyUnion<XmlUnionShape> {
   const factory XmlUnionShape.unionValue(XmlUnionShape unionValue) =
       XmlUnionShapeUnionValue;
 
-  const factory XmlUnionShape.structValue(
-      _i3.XmlNestedUnionStruct structValue) = XmlUnionShapeStructValue;
+  factory XmlUnionShape.structValue({
+    String? stringValue,
+    bool? booleanValue,
+    int? byteValue,
+    int? shortValue,
+    int? integerValue,
+    _i2.Int64? longValue,
+    double? floatValue,
+    double? doubleValue,
+  }) =>
+      XmlUnionShapeStructValue(_i3.XmlNestedUnionStruct(
+        stringValue: stringValue,
+        booleanValue: booleanValue,
+        byteValue: byteValue,
+        shortValue: shortValue,
+        integerValue: integerValue,
+        longValue: longValue,
+        floatValue: floatValue,
+        doubleValue: doubleValue,
+      ));
 
   const factory XmlUnionShape.sdkUnknown(
     String name,

--- a/packages/smithy/smithy_codegen/lib/src/generator/structure_generator.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/structure_generator.dart
@@ -179,7 +179,7 @@ class StructureGenerator extends LibraryGenerator<StructureShape>
         ..docs.addAll([
           if (shape.hasDocs(context)) shape.formattedDocs(context),
         ])
-        ..optionalParameters.addAll(members.map(_memberParameter))
+        ..optionalParameters.addAll(members.map(memberParameter))
         ..body = body,
     );
   }
@@ -210,7 +210,7 @@ class StructureGenerator extends LibraryGenerator<StructureShape>
       );
 
   /// Creates a constructor [Parameter] for [member].
-  Parameter _memberParameter(MemberShape member) {
+  Parameter memberParameter(MemberShape member) {
     final deprecatedAnnotation = member.deprecatedAnnotation ??
         context.shapeFor(member.target).deprecatedAnnotation;
     final symbol = memberSymbols[member]!.transformFromInternal();

--- a/packages/storage/amplify_storage_s3_dart/lib/src/sdk/src/s3/model/select_object_content_event_stream.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/sdk/src/s3/model/select_object_content_event_stream.dart
@@ -3,16 +3,21 @@
 
 library amplify_storage_s3_dart.s3.model.select_object_content_event_stream; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:typed_data' as _i2;
+
 import 'package:amplify_storage_s3_dart/src/sdk/src/s3/model/continuation_event.dart'
-    as _i5;
+    as _i8;
 import 'package:amplify_storage_s3_dart/src/sdk/src/s3/model/end_event.dart'
+    as _i9;
+import 'package:amplify_storage_s3_dart/src/sdk/src/s3/model/progress.dart'
     as _i6;
 import 'package:amplify_storage_s3_dart/src/sdk/src/s3/model/progress_event.dart'
-    as _i4;
+    as _i7;
 import 'package:amplify_storage_s3_dart/src/sdk/src/s3/model/records_event.dart'
-    as _i2;
-import 'package:amplify_storage_s3_dart/src/sdk/src/s3/model/stats_event.dart'
     as _i3;
+import 'package:amplify_storage_s3_dart/src/sdk/src/s3/model/stats.dart' as _i4;
+import 'package:amplify_storage_s3_dart/src/sdk/src/s3/model/stats_event.dart'
+    as _i5;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i1;
@@ -22,20 +27,21 @@ sealed class SelectObjectContentEventStream
     extends _i1.SmithyUnion<SelectObjectContentEventStream> {
   const SelectObjectContentEventStream._();
 
-  const factory SelectObjectContentEventStream.records(
-      _i2.RecordsEvent records) = SelectObjectContentEventStreamRecords;
+  factory SelectObjectContentEventStream.records({_i2.Uint8List? payload}) =>
+      SelectObjectContentEventStreamRecords(_i3.RecordsEvent(payload: payload));
 
-  const factory SelectObjectContentEventStream.stats(_i3.StatsEvent stats) =
-      SelectObjectContentEventStreamStats;
+  factory SelectObjectContentEventStream.stats({_i4.Stats? details}) =>
+      SelectObjectContentEventStreamStats(_i5.StatsEvent(details: details));
 
-  const factory SelectObjectContentEventStream.progress(
-      _i4.ProgressEvent progress) = SelectObjectContentEventStreamProgress;
+  factory SelectObjectContentEventStream.progress({_i6.Progress? details}) =>
+      SelectObjectContentEventStreamProgress(
+          _i7.ProgressEvent(details: details));
 
-  const factory SelectObjectContentEventStream.cont(
-      _i5.ContinuationEvent cont) = SelectObjectContentEventStreamCont;
+  factory SelectObjectContentEventStream.cont() =>
+      SelectObjectContentEventStreamCont(_i8.ContinuationEvent());
 
-  const factory SelectObjectContentEventStream.end(_i6.EndEvent end) =
-      SelectObjectContentEventStreamEnd;
+  factory SelectObjectContentEventStream.end() =>
+      SelectObjectContentEventStreamEnd(_i9.EndEvent());
 
   const factory SelectObjectContentEventStream.sdkUnknown(
     String name,
@@ -46,19 +52,19 @@ sealed class SelectObjectContentEventStream
       serializers = [SelectObjectContentEventStreamRestXmlSerializer()];
 
   /// The Records Event.
-  _i2.RecordsEvent? get records => null;
+  _i3.RecordsEvent? get records => null;
 
   /// The Stats Event.
-  _i3.StatsEvent? get stats => null;
+  _i5.StatsEvent? get stats => null;
 
   /// The Progress Event.
-  _i4.ProgressEvent? get progress => null;
+  _i7.ProgressEvent? get progress => null;
 
   /// The Continuation Event.
-  _i5.ContinuationEvent? get cont => null;
+  _i8.ContinuationEvent? get cont => null;
 
   /// The End Event.
-  _i6.EndEvent? get end => null;
+  _i9.EndEvent? get end => null;
   @override
   Object get value => (records ?? stats ?? progress ?? cont ?? end)!;
   @override
@@ -104,7 +110,7 @@ final class SelectObjectContentEventStreamRecords
   const SelectObjectContentEventStreamRecords(this.records) : super._();
 
   @override
-  final _i2.RecordsEvent records;
+  final _i3.RecordsEvent records;
 
   @override
   String get name => 'Records';
@@ -115,7 +121,7 @@ final class SelectObjectContentEventStreamStats
   const SelectObjectContentEventStreamStats(this.stats) : super._();
 
   @override
-  final _i3.StatsEvent stats;
+  final _i5.StatsEvent stats;
 
   @override
   String get name => 'Stats';
@@ -126,7 +132,7 @@ final class SelectObjectContentEventStreamProgress
   const SelectObjectContentEventStreamProgress(this.progress) : super._();
 
   @override
-  final _i4.ProgressEvent progress;
+  final _i7.ProgressEvent progress;
 
   @override
   String get name => 'Progress';
@@ -137,7 +143,7 @@ final class SelectObjectContentEventStreamCont
   const SelectObjectContentEventStreamCont(this.cont) : super._();
 
   @override
-  final _i5.ContinuationEvent cont;
+  final _i8.ContinuationEvent cont;
 
   @override
   String get name => 'Cont';
@@ -148,7 +154,7 @@ final class SelectObjectContentEventStreamEnd
   const SelectObjectContentEventStreamEnd(this.end) : super._();
 
   @override
-  final _i6.EndEvent end;
+  final _i9.EndEvent end;
 
   @override
   String get name => 'End';
@@ -200,28 +206,28 @@ class SelectObjectContentEventStreamRestXmlSerializer
       case 'Records':
         return SelectObjectContentEventStreamRecords((serializers.deserialize(
           value,
-          specifiedType: const FullType(_i2.RecordsEvent),
-        ) as _i2.RecordsEvent));
+          specifiedType: const FullType(_i3.RecordsEvent),
+        ) as _i3.RecordsEvent));
       case 'Stats':
         return SelectObjectContentEventStreamStats((serializers.deserialize(
           value,
-          specifiedType: const FullType(_i3.StatsEvent),
-        ) as _i3.StatsEvent));
+          specifiedType: const FullType(_i5.StatsEvent),
+        ) as _i5.StatsEvent));
       case 'Progress':
         return SelectObjectContentEventStreamProgress((serializers.deserialize(
           value,
-          specifiedType: const FullType(_i4.ProgressEvent),
-        ) as _i4.ProgressEvent));
+          specifiedType: const FullType(_i7.ProgressEvent),
+        ) as _i7.ProgressEvent));
       case 'Cont':
         return SelectObjectContentEventStreamCont((serializers.deserialize(
           value,
-          specifiedType: const FullType(_i5.ContinuationEvent),
-        ) as _i5.ContinuationEvent));
+          specifiedType: const FullType(_i8.ContinuationEvent),
+        ) as _i8.ContinuationEvent));
       case 'End':
         return SelectObjectContentEventStreamEnd((serializers.deserialize(
           value,
-          specifiedType: const FullType(_i6.EndEvent),
-        ) as _i6.EndEvent));
+          specifiedType: const FullType(_i9.EndEvent),
+        ) as _i9.EndEvent));
     }
     return SelectObjectContentEventStream.sdkUnknown(
       key,
@@ -241,27 +247,27 @@ class SelectObjectContentEventStreamRestXmlSerializer
         SelectObjectContentEventStreamRecords(:final value) =>
           serializers.serialize(
             value,
-            specifiedType: const FullType(_i2.RecordsEvent),
+            specifiedType: const FullType(_i3.RecordsEvent),
           ),
         SelectObjectContentEventStreamStats(:final value) =>
           serializers.serialize(
             value,
-            specifiedType: const FullType(_i3.StatsEvent),
+            specifiedType: const FullType(_i5.StatsEvent),
           ),
         SelectObjectContentEventStreamProgress(:final value) =>
           serializers.serialize(
             value,
-            specifiedType: const FullType(_i4.ProgressEvent),
+            specifiedType: const FullType(_i7.ProgressEvent),
           ),
         SelectObjectContentEventStreamCont(:final value) =>
           serializers.serialize(
             value,
-            specifiedType: const FullType(_i5.ContinuationEvent),
+            specifiedType: const FullType(_i8.ContinuationEvent),
           ),
         SelectObjectContentEventStreamEnd(:final value) =>
           serializers.serialize(
             value,
-            specifiedType: const FullType(_i6.EndEvent),
+            specifiedType: const FullType(_i9.EndEvent),
           ),
         SelectObjectContentEventStreamSdkUnknown(:final value) => value,
       },


### PR DESCRIPTION
Currently to construct a union member, you need to pass an instance of the represented object, for example:

```dart
sealed class AnalyticsFilter extends SmithyUnion<AnalyticsFilter> {
  const factory AnalyticsFilter.tag(Tag tag) = AnalyticsFilterTag;
}

void usage() {
  final filter = AnalyticsFilter.tag(Tag(key: key, value: value));
}
```

This was uncovered as a less-than-desirable DX when exploring the config object. Instead, we can inline the parameters needed to construct the object to save the extra construction:

```dart
sealed class AnalyticsFilter extends SmithyUnion<AnalyticsFilter> {
  factory AnalyticsFilter.tag({
    required String key,
    required String value,
  }) =>
      AnalyticsFilterTag(_i2.Tag(
        key: key,
        value: value,
      ));
}

void usage() {
  final filter = AnalyticsFilter.tag(key: key, value: value);
}
```

This also means you don't need to know the underlying object type which is often just a required abstraction for Smithy - more often than not they are just anonymous groups of properties.

The old behavior is still available by invoking the union subclass constructor directly, e.g.

```dart
void usage() {
  final filter = AnalyticsFilterTag(Tag(key: key, value: value));
}
```