### PR TITLE
chore(datastore): Amplify Swift version bump to 1.30.4

### DIFF
--- a/packages/amplify_datastore/ios/Classes/types/model/FlutterModelSchema.swift
+++ b/packages/amplify_datastore/ios/Classes/types/model/FlutterModelSchema.swift
@@ -4,6 +4,7 @@
 import Flutter
 import Foundation
 import Amplify
+import AWSPluginsCore
 
 struct FlutterModelSchema {
     let name: String
@@ -97,4 +98,12 @@ struct FlutterModelSchema {
 
         return (fields, name)
     }
+}
+
+// This enables custom selection set behavior within Amplify-Swift v1.
+// Which allows models to be decoded when created on Android and received to iOS 
+extension FlutterModelSchema: SubscriptionSelectionSetBehavior {
+    public var includePrimaryKeysOnly: Bool {
+        return true
+    }    
 }

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,9 +15,9 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.29.2'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.29.2'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.29.2'
+  s.dependency 'Amplify', '1.30.4'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.30.4'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.30.4'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/663
https://github.com/aws-amplify/amplify-flutter/issues/1693
https://github.com/aws-amplify/amplify-flutter/issues/2527
https://github.com/aws-amplify/amplify-swift/issues/2873

*Description of changes:*
Bumps Amplify Swift version to 1.30.4. 

The new Amplify Swift version fixes a couple of known issues. 

In particular, #663, a longstanding issue where models were not decoded/synced correctly on iOS devices when they were modified on Android devices 🎉 

Like wise some observed multi auth issues have been fixed in this release too. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
