### PR TITLE
chore(repo): Various fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
     "packages/smithy/goldens/lib",
     "packages/smithy/goldens/lib2"
   ],
+  "dart.onlyAnalyzeProjectsWithOpenFiles": true,
   "files.insertFinalNewline": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": true,

--- a/infra/tool/create_configs.dart
+++ b/infra/tool/create_configs.dart
@@ -25,14 +25,18 @@ const exampleApps = {
 
 late final Directory repoRoot = () {
   Directory dir = Directory.current;
+  Directory? rootDir;
   while (p.absolute(dir.parent.path) != p.absolute(dir.path)) {
     final files = dir.listSync().whereType<File>();
-    if (files.any((f) => p.basename(f.path) == 'aft.yaml')) {
-      return dir;
+    if (files.any((f) => p.basename(f.path) == 'pubspec.yaml')) {
+      rootDir = dir;
     }
     dir = dir.parent;
   }
-  throw StateError('Could not locate repo root');
+  if (rootDir == null) {
+    throw StateError('Could not locate repo root');
+  }
+  return rootDir;
 }();
 
 void main() {

--- a/packages/amplify_core/test/state_machine/my_state_machine.dart
+++ b/packages/amplify_core/test/state_machine/my_state_machine.dart
@@ -12,7 +12,7 @@ final _builders = <StateMachineToken,
   WorkerMachine.type: WorkerMachine.new,
 };
 
-enum MyType { initial, doWork, tryWork, delegateWork, success, error }
+enum MyType { initial, doWork, tryWork, delegateWork, failHard, success, error }
 
 class MyPreconditionException implements PreconditionException {
   const MyPreconditionException(this.precondition);
@@ -105,6 +105,8 @@ class MyStateMachine extends StateMachine<MyEvent, MyState, StateMachineEvent,
       case MyType.delegateWork:
         await manager.delegateWork();
         emit(const MyState(MyType.success));
+      case MyType.failHard:
+        await Future<void>.error(StateError('Worker crashed'));
     }
   }
 
@@ -240,4 +242,7 @@ class MyStateMachineManager extends StateMachineManager<StateMachineEvent,
     }
     throw ArgumentError('Invalid event: $event');
   }
+
+  @override
+  String get runtimeTypeName => 'MyStateMachineManager';
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/cognito_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/cognito_state_machine.dart
@@ -125,4 +125,7 @@ class CognitoAuthStateMachine
     final authSession = await loadSession();
     return authSession.userPoolTokensResult.value;
   }
+
+  @override
+  String get runtimeTypeName => 'CognitoAuthStateMachine';
 }


### PR DESCRIPTION
- Further improves analysis speed in the repo by only analyzing the projects which have files open.
- Fixes the `create_configs` script for new `aft.yaml` refactor
- Cleans up some code in the sign-in state machine and adds logging

Most importantly, this fixes an issue with Zones in the state machine code I was not aware of which effectively bricks the state machines when there is an unhandled error.