### PR TITLE
feat(aft): Generate AWS config

### DIFF
--- a/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
@@ -364,6 +364,8 @@ class GenerateSdkCommand extends AmplifyCommand with GlobOptions {
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// Generated with `aft generate sdk`. Do not modify by hand.
+
 ${library.accept(emitter)}
 ''';
 

--- a/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
@@ -8,7 +8,9 @@ import 'dart:io';
 import 'package:aft/aft.dart';
 import 'package:aft/src/options/glob_options.dart';
 import 'package:async/async.dart';
+import 'package:aws_common/aws_common.dart';
 import 'package:checked_yaml/checked_yaml.dart';
+import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
 import 'package:git/git.dart';
 import 'package:path/path.dart' as p;
@@ -146,6 +148,9 @@ class GenerateSdkCommand extends AmplifyCommand with GlobOptions {
 
   /// Generates the SDK for [package].
   Future<void> _generateForPackage(PackageInfo package) async {
+    if (package.name == 'aws_common') {
+      return _generateAwsConfig(package);
+    }
     final configFile = File(p.join(package.path, 'sdk.yaml'));
     if (!await configFile.exists()) {
       return;
@@ -273,6 +278,110 @@ class GenerateSdkCommand extends AmplifyCommand with GlobOptions {
     if (exitCode != 0) {
       exitError('`dart run build_runner build` failed: $exitCode.');
     }
+  }
+
+  /// Generates common AWS configuration files, e.g. `aws_service.dart`.
+  Future<void> _generateAwsConfig(PackageInfo awsCommon) async {
+    logger.info('Generating AWS configuration files...');
+    const classDocs = '''
+    /// The enumeration of AWS services.
+    /// 
+    /// This enumeration is used to configure the SigV4 signer. To use a service
+    /// that is not listed here, call [AWSService.new] directly.''';
+    final builder = LibraryBuilder();
+    final awsService = ClassBuilder()
+      ..name = 'AWSService'
+      ..docs.add(classDocs)
+      ..constructors.add(
+        Constructor(
+          (c) => c
+            ..constant = true
+            ..docs.add(
+              '/// Creates a new [AWSService] instance which can be passed to a SigV4 signer.',
+            )
+            ..requiredParameters.addAll([
+              Parameter(
+                (p) => p
+                  ..toThis = true
+                  ..name = 'service',
+              )
+            ]),
+        ),
+      )
+      ..fields.addAll([
+        Field(
+          (f) => f
+            ..modifier = FieldModifier.final$
+            ..docs.add('/// The SigV4 service name, used in signing.')
+            ..name = 'service'
+            ..type = refer('String'),
+        )
+      ]);
+
+    final modelsDir = await _modelsDirForRef('master');
+    final models = modelsDir.list().whereType<File>();
+    final services = <Field>[];
+    await for (final model in models) {
+      final astJson = await model.readAsString();
+      final ast = parseAstJson(astJson);
+      final serviceShape = ast.shapes.values.whereType<ServiceShape>().single;
+      final sigV4Trait = serviceShape.getTrait<SigV4Trait>();
+      final serviceTrait = serviceShape.expectTrait<ServiceTrait>();
+      final serviceName = serviceTrait.sdkId.camelCase;
+      final sigV4Service = sigV4Trait?.name;
+      if (sigV4Service == null) {
+        logger.warn('Skipping $serviceName (no SigV4 service name)');
+        continue;
+      }
+      final title = serviceShape.getTrait<TitleTrait>()?.value;
+      logger.debug('Found AWS service "$serviceName"');
+      services.add(
+        Field(
+          (f) => f
+            ..static = true
+            ..modifier = FieldModifier.constant
+            ..docs.addAll([if (title != null) '/// $title'])
+            ..name = serviceName
+            ..assignment = refer('AWSService').constInstance([
+              literalString(sigV4Service),
+            ]).code,
+        ),
+      );
+    }
+
+    awsService.fields.addAll(
+      services..sort((a, b) => a.name.compareTo(b.name)),
+    );
+    builder.body.add(awsService.build());
+
+    final library = builder.build();
+    final emitter = DartEmitter(
+      allocator: Allocator(),
+      orderDirectives: true,
+      useNullSafetySyntax: true,
+    );
+    final code = '''
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+${library.accept(emitter)}
+''';
+
+    final output = File(
+      p.join(
+        awsCommon.path,
+        'lib',
+        'src',
+        'config',
+        'aws_service.dart',
+      ),
+    );
+    await output.writeAsString(code);
+    await Process.run(
+      'dart',
+      ['format', output.path],
+      workingDirectory: awsCommon.path,
+    );
   }
 
   @override

--- a/packages/aft/pubspec.yaml
+++ b/packages/aft/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   built_value: ">=8.6.0 <8.7.0"
   checked_yaml: ^2.0.0
   cli_util: ^0.3.5
+  code_builder: 4.5.0
   collection: ^1.16.0
   file: ^7.0.0
   git: ^2.0.0

--- a/packages/aws_common/lib/src/config/aws_service.dart
+++ b/packages/aws_common/lib/src/config/aws_service.dart
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// Generated with `aft generate sdk`. Do not modify by hand.
+
 /// The enumeration of AWS services.
 ///
 /// This enumeration is used to configure the SigV4 signer. To use a service

--- a/packages/aws_common/lib/src/config/aws_service.dart
+++ b/packages/aws_common/lib/src/config/aws_service.dart
@@ -1,11 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/// {@template aws_common.aws_service}
-/// Enumeration of AWS services.
-/// {@endtemplate}
-final class AWSService {
-  /// {@macro aws_common.aws_service}
+/// The enumeration of AWS services.
+///
+/// This enumeration is used to configure the SigV4 signer. To use a service
+/// that is not listed here, call [AWSService.new] directly.
+class AWSService {
+  /// Creates a new [AWSService] instance which can be passed to a SigV4 signer.
   const AWSService(this.service);
 
   /// The SigV4 service name, used in signing.
@@ -52,6 +53,9 @@ final class AWSService {
 
   /// AWS AppConfig Data
   static const appConfigData = AWSService('appconfig');
+
+  /// AppFabric
+  static const appFabric = AWSService('appfabric');
 
   /// Amazon AppIntegrations Service
   static const appIntegrations = AWSService('app-integrations');


### PR DESCRIPTION
Generates the list of AWS services directly via the `aft generate sdk` command. Later, this will be expanded to include AWS regions and other common configuration values.
