### PR TITLE
chore(smithy): Cascade in `_init`

### DIFF
--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/canary_settings.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/canary_settings.dart
@@ -46,8 +46,9 @@ abstract class CanarySettings
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(CanarySettingsBuilder b) {
-    b.percentTraffic = 0;
-    b.useStageCache = false;
+    b
+      ..percentTraffic = 0
+      ..useStageCache = false;
   }
 
   /// The percent (0-100) of traffic diverted to a canary deployment.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/create_api_key_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/create_api_key_request.dart
@@ -63,8 +63,9 @@ abstract class CreateApiKeyRequest
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(CreateApiKeyRequestBuilder b) {
-    b.enabled = false;
-    b.generateDistinctId = false;
+    b
+      ..enabled = false
+      ..generateDistinctId = false;
   }
 
   /// The name of the ApiKey.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/create_request_validator_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/create_request_validator_request.dart
@@ -63,8 +63,9 @@ abstract class CreateRequestValidatorRequest
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(CreateRequestValidatorRequestBuilder b) {
-    b.validateRequestBody = false;
-    b.validateRequestParameters = false;
+    b
+      ..validateRequestBody = false
+      ..validateRequestParameters = false;
   }
 
   /// The string identifier of the associated RestApi.
@@ -142,8 +143,9 @@ abstract class CreateRequestValidatorRequestPayload
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(CreateRequestValidatorRequestPayloadBuilder b) {
-    b.validateRequestBody = false;
-    b.validateRequestParameters = false;
+    b
+      ..validateRequestBody = false
+      ..validateRequestParameters = false;
   }
 
   /// The name of the to-be-created RequestValidator.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/create_stage_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/create_stage_request.dart
@@ -94,8 +94,9 @@ abstract class CreateStageRequest
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(CreateStageRequestBuilder b) {
-    b.cacheClusterEnabled = false;
-    b.tracingEnabled = false;
+    b
+      ..cacheClusterEnabled = false
+      ..tracingEnabled = false;
   }
 
   /// The string identifier of the associated RestApi.
@@ -239,8 +240,9 @@ abstract class CreateStageRequestPayload
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(CreateStageRequestPayloadBuilder b) {
-    b.cacheClusterEnabled = false;
-    b.tracingEnabled = false;
+    b
+      ..cacheClusterEnabled = false
+      ..tracingEnabled = false;
   }
 
   /// Whether cache clustering is enabled for the stage.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/deployment_canary_settings.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/deployment_canary_settings.dart
@@ -45,8 +45,9 @@ abstract class DeploymentCanarySettings
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(DeploymentCanarySettingsBuilder b) {
-    b.percentTraffic = 0;
-    b.useStageCache = false;
+    b
+      ..percentTraffic = 0
+      ..useStageCache = false;
   }
 
   /// The percentage (0.0-100.0) of traffic routed to the canary deployment.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/method_setting.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/method_setting.dart
@@ -65,14 +65,15 @@ abstract class MethodSetting
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(MethodSettingBuilder b) {
-    b.metricsEnabled = false;
-    b.dataTraceEnabled = false;
-    b.throttlingBurstLimit = 0;
-    b.throttlingRateLimit = 0;
-    b.cachingEnabled = false;
-    b.cacheTtlInSeconds = 0;
-    b.cacheDataEncrypted = false;
-    b.requireAuthorizationForCacheControl = false;
+    b
+      ..metricsEnabled = false
+      ..dataTraceEnabled = false
+      ..throttlingBurstLimit = 0
+      ..throttlingRateLimit = 0
+      ..cachingEnabled = false
+      ..cacheTtlInSeconds = 0
+      ..cacheDataEncrypted = false
+      ..requireAuthorizationForCacheControl = false;
   }
 
   /// Specifies whether Amazon CloudWatch metrics are enabled for this method. The PATCH path for this setting is `/{method\_setting\_key}/metrics/enabled`, and the value is a Boolean.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/quota_settings.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/quota_settings.dart
