### PR TITLE
chore(smithy): Various improvements

### DIFF
--- a/packages/aws_common/lib/src/util/recase.dart
+++ b/packages/aws_common/lib/src/util/recase.dart
@@ -22,9 +22,16 @@ extension StringRecase on String {
   String get paramCase =>
       groupIntoWords().map((word) => word.toLowerCase()).join('-');
 
+  /// Acronyms for which we should maintain casing.
+  static const _maintainCase = ['AWS'];
+
   /// The `PascalCase` version of `this`.
-  String get pascalCase =>
-      groupIntoWords().map((word) => word.capitalized).join();
+  String get pascalCase => groupIntoWords().map((word) {
+        if (_maintainCase.contains(word)) {
+          return word;
+        }
+        return word.capitalized;
+      }).join();
 
   /// The `snake_case` version of `this`.
   String get snakeCase =>

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/player_action.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/player_action.dart
@@ -39,15 +39,12 @@ sealed class PlayerAction extends _i1.SmithyUnion<PlayerAction> {
 }
 
 final class PlayerActionQuit extends PlayerAction {
-  const PlayerActionQuit()
-      : quit = const _i1.Unit(),
-        super._();
-
-  @override
-  final _i1.Unit quit;
+  const PlayerActionQuit() : super._();
 
   @override
   String get name => 'quit';
+  @override
+  _i1.Unit get quit => const _i1.Unit();
 }
 
 final class PlayerActionSdkUnknown extends PlayerAction {

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/player_action.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/player_action.dart
@@ -39,15 +39,12 @@ sealed class PlayerAction extends _i1.SmithyUnion<PlayerAction> {
 }
 
 final class PlayerActionQuit extends PlayerAction {
-  const PlayerActionQuit()
-      : quit = const _i1.Unit(),
-        super._();
-
-  @override
-  final _i1.Unit quit;
+  const PlayerActionQuit() : super._();
 
   @override
   String get name => 'quit';
+  @override
+  _i1.Unit get quit => const _i1.Unit();
 }
 
 final class PlayerActionSdkUnknown extends PlayerAction {

--- a/packages/smithy/smithy_codegen/lib/src/generate.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generate.dart
@@ -36,6 +36,7 @@ CodegenContext buildContext(
   Iterable<ShapeId> includeShapes = const [],
   Iterable<ShapeId> additionalShapes = const [],
   bool generateServer = false,
+  Map<ShapeId, Reference>? symbolOverrides,
 }) {
   // Builds a service closure with just one service shape. All the other
   // shapes can remain - they will not be generated for services which do
@@ -58,6 +59,7 @@ CodegenContext buildContext(
     serviceName: serviceName,
     additionalShapes: additionalShapes,
     generateServer: generateServer,
+    symbolOverrides: symbolOverrides,
   );
 }
 
@@ -85,6 +87,7 @@ Map<ShapeId, GeneratedOutput> generateForAst(
   Iterable<ShapeId> includeShapes = const [],
   Iterable<ShapeId> additionalShapes = const [],
   bool generateServer = false,
+  Map<ShapeId, Reference>? symbolOverrides,
 }) {
   const transformers = <ShapeVisitor<void>>[
     _OptionalAuthVisitor(),
@@ -117,6 +120,7 @@ Map<ShapeId, GeneratedOutput> generateForAst(
       includeShapes: includeShapes,
       additionalShapes: additionalShapes,
       generateServer: generateServer,
+      symbolOverrides: symbolOverrides,
     );
 
     context.run(() {

--- a/packages/smithy/smithy_codegen/lib/src/generate.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generate.dart
@@ -119,20 +119,22 @@ Map<ShapeId, GeneratedOutput> generateForAst(
       generateServer: generateServer,
     );
 
-    // Generate libraries for relevant shape types.
-    //
-    // Build service shapes last, since they aggregate generated types.
-    final operations = context.shapes.values.whereType<OperationShape>();
-    final visitor = LibraryVisitor(context);
-    final libraries = [
-      ...operations,
-      ...additionalShapes.map(context.shapeFor),
-      serviceShape
-    ].expand<GeneratedLibrary>((shape) => shape.accept(visitor) ?? const []);
-    outputs[serviceShape.shapeId] = GeneratedOutput(
-      context: context,
-      libraries: libraries.toSet().toList(),
-    );
+    context.run(() {
+      // Generate libraries for relevant shape types.
+      //
+      // Build service shapes last, since they aggregate generated types.
+      final operations = context.shapes.values.whereType<OperationShape>();
+      final visitor = LibraryVisitor(context);
+      final libraries = [
+        ...operations,
+        ...additionalShapes.map(context.shapeFor),
+        serviceShape
+      ].expand<GeneratedLibrary>((shape) => shape.accept(visitor) ?? const []);
+      outputs[serviceShape.shapeId] = GeneratedOutput(
+        context: context,
+        libraries: libraries.toSet().toList(),
+      );
+    });
   }
 
   return outputs;

--- a/packages/smithy/smithy_codegen/lib/src/generator/context.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/context.dart
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'dart:async';
+
 import 'package:aws_common/aws_common.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
@@ -9,6 +11,9 @@ import 'package:smithy/ast.dart';
 import 'package:smithy/smithy.dart';
 import 'package:smithy_codegen/smithy_codegen.dart';
 import 'package:smithy_codegen/src/generator/visitors/symbol_visitor.dart';
+
+/// The global [CodegenContext].
+CodegenContext get context => Zone.current[CodegenContext] as CodegenContext;
 
 /// The context for code generation.
 class CodegenContext {
@@ -193,4 +198,8 @@ class CodegenContext {
     filename: serviceName,
     basePath: basePath,
   );
+
+  /// Runs [action] with the `this` as the global [CodegenContext].
+  R run<R>(R Function() action) =>
+      runZoned(action, zoneValues: {CodegenContext: this});
 }

--- a/packages/smithy/smithy_codegen/lib/src/generator/context.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/context.dart
@@ -10,6 +10,7 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:smithy/ast.dart';
 import 'package:smithy/smithy.dart';
 import 'package:smithy_codegen/smithy_codegen.dart';
+import 'package:smithy_codegen/src/generator/types.dart';
 import 'package:smithy_codegen/src/generator/visitors/symbol_visitor.dart';
 
 /// The global [CodegenContext].
@@ -28,13 +29,18 @@ class CodegenContext {
     this.pubspec,
     Iterable<ShapeId> additionalShapes = const {},
     this.generateServer = false,
+    Map<ShapeId, Reference>? symbolOverrides,
   })  : _shapes = shapes,
         _serviceName = serviceName,
         serviceShapeId = serviceShapeId ??
             shapes.entries.singleWhereOrNull((entry) {
               return entry.value is ServiceShape;
             })?.key,
-        _additionalShapes = additionalShapes.toSet() {
+        _additionalShapes = additionalShapes.toSet(),
+        symbolOverrides = {
+          Shape.unit: DartTypes.smithy.unit,
+          ...?symbolOverrides,
+        } {
     if (serviceShapeId == null && serviceName == null) {
       throw ArgumentError(
         'Either serviceShapeId or serviceName must be provided.',
@@ -101,6 +107,8 @@ class CodegenContext {
   /// The pubspec of the package being generated. If included, dependencies will
   /// be added as needed during code generation.
   final Pubspec? pubspec;
+
+  final Map<ShapeId, Reference> symbolOverrides;
 
   /// The service shape being generated.
   late final ServiceShape? service =

--- a/packages/smithy/smithy_codegen/lib/src/generator/enum_generator.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/enum_generator.dart
@@ -23,7 +23,7 @@ class EnumGenerator extends LibraryGenerator<EnumShape> {
 
   late final List<MemberShape> sortedDefinitions = shape.enumValues.toList()
     ..sort((a, b) {
-      return a.variantName.compareTo(b.variantName);
+      return a.enumVariantName.compareTo(b.enumVariantName);
     });
 
   late final List<EnumValueTrait> sortedEnumValues = sortedDefinitions
@@ -140,7 +140,7 @@ class EnumGenerator extends LibraryGenerator<EnumShape> {
           f
             ..static = true
             ..modifier = FieldModifier.constant
-            ..name = definition.variantName
+            ..name = definition.enumVariantName
             ..assignment = symbol.newInstanceNamed('_', [
               literalNum(index),
               literalString(definition.memberName),
@@ -157,7 +157,7 @@ class EnumGenerator extends LibraryGenerator<EnumShape> {
           ..name = 'values'
           ..docs.add('/// All values of [$className].')
           ..assignment = literalList(
-            sortedDefinitions.map((e) => symbol.property(e.variantName)),
+            sortedDefinitions.map((e) => symbol.property(e.enumVariantName)),
             symbol,
           ).code,
       );
@@ -263,5 +263,6 @@ class EnumGenerator extends LibraryGenerator<EnumShape> {
 
 extension EnumVariantName on MemberShape {
   /// The name of the enum variant.
-  String get variantName => memberName.camelCase.nameEscaped(ShapeType.enum_);
+  String get enumVariantName =>
+      memberName.camelCase.nameEscaped(ShapeType.enum_);
 }

--- a/packages/smithy/smithy_codegen/lib/src/generator/serialization/structure_serializer_generator.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/serialization/structure_serializer_generator.dart
@@ -244,12 +244,7 @@ class StructureSerializerGenerator extends SerializerGenerator<StructureShape>
       final wireName = memberWireName(member);
       final memberSymbol = memberSymbols[member]!;
       final targetShape = context.shapeFor(member.target);
-      final hasNestedBuilder = [
-        ShapeType.map,
-        ShapeType.list,
-        ShapeType.set,
-        ShapeType.structure,
-      ].contains(targetShape.getType());
+      final hasNestedBuilder = targetShape.hasNestedBuilder;
       final value = refer('value');
       yield Block.of([
         const Code('case '),

--- a/packages/smithy/smithy_codegen/lib/src/generator/serialization/structure_xml_serializer_generator.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/serialization/structure_xml_serializer_generator.dart
@@ -356,12 +356,7 @@ class StructureXmlSerializerGenerator extends StructureSerializerGenerator {
       final wireName = memberWireName(member);
       var memberSymbol = memberSymbols[member]!;
       final targetShape = context.shapeFor(member.target);
-      final hasNestedBuilder = [
-        ShapeType.map,
-        ShapeType.list,
-        ShapeType.set,
-        ShapeType.structure,
-      ].contains(targetShape.getType());
+      final hasNestedBuilder = targetShape.hasNestedBuilder;
       final isFlattened = flattenedMembers.contains(member);
       var targetMember = member;
       var nestedMethod = 'replace';

--- a/packages/smithy/smithy_codegen/lib/src/generator/visitors/library_visitor.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/visitors/library_visitor.dart
@@ -223,6 +223,9 @@ class LibraryVisitor extends DefaultVisitor<Iterable<GeneratedLibrary>> {
     if (Shape.preludeShapes.keys.contains(shape.shapeId)) {
       return;
     }
+    if (context.symbolOverrides.containsKey(shape.shapeId)) {
+      return;
+    }
     yield* _foreignMembers(shape.members.values.map((member) => member.target));
     yield _buildLibrary(
       shape,

--- a/packages/smithy/smithy_codegen/lib/src/generator/visitors/symbol_visitor.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/visitors/symbol_visitor.dart
@@ -132,8 +132,8 @@ class SymbolVisitor extends CategoryShapeVisitor<Reference> {
 
   @override
   Reference structureShape(StructureShape shape, [Shape? parent]) {
-    if (shape.hasTrait<UnitTypeTrait>()) {
-      return DartTypes.smithy.unit;
+    if (context.symbolOverrides[shape.shapeId] case final override?) {
+      return override;
     }
     return createSymbol(shape);
   }

--- a/packages/smithy/smithy_codegen/lib/src/util/shape_ext.dart
+++ b/packages/smithy/smithy_codegen/lib/src/util/shape_ext.dart
@@ -396,6 +396,20 @@ extension ShapeUtils on Shape {
         ..pageSizePath = trait.pageSize,
     );
   }
+
+  /// Whether the type generates a built_value builder.
+  bool get hasNestedBuilder {
+    if (context.symbolOverrides.containsKey(shapeId)) {
+      // We can't assume these types are built_value types.
+      return false;
+    }
+    return const [
+      ShapeType.map,
+      ShapeType.list,
+      ShapeType.set,
+      ShapeType.structure,
+    ].contains(getType());
+  }
 }
 
 extension NamedMembersShapeUtil on NamedMembersShape {

--- a/packages/smithy/smithy_codegen/test/default_value_test.dart
+++ b/packages/smithy/smithy_codegen/test/default_value_test.dart
@@ -10,16 +10,19 @@ import 'package:smithy_test/smithy_test.dart';
 import 'common.dart';
 
 void main() {
-  void testDefaultValue(StructureShape struct, CodegenContext context) {
-    final generator = StructureGenerator(struct, context);
-    final method = generator.defaultValues(
-      members: generator.payloadMembers,
-      builderSymbol: generator.payloadBuilderSymbol,
-    );
-    final emitter = buildEmitter(Allocator.none);
-    final output = method.accept(emitter).toString();
-    expect(output, contains('b.defaultValue = 0'));
-  }
+  void testDefaultValue(StructureShape struct, CodegenContext context) =>
+      context.run(() {
+        {
+          final generator = StructureGenerator(struct, context);
+          final method = generator.defaultValues(
+            members: generator.payloadMembers,
+            builderSymbol: generator.payloadBuilderSymbol,
+          );
+          final emitter = buildEmitter(Allocator.none);
+          final output = method.accept(emitter).toString();
+          expect(output, contains('b.defaultValue = 0'));
+        }
+      });
 
   group('default value', () {
     test('v1', () {

--- a/packages/smithy/smithy_codegen/test/generator/documentation_test.dart
+++ b/packages/smithy/smithy_codegen/test/generator/documentation_test.dart
@@ -51,24 +51,25 @@ void main() {
           ..traits = TraitMap.fromTraits(const [DocumentationTrait(docs)]),
       );
       final context = createTestContext([struct]);
+      context.run(() {
+        expect(struct.hasDocs(context), isTrue);
+        expect(struct.formattedDocs(context), contains(docs));
 
-      expect(struct.hasDocs(context), isTrue);
-      expect(struct.formattedDocs(context), contains(docs));
+        final generator = StructureGenerator(struct, context);
+        final emitter = buildEmitter(Allocator.none);
 
-      final generator = StructureGenerator(struct, context);
-      final emitter = buildEmitter(Allocator.none);
+        final ctor = generator.factoryConstructor;
+        expect(ctor.docs, isNotEmpty);
+        final ctorOutput =
+            emitter.visitConstructor(ctor, generator.className).toString();
+        expect(ctorOutput, contains(docs));
 
-      final ctor = generator.factoryConstructor;
-      expect(ctor.docs, isNotEmpty);
-      final ctorOutput =
-          emitter.visitConstructor(ctor, generator.className).toString();
-      expect(ctorOutput, contains(docs));
-
-      final response = generator.fromResponseConstructor;
-      expect(ctor.docs, isNotEmpty);
-      final responseOutput =
-          emitter.visitConstructor(response, generator.className).toString();
-      expect(responseOutput, startsWith('/// '));
+        final response = generator.fromResponseConstructor;
+        expect(ctor.docs, isNotEmpty);
+        final responseOutput =
+            emitter.visitConstructor(response, generator.className).toString();
+        expect(responseOutput, startsWith('/// '));
+      });
     });
   });
 }

--- a/packages/smithy/smithy_codegen/test/naming_test.dart
+++ b/packages/smithy/smithy_codegen/test/naming_test.dart
@@ -221,7 +221,7 @@ void main() {
               ..traits = TraitMap.fromTraits(const [EnumValueTrait('index')]),
           ),
         ];
-        final memberNames = traits.map((def) => def.variantName);
+        final memberNames = traits.map((def) => def.enumVariantName);
         expect(
           memberNames,
           unorderedEquals([


### PR DESCRIPTION
- Fixes lint with unions
- Makes `CodegenContext` global to allow access from anywhere
- Adds default value support for strings and string enums
- Adds special casing rule for `AWS` to prevent recasing
- Allows overriding symbol types for certain shape IDs