### PR TITLE
chore: Global Metric Tracking 

### DIFF
--- a/.github/composite_actions/log_metric/action.yaml
+++ b/.github/composite_actions/log_metric/action.yaml
@@ -1,5 +1,5 @@
 name: Log Metric
-description: Log data point to a metric with the provided value. If the metric is not there, it will create one
+description: Log data point to a metric with the provided value. If the metric is not there, it will create one.
 # To avoid 'Credentials could not be loaded' calling workflows must include:
 # permissions:
 #  id-token: write
@@ -7,23 +7,77 @@ description: Log data point to a metric with the provided value. If the metric i
 inputs:
   aws-region:
     required: true
-    description: The AWS region
+    description: The AWS region.
   role-to-assume:
     required: true
-    description: The role to assume in the STS session
-  metric-name:
-    description: Name of the metric to track in Cloudwatch.
+    description: The role to assume in the STS session.
+  github-token:
     required: true
-  value:
+    description: Github token for requesting failing steps 
+
+  #value:
     # Why we publish value 0 on success: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#publishingZero
-    description: Value of the metric to track in Cloudwatch.
+   # description: Value of the metric to track in Cloudwatch.
+#    required: true
+
+  job-status: 
+    description: Job status 
+    required: true 
+  job-identifier: 
+    desciption: Identifiers for the job
+    required: true 
+
+
+
+  # Global Metric Dimensions 
+  testType:
+    description: canary, integration, unit testType.
     required: true
-  dimensions:
-    description: Dimensions of metric to track in Cloudwatch, in format dimensionName1=value,dimensionName2=value,...
+  category:
+    description: analytics, api, authenticator, etc. 
+    required: true
+  workflowName: 
+    description: The Github Action workflow.yaml file name.  ie "AmplifyCanaries".
+    required: true 
+  # failingStep: Look into getting via code 
+
+
+  # FlutterDart Workflows Metric Dimensions 
+  framework:
+    description: flutter, dart. 
     required: false
+  flutterDartChannel:
+    description: beta, stable. 
+    required: false
+  dartVersion: 
+    description: 3, 2.19, 2.18, etc. 
+    required: false
+  flutterVersion:
+    description: 3.10.6, 3.10.5, etc. 
+    required: false
+  dartCompiler:
+    description: dart2js, ddc, dart, dart2wasm.
+    required: false
+
+  # Platform Workflows Metric Dimensions
+  platform:
+    description: android, ios, web, linux, windows.
+    required: false
+  platformVersion: 
+    description: ios-14.5, ios-16, android-25-x86, etc. 
+    required: false 
+
 runs:
   using: 'composite'
   steps:
+    #- name: Exit if not scheduled
+   #   shell: bash
+    #  run: |
+    #    if [ "${{ github.event_name }}" != "schedule" ]; then
+    #      echo "This was not triggered by a schedule, exiting."
+    #      exit 1
+    #    fi
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # 1.7.0
       with:
@@ -31,7 +85,49 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         role-duration-seconds: 900
 
+    - name: Get Job ID
+      run: |
+        substring="${{ inputs.job-identifier }}"
+
+        jobs_json=$(curl -s -H "Authorization: token ${{ inputs.github-token }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/fjnoyp/amplify-flutter/actions/runs/${{ github.run_id }}/jobs")
+
+        job_id=$(echo "$jobs_json" | jq --arg substring "$substring" '.jobs[] | select(.name | contains($substring)) | .id')
+
+        echo "substring is $substring"
+        echo "job json is $jobs_json"
+        echo "github run id is ${{ github.run_id}}"
+
+        echo "Job ID for job containing $substring is $job_id"
+        echo "job_id=$job_id" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Get Failing Step
+      if: ${{ job.status == 'failure' }}
+      shell: bash
+      run: |
+        response=$(curl -s -H "Authorization: token ${{ inputs.github-token }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/fjnoyp/amplify-flutter/actions/jobs/${{ env.job_id }}")
+        failing_step_name=$(echo "$response" | jq -r '.steps[] | select(.conclusion == "failure") | .name')
+
+        echo "FAILING_STEP=$failing_step_name" >> $GITHUB_ENV
+
     - name: Run Dart script
       # Run a Dart script to put metric data.
-      run: dart ./tool/send_metric_data.dart ${{ inputs.metric-name }} ${{ inputs.value }} ${{ inputs.dimensions }}
+      run: dart ./tool/send_metric_data.dart \
+        github_metric_1.0 \
+        ${{ job.status == 'failure' }} \
+        ${{ inputs.testType }} \
+        ${{ inputs.category }} \
+        ${{ inputs.workflowName }} \
+        ${{ inputs.framework }} \
+        ${{ inputs.flutterDartChannel }} \
+        ${{ inputs.dartVersion }} \
+        ${{ inputs.flutterVersion }} \
+        ${{ inputs.dartCompiler }} \
+        ${{ inputs.platform }} \
+        ${{ inputs.platformVersion }} \
+        ${{ env.FAILING_STEP }}
       shell: bash

