### PR TITLE
ci(dependabot): Ignore Kotlin gradle plugin

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -185,6 +185,7 @@ updates:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
       - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
       
       # Ignore patch version bumps
       - dependency-name: "*"
@@ -258,6 +259,7 @@ updates:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
       - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
       
       # Ignore patch version bumps
       - dependency-name: "*"
@@ -305,6 +307,7 @@ updates:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
       - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
       
       # Ignore patch version bumps
       - dependency-name: "*"
@@ -454,6 +457,7 @@ updates:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
       - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
       
       # Ignore patch version bumps
       - dependency-name: "*"
@@ -711,6 +715,7 @@ updates:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
       - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
       
       # Ignore patch version bumps
       - dependency-name: "*"
@@ -805,6 +810,7 @@ updates:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
       - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
       
       # Ignore patch version bumps
       - dependency-name: "*"
@@ -907,6 +913,7 @@ updates:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
       - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
       
       # Ignore patch version bumps
       - dependency-name: "*"

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -278,6 +278,7 @@ jobs:
       # Ignore Kotlin updates since we should always match Flutter stable
       # to ensure users can have Kt versions >= Flutter stable.
       - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
       
       # Ignore patch version bumps
       - dependency-name: "*"


### PR DESCRIPTION
For the same reason we ignore the Kotlin version itself