### PR TITLE
ci(canaries): More improvements

### DIFF
--- a/.github/composite_actions/launch_ios_simulator/action.yaml
+++ b/.github/composite_actions/launch_ios_simulator/action.yaml
@@ -23,8 +23,14 @@ runs:
         get_runtime() {
           xcrun simctl list runtimes -j | jq -r '.runtimes[] | select(.name | startswith("iOS ${{ inputs.ios-version }}")) | .identifier' | head -n 1
         }
+        # Clears the cache from previous attempts
+        clear_cache() {
+          sudo rm -rf ~/Library/Caches/com.robotsandpencils.xcodes/*
+          sudo rm -rf ~/Downloads/*
+        }
         if [[ -z "$(get_runtime)" ]]; then
           echo "No runtime found for iOS ${{ inputs.ios-version }}" >&2
+          clear_cache
           sudo xcodes runtimes install 'iOS ${{ inputs.ios-version }}'
         fi
         xcrun simctl create test "iPhone 11" "$(get_runtime)"

--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -124,8 +124,8 @@ jobs:
         timeout-minutes: 45
         uses: ./.github/composite_actions/launch_android_emulator
         with:
-          script: |
-            cd canaries && flutter test -d emulator-5554 integration_test/main_test.dart
+          # Perform a build to reduce startup time of `flutter test` and prevent timeout
+          script: cd canaries && flutter build apk --debug && flutter test -d emulator-5554 integration_test/main_test.dart
 
       - name: Log failing android runs
         if: ${{ failure() }}
@@ -147,7 +147,7 @@ jobs:
           dimensions: channel=${{ matrix.channel }},platform=android
 
   e2e-ios:
-    runs-on: macos-latest
+    runs-on: macos-13
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
@@ -212,6 +212,7 @@ jobs:
         timeout-minutes: 45
         working-directory: canaries
         run: |
+          # Perform a build to reduce startup time of `flutter test` and prevent timeout 
           flutter build ios --simulator --target=integration_test/main_test.dart
           flutter test -d test integration_test/main_test.dart --verbose
 


### PR DESCRIPTION
- Switches to `macos-13` for iOS canaries (seems to be more reliable)
- Adds pre-build to Android to prevent timeouts
- Adds cache removal for iOS launcher action to improve flakiness