--- a/.github/composite_actions/log_metric/action.yaml
+++ b/.github/composite_actions/log_metric/action.yaml
@@ -66,7 +66,7 @@ runs:
       run: |
         if [ "${{ github.event_name }}" != "schedule" ]; then
           echo "This was not triggered by a schedule, exiting."
-          exit 1
+          exit 0
         fi
 
     - name: Configure AWS credentials

--- a/.github/composite_actions/log_metric/action.yaml
+++ b/.github/composite_actions/log_metric/action.yaml
@@ -13,20 +13,13 @@ inputs:
     description: The role to assume in the STS session.
   github-token:
     required: true
-    description: Github token for requesting failing steps 
-
-  #value:
-    # Why we publish value 0 on success: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#publishingZero
-   # description: Value of the metric to track in Cloudwatch.
-#    required: true
-
-  job-status: 
-    description: Job status 
+    description: Github token for requesting failing steps.
+  job-status:
+    description: Used to determine if we track success or failure.
     required: true 
   job-identifier: 
-    desciption: Identifiers for the job
+    description: For differentiating jobs of a run.
     required: true 
-
 
 
   # Global Metric Dimensions 
@@ -39,8 +32,6 @@ inputs:
   workflowName: 
     description: The Github Action workflow.yaml file name.  ie "AmplifyCanaries".
     required: true 
-  # failingStep: Look into getting via code 
-
 
   # FlutterDart Workflows Metric Dimensions 
   framework:
@@ -70,13 +61,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    #- name: Exit if not scheduled
-   #   shell: bash
-    #  run: |
-    #    if [ "${{ github.event_name }}" != "schedule" ]; then
-    #      echo "This was not triggered by a schedule, exiting."
-    #      exit 1
-    #    fi
+    - name: Exit if not scheduled
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" != "schedule" ]; then
+          echo "This was not triggered by a schedule, exiting."
+          exit 1
+        fi
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # 1.7.0
@@ -114,20 +105,28 @@ runs:
 
         echo "FAILING_STEP=$failing_step_name" >> $GITHUB_ENV
 
+    - name: Change to Dart script directory
+      run: cd ./tool
+      shell: bash
+
+    - name: Install Dart dependencies (args)
+      run: dart pub get
+      shell: bash
+
     - name: Run Dart script
-      # Run a Dart script to put metric data.
-      run: dart ./tool/send_metric_data.dart \
-        github_metric_1.0 \
-        ${{ job.status == 'failure' }} \
-        ${{ inputs.testType }} \
-        ${{ inputs.category }} \
-        ${{ inputs.workflowName }} \
-        ${{ inputs.framework }} \
-        ${{ inputs.flutterDartChannel }} \
-        ${{ inputs.dartVersion }} \
-        ${{ inputs.flutterVersion }} \
-        ${{ inputs.dartCompiler }} \
-        ${{ inputs.platform }} \
-        ${{ inputs.platformVersion }} \
-        ${{ env.FAILING_STEP }}
+      run: |
+        dart ./tool/send_metric_data.dart \
+          --metric-name="github_metric_1.0" \
+          --job-status="${{ job.status == 'failure' }}" \
+          --test-type="${{ inputs.testType }}" \
+          --category="${{ inputs.category }}" \
+          --workflow-name="${{ inputs.workflowName }}" \
+          --framework="${{ inputs.framework }}" \
+          --flutter-dart-channel="${{ inputs.flutterDartChannel }}" \
+          --dart-version="${{ inputs.dartVersion }}" \
+          --flutter-version="${{ inputs.flutterVersion }}" \
+          --dart-compiler="${{ inputs.dartCompiler }}" \
+          --platform="${{ inputs.platform }}" \
+          --platform-version="${{ inputs.platformVersion }}" \
+          --failing-step="${{ env.FAILING_STEP }}"
       shell: bash

--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -31,7 +31,8 @@ jobs:
           - channel: "stable"
             flutter-version: "3.10.1"
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # 3.5.3
+      - name: Git Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # 3.5.3
         with:
           persist-credentials: false
 
@@ -53,24 +54,21 @@ jobs:
       - name: Build Canary (Android)
         run: build-support/build_canary.sh apk
 
-      - name: Log failing builds
-        if: ${{ failure() }}
+      - name: Log success/failure
+        if: always()
         uses: ./.github/composite_actions/log_metric
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          metric-name: BuildCanaryTestFailure
-          value: 1
-          dimensions: channel=${{ matrix.channel }}
-      - name: Log succeeding builds
-        if: ${{ success() }}
-        uses: ./.github/composite_actions/log_metric
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          metric-name: BuildCanaryTestFailure
-          value: 0
-          dimensions: channel=${{ matrix.channel }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.channel }}, ${{ matrix.flutter-version}}
+          testType: canary
+          category: all
+          workflowName: amplify_canaries/build
+          framework: flutter          
+          flutterDartChannel: ${{ matrix.channel }}
+          flutterVersion: ${{ matrix.flutter-version }}
 
   e2e-android:
     runs-on: macos-latest
