### PR TITLE
chore: run integ in v0 push

### DIFF
--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -1,7 +1,7 @@
 name: Amplify Integration Tests
 on:
   push:
-    branches: [main, next, stable, feat/*]
+    branches: [main, next, stable, feat/*, v0]
   schedule:
     # 6am pacific time daily, only runs on default branch
     - cron:  '0 13 * * *'


### PR DESCRIPTION
Run integ tests in CI for v0 branch push. We moved some branches around w v1 release but never changed integ test config to match in v0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