@@ -43,8 +43,9 @@ abstract class QuotaSettings
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(QuotaSettingsBuilder b) {
-    b.limit = 0;
-    b.offset = 0;
+    b
+      ..limit = 0
+      ..offset = 0;
   }
 
   /// The target maximum number of requests that can be made in a given time period.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/request_validator.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/request_validator.dart
@@ -50,8 +50,9 @@ abstract class RequestValidator
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(RequestValidatorBuilder b) {
-    b.validateRequestBody = false;
-    b.validateRequestParameters = false;
+    b
+      ..validateRequestBody = false
+      ..validateRequestParameters = false;
   }
 
   /// The identifier of this RequestValidator.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/stage.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/stage.dart
@@ -87,8 +87,9 @@ abstract class Stage
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(StageBuilder b) {
-    b.cacheClusterEnabled = false;
-    b.tracingEnabled = false;
+    b
+      ..cacheClusterEnabled = false
+      ..tracingEnabled = false;
   }
 
   /// The identifier of the Deployment that the stage points to.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/test_invoke_authorizer_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/test_invoke_authorizer_response.dart
@@ -62,8 +62,9 @@ abstract class TestInvokeAuthorizerResponse
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(TestInvokeAuthorizerResponseBuilder b) {
-    b.clientStatus = 0;
-    b.latency = _i2.Int64.ZERO;
+    b
+      ..clientStatus = 0
+      ..latency = _i2.Int64.ZERO;
   }
 
   /// The HTTP status code that the client would have received. Value is 0 if the authorizer succeeded.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/test_invoke_method_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/test_invoke_method_response.dart
@@ -59,8 +59,9 @@ abstract class TestInvokeMethodResponse
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(TestInvokeMethodResponseBuilder b) {
-    b.status = 0;
-    b.latency = _i2.Int64.ZERO;
+    b
+      ..status = 0
+      ..latency = _i2.Int64.ZERO;
   }
 
   /// The HTTP status code.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/throttle_settings.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/model/throttle_settings.dart
@@ -39,8 +39,9 @@ abstract class ThrottleSettings
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(ThrottleSettingsBuilder b) {
-    b.burstLimit = 0;
-    b.rateLimit = 0;
+    b
+      ..burstLimit = 0
+      ..rateLimit = 0;
   }
 
   /// The API target request burst rate limit. This allows more requests through for a period of time than the target rate limit.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/create_stack_instances_input.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/create_stack_instances_input.dart
@@ -35,11 +35,9 @@ abstract class CreateStackInstancesInput
     String? operationId,
     _i6.CallAs? callAs,
   }) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      operationId ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      operationId ??= _i2.uuid(secure: true);
-    }
+    operationId ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$CreateStackInstancesInput._(
       stackSetName: stackSetName,
       accounts: accounts == null ? null : _i7.BuiltList(accounts),
@@ -71,11 +69,9 @@ abstract class CreateStackInstancesInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(CreateStackInstancesInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.operationId = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.operationId = _i2.uuid(secure: true);
-    }
+    b.operationId = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   /// The name or unique ID of the stack set that you want to create stack instances from.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/create_stack_set_input.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/create_stack_set_input.dart
@@ -46,11 +46,9 @@ abstract class CreateStackSetInput
     String? clientRequestToken,
     _i9.ManagedExecution? managedExecution,
   }) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      clientRequestToken ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      clientRequestToken ??= _i2.uuid(secure: true);