@@ -127,24 +125,22 @@ jobs:
           # Perform a build to reduce startup time of `flutter test` and prevent timeout
           script: cd canaries && flutter build apk --debug && flutter test -d emulator-5554 integration_test/main_test.dart
 
-      - name: Log failing android runs
-        if: ${{ failure() }}
+      - name: Log success/failure
+        if: always()
         uses: ./.github/composite_actions/log_metric
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          metric-name: E2ECanaryTestFailure
-          value: 1
-          dimensions: channel=${{ matrix.channel }},platform=android
-      - name: Log succeeding android runs
-        if: ${{ success() }}
-        uses: ./.github/composite_actions/log_metric
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          metric-name: E2ECanaryTestFailure
-          value: 0
-          dimensions: channel=${{ matrix.channel }},platform=android
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.channel }}, ${{ matrix.flutter-version}}
+          testType: canary
+          category: all
+          workflowName: amplify_canaries/e2e-android
+          framework: flutter
+          platform: android
+          flutterDartChannel: ${{ matrix.channel }}
+          flutterVersion: ${{ matrix.flutter-version }}
 
   e2e-ios:
     runs-on: macos-13
@@ -205,21 +201,22 @@ jobs:
           flutter build ios --simulator --target=integration_test/main_test.dart
           flutter test -d test integration_test/main_test.dart --verbose
 
-      - name: Log failing ios runs
-        if: ${{ failure() }}
+      - name: Log success/failure
+        if: always()
         uses: ./.github/composite_actions/log_metric
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          metric-name: E2ECanaryTestFailure
-          value: 1
-          dimensions: channel=${{ matrix.channel }},platform=ios
-      - name: Log succeeding ios runs
-        if: ${{ success() }}
-        uses: ./.github/composite_actions/log_metric
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          metric-name: E2ECanaryTestFailure
-          value: 0
-          dimensions: channel=${{ matrix.channel }},platform=ios
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.channel }}, ${{ matrix.flutter-version}}
+          testType: canary
+          category: all
+          workflowName: amplify_canaries/e2e-ios
+          framework: flutter
+          platform: ios
+          platformVersion: ${{ matrix.ios-version }}
+          flutterDartChannel: ${{ matrix.channel }}
+          flutterVersion: ${{ matrix.flutter-version }}
+
+  

--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -60,7 +60,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.channel }}, ${{ matrix.flutter-version}}
           testType: canary
@@ -131,7 +131,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.channel }}, ${{ matrix.flutter-version}}
           testType: canary
@@ -207,7 +207,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.channel }}, ${{ matrix.flutter-version}}
           testType: canary

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -88,7 +88,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.scope }}, ${{ matrix.api-level}}, ${{ matrix.target }}
           testType: integration
@@ -149,7 +149,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.scope }}
           testType: integration
@@ -210,7 +210,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.scope }}
           testType: integration
@@ -313,7 +313,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.scope }}
           testType: integration
@@ -374,7 +374,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.scope }}
           testType: integration

--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -82,6 +82,23 @@ jobs:
           arch: ${{ matrix.arch }}
           script: aft exec --include=${{ matrix.scope }} -- small=true "<AFT_ROOT>/build-support/integ_test.sh" -d emulator-5554 --retries 1
 
+      - name: Log success/failure
+        if: always()
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.scope }}, ${{ matrix.api-level}}, ${{ matrix.target }}
+          testType: integration
+          category: ${{ matrix.scope }}
+          workflowName: ${{ matrix.scope }}/amplify_integration_tests
+          framework: flutter
+          flutterDartChannel: stable 
+          platform: android
+          platformVersion: ${{ matrix.api-level }} ${{ matrix.arch }}     
+
   ios:
     runs-on: macos-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
@@ -124,7 +141,23 @@ jobs:
 
       - name: Run integration tests
         timeout-minutes: 60
-        run: aft exec --include=${{ matrix.scope }} -- small=true "<AFT_ROOT>/build-support/integ_test_ios.sh" -d test
+        run: aft exec --include=${{ matrix.scope }} -- small=true "<AFT_ROOT>/build-support/integ_test_ios.sh" -d test    
+
+      - name: Log success/failure
+        if: always()
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.scope }}
+          testType: integration
+          category: ${{ matrix.scope }}
+          workflowName: ${{ matrix.scope }}/amplify_integration_tests
+          framework: flutter
+          flutterDartChannel: stable 
+          platform: ios     
 
   web:
     runs-on: ubuntu-latest
