### PR TITLE
ci(dependabot): Fix kotlin name

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -184,7 +184,7 @@ updates:
     ignore:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
-      - dependency-name: "kotlin"
+      - dependency-name: "kotlin_version"
       
       # Ignore patch version bumps
       - dependency-name: "*"
@@ -257,7 +257,7 @@ updates:
     ignore:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
-      - dependency-name: "kotlin"
+      - dependency-name: "kotlin_version"
       
       # Ignore patch version bumps
       - dependency-name: "*"
@@ -304,7 +304,7 @@ updates:
     ignore:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
-      - dependency-name: "kotlin"
+      - dependency-name: "kotlin_version"
       
       # Ignore patch version bumps
       - dependency-name: "*"
@@ -453,7 +453,7 @@ updates:
     ignore:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
-      - dependency-name: "kotlin"
+      - dependency-name: "kotlin_version"
       
       # Ignore patch version bumps
       - dependency-name: "*"
@@ -710,7 +710,7 @@ updates:
     ignore:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
-      - dependency-name: "kotlin"
+      - dependency-name: "kotlin_version"
       
       # Ignore patch version bumps
       - dependency-name: "*"
@@ -804,7 +804,7 @@ updates:
     ignore:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
-      - dependency-name: "kotlin"
+      - dependency-name: "kotlin_version"
       
       # Ignore patch version bumps
       - dependency-name: "*"
@@ -906,7 +906,7 @@ updates:
     ignore:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
-      - dependency-name: "kotlin"
+      - dependency-name: "kotlin_version"
       
       # Ignore patch version bumps
       - dependency-name: "*"

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -277,7 +277,7 @@ jobs:
     ignore:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
-      - dependency-name: "kotlin"
+      - dependency-name: "kotlin_version"
       
       # Ignore patch version bumps
       - dependency-name: "*"


### PR DESCRIPTION
Should be `kotlin_version` I think given recent dependabot PRs