-    }
+    clientRequestToken ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$CreateStackSetInput._(
       stackSetName: stackSetName,
       description: description,
@@ -89,11 +87,9 @@ abstract class CreateStackSetInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(CreateStackSetInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.clientRequestToken = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.clientRequestToken = _i2.uuid(secure: true);
-    }
+    b.clientRequestToken = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   /// The name to associate with the stack set. The name must be unique in the Region where you create your stack set.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/delete_stack_instances_input.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/delete_stack_instances_input.dart
@@ -34,11 +34,9 @@ abstract class DeleteStackInstancesInput
     _i5.CallAs? callAs,
   }) {
     retainStacks ??= false;
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      operationId ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      operationId ??= _i2.uuid(secure: true);
-    }
+    operationId ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$DeleteStackInstancesInput._(
       stackSetName: stackSetName,
       accounts: accounts == null ? null : _i6.BuiltList(accounts),
@@ -69,12 +67,11 @@ abstract class DeleteStackInstancesInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(DeleteStackInstancesInputBuilder b) {
-    b.retainStacks = false;
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.operationId = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.operationId = _i2.uuid(secure: true);
-    }
+    b
+      ..retainStacks = false
+      ..operationId = const bool.hasEnvironment('SMITHY_TEST')
+          ? '00000000-0000-4000-8000-000000000000'
+          : _i2.uuid(secure: true);
   }
 
   /// The name or unique ID of the stack set that you want to delete stack instances for.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/detect_stack_set_drift_input.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/detect_stack_set_drift_input.dart
@@ -26,11 +26,9 @@ abstract class DetectStackSetDriftInput
     String? operationId,
     _i4.CallAs? callAs,
   }) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      operationId ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      operationId ??= _i2.uuid(secure: true);
-    }
+    operationId ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$DetectStackSetDriftInput._(
       stackSetName: stackSetName,
       operationPreferences: operationPreferences,
@@ -57,11 +55,9 @@ abstract class DetectStackSetDriftInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(DetectStackSetDriftInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.operationId = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.operationId = _i2.uuid(secure: true);
-    }
+    b.operationId = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   /// The name of the stack set on which to perform the drift detection operation.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/import_stacks_to_stack_set_input.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/import_stacks_to_stack_set_input.dart
@@ -30,11 +30,9 @@ abstract class ImportStacksToStackSetInput
     String? operationId,
     _i4.CallAs? callAs,
   }) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      operationId ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      operationId ??= _i2.uuid(secure: true);
-    }
+    operationId ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$ImportStacksToStackSetInput._(
       stackSetName: stackSetName,
       stackIds: stackIds == null ? null : _i5.BuiltList(stackIds),
@@ -66,11 +64,9 @@ abstract class ImportStacksToStackSetInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(ImportStacksToStackSetInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.operationId = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.operationId = _i2.uuid(secure: true);
-    }
+    b.operationId = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   /// The name of the stack set. The name must be unique in the Region where you create your stack set.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/stack_set_drift_detection_details.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/stack_set_drift_detection_details.dart
@@ -79,11 +79,12 @@ abstract class StackSetDriftDetectionDetails
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(StackSetDriftDetectionDetailsBuilder b) {
-    b.totalStackInstancesCount = 0;
-    b.driftedStackInstancesCount = 0;
-    b.inSyncStackInstancesCount = 0;
-    b.inProgressStackInstancesCount = 0;
-    b.failedStackInstancesCount = 0;
+    b
+      ..totalStackInstancesCount = 0
+      ..driftedStackInstancesCount = 0
+      ..inSyncStackInstancesCount = 0
+      ..inProgressStackInstancesCount = 0
+      ..failedStackInstancesCount = 0;
   }
 
   /// Status of the stack set's actual configuration compared to its expected template and parameter configuration. A stack set is considered to have drifted if one or more of its stack instances have drifted from their expected template and parameter configuration.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/update_stack_instances_input.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/update_stack_instances_input.dart
@@ -35,11 +35,9 @@ abstract class UpdateStackInstancesInput
     String? operationId,
     _i6.CallAs? callAs,
   }) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      operationId ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      operationId ??= _i2.uuid(secure: true);
-    }
+    operationId ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$UpdateStackInstancesInput._(
       stackSetName: stackSetName,
       accounts: accounts == null ? null : _i7.BuiltList(accounts),
@@ -71,11 +69,9 @@ abstract class UpdateStackInstancesInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(UpdateStackInstancesInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.operationId = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.operationId = _i2.uuid(secure: true);
-    }
+    b.operationId = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   /// The name or unique ID of the stack set associated with the stack instances.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/update_stack_set_input.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/model/update_stack_set_input.dart
@@ -54,11 +54,9 @@ abstract class UpdateStackSetInput
     _i10.CallAs? callAs,
     _i11.ManagedExecution? managedExecution,
   }) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      operationId ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      operationId ??= _i2.uuid(secure: true);