@@ -170,6 +203,23 @@ jobs:
         run: |
           chromedriver --port=4444 &
           aft exec --include=${{ matrix.scope }} -- "<AFT_ROOT>/build-support/integ_test.sh" -d web-server
+
+      - name: Log success/failure
+        if: always()
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.scope }}
+          testType: integration
+          category: ${{ matrix.scope }}
+          workflowName: ${{ matrix.scope }}/amplify_integration_tests
+          framework: flutter          
+          flutterDartChannel: stable 
+          platform: web      
+          platformVersion: chrome
 
   # TODO(dnys1): Re-enable with self-hosted runners
   # macos:
@@ -257,6 +307,22 @@ jobs:
           flutter config --enable-linux-desktop
           aft exec --include=${{ matrix.scope }} -- "<AFT_ROOT>/build-support/integ_test.sh" -d linux
 
+      - name: Log success/failure
+        if: always()
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.scope }}
+          testType: integration
+          category: ${{ matrix.scope }}
+          workflowName: ${{ matrix.scope }}/amplify_integration_tests
+          framework: flutter          
+          flutterDartChannel: stable 
+          platform: linux     
+
   windows:
     runs-on: windows-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
@@ -301,3 +367,19 @@ jobs:
         run: |
           flutter config --enable-windows-desktop
           dart pub global run aft exec --include=${{ matrix.scope }} -- flutter test integration_test/main_test.dart -d windows
+
+      - name: Log success/failure
+        if: always()
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.scope }}
+          testType: integration
+          category: ${{ matrix.scope }}
+          workflowName: ${{ matrix.scope }}/amplify_integration_tests
+          framework: flutter          
+          flutterDartChannel: stable 
+          platform: windows    

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -95,7 +95,7 @@ jobs:
           job-identifier: ${{ matrix.sdk }}, ${{ matrix.browser }}
           testType: unit test
           category: ${{ inputs.working-directory }}
-          workflowName: ${{ package-name }}/dart_dart2js
+          workflowName: ${{ inputs.package-name }}/dart_dart2js
           framework: dart
           flutterDartChannel: ${{ matrix.sdk }}
           dartCompiler: dart2js

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -94,7 +94,7 @@ jobs:
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.sdk }}, ${{ matrix.browser }}
           testType: unit test
-          category: ${{ working-directory }}
+          category: ${{ inputs.working-directory }}
           workflowName: ${{ package-name }}/dart_dart2js
           framework: dart
           flutterDartChannel: ${{ matrix.sdk }}

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -91,7 +91,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.sdk }}, ${{ matrix.browser }}
           testType: unit test

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -84,3 +84,22 @@ jobs:
         if: "always() && steps.bootstrap.conclusion == 'success'"
         run: dart run build_runner test --release --delete-conflicting-outputs -- -p ${{ matrix.browser }}
         working-directory: ${{ inputs.working-directory }}
+
+      - name: Log success/failure
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.sdk }}, ${{ matrix.browser }}
+          testType: unit test
+          category: ${{ working-directory }}
+          workflowName: ${{ package-name }}/dart_dart2js
+          framework: dart
+          flutterDartChannel: ${{ matrix.sdk }}
+          dartCompiler: dart2js
+          platform: web
+          # 'chrome/firefox'
+          platformVersion: $${{ matrix.browser }}
+

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -86,6 +86,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Log success/failure
+        if: always()
         uses: ./.github/composite_actions/log_metric
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -94,7 +94,7 @@ jobs:
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.sdk }}, ${{ matrix.browser }}
           testType: unit test
-          category: ${{ working-directory }}
+          category: ${{ inputs.working-directory }}
           workflowName: ${{ package-name }}/dart_ddc
           framework: dart
           flutterDartChannel: ${{ matrix.sdk }}

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -95,7 +95,7 @@ jobs:
           job-identifier: ${{ matrix.sdk }}, ${{ matrix.browser }}
           testType: unit test
           category: ${{ inputs.working-directory }}
-          workflowName: ${{ package-name }}/dart_ddc
+          workflowName: ${{ inputs.package-name }}/dart_ddc
           framework: dart
           flutterDartChannel: ${{ matrix.sdk }}
           dartCompiler: dart2js

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -91,7 +91,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.sdk }}, ${{ matrix.browser }}
           testType: unit test

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -84,3 +84,21 @@ jobs:
         if: "always() && steps.bootstrap.conclusion == 'success'"
         run: dart run build_runner test --delete-conflicting-outputs -- -p ${{ matrix.browser }}
         working-directory: ${{ inputs.working-directory }}
