### PR TITLE
chore(deps): Bump nanasess/setup-chromedriver from 2.1.1 to 2.1.2 (#3…

### DIFF
--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -163,7 +163,7 @@ jobs:
           scope: ${{ matrix.scope }}
           secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
 
-      - uses: nanasess/setup-chromedriver@6fb8f5ffa6b7dc11e631ff695fbd2fec0b04bb52 # 2.1.1
+      - uses: nanasess/setup-chromedriver@69cc01d772a1595b8aee87d52f53e71b3904d9d0 # 2.1.2
 
       - name: Run integration tests
         timeout-minutes: 60


### PR DESCRIPTION
Cherry picks dependabot PR https://github.com/aws-amplify/amplify-flutter/pull/3521#pullrequestreview-1566188657 from main (cherry picks the commit from main) so that we can run chrome integ tests on stable before release.