-    }
+    operationId ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$UpdateStackSetInput._(
       stackSetName: stackSetName,
       description: description,
@@ -101,11 +99,9 @@ abstract class UpdateStackSetInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(UpdateStackSetInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.operationId = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.operationId = _i2.uuid(secure: true);
-    }
+    b.operationId = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   /// The name or unique ID of the stack set that you want to update.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/aggregate_conformance_pack_compliance.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/aggregate_conformance_pack_compliance.dart
@@ -55,9 +55,10 @@ abstract class AggregateConformancePackCompliance
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(AggregateConformancePackComplianceBuilder b) {
-    b.compliantRuleCount = 0;
-    b.nonCompliantRuleCount = 0;
-    b.totalRuleCount = 0;
+    b
+      ..compliantRuleCount = 0
+      ..nonCompliantRuleCount = 0
+      ..totalRuleCount = 0;
   }
 
   /// The compliance status of the conformance pack.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/aggregate_conformance_pack_compliance_count.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/aggregate_conformance_pack_compliance_count.dart
@@ -45,8 +45,9 @@ abstract class AggregateConformancePackComplianceCount
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(AggregateConformancePackComplianceCountBuilder b) {
-    b.compliantConformancePackCount = 0;
-    b.nonCompliantConformancePackCount = 0;
+    b
+      ..compliantConformancePackCount = 0
+      ..nonCompliantConformancePackCount = 0;
   }
 
   /// Number of compliant conformance packs.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/compliance_contributor_count.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/compliance_contributor_count.dart
@@ -40,8 +40,9 @@ abstract class ComplianceContributorCount
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(ComplianceContributorCountBuilder b) {
-    b.cappedCount = 0;
-    b.capExceeded = false;
+    b
+      ..cappedCount = 0
+      ..capExceeded = false;
   }
 
   /// The number of Amazon Web Services resources or Config rules responsible for the current compliance of the item.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/list_discovered_resources_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/list_discovered_resources_request.dart
@@ -58,8 +58,9 @@ abstract class ListDiscoveredResourcesRequest
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(ListDiscoveredResourcesRequestBuilder b) {
-    b.limit = 0;
-    b.includeDeletedResources = false;
+    b
+      ..limit = 0
+      ..includeDeletedResources = false;
   }
 
   /// The type of resources that you want Config to list in the response.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/recording_group.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/recording_group.dart
@@ -89,8 +89,9 @@ abstract class RecordingGroup
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(RecordingGroupBuilder b) {
-    b.allSupported = false;
-    b.includeGlobalResourceTypes = false;
+    b
+      ..allSupported = false
+      ..includeGlobalResourceTypes = false;
   }
 
   /// Specifies whether Config records configuration changes for all supported regional resource types.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/select_aggregate_resource_config_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/select_aggregate_resource_config_request.dart
@@ -53,8 +53,9 @@ abstract class SelectAggregateResourceConfigRequest
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(SelectAggregateResourceConfigRequestBuilder b) {
-    b.limit = 0;
-    b.maxResults = 0;
+    b
+      ..limit = 0
+      ..maxResults = 0;
   }
 
   /// The SQL query SELECT command.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/execute_transaction_input.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/execute_transaction_input.dart
@@ -25,11 +25,9 @@ abstract class ExecuteTransactionInput
     String? clientRequestToken,
     _i4.ReturnConsumedCapacity? returnConsumedCapacity,
   }) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      clientRequestToken ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      clientRequestToken ??= _i2.uuid(secure: true);
-    }
+    clientRequestToken ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$ExecuteTransactionInput._(
       transactStatements: _i5.BuiltList(transactStatements),
       clientRequestToken: clientRequestToken,
@@ -55,11 +53,9 @@ abstract class ExecuteTransactionInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(ExecuteTransactionInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.clientRequestToken = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.clientRequestToken = _i2.uuid(secure: true);
-    }
+    b.clientRequestToken = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   /// The list of PartiQL statements representing the transaction to run.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/export_table_to_point_in_time_input.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/export_table_to_point_in_time_input.dart
@@ -32,11 +32,9 @@ abstract class ExportTableToPointInTimeInput
     String? s3SseKmsKeyId,
     _i4.ExportFormat? exportFormat,
   }) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      clientToken ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      clientToken ??= _i2.uuid(secure: true);
