### PR TITLE
chore: increase timeout for iOS canaries

### DIFF
--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -196,7 +196,7 @@ jobs:
       - name: Launch iOS simulator (attempt 1)
         id: launch
         uses: ./.github/composite_actions/launch_ios_simulator
-        timeout-minutes: 15
+        timeout-minutes: 30
         continue-on-error: true
         with:
           ios-version: ${{ matrix.ios-version }}
@@ -204,7 +204,7 @@ jobs:
       - name: Launch iOS simulator (attempt 2)
         if: steps.launch.outcome == 'failure'
         uses: ./.github/composite_actions/launch_ios_simulator
-        timeout-minutes: 15
+        timeout-minutes: 30
         with:
           ios-version: ${{ matrix.ios-version }}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Increase timeout from 15m to 30m. The iOS canary tests will require installing iOS for versions not already installed. This can take longer than the current 15 minute timeout.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
