### PR TITLE
ci: Speed up bootstrap

### DIFF
--- a/.github/workflows/amplify_analytics_pinpoint.yaml
+++ b/.github/workflows/amplify_analytics_pinpoint.yaml
@@ -50,4 +50,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_analytics_pinpoint
       working-directory: packages/analytics/amplify_analytics_pinpoint

--- a/.github/workflows/amplify_analytics_pinpoint_dart.yaml
+++ b/.github/workflows/amplify_analytics_pinpoint_dart.yaml
@@ -48,19 +48,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: amplify_analytics_pinpoint_dart
       working-directory: packages/analytics/amplify_analytics_pinpoint_dart
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: amplify_analytics_pinpoint_dart
       working-directory: packages/analytics/amplify_analytics_pinpoint_dart
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: amplify_analytics_pinpoint_dart
       working-directory: packages/analytics/amplify_analytics_pinpoint_dart
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: amplify_analytics_pinpoint_dart
       working-directory: packages/analytics/amplify_analytics_pinpoint_dart

--- a/.github/workflows/amplify_api.yaml
+++ b/.github/workflows/amplify_api.yaml
@@ -44,4 +44,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_api
       working-directory: packages/api/amplify_api

--- a/.github/workflows/amplify_api_dart.yaml
+++ b/.github/workflows/amplify_api_dart.yaml
@@ -36,19 +36,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: amplify_api_dart
       working-directory: packages/api/amplify_api_dart
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: amplify_api_dart
       working-directory: packages/api/amplify_api_dart
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: amplify_api_dart
       working-directory: packages/api/amplify_api_dart
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: amplify_api_dart
       working-directory: packages/api/amplify_api_dart

--- a/.github/workflows/amplify_auth_cognito.yaml
+++ b/.github/workflows/amplify_auth_cognito.yaml
@@ -58,4 +58,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_auth_cognito
       working-directory: packages/auth/amplify_auth_cognito

--- a/.github/workflows/amplify_auth_cognito_dart.yaml
+++ b/.github/workflows/amplify_auth_cognito_dart.yaml
@@ -49,9 +49,11 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: amplify_auth_cognito_dart
       working-directory: packages/auth/amplify_auth_cognito_dart
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: amplify_auth_cognito_dart
       working-directory: packages/auth/amplify_auth_cognito_dart

--- a/.github/workflows/amplify_auth_cognito_test.yaml
+++ b/.github/workflows/amplify_auth_cognito_test.yaml
@@ -54,19 +54,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: amplify_auth_cognito_test
       working-directory: packages/auth/amplify_auth_cognito_test
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: amplify_auth_cognito_test
       working-directory: packages/auth/amplify_auth_cognito_test
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: amplify_auth_cognito_test
       working-directory: packages/auth/amplify_auth_cognito_test
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: amplify_auth_cognito_test
       working-directory: packages/auth/amplify_auth_cognito_test

--- a/.github/workflows/amplify_authenticator.yaml
+++ b/.github/workflows/amplify_authenticator.yaml
@@ -60,4 +60,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_authenticator
       working-directory: packages/authenticator/amplify_authenticator

--- a/.github/workflows/amplify_core.yaml
+++ b/.github/workflows/amplify_core.yaml
@@ -34,19 +34,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: amplify_core
       working-directory: packages/amplify_core
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: amplify_core
       working-directory: packages/amplify_core
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: amplify_core
       working-directory: packages/amplify_core
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: amplify_core
       working-directory: packages/amplify_core

--- a/.github/workflows/amplify_datastore.yaml
+++ b/.github/workflows/amplify_datastore.yaml
@@ -34,4 +34,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_datastore
       working-directory: packages/amplify_datastore

--- a/.github/workflows/amplify_datastore_plugin_interface.yaml
+++ b/.github/workflows/amplify_datastore_plugin_interface.yaml
@@ -32,4 +32,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_datastore_plugin_interface
       working-directory: packages/amplify_datastore_plugin_interface

--- a/.github/workflows/amplify_db_common.yaml
+++ b/.github/workflows/amplify_db_common.yaml
@@ -34,4 +34,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_db_common
       working-directory: packages/common/amplify_db_common