-    }
+    clientToken ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$ExportTableToPointInTimeInput._(
       tableArn: tableArn,
       exportTime: exportTime,
@@ -68,11 +66,9 @@ abstract class ExportTableToPointInTimeInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(ExportTableToPointInTimeInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.clientToken = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.clientToken = _i2.uuid(secure: true);
-    }
+    b.clientToken = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   /// The Amazon Resource Name (ARN) associated with the table to export.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/import_table_description.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/import_table_description.dart
@@ -87,9 +87,10 @@ abstract class ImportTableDescription
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(ImportTableDescriptionBuilder b) {
-    b.errorCount = _i4.Int64.ZERO;
-    b.processedItemCount = _i4.Int64.ZERO;
-    b.importedItemCount = _i4.Int64.ZERO;
+    b
+      ..errorCount = _i4.Int64.ZERO
+      ..processedItemCount = _i4.Int64.ZERO
+      ..importedItemCount = _i4.Int64.ZERO;
   }
 
   /// The Amazon Resource Number (ARN) corresponding to the import request.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/import_table_input.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/import_table_input.dart
@@ -31,11 +31,9 @@ abstract class ImportTableInput
     _i6.InputCompressionType? inputCompressionType,
     required _i7.TableCreationParameters tableCreationParameters,
   }) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      clientToken ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      clientToken ??= _i2.uuid(secure: true);
-    }
+    clientToken ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$ImportTableInput._(
       clientToken: clientToken,
       s3BucketSource: s3BucketSource,
@@ -64,11 +62,9 @@ abstract class ImportTableInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(ImportTableInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.clientToken = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.clientToken = _i2.uuid(secure: true);
-    }
+    b.clientToken = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   /// Providing a `ClientToken` makes the call to `ImportTableInput` idempotent, meaning that multiple identical calls have the same effect as one single call.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/provisioned_throughput.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/provisioned_throughput.dart
@@ -47,8 +47,9 @@ abstract class ProvisionedThroughput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(ProvisionedThroughputBuilder b) {
-    b.readCapacityUnits = _i2.Int64.ZERO;
-    b.writeCapacityUnits = _i2.Int64.ZERO;
+    b
+      ..readCapacityUnits = _i2.Int64.ZERO
+      ..writeCapacityUnits = _i2.Int64.ZERO;
   }
 
   /// The maximum number of strongly consistent reads consumed per second before DynamoDB returns a `ThrottlingException`. For more information, see [Specifying Read and Write Requirements](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html) in the _Amazon DynamoDB Developer Guide_.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/query_output.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/query_output.dart
@@ -60,8 +60,9 @@ abstract class QueryOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(QueryOutputBuilder b) {
-    b.count = 0;
-    b.scannedCount = 0;
+    b
+      ..count = 0
+      ..scannedCount = 0;
   }
 
   /// An array of item attributes that match the query criteria. Each element in this array consists of an attribute name and the value for that attribute.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/scan_output.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/scan_output.dart
@@ -60,8 +60,9 @@ abstract class ScanOutput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(ScanOutputBuilder b) {
-    b.count = 0;
-    b.scannedCount = 0;
+    b
+      ..count = 0
+      ..scannedCount = 0;
   }
 
   /// An array of item attributes that match the scan criteria. Each element in this array consists of an attribute name and the value for that attribute.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/transact_write_items_input.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/transact_write_items_input.dart
@@ -28,11 +28,9 @@ abstract class TransactWriteItemsInput
     _i5.ReturnItemCollectionMetrics? returnItemCollectionMetrics,
     String? clientRequestToken,
   }) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      clientRequestToken ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      clientRequestToken ??= _i2.uuid(secure: true);
