### PR TITLE
chore(aft): Better handling of pre-release Dart SDK usage

### DIFF
--- a/packages/aft/lib/src/commands/amplify_command.dart
+++ b/packages/aft/lib/src/commands/amplify_command.dart
@@ -190,7 +190,9 @@ abstract class AmplifyCommand extends Command<void>
     if (globalResults?['verbose'] as bool? ?? false) {
       AWSLogger().logLevel = LogLevel.verbose;
     }
-    logger.verbose('Got configuration: $aftConfig');
+    logger
+      ..info('Found Dart SDK: $activeDartSdkVersion')
+      ..verbose('Got configuration: $aftConfig');
     repo = await Repo.open(aftConfig, logger: logger);
   }
 

--- a/packages/aft/test/common.dart
+++ b/packages/aft/test/common.dart
@@ -1,0 +1,70 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:aft/aft.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/yaml_edit.dart';
+
+/// Creates a dummy package for testing repo operations.
+MapEntry<PackageInfo, List<PackageInfo>> dummyPackage(
+  String name, {
+  Version? version,
+  bool publishable = true,
+  VersionConstraint? sdkConstraint,
+  Map<PackageInfo, VersionConstraint> deps = const {},
+  Map<PackageInfo, VersionConstraint> devDeps = const {},
+}) {
+  final path = 'packages/$name';
+  sdkConstraint ??= VersionConstraint.compatibleWith(Version(3, 0, 0));
+
+  final pubspecEditor = YamlEditor('''
+name: $name
+
+environment:
+  sdk: $sdkConstraint
+
+dependencies: {}
+
+dev_dependencies: {}
+''');
+
+  if (version != null) {
+    pubspecEditor.update(['version'], version.toString());
+  }
+
+  void addConstraints(
+    Map<PackageInfo, VersionConstraint> constraints,
+    DependencyType type,
+  ) {
+    for (final MapEntry(key: dep, value: constraint) in constraints.entries) {
+      final path = <String>[type.key, dep.name];
+      pubspecEditor.update(path, constraint.toString());
+    }
+  }
+
+  addConstraints(deps, DependencyType.dependency);
+  addConstraints(devDeps, DependencyType.devDependency);
+
+  if (!publishable) {
+    pubspecEditor.update(['publish_to'], 'none');
+  }
+
+  final pubspecYaml = pubspecEditor.toString();
+  final pubspec = Pubspec.parse(pubspecYaml);
+  final pubspecMap = loadYamlNode(pubspecYaml) as YamlMap;
+
+  final package = PackageInfo(
+    name: name,
+    path: path,
+    pubspecInfo: PubspecInfo(
+      pubspec: pubspec,
+      pubspecYaml: pubspecYaml,
+      pubspecMap: pubspecMap,
+      uri: Uri.base.resolve(path),
+    ),
+    flavor: PackageFlavor.dart,
+  );
+  return MapEntry(package, [...deps.keys, ...devDeps.keys]);
+}

--- a/packages/aft/test/model_test.dart
+++ b/packages/aft/test/model_test.dart
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:io';
+
 import 'package:aft/src/models.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
+
+import 'common.dart';
 
 void main() {
   group('AmplifyVersion', () {
@@ -108,6 +112,29 @@ void main() {
       final breaking = version.nextAmplifyVersion(VersionBumpType.breaking);
       expect(breaking, Version(2, 0, 0));
       expect(proagation.propagateToComponent(version, breaking), true);
+    });
+  });
+
+  group('PackageInfo', () {
+    test('compatibleWithActiveSdk', () {
+      final currentDartVersion = Version.parse(
+        Platform.version.split(RegExp(r'\s+')).first,
+      );
+      final stablePackage = dummyPackage('stable_pkg');
+      final previewPackage = dummyPackage(
+        'preview_pkg',
+        sdkConstraint: VersionConstraint.compatibleWith(
+          Version(3, 2, 0, pre: '0'),
+        ),
+      );
+      expect(
+        stablePackage.key.compatibleWithActiveSdk,
+        isTrue,
+      );
+      expect(
+        previewPackage.key.compatibleWithActiveSdk,
+        currentDartVersion.isPreRelease,
+      );
     });
   });
 }


### PR DESCRIPTION
Some packages in the repo (for example, the `actions` pkg) set a pre-release Dart SDK constraint so that preview features of Dart can be leveraged. This updates `aft` so that:
1. `bootstrap` skips packages which set this constraint if the current Dart SDK doesn't support it.
2.  The constraints checker ignores preview constraints since these packages do not need to conform to the global setting.