--- a/.github/workflows/amplify_db_common_dart.yaml
+++ b/.github/workflows/amplify_db_common_dart.yaml
@@ -36,19 +36,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: amplify_db_common_dart
       working-directory: packages/common/amplify_db_common_dart
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: amplify_db_common_dart
       working-directory: packages/common/amplify_db_common_dart
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: amplify_db_common_dart
       working-directory: packages/common/amplify_db_common_dart
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: amplify_db_common_dart
       working-directory: packages/common/amplify_db_common_dart

--- a/.github/workflows/amplify_flutter.yaml
+++ b/.github/workflows/amplify_flutter.yaml
@@ -40,4 +40,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_flutter
       working-directory: packages/amplify/amplify_flutter

--- a/.github/workflows/amplify_lints.yaml
+++ b/.github/workflows/amplify_lints.yaml
@@ -24,4 +24,5 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: amplify_lints
       working-directory: packages/amplify_lints

--- a/.github/workflows/amplify_native_legacy_wrapper.yaml
+++ b/.github/workflows/amplify_native_legacy_wrapper.yaml
@@ -26,4 +26,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_native_legacy_wrapper
       working-directory: packages/amplify_native_legacy_wrapper

--- a/.github/workflows/amplify_push_notifications.yaml
+++ b/.github/workflows/amplify_push_notifications.yaml
@@ -43,4 +43,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_push_notifications
       working-directory: packages/notifications/push/amplify_push_notifications

--- a/.github/workflows/amplify_push_notifications_pinpoint.yaml
+++ b/.github/workflows/amplify_push_notifications_pinpoint.yaml
@@ -62,4 +62,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_push_notifications_pinpoint
       working-directory: packages/notifications/push/amplify_push_notifications_pinpoint

--- a/.github/workflows/amplify_secure_storage.yaml
+++ b/.github/workflows/amplify_secure_storage.yaml
@@ -34,4 +34,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_secure_storage
       working-directory: packages/secure_storage/amplify_secure_storage

--- a/.github/workflows/amplify_secure_storage_dart.yaml
+++ b/.github/workflows/amplify_secure_storage_dart.yaml
@@ -32,4 +32,5 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: amplify_secure_storage_dart
       working-directory: packages/secure_storage/amplify_secure_storage_dart

--- a/.github/workflows/amplify_secure_storage_test.yaml
+++ b/.github/workflows/amplify_secure_storage_test.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: amplify_secure_storage_test
       working-directory: packages/secure_storage/amplify_secure_storage_test
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: amplify_secure_storage_test
       working-directory: packages/secure_storage/amplify_secure_storage_test
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: amplify_secure_storage_test
       working-directory: packages/secure_storage/amplify_secure_storage_test
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: amplify_secure_storage_test
       working-directory: packages/secure_storage/amplify_secure_storage_test

--- a/.github/workflows/amplify_storage_s3.yaml
+++ b/.github/workflows/amplify_storage_s3.yaml
@@ -42,4 +42,5 @@ jobs:
   test:
     uses: ./.github/workflows/flutter_vm.yaml
     with:
+      package-name: amplify_storage_s3
       working-directory: packages/storage/amplify_storage_s3

--- a/.github/workflows/amplify_storage_s3_dart.yaml
+++ b/.github/workflows/amplify_storage_s3_dart.yaml
@@ -39,9 +39,11 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: amplify_storage_s3_dart
       working-directory: packages/storage/amplify_storage_s3_dart
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: amplify_storage_s3_dart
       working-directory: packages/storage/amplify_storage_s3_dart

--- a/.github/workflows/aws_common.yaml
+++ b/.github/workflows/aws_common.yaml
@@ -30,19 +30,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: aws_common
       working-directory: packages/aws_common
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: aws_common
       working-directory: packages/aws_common
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: aws_common
       working-directory: packages/aws_common
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: aws_common
       working-directory: packages/aws_common