-    }
+    clientRequestToken ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$TransactWriteItemsInput._(
       transactItems: _i6.BuiltList(transactItems),
       returnConsumedCapacity: returnConsumedCapacity,
@@ -59,11 +57,9 @@ abstract class TransactWriteItemsInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(TransactWriteItemsInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.clientRequestToken = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.clientRequestToken = _i2.uuid(secure: true);
-    }
+    b.clientRequestToken = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   /// An ordered array of up to 100 `TransactWriteItem` objects, each of which contains a `ConditionCheck`, `Put`, `Update`, or `Delete` object. These can operate on items in different tables, but the tables must reside in the same Amazon Web Services account and Region, and no two of them can operate on the same item.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/password_policy.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/password_policy.dart
@@ -65,12 +65,13 @@ abstract class PasswordPolicy
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(PasswordPolicyBuilder b) {
-    b.requireSymbols = false;
-    b.requireNumbers = false;
-    b.requireUppercaseCharacters = false;
-    b.requireLowercaseCharacters = false;
-    b.allowUsersToChangePassword = false;
-    b.expirePasswords = false;
+    b
+      ..requireSymbols = false
+      ..requireNumbers = false
+      ..requireUppercaseCharacters = false
+      ..requireLowercaseCharacters = false
+      ..allowUsersToChangePassword = false
+      ..expirePasswords = false;
   }
 
   /// Minimum length to require for IAM user passwords.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/position.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/position.dart
@@ -44,8 +44,9 @@ abstract class Position
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(PositionBuilder b) {
-    b.line = 0;
-    b.column = 0;
+    b
+      ..line = 0
+      ..column = 0;
   }
 
   /// The line containing the specified position in the document.

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/update_account_password_policy_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/update_account_password_policy_request.dart
@@ -64,11 +64,12 @@ abstract class UpdateAccountPasswordPolicyRequest
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(UpdateAccountPasswordPolicyRequestBuilder b) {
-    b.requireSymbols = false;
-    b.requireNumbers = false;
-    b.requireUppercaseCharacters = false;
-    b.requireLowercaseCharacters = false;
-    b.allowUsersToChangePassword = false;
+    b
+      ..requireSymbols = false
+      ..requireNumbers = false
+      ..requireUppercaseCharacters = false
+      ..requireLowercaseCharacters = false
+      ..allowUsersToChangePassword = false;
   }
 
   /// The minimum number of characters allowed in an IAM user password.

--- a/packages/smithy/goldens/lib/awsQuery/lib/src/query_protocol/model/query_idempotency_token_auto_fill_input.dart
+++ b/packages/smithy/goldens/lib/awsQuery/lib/src/query_protocol/model/query_idempotency_token_auto_fill_input.dart
@@ -18,11 +18,9 @@ abstract class QueryIdempotencyTokenAutoFillInput
         Built<QueryIdempotencyTokenAutoFillInput,
             QueryIdempotencyTokenAutoFillInputBuilder> {
   factory QueryIdempotencyTokenAutoFillInput({String? token}) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      token ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      token ??= _i2.uuid(secure: true);
-    }
+    token ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$QueryIdempotencyTokenAutoFillInput._(token: token);
   }
 
@@ -44,11 +42,9 @@ abstract class QueryIdempotencyTokenAutoFillInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(QueryIdempotencyTokenAutoFillInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.token = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.token = _i2.uuid(secure: true);
-    }
+    b.token = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   String? get token;

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/http_request_with_float_labels_input.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/http_request_with_float_labels_input.dart
@@ -58,8 +58,9 @@ abstract class HttpRequestWithFloatLabelsInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(HttpRequestWithFloatLabelsInputBuilder b) {
-    b.float = 0;
-    b.double_ = 0;
+    b
+      ..float = 0
+      ..double_ = 0;
   }
 
   double get float;

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/http_request_with_labels_input.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/http_request_with_labels_input.dart
@@ -94,12 +94,13 @@ abstract class HttpRequestWithLabelsInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(HttpRequestWithLabelsInputBuilder b) {
-    b.short = 0;
-    b.integer = 0;
-    b.long = _i3.Int64.ZERO;
-    b.float = 0;
-    b.double_ = 0;
-    b.boolean = false;
+    b
+      ..short = 0
+      ..integer = 0
+      ..long = _i3.Int64.ZERO
+      ..float = 0
+      ..double_ = 0
+      ..boolean = false;
   }
 
   String get string;

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/query_idempotency_token_auto_fill_input.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/model/query_idempotency_token_auto_fill_input.dart
@@ -21,11 +21,9 @@ abstract class QueryIdempotencyTokenAutoFillInput
         _i1.EmptyPayload,
         _i1.HasPayload<QueryIdempotencyTokenAutoFillInputPayload> {
   factory QueryIdempotencyTokenAutoFillInput({String? token}) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      token ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      token ??= _i2.uuid(secure: true);
-    }
+    token ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$QueryIdempotencyTokenAutoFillInput._(token: token);
   }
 
