### PR TITLE
chore(datastore): Amplify Swift version bump to 1.30.4

### DIFF
--- a/packages/amplify/amplify_flutter_ios/ios/amplify_flutter_ios.podspec
+++ b/packages/amplify/amplify_flutter_ios/ios/amplify_flutter_ios.podspec
@@ -17,9 +17,9 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.29.1'
-  s.dependency 'AWSPluginsCore', '1.29.1'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.29.1'
+  s.dependency 'Amplify', '1.30.4'
+  s.dependency 'AWSPluginsCore', '1.30.4'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.30.4'
   s.dependency 'amplify_core'
   s.dependency 'SwiftLint', '0.48.0'
   s.dependency 'SwiftFormat/CLI'

--- a/packages/amplify_datastore/ios/Classes/types/model/FlutterModelSchema.swift
+++ b/packages/amplify_datastore/ios/Classes/types/model/FlutterModelSchema.swift
@@ -16,6 +16,7 @@
 import Flutter
 import Foundation
 import Amplify
+import AWSPluginsCore
 
 struct FlutterModelSchema {
     let name: String
@@ -109,4 +110,12 @@ struct FlutterModelSchema {
 
         return (fields, name)
     }
+}
+
+// This enables custom selection set behavior within Amplify-Swift v1.
+// Which allows models to be decoded when created on Android and received to iOS 
+extension FlutterModelSchema: SubscriptionSelectionSetBehavior {
+    public var includePrimaryKeysOnly: Bool {
+        return true
+    }    
 }

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,8 +15,8 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.29.1'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.29.1'
+  s.dependency 'Amplify', '1.30.4'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.30.4'
   s.dependency 'amplify_core'
   s.platform = :ios, '13.0'
 

--- a/packages/analytics/amplify_analytics_pinpoint_ios/ios/amplify_analytics_pinpoint_ios.podspec
+++ b/packages/analytics/amplify_analytics_pinpoint_ios/ios/amplify_analytics_pinpoint_ios.podspec
@@ -15,8 +15,8 @@ This code is the iOS part of the Amplify Flutter Pinpoint Analytics Plugin.  The
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.29.1'
-  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.29.1'
+  s.dependency 'Amplify', '1.30.4'
+  s.dependency 'AmplifyPlugins/AWSPinpointAnalyticsPlugin', '1.30.4'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/api/amplify_api_ios/ios/amplify_api_ios.podspec
+++ b/packages/api/amplify_api_ios/ios/amplify_api_ios.podspec
@@ -15,8 +15,8 @@ The API module for Amplify Flutter.
   s.source           = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.29.1'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.29.1'
+  s.dependency 'Amplify', '1.30.4'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.30.4'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 

--- a/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
+++ b/packages/auth/amplify_auth_cognito_ios/ios/amplify_auth_cognito_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.29.1'
-  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.29.1'
+  s.dependency 'Amplify', '1.30.4'
+  s.dependency 'AmplifyPlugins/AWSCognitoAuthPlugin', '1.30.4'
   s.dependency 'ObjectMapper'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'

--- a/packages/storage/amplify_storage_s3_ios/ios/amplify_storage_s3_ios.podspec
+++ b/packages/storage/amplify_storage_s3_ios/ios/amplify_storage_s3_ios.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.29.1'
-  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.29.1'
+  s.dependency 'Amplify', '1.30.4'
+  s.dependency 'AmplifyPlugins/AWSS3StoragePlugin', '1.30.4'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/663
https://github.com/aws-amplify/amplify-flutter/issues/1693
https://github.com/aws-amplify/amplify-flutter/issues/2527
https://github.com/aws-amplify/amplify-swift/issues/2873

*Description of changes:*
Bumps Amplify Swift version to 1.30.4. 

The new Amplify Swift version fixes a couple of known issues. 

In particular, #663, a longstanding issue where models were not decoded/synced correctly on iOS devices when they were modified on Android devices 🎉 

Like wise some observed multi auth issues have been fixed in this release too. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
