### PR TITLE
chore: update mocktail to 1.0.0

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -34,7 +34,7 @@ dev_dependencies:
   build_web_compilers: ^4.0.0
   built_value_generator: 8.6.1
   drift_dev: ^2.2.0+1
-  mocktail: ^0.3.0
+  mocktail: ^1.0.0
   test: ^1.22.1
 
   # TODO - use cipher libraries for encrypted cached Analytics Events

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -36,4 +36,4 @@ dev_dependencies:
   connectivity_plus_platform_interface: any
   flutter_test:
     sdk: flutter
-  mocktail: ^0.3.0
+  mocktail: ^1.0.0

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -36,7 +36,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   golden_toolkit: ^0.13.0
-  mocktail: ^0.3.0
+  mocktail: ^1.0.0
   path: any
 
 flutter:

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -35,4 +35,4 @@ dev_dependencies:
   aws_signature_v4: ">=0.4.0+2 <0.5.0"
   flutter_test:
     sdk: flutter
-  mocktail: ^0.3.0
+  mocktail: ^1.0.0

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -31,5 +31,5 @@ dev_dependencies:
   built_value_generator: 8.6.1
   drift_dev: ^2.2.0+1
   json_serializable: 6.7.1
-  mocktail: ^0.3.0
+  mocktail: ^1.0.0
   test: ^1.22.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Bumps mocktail to 1.0.0. Dependabot bumped to include a range in https://github.com/aws-amplify/amplify-flutter/pull/3501 but we can just increase to 1.0.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