--- a/.github/workflows/aws_json1_0_v1.yaml
+++ b/.github/workflows/aws_json1_0_v1.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: aws_json1_0_v1
       working-directory: packages/smithy/goldens/lib/awsJson1_0
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: aws_json1_0_v1
       working-directory: packages/smithy/goldens/lib/awsJson1_0
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: aws_json1_0_v1
       working-directory: packages/smithy/goldens/lib/awsJson1_0
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: aws_json1_0_v1
       working-directory: packages/smithy/goldens/lib/awsJson1_0

--- a/.github/workflows/aws_json1_0_v2.yaml
+++ b/.github/workflows/aws_json1_0_v2.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: aws_json1_0_v2
       working-directory: packages/smithy/goldens/lib2/awsJson1_0
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: aws_json1_0_v2
       working-directory: packages/smithy/goldens/lib2/awsJson1_0
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: aws_json1_0_v2
       working-directory: packages/smithy/goldens/lib2/awsJson1_0
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: aws_json1_0_v2
       working-directory: packages/smithy/goldens/lib2/awsJson1_0

--- a/.github/workflows/aws_json1_1_v1.yaml
+++ b/.github/workflows/aws_json1_1_v1.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: aws_json1_1_v1
       working-directory: packages/smithy/goldens/lib/awsJson1_1
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: aws_json1_1_v1
       working-directory: packages/smithy/goldens/lib/awsJson1_1
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: aws_json1_1_v1
       working-directory: packages/smithy/goldens/lib/awsJson1_1
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: aws_json1_1_v1
       working-directory: packages/smithy/goldens/lib/awsJson1_1

--- a/.github/workflows/aws_json1_1_v2.yaml
+++ b/.github/workflows/aws_json1_1_v2.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: aws_json1_1_v2
       working-directory: packages/smithy/goldens/lib2/awsJson1_1
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: aws_json1_1_v2
       working-directory: packages/smithy/goldens/lib2/awsJson1_1
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: aws_json1_1_v2
       working-directory: packages/smithy/goldens/lib2/awsJson1_1
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: aws_json1_1_v2
       working-directory: packages/smithy/goldens/lib2/awsJson1_1

--- a/.github/workflows/aws_query_v1.yaml
+++ b/.github/workflows/aws_query_v1.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: aws_query_v1
       working-directory: packages/smithy/goldens/lib/awsQuery
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: aws_query_v1
       working-directory: packages/smithy/goldens/lib/awsQuery
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: aws_query_v1
       working-directory: packages/smithy/goldens/lib/awsQuery
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: aws_query_v1
       working-directory: packages/smithy/goldens/lib/awsQuery

--- a/.github/workflows/aws_query_v2.yaml
+++ b/.github/workflows/aws_query_v2.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: aws_query_v2
       working-directory: packages/smithy/goldens/lib2/awsQuery
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: aws_query_v2
       working-directory: packages/smithy/goldens/lib2/awsQuery
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: aws_query_v2
       working-directory: packages/smithy/goldens/lib2/awsQuery
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: aws_query_v2
       working-directory: packages/smithy/goldens/lib2/awsQuery

--- a/.github/workflows/aws_signature_v4.yaml
+++ b/.github/workflows/aws_signature_v4.yaml
@@ -32,19 +32,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: aws_signature_v4
       working-directory: packages/aws_signature_v4
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: aws_signature_v4
       working-directory: packages/aws_signature_v4
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: aws_signature_v4
       working-directory: packages/aws_signature_v4
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: aws_signature_v4
       working-directory: packages/aws_signature_v4

--- a/.github/workflows/custom_v1.yaml
+++ b/.github/workflows/custom_v1.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: custom_v1
       working-directory: packages/smithy/goldens/lib/custom
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: custom_v1
       working-directory: packages/smithy/goldens/lib/custom
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: custom_v1
       working-directory: packages/smithy/goldens/lib/custom
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: custom_v1
       working-directory: packages/smithy/goldens/lib/custom

--- a/.github/workflows/custom_v2.yaml
+++ b/.github/workflows/custom_v2.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: custom_v2
       working-directory: packages/smithy/goldens/lib2/custom
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: custom_v2
       working-directory: packages/smithy/goldens/lib2/custom
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: custom_v2
       working-directory: packages/smithy/goldens/lib2/custom
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: custom_v2
       working-directory: packages/smithy/goldens/lib2/custom

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -2,6 +2,10 @@ name: Dart (dart2js)
 on:
   workflow_call:
     inputs:
+      package-name:
+        description: The name of the package being tested
+        required: true
+        type: string
       working-directory:
         description: The working directory relative to the repo root
         required: true
@@ -65,7 +69,7 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
-        run: aft bootstrap --fail-fast
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }}
 
       - name: Setup Package
         if: "always() && steps.bootstrap.conclusion == 'success'"

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -2,6 +2,10 @@ name: Dart (DDC)
 on:
   workflow_call:
     inputs:
+      package-name:
+        description: The name of the package being tested
+        required: true
+        type: string
       working-directory:
         description: The working directory relative to the repo root
         required: true
@@ -65,7 +69,7 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
-        run: aft bootstrap --fail-fast
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }}
 
       - name: Setup Package
         if: "always() && steps.bootstrap.conclusion == 'success'"

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -3,6 +3,10 @@ name: Dart (Native)
 on:
   workflow_call:
     inputs:
+      package-name:
+        description: The name of the package being tested
+        required: true
+        type: string
       working-directory:
         description: The working directory relative to the repo root
         required: true
@@ -73,7 +77,7 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
-        run: aft bootstrap --fail-fast
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }}
 
       - name: Setup Package
         if: "always() && steps.bootstrap.conclusion == 'success'"

--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -2,6 +2,10 @@ name: Dart (VM)
 on:
   workflow_call:
     inputs:
+      package-name:
+        description: The name of the package being tested
+        required: true
+        type: string
       working-directory:
         description: The working directory relative to the repo root
         required: true
@@ -56,7 +60,7 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
-        run: aft bootstrap --fail-fast
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }}
 
       - name: Check Formatting
         if: "always() && steps.bootstrap.conclusion == 'success' && matrix.sdk == 'stable'"

--- a/.github/workflows/flutter_android.build.yaml
+++ b/.github/workflows/flutter_android.build.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
-        run: aft bootstrap --fail-fast
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }}
 
       - name: Build for Android
         run: flutter build apk --debug --verbose

--- a/.github/workflows/flutter_android.test.yaml
+++ b/.github/workflows/flutter_android.test.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
-        run: aft bootstrap --fail-fast
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }}
 
       - name: Run Android unit tests
         run: |

--- a/.github/workflows/flutter_ios.yaml
+++ b/.github/workflows/flutter_ios.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
-        run: aft bootstrap --fail-fast
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }}
 
       - name: Run iOS unit tests
         run: |

--- a/.github/workflows/flutter_vm.yaml
+++ b/.github/workflows/flutter_vm.yaml
@@ -2,6 +2,10 @@ name: Flutter (VM)
 on:
   workflow_call:
     inputs:
+      package-name:
+        description: The name of the package being tested
+        required: true
+        type: string
       working-directory:
         description: The working directory relative to the repo root
         required: true
@@ -44,7 +48,7 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
-        run: aft bootstrap --fail-fast
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }}
 
       - name: Check Formatting
         if: "always() && steps.bootstrap.conclusion == 'success'"

--- a/.github/workflows/rest_json1_v1.yaml
+++ b/.github/workflows/rest_json1_v1.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: rest_json1_v1
       working-directory: packages/smithy/goldens/lib/restJson1
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: rest_json1_v1
       working-directory: packages/smithy/goldens/lib/restJson1
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: rest_json1_v1
       working-directory: packages/smithy/goldens/lib/restJson1
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: rest_json1_v1
       working-directory: packages/smithy/goldens/lib/restJson1

--- a/.github/workflows/rest_json1_v2.yaml
+++ b/.github/workflows/rest_json1_v2.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: rest_json1_v2
       working-directory: packages/smithy/goldens/lib2/restJson1
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: rest_json1_v2
       working-directory: packages/smithy/goldens/lib2/restJson1
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: rest_json1_v2
       working-directory: packages/smithy/goldens/lib2/restJson1
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: rest_json1_v2
       working-directory: packages/smithy/goldens/lib2/restJson1

