### PR TITLE
perf(auth): Fetch auth session

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart
@@ -49,8 +49,12 @@ final class CredentialStoreStateMachine
   Future<void> resolve(CredentialStoreEvent event) async {
     switch (event) {
       case CredentialStoreLoadCredentialStore _:
-        emit(const CredentialStoreState.loadingStoredCredentials());
-        await onLoadCredentialStore(event);
+        if (currentState case final CredentialStoreSuccess success) {
+          emit(success);
+        } else {
+          emit(const CredentialStoreState.loadingStoredCredentials());
+          await onLoadCredentialStore(event);
+        }
       case CredentialStoreStoreCredentials _:
         emit(const CredentialStoreState.storingCredentials());
         await onStoreCredentials(event);


### PR DESCRIPTION
When a query is made to the credential store, we currently always hit the underlying store. However, due to the queuing nature of the store, if it's in a `success` state we can immediately return since we are guaranteed to have the latest data.
