### PR TITLE
chore(deps): Update Amplify Android

### DIFF
--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -72,10 +72,10 @@ dependencies {
     // Support for Java 8 features
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 
-    implementation 'com.amplifyframework:aws-auth-cognito:2.8.6'
-    implementation "com.amplifyframework:aws-api:2.8.6"
-    implementation "com.amplifyframework:aws-datastore:2.8.6"
-    implementation "com.amplifyframework:aws-api-appsync:2.8.6"
+    implementation 'com.amplifyframework:aws-auth-cognito:2.10.0'
+    implementation "com.amplifyframework:aws-api:2.10.0"
+    implementation "com.amplifyframework:aws-datastore:2.10.0"
+    implementation "com.amplifyframework:aws-api-appsync:2.10.0"
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1'
 

--- a/packages/amplify_native_legacy_wrapper/android/build.gradle
+++ b/packages/amplify_native_legacy_wrapper/android/build.gradle
@@ -47,6 +47,6 @@ android {
     namespace 'com.amazonaws.amplify.amplify_native_legacy_wrapper'
 }
 dependencies {
-    implementation 'com.amazonaws:aws-android-sdk-mobile-client:2.71.0'
-    implementation 'com.amazonaws:aws-android-sdk-cognitoauth:2.71.0'
+    implementation 'com.amazonaws:aws-android-sdk-mobile-client:2.72.0'
+    implementation 'com.amazonaws:aws-android-sdk-cognitoauth:2.72.0'
 }

--- a/packages/notifications/push/amplify_push_notifications/android/build.gradle
+++ b/packages/notifications/push/amplify_push_notifications/android/build.gradle
@@ -65,7 +65,7 @@ android {
 dependencies {
     api "com.google.firebase:firebase-messaging:23.1.2"
     // Import support library for Amplify push utils
-    implementation 'com.amplifyframework:aws-push-notifications-pinpoint-common:2.8.6'
+    implementation 'com.amplifyframework:aws-push-notifications-pinpoint-common:2.10.0'
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
     implementation project(path: ':flutter_plugin_android_lifecycle')
     implementation 'androidx.test:core-ktx:1.5.0'


### PR DESCRIPTION
- Updates Amplify Android to `2.10.0`
- Updates legacy Android to `2.72.0`