### PR TITLE
fix(aft): generate sdk from local directory which is not a git repository

### DIFF
--- a/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
@@ -134,7 +134,14 @@ class GenerateSdkCommand extends AmplifyCommand with GlobOptions {
       if (!await modelsDir.exists()) {
         exitError('Model directory ($modelsDir) does not exist');
       }
-      modelsDir = await _checkoutModelsRef(modelsDir, ref);
+      // Checkout models if modelsPath is a git repository.
+      if (File(p.join(modelsPath, '.git')).existsSync()) {
+        modelsDir = await _checkoutModelsRef(modelsDir, ref);
+      } else {
+        logger.warn(
+          'Unable to check out $ref since $modelsDir is not a git repo',
+        );
+      }
       modelsDir = await _organizeModels(modelsDir);
     } else {
       modelsDir = await _downloadModels();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`aft generate sdk -m [path to models]` to checkout models only if the local directory is a git repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
