### PR TITLE
ci: fix canaries ios metric name

### DIFF
--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -220,7 +220,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          metric-name: e2eCanaryTestFailure
+          metric-name: E2ECanaryTestFailure
           value: 1
           dimensions: channel=${{ matrix.channel }},platform=ios
       - name: Log succeeding ios runs
@@ -229,6 +229,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          metric-name: e2eCanaryTestFailure
+          metric-name: E2ECanaryTestFailure
           value: 0
           dimensions: channel=${{ matrix.channel }},platform=ios


### PR DESCRIPTION
*Issue #, if available:*

iOS e2e reports wrong metric name (casing is off) 

This causes those reported metrics to be missed by our CW alarms. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