@@ -52,11 +50,9 @@ abstract class QueryIdempotencyTokenAutoFillInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(QueryIdempotencyTokenAutoFillInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.token = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.token = _i2.uuid(secure: true);
-    }
+    b.token = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   String? get token;

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/http_request_with_float_labels_input.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/http_request_with_float_labels_input.dart
@@ -58,8 +58,9 @@ abstract class HttpRequestWithFloatLabelsInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(HttpRequestWithFloatLabelsInputBuilder b) {
-    b.float = 0;
-    b.double_ = 0;
+    b
+      ..float = 0
+      ..double_ = 0;
   }
 
   double get float;

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/http_request_with_labels_input.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/http_request_with_labels_input.dart
@@ -94,12 +94,13 @@ abstract class HttpRequestWithLabelsInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(HttpRequestWithLabelsInputBuilder b) {
-    b.short = 0;
-    b.integer = 0;
-    b.long = _i3.Int64.ZERO;
-    b.float = 0;
-    b.double_ = 0;
-    b.boolean = false;
+    b
+      ..short = 0
+      ..integer = 0
+      ..long = _i3.Int64.ZERO
+      ..float = 0
+      ..double_ = 0
+      ..boolean = false;
   }
 
   String get string;

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/query_idempotency_token_auto_fill_input.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/query_idempotency_token_auto_fill_input.dart
@@ -21,11 +21,9 @@ abstract class QueryIdempotencyTokenAutoFillInput
         _i1.EmptyPayload,
         _i1.HasPayload<QueryIdempotencyTokenAutoFillInputPayload> {
   factory QueryIdempotencyTokenAutoFillInput({String? token}) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      token ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      token ??= _i2.uuid(secure: true);
-    }
+    token ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$QueryIdempotencyTokenAutoFillInput._(token: token);
   }
 
@@ -52,11 +50,9 @@ abstract class QueryIdempotencyTokenAutoFillInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(QueryIdempotencyTokenAutoFillInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.token = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.token = _i2.uuid(secure: true);
-    }
+    b.token = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   String? get token;

--- a/packages/smithy/goldens/lib2/awsQuery/lib/src/query_protocol/model/query_idempotency_token_auto_fill_input.dart
+++ b/packages/smithy/goldens/lib2/awsQuery/lib/src/query_protocol/model/query_idempotency_token_auto_fill_input.dart
@@ -18,11 +18,9 @@ abstract class QueryIdempotencyTokenAutoFillInput
         Built<QueryIdempotencyTokenAutoFillInput,
             QueryIdempotencyTokenAutoFillInputBuilder> {
   factory QueryIdempotencyTokenAutoFillInput({String? token}) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      token ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      token ??= _i2.uuid(secure: true);
-    }
+    token ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$QueryIdempotencyTokenAutoFillInput._(token: token);
   }
 