--- a/.github/workflows/rest_xml_v1.yaml
+++ b/.github/workflows/rest_xml_v1.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: rest_xml_v1
       working-directory: packages/smithy/goldens/lib/restXml
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: rest_xml_v1
       working-directory: packages/smithy/goldens/lib/restXml
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: rest_xml_v1
       working-directory: packages/smithy/goldens/lib/restXml
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: rest_xml_v1
       working-directory: packages/smithy/goldens/lib/restXml

--- a/.github/workflows/rest_xml_v2.yaml
+++ b/.github/workflows/rest_xml_v2.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: rest_xml_v2
       working-directory: packages/smithy/goldens/lib2/restXml
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: rest_xml_v2
       working-directory: packages/smithy/goldens/lib2/restXml
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: rest_xml_v2
       working-directory: packages/smithy/goldens/lib2/restXml
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: rest_xml_v2
       working-directory: packages/smithy/goldens/lib2/restXml

--- a/.github/workflows/rest_xml_with_namespace_v1.yaml
+++ b/.github/workflows/rest_xml_with_namespace_v1.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: rest_xml_with_namespace_v1
       working-directory: packages/smithy/goldens/lib/restXmlWithNamespace
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: rest_xml_with_namespace_v1
       working-directory: packages/smithy/goldens/lib/restXmlWithNamespace
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: rest_xml_with_namespace_v1
       working-directory: packages/smithy/goldens/lib/restXmlWithNamespace
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: rest_xml_with_namespace_v1
       working-directory: packages/smithy/goldens/lib/restXmlWithNamespace

--- a/.github/workflows/rest_xml_with_namespace_v2.yaml
+++ b/.github/workflows/rest_xml_with_namespace_v2.yaml
@@ -38,19 +38,23 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: rest_xml_with_namespace_v2
       working-directory: packages/smithy/goldens/lib2/restXmlWithNamespace
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: rest_xml_with_namespace_v2
       working-directory: packages/smithy/goldens/lib2/restXmlWithNamespace
   ddc_test:
     needs: test
     uses: ./.github/workflows/dart_ddc.yaml
     with:
+      package-name: rest_xml_with_namespace_v2
       working-directory: packages/smithy/goldens/lib2/restXmlWithNamespace
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
     with:
+      package-name: rest_xml_with_namespace_v2
       working-directory: packages/smithy/goldens/lib2/restXmlWithNamespace

--- a/.github/workflows/smithy.yaml
+++ b/.github/workflows/smithy.yaml
@@ -29,9 +29,11 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: smithy
       working-directory: packages/smithy/smithy
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: smithy
       working-directory: packages/smithy/smithy

--- a/.github/workflows/smithy_aws.yaml
+++ b/.github/workflows/smithy_aws.yaml
@@ -33,9 +33,11 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: smithy_aws
       working-directory: packages/smithy/smithy_aws
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: smithy_aws
       working-directory: packages/smithy/smithy_aws

--- a/.github/workflows/smithy_codegen.yaml
+++ b/.github/workflows/smithy_codegen.yaml
@@ -35,9 +35,11 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: smithy_codegen
       working-directory: packages/smithy/smithy_codegen
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     with:
+      package-name: smithy_codegen
       working-directory: packages/smithy/smithy_codegen

--- a/.github/workflows/worker_bee.yaml
+++ b/.github/workflows/worker_bee.yaml
@@ -28,4 +28,5 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: worker_bee
       working-directory: packages/worker_bee/worker_bee

--- a/.github/workflows/worker_bee_builder.yaml
+++ b/.github/workflows/worker_bee_builder.yaml
@@ -30,4 +30,5 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     with:
+      package-name: worker_bee_builder
       working-directory: packages/worker_bee/worker_bee_builder