+
+      - name: Log success/failure
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.sdk }}, ${{ matrix.browser }}
+          testType: unit test
+          category: ${{ working-directory }}
+          workflowName: ${{ package-name }}/dart_ddc
+          framework: dart
+          flutterDartChannel: ${{ matrix.sdk }}
+          dartCompiler: dart2js
+          platform: web
+          # 'chrome/firefox'
+          platformVersion: $${{ matrix.browser }}

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -86,6 +86,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Log success/failure
+        if: always()
         uses: ./.github/composite_actions/log_metric
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -99,7 +99,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.os }}
           testType: unit test

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -103,7 +103,7 @@ jobs:
           job-identifier: ${{ matrix.os }}
           testType: unit test
           category: ${{ inputs.working-directory }}
-          workflowName: ${{ package-name }}/dart_native
+          workflowName: ${{ inputs.package-name }}/dart_native
           framework: dart
           flutterDartChannel: stable
           dartCompiler: dart

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -94,6 +94,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Log success/failure
+        if: always()
         uses: ./.github/composite_actions/log_metric
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -92,3 +92,18 @@ jobs:
         if: "always() && steps.bootstrap.conclusion == 'success'"
         run: dart test --exclude-tags=build
         working-directory: ${{ inputs.working-directory }}
+
+      - name: Log success/failure
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.os }}
+          testType: unit test
+          category: ${{ working-directory }}
+          workflowName: ${{ package-name }}/dart_native
+          framework: dart
+          flutterDartChannel: stable
+          dartCompiler: dart

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -102,7 +102,7 @@ jobs:
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.os }}
           testType: unit test
-          category: ${{ working-directory }}
+          category: ${{ inputs.working-directory }}
           workflowName: ${{ package-name }}/dart_native
           framework: dart
           flutterDartChannel: stable

--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -129,7 +129,7 @@ jobs:
           job-identifier: ${{ matrix.sdk }}
           testType: unit test
           category: ${{ inputs.working-directory }}
-          workflowName: ${{ package-name }}/dart_vm
+          workflowName: ${{ inputs.package-name }}/dart_vm
           framework: dart
           flutterDartChannel: ${{ matrix.sdk }}
           dartCompiler: dart

--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -128,7 +128,7 @@ jobs:
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.sdk }}
           testType: unit test
-          category: ${{ working-directory }}
+          category: ${{ inputs.working-directory }}
           workflowName: ${{ package-name }}/dart_vm
           framework: dart
           flutterDartChannel: ${{ matrix.sdk }}

--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -125,7 +125,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.sdk }}
           testType: unit test

--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -120,6 +120,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Log success/failure
+        if: always()
         uses: ./.github/composite_actions/log_metric
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -118,3 +118,19 @@ jobs:
         if: "always() && steps.bootstrap.conclusion == 'success' && steps.testCheck.outputs.hasTests == 'true' && matrix.sdk != 'stable'"
         run: dart test --exclude-tags=build
         working-directory: ${{ inputs.working-directory }}
+
+      - name: Log success/failure
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.sdk }}
+          testType: unit test
+          category: ${{ working-directory }}
+          workflowName: ${{ package-name }}/dart_vm
+          framework: dart
+          flutterDartChannel: ${{ matrix.sdk }}
+          dartCompiler: dart
+

--- a/.github/workflows/flutter_android.build.yaml
+++ b/.github/workflows/flutter_android.build.yaml
@@ -58,7 +58,7 @@ jobs:
           job-identifier: ${{ matrix.channel }}
           testType: unit test
           category: ${{ inputs.working-directory }}
-          workflowName: ${{ package-name }}/flutter_android.build
+          workflowName: ${{ inputs.package-name }}/flutter_android.build
           framework: flutter
           flutterDartChannel: ${{ matrix.channel }}
           platform: android

--- a/.github/workflows/flutter_android.build.yaml
+++ b/.github/workflows/flutter_android.build.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.channel }}
           testType: unit test

--- a/.github/workflows/flutter_android.build.yaml
+++ b/.github/workflows/flutter_android.build.yaml
@@ -47,3 +47,18 @@ jobs:
       - name: Build for Android
         run: flutter build apk --debug --verbose
         working-directory: ${{ inputs.working-directory }}
+
+      - name: Log success/failure
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.channel }}
+          testType: unit test
+          category: ${{ working-directory }}
+          workflowName: ${{ package-name }}/flutter_android.build
+          framework: flutter
+          flutterDartChannel: ${{ matrix.channel }}
+          platform: android

--- a/.github/workflows/flutter_android.build.yaml
+++ b/.github/workflows/flutter_android.build.yaml
@@ -57,7 +57,7 @@ jobs:
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.channel }}
           testType: unit test
-          category: ${{ working-directory }}
+          category: ${{ inputs.working-directory }}
           workflowName: ${{ package-name }}/flutter_android.build
           framework: flutter
           flutterDartChannel: ${{ matrix.channel }}

