### PR TITLE
chore(datastore): removed analysis options

### DIFF
--- a/packages/amplify_datastore/analysis_options.yaml
+++ b/packages/amplify_datastore/analysis_options.yaml
@@ -1,3 +1,0 @@
-analyzer:
-  exclude:
-    - example

--- a/packages/amplify_datastore/example/lib/main.dart
+++ b/packages/amplify_datastore/example/lib/main.dart
@@ -237,6 +237,24 @@ class _MyAppState extends State<MyApp> {
     }
   }
 
+  void updateQueriesToView(String value) {
+    setState(() {
+      _queriesToView = value;
+    });
+  }
+
+  void updateSelectedBlogForNewPost(Blog value) {
+    setState(() {
+      _selectedBlogForNewPost = value;
+    });
+  }
+
+  void updateSelectedPostForNewComment(Post value) {
+    setState(() {
+      _selectedPostForNewComment = value;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     executeAfterBuild();
@@ -272,22 +290,30 @@ class _MyAppState extends State<MyApp> {
 
             // Row for saving post
             addPostWidget(
-                titleController: _titleController,
-                ratingController: _ratingController,
-                isAmplifyConfigured: _isAmplifyConfigured,
-                allBlogs: _blogs,
-                saveFn: savePost,
-                app: this,
-                defaultBlog: _selectedBlogForNewPost),
+              titleController: _titleController,
+              ratingController: _ratingController,
+              isAmplifyConfigured: _isAmplifyConfigured,
+              allBlogs: _blogs,
+              selectedBlog: _selectedBlogForNewPost,
+              saveFn: savePost,
+              updateSelectedBlogForNewPost: updateSelectedBlogForNewPost,
+            ),
 
             // Row for saving comment
-            addCommentWidget(_contentController, _isAmplifyConfigured,
-                _selectedPostForNewComment, _posts, saveComment, this),
+            addCommentWidget(
+                _contentController,
+                _isAmplifyConfigured,
+                _selectedPostForNewComment,
+                _posts,
+                _selectedPostForNewComment,
+                saveComment,
+                updateSelectedPostForNewComment),
 
             Padding(padding: EdgeInsets.all(10.0)),
 
             // Row for query buttons
-            displayQueryButtons(_isAmplifyConfigured, this),
+            displayQueryButtons(
+                _isAmplifyConfigured, _queriesToView, updateQueriesToView),
 
             Padding(padding: EdgeInsets.all(5.0)),
             Text("Listen to DataStore Hub"),

--- a/packages/amplify_datastore/example/lib/queries_display_widgets.dart
+++ b/packages/amplify_datastore/example/lib/queries_display_widgets.dart
@@ -3,7 +3,8 @@
 
 part of sample_app;
 
-Widget displayQueryButtons(bool isAmplifyConfigured, _MyAppState app) {
+Widget displayQueryButtons(bool isAmplifyConfigured, String queriesToView,
+    Function updateQueriesToView) {
   var boldText =
       TextStyle(fontWeight: FontWeight.bold, color: Colors.black, fontSize: 14);
   return Row(mainAxisAlignment: MainAxisAlignment.center, children: [
@@ -14,60 +15,54 @@ Widget displayQueryButtons(bool isAmplifyConfigured, _MyAppState app) {
     ElevatedButton(
       onPressed: () {
         if (isAmplifyConfigured) {
-          app.setState(() {
-            app._queriesToView = "Blog";
-          });
+          updateQueriesToView("Blog");
         }
         return null;
       },
       style: ButtonStyle(
         backgroundColor: MaterialStateProperty.all(
-          app._queriesToView == "Blog" ? Colors.white10 : Colors.white60,
+          queriesToView == "Blog" ? Colors.white10 : Colors.white60,
         ),
       ),
       child: Text(
         'Blogs',
-        style: app._queriesToView == "Blog" ? boldText : TextStyle(),
+        style: queriesToView == "Blog" ? boldText : TextStyle(),
       ),
     ),
     divider,
     ElevatedButton(
       onPressed: () {
         if (isAmplifyConfigured) {
-          app.setState(() {
-            app._queriesToView = "Post";
-          });
+          updateQueriesToView("Post");
         }
         return null;
       },
       style: ButtonStyle(
         backgroundColor: MaterialStateProperty.all(
-          app._queriesToView == "Post" ? Colors.white10 : Colors.white60,
+          queriesToView == "Post" ? Colors.white10 : Colors.white60,
         ),
       ),
       child: Text(
         'Posts',
-        style: app._queriesToView == "Post" ? boldText : TextStyle(),
+        style: queriesToView == "Post" ? boldText : TextStyle(),
       ),
     ),
     divider,
     ElevatedButton(
       onPressed: () {
         if (isAmplifyConfigured) {
-          app.setState(() {
-            app._queriesToView = "Comment";
-          });
+          updateQueriesToView("Comment");
         }
         return null;
       },
       style: ButtonStyle(
         backgroundColor: MaterialStateProperty.all(
-          app._queriesToView == "Comment" ? Colors.white10 : Colors.white60,
+          queriesToView == "Comment" ? Colors.white10 : Colors.white60,
         ),
       ),
       child: Text(
         'Comments',
-        style: app._queriesToView == "Comment" ? boldText : TextStyle(),
+        style: queriesToView == "Comment" ? boldText : TextStyle(),
       ),
     ),
   ]);

--- a/packages/amplify_datastore/example/lib/save_model_widgets.dart
+++ b/packages/amplify_datastore/example/lib/save_model_widgets.dart
@@ -37,8 +37,8 @@ Widget addPostWidget(
     required bool isAmplifyConfigured,
     required List<Blog> allBlogs,
     required Function saveFn,
-    required _MyAppState app,
-    Blog? defaultBlog}) {
+    required Function updateSelectedBlogForNewPost,
+    Blog? selectedBlog}) {
   return Row(
     children: [
       divider,
@@ -62,7 +62,7 @@ Widget addPostWidget(
       ),
       divider,
       DropdownButton<Blog>(
-          value: defaultBlog,
+          value: selectedBlog,
           hint: Text("Blog"),
           items: allBlogs
               .map((e) => DropdownMenuItem(
@@ -70,17 +70,13 @@ Widget addPostWidget(
                     value: e,
                   ))
               .toList(), //_dropdownMenuItems,
-          onChanged: (value) {
-            app.setState(() {
-              app._selectedBlogForNewPost = value;
-            });
-          }),
+          onChanged: (value) => updateSelectedBlogForNewPost(value)),
       divider,
       ElevatedButton(
         onPressed: () async {
           if (isAmplifyConfigured) {
             await saveFn(titleController.text, int.parse(ratingController.text),
-                app._selectedBlogForNewPost);
+                selectedBlog);
             titleController.clear();
             ratingController.clear();
             return;
@@ -99,8 +95,9 @@ Widget addCommentWidget(
     bool isAmplifyConfigured,
     Post? defaultPost,
     List<Post> allPosts,
+    Post? selectedPostForNewComment,
     Function saveFn,
-    _MyAppState app) {
+    Function updateSelectedPostForNewComment) {
   return Row(
     children: [
       divider,
@@ -121,15 +118,13 @@ Widget addCommentWidget(
                   ))
               .toList(), //_dropdownMenuItems,
           onChanged: (value) {
-            app.setState(() {
-              app._selectedPostForNewComment = value;
-            });
+            updateSelectedPostForNewComment(value);
           }),
       divider,
       ElevatedButton(
         onPressed: () async {
           if (isAmplifyConfigured) {
-            await saveFn(controller.text, app._selectedPostForNewComment);
+            await saveFn(controller.text, selectedPostForNewComment);
             controller.clear();
             return;
           }

--- a/packages/amplify_datastore/test/amplify_datastore_stream_controller_test.dart
+++ b/packages/amplify_datastore/test/amplify_datastore_stream_controller_test.dart
@@ -39,6 +39,8 @@ void main() {
         .setMockMessageHandler(channelName, null);
   });
 
+  tearDownAll(() => dataStoreStreamController.close());
+
   handler(event) {
     ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
       channelName,
@@ -140,8 +142,7 @@ void main() {
     );
 
     List<DataStoreHubEvent> events = [];
-    StreamSubscription sub =
-        await dataStoreStreamController.stream.listen((event) {
+    StreamSubscription sub = dataStoreStreamController.stream.listen((event) {
       events.add(event);
     });
 
@@ -168,8 +169,7 @@ void main() {
     );
 
     List<DataStoreHubEvent> events = [];
-    StreamSubscription sub =
-        await dataStoreStreamController.stream.listen((event) {
+    StreamSubscription sub = dataStoreStreamController.stream.listen((event) {
       events.add(event);
     });
 
@@ -200,8 +200,7 @@ void main() {
     );
 
     List<DataStoreHubEvent> events = [];
-    StreamSubscription sub =
-        await dataStoreStreamController.stream.listen((event) {
+    StreamSubscription sub = dataStoreStreamController.stream.listen((event) {
       events.add(event);
     });
 
@@ -236,8 +235,7 @@ void main() {
     );
 
     List<DataStoreHubEvent> events = [];
-    StreamSubscription sub =
-        await dataStoreStreamController.stream.listen((event) {
+    StreamSubscription sub = dataStoreStreamController.stream.listen((event) {
       events.add(event);
     });
 
@@ -278,8 +276,7 @@ void main() {
     );
 
     List<DataStoreHubEvent> events = [];
-    StreamSubscription sub =
-        await dataStoreStreamController.stream.listen((event) {
+    StreamSubscription sub = dataStoreStreamController.stream.listen((event) {
       events.add(event);
     });
 
@@ -307,8 +304,7 @@ void main() {
     );
 
     List<DataStoreHubEvent> events = [];
-    StreamSubscription sub =
-        await dataStoreStreamController.stream.listen((event) {
+    StreamSubscription sub = dataStoreStreamController.stream.listen((event) {
       events.add(event);
     });
 

--- a/packages/amplify_datastore/test/stream_utils/throttle_test.dart
+++ b/packages/amplify_datastore/test/stream_utils/throttle_test.dart
@@ -148,6 +148,11 @@ void main() {
         controllers = [controller, broadcastController];
       });
 
+      tearDownAll(() {
+        controller.close();
+        broadcastController.close();
+      });
+
       test('the source stream can be cancelled', () async {
         for (var controller in controllers) {
           var streamWasCanceled = false;


### PR DESCRIPTION
*Description of changes:*
Removes the analysis options that only excluded the example app. This was causing friction when trying to use the example app and resolve local deps. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