@@ -44,11 +42,9 @@ abstract class QueryIdempotencyTokenAutoFillInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(QueryIdempotencyTokenAutoFillInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.token = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.token = _i2.uuid(secure: true);
-    }
+    b.token = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   String? get token;

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/http_request_with_float_labels_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/http_request_with_float_labels_input.dart
@@ -58,8 +58,9 @@ abstract class HttpRequestWithFloatLabelsInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(HttpRequestWithFloatLabelsInputBuilder b) {
-    b.float = 0;
-    b.double_ = 0;
+    b
+      ..float = 0
+      ..double_ = 0;
   }
 
   double get float;

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/http_request_with_labels_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/http_request_with_labels_input.dart
@@ -94,12 +94,13 @@ abstract class HttpRequestWithLabelsInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(HttpRequestWithLabelsInputBuilder b) {
-    b.short = 0;
-    b.integer = 0;
-    b.long = _i3.Int64.ZERO;
-    b.float = 0;
-    b.double_ = 0;
-    b.boolean = false;
+    b
+      ..short = 0
+      ..integer = 0
+      ..long = _i3.Int64.ZERO
+      ..float = 0
+      ..double_ = 0
+      ..boolean = false;
   }
 
   String get string;

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/query_idempotency_token_auto_fill_input.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/model/query_idempotency_token_auto_fill_input.dart
@@ -21,11 +21,9 @@ abstract class QueryIdempotencyTokenAutoFillInput
         _i1.EmptyPayload,
         _i1.HasPayload<QueryIdempotencyTokenAutoFillInputPayload> {
   factory QueryIdempotencyTokenAutoFillInput({String? token}) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      token ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      token ??= _i2.uuid(secure: true);
-    }
+    token ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$QueryIdempotencyTokenAutoFillInput._(token: token);
   }
 
@@ -52,11 +50,9 @@ abstract class QueryIdempotencyTokenAutoFillInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(QueryIdempotencyTokenAutoFillInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.token = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.token = _i2.uuid(secure: true);
-    }
+    b.token = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   String? get token;

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/http_request_with_float_labels_input.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/http_request_with_float_labels_input.dart
@@ -58,8 +58,9 @@ abstract class HttpRequestWithFloatLabelsInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(HttpRequestWithFloatLabelsInputBuilder b) {
-    b.float = 0;
-    b.double_ = 0;
+    b
+      ..float = 0
+      ..double_ = 0;
   }
 
   double get float;

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/http_request_with_labels_input.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/http_request_with_labels_input.dart
@@ -94,12 +94,13 @@ abstract class HttpRequestWithLabelsInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(HttpRequestWithLabelsInputBuilder b) {
-    b.short = 0;
-    b.integer = 0;
-    b.long = _i3.Int64.ZERO;
-    b.float = 0;
-    b.double_ = 0;
-    b.boolean = false;
+    b
+      ..short = 0
+      ..integer = 0
+      ..long = _i3.Int64.ZERO
+      ..float = 0
+      ..double_ = 0
+      ..boolean = false;
   }
 
   String get string;

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/query_idempotency_token_auto_fill_input.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/query_idempotency_token_auto_fill_input.dart
@@ -21,11 +21,9 @@ abstract class QueryIdempotencyTokenAutoFillInput
         _i1.EmptyPayload,
         _i1.HasPayload<QueryIdempotencyTokenAutoFillInputPayload> {
   factory QueryIdempotencyTokenAutoFillInput({String? token}) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      token ??= '00000000-0000-4000-8000-000000000000';
-    } else {
-      token ??= _i2.uuid(secure: true);
-    }
+    token ??= const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
     return _$QueryIdempotencyTokenAutoFillInput._(token: token);
   }
 
@@ -52,11 +50,9 @@ abstract class QueryIdempotencyTokenAutoFillInput
 
   @BuiltValueHook(initializeBuilder: true)
   static void _init(QueryIdempotencyTokenAutoFillInputBuilder b) {
-    if (const bool.hasEnvironment('SMITHY_TEST')) {
-      b.token = '00000000-0000-4000-8000-000000000000';
-    } else {
-      b.token = _i2.uuid(secure: true);
-    }
+    b.token = const bool.hasEnvironment('SMITHY_TEST')
+        ? '00000000-0000-4000-8000-000000000000'
+        : _i2.uuid(secure: true);
   }
 
   String? get token;


### PR DESCRIPTION
Fixes `cascade_invocations` lint violations.