--- a/.github/workflows/flutter_android.build.yaml
+++ b/.github/workflows/flutter_android.build.yaml
@@ -49,6 +49,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Log success/failure
+        if: always()
         uses: ./.github/composite_actions/log_metric
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/flutter_android.test.yaml
+++ b/.github/workflows/flutter_android.test.yaml
@@ -49,3 +49,18 @@ jobs:
           flutter build apk --debug --verbose
           ./gradlew :"${{ inputs.package-name }}":testDebugUnitTest --stacktrace
         working-directory: ${{ inputs.working-directory }}
+
+      - name: Log success/failure
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.channel }}
+          testType: unit test
+          category: ${{ working-directory }}
+          workflowName: ${{ package-name }}/flutter_android.test
+          framework: flutter
+          flutterDartChannel: ${{ matrix.channel }}
+          platform: android

--- a/.github/workflows/flutter_android.test.yaml
+++ b/.github/workflows/flutter_android.test.yaml
@@ -51,6 +51,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Log success/failure
+        if: always()
         uses: ./.github/composite_actions/log_metric
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/flutter_android.test.yaml
+++ b/.github/workflows/flutter_android.test.yaml
@@ -60,7 +60,7 @@ jobs:
           job-identifier: ${{ matrix.channel }}
           testType: unit test
           category: ${{ inputs.working-directory }}
-          workflowName: ${{ package-name }}/flutter_android.test
+          workflowName: ${{ inputs.package-name }}/flutter_android.test
           framework: flutter
           flutterDartChannel: ${{ matrix.channel }}
           platform: android

--- a/.github/workflows/flutter_android.test.yaml
+++ b/.github/workflows/flutter_android.test.yaml
@@ -56,7 +56,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.channel }}
           testType: unit test

--- a/.github/workflows/flutter_android.test.yaml
+++ b/.github/workflows/flutter_android.test.yaml
@@ -59,7 +59,7 @@ jobs:
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.channel }}
           testType: unit test
-          category: ${{ working-directory }}
+          category: ${{ inputs.working-directory }}
           workflowName: ${{ package-name }}/flutter_android.test
           framework: flutter
           flutterDartChannel: ${{ matrix.channel }}

--- a/.github/workflows/flutter_ios.yaml
+++ b/.github/workflows/flutter_ios.yaml
@@ -66,7 +66,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.channel }}
           testType: unit test

--- a/.github/workflows/flutter_ios.yaml
+++ b/.github/workflows/flutter_ios.yaml
@@ -69,7 +69,7 @@ jobs:
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.channel }}
           testType: unit test
-          category: ${{ working-directory }}
+          category: ${{ inputs.working-directory }}
           workflowName: ${{ package-name }}/flutter_ios
           framework: flutter
           flutterDartChannel: ${{ matrix.channel }}

--- a/.github/workflows/flutter_ios.yaml
+++ b/.github/workflows/flutter_ios.yaml
@@ -59,3 +59,18 @@ jobs:
               -scheme Runner \
               -destination "$XCODEBUILD_DESTINATION" | xcpretty
         working-directory: ${{ inputs.working-directory }}
+
+      - name: Log success/failure
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.channel }}
+          testType: unit test
+          category: ${{ working-directory }}
+          workflowName: ${{ package-name }}/flutter_ios
+          framework: flutter
+          flutterDartChannel: ${{ matrix.channel }}
+          platform: ios

--- a/.github/workflows/flutter_ios.yaml
+++ b/.github/workflows/flutter_ios.yaml
@@ -61,6 +61,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Log success/failure
+        if: always()
         uses: ./.github/composite_actions/log_metric
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/flutter_ios.yaml
+++ b/.github/workflows/flutter_ios.yaml
@@ -70,7 +70,7 @@ jobs:
           job-identifier: ${{ matrix.channel }}
           testType: unit test
           category: ${{ inputs.working-directory }}
-          workflowName: ${{ package-name }}/flutter_ios
+          workflowName: ${{ inputs.package-name }}/flutter_ios
           framework: flutter
           flutterDartChannel: ${{ matrix.channel }}
           platform: ios

--- a/.github/workflows/flutter_vm.yaml
+++ b/.github/workflows/flutter_vm.yaml
@@ -87,6 +87,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Log success/failure
+        if: always()
         uses: ./.github/composite_actions/log_metric
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/flutter_vm.yaml
+++ b/.github/workflows/flutter_vm.yaml
@@ -92,7 +92,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}     
-          github-token: ${{ secrets.GH_TOKEN }}    
+          github-token: ${{ secrets.GITHUB_TOKEN }}    
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.channel }}, ${{ matrix.flutter-version }}
           testType: unit test

--- a/.github/workflows/flutter_vm.yaml
+++ b/.github/workflows/flutter_vm.yaml
@@ -95,7 +95,7 @@ jobs:
           job-status: ${{ job.status }}
           job-identifier: ${{ matrix.channel }}, ${{ matrix.flutter-version }}
           testType: unit test
