### PR TITLE
ci: Use Flutter stable in Dart pipelines

### DIFF
--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -54,7 +54,7 @@ jobs:
         uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa # 2.10.0
         with:
           cache: true
-          channel: beta
+          channel: stable
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@cdb51fff2b088939ef86fe041b18e82cb4733522 # main

--- a/packages/aws_common/test/config/file_location_test.dart
+++ b/packages/aws_common/test/config/file_location_test.dart
@@ -21,7 +21,7 @@ void main() {
               'HOME': r'/home/user',
               'USERPROFILE': r'ignored',
               'HOMEDRIVE': r'ignored',
-              'HOMEPATH': r'ignored'
+              'HOMEPATH': r'ignored',
             },
             () {
               expect(
@@ -49,7 +49,7 @@ void main() {
               'HOME': r'C:\users\user',
               'USERPROFILE': r'ignored',
               'HOMEDRIVE': r'ignored',
-              'HOMEPATH': r'ignored'
+              'HOMEPATH': r'ignored',
             },
             () {
               expect(
@@ -76,7 +76,7 @@ void main() {
             {
               'USERPROFILE': r'C:\users\user',
               'HOMEDRIVE': r'ignored',
-              'HOMEPATH': r'ignored'
+              'HOMEPATH': r'ignored',
             },
             () {
               expect(
@@ -100,7 +100,10 @@ void main() {
         const OperatingSystem('windows', ''),
         () {
           overrideEnvironment(
-            {'HOMEDRIVE': r'C:', 'HOMEPATH': r'\users\user'},
+            {
+              'HOMEDRIVE': r'C:',
+              'HOMEPATH': r'\users\user',
+            },
             () {
               expect(
                 pathProvider.configFileLocation,
@@ -123,7 +126,10 @@ void main() {
         const OperatingSystem('linux', ''),
         () {
           overrideEnvironment(
-            {'AWS_CONFIG_FILE': r'/other/path/config', 'HOME': r'/home/user'},
+            {
+              'AWS_CONFIG_FILE': r'/other/path/config',
+              'HOME': r'/home/user',
+            },
             () {
               expect(
                 pathProvider.configFileLocation,
@@ -148,7 +154,7 @@ void main() {
           overrideEnvironment(
             {
               'AWS_SHARED_CREDENTIALS_FILE': r'/other/path/credentials',
-              'HOME': r'/home/user'
+              'HOME': r'/home/user',
             },
             () {
               expect(
@@ -174,7 +180,7 @@ void main() {
           overrideEnvironment(
             {
               'AWS_CONFIG_FILE': r'C:\other\path\config',
-              'HOME': r'C:\users\user'
+              'HOME': r'C:\users\user',
             },
             () {
               expect(
@@ -200,7 +206,7 @@ void main() {
           overrideEnvironment(
             {
               'AWS_SHARED_CREDENTIALS_FILE': r'C:\other\path\credentials',
-              'HOME': r'C:\users\user'
+              'HOME': r'C:\users\user',
             },
             () {
               expect(
@@ -223,7 +229,10 @@ void main() {
         const OperatingSystem('linux', ''),
         () {
           overrideEnvironment(
-            {'AWS_PROFILE': r'other', 'HOME': r'/home/user'},
+            {
+              'AWS_PROFILE': r'other',
+              'HOME': r'/home/user',
+            },
             () {
               expect(
                 pathProvider.configFileLocation,

--- a/packages/aws_common/tool/generate_tests.dart
+++ b/packages/aws_common/tool/generate_tests.dart
@@ -165,7 +165,7 @@ void main() {
 test(r'${test.name}', () {
   overrideOperatingSystem(const OperatingSystem('${test.platform.name}', ''), () {
      overrideEnvironment({
-      ${test.environment.entries.map((entry) => "'${entry.key}': r'${entry.value}'").join(',\n')}
+      ${test.environment.entries.map((entry) => "'${entry.key}': r'${entry.value}',").join('\n')}
      }, () {
           expect(pathProvider.configFileLocation, completion(r'${test.configLocation}'),);
           expect(pathProvider.sharedCredentialsFileLocation, completion(r'${test.credentialsLocation}'),);
@@ -178,7 +178,13 @@ test(r'${test.name}', () {
   output.writeln('});}');
 
   await File(outputFilepath).writeAsString(output.toString());
-  await Process.run('dart', ['format', '--fix', outputFilepath]);
+  final formatRes = await Process.run(
+    'dart',
+    ['format', '--fix', outputFilepath],
+  );
+  if (formatRes.exitCode != 0) {
+    throw Exception(formatRes.stderr);
+  }
 }
 
 Future<void> generateProfileTests() async {

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_account_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_account_operation.dart
@@ -37,9 +37,8 @@ class GetAccountOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<GetAccountRequest, GetAccountRequest, Account, Account>>
-      protocols = [
+      _i1.HttpProtocol<GetAccountRequest, GetAccountRequest, Account,
+          Account>> protocols = [
     _i3.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_model_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_model_operation.dart
@@ -37,9 +37,8 @@ class GetModelOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<GetModelRequestPayload, GetModelRequest, Model, Model>>
-      protocols = [
+      _i1.HttpProtocol<GetModelRequestPayload, GetModelRequest, Model,
+          Model>> protocols = [
     _i3.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_stage_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_stage_operation.dart
@@ -39,9 +39,8 @@ class GetStageOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<GetStageRequestPayload, GetStageRequest, Stage, Stage>>
-      protocols = [
+      _i1.HttpProtocol<GetStageRequestPayload, GetStageRequest, Stage,
+          Stage>> protocols = [
     _i3.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_usage_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_usage_operation.dart
@@ -45,9 +45,8 @@ class GetUsageOperation extends _i1.PaginatedHttpOperation<
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<GetUsageRequestPayload, GetUsageRequest, Usage, Usage>>
-      protocols = [
+      _i1.HttpProtocol<GetUsageRequestPayload, GetUsageRequest, Usage,
+          Usage>> protocols = [
     _i5.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/import_rest_api_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/import_rest_api_operation.dart
@@ -40,9 +40,8 @@ class ImportRestApiOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<_i2.Uint8List, ImportRestApiRequest, RestApi, RestApi>>
-      protocols = [
+      _i1.HttpProtocol<_i2.Uint8List, ImportRestApiRequest, RestApi,
+          RestApi>> protocols = [
     _i4.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/cloud_formation_client.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/cloud_formation_client.dart
@@ -1222,9 +1222,8 @@ class CloudFormationClient {
   ///
   /// For deleted stacks, ListStackResources returns resource information for up to 90 days after the stack has been deleted.
   _i3.SmithyOperation<
-          _i3
-          .PaginatedResult<_i4.BuiltList<StackResourceSummary>, void, String>>
-      listStackResources(
+      _i3.PaginatedResult<_i4.BuiltList<StackResourceSummary>, void,
+          String>> listStackResources(
     ListStackResourcesInput input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/operation/delete_stack_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/operation/delete_stack_operation.dart
@@ -33,9 +33,8 @@ class DeleteStackOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<DeleteStackInput, DeleteStackInput, _i1.Unit, _i1.Unit>>
-      protocols = [
+      _i1.HttpProtocol<DeleteStackInput, DeleteStackInput, _i1.Unit,
+          _i1.Unit>> protocols = [
     _i3.AwsQueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/config_client.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/config_client.dart
@@ -738,9 +738,8 @@ class ConfigClient {
   ///
   /// *   The rule's Lambda function has returned `NOT_APPLICABLE` for all evaluation results. This can occur if the resources were deleted or removed from the rule's scope.
   _i3.SmithyOperation<
-          _i3
-          .PaginatedResult<_i4.BuiltList<ComplianceByConfigRule>, void, String>>
-      describeComplianceByConfigRule(
+      _i3.PaginatedResult<_i4.BuiltList<ComplianceByConfigRule>, void,
+          String>> describeComplianceByConfigRule(
     DescribeComplianceByConfigRuleRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -829,9 +828,8 @@ class ConfigClient {
 
   /// Returns status information for sources within an aggregator. The status includes information about the last time Config verified authorization between the source account and an aggregator account. In case of a failure, the status contains the related error code or message.
   _i3.SmithyOperation<
-          _i3
-          .PaginatedResult<_i4.BuiltList<AggregatedSourceStatus>, int, String>>
-      describeConfigurationAggregatorSourcesStatus(
+      _i3.PaginatedResult<_i4.BuiltList<AggregatedSourceStatus>, int,
+          String>> describeConfigurationAggregatorSourcesStatus(
     DescribeConfigurationAggregatorSourcesStatusRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -850,9 +848,8 @@ class ConfigClient {
 
   /// Returns the details of one or more configuration aggregators. If the configuration aggregator is not specified, this action returns the details for all the configuration aggregators associated with the account.
   _i3.SmithyOperation<
-          _i3
-          .PaginatedResult<_i4.BuiltList<ConfigurationAggregator>, int, String>>
-      describeConfigurationAggregators(
+      _i3.PaginatedResult<_i4.BuiltList<ConfigurationAggregator>, int,
+          String>> describeConfigurationAggregators(
     DescribeConfigurationAggregatorsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -957,9 +954,8 @@ class ConfigClient {
 
   /// Returns a list of one or more conformance packs.
   _i3.SmithyOperation<
-          _i3
-          .PaginatedResult<_i4.BuiltList<ConformancePackDetail>, int, String>>
-      describeConformancePacks(
+      _i3.PaginatedResult<_i4.BuiltList<ConformancePackDetail>, int,
+          String>> describeConformancePacks(
     DescribeConformancePacksRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -1052,9 +1048,8 @@ class ConfigClient {
   ///
   /// If you deploy an organizational rule or conformance pack in an organization administrator account, and then establish a delegated administrator and deploy an organizational rule or conformance pack in the delegated administrator account, you won't be able to see the organizational rule or conformance pack in the organization administrator account from the delegated administrator account or see the organizational rule or conformance pack in the delegated administrator account from organization administrator account. The `DescribeOrganizationConfigRules` and `DescribeOrganizationConformancePacks` APIs can only see and interact with the organization-related resource that were deployed from within the account calling those APIs.
   _i3.SmithyOperation<
-          _i3
-          .PaginatedResult<_i4.BuiltList<OrganizationConfigRule>, int, String>>
-      describeOrganizationConfigRules(
+      _i3.PaginatedResult<_i4.BuiltList<OrganizationConfigRule>, int,
+          String>> describeOrganizationConfigRules(
     DescribeOrganizationConfigRulesRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -1170,9 +1165,8 @@ class ConfigClient {
   ///
   /// Limit and next token are not applicable if you request resources in batch. It is only applicable, when you request all resources.
   _i3.SmithyOperation<
-          _i3
-          .PaginatedResult<DescribeRemediationExceptionsResponse, int, String>>
-      describeRemediationExceptions(
+      _i3.PaginatedResult<DescribeRemediationExceptionsResponse, int,
+          String>> describeRemediationExceptions(
     DescribeRemediationExceptionsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -1213,9 +1207,8 @@ class ConfigClient {
   ///
   /// Currently, Config supports only one retention configuration per region in your account.
   _i3.SmithyOperation<
-          _i3
-          .PaginatedResult<_i4.BuiltList<RetentionConfiguration>, void, String>>
-      describeRetentionConfigurations(
+      _i3.PaginatedResult<_i4.BuiltList<RetentionConfiguration>, void,
+          String>> describeRetentionConfigurations(
     DescribeRetentionConfigurationsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/aggregate_conformance_pack_compliance_summary_filters.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/aggregate_conformance_pack_compliance_summary_filters.dart
@@ -36,9 +36,8 @@ abstract class AggregateConformancePackComplianceSummaryFilters
   const AggregateConformancePackComplianceSummaryFilters._();
 
   static const List<
-          _i2
-          .SmithySerializer<AggregateConformancePackComplianceSummaryFilters>>
-      serializers = [
+      _i2.SmithySerializer<
+          AggregateConformancePackComplianceSummaryFilters>> serializers = [
     AggregateConformancePackComplianceSummaryFiltersAwsJson11Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/aggregate_conformance_pack_compliance_summary_group_key.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/aggregate_conformance_pack_compliance_summary_group_key.dart
@@ -36,9 +36,8 @@ class AggregateConformancePackComplianceSummaryGroupKey
   ];
 
   static const List<
-          _i1
-          .SmithySerializer<AggregateConformancePackComplianceSummaryGroupKey>>
-      serializers = [
+      _i1.SmithySerializer<
+          AggregateConformancePackComplianceSummaryGroupKey>> serializers = [
     _i1.SmithyEnumSerializer(
       'AggregateConformancePackComplianceSummaryGroupKey',
       values: values,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_aggregate_compliance_by_config_rules_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_aggregate_compliance_by_config_rules_response.dart
@@ -44,9 +44,8 @@ abstract class DescribeAggregateComplianceByConfigRulesResponse
       payload;
 
   static const List<
-          _i3
-          .SmithySerializer<DescribeAggregateComplianceByConfigRulesResponse>>
-      serializers = [
+      _i3.SmithySerializer<
+          DescribeAggregateComplianceByConfigRulesResponse>> serializers = [
     DescribeAggregateComplianceByConfigRulesResponseAwsJson11Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_organization_config_rule_statuses_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_organization_config_rule_statuses_request.dart
@@ -94,8 +94,8 @@ abstract class DescribeOrganizationConfigRuleStatusesRequest
 }
 
 class DescribeOrganizationConfigRuleStatusesRequestAwsJson11Serializer
-    extends _i1
-    .StructuredSmithySerializer<DescribeOrganizationConfigRuleStatusesRequest> {
+    extends _i1.StructuredSmithySerializer<
+        DescribeOrganizationConfigRuleStatusesRequest> {
   const DescribeOrganizationConfigRuleStatusesRequestAwsJson11Serializer()
       : super('DescribeOrganizationConfigRuleStatusesRequest');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_organization_conformance_pack_statuses_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_organization_conformance_pack_statuses_request.dart
@@ -47,9 +47,8 @@ abstract class DescribeOrganizationConformancePackStatusesRequest
       payload;
 
   static const List<
-          _i1
-          .SmithySerializer<DescribeOrganizationConformancePackStatusesRequest>>
-      serializers = [
+      _i1.SmithySerializer<
+          DescribeOrganizationConformancePackStatusesRequest>> serializers = [
     DescribeOrganizationConformancePackStatusesRequestAwsJson11Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_organization_conformance_packs_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_organization_conformance_packs_response.dart
@@ -76,8 +76,8 @@ abstract class DescribeOrganizationConformancePacksResponse
 }
 
 class DescribeOrganizationConformancePacksResponseAwsJson11Serializer
-    extends _i3
-    .StructuredSmithySerializer<DescribeOrganizationConformancePacksResponse> {
+    extends _i3.StructuredSmithySerializer<
+        DescribeOrganizationConformancePacksResponse> {
   const DescribeOrganizationConformancePacksResponseAwsJson11Serializer()
       : super('DescribeOrganizationConformancePacksResponse');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/get_aggregate_compliance_details_by_config_rule_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/get_aggregate_compliance_details_by_config_rule_request.dart
@@ -53,9 +53,8 @@ abstract class GetAggregateComplianceDetailsByConfigRuleRequest
       payload;
 
   static const List<
-          _i1
-          .SmithySerializer<GetAggregateComplianceDetailsByConfigRuleRequest>>
-      serializers = [
+      _i1.SmithySerializer<
+          GetAggregateComplianceDetailsByConfigRuleRequest>> serializers = [
     GetAggregateComplianceDetailsByConfigRuleRequestAwsJson11Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/get_aggregate_compliance_details_by_config_rule_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/get_aggregate_compliance_details_by_config_rule_response.dart
@@ -44,9 +44,8 @@ abstract class GetAggregateComplianceDetailsByConfigRuleResponse
       payload;
 
   static const List<
-          _i3
-          .SmithySerializer<GetAggregateComplianceDetailsByConfigRuleResponse>>
-      serializers = [
+      _i3.SmithySerializer<
+          GetAggregateComplianceDetailsByConfigRuleResponse>> serializers = [
     GetAggregateComplianceDetailsByConfigRuleResponseAwsJson11Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/get_aggregate_discovered_resource_counts_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/get_aggregate_discovered_resource_counts_response.dart
@@ -103,8 +103,8 @@ abstract class GetAggregateDiscoveredResourceCountsResponse
 }
 
 class GetAggregateDiscoveredResourceCountsResponseAwsJson11Serializer
-    extends _i4
-    .StructuredSmithySerializer<GetAggregateDiscoveredResourceCountsResponse> {
+    extends _i4.StructuredSmithySerializer<
+        GetAggregateDiscoveredResourceCountsResponse> {
   const GetAggregateDiscoveredResourceCountsResponseAwsJson11Serializer()
       : super('GetAggregateDiscoveredResourceCountsResponse');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_configuration_recorders_exceeded_exception.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_configuration_recorders_exceeded_exception.dart
@@ -43,9 +43,8 @@ abstract class MaxNumberOfConfigurationRecordersExceededException
       });
 
   static const List<
-          _i2
-          .SmithySerializer<MaxNumberOfConfigurationRecordersExceededException>>
-      serializers = [
+      _i2.SmithySerializer<
+          MaxNumberOfConfigurationRecordersExceededException>> serializers = [
     MaxNumberOfConfigurationRecordersExceededExceptionAwsJson11Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_conformance_packs_exceeded_exception.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_conformance_packs_exceeded_exception.dart
@@ -79,8 +79,8 @@ abstract class MaxNumberOfConformancePacksExceededException
 }
 
 class MaxNumberOfConformancePacksExceededExceptionAwsJson11Serializer
-    extends _i2
-    .StructuredSmithySerializer<MaxNumberOfConformancePacksExceededException> {
+    extends _i2.StructuredSmithySerializer<
+        MaxNumberOfConformancePacksExceededException> {
   const MaxNumberOfConformancePacksExceededExceptionAwsJson11Serializer()
       : super('MaxNumberOfConformancePacksExceededException');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_delivery_channels_exceeded_exception.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_delivery_channels_exceeded_exception.dart
@@ -79,8 +79,8 @@ abstract class MaxNumberOfDeliveryChannelsExceededException
 }
 
 class MaxNumberOfDeliveryChannelsExceededExceptionAwsJson11Serializer
-    extends _i2
-    .StructuredSmithySerializer<MaxNumberOfDeliveryChannelsExceededException> {
+    extends _i2.StructuredSmithySerializer<
+        MaxNumberOfDeliveryChannelsExceededException> {
   const MaxNumberOfDeliveryChannelsExceededExceptionAwsJson11Serializer()
       : super('MaxNumberOfDeliveryChannelsExceededException');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_organization_conformance_packs_exceeded_exception.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_organization_conformance_packs_exceeded_exception.dart
@@ -13,8 +13,8 @@ part 'max_number_of_organization_conformance_packs_exceeded_exception.g.dart';
 /// You have reached the limit of the number of organization conformance packs you can create in an account. For more information, see [**Service Limits**](https://docs.aws.amazon.com/config/latest/developerguide/configlimits.html) in the _Config Developer Guide_.
 abstract class MaxNumberOfOrganizationConformancePacksExceededException
     with
-        _i1
-        .AWSEquatable<MaxNumberOfOrganizationConformancePacksExceededException>
+        _i1.AWSEquatable<
+            MaxNumberOfOrganizationConformancePacksExceededException>
     implements
         Built<MaxNumberOfOrganizationConformancePacksExceededException,
             MaxNumberOfOrganizationConformancePacksExceededExceptionBuilder>,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/organization_custom_policy_rule_metadata_no_policy.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/organization_custom_policy_rule_metadata_no_policy.dart
@@ -163,8 +163,8 @@ abstract class OrganizationCustomPolicyRuleMetadataNoPolicy
 }
 
 class OrganizationCustomPolicyRuleMetadataNoPolicyAwsJson11Serializer
-    extends _i3
-    .StructuredSmithySerializer<OrganizationCustomPolicyRuleMetadataNoPolicy> {
+    extends _i3.StructuredSmithySerializer<
+        OrganizationCustomPolicyRuleMetadataNoPolicy> {
   const OrganizationCustomPolicyRuleMetadataNoPolicyAwsJson11Serializer()
       : super('OrganizationCustomPolicyRuleMetadataNoPolicy');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_aggregate_compliance_by_config_rules_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_aggregate_compliance_by_config_rules_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Returns a list of compliant and noncompliant rules with the number of resources for compliant and noncompliant rules. Does not display rules that do not have compliance results.
 ///
 /// The results can return an empty result page, but if you have a `nextToken`, the results are displayed on the next page.
-class DescribeAggregateComplianceByConfigRulesOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeAggregateComplianceByConfigRulesOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeAggregateComplianceByConfigRulesRequest,
         DescribeAggregateComplianceByConfigRulesRequest,
         DescribeAggregateComplianceByConfigRulesResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_aggregate_compliance_by_conformance_packs_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_aggregate_compliance_by_conformance_packs_operation.dart
@@ -23,8 +23,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Returns a list of the conformance packs and their associated compliance status with the count of compliant and noncompliant Config rules within each conformance pack. Also returns the total rule count which includes compliant rules, noncompliant rules, and rules that cannot be evaluated due to insufficient data.
 ///
 /// The results can return an empty result page, but if you have a `nextToken`, the results are displayed on the next page.
-class DescribeAggregateComplianceByConformancePacksOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeAggregateComplianceByConformancePacksOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeAggregateComplianceByConformancePacksRequest,
         DescribeAggregateComplianceByConformancePacksRequest,
         DescribeAggregateComplianceByConformancePacksResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_aggregation_authorizations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_aggregation_authorizations_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_next_token_e
 import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_value_exception.dart';
 
 /// Returns a list of authorizations granted to various aggregator accounts and regions.
-class DescribeAggregationAuthorizationsOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeAggregationAuthorizationsOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeAggregationAuthorizationsRequest,
         DescribeAggregationAuthorizationsRequest,
         DescribeAggregationAuthorizationsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_compliance_by_config_rule_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_compliance_by_config_rule_operation.dart
@@ -30,8 +30,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/no_such_config_rule_
 /// *   The rule's Lambda function is failing to send evaluation results to Config. Verify that the role you assigned to your configuration recorder includes the `config:PutEvaluations` permission. If the rule is a custom rule, verify that the Lambda execution role includes the `config:PutEvaluations` permission.
 ///
 /// *   The rule's Lambda function has returned `NOT_APPLICABLE` for all evaluation results. This can occur if the resources were deleted or removed from the rule's scope.
-class DescribeComplianceByConfigRuleOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeComplianceByConfigRuleOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeComplianceByConfigRuleRequest,
         DescribeComplianceByConfigRuleRequest,
         DescribeComplianceByConfigRuleResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_config_rule_evaluation_status_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_config_rule_evaluation_status_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_va
 import 'package:smoke_test/src/sdk/src/config_service/model/no_such_config_rule_exception.dart';
 
 /// Returns status information for each of your Config managed rules. The status includes information such as the last time Config invoked the rule, the last time Config failed to invoke the rule, and the related error for the last failure.
-class DescribeConfigRuleEvaluationStatusOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeConfigRuleEvaluationStatusOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeConfigRuleEvaluationStatusRequest,
         DescribeConfigRuleEvaluationStatusRequest,
         DescribeConfigRuleEvaluationStatusResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_configuration_aggregator_sources_status_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_configuration_aggregator_sources_status_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_va
 import 'package:smoke_test/src/sdk/src/config_service/model/no_such_configuration_aggregator_exception.dart';
 
 /// Returns status information for sources within an aggregator. The status includes information about the last time Config verified authorization between the source account and an aggregator account. In case of a failure, the status contains the related error code or message.
-class DescribeConfigurationAggregatorSourcesStatusOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeConfigurationAggregatorSourcesStatusOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeConfigurationAggregatorSourcesStatusRequest,
         DescribeConfigurationAggregatorSourcesStatusRequest,
         DescribeConfigurationAggregatorSourcesStatusResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_configuration_aggregators_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_configuration_aggregators_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_va
 import 'package:smoke_test/src/sdk/src/config_service/model/no_such_configuration_aggregator_exception.dart';
 
 /// Returns the details of one or more configuration aggregators. If the configuration aggregator is not specified, this action returns the details for all the configuration aggregators associated with the account.
-class DescribeConfigurationAggregatorsOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeConfigurationAggregatorsOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeConfigurationAggregatorsRequest,
         DescribeConfigurationAggregatorsRequest,
         DescribeConfigurationAggregatorsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_conformance_pack_compliance_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_conformance_pack_compliance_operation.dart
@@ -22,8 +22,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/no_such_conformance_
 /// Returns compliance details for each rule in that conformance pack.
 ///
 /// You must provide exact rule names.
-class DescribeConformancePackComplianceOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeConformancePackComplianceOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeConformancePackComplianceRequest,
         DescribeConformancePackComplianceRequest,
         DescribeConformancePackComplianceResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_config_rule_statuses_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_config_rule_statuses_operation.dart
@@ -25,8 +25,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/organization_config_
 /// The status is not considered successful until organization Config rule is successfully deployed in all the member accounts with an exception of excluded accounts.
 ///
 /// When you specify the limit and the next token, you receive a paginated response. Limit and next token are not applicable if you specify organization Config rule names. It is only applicable, when you request all the organization Config rules.
-class DescribeOrganizationConfigRuleStatusesOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeOrganizationConfigRuleStatusesOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeOrganizationConfigRuleStatusesRequest,
         DescribeOrganizationConfigRuleStatusesRequest,
         DescribeOrganizationConfigRuleStatusesResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_config_rules_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_config_rules_operation.dart
@@ -29,8 +29,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/organization_config_
 /// _For accounts within an organzation_
 ///
 /// If you deploy an organizational rule or conformance pack in an organization administrator account, and then establish a delegated administrator and deploy an organizational rule or conformance pack in the delegated administrator account, you won't be able to see the organizational rule or conformance pack in the organization administrator account from the delegated administrator account or see the organizational rule or conformance pack in the delegated administrator account from organization administrator account. The `DescribeOrganizationConfigRules` and `DescribeOrganizationConformancePacks` APIs can only see and interact with the organization-related resource that were deployed from within the account calling those APIs.
-class DescribeOrganizationConfigRulesOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeOrganizationConfigRulesOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeOrganizationConfigRulesRequest,
         DescribeOrganizationConfigRulesRequest,
         DescribeOrganizationConfigRulesResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_conformance_pack_statuses_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_conformance_pack_statuses_operation.dart
@@ -25,8 +25,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/organization_conform
 /// The status is not considered successful until organization conformance pack is successfully deployed in all the member accounts with an exception of excluded accounts.
 ///
 /// When you specify the limit and the next token, you receive a paginated response. Limit and next token are not applicable if you specify organization conformance pack names. They are only applicable, when you request all the organization conformance packs.
-class DescribeOrganizationConformancePackStatusesOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeOrganizationConformancePackStatusesOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeOrganizationConformancePackStatusesRequest,
         DescribeOrganizationConformancePackStatusesRequest,
         DescribeOrganizationConformancePackStatusesResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_conformance_packs_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_conformance_packs_operation.dart
@@ -29,8 +29,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/organization_conform
 /// _For accounts within an organzation_
 ///
 /// If you deploy an organizational rule or conformance pack in an organization administrator account, and then establish a delegated administrator and deploy an organizational rule or conformance pack in the delegated administrator account, you won't be able to see the organizational rule or conformance pack in the organization administrator account from the delegated administrator account or see the organizational rule or conformance pack in the delegated administrator account from organization administrator account. The `DescribeOrganizationConfigRules` and `DescribeOrganizationConformancePacks` APIs can only see and interact with the organization-related resource that were deployed from within the account calling those APIs.
-class DescribeOrganizationConformancePacksOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeOrganizationConformancePacksOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeOrganizationConformancePacksRequest,
         DescribeOrganizationConformancePacksRequest,
         DescribeOrganizationConformancePacksResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_pending_aggregation_requests_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_pending_aggregation_requests_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_va
 import 'package:smoke_test/src/sdk/src/config_service/model/pending_aggregation_request.dart';
 
 /// Returns a list of all pending aggregation requests.
-class DescribePendingAggregationRequestsOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribePendingAggregationRequestsOperation
+    extends _i1.PaginatedHttpOperation<
         DescribePendingAggregationRequestsRequest,
         DescribePendingAggregationRequestsRequest,
         DescribePendingAggregationRequestsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_remediation_execution_status_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_remediation_execution_status_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/no_such_remediation_
 import 'package:smoke_test/src/sdk/src/config_service/model/remediation_execution_status.dart';
 
 /// Provides a detailed view of a Remediation Execution for a set of resources including state, timestamps for when steps for the remediation execution occur, and any error messages for steps that have failed. When you specify the limit and the next token, you receive a paginated response.
-class DescribeRemediationExecutionStatusOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeRemediationExecutionStatusOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeRemediationExecutionStatusRequest,
         DescribeRemediationExecutionStatusRequest,
         DescribeRemediationExecutionStatusResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_retention_configurations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_retention_configurations_operation.dart
@@ -22,8 +22,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/retention_configurat
 /// Returns the details of one or more retention configurations. If the retention configuration name is not specified, this action returns the details for all the retention configurations for that account.
 ///
 /// Currently, Config supports only one retention configuration per region in your account.
-class DescribeRetentionConfigurationsOperation extends _i1
-    .PaginatedHttpOperation<
+class DescribeRetentionConfigurationsOperation
+    extends _i1.PaginatedHttpOperation<
         DescribeRetentionConfigurationsRequest,
         DescribeRetentionConfigurationsRequest,
         DescribeRetentionConfigurationsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_compliance_details_by_config_rule_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_compliance_details_by_config_rule_operation.dart
@@ -23,8 +23,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Returns the evaluation results for the specified Config rule for a specific resource in a rule. The results indicate which Amazon Web Services resources were evaluated by the rule, when each resource was last evaluated, and whether each resource complies with the rule.
 ///
 /// The results can return an empty result page. But if you have a `nextToken`, the results are displayed on the next page.
-class GetAggregateComplianceDetailsByConfigRuleOperation extends _i1
-    .PaginatedHttpOperation<
+class GetAggregateComplianceDetailsByConfigRuleOperation
+    extends _i1.PaginatedHttpOperation<
         GetAggregateComplianceDetailsByConfigRuleRequest,
         GetAggregateComplianceDetailsByConfigRuleRequest,
         GetAggregateComplianceDetailsByConfigRuleResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_config_rule_compliance_summary_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_config_rule_compliance_summary_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Returns the number of compliant and noncompliant rules for one or more accounts and regions in an aggregator.
 ///
 /// The results can return an empty result page, but if you have a nextToken, the results are displayed on the next page.
-class GetAggregateConfigRuleComplianceSummaryOperation extends _i1
-    .PaginatedHttpOperation<
+class GetAggregateConfigRuleComplianceSummaryOperation
+    extends _i1.PaginatedHttpOperation<
         GetAggregateConfigRuleComplianceSummaryRequest,
         GetAggregateConfigRuleComplianceSummaryRequest,
         GetAggregateConfigRuleComplianceSummaryResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_conformance_pack_compliance_summary_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_conformance_pack_compliance_summary_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Returns the count of compliant and noncompliant conformance packs across all Amazon Web Services accounts and Amazon Web Services Regions in an aggregator. You can filter based on Amazon Web Services account ID or Amazon Web Services Region.
 ///
 /// The results can return an empty result page, but if you have a nextToken, the results are displayed on the next page.
-class GetAggregateConformancePackComplianceSummaryOperation extends _i1
-    .PaginatedHttpOperation<
+class GetAggregateConformancePackComplianceSummaryOperation
+    extends _i1.PaginatedHttpOperation<
         GetAggregateConformancePackComplianceSummaryRequest,
         GetAggregateConformancePackComplianceSummaryRequest,
         GetAggregateConformancePackComplianceSummaryResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_discovered_resource_counts_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_discovered_resource_counts_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Returns the resource counts across accounts and regions that are present in your Config aggregator. You can request the resource counts by providing filters and GroupByKey.
 ///
 /// For example, if the input contains accountID 12345678910 and region us-east-1 in filters, the API returns the count of resources in account ID 12345678910 and region us-east-1. If the input contains ACCOUNT_ID as a GroupByKey, the API returns resource counts for all source accounts that are present in your aggregator.
-class GetAggregateDiscoveredResourceCountsOperation extends _i1
-    .PaginatedHttpOperation<
+class GetAggregateDiscoveredResourceCountsOperation
+    extends _i1.PaginatedHttpOperation<
         GetAggregateDiscoveredResourceCountsRequest,
         GetAggregateDiscoveredResourceCountsRequest,
         GetAggregateDiscoveredResourceCountsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_compliance_details_by_config_rule_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_compliance_details_by_config_rule_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_va
 import 'package:smoke_test/src/sdk/src/config_service/model/no_such_config_rule_exception.dart';
 
 /// Returns the evaluation results for the specified Config rule. The results indicate which Amazon Web Services resources were evaluated by the rule, when each resource was last evaluated, and whether each resource complies with the rule.
-class GetComplianceDetailsByConfigRuleOperation extends _i1
-    .PaginatedHttpOperation<
+class GetComplianceDetailsByConfigRuleOperation
+    extends _i1.PaginatedHttpOperation<
         GetComplianceDetailsByConfigRuleRequest,
         GetComplianceDetailsByConfigRuleRequest,
         GetComplianceDetailsByConfigRuleResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_compliance_details_by_resource_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_compliance_details_by_resource_operation.dart
@@ -18,8 +18,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/get_compliance_detai
 import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_value_exception.dart';
 
 /// Returns the evaluation results for the specified Amazon Web Services resource. The results indicate which Config rules were used to evaluate the resource, when each rule was last invoked, and whether the resource complies with each rule.
-class GetComplianceDetailsByResourceOperation extends _i1
-    .PaginatedHttpOperation<
+class GetComplianceDetailsByResourceOperation
+    extends _i1.PaginatedHttpOperation<
         GetComplianceDetailsByResourceRequest,
         GetComplianceDetailsByResourceRequest,
         GetComplianceDetailsByResourceResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_conformance_pack_compliance_details_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_conformance_pack_compliance_details_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/no_such_config_rule_
 import 'package:smoke_test/src/sdk/src/config_service/model/no_such_conformance_pack_exception.dart';
 
 /// Returns compliance details of a conformance pack for all Amazon Web Services resources that are monitered by conformance pack.
-class GetConformancePackComplianceDetailsOperation extends _i1
-    .PaginatedHttpOperation<
+class GetConformancePackComplianceDetailsOperation
+    extends _i1.PaginatedHttpOperation<
         GetConformancePackComplianceDetailsRequest,
         GetConformancePackComplianceDetailsRequest,
         GetConformancePackComplianceDetailsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_conformance_pack_compliance_summary_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_conformance_pack_compliance_summary_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_next_token_e
 import 'package:smoke_test/src/sdk/src/config_service/model/no_such_conformance_pack_exception.dart';
 
 /// Returns compliance details for the conformance pack based on the cumulative compliance results of all the rules in that conformance pack.
-class GetConformancePackComplianceSummaryOperation extends _i1
-    .PaginatedHttpOperation<
+class GetConformancePackComplianceSummaryOperation
+    extends _i1.PaginatedHttpOperation<
         GetConformancePackComplianceSummaryRequest,
         GetConformancePackComplianceSummaryRequest,
         GetConformancePackComplianceSummaryResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_organization_config_rule_detailed_status_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_organization_config_rule_detailed_status_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/no_such_organization
 import 'package:smoke_test/src/sdk/src/config_service/model/organization_access_denied_exception.dart';
 
 /// Returns detailed status for each member account within an organization for a given organization Config rule.
-class GetOrganizationConfigRuleDetailedStatusOperation extends _i1
-    .PaginatedHttpOperation<
+class GetOrganizationConfigRuleDetailedStatusOperation
+    extends _i1.PaginatedHttpOperation<
         GetOrganizationConfigRuleDetailedStatusRequest,
         GetOrganizationConfigRuleDetailedStatusRequest,
         GetOrganizationConfigRuleDetailedStatusResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_organization_conformance_pack_detailed_status_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_organization_conformance_pack_detailed_status_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/organization_access_
 import 'package:smoke_test/src/sdk/src/config_service/model/organization_conformance_pack_detailed_status.dart';
 
 /// Returns detailed status for each member account within an organization for a given organization conformance pack.
-class GetOrganizationConformancePackDetailedStatusOperation extends _i1
-    .PaginatedHttpOperation<
+class GetOrganizationConformancePackDetailedStatusOperation
+    extends _i1.PaginatedHttpOperation<
         GetOrganizationConformancePackDetailedStatusRequest,
         GetOrganizationConformancePackDetailedStatusRequest,
         GetOrganizationConformancePackDetailedStatusResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/list_aggregate_discovered_resources_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/list_aggregate_discovered_resources_operation.dart
@@ -23,8 +23,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Accepts a resource type and returns a list of resource identifiers that are aggregated for a specific resource type across accounts and regions. A resource identifier includes the resource type, ID, (if available) the custom resource name, source account, and source region. You can narrow the results to include only resources that have specific resource IDs, or a resource name, or source account ID, or source region.
 ///
 /// For example, if the input consists of accountID 12345678910 and the region is us-east-1 for resource type `AWS::EC2::Instance` then the API returns all the EC2 instance identifiers of accountID 12345678910 and region us-east-1.
-class ListAggregateDiscoveredResourcesOperation extends _i1
-    .PaginatedHttpOperation<
+class ListAggregateDiscoveredResourcesOperation
+    extends _i1.PaginatedHttpOperation<
         ListAggregateDiscoveredResourcesRequest,
         ListAggregateDiscoveredResourcesRequest,
         ListAggregateDiscoveredResourcesResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/list_conformance_pack_compliance_scores_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/list_conformance_pack_compliance_scores_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/list_conformance_pac
 /// Returns a list of conformance pack compliance scores. A compliance score is the percentage of the number of compliant rule-resource combinations in a conformance pack compared to the number of total possible rule-resource combinations in the conformance pack. This metric provides you with a high-level view of the compliance state of your conformance packs. You can use it to identify, investigate, and understand the level of compliance in your conformance packs.
 ///
 /// Conformance packs with no evaluation results will have a compliance score of `INSUFFICIENT_DATA`.
-class ListConformancePackComplianceScoresOperation extends _i1
-    .PaginatedHttpOperation<
+class ListConformancePackComplianceScoresOperation
+    extends _i1.PaginatedHttpOperation<
         ListConformancePackComplianceScoresRequest,
         ListConformancePackComplianceScoresRequest,
         ListConformancePackComplianceScoresResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/auto_scaling_target_tracking_scaling_policy_configuration_update.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/auto_scaling_target_tracking_scaling_policy_configuration_update.dart
@@ -13,8 +13,8 @@ part 'auto_scaling_target_tracking_scaling_policy_configuration_update.g.dart';
 /// Represents the settings of a target tracking scaling policy that will be modified.
 abstract class AutoScalingTargetTrackingScalingPolicyConfigurationUpdate
     with
-        _i1
-        .AWSEquatable<AutoScalingTargetTrackingScalingPolicyConfigurationUpdate>
+        _i1.AWSEquatable<
+            AutoScalingTargetTrackingScalingPolicyConfigurationUpdate>
     implements
         Built<AutoScalingTargetTrackingScalingPolicyConfigurationUpdate,
             AutoScalingTargetTrackingScalingPolicyConfigurationUpdateBuilder> {

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/global_table_global_secondary_index_settings_update.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/global_table_global_secondary_index_settings_update.dart
@@ -83,8 +83,8 @@ abstract class GlobalTableGlobalSecondaryIndexSettingsUpdate
 }
 
 class GlobalTableGlobalSecondaryIndexSettingsUpdateAwsJson10Serializer
-    extends _i3
-    .StructuredSmithySerializer<GlobalTableGlobalSecondaryIndexSettingsUpdate> {
+    extends _i3.StructuredSmithySerializer<
+        GlobalTableGlobalSecondaryIndexSettingsUpdate> {
   const GlobalTableGlobalSecondaryIndexSettingsUpdateAwsJson10Serializer()
       : super('GlobalTableGlobalSecondaryIndexSettingsUpdate');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/replica_global_secondary_index_auto_scaling_description.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/replica_global_secondary_index_auto_scaling_description.dart
@@ -44,9 +44,8 @@ abstract class ReplicaGlobalSecondaryIndexAutoScalingDescription
   const ReplicaGlobalSecondaryIndexAutoScalingDescription._();
 
   static const List<
-          _i2
-          .SmithySerializer<ReplicaGlobalSecondaryIndexAutoScalingDescription>>
-      serializers = [
+      _i2.SmithySerializer<
+          ReplicaGlobalSecondaryIndexAutoScalingDescription>> serializers = [
     ReplicaGlobalSecondaryIndexAutoScalingDescriptionAwsJson10Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/replica_global_secondary_index_auto_scaling_update.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/replica_global_secondary_index_auto_scaling_update.dart
@@ -70,8 +70,8 @@ abstract class ReplicaGlobalSecondaryIndexAutoScalingUpdate
 }
 
 class ReplicaGlobalSecondaryIndexAutoScalingUpdateAwsJson10Serializer
-    extends _i2
-    .StructuredSmithySerializer<ReplicaGlobalSecondaryIndexAutoScalingUpdate> {
+    extends _i2.StructuredSmithySerializer<
+        ReplicaGlobalSecondaryIndexAutoScalingUpdate> {
   const ReplicaGlobalSecondaryIndexAutoScalingUpdateAwsJson10Serializer()
       : super('ReplicaGlobalSecondaryIndexAutoScalingUpdate');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/operation/tag_resource_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/operation/tag_resource_operation.dart
@@ -41,9 +41,8 @@ class TagResourceOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<TagResourceInput, TagResourceInput, _i1.Unit, _i1.Unit>>
-      protocols = [
+      _i1.HttpProtocol<TagResourceInput, TagResourceInput, _i1.Unit,
+          _i1.Unit>> protocols = [
     _i3.AwsJson1_0Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/iam_client.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/iam_client.dart
@@ -1636,9 +1636,8 @@ class IamClient {
   ///
   /// You can optionally filter the results using the `Filter` parameter. You can paginate the results using the `MaxItems` and `Marker` parameters.
   _i3.SmithyOperation<
-          _i3
-          .PaginatedResult<GetAccountAuthorizationDetailsResponse, int, String>>
-      getAccountAuthorizationDetails(
+      _i3.PaginatedResult<GetAccountAuthorizationDetailsResponse, int,
+          String>> getAccountAuthorizationDetails(
     GetAccountAuthorizationDetailsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/get_service_last_accessed_details_with_entities_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/get_service_last_accessed_details_with_entities_request.dart
@@ -45,9 +45,8 @@ abstract class GetServiceLastAccessedDetailsWithEntitiesRequest
       payload;
 
   static const List<
-          _i1
-          .SmithySerializer<GetServiceLastAccessedDetailsWithEntitiesRequest>>
-      serializers = [
+      _i1.SmithySerializer<
+          GetServiceLastAccessedDetailsWithEntitiesRequest>> serializers = [
     GetServiceLastAccessedDetailsWithEntitiesRequestAwsQuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/get_service_last_accessed_details_with_entities_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/get_service_last_accessed_details_with_entities_response.dart
@@ -55,9 +55,8 @@ abstract class GetServiceLastAccessedDetailsWithEntitiesResponse
       payload;
 
   static const List<
-          _i3
-          .SmithySerializer<GetServiceLastAccessedDetailsWithEntitiesResponse>>
-      serializers = [
+      _i3.SmithySerializer<
+          GetServiceLastAccessedDetailsWithEntitiesResponse>> serializers = [
     GetServiceLastAccessedDetailsWithEntitiesResponseAwsQuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/get_account_authorization_details_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/get_account_authorization_details_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/iam/model/service_failure_exception.dart'
 /// Policies returned by this operation are URL-encoded compliant with [RFC 3986](https://tools.ietf.org/html/rfc3986). You can use a URL decoding method to convert the policy back to plain JSON text. For example, if you use Java, you can use the `decode` method of the `java.net.URLDecoder` utility class in the Java SDK. Other languages and SDKs provide similar functionality.
 ///
 /// You can optionally filter the results using the `Filter` parameter. You can paginate the results using the `MaxItems` and `Marker` parameters.
-class GetAccountAuthorizationDetailsOperation extends _i1
-    .PaginatedHttpOperation<
+class GetAccountAuthorizationDetailsOperation
+    extends _i1.PaginatedHttpOperation<
         GetAccountAuthorizationDetailsRequest,
         GetAccountAuthorizationDetailsRequest,
         GetAccountAuthorizationDetailsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/get_service_last_accessed_details_with_entities_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/get_service_last_accessed_details_with_entities_operation.dart
@@ -28,8 +28,8 @@ import 'package:smoke_test/src/sdk/src/iam/model/no_such_entity_exception.dart';
 /// If the operation fails, the `GetServiceLastAccessedDetailsWithEntities` operation returns the reason that it failed.
 ///
 /// By default, the list of associated entities is sorted by date, with the most recent access listed first.
-class GetServiceLastAccessedDetailsWithEntitiesOperation extends _i1
-    .HttpOperation<
+class GetServiceLastAccessedDetailsWithEntitiesOperation
+    extends _i1.HttpOperation<
         GetServiceLastAccessedDetailsWithEntitiesRequest,
         GetServiceLastAccessedDetailsWithEntitiesRequest,
         GetServiceLastAccessedDetailsWithEntitiesResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/remove_client_id_from_open_id_connect_provider_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/remove_client_id_from_open_id_connect_provider_operation.dart
@@ -19,8 +19,8 @@ import 'package:smoke_test/src/sdk/src/iam/model/service_failure_exception.dart'
 /// Removes the specified client ID (also known as audience) from the list of client IDs registered for the specified IAM OpenID Connect (OIDC) provider resource object.
 ///
 /// This operation is idempotent; it does not fail or return an error if you try to remove a client ID that does not exist.
-class RemoveClientIdFromOpenIdConnectProviderOperation extends _i1
-    .HttpOperation<RemoveClientIdFromOpenIdConnectProviderRequest,
+class RemoveClientIdFromOpenIdConnectProviderOperation
+    extends _i1.HttpOperation<RemoveClientIdFromOpenIdConnectProviderRequest,
         RemoveClientIdFromOpenIdConnectProviderRequest, _i1.Unit, _i1.Unit> {
   /// Removes the specified client ID (also known as audience) from the list of client IDs registered for the specified IAM OpenID Connect (OIDC) provider resource object.
   ///

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/tag_policy_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/tag_policy_operation.dart
@@ -59,9 +59,8 @@ class TagPolicyOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<TagPolicyRequest, TagPolicyRequest, _i1.Unit, _i1.Unit>>
-      protocols = [
+      _i1.HttpProtocol<TagPolicyRequest, TagPolicyRequest, _i1.Unit,
+          _i1.Unit>> protocols = [
     _i3.AwsQueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/untag_role_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/untag_role_operation.dart
@@ -35,9 +35,8 @@ class UntagRoleOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<UntagRoleRequest, UntagRoleRequest, _i1.Unit, _i1.Unit>>
-      protocols = [
+      _i1.HttpProtocol<UntagRoleRequest, UntagRoleRequest, _i1.Unit,
+          _i1.Unit>> protocols = [
     _i3.AwsQueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/untag_user_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/untag_user_operation.dart
@@ -35,9 +35,8 @@ class UntagUserOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<UntagUserRequest, UntagUserRequest, _i1.Unit, _i1.Unit>>
-      protocols = [
+      _i1.HttpProtocol<UntagUserRequest, UntagUserRequest, _i1.Unit,
+          _i1.Unit>> protocols = [
     _i3.AwsQueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_analytics_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_analytics_configuration_request.dart
@@ -57,9 +57,8 @@ abstract class DeleteBucketAnalyticsConfigurationRequest
       });
 
   static const List<
-          _i1
-          .SmithySerializer<DeleteBucketAnalyticsConfigurationRequestPayload>>
-      serializers = [
+      _i1.SmithySerializer<
+          DeleteBucketAnalyticsConfigurationRequestPayload>> serializers = [
     DeleteBucketAnalyticsConfigurationRequestRestXmlSerializer()
   ];
 
@@ -136,8 +135,8 @@ abstract class DeleteBucketAnalyticsConfigurationRequestPayload
   }
 }
 
-class DeleteBucketAnalyticsConfigurationRequestRestXmlSerializer extends _i1
-    .StructuredSmithySerializer<
+class DeleteBucketAnalyticsConfigurationRequestRestXmlSerializer
+    extends _i1.StructuredSmithySerializer<
         DeleteBucketAnalyticsConfigurationRequestPayload> {
   const DeleteBucketAnalyticsConfigurationRequestRestXmlSerializer()
       : super('DeleteBucketAnalyticsConfigurationRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_intelligent_tiering_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_intelligent_tiering_configuration_request.dart
@@ -13,15 +13,15 @@ part 'delete_bucket_intelligent_tiering_configuration_request.g.dart';
 
 abstract class DeleteBucketIntelligentTieringConfigurationRequest
     with
-        _i1
-        .HttpInput<DeleteBucketIntelligentTieringConfigurationRequestPayload>,
+        _i1.HttpInput<
+            DeleteBucketIntelligentTieringConfigurationRequestPayload>,
         _i2.AWSEquatable<DeleteBucketIntelligentTieringConfigurationRequest>
     implements
         Built<DeleteBucketIntelligentTieringConfigurationRequest,
             DeleteBucketIntelligentTieringConfigurationRequestBuilder>,
         _i1.EmptyPayload,
-        _i1
-        .HasPayload<DeleteBucketIntelligentTieringConfigurationRequestPayload> {
+        _i1.HasPayload<
+            DeleteBucketIntelligentTieringConfigurationRequestPayload> {
   factory DeleteBucketIntelligentTieringConfigurationRequest({
     required String bucket,
     required String id,
@@ -103,8 +103,8 @@ abstract class DeleteBucketIntelligentTieringConfigurationRequest
 @_i3.internal
 abstract class DeleteBucketIntelligentTieringConfigurationRequestPayload
     with
-        _i2
-        .AWSEquatable<DeleteBucketIntelligentTieringConfigurationRequestPayload>
+        _i2.AWSEquatable<
+            DeleteBucketIntelligentTieringConfigurationRequestPayload>
     implements
         Built<DeleteBucketIntelligentTieringConfigurationRequestPayload,
             DeleteBucketIntelligentTieringConfigurationRequestPayloadBuilder>,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_inventory_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_inventory_configuration_request.dart
@@ -57,9 +57,8 @@ abstract class DeleteBucketInventoryConfigurationRequest
       });
 
   static const List<
-          _i1
-          .SmithySerializer<DeleteBucketInventoryConfigurationRequestPayload>>
-      serializers = [
+      _i1.SmithySerializer<
+          DeleteBucketInventoryConfigurationRequestPayload>> serializers = [
     DeleteBucketInventoryConfigurationRequestRestXmlSerializer()
   ];
 
@@ -136,8 +135,8 @@ abstract class DeleteBucketInventoryConfigurationRequestPayload
   }
 }
 
-class DeleteBucketInventoryConfigurationRequestRestXmlSerializer extends _i1
-    .StructuredSmithySerializer<
+class DeleteBucketInventoryConfigurationRequestRestXmlSerializer
+    extends _i1.StructuredSmithySerializer<
         DeleteBucketInventoryConfigurationRequestPayload> {
   const DeleteBucketInventoryConfigurationRequestRestXmlSerializer()
       : super('DeleteBucketInventoryConfigurationRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_metrics_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_metrics_configuration_request.dart
@@ -135,8 +135,8 @@ abstract class DeleteBucketMetricsConfigurationRequestPayload
   }
 }
 
-class DeleteBucketMetricsConfigurationRequestRestXmlSerializer extends _i1
-    .StructuredSmithySerializer<
+class DeleteBucketMetricsConfigurationRequestRestXmlSerializer
+    extends _i1.StructuredSmithySerializer<
         DeleteBucketMetricsConfigurationRequestPayload> {
   const DeleteBucketMetricsConfigurationRequestRestXmlSerializer()
       : super('DeleteBucketMetricsConfigurationRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/get_bucket_accelerate_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/get_bucket_accelerate_configuration_request.dart
@@ -137,8 +137,8 @@ abstract class GetBucketAccelerateConfigurationRequestPayload
   }
 }
 
-class GetBucketAccelerateConfigurationRequestRestXmlSerializer extends _i1
-    .StructuredSmithySerializer<
+class GetBucketAccelerateConfigurationRequestRestXmlSerializer
+    extends _i1.StructuredSmithySerializer<
         GetBucketAccelerateConfigurationRequestPayload> {
   const GetBucketAccelerateConfigurationRequestRestXmlSerializer()
       : super('GetBucketAccelerateConfigurationRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/get_bucket_notification_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/get_bucket_notification_configuration_request.dart
@@ -52,9 +52,8 @@ abstract class GetBucketNotificationConfigurationRequest
       });
 
   static const List<
-          _i1
-          .SmithySerializer<GetBucketNotificationConfigurationRequestPayload>>
-      serializers = [
+      _i1.SmithySerializer<
+          GetBucketNotificationConfigurationRequestPayload>> serializers = [
     GetBucketNotificationConfigurationRequestRestXmlSerializer()
   ];
 
@@ -127,8 +126,8 @@ abstract class GetBucketNotificationConfigurationRequestPayload
   }
 }
 
-class GetBucketNotificationConfigurationRequestRestXmlSerializer extends _i1
-    .StructuredSmithySerializer<
+class GetBucketNotificationConfigurationRequestRestXmlSerializer
+    extends _i1.StructuredSmithySerializer<
         GetBucketNotificationConfigurationRequestPayload> {
   const GetBucketNotificationConfigurationRequestRestXmlSerializer()
       : super('GetBucketNotificationConfigurationRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_analytics_configurations_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_analytics_configurations_request.dart
@@ -135,8 +135,8 @@ abstract class ListBucketAnalyticsConfigurationsRequestPayload
   }
 }
 
-class ListBucketAnalyticsConfigurationsRequestRestXmlSerializer extends _i1
-    .StructuredSmithySerializer<
+class ListBucketAnalyticsConfigurationsRequestRestXmlSerializer
+    extends _i1.StructuredSmithySerializer<
         ListBucketAnalyticsConfigurationsRequestPayload> {
   const ListBucketAnalyticsConfigurationsRequestRestXmlSerializer()
       : super('ListBucketAnalyticsConfigurationsRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_intelligent_tiering_configurations_output.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_intelligent_tiering_configurations_output.dart
@@ -49,9 +49,8 @@ abstract class ListBucketIntelligentTieringConfigurationsOutput
       payload;
 
   static const List<
-          _i3
-          .SmithySerializer<ListBucketIntelligentTieringConfigurationsOutput>>
-      serializers = [
+      _i3.SmithySerializer<
+          ListBucketIntelligentTieringConfigurationsOutput>> serializers = [
     ListBucketIntelligentTieringConfigurationsOutputRestXmlSerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_intelligent_tiering_configurations_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_intelligent_tiering_configurations_request.dart
@@ -19,8 +19,8 @@ abstract class ListBucketIntelligentTieringConfigurationsRequest
         Built<ListBucketIntelligentTieringConfigurationsRequest,
             ListBucketIntelligentTieringConfigurationsRequestBuilder>,
         _i1.EmptyPayload,
-        _i1
-        .HasPayload<ListBucketIntelligentTieringConfigurationsRequestPayload> {
+        _i1.HasPayload<
+            ListBucketIntelligentTieringConfigurationsRequestPayload> {
   factory ListBucketIntelligentTieringConfigurationsRequest({
     required String bucket,
     String? continuationToken,
@@ -102,8 +102,8 @@ abstract class ListBucketIntelligentTieringConfigurationsRequest
 @_i3.internal
 abstract class ListBucketIntelligentTieringConfigurationsRequestPayload
     with
-        _i2
-        .AWSEquatable<ListBucketIntelligentTieringConfigurationsRequestPayload>
+        _i2.AWSEquatable<
+            ListBucketIntelligentTieringConfigurationsRequestPayload>
     implements
         Built<ListBucketIntelligentTieringConfigurationsRequestPayload,
             ListBucketIntelligentTieringConfigurationsRequestPayloadBuilder>,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_inventory_configurations_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_inventory_configurations_request.dart
@@ -135,8 +135,8 @@ abstract class ListBucketInventoryConfigurationsRequestPayload
   }
 }
 
-class ListBucketInventoryConfigurationsRequestRestXmlSerializer extends _i1
-    .StructuredSmithySerializer<
+class ListBucketInventoryConfigurationsRequestRestXmlSerializer
+    extends _i1.StructuredSmithySerializer<
         ListBucketInventoryConfigurationsRequestPayload> {
   const ListBucketInventoryConfigurationsRequestRestXmlSerializer()
       : super('ListBucketInventoryConfigurationsRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/delete_bucket_intelligent_tiering_configuration_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/delete_bucket_intelligent_tiering_configuration_operation.dart
@@ -28,8 +28,8 @@ import 'package:smoke_test/src/sdk/src/s3/model/delete_bucket_intelligent_tierin
 /// *   [PutBucketIntelligentTieringConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html)
 ///
 /// *   [ListBucketIntelligentTieringConfigurations](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html)
-class DeleteBucketIntelligentTieringConfigurationOperation extends _i1
-    .HttpOperation<
+class DeleteBucketIntelligentTieringConfigurationOperation
+    extends _i1.HttpOperation<
         DeleteBucketIntelligentTieringConfigurationRequestPayload,
         DeleteBucketIntelligentTieringConfigurationRequest,
         _i1.Unit,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/get_bucket_intelligent_tiering_configuration_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/get_bucket_intelligent_tiering_configuration_operation.dart
@@ -30,8 +30,8 @@ import 'package:smoke_test/src/sdk/src/s3/model/intelligent_tiering_configuratio
 /// *   [PutBucketIntelligentTieringConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html)
 ///
 /// *   [ListBucketIntelligentTieringConfigurations](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html)
-class GetBucketIntelligentTieringConfigurationOperation extends _i1
-    .HttpOperation<
+class GetBucketIntelligentTieringConfigurationOperation
+    extends _i1.HttpOperation<
         GetBucketIntelligentTieringConfigurationRequestPayload,
         GetBucketIntelligentTieringConfigurationRequest,
         IntelligentTieringConfiguration,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/list_bucket_intelligent_tiering_configurations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/list_bucket_intelligent_tiering_configurations_operation.dart
@@ -29,8 +29,8 @@ import 'package:smoke_test/src/sdk/src/s3/model/list_bucket_intelligent_tiering_
 /// *   [PutBucketIntelligentTieringConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html)
 ///
 /// *   [GetBucketIntelligentTieringConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html)
-class ListBucketIntelligentTieringConfigurationsOperation extends _i1
-    .HttpOperation<
+class ListBucketIntelligentTieringConfigurationsOperation
+    extends _i1.HttpOperation<
         ListBucketIntelligentTieringConfigurationsRequestPayload,
         ListBucketIntelligentTieringConfigurationsRequest,
         ListBucketIntelligentTieringConfigurationsOutput,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/put_bucket_intelligent_tiering_configuration_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/put_bucket_intelligent_tiering_configuration_operation.dart
@@ -50,8 +50,8 @@ import 'package:smoke_test/src/sdk/src/s3/model/put_bucket_intelligent_tiering_c
 /// HTTP 403 Forbidden Error
 ///
 /// _Cause:_ You are not the owner of the specified bucket, or you do not have the `s3:PutIntelligentTieringConfiguration` bucket permission to set the configuration on the bucket.
-class PutBucketIntelligentTieringConfigurationOperation extends _i1
-    .HttpOperation<IntelligentTieringConfiguration,
+class PutBucketIntelligentTieringConfigurationOperation
+    extends _i1.HttpOperation<IntelligentTieringConfiguration,
         PutBucketIntelligentTieringConfigurationRequest, _i1.Unit, _i1.Unit> {
   /// Puts a S3 Intelligent-Tiering configuration to the specified bucket. You can have up to 1,000 S3 Intelligent-Tiering configurations per bucket.
   ///

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/put_bucket_tagging_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/put_bucket_tagging_operation.dart
@@ -97,9 +97,8 @@ class PutBucketTaggingOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<Tagging, PutBucketTaggingRequest, _i1.Unit, _i1.Unit>>
-      protocols = [
+      _i1.HttpProtocol<Tagging, PutBucketTaggingRequest, _i1.Unit,
+          _i1.Unit>> protocols = [
     _i2.RestXmlProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/json_protocol_server.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/json_protocol_server.dart
@@ -165,7 +165,7 @@ class _JsonProtocolServer extends _i1.HttpServer<JsonProtocolServerBase> {
   );
 
   late final _i1
-      .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
+          .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
       _endpointWithHostLabelOperationProtocol = _i2.AwsJson1_1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -219,7 +219,7 @@ class _JsonProtocolServer extends _i1.HttpServer<JsonProtocolServerBase> {
   );
 
   late final _i1
-      .HttpProtocol<KitchenSink, KitchenSink, KitchenSink, KitchenSink>
+          .HttpProtocol<KitchenSink, KitchenSink, KitchenSink, KitchenSink>
       _kitchenSinkOperationProtocol = _i2.AwsJson1_1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/machine_learning_server.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/machine_learning_server.dart
@@ -53,9 +53,8 @@ class _MachineLearningServer extends _i1.HttpServer<MachineLearningServerBase> {
   @override
   final MachineLearningServerBase service;
 
-  late final _i1
-      .HttpProtocol<PredictInput, PredictInput, PredictOutput, PredictOutput>
-      _predictProtocol = _i2.AwsJson1_1Protocol(
+  late final _i1.HttpProtocol<PredictInput, PredictInput, PredictOutput,
+      PredictOutput> _predictProtocol = _i2.AwsJson1_1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );

--- a/packages/smithy/goldens/lib/awsQuery/lib/src/query_protocol/operation/query_lists_operation.dart
+++ b/packages/smithy/goldens/lib/awsQuery/lib/src/query_protocol/operation/query_lists_operation.dart
@@ -28,9 +28,8 @@ class QueryListsOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<QueryListsInput, QueryListsInput, _i1.Unit, _i1.Unit>>
-      protocols = [
+      _i1.HttpProtocol<QueryListsInput, QueryListsInput, _i1.Unit,
+          _i1.Unit>> protocols = [
     _i2.AwsQueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
@@ -13,9 +13,12 @@ import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
 /// The example tests how requests serialize different timestamp formats in the URI path.
-class HttpRequestWithLabelsAndTimestampFormatOperation extends _i1
-    .HttpOperation<HttpRequestWithLabelsAndTimestampFormatInputPayload,
-        HttpRequestWithLabelsAndTimestampFormatInput, _i1.Unit, _i1.Unit> {
+class HttpRequestWithLabelsAndTimestampFormatOperation
+    extends _i1.HttpOperation<
+        HttpRequestWithLabelsAndTimestampFormatInputPayload,
+        HttpRequestWithLabelsAndTimestampFormatInput,
+        _i1.Unit,
+        _i1.Unit> {
   /// The example tests how requests serialize different timestamp formats in the URI path.
   HttpRequestWithLabelsAndTimestampFormatOperation({
     required String region,

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/operation/http_string_payload_operation.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/operation/http_string_payload_operation.dart
@@ -26,9 +26,8 @@ class HttpStringPayloadOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<String, StringPayloadInput, String, StringPayloadInput>>
-      protocols = [
+      _i1.HttpProtocol<String, StringPayloadInput, String,
+          StringPayloadInput>> protocols = [
     _i2.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/operation/malformed_content_type_without_body_empty_input_operation.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/operation/malformed_content_type_without_body_empty_input_operation.dart
@@ -12,9 +12,12 @@ import 'package:rest_json1_v1/src/rest_json_protocol/model/malformed_content_typ
 import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
-class MalformedContentTypeWithoutBodyEmptyInputOperation extends _i1
-    .HttpOperation<MalformedContentTypeWithoutBodyEmptyInputInputPayload,
-        MalformedContentTypeWithoutBodyEmptyInputInput, _i1.Unit, _i1.Unit> {
+class MalformedContentTypeWithoutBodyEmptyInputOperation
+    extends _i1.HttpOperation<
+        MalformedContentTypeWithoutBodyEmptyInputInputPayload,
+        MalformedContentTypeWithoutBodyEmptyInputInput,
+        _i1.Unit,
+        _i1.Unit> {
   MalformedContentTypeWithoutBodyEmptyInputOperation({
     required String region,
     Uri? baseUri,

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/rest_json_protocol_server.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/rest_json_protocol_server.dart
@@ -1051,7 +1051,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-      .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
+          .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
       _endpointWithHostLabelOperationProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1087,9 +1087,8 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1
-      .HttpProtocol<StringEnum, EnumPayloadInput, StringEnum, EnumPayloadInput>
-      _httpEnumPayloadProtocol = _i2.RestJson1Protocol(
+  late final _i1.HttpProtocol<StringEnum, EnumPayloadInput, StringEnum,
+      EnumPayloadInput> _httpEnumPayloadProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );
@@ -1193,7 +1192,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-      .HttpProtocol<String, StringPayloadInput, String, StringPayloadInput>
+          .HttpProtocol<String, StringPayloadInput, String, StringPayloadInput>
       _httpStringPayloadProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1281,7 +1280,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-      .HttpProtocol<_i1.Unit, _i1.Unit, GreetingStruct, GreetingStruct>
+          .HttpProtocol<_i1.Unit, _i1.Unit, GreetingStruct, GreetingStruct>
       _malformedAcceptWithBodyProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1301,9 +1300,8 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1
-      .HttpProtocol<MalformedBlobInput, MalformedBlobInput, _i1.Unit, _i1.Unit>
-      _malformedBlobProtocol = _i2.RestJson1Protocol(
+  late final _i1.HttpProtocol<MalformedBlobInput, MalformedBlobInput, _i1.Unit,
+      _i1.Unit> _malformedBlobProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );
@@ -1324,7 +1322,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-      .HttpProtocol<GreetingStruct, GreetingStruct, _i1.Unit, _i1.Unit>
+          .HttpProtocol<GreetingStruct, GreetingStruct, _i1.Unit, _i1.Unit>
       _malformedContentTypeWithBodyProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1382,9 +1380,8 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1
-      .HttpProtocol<MalformedListInput, MalformedListInput, _i1.Unit, _i1.Unit>
-      _malformedListProtocol = _i2.RestJson1Protocol(
+  late final _i1.HttpProtocol<MalformedListInput, MalformedListInput, _i1.Unit,
+      _i1.Unit> _malformedListProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );
@@ -1395,9 +1392,8 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1
-      .HttpProtocol<MalformedMapInput, MalformedMapInput, _i1.Unit, _i1.Unit>
-      _malformedMapProtocol = _i2.RestJson1Protocol(
+  late final _i1.HttpProtocol<MalformedMapInput, MalformedMapInput, _i1.Unit,
+      _i1.Unit> _malformedMapProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/rest_json_validation_protocol_server.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/rest_json_validation_protocol_server.dart
@@ -156,9 +156,8 @@ class _RestJsonValidationProtocolServer
   @override
   final RestJsonValidationProtocolServerBase service;
 
-  late final _i1
-      .HttpProtocol<MalformedEnumInput, MalformedEnumInput, _i1.Unit, _i1.Unit>
-      _malformedEnumProtocol = _i2.RestJson1Protocol(
+  late final _i1.HttpProtocol<MalformedEnumInput, MalformedEnumInput, _i1.Unit,
+      _i1.Unit> _malformedEnumProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );

--- a/packages/smithy/goldens/lib/restJson1/test/rest_json_protocol/http_request_with_labels_and_timestamp_format_operation_test.dart
+++ b/packages/smithy/goldens/lib/restJson1/test/rest_json_protocol/http_request_with_labels_and_timestamp_format_operation_test.dart
@@ -64,8 +64,8 @@ void main() {
 }
 
 class HttpRequestWithLabelsAndTimestampFormatInputRestJson1Serializer
-    extends _i3
-    .StructuredSmithySerializer<HttpRequestWithLabelsAndTimestampFormatInput> {
+    extends _i3.StructuredSmithySerializer<
+        HttpRequestWithLabelsAndTimestampFormatInput> {
   const HttpRequestWithLabelsAndTimestampFormatInputRestJson1Serializer()
       : super('HttpRequestWithLabelsAndTimestampFormatInput');
 

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/http_request_with_labels_and_timestamp_format_input.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/http_request_with_labels_and_timestamp_format_input.dart
@@ -220,8 +220,8 @@ abstract class HttpRequestWithLabelsAndTimestampFormatInputPayload
   }
 }
 
-class HttpRequestWithLabelsAndTimestampFormatInputRestXmlSerializer extends _i1
-    .StructuredSmithySerializer<
+class HttpRequestWithLabelsAndTimestampFormatInputRestXmlSerializer
+    extends _i1.StructuredSmithySerializer<
         HttpRequestWithLabelsAndTimestampFormatInputPayload> {
   const HttpRequestWithLabelsAndTimestampFormatInputRestXmlSerializer()
       : super('HttpRequestWithLabelsAndTimestampFormatInput');

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
@@ -13,9 +13,12 @@ import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
 /// The example tests how requests serialize different timestamp formats in the URI path.
-class HttpRequestWithLabelsAndTimestampFormatOperation extends _i1
-    .HttpOperation<HttpRequestWithLabelsAndTimestampFormatInputPayload,
-        HttpRequestWithLabelsAndTimestampFormatInput, _i1.Unit, _i1.Unit> {
+class HttpRequestWithLabelsAndTimestampFormatOperation
+    extends _i1.HttpOperation<
+        HttpRequestWithLabelsAndTimestampFormatInputPayload,
+        HttpRequestWithLabelsAndTimestampFormatInput,
+        _i1.Unit,
+        _i1.Unit> {
   /// The example tests how requests serialize different timestamp formats in the URI path.
   HttpRequestWithLabelsAndTimestampFormatOperation({
     required String region,

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/rest_xml_protocol_server.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/rest_xml_protocol_server.dart
@@ -686,7 +686,7 @@ class _RestXmlProtocolServer extends _i1.HttpServer<RestXmlProtocolServerBase> {
   );
 
   late final _i1
-      .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
+          .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
       _endpointWithHostLabelOperationProtocol = _i2.RestXmlProtocol(
     serializers: serializers,
     builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/json_protocol_server.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/json_protocol_server.dart
@@ -165,7 +165,7 @@ class _JsonProtocolServer extends _i1.HttpServer<JsonProtocolServerBase> {
   );
 
   late final _i1
-      .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
+          .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
       _endpointWithHostLabelOperationProtocol = _i2.AwsJson1_1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -219,7 +219,7 @@ class _JsonProtocolServer extends _i1.HttpServer<JsonProtocolServerBase> {
   );
 
   late final _i1
-      .HttpProtocol<KitchenSink, KitchenSink, KitchenSink, KitchenSink>
+          .HttpProtocol<KitchenSink, KitchenSink, KitchenSink, KitchenSink>
       _kitchenSinkOperationProtocol = _i2.AwsJson1_1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/machine_learning_server.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/machine_learning_server.dart
@@ -53,9 +53,8 @@ class _MachineLearningServer extends _i1.HttpServer<MachineLearningServerBase> {
   @override
   final MachineLearningServerBase service;
 
-  late final _i1
-      .HttpProtocol<PredictInput, PredictInput, PredictOutput, PredictOutput>
-      _predictProtocol = _i2.AwsJson1_1Protocol(
+  late final _i1.HttpProtocol<PredictInput, PredictInput, PredictOutput,
+      PredictOutput> _predictProtocol = _i2.AwsJson1_1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );

--- a/packages/smithy/goldens/lib2/awsQuery/lib/src/query_protocol/operation/query_lists_operation.dart
+++ b/packages/smithy/goldens/lib2/awsQuery/lib/src/query_protocol/operation/query_lists_operation.dart
@@ -28,9 +28,8 @@ class QueryListsOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<QueryListsInput, QueryListsInput, _i1.Unit, _i1.Unit>>
-      protocols = [
+      _i1.HttpProtocol<QueryListsInput, QueryListsInput, _i1.Unit,
+          _i1.Unit>> protocols = [
     _i2.AwsQueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
@@ -13,9 +13,12 @@ import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
 /// The example tests how requests serialize different timestamp formats in the URI path.
-class HttpRequestWithLabelsAndTimestampFormatOperation extends _i1
-    .HttpOperation<HttpRequestWithLabelsAndTimestampFormatInputPayload,
-        HttpRequestWithLabelsAndTimestampFormatInput, _i1.Unit, _i1.Unit> {
+class HttpRequestWithLabelsAndTimestampFormatOperation
+    extends _i1.HttpOperation<
+        HttpRequestWithLabelsAndTimestampFormatInputPayload,
+        HttpRequestWithLabelsAndTimestampFormatInput,
+        _i1.Unit,
+        _i1.Unit> {
   /// The example tests how requests serialize different timestamp formats in the URI path.
   HttpRequestWithLabelsAndTimestampFormatOperation({
     required String region,

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/operation/http_string_payload_operation.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/operation/http_string_payload_operation.dart
@@ -26,9 +26,8 @@ class HttpStringPayloadOperation extends _i1
 
   @override
   late final List<
-          _i1
-          .HttpProtocol<String, StringPayloadInput, String, StringPayloadInput>>
-      protocols = [
+      _i1.HttpProtocol<String, StringPayloadInput, String,
+          StringPayloadInput>> protocols = [
     _i2.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/operation/malformed_content_type_without_body_empty_input_operation.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/operation/malformed_content_type_without_body_empty_input_operation.dart
@@ -12,9 +12,12 @@ import 'package:rest_json1_v2/src/rest_json_protocol/model/malformed_content_typ
 import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
-class MalformedContentTypeWithoutBodyEmptyInputOperation extends _i1
-    .HttpOperation<MalformedContentTypeWithoutBodyEmptyInputInputPayload,
-        MalformedContentTypeWithoutBodyEmptyInputInput, _i1.Unit, _i1.Unit> {
+class MalformedContentTypeWithoutBodyEmptyInputOperation
+    extends _i1.HttpOperation<
+        MalformedContentTypeWithoutBodyEmptyInputInputPayload,
+        MalformedContentTypeWithoutBodyEmptyInputInput,
+        _i1.Unit,
+        _i1.Unit> {
   MalformedContentTypeWithoutBodyEmptyInputOperation({
     required String region,
     Uri? baseUri,

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/rest_json_protocol_server.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/rest_json_protocol_server.dart
@@ -1051,7 +1051,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-      .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
+          .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
       _endpointWithHostLabelOperationProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1087,9 +1087,8 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1
-      .HttpProtocol<StringEnum, EnumPayloadInput, StringEnum, EnumPayloadInput>
-      _httpEnumPayloadProtocol = _i2.RestJson1Protocol(
+  late final _i1.HttpProtocol<StringEnum, EnumPayloadInput, StringEnum,
+      EnumPayloadInput> _httpEnumPayloadProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );
@@ -1193,7 +1192,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-      .HttpProtocol<String, StringPayloadInput, String, StringPayloadInput>
+          .HttpProtocol<String, StringPayloadInput, String, StringPayloadInput>
       _httpStringPayloadProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1281,7 +1280,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-      .HttpProtocol<_i1.Unit, _i1.Unit, GreetingStruct, GreetingStruct>
+          .HttpProtocol<_i1.Unit, _i1.Unit, GreetingStruct, GreetingStruct>
       _malformedAcceptWithBodyProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1301,9 +1300,8 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1
-      .HttpProtocol<MalformedBlobInput, MalformedBlobInput, _i1.Unit, _i1.Unit>
-      _malformedBlobProtocol = _i2.RestJson1Protocol(
+  late final _i1.HttpProtocol<MalformedBlobInput, MalformedBlobInput, _i1.Unit,
+      _i1.Unit> _malformedBlobProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );
@@ -1324,7 +1322,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-      .HttpProtocol<GreetingStruct, GreetingStruct, _i1.Unit, _i1.Unit>
+          .HttpProtocol<GreetingStruct, GreetingStruct, _i1.Unit, _i1.Unit>
       _malformedContentTypeWithBodyProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1382,9 +1380,8 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1
-      .HttpProtocol<MalformedListInput, MalformedListInput, _i1.Unit, _i1.Unit>
-      _malformedListProtocol = _i2.RestJson1Protocol(
+  late final _i1.HttpProtocol<MalformedListInput, MalformedListInput, _i1.Unit,
+      _i1.Unit> _malformedListProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );
@@ -1395,9 +1392,8 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1
-      .HttpProtocol<MalformedMapInput, MalformedMapInput, _i1.Unit, _i1.Unit>
-      _malformedMapProtocol = _i2.RestJson1Protocol(
+  late final _i1.HttpProtocol<MalformedMapInput, MalformedMapInput, _i1.Unit,
+      _i1.Unit> _malformedMapProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/rest_json_validation_protocol_server.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/rest_json_validation_protocol_server.dart
@@ -156,9 +156,8 @@ class _RestJsonValidationProtocolServer
   @override
   final RestJsonValidationProtocolServerBase service;
 
-  late final _i1
-      .HttpProtocol<MalformedEnumInput, MalformedEnumInput, _i1.Unit, _i1.Unit>
-      _malformedEnumProtocol = _i2.RestJson1Protocol(
+  late final _i1.HttpProtocol<MalformedEnumInput, MalformedEnumInput, _i1.Unit,
+      _i1.Unit> _malformedEnumProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );

--- a/packages/smithy/goldens/lib2/restJson1/test/rest_json_protocol/http_request_with_labels_and_timestamp_format_operation_test.dart
+++ b/packages/smithy/goldens/lib2/restJson1/test/rest_json_protocol/http_request_with_labels_and_timestamp_format_operation_test.dart
@@ -64,8 +64,8 @@ void main() {
 }
 
 class HttpRequestWithLabelsAndTimestampFormatInputRestJson1Serializer
-    extends _i3
-    .StructuredSmithySerializer<HttpRequestWithLabelsAndTimestampFormatInput> {
+    extends _i3.StructuredSmithySerializer<
+        HttpRequestWithLabelsAndTimestampFormatInput> {
   const HttpRequestWithLabelsAndTimestampFormatInputRestJson1Serializer()
       : super('HttpRequestWithLabelsAndTimestampFormatInput');
 

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/http_request_with_labels_and_timestamp_format_input.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/http_request_with_labels_and_timestamp_format_input.dart
@@ -220,8 +220,8 @@ abstract class HttpRequestWithLabelsAndTimestampFormatInputPayload
   }
 }
 
-class HttpRequestWithLabelsAndTimestampFormatInputRestXmlSerializer extends _i1
-    .StructuredSmithySerializer<
+class HttpRequestWithLabelsAndTimestampFormatInputRestXmlSerializer
+    extends _i1.StructuredSmithySerializer<
         HttpRequestWithLabelsAndTimestampFormatInputPayload> {
   const HttpRequestWithLabelsAndTimestampFormatInputRestXmlSerializer()
       : super('HttpRequestWithLabelsAndTimestampFormatInput');

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
@@ -13,9 +13,12 @@ import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
 /// The example tests how requests serialize different timestamp formats in the URI path.
-class HttpRequestWithLabelsAndTimestampFormatOperation extends _i1
-    .HttpOperation<HttpRequestWithLabelsAndTimestampFormatInputPayload,
-        HttpRequestWithLabelsAndTimestampFormatInput, _i1.Unit, _i1.Unit> {
+class HttpRequestWithLabelsAndTimestampFormatOperation
+    extends _i1.HttpOperation<
+        HttpRequestWithLabelsAndTimestampFormatInputPayload,
+        HttpRequestWithLabelsAndTimestampFormatInput,
+        _i1.Unit,
+        _i1.Unit> {
   /// The example tests how requests serialize different timestamp formats in the URI path.
   HttpRequestWithLabelsAndTimestampFormatOperation({
     required String region,

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/rest_xml_protocol_server.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/rest_xml_protocol_server.dart
@@ -686,7 +686,7 @@ class _RestXmlProtocolServer extends _i1.HttpServer<RestXmlProtocolServerBase> {
   );
 
   late final _i1
-      .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
+          .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
       _endpointWithHostLabelOperationProtocol = _i2.RestXmlProtocol(
     serializers: serializers,
     builderFactories: builderFactories,


### PR DESCRIPTION
This was set to `beta` initially because our docs package tool required a version of Dart which had not been rolled into Flutter yet.

Runs `dart format` throughout the repo as some files had been formatted to Flutter beta standards.
