### PR TITLE
chore: remove some cupertino icon usage

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -29,9 +29,6 @@ dependencies:
   amplify_analytics_pinpoint: 0.6.5
   amplify_auth_cognito: 0.6.5
   amplify_storage_s3: 0.6.5
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
 
 dev_dependencies:
   flutter_test:

--- a/packages/amplify_datastore/example/pubspec.yaml
+++ b/packages/amplify_datastore/example/pubspec.yaml
@@ -29,10 +29,6 @@ dependencies:
   integration_test:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
-
 dev_dependencies:
   amplify_test:
     path: ../../amplify_test

--- a/packages/api/amplify_api/example/pubspec.yaml
+++ b/packages/api/amplify_api/example/pubspec.yaml
@@ -23,10 +23,6 @@ dependencies:
     path: ../../../amplify/amplify_flutter
   aws_common: ^0.1.1
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
-
   flutter:
     sdk: flutter
 

--- a/packages/auth/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec.yaml
@@ -23,9 +23,6 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
 
 dev_dependencies:
   amplify_lints: ^1.0.0

--- a/packages/storage/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/example/pubspec.yaml
@@ -26,10 +26,6 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
-
 dev_dependencies:
   amplify_test:
     path: ../../../amplify_test


### PR DESCRIPTION
Old versions of cupertino icons in example apps were causing `melos bootstrap` errors in v0 so integ test apps won't build. This PR removes them so apps can be tested.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