-          category: ${{ working-directory }}
+          category: ${{ inputs.working-directory }}
           workflowName: ${{ package-name }}/flutter_vm
           framework: flutter
           flutterDartChannel: ${{ matrix.channel }}

--- a/.github/workflows/flutter_vm.yaml
+++ b/.github/workflows/flutter_vm.yaml
@@ -85,3 +85,17 @@ jobs:
         if: "always() && steps.bootstrap.conclusion == 'success' && steps.testCheck.outputs.hasTests == 'true'"
         run: flutter test
         working-directory: ${{ inputs.working-directory }}
+
+      - name: Log success/failure
+        uses: ./.github/composite_actions/log_metric
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}     
+          github-token: ${{ secrets.GH_TOKEN }}    
+          job-status: ${{ job.status }}
+          job-identifier: ${{ matrix.channel }}, ${{ matrix.flutter-version }}
+          testType: unit test
+          category: ${{ working-directory }}
+          workflowName: ${{ package-name }}/flutter_vm
+          framework: flutter
+          flutterDartChannel: ${{ matrix.channel }}

--- a/.github/workflows/flutter_vm.yaml
+++ b/.github/workflows/flutter_vm.yaml
@@ -96,6 +96,6 @@ jobs:
           job-identifier: ${{ matrix.channel }}, ${{ matrix.flutter-version }}
           testType: unit test
           category: ${{ inputs.working-directory }}
-          workflowName: ${{ package-name }}/flutter_vm
+          workflowName: ${{ inputs.package-name }}/flutter_vm
           framework: flutter
           flutterDartChannel: ${{ matrix.channel }}

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -1,0 +1,8 @@
+name: send_metric_data
+description: A Dart helper script to send metric data
+
+environment:
+  sdk: ^3.0.0
+
+dependencies:
+  args: ^2.0.0

--- a/tool/send_metric_data.dart
+++ b/tool/send_metric_data.dart
@@ -3,34 +3,91 @@
 
 import 'dart:io';
 