--- a/packages/aft/lib/src/commands/bootstrap_command.dart
+++ b/packages/aft/lib/src/commands/bootstrap_command.dart
@@ -88,7 +88,17 @@ const amplifyEnvironments = <String, String>{};
       [for (final package in bootstrapPackages) _createEmptyConfig(package)],
     );
     if (build) {
-      for (final package in bootstrapPackages) {
+      // Packages which must be built because they vendor assets required for
+      // running all downstream packages.
+      const mustBuild = [
+        'amplify_auth_cognito_dart',
+        'amplify_secure_storage_dart'
+      ];
+      final buildPackages = repo.allPackages.values.where(
+        (pkg) =>
+            bootstrapPackages.contains(pkg) || mustBuild.contains(pkg.name),
+      );
+      for (final package in buildPackages) {
         // Only run build_runner for packages which need it for development,
         // i.e. those packages which specify worker JS files in their assets.
         final needsBuild = package.needsBuildRunner &&

--- a/packages/aft/lib/src/commands/bootstrap_command.dart
+++ b/packages/aft/lib/src/commands/bootstrap_command.dart
@@ -98,13 +98,12 @@ const amplifyEnvironments = <String, String>{};
         'amplify_secure_storage_dart'
       ].map((pkgName) => repo.allPackages[pkgName]!);
       final buildPackages = [
-        ...commandPackages.values,
+        ...bootstrapPackages,
 
         // Include "must build" packages if any of the command packages depend
         // on them.
         for (final mustBuildPkg in mustBuild)
-          if (commandPackages.values
-              .any((pkg) => pkg.dependsOn(mustBuildPkg, repo)))
+          if (bootstrapPackages.any((pkg) => pkg.dependsOn(mustBuildPkg, repo)))
             mustBuildPkg,
       ];
       for (final package in buildPackages) {

--- a/packages/aft/lib/src/commands/bootstrap_command.dart
+++ b/packages/aft/lib/src/commands/bootstrap_command.dart
@@ -79,12 +79,8 @@ const amplifyEnvironments = <String, String>{};
           // command is significantly newer/older than the embedded one.
           (pkg) => pkg.name != 'aft',
         )
-        .expand(
-          (pkg) => [
-            pkg,
-            if (pkg.example case final example?) example,
-          ],
-        );
+        .expand((pkg) => [pkg, pkg.example])
+        .nonNulls;
     for (final package in bootstrapPackages) {
       await pubAction(
         arguments: [if (upgrade) 'upgrade' else 'get'],

--- a/packages/aft/lib/src/commands/bootstrap_command.dart
+++ b/packages/aft/lib/src/commands/bootstrap_command.dart
@@ -84,9 +84,15 @@ const amplifyEnvironments = <String, String>{};
         package: package,
       );
     }
-    await Future.wait(
-      [for (final package in bootstrapPackages) _createEmptyConfig(package)],
-    );
+    await Future.wait([
+      for (final package in bootstrapPackages.expand(
+        (pkg) => [
+          pkg,
+          if (pkg.example case final example?) example,
+        ],
+      ))
+        _createEmptyConfig(package),
+    ]);
     if (build) {
       // Packages which must be built because they vendor assets required for
       // running all downstream packages.

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -164,6 +164,7 @@ jobs:
   test:
     uses: ./.github/workflows/$analyzeAndTestWorkflow
     with:
+      package-name: ${package.name}
       working-directory: $repoRelativePath
 ''',
       );
@@ -175,6 +176,7 @@ jobs:
     needs: test
     uses: ./.github/workflows/$nativeWorkflow
     with:
+      package-name: ${package.name}
       working-directory: $repoRelativePath
 ''',
         );
@@ -186,11 +188,13 @@ jobs:
     needs: test
     uses: ./.github/workflows/$ddcWorkflow
     with:
+      package-name: ${package.name}
       working-directory: $repoRelativePath
   dart2js_test:
     needs: test
     uses: ./.github/workflows/$dart2JsWorkflow
     with:
+      package-name: ${package.name}
       working-directory: $repoRelativePath
 ''',
           );

--- a/packages/aft/lib/src/models/config.dart
+++ b/packages/aft/lib/src/models/config.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:aft/src/changelog/changelog.dart';
 import 'package:aft/src/models.dart';
+import 'package:aft/src/repo.dart';
 import 'package:aft/src/util.dart';
 import 'package:aws_common/aws_common.dart';
 import 'package:collection/collection.dart';
@@ -221,6 +222,19 @@ class PackageInfo
     return p.basename(path).endsWith('_test') ||
         path.contains('goldens') ||
         p.basename(path).contains('e2e');
+  }
+
+  /// Whether [package] is a direct or transitive dependency of `this`.
+  bool dependsOn(PackageInfo package, Repo repo) {
+    var found = false;
+    dfs(
+      repo.getPackageGraph(includeDevDependencies: true),
+      root: this,
+      (pkg) {
+        if (pkg == package) found = true;
+      },
+    );
+    return found;
   }
 
   /// The parsed `CHANGELOG.md`.

--- a/packages/aft/lib/src/models/config.dart
+++ b/packages/aft/lib/src/models/config.dart
@@ -116,7 +116,10 @@ class AftComponent with AWSSerializable<Map<String, Object?>>, AWSDebuggable {
 /// {@endtemplate}
 @yamlSerializable
 class PackageInfo
-    with AWSSerializable<Map<String, Object?>>, AWSDebuggable
+    with
+        AWSEquatable<PackageInfo>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable
     implements Comparable<PackageInfo> {
   /// {@macro amplify_tools.package_info}
   const PackageInfo({
@@ -237,6 +240,19 @@ class PackageInfo
     return found;
   }
 
+  /// Whether [package] has `this` as a direct or transitive dependency.
+  bool isDependedOnBy(PackageInfo package, Repo repo) {
+    var found = false;
+    dfs(
+      repo.getReversedPackageGraph(includeDevDependencies: true),
+      root: this,
+      (pkg) {
+        if (pkg == package) found = true;
+      },
+    );
+    return found;
+  }
+
   /// The parsed `CHANGELOG.md`.
   Changelog get changelog {
     final changelogMd = File(p.join(path, 'CHANGELOG.md')).readAsStringSync();
@@ -260,6 +276,9 @@ class PackageInfo
         getEnv('FLUTTER_ROOT') == null &&
         flavor == PackageFlavor.flutter;
   }
+
+  @override
+  List<Object?> get props => [name];
 
   @override
   int compareTo(PackageInfo other) {

--- a/packages/aft/lib/src/repo.dart
+++ b/packages/aft/lib/src/repo.dart
@@ -90,7 +90,7 @@ class Repo {
 
   /// Returns the directed graph of packages to the packages it depends on.
   ///
-  /// Will include dev dependencies if [includeDevDependencies] is true.
+  /// Will include dev dependencies if [includeDevDependencies] is `true`.
   Map<PackageInfo, List<PackageInfo>> getPackageGraph({
     bool includeDevDependencies = false,
   }) =>
@@ -114,8 +114,18 @@ class Repo {
   ///
   /// Provides a mapping from each packages to the packages which directly
   /// depend on it.
-  late final Map<PackageInfo, List<PackageInfo>> reversedPackageGraph = () {
-    final packageGraph = this.packageGraph;
+  late final Map<PackageInfo, List<PackageInfo>> reversedPackageGraph =
+      getReversedPackageGraph();
+
+  /// Returns the directed graph of packages to the packages which depend on it.
+  ///
+  /// Will include dev dependencies if [includeDevDependencies] is `true`.
+  Map<PackageInfo, List<PackageInfo>> getReversedPackageGraph({
+    bool includeDevDependencies = false,
+  }) {
+    final packageGraph = getPackageGraph(
+      includeDevDependencies: includeDevDependencies,
+    );
     final reversedPackageGraph = <PackageInfo, List<PackageInfo>>{
       for (final package in allPackages.values) package: [],
     };
@@ -125,7 +135,7 @@ class Repo {
       }
     }
     return UnmodifiableMapView(reversedPackageGraph);
-  }();
+  }
 
   /// The git diff between [oldTree] and [newTree].
   ///


### PR DESCRIPTION
Reduces `aft bootstrap` time in CI by only bootstrapping necessary packages.

This improves average workflow speed by 80-90% (seriously quick now!) and should help flakiness since we're no longer DDoS'ing pub as bad in our workflows.