### PR TITLE
chore: v0 migration/README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ We are iterating and looking for feedback and collaboration, so please [**let us
 - [Example Application](https://github.com/aws-amplify/amplify-flutter/tree/main/example)
 - [Roadmap/Provide Feedback](https://github.com/aws-amplify/amplify-flutter/issues/5)
 
-⚠️ **For breaking changes from the developer preview versions please refer to this [issue](https://github.com/aws-amplify/amplify-flutter/issues/274) for migration details.**
+⚠️ **Amplify Flutter v0 is now in Maintenance Mode until July 19th, 2024. This means that we will continue to include updates to ensure compatibility with backend services and security. No new features will be introduced in v0.**
+
+Please use the latest version (v1) of Amplify Flutter. If you are currently using v0, follow [these instructions](https://docs.amplify.aws/lib/project-setup/upgrade-guide/q/platform/flutter/) to upgrade to v1.
 
 ## Supported Amplify Categories
 
@@ -55,7 +57,7 @@ We are iterating and looking for feedback and collaboration, so please [**let us
 
 ## Category / Platform Support
 
-### Stable Release
+### v0
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
 | -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
@@ -66,7 +68,7 @@ We are iterating and looking for feedback and collaboration, so please [**let us
 | DataStore      |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
 | Storage        |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
 
-### Developer Preview Release
+### v1
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
 | -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |

--- a/README.md
+++ b/README.md
@@ -57,17 +57,6 @@ Please use the latest version (v1) of Amplify Flutter. If you are currently usin
 
 ## Category / Platform Support
 
-### v0
-
-| Category       | Android | iOS | Web | Windows | MacOS | Linux |
-| -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
-| Analytics      |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
-| API (REST)     |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
-| API (GraphQL)  |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
-| Authentication |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
-| DataStore      |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
-| Storage        |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
-
 ### v1
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
@@ -78,6 +67,17 @@ Please use the latest version (v1) of Amplify Flutter. If you are currently usin
 | Authentication |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | DataStore      |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
 | Storage        |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
+
+### v0
+
+| Category       | Android | iOS | Web | Windows | MacOS | Linux |
+| -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
+| Analytics      |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| API (REST)     |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| API (GraphQL)  |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| Authentication |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| DataStore      |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| Storage        |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
 
 ### To Be Implemented
 

--- a/packages/amplify/amplify_flutter/README.md
+++ b/packages/amplify/amplify_flutter/README.md
@@ -2,9 +2,13 @@
 
 The top level module for Amplify Flutter.
 
+⚠️ **Amplify Flutter v0 is now in Maintenance Mode until July 19th, 2024. This means that we will continue to include updates to ensure compatibility with backend services and security. No new features will be introduced in v0.**
+
+Please use the latest version (v1) of Amplify Flutter. If you are currently using v0, follow [these instructions](https://docs.amplify.aws/lib/project-setup/upgrade-guide/q/platform/flutter/) to upgrade to v1.
+
 ## Category / Platform Support
 
-### Stable Release
+### v0
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
 | -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
@@ -15,7 +19,7 @@ The top level module for Amplify Flutter.
 | DataStore      |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
 | Storage        |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
 
-### Developer Preview Release
+### v1
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
 | -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |

--- a/packages/amplify/amplify_flutter/README.md
+++ b/packages/amplify/amplify_flutter/README.md
@@ -8,17 +8,6 @@ Please use the latest version (v1) of Amplify Flutter. If you are currently usin
 
 ## Category / Platform Support
 
-### v0
-
-| Category       | Android | iOS | Web | Windows | MacOS | Linux |
-| -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
-| Analytics      |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
-| API (REST)     |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
-| API (GraphQL)  |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
-| Authentication |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
-| DataStore      |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
-| Storage        |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
-
 ### v1
 
 | Category       | Android | iOS | Web | Windows | MacOS | Linux |
@@ -29,6 +18,17 @@ Please use the latest version (v1) of Amplify Flutter. If you are currently usin
 | Authentication |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | DataStore      |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
 | Storage        |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
+
+### v0
+
+| Category       | Android | iOS | Web | Windows | MacOS | Linux |
+| -------------- | :-----: | :-: | :-: | :-----: | :---: | :---: |
+| Analytics      |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| API (REST)     |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| API (GraphQL)  |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| Authentication |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| DataStore      |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
+| Storage        |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
 
 ## Getting Started
 

--- a/packages/amplify_datastore/README.md
+++ b/packages/amplify_datastore/README.md
@@ -2,6 +2,10 @@
 
 Default plugin for the Amplify Flutter DataStore category
 
+⚠️ **Amplify Flutter v0 is now in Maintenance Mode until July 19th, 2024. This means that we will continue to include updates to ensure compatibility with backend services and security. No new features will be introduced in v0.**
+
+Please use the latest version (v1) of Amplify Flutter. If you are currently using v0, follow [these instructions](https://docs.amplify.aws/lib/project-setup/upgrade-guide/q/platform/flutter/) to upgrade to v1.
+
 ## Getting Started
 
 ### Visit our [Web Site](https://docs.amplify.aws/) to learn more about AWS Amplify.

--- a/packages/analytics/amplify_analytics_pinpoint/README.md
+++ b/packages/analytics/amplify_analytics_pinpoint/README.md
@@ -2,6 +2,10 @@
 
 The Amplify Flutter Analytics category plugin using the AWS Pinpoint provider.
 
+⚠️ **Amplify Flutter v0 is now in Maintenance Mode until July 19th, 2024. This means that we will continue to include updates to ensure compatibility with backend services and security. No new features will be introduced in v0.**
+
+Please use the latest version (v1) of Amplify Flutter. If you are currently using v0, follow [these instructions](https://docs.amplify.aws/lib/project-setup/upgrade-guide/q/platform/flutter/) to upgrade to v1.
+
 ## Getting Started
 
 ### Visit our [Web Site](https://docs.amplify.aws/) to learn more about AWS Amplify.

--- a/packages/api/amplify_api/README.md
+++ b/packages/api/amplify_api/README.md
@@ -6,6 +6,11 @@ The Amplify Flutter API category plugin.
 
 ### Visit our [Web Site](https://docs.amplify.aws/) to learn more about AWS Amplify.
 
+⚠️ **Amplify Flutter v0 is now in Maintenance Mode until July 19th, 2024. This means that we will continue to include updates to ensure compatibility with backend services and security. No new features will be introduced in v0.**
+
+Please use the latest version (v1) of Amplify Flutter. If you are currently using v0, follow [these instructions](https://docs.amplify.aws/lib/project-setup/upgrade-guide/q/platform/flutter/) to upgrade to v1.
+
+
 ## Changes for version 0.3.0 and above
 
 When creating subscriptions, now, a [`Stream`](https://api.dart.dev/stable/dart-async/Stream-class.html) object will be returned to you. This `Stream` will continue producing events until either the subscription encounters an error, or you cancel the subscription. In the case of [`await for`](https://dart.dev/tutorials/language/streams), this cancellation occurs when breaking out of the loop.

--- a/packages/auth/amplify_auth_cognito/README.md
+++ b/packages/auth/amplify_auth_cognito/README.md
@@ -2,6 +2,10 @@
 
 The Amplify Flutter Auth category plugin using the AWS Cognito provider.
 
+⚠️ **Amplify Flutter v0 is now in Maintenance Mode until July 19th, 2024. This means that we will continue to include updates to ensure compatibility with backend services and security. No new features will be introduced in v0.**
+
+Please use the latest version (v1) of Amplify Flutter. If you are currently using v0, follow [these instructions](https://docs.amplify.aws/lib/project-setup/upgrade-guide/q/platform/flutter/) to upgrade to v1.
+
 ## Getting Started
 
 ### Visit our [Web Site](https://docs.amplify.aws/) to learn more about AWS Amplify.

--- a/packages/storage/amplify_storage_s3/README.md
+++ b/packages/storage/amplify_storage_s3/README.md
@@ -2,6 +2,10 @@
 
 The Amplify Flutter Storage category plugin using the AWS S3 provider.
 
+⚠️ **Amplify Flutter v0 is now in Maintenance Mode until July 19th, 2024. This means that we will continue to include updates to ensure compatibility with backend services and security. No new features will be introduced in v0.**
+
+Please use the latest version (v1) of Amplify Flutter. If you are currently using v0, follow [these instructions](https://docs.amplify.aws/lib/project-setup/upgrade-guide/q/platform/flutter/) to upgrade to v1.
+
 ## Getting Started
 
 ### Visit our [Web Site](https://docs.amplify.aws/) to learn more about AWS Amplify.


### PR DESCRIPTION
Adds some v0/v1 migration info in the README. See live version https://github.com/ragingsquirrel3/amplify-flutter/tree/chore/readme-v0-deprecation#supported-amplify-categories

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