-/// Parse and send metric data using AWS CLI
+final testTypes = [
+  'canary',
+  'integration',
+  'unit test',
+];
+
+final frameworkTypes = [
+  'flutter',
+  'dart',
+];
+
+final platformTypes = ['web', 'android', 'ios', 'linux', 'windows'];
+
 void main(List<String> args) {
-  final metricName = args[0];
-  final value = args[1];
-  final dimensions = args.length > 2 ? args[2] : '';
+  final metricName = args[0].trim();
+  final isFailed = args[1] == 'failed';
+  final testType = args[2].trim();
+  var category = args[3].trim();
+  final workflowName = args[4].trim();
+  final framework = args[5].trim();
+  final flutterDartChannel = args[6].trim();
+  final dartVersion = args[7].trim();
+  final flutterVersion = args[8].trim();
+  final dartCompiler = args[9].trim();
+  final platform = args[10].trim();
+  final platformVersion = args[11].trim();
+  final failingStep = args[12].trim();
 
-  final metricNameTrimmed = metricName.trim();
-  final valueTrimmed = value.trim();
-  final dimensionsTrimmed = dimensions.trim();
-
-  final metricNameRegex = RegExp(r'^[a-zA-Z0-9\ \_\-]+$');
-  final valueRegex = RegExp(r'^[-+]?[0-9]+\.?[0-9]*$');
-  final dimensionsRegex = RegExp(r'^([^=,]+=[^=,]+(?:,[^=,]+=[^=,]+)*)?$');
-
-  if (!metricNameRegex.hasMatch(metricNameTrimmed)) {
-    print(
-        'Metric name can only contain alphanumeric characters, space character, -, and _.');
+  if (metricName.isEmpty) {
+    print('Must provide metricName');
     exit(1);
   }
-  if (!valueRegex.hasMatch(valueTrimmed)) {
-    print('Metric value must be a valid number');
+
+  final value = isFailed ? '1' : '0';
+
+  if (testType.isEmpty) {
+    print('Must provide testType dimension');
+    exit(1);
+  } else if (!testTypes.contains(testType)) {
+    print('TestType is not valid: ${testType}');
     exit(1);
   }
-  if (!dimensionsRegex.hasMatch(dimensionsTrimmed)) {
-    print(
-        'Dimensions must be empty or be in format string=string,string=string,...');
+
+  if (category.isEmpty) {
+    print('Must provide category dimension');
+    exit(1);
+  } else if (category.contains('/')) {
+    // For working directory "packages/analytics/amplify_analytics_pinpoint"
+    category = category.split('/')[1];
+  } else if (category.contains('_')) {
+    // For integration test scope "amplify_analytics_pinpoint_example"
+    category = category.split('_')[1];
+  }
+
+  if (workflowName.isEmpty) {
+    print('Must provide workflowName dimension');
     exit(1);
   }
+
+  if (framework.isNotEmpty && !frameworkTypes.contains(framework)) {
+    print('Framework is not valid: ${framework}');
+    exit(1);
+  }
+
+  if (platform.isNotEmpty && !platformTypes.contains(platform)) {
+    print('Platform is not valid: ${platform}');
+    exit(1);
+  }
+
+  final dimensions = {
+    'testType': testType,
+    'category': category,
+    'workflowName': workflowName,
+    if (framework.isNotEmpty) 'framework': framework,
+    if (flutterDartChannel.isNotEmpty) 'flutterDartChannel': flutterDartChannel,
+    if (dartVersion.isNotEmpty) 'dartVersion': dartVersion,
+    if (flutterVersion.isNotEmpty) 'flutterVersion': flutterVersion,
+    if (dartCompiler.isNotEmpty) 'dartCompiler': dartCompiler,
+    if (platform.isNotEmpty) 'platform': platform,
+    if (platformVersion.isNotEmpty) 'platformVersion': platformVersion,
+    if (failingStep.isNotEmpty) 'failingStep': failingStep,
+  };
+
+  final dimensionString =
+      dimensions.entries.map((e) => '${e.key}=${e.value}').join(',');
 
   final cloudArgs = [
     'cloudwatch',
@@ -41,12 +98,9 @@ void main(List<String> args) {
     'GithubCanaryApps',
     '--value',
     value,
+    '--dimension',
+    dimensionString,
   ];
-
-  if (!dimensionsTrimmed.isEmpty) {
-    cloudArgs.add('--dimensions');
-    cloudArgs.add(dimensionsTrimmed);
-  }
 
   Process.runSync('aws', cloudArgs);
 }

--- a/tool/send_metric_data.dart
+++ b/tool/send_metric_data.dart
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:io';
+import 'package:args/args.dart';
+
 
 final testTypes = [
   'canary',
@@ -17,19 +19,36 @@ final frameworkTypes = [
 final platformTypes = ['web', 'android', 'ios', 'linux', 'windows'];
 
 void main(List<String> args) {
-  final metricName = args[0].trim();
-  final isFailed = args[1] == 'failed';
-  final testType = args[2].trim();
-  var category = args[3].trim();
-  final workflowName = args[4].trim();
-  final framework = args[5].trim();
-  final flutterDartChannel = args[6].trim();
-  final dartVersion = args[7].trim();
-  final flutterVersion = args[8].trim();
-  final dartCompiler = args[9].trim();
-  final platform = args[10].trim();
-  final platformVersion = args[11].trim();
-  final failingStep = args[12].trim();
+  final parser = ArgParser()
+    ..addOption('metric-name')
+    ..addOption('is-failed')
+    ..addOption('testType')
+    ..addOption('category')
+    ..addOption('workflowName')
+    ..addOption('framework')
+    ..addOption('flutterDartChannel')
+    ..addOption('dartVersion')
+    ..addOption('flutterVersion')
+    ..addOption('dartCompiler')
+    ..addOption('platform')
+    ..addOption('platformVersion')
+    ..addOption('failingStep');
+
+  final results = parser.parse(args);
+
+  final metricName = results['metric-name']?.trim();
+  final isFailed = results['is-failed'] == 'true';
+  final testType = results['testType']?.trim();
+  var category = results['category']?.trim();
+  final workflowName = results['workflowName']?.trim();
+  final framework = results['framework']?.trim();
+  final flutterDartChannel = results['flutterDartChannel']?.trim();
+  final dartVersion = results['dartVersion']?.trim();
+  final flutterVersion = results['flutterVersion']?.trim();
+  final dartCompiler = results['dartCompiler']?.trim();
+  final platform = results['platform']?.trim();
+  final platformVersion = results['platformVersion']?.trim();
+  final failingStep = results['failingStep']?.trim();
 
   if (metricName.isEmpty) {
     print('Must provide metricName');
@@ -89,7 +108,7 @@ void main(List<String> args) {
   final dimensionString =
       dimensions.entries.map((e) => '${e.key}=${e.value}').join(',');
 
-  final cloudArgs = [
+  final List<String> cloudArgs = [
     'cloudwatch',
     'put-metric-data',
     '--metric-name',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Track the fields of global metrics that we discussed. 

Add code to track the failing step.  Identifying the failing job was a bit tricky, so we send all the matrix values comma delimited to parse the jobs json response from github to get the job id for getting the failing step in another step. 

**Please Note**
I am unable to test on this repo because the github secrets needs to be updated with a Github Token for making the requests to Github API for which step has failed on the job. 

Thus this PR cannot be pushed as is.  Furthermore you'll see that the repo URL in the requests are pointing to my github repo (fnoyp/amplify-flutter) instead of (aws-amplifiy/amplify-flutter). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
