### PR TITLE
chore(repo): Dart 3.1 format fixes

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/platform/macos_bindings.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/platform/macos_bindings.g.dart
@@ -13578,7 +13578,8 @@ class ObjCBlock3 extends _ObjCBlockBase {
   ObjCBlock3.fromFunctionPointer(
       NativeMacOsFramework lib,
       ffi.Pointer<
-              ffi.NativeFunction<
+              ffi
+              .NativeFunction<
                   ffi.Void Function(ffi.Pointer<ObjCObject> arg0,
                       ffi.UnsignedLong arg1, ffi.Pointer<ffi.Bool> arg2)>>
           ptr)
@@ -17234,8 +17235,8 @@ class ObjCBlock16 extends _ObjCBlockBase {
   void call() {
     return _id.ref.invoke
         .cast<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<_ObjCBlock> block)>>()
+            ffi
+            .NativeFunction<ffi.Void Function(ffi.Pointer<_ObjCBlock> block)>>()
         .asFunction<void Function(ffi.Pointer<_ObjCBlock> block)>()(_id);
   }
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity/operation/get_id_operation.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity/operation/get_id_operation.dart
@@ -45,8 +45,9 @@ class GetIdOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<GetIdInput, GetIdInput, GetIdResponse,
-          GetIdResponse>> protocols = [
+          _i1
+          .HttpProtocol<GetIdInput, GetIdInput, GetIdResponse, GetIdResponse>>
+      protocols = [
     _i3.AwsJson1_1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_account_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_account_operation.dart
@@ -37,8 +37,9 @@ class GetAccountOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<GetAccountRequest, GetAccountRequest, Account,
-          Account>> protocols = [
+          _i1
+          .HttpProtocol<GetAccountRequest, GetAccountRequest, Account, Account>>
+      protocols = [
     _i3.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_model_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_model_operation.dart
@@ -37,8 +37,9 @@ class GetModelOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<GetModelRequestPayload, GetModelRequest, Model,
-          Model>> protocols = [
+          _i1
+          .HttpProtocol<GetModelRequestPayload, GetModelRequest, Model, Model>>
+      protocols = [
     _i3.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_stage_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_stage_operation.dart
@@ -39,8 +39,9 @@ class GetStageOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<GetStageRequestPayload, GetStageRequest, Stage,
-          Stage>> protocols = [
+          _i1
+          .HttpProtocol<GetStageRequestPayload, GetStageRequest, Stage, Stage>>
+      protocols = [
     _i3.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_usage_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/get_usage_operation.dart
@@ -45,8 +45,9 @@ class GetUsageOperation extends _i1.PaginatedHttpOperation<
 
   @override
   late final List<
-      _i1.HttpProtocol<GetUsageRequestPayload, GetUsageRequest, Usage,
-          Usage>> protocols = [
+          _i1
+          .HttpProtocol<GetUsageRequestPayload, GetUsageRequest, Usage, Usage>>
+      protocols = [
     _i5.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/import_rest_api_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/api_gateway/operation/import_rest_api_operation.dart
@@ -40,8 +40,9 @@ class ImportRestApiOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<_i2.Uint8List, ImportRestApiRequest, RestApi,
-          RestApi>> protocols = [
+          _i1
+          .HttpProtocol<_i2.Uint8List, ImportRestApiRequest, RestApi, RestApi>>
+      protocols = [
     _i4.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/cloud_formation_client.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/cloud_formation_client.dart
@@ -1222,8 +1222,9 @@ class CloudFormationClient {
   ///
   /// For deleted stacks, ListStackResources returns resource information for up to 90 days after the stack has been deleted.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<StackResourceSummary>, void,
-          String>> listStackResources(
+          _i3
+          .PaginatedResult<_i4.BuiltList<StackResourceSummary>, void, String>>
+      listStackResources(
     ListStackResourcesInput input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/operation/delete_stack_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/cloud_formation/operation/delete_stack_operation.dart
@@ -33,8 +33,9 @@ class DeleteStackOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<DeleteStackInput, DeleteStackInput, _i1.Unit,
-          _i1.Unit>> protocols = [
+          _i1
+          .HttpProtocol<DeleteStackInput, DeleteStackInput, _i1.Unit, _i1.Unit>>
+      protocols = [
     _i3.AwsQueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/config_client.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/config_client.dart
@@ -738,8 +738,9 @@ class ConfigClient {
   ///
   /// *   The rule's Lambda function has returned `NOT_APPLICABLE` for all evaluation results. This can occur if the resources were deleted or removed from the rule's scope.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<ComplianceByConfigRule>, void,
-          String>> describeComplianceByConfigRule(
+          _i3
+          .PaginatedResult<_i4.BuiltList<ComplianceByConfigRule>, void, String>>
+      describeComplianceByConfigRule(
     DescribeComplianceByConfigRuleRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -828,8 +829,9 @@ class ConfigClient {
 
   /// Returns status information for sources within an aggregator. The status includes information about the last time Config verified authorization between the source account and an aggregator account. In case of a failure, the status contains the related error code or message.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<AggregatedSourceStatus>, int,
-          String>> describeConfigurationAggregatorSourcesStatus(
+          _i3
+          .PaginatedResult<_i4.BuiltList<AggregatedSourceStatus>, int, String>>
+      describeConfigurationAggregatorSourcesStatus(
     DescribeConfigurationAggregatorSourcesStatusRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -848,8 +850,9 @@ class ConfigClient {
 
   /// Returns the details of one or more configuration aggregators. If the configuration aggregator is not specified, this action returns the details for all the configuration aggregators associated with the account.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<ConfigurationAggregator>, int,
-          String>> describeConfigurationAggregators(
+          _i3
+          .PaginatedResult<_i4.BuiltList<ConfigurationAggregator>, int, String>>
+      describeConfigurationAggregators(
     DescribeConfigurationAggregatorsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -954,8 +957,9 @@ class ConfigClient {
 
   /// Returns a list of one or more conformance packs.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<ConformancePackDetail>, int,
-          String>> describeConformancePacks(
+          _i3
+          .PaginatedResult<_i4.BuiltList<ConformancePackDetail>, int, String>>
+      describeConformancePacks(
     DescribeConformancePacksRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -1048,8 +1052,9 @@ class ConfigClient {
   ///
   /// If you deploy an organizational rule or conformance pack in an organization administrator account, and then establish a delegated administrator and deploy an organizational rule or conformance pack in the delegated administrator account, you won't be able to see the organizational rule or conformance pack in the organization administrator account from the delegated administrator account or see the organizational rule or conformance pack in the delegated administrator account from organization administrator account. The `DescribeOrganizationConfigRules` and `DescribeOrganizationConformancePacks` APIs can only see and interact with the organization-related resource that were deployed from within the account calling those APIs.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<OrganizationConfigRule>, int,
-          String>> describeOrganizationConfigRules(
+          _i3
+          .PaginatedResult<_i4.BuiltList<OrganizationConfigRule>, int, String>>
+      describeOrganizationConfigRules(
     DescribeOrganizationConfigRulesRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -1165,8 +1170,9 @@ class ConfigClient {
   ///
   /// Limit and next token are not applicable if you request resources in batch. It is only applicable, when you request all resources.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<DescribeRemediationExceptionsResponse, int,
-          String>> describeRemediationExceptions(
+          _i3
+          .PaginatedResult<DescribeRemediationExceptionsResponse, int, String>>
+      describeRemediationExceptions(
     DescribeRemediationExceptionsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -1207,8 +1213,9 @@ class ConfigClient {
   ///
   /// Currently, Config supports only one retention configuration per region in your account.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<RetentionConfiguration>, void,
-          String>> describeRetentionConfigurations(
+          _i3
+          .PaginatedResult<_i4.BuiltList<RetentionConfiguration>, void, String>>
+      describeRetentionConfigurations(
     DescribeRetentionConfigurationsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/aggregate_conformance_pack_compliance_summary_filters.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/aggregate_conformance_pack_compliance_summary_filters.dart
@@ -36,8 +36,9 @@ abstract class AggregateConformancePackComplianceSummaryFilters
   const AggregateConformancePackComplianceSummaryFilters._();
 
   static const List<
-      _i2.SmithySerializer<
-          AggregateConformancePackComplianceSummaryFilters>> serializers = [
+          _i2
+          .SmithySerializer<AggregateConformancePackComplianceSummaryFilters>>
+      serializers = [
     AggregateConformancePackComplianceSummaryFiltersAwsJson11Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/aggregate_conformance_pack_compliance_summary_group_key.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/aggregate_conformance_pack_compliance_summary_group_key.dart
@@ -36,8 +36,9 @@ class AggregateConformancePackComplianceSummaryGroupKey
   ];
 
   static const List<
-      _i1.SmithySerializer<
-          AggregateConformancePackComplianceSummaryGroupKey>> serializers = [
+          _i1
+          .SmithySerializer<AggregateConformancePackComplianceSummaryGroupKey>>
+      serializers = [
     _i1.SmithyEnumSerializer(
       'AggregateConformancePackComplianceSummaryGroupKey',
       values: values,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_aggregate_compliance_by_config_rules_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_aggregate_compliance_by_config_rules_response.dart
@@ -44,8 +44,9 @@ abstract class DescribeAggregateComplianceByConfigRulesResponse
       payload;
 
   static const List<
-      _i3.SmithySerializer<
-          DescribeAggregateComplianceByConfigRulesResponse>> serializers = [
+          _i3
+          .SmithySerializer<DescribeAggregateComplianceByConfigRulesResponse>>
+      serializers = [
     DescribeAggregateComplianceByConfigRulesResponseAwsJson11Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_organization_config_rule_statuses_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_organization_config_rule_statuses_request.dart
@@ -94,8 +94,8 @@ abstract class DescribeOrganizationConfigRuleStatusesRequest
 }
 
 class DescribeOrganizationConfigRuleStatusesRequestAwsJson11Serializer
-    extends _i1.StructuredSmithySerializer<
-        DescribeOrganizationConfigRuleStatusesRequest> {
+    extends _i1
+    .StructuredSmithySerializer<DescribeOrganizationConfigRuleStatusesRequest> {
   const DescribeOrganizationConfigRuleStatusesRequestAwsJson11Serializer()
       : super('DescribeOrganizationConfigRuleStatusesRequest');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_organization_conformance_pack_statuses_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_organization_conformance_pack_statuses_request.dart
@@ -47,8 +47,9 @@ abstract class DescribeOrganizationConformancePackStatusesRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          DescribeOrganizationConformancePackStatusesRequest>> serializers = [
+          _i1
+          .SmithySerializer<DescribeOrganizationConformancePackStatusesRequest>>
+      serializers = [
     DescribeOrganizationConformancePackStatusesRequestAwsJson11Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_organization_conformance_packs_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/describe_organization_conformance_packs_response.dart
@@ -76,8 +76,8 @@ abstract class DescribeOrganizationConformancePacksResponse
 }
 
 class DescribeOrganizationConformancePacksResponseAwsJson11Serializer
-    extends _i3.StructuredSmithySerializer<
-        DescribeOrganizationConformancePacksResponse> {
+    extends _i3
+    .StructuredSmithySerializer<DescribeOrganizationConformancePacksResponse> {
   const DescribeOrganizationConformancePacksResponseAwsJson11Serializer()
       : super('DescribeOrganizationConformancePacksResponse');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/get_aggregate_compliance_details_by_config_rule_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/get_aggregate_compliance_details_by_config_rule_request.dart
@@ -53,8 +53,9 @@ abstract class GetAggregateComplianceDetailsByConfigRuleRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          GetAggregateComplianceDetailsByConfigRuleRequest>> serializers = [
+          _i1
+          .SmithySerializer<GetAggregateComplianceDetailsByConfigRuleRequest>>
+      serializers = [
     GetAggregateComplianceDetailsByConfigRuleRequestAwsJson11Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/get_aggregate_compliance_details_by_config_rule_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/get_aggregate_compliance_details_by_config_rule_response.dart
@@ -44,8 +44,9 @@ abstract class GetAggregateComplianceDetailsByConfigRuleResponse
       payload;
 
   static const List<
-      _i3.SmithySerializer<
-          GetAggregateComplianceDetailsByConfigRuleResponse>> serializers = [
+          _i3
+          .SmithySerializer<GetAggregateComplianceDetailsByConfigRuleResponse>>
+      serializers = [
     GetAggregateComplianceDetailsByConfigRuleResponseAwsJson11Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/get_aggregate_discovered_resource_counts_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/get_aggregate_discovered_resource_counts_response.dart
@@ -103,8 +103,8 @@ abstract class GetAggregateDiscoveredResourceCountsResponse
 }
 
 class GetAggregateDiscoveredResourceCountsResponseAwsJson11Serializer
-    extends _i4.StructuredSmithySerializer<
-        GetAggregateDiscoveredResourceCountsResponse> {
+    extends _i4
+    .StructuredSmithySerializer<GetAggregateDiscoveredResourceCountsResponse> {
   const GetAggregateDiscoveredResourceCountsResponseAwsJson11Serializer()
       : super('GetAggregateDiscoveredResourceCountsResponse');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_configuration_recorders_exceeded_exception.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_configuration_recorders_exceeded_exception.dart
@@ -43,8 +43,9 @@ abstract class MaxNumberOfConfigurationRecordersExceededException
       });
 
   static const List<
-      _i2.SmithySerializer<
-          MaxNumberOfConfigurationRecordersExceededException>> serializers = [
+          _i2
+          .SmithySerializer<MaxNumberOfConfigurationRecordersExceededException>>
+      serializers = [
     MaxNumberOfConfigurationRecordersExceededExceptionAwsJson11Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_conformance_packs_exceeded_exception.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_conformance_packs_exceeded_exception.dart
@@ -79,8 +79,8 @@ abstract class MaxNumberOfConformancePacksExceededException
 }
 
 class MaxNumberOfConformancePacksExceededExceptionAwsJson11Serializer
-    extends _i2.StructuredSmithySerializer<
-        MaxNumberOfConformancePacksExceededException> {
+    extends _i2
+    .StructuredSmithySerializer<MaxNumberOfConformancePacksExceededException> {
   const MaxNumberOfConformancePacksExceededExceptionAwsJson11Serializer()
       : super('MaxNumberOfConformancePacksExceededException');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_delivery_channels_exceeded_exception.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_delivery_channels_exceeded_exception.dart
@@ -79,8 +79,8 @@ abstract class MaxNumberOfDeliveryChannelsExceededException
 }
 
 class MaxNumberOfDeliveryChannelsExceededExceptionAwsJson11Serializer
-    extends _i2.StructuredSmithySerializer<
-        MaxNumberOfDeliveryChannelsExceededException> {
+    extends _i2
+    .StructuredSmithySerializer<MaxNumberOfDeliveryChannelsExceededException> {
   const MaxNumberOfDeliveryChannelsExceededExceptionAwsJson11Serializer()
       : super('MaxNumberOfDeliveryChannelsExceededException');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_organization_conformance_packs_exceeded_exception.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/max_number_of_organization_conformance_packs_exceeded_exception.dart
@@ -13,8 +13,8 @@ part 'max_number_of_organization_conformance_packs_exceeded_exception.g.dart';
 /// You have reached the limit of the number of organization conformance packs you can create in an account. For more information, see [**Service Limits**](https://docs.aws.amazon.com/config/latest/developerguide/configlimits.html) in the _Config Developer Guide_.
 abstract class MaxNumberOfOrganizationConformancePacksExceededException
     with
-        _i1.AWSEquatable<
-            MaxNumberOfOrganizationConformancePacksExceededException>
+        _i1
+        .AWSEquatable<MaxNumberOfOrganizationConformancePacksExceededException>
     implements
         Built<MaxNumberOfOrganizationConformancePacksExceededException,
             MaxNumberOfOrganizationConformancePacksExceededExceptionBuilder>,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/organization_custom_policy_rule_metadata_no_policy.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/model/organization_custom_policy_rule_metadata_no_policy.dart
@@ -163,8 +163,8 @@ abstract class OrganizationCustomPolicyRuleMetadataNoPolicy
 }
 
 class OrganizationCustomPolicyRuleMetadataNoPolicyAwsJson11Serializer
-    extends _i3.StructuredSmithySerializer<
-        OrganizationCustomPolicyRuleMetadataNoPolicy> {
+    extends _i3
+    .StructuredSmithySerializer<OrganizationCustomPolicyRuleMetadataNoPolicy> {
   const OrganizationCustomPolicyRuleMetadataNoPolicyAwsJson11Serializer()
       : super('OrganizationCustomPolicyRuleMetadataNoPolicy');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_aggregate_compliance_by_config_rules_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_aggregate_compliance_by_config_rules_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Returns a list of compliant and noncompliant rules with the number of resources for compliant and noncompliant rules. Does not display rules that do not have compliance results.
 ///
 /// The results can return an empty result page, but if you have a `nextToken`, the results are displayed on the next page.
-class DescribeAggregateComplianceByConfigRulesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeAggregateComplianceByConfigRulesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeAggregateComplianceByConfigRulesRequest,
         DescribeAggregateComplianceByConfigRulesRequest,
         DescribeAggregateComplianceByConfigRulesResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_aggregate_compliance_by_conformance_packs_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_aggregate_compliance_by_conformance_packs_operation.dart
@@ -23,8 +23,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Returns a list of the conformance packs and their associated compliance status with the count of compliant and noncompliant Config rules within each conformance pack. Also returns the total rule count which includes compliant rules, noncompliant rules, and rules that cannot be evaluated due to insufficient data.
 ///
 /// The results can return an empty result page, but if you have a `nextToken`, the results are displayed on the next page.
-class DescribeAggregateComplianceByConformancePacksOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeAggregateComplianceByConformancePacksOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeAggregateComplianceByConformancePacksRequest,
         DescribeAggregateComplianceByConformancePacksRequest,
         DescribeAggregateComplianceByConformancePacksResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_aggregation_authorizations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_aggregation_authorizations_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_next_token_e
 import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_value_exception.dart';
 
 /// Returns a list of authorizations granted to various aggregator accounts and regions.
-class DescribeAggregationAuthorizationsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeAggregationAuthorizationsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeAggregationAuthorizationsRequest,
         DescribeAggregationAuthorizationsRequest,
         DescribeAggregationAuthorizationsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_compliance_by_config_rule_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_compliance_by_config_rule_operation.dart
@@ -30,8 +30,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/no_such_config_rule_
 /// *   The rule's Lambda function is failing to send evaluation results to Config. Verify that the role you assigned to your configuration recorder includes the `config:PutEvaluations` permission. If the rule is a custom rule, verify that the Lambda execution role includes the `config:PutEvaluations` permission.
 ///
 /// *   The rule's Lambda function has returned `NOT_APPLICABLE` for all evaluation results. This can occur if the resources were deleted or removed from the rule's scope.
-class DescribeComplianceByConfigRuleOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeComplianceByConfigRuleOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeComplianceByConfigRuleRequest,
         DescribeComplianceByConfigRuleRequest,
         DescribeComplianceByConfigRuleResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_config_rule_evaluation_status_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_config_rule_evaluation_status_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_va
 import 'package:smoke_test/src/sdk/src/config_service/model/no_such_config_rule_exception.dart';
 
 /// Returns status information for each of your Config managed rules. The status includes information such as the last time Config invoked the rule, the last time Config failed to invoke the rule, and the related error for the last failure.
-class DescribeConfigRuleEvaluationStatusOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeConfigRuleEvaluationStatusOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeConfigRuleEvaluationStatusRequest,
         DescribeConfigRuleEvaluationStatusRequest,
         DescribeConfigRuleEvaluationStatusResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_configuration_aggregator_sources_status_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_configuration_aggregator_sources_status_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_va
 import 'package:smoke_test/src/sdk/src/config_service/model/no_such_configuration_aggregator_exception.dart';
 
 /// Returns status information for sources within an aggregator. The status includes information about the last time Config verified authorization between the source account and an aggregator account. In case of a failure, the status contains the related error code or message.
-class DescribeConfigurationAggregatorSourcesStatusOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeConfigurationAggregatorSourcesStatusOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeConfigurationAggregatorSourcesStatusRequest,
         DescribeConfigurationAggregatorSourcesStatusRequest,
         DescribeConfigurationAggregatorSourcesStatusResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_configuration_aggregators_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_configuration_aggregators_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_va
 import 'package:smoke_test/src/sdk/src/config_service/model/no_such_configuration_aggregator_exception.dart';
 
 /// Returns the details of one or more configuration aggregators. If the configuration aggregator is not specified, this action returns the details for all the configuration aggregators associated with the account.
-class DescribeConfigurationAggregatorsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeConfigurationAggregatorsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeConfigurationAggregatorsRequest,
         DescribeConfigurationAggregatorsRequest,
         DescribeConfigurationAggregatorsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_conformance_pack_compliance_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_conformance_pack_compliance_operation.dart
@@ -22,8 +22,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/no_such_conformance_
 /// Returns compliance details for each rule in that conformance pack.
 ///
 /// You must provide exact rule names.
-class DescribeConformancePackComplianceOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeConformancePackComplianceOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeConformancePackComplianceRequest,
         DescribeConformancePackComplianceRequest,
         DescribeConformancePackComplianceResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_config_rule_statuses_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_config_rule_statuses_operation.dart
@@ -25,8 +25,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/organization_config_
 /// The status is not considered successful until organization Config rule is successfully deployed in all the member accounts with an exception of excluded accounts.
 ///
 /// When you specify the limit and the next token, you receive a paginated response. Limit and next token are not applicable if you specify organization Config rule names. It is only applicable, when you request all the organization Config rules.
-class DescribeOrganizationConfigRuleStatusesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeOrganizationConfigRuleStatusesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeOrganizationConfigRuleStatusesRequest,
         DescribeOrganizationConfigRuleStatusesRequest,
         DescribeOrganizationConfigRuleStatusesResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_config_rules_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_config_rules_operation.dart
@@ -29,8 +29,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/organization_config_
 /// _For accounts within an organzation_
 ///
 /// If you deploy an organizational rule or conformance pack in an organization administrator account, and then establish a delegated administrator and deploy an organizational rule or conformance pack in the delegated administrator account, you won't be able to see the organizational rule or conformance pack in the organization administrator account from the delegated administrator account or see the organizational rule or conformance pack in the delegated administrator account from organization administrator account. The `DescribeOrganizationConfigRules` and `DescribeOrganizationConformancePacks` APIs can only see and interact with the organization-related resource that were deployed from within the account calling those APIs.
-class DescribeOrganizationConfigRulesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeOrganizationConfigRulesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeOrganizationConfigRulesRequest,
         DescribeOrganizationConfigRulesRequest,
         DescribeOrganizationConfigRulesResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_conformance_pack_statuses_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_conformance_pack_statuses_operation.dart
@@ -25,8 +25,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/organization_conform
 /// The status is not considered successful until organization conformance pack is successfully deployed in all the member accounts with an exception of excluded accounts.
 ///
 /// When you specify the limit and the next token, you receive a paginated response. Limit and next token are not applicable if you specify organization conformance pack names. They are only applicable, when you request all the organization conformance packs.
-class DescribeOrganizationConformancePackStatusesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeOrganizationConformancePackStatusesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeOrganizationConformancePackStatusesRequest,
         DescribeOrganizationConformancePackStatusesRequest,
         DescribeOrganizationConformancePackStatusesResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_conformance_packs_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_organization_conformance_packs_operation.dart
@@ -29,8 +29,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/organization_conform
 /// _For accounts within an organzation_
 ///
 /// If you deploy an organizational rule or conformance pack in an organization administrator account, and then establish a delegated administrator and deploy an organizational rule or conformance pack in the delegated administrator account, you won't be able to see the organizational rule or conformance pack in the organization administrator account from the delegated administrator account or see the organizational rule or conformance pack in the delegated administrator account from organization administrator account. The `DescribeOrganizationConfigRules` and `DescribeOrganizationConformancePacks` APIs can only see and interact with the organization-related resource that were deployed from within the account calling those APIs.
-class DescribeOrganizationConformancePacksOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeOrganizationConformancePacksOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeOrganizationConformancePacksRequest,
         DescribeOrganizationConformancePacksRequest,
         DescribeOrganizationConformancePacksResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_pending_aggregation_requests_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_pending_aggregation_requests_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_va
 import 'package:smoke_test/src/sdk/src/config_service/model/pending_aggregation_request.dart';
 
 /// Returns a list of all pending aggregation requests.
-class DescribePendingAggregationRequestsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribePendingAggregationRequestsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribePendingAggregationRequestsRequest,
         DescribePendingAggregationRequestsRequest,
         DescribePendingAggregationRequestsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_remediation_execution_status_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_remediation_execution_status_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/no_such_remediation_
 import 'package:smoke_test/src/sdk/src/config_service/model/remediation_execution_status.dart';
 
 /// Provides a detailed view of a Remediation Execution for a set of resources including state, timestamps for when steps for the remediation execution occur, and any error messages for steps that have failed. When you specify the limit and the next token, you receive a paginated response.
-class DescribeRemediationExecutionStatusOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeRemediationExecutionStatusOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeRemediationExecutionStatusRequest,
         DescribeRemediationExecutionStatusRequest,
         DescribeRemediationExecutionStatusResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_retention_configurations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/describe_retention_configurations_operation.dart
@@ -22,8 +22,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/retention_configurat
 /// Returns the details of one or more retention configurations. If the retention configuration name is not specified, this action returns the details for all the retention configurations for that account.
 ///
 /// Currently, Config supports only one retention configuration per region in your account.
-class DescribeRetentionConfigurationsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeRetentionConfigurationsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeRetentionConfigurationsRequest,
         DescribeRetentionConfigurationsRequest,
         DescribeRetentionConfigurationsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_compliance_details_by_config_rule_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_compliance_details_by_config_rule_operation.dart
@@ -23,8 +23,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Returns the evaluation results for the specified Config rule for a specific resource in a rule. The results indicate which Amazon Web Services resources were evaluated by the rule, when each resource was last evaluated, and whether each resource complies with the rule.
 ///
 /// The results can return an empty result page. But if you have a `nextToken`, the results are displayed on the next page.
-class GetAggregateComplianceDetailsByConfigRuleOperation
-    extends _i1.PaginatedHttpOperation<
+class GetAggregateComplianceDetailsByConfigRuleOperation extends _i1
+    .PaginatedHttpOperation<
         GetAggregateComplianceDetailsByConfigRuleRequest,
         GetAggregateComplianceDetailsByConfigRuleRequest,
         GetAggregateComplianceDetailsByConfigRuleResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_config_rule_compliance_summary_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_config_rule_compliance_summary_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Returns the number of compliant and noncompliant rules for one or more accounts and regions in an aggregator.
 ///
 /// The results can return an empty result page, but if you have a nextToken, the results are displayed on the next page.
-class GetAggregateConfigRuleComplianceSummaryOperation
-    extends _i1.PaginatedHttpOperation<
+class GetAggregateConfigRuleComplianceSummaryOperation extends _i1
+    .PaginatedHttpOperation<
         GetAggregateConfigRuleComplianceSummaryRequest,
         GetAggregateConfigRuleComplianceSummaryRequest,
         GetAggregateConfigRuleComplianceSummaryResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_conformance_pack_compliance_summary_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_conformance_pack_compliance_summary_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Returns the count of compliant and noncompliant conformance packs across all Amazon Web Services accounts and Amazon Web Services Regions in an aggregator. You can filter based on Amazon Web Services account ID or Amazon Web Services Region.
 ///
 /// The results can return an empty result page, but if you have a nextToken, the results are displayed on the next page.
-class GetAggregateConformancePackComplianceSummaryOperation
-    extends _i1.PaginatedHttpOperation<
+class GetAggregateConformancePackComplianceSummaryOperation extends _i1
+    .PaginatedHttpOperation<
         GetAggregateConformancePackComplianceSummaryRequest,
         GetAggregateConformancePackComplianceSummaryRequest,
         GetAggregateConformancePackComplianceSummaryResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_discovered_resource_counts_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_aggregate_discovered_resource_counts_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Returns the resource counts across accounts and regions that are present in your Config aggregator. You can request the resource counts by providing filters and GroupByKey.
 ///
 /// For example, if the input contains accountID 12345678910 and region us-east-1 in filters, the API returns the count of resources in account ID 12345678910 and region us-east-1. If the input contains ACCOUNT_ID as a GroupByKey, the API returns resource counts for all source accounts that are present in your aggregator.
-class GetAggregateDiscoveredResourceCountsOperation
-    extends _i1.PaginatedHttpOperation<
+class GetAggregateDiscoveredResourceCountsOperation extends _i1
+    .PaginatedHttpOperation<
         GetAggregateDiscoveredResourceCountsRequest,
         GetAggregateDiscoveredResourceCountsRequest,
         GetAggregateDiscoveredResourceCountsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_compliance_details_by_config_rule_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_compliance_details_by_config_rule_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_va
 import 'package:smoke_test/src/sdk/src/config_service/model/no_such_config_rule_exception.dart';
 
 /// Returns the evaluation results for the specified Config rule. The results indicate which Amazon Web Services resources were evaluated by the rule, when each resource was last evaluated, and whether each resource complies with the rule.
-class GetComplianceDetailsByConfigRuleOperation
-    extends _i1.PaginatedHttpOperation<
+class GetComplianceDetailsByConfigRuleOperation extends _i1
+    .PaginatedHttpOperation<
         GetComplianceDetailsByConfigRuleRequest,
         GetComplianceDetailsByConfigRuleRequest,
         GetComplianceDetailsByConfigRuleResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_compliance_details_by_resource_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_compliance_details_by_resource_operation.dart
@@ -18,8 +18,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/get_compliance_detai
 import 'package:smoke_test/src/sdk/src/config_service/model/invalid_parameter_value_exception.dart';
 
 /// Returns the evaluation results for the specified Amazon Web Services resource. The results indicate which Config rules were used to evaluate the resource, when each rule was last invoked, and whether the resource complies with each rule.
-class GetComplianceDetailsByResourceOperation
-    extends _i1.PaginatedHttpOperation<
+class GetComplianceDetailsByResourceOperation extends _i1
+    .PaginatedHttpOperation<
         GetComplianceDetailsByResourceRequest,
         GetComplianceDetailsByResourceRequest,
         GetComplianceDetailsByResourceResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_conformance_pack_compliance_details_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_conformance_pack_compliance_details_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/no_such_config_rule_
 import 'package:smoke_test/src/sdk/src/config_service/model/no_such_conformance_pack_exception.dart';
 
 /// Returns compliance details of a conformance pack for all Amazon Web Services resources that are monitered by conformance pack.
-class GetConformancePackComplianceDetailsOperation
-    extends _i1.PaginatedHttpOperation<
+class GetConformancePackComplianceDetailsOperation extends _i1
+    .PaginatedHttpOperation<
         GetConformancePackComplianceDetailsRequest,
         GetConformancePackComplianceDetailsRequest,
         GetConformancePackComplianceDetailsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_conformance_pack_compliance_summary_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_conformance_pack_compliance_summary_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/invalid_next_token_e
 import 'package:smoke_test/src/sdk/src/config_service/model/no_such_conformance_pack_exception.dart';
 
 /// Returns compliance details for the conformance pack based on the cumulative compliance results of all the rules in that conformance pack.
-class GetConformancePackComplianceSummaryOperation
-    extends _i1.PaginatedHttpOperation<
+class GetConformancePackComplianceSummaryOperation extends _i1
+    .PaginatedHttpOperation<
         GetConformancePackComplianceSummaryRequest,
         GetConformancePackComplianceSummaryRequest,
         GetConformancePackComplianceSummaryResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_organization_config_rule_detailed_status_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_organization_config_rule_detailed_status_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/no_such_organization
 import 'package:smoke_test/src/sdk/src/config_service/model/organization_access_denied_exception.dart';
 
 /// Returns detailed status for each member account within an organization for a given organization Config rule.
-class GetOrganizationConfigRuleDetailedStatusOperation
-    extends _i1.PaginatedHttpOperation<
+class GetOrganizationConfigRuleDetailedStatusOperation extends _i1
+    .PaginatedHttpOperation<
         GetOrganizationConfigRuleDetailedStatusRequest,
         GetOrganizationConfigRuleDetailedStatusRequest,
         GetOrganizationConfigRuleDetailedStatusResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_organization_conformance_pack_detailed_status_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/get_organization_conformance_pack_detailed_status_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/organization_access_
 import 'package:smoke_test/src/sdk/src/config_service/model/organization_conformance_pack_detailed_status.dart';
 
 /// Returns detailed status for each member account within an organization for a given organization conformance pack.
-class GetOrganizationConformancePackDetailedStatusOperation
-    extends _i1.PaginatedHttpOperation<
+class GetOrganizationConformancePackDetailedStatusOperation extends _i1
+    .PaginatedHttpOperation<
         GetOrganizationConformancePackDetailedStatusRequest,
         GetOrganizationConformancePackDetailedStatusRequest,
         GetOrganizationConformancePackDetailedStatusResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/list_aggregate_discovered_resources_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/list_aggregate_discovered_resources_operation.dart
@@ -23,8 +23,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/validation_exception
 /// Accepts a resource type and returns a list of resource identifiers that are aggregated for a specific resource type across accounts and regions. A resource identifier includes the resource type, ID, (if available) the custom resource name, source account, and source region. You can narrow the results to include only resources that have specific resource IDs, or a resource name, or source account ID, or source region.
 ///
 /// For example, if the input consists of accountID 12345678910 and the region is us-east-1 for resource type `AWS::EC2::Instance` then the API returns all the EC2 instance identifiers of accountID 12345678910 and region us-east-1.
-class ListAggregateDiscoveredResourcesOperation
-    extends _i1.PaginatedHttpOperation<
+class ListAggregateDiscoveredResourcesOperation extends _i1
+    .PaginatedHttpOperation<
         ListAggregateDiscoveredResourcesRequest,
         ListAggregateDiscoveredResourcesRequest,
         ListAggregateDiscoveredResourcesResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/list_conformance_pack_compliance_scores_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/config_service/operation/list_conformance_pack_compliance_scores_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/config_service/model/list_conformance_pac
 /// Returns a list of conformance pack compliance scores. A compliance score is the percentage of the number of compliant rule-resource combinations in a conformance pack compared to the number of total possible rule-resource combinations in the conformance pack. This metric provides you with a high-level view of the compliance state of your conformance packs. You can use it to identify, investigate, and understand the level of compliance in your conformance packs.
 ///
 /// Conformance packs with no evaluation results will have a compliance score of `INSUFFICIENT_DATA`.
-class ListConformancePackComplianceScoresOperation
-    extends _i1.PaginatedHttpOperation<
+class ListConformancePackComplianceScoresOperation extends _i1
+    .PaginatedHttpOperation<
         ListConformancePackComplianceScoresRequest,
         ListConformancePackComplianceScoresRequest,
         ListConformancePackComplianceScoresResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/auto_scaling_target_tracking_scaling_policy_configuration_update.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/auto_scaling_target_tracking_scaling_policy_configuration_update.dart
@@ -13,8 +13,8 @@ part 'auto_scaling_target_tracking_scaling_policy_configuration_update.g.dart';
 /// Represents the settings of a target tracking scaling policy that will be modified.
 abstract class AutoScalingTargetTrackingScalingPolicyConfigurationUpdate
     with
-        _i1.AWSEquatable<
-            AutoScalingTargetTrackingScalingPolicyConfigurationUpdate>
+        _i1
+        .AWSEquatable<AutoScalingTargetTrackingScalingPolicyConfigurationUpdate>
     implements
         Built<AutoScalingTargetTrackingScalingPolicyConfigurationUpdate,
             AutoScalingTargetTrackingScalingPolicyConfigurationUpdateBuilder> {

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/global_table_global_secondary_index_settings_update.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/global_table_global_secondary_index_settings_update.dart
@@ -83,8 +83,8 @@ abstract class GlobalTableGlobalSecondaryIndexSettingsUpdate
 }
 
 class GlobalTableGlobalSecondaryIndexSettingsUpdateAwsJson10Serializer
-    extends _i3.StructuredSmithySerializer<
-        GlobalTableGlobalSecondaryIndexSettingsUpdate> {
+    extends _i3
+    .StructuredSmithySerializer<GlobalTableGlobalSecondaryIndexSettingsUpdate> {
   const GlobalTableGlobalSecondaryIndexSettingsUpdateAwsJson10Serializer()
       : super('GlobalTableGlobalSecondaryIndexSettingsUpdate');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/replica_global_secondary_index_auto_scaling_description.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/replica_global_secondary_index_auto_scaling_description.dart
@@ -44,8 +44,9 @@ abstract class ReplicaGlobalSecondaryIndexAutoScalingDescription
   const ReplicaGlobalSecondaryIndexAutoScalingDescription._();
 
   static const List<
-      _i2.SmithySerializer<
-          ReplicaGlobalSecondaryIndexAutoScalingDescription>> serializers = [
+          _i2
+          .SmithySerializer<ReplicaGlobalSecondaryIndexAutoScalingDescription>>
+      serializers = [
     ReplicaGlobalSecondaryIndexAutoScalingDescriptionAwsJson10Serializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/replica_global_secondary_index_auto_scaling_update.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/model/replica_global_secondary_index_auto_scaling_update.dart
@@ -70,8 +70,8 @@ abstract class ReplicaGlobalSecondaryIndexAutoScalingUpdate
 }
 
 class ReplicaGlobalSecondaryIndexAutoScalingUpdateAwsJson10Serializer
-    extends _i2.StructuredSmithySerializer<
-        ReplicaGlobalSecondaryIndexAutoScalingUpdate> {
+    extends _i2
+    .StructuredSmithySerializer<ReplicaGlobalSecondaryIndexAutoScalingUpdate> {
   const ReplicaGlobalSecondaryIndexAutoScalingUpdateAwsJson10Serializer()
       : super('ReplicaGlobalSecondaryIndexAutoScalingUpdate');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/operation/tag_resource_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/dynamo_db/operation/tag_resource_operation.dart
@@ -41,8 +41,9 @@ class TagResourceOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<TagResourceInput, TagResourceInput, _i1.Unit,
-          _i1.Unit>> protocols = [
+          _i1
+          .HttpProtocol<TagResourceInput, TagResourceInput, _i1.Unit, _i1.Unit>>
+      protocols = [
     _i3.AwsJson1_0Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/ec2_client.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/ec2_client.dart
@@ -7450,8 +7450,9 @@ class Ec2Client {
 
   /// Describes IPAM resource discoveries. A resource discovery is an IPAM component that enables IPAM to manage and monitor resources that belong to the owning account.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<IpamResourceDiscovery>, int,
-          String>> describeIpamResourceDiscoveries(
+          _i3
+          .PaginatedResult<_i4.BuiltList<IpamResourceDiscovery>, int, String>>
+      describeIpamResourceDiscoveries(
     DescribeIpamResourceDiscoveriesRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -7570,8 +7571,9 @@ class Ec2Client {
 
   /// Describes one or more versions of a specified launch template. You can describe all versions, individual versions, or a range of versions. You can also describe all the latest versions or all the default versions of all the launch templates in your account.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<LaunchTemplateVersion>, int,
-          String>> describeLaunchTemplateVersions(
+          _i3
+          .PaginatedResult<_i4.BuiltList<LaunchTemplateVersion>, int, String>>
+      describeLaunchTemplateVersions(
     DescribeLaunchTemplateVersionsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -7609,11 +7611,14 @@ class Ec2Client {
   }
 
   /// Describes the associations between virtual interface groups and local gateway route tables.
-  _i3.SmithyOperation<
-      _i3.PaginatedResult<
-          _i4.BuiltList<LocalGatewayRouteTableVirtualInterfaceGroupAssociation>,
-          int,
-          String>> describeLocalGatewayRouteTableVirtualInterfaceGroupAssociations(
+  _i3
+      .SmithyOperation<
+          _i3.PaginatedResult<
+              _i4.BuiltList<
+                  LocalGatewayRouteTableVirtualInterfaceGroupAssociation>,
+              int,
+              String>>
+      describeLocalGatewayRouteTableVirtualInterfaceGroupAssociations(
     DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest
         input, {
     _i1.AWSHttpClient? client,
@@ -7653,8 +7658,9 @@ class Ec2Client {
 
   /// Describes one or more local gateway route tables. By default, all local gateway route tables are described. Alternatively, you can filter the results.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<LocalGatewayRouteTable>, int,
-          String>> describeLocalGatewayRouteTables(
+          _i3
+          .PaginatedResult<_i4.BuiltList<LocalGatewayRouteTable>, int, String>>
+      describeLocalGatewayRouteTables(
     DescribeLocalGatewayRouteTablesRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -7859,8 +7865,9 @@ class Ec2Client {
 
   /// Describes one or more of your network insights analyses.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<NetworkInsightsAnalysis>, int,
-          String>> describeNetworkInsightsAnalyses(
+          _i3
+          .PaginatedResult<_i4.BuiltList<NetworkInsightsAnalysis>, int, String>>
+      describeNetworkInsightsAnalyses(
     DescribeNetworkInsightsAnalysesRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -8064,8 +8071,9 @@ class Ec2Client {
 
   /// Describes a root volume replacement task. For more information, see [Replace a root volume](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/replace-root.html) in the _Amazon Elastic Compute Cloud User Guide_.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<ReplaceRootVolumeTask>, int,
-          String>> describeReplaceRootVolumeTasks(
+          _i3
+          .PaginatedResult<_i4.BuiltList<ReplaceRootVolumeTask>, int, String>>
+      describeReplaceRootVolumeTasks(
     DescribeReplaceRootVolumeTasksRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -8453,8 +8461,9 @@ class Ec2Client {
   ///
   /// Spot Fleet requests are deleted 48 hours after they are canceled and their instances are terminated.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<SpotFleetRequestConfig>, int,
-          String>> describeSpotFleetRequests(
+          _i3
+          .PaginatedResult<_i4.BuiltList<SpotFleetRequestConfig>, int, String>>
+      describeSpotFleetRequests(
     DescribeSpotFleetRequestsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -8712,8 +8721,9 @@ class Ec2Client {
 
   /// Describes one or more Connect attachments.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<TransitGatewayConnect>, int,
-          String>> describeTransitGatewayConnects(
+          _i3
+          .PaginatedResult<_i4.BuiltList<TransitGatewayConnect>, int, String>>
+      describeTransitGatewayConnects(
     DescribeTransitGatewayConnectsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -8894,8 +8904,9 @@ class Ec2Client {
 
   /// Describes the specified Amazon Web Services Verified Access endpoints.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<VerifiedAccessEndpoint>, int,
-          String>> describeVerifiedAccessEndpoints(
+          _i3
+          .PaginatedResult<_i4.BuiltList<VerifiedAccessEndpoint>, int, String>>
+      describeVerifiedAccessEndpoints(
     DescribeVerifiedAccessEndpointsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -8956,8 +8967,9 @@ class Ec2Client {
 
   /// Describes the specified Amazon Web Services Verified Access instances.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<VerifiedAccessInstance>, int,
-          String>> describeVerifiedAccessInstances(
+          _i3
+          .PaginatedResult<_i4.BuiltList<VerifiedAccessInstance>, int, String>>
+      describeVerifiedAccessInstances(
     DescribeVerifiedAccessInstancesRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -9133,8 +9145,9 @@ class Ec2Client {
   ///
   /// Describes the ClassicLink DNS support status of one or more VPCs. If enabled, the DNS hostname of a linked EC2-Classic instance resolves to its private IP address when addressed from an instance in the VPC to which it's linked. Similarly, the DNS hostname of an instance in a VPC resolves to its private IP address when addressed from a linked EC2-Classic instance.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<ClassicLinkDnsSupport>, int,
-          String>> describeVpcClassicLinkDnsSupport(
+          _i3
+          .PaginatedResult<_i4.BuiltList<ClassicLinkDnsSupport>, int, String>>
+      describeVpcClassicLinkDnsSupport(
     DescribeVpcClassicLinkDnsSupportRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -9153,8 +9166,9 @@ class Ec2Client {
 
   /// Describes the connection notifications for VPC endpoints and VPC endpoint services.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<ConnectionNotification>, int,
-          String>> describeVpcEndpointConnectionNotifications(
+          _i3
+          .PaginatedResult<_i4.BuiltList<ConnectionNotification>, int, String>>
+      describeVpcEndpointConnectionNotifications(
     DescribeVpcEndpointConnectionNotificationsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -9173,8 +9187,9 @@ class Ec2Client {
 
   /// Describes the VPC endpoint connections to your VPC endpoint services, including any endpoints that are pending your acceptance.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<VpcEndpointConnection>, int,
-          String>> describeVpcEndpointConnections(
+          _i3
+          .PaginatedResult<_i4.BuiltList<VpcEndpointConnection>, int, String>>
+      describeVpcEndpointConnections(
     DescribeVpcEndpointConnectionsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -10698,8 +10713,9 @@ class Ec2Client {
 
   /// Gets IPAM discovered accounts. A discovered account is an Amazon Web Services account that is monitored under a resource discovery. If you have integrated IPAM with Amazon Web Services Organizations, all accounts in the organization are discovered accounts. Only the IPAM account can get all discovered accounts in the organization.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<IpamDiscoveredAccount>, int,
-          String>> getIpamDiscoveredAccounts(
+          _i3
+          .PaginatedResult<_i4.BuiltList<IpamDiscoveredAccount>, int, String>>
+      getIpamDiscoveredAccounts(
     GetIpamDiscoveredAccountsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -10820,8 +10836,9 @@ class Ec2Client {
 
   /// Gets information about the resources that are associated with the specified managed prefix list.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<PrefixListAssociation>, int,
-          String>> getManagedPrefixListAssociations(
+          _i3
+          .PaginatedResult<_i4.BuiltList<PrefixListAssociation>, int, String>>
+      getManagedPrefixListAssociations(
     GetManagedPrefixListAssociationsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -11204,8 +11221,9 @@ class Ec2Client {
 
   /// Obtain a list of customer gateway devices for which sample configuration files can be provided. The request has no additional parameters. You can also see the list of device types with sample configuration files available under [Your customer gateway device](https://docs.aws.amazon.com/vpn/latest/s2svpn/your-cgw.html) in the _Amazon Web Services Site-to-Site VPN User Guide_.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<VpnConnectionDeviceType>, int,
-          String>> getVpnConnectionDeviceTypes(
+          _i3
+          .PaginatedResult<_i4.BuiltList<VpnConnectionDeviceType>, int, String>>
+      getVpnConnectionDeviceTypes(
     GetVpnConnectionDeviceTypesRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
@@ -11398,8 +11416,9 @@ class Ec2Client {
 
   /// Lists one or more snapshots that are currently in the Recycle Bin.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<_i4.BuiltList<SnapshotRecycleBinInfo>, int,
-          String>> listSnapshotsInRecycleBin(
+          _i3
+          .PaginatedResult<_i4.BuiltList<SnapshotRecycleBinInfo>, int, String>>
+      listSnapshotsInRecycleBin(
     ListSnapshotsInRecycleBinRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/apply_security_groups_to_client_vpn_target_network_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/apply_security_groups_to_client_vpn_target_network_request.dart
@@ -48,8 +48,9 @@ abstract class ApplySecurityGroupsToClientVpnTargetNetworkRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          ApplySecurityGroupsToClientVpnTargetNetworkRequest>> serializers = [
+          _i1
+          .SmithySerializer<ApplySecurityGroupsToClientVpnTargetNetworkRequest>>
+      serializers = [
     ApplySecurityGroupsToClientVpnTargetNetworkRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/apply_security_groups_to_client_vpn_target_network_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/apply_security_groups_to_client_vpn_target_network_result.dart
@@ -38,8 +38,9 @@ abstract class ApplySecurityGroupsToClientVpnTargetNetworkResult
       payload;
 
   static const List<
-      _i3.SmithySerializer<
-          ApplySecurityGroupsToClientVpnTargetNetworkResult>> serializers = [
+          _i3
+          .SmithySerializer<ApplySecurityGroupsToClientVpnTargetNetworkResult>>
+      serializers = [
     ApplySecurityGroupsToClientVpnTargetNetworkResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/associate_transit_gateway_multicast_domain_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/associate_transit_gateway_multicast_domain_request.dart
@@ -102,8 +102,8 @@ abstract class AssociateTransitGatewayMulticastDomainRequest
 }
 
 class AssociateTransitGatewayMulticastDomainRequestEc2QuerySerializer
-    extends _i1.StructuredSmithySerializer<
-        AssociateTransitGatewayMulticastDomainRequest> {
+    extends _i1
+    .StructuredSmithySerializer<AssociateTransitGatewayMulticastDomainRequest> {
   const AssociateTransitGatewayMulticastDomainRequestEc2QuerySerializer()
       : super('AssociateTransitGatewayMulticastDomainRequest');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/client_vpn_endpoint.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/client_vpn_endpoint.dart
@@ -38,8 +38,9 @@ abstract class ClientVpnEndpoint
     VpnProtocol? vpnProtocol,
     TransportProtocol? transportProtocol,
     int? vpnPort,
-    @Deprecated('This property is deprecated. To view the target networks associated with a Client VPN endpoint, call DescribeClientVpnTargetNetworks and inspect the clientVpnTargetNetworks response element.')
-        List<AssociatedTargetNetwork>? associatedTargetNetworks,
+    @Deprecated(
+        'This property is deprecated. To view the target networks associated with a Client VPN endpoint, call DescribeClientVpnTargetNetworks and inspect the clientVpnTargetNetworks response element.')
+    List<AssociatedTargetNetwork>? associatedTargetNetworks,
     String? serverCertificateArn,
     List<ClientVpnAuthentication>? authenticationOptions,
     ConnectionLogResponseOptions? connectionLogOptions,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_local_gateway_route_table_vpc_association_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_local_gateway_route_table_vpc_association_request.dart
@@ -49,8 +49,9 @@ abstract class CreateLocalGatewayRouteTableVpcAssociationRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          CreateLocalGatewayRouteTableVpcAssociationRequest>> serializers = [
+          _i1
+          .SmithySerializer<CreateLocalGatewayRouteTableVpcAssociationRequest>>
+      serializers = [
     CreateLocalGatewayRouteTableVpcAssociationRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_local_gateway_route_table_vpc_association_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_local_gateway_route_table_vpc_association_result.dart
@@ -39,8 +39,9 @@ abstract class CreateLocalGatewayRouteTableVpcAssociationResult
       payload;
 
   static const List<
-      _i2.SmithySerializer<
-          CreateLocalGatewayRouteTableVpcAssociationResult>> serializers = [
+          _i2
+          .SmithySerializer<CreateLocalGatewayRouteTableVpcAssociationResult>>
+      serializers = [
     CreateLocalGatewayRouteTableVpcAssociationResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_transit_gateway_multicast_domain_request_options.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_transit_gateway_multicast_domain_request_options.dart
@@ -41,8 +41,9 @@ abstract class CreateTransitGatewayMulticastDomainRequestOptions
   const CreateTransitGatewayMulticastDomainRequestOptions._();
 
   static const List<
-      _i2.SmithySerializer<
-          CreateTransitGatewayMulticastDomainRequestOptions>> serializers = [
+          _i2
+          .SmithySerializer<CreateTransitGatewayMulticastDomainRequestOptions>>
+      serializers = [
     CreateTransitGatewayMulticastDomainRequestOptionsEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_transit_gateway_prefix_list_reference_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_transit_gateway_prefix_list_reference_result.dart
@@ -59,8 +59,8 @@ abstract class CreateTransitGatewayPrefixListReferenceResult
 }
 
 class CreateTransitGatewayPrefixListReferenceResultEc2QuerySerializer
-    extends _i2.StructuredSmithySerializer<
-        CreateTransitGatewayPrefixListReferenceResult> {
+    extends _i2
+    .StructuredSmithySerializer<CreateTransitGatewayPrefixListReferenceResult> {
   const CreateTransitGatewayPrefixListReferenceResultEc2QuerySerializer()
       : super('CreateTransitGatewayPrefixListReferenceResult');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_transit_gateway_route_table_announcement_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_transit_gateway_route_table_announcement_request.dart
@@ -49,8 +49,9 @@ abstract class CreateTransitGatewayRouteTableAnnouncementRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          CreateTransitGatewayRouteTableAnnouncementRequest>> serializers = [
+          _i1
+          .SmithySerializer<CreateTransitGatewayRouteTableAnnouncementRequest>>
+      serializers = [
     CreateTransitGatewayRouteTableAnnouncementRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_transit_gateway_route_table_announcement_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_transit_gateway_route_table_announcement_result.dart
@@ -39,8 +39,9 @@ abstract class CreateTransitGatewayRouteTableAnnouncementResult
       payload;
 
   static const List<
-      _i2.SmithySerializer<
-          CreateTransitGatewayRouteTableAnnouncementResult>> serializers = [
+          _i2
+          .SmithySerializer<CreateTransitGatewayRouteTableAnnouncementResult>>
+      serializers = [
     CreateTransitGatewayRouteTableAnnouncementResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_vpc_endpoint_connection_notification_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/create_vpc_endpoint_connection_notification_result.dart
@@ -73,8 +73,8 @@ abstract class CreateVpcEndpointConnectionNotificationResult
 }
 
 class CreateVpcEndpointConnectionNotificationResultEc2QuerySerializer
-    extends _i2.StructuredSmithySerializer<
-        CreateVpcEndpointConnectionNotificationResult> {
+    extends _i2
+    .StructuredSmithySerializer<CreateVpcEndpointConnectionNotificationResult> {
   const CreateVpcEndpointConnectionNotificationResultEc2QuerySerializer()
       : super('CreateVpcEndpointConnectionNotificationResult');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_launch_template_versions_response_error_item.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_launch_template_versions_response_error_item.dart
@@ -96,8 +96,8 @@ abstract class DeleteLaunchTemplateVersionsResponseErrorItem
 }
 
 class DeleteLaunchTemplateVersionsResponseErrorItemEc2QuerySerializer
-    extends _i3.StructuredSmithySerializer<
-        DeleteLaunchTemplateVersionsResponseErrorItem> {
+    extends _i3
+    .StructuredSmithySerializer<DeleteLaunchTemplateVersionsResponseErrorItem> {
   const DeleteLaunchTemplateVersionsResponseErrorItemEc2QuerySerializer()
       : super('DeleteLaunchTemplateVersionsResponseErrorItem');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_local_gateway_route_table_vpc_association_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_local_gateway_route_table_vpc_association_request.dart
@@ -43,8 +43,9 @@ abstract class DeleteLocalGatewayRouteTableVpcAssociationRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          DeleteLocalGatewayRouteTableVpcAssociationRequest>> serializers = [
+          _i1
+          .SmithySerializer<DeleteLocalGatewayRouteTableVpcAssociationRequest>>
+      serializers = [
     DeleteLocalGatewayRouteTableVpcAssociationRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_local_gateway_route_table_vpc_association_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_local_gateway_route_table_vpc_association_result.dart
@@ -39,8 +39,9 @@ abstract class DeleteLocalGatewayRouteTableVpcAssociationResult
       payload;
 
   static const List<
-      _i2.SmithySerializer<
-          DeleteLocalGatewayRouteTableVpcAssociationResult>> serializers = [
+          _i2
+          .SmithySerializer<DeleteLocalGatewayRouteTableVpcAssociationResult>>
+      serializers = [
     DeleteLocalGatewayRouteTableVpcAssociationResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_transit_gateway_prefix_list_reference_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_transit_gateway_prefix_list_reference_result.dart
@@ -59,8 +59,8 @@ abstract class DeleteTransitGatewayPrefixListReferenceResult
 }
 
 class DeleteTransitGatewayPrefixListReferenceResultEc2QuerySerializer
-    extends _i2.StructuredSmithySerializer<
-        DeleteTransitGatewayPrefixListReferenceResult> {
+    extends _i2
+    .StructuredSmithySerializer<DeleteTransitGatewayPrefixListReferenceResult> {
   const DeleteTransitGatewayPrefixListReferenceResultEc2QuerySerializer()
       : super('DeleteTransitGatewayPrefixListReferenceResult');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_transit_gateway_route_table_announcement_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_transit_gateway_route_table_announcement_request.dart
@@ -43,8 +43,9 @@ abstract class DeleteTransitGatewayRouteTableAnnouncementRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          DeleteTransitGatewayRouteTableAnnouncementRequest>> serializers = [
+          _i1
+          .SmithySerializer<DeleteTransitGatewayRouteTableAnnouncementRequest>>
+      serializers = [
     DeleteTransitGatewayRouteTableAnnouncementRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_transit_gateway_route_table_announcement_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_transit_gateway_route_table_announcement_result.dart
@@ -39,8 +39,9 @@ abstract class DeleteTransitGatewayRouteTableAnnouncementResult
       payload;
 
   static const List<
-      _i2.SmithySerializer<
-          DeleteTransitGatewayRouteTableAnnouncementResult>> serializers = [
+          _i2
+          .SmithySerializer<DeleteTransitGatewayRouteTableAnnouncementResult>>
+      serializers = [
     DeleteTransitGatewayRouteTableAnnouncementResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_vpc_endpoint_service_configurations_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/delete_vpc_endpoint_service_configurations_request.dart
@@ -82,8 +82,8 @@ abstract class DeleteVpcEndpointServiceConfigurationsRequest
 }
 
 class DeleteVpcEndpointServiceConfigurationsRequestEc2QuerySerializer
-    extends _i1.StructuredSmithySerializer<
-        DeleteVpcEndpointServiceConfigurationsRequest> {
+    extends _i1
+    .StructuredSmithySerializer<DeleteVpcEndpointServiceConfigurationsRequest> {
   const DeleteVpcEndpointServiceConfigurationsRequestEc2QuerySerializer()
       : super('DeleteVpcEndpointServiceConfigurationsRequest');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_aws_network_performance_metric_subscriptions_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_aws_network_performance_metric_subscriptions_request.dart
@@ -15,8 +15,8 @@ part 'describe_aws_network_performance_metric_subscriptions_request.g.dart';
 abstract class DescribeAwsNetworkPerformanceMetricSubscriptionsRequest
     with
         _i1.HttpInput<DescribeAwsNetworkPerformanceMetricSubscriptionsRequest>,
-        _i2.AWSEquatable<
-            DescribeAwsNetworkPerformanceMetricSubscriptionsRequest>
+        _i2
+        .AWSEquatable<DescribeAwsNetworkPerformanceMetricSubscriptionsRequest>
     implements
         Built<DescribeAwsNetworkPerformanceMetricSubscriptionsRequest,
             DescribeAwsNetworkPerformanceMetricSubscriptionsRequestBuilder> {

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_iam_instance_profile_associations_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_iam_instance_profile_associations_request.dart
@@ -108,8 +108,8 @@ abstract class DescribeIamInstanceProfileAssociationsRequest
 }
 
 class DescribeIamInstanceProfileAssociationsRequestEc2QuerySerializer
-    extends _i1.StructuredSmithySerializer<
-        DescribeIamInstanceProfileAssociationsRequest> {
+    extends _i1
+    .StructuredSmithySerializer<DescribeIamInstanceProfileAssociationsRequest> {
   const DescribeIamInstanceProfileAssociationsRequestEc2QuerySerializer()
       : super('DescribeIamInstanceProfileAssociationsRequest');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_instance_event_notification_attributes_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_instance_event_notification_attributes_request.dart
@@ -37,8 +37,9 @@ abstract class DescribeInstanceEventNotificationAttributesRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          DescribeInstanceEventNotificationAttributesRequest>> serializers = [
+          _i1
+          .SmithySerializer<DescribeInstanceEventNotificationAttributesRequest>>
+      serializers = [
     DescribeInstanceEventNotificationAttributesRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_instance_event_notification_attributes_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_instance_event_notification_attributes_result.dart
@@ -37,8 +37,9 @@ abstract class DescribeInstanceEventNotificationAttributesResult
       payload;
 
   static const List<
-      _i2.SmithySerializer<
-          DescribeInstanceEventNotificationAttributesResult>> serializers = [
+          _i2
+          .SmithySerializer<DescribeInstanceEventNotificationAttributesResult>>
+      serializers = [
     DescribeInstanceEventNotificationAttributesResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_ipam_resource_discovery_associations_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_ipam_resource_discovery_associations_request.dart
@@ -54,8 +54,9 @@ abstract class DescribeIpamResourceDiscoveryAssociationsRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          DescribeIpamResourceDiscoveryAssociationsRequest>> serializers = [
+          _i1
+          .SmithySerializer<DescribeIpamResourceDiscoveryAssociationsRequest>>
+      serializers = [
     DescribeIpamResourceDiscoveryAssociationsRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_local_gateway_virtual_interface_groups_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_local_gateway_virtual_interface_groups_request.dart
@@ -54,8 +54,9 @@ abstract class DescribeLocalGatewayVirtualInterfaceGroupsRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          DescribeLocalGatewayVirtualInterfaceGroupsRequest>> serializers = [
+          _i1
+          .SmithySerializer<DescribeLocalGatewayVirtualInterfaceGroupsRequest>>
+      serializers = [
     DescribeLocalGatewayVirtualInterfaceGroupsRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_local_gateway_virtual_interface_groups_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_local_gateway_virtual_interface_groups_result.dart
@@ -45,8 +45,9 @@ abstract class DescribeLocalGatewayVirtualInterfaceGroupsResult
       payload;
 
   static const List<
-      _i3.SmithySerializer<
-          DescribeLocalGatewayVirtualInterfaceGroupsResult>> serializers = [
+          _i3
+          .SmithySerializer<DescribeLocalGatewayVirtualInterfaceGroupsResult>>
+      serializers = [
     DescribeLocalGatewayVirtualInterfaceGroupsResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_network_insights_access_scope_analyses_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_network_insights_access_scope_analyses_request.dart
@@ -60,8 +60,9 @@ abstract class DescribeNetworkInsightsAccessScopeAnalysesRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          DescribeNetworkInsightsAccessScopeAnalysesRequest>> serializers = [
+          _i1
+          .SmithySerializer<DescribeNetworkInsightsAccessScopeAnalysesRequest>>
+      serializers = [
     DescribeNetworkInsightsAccessScopeAnalysesRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_network_insights_access_scope_analyses_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_network_insights_access_scope_analyses_result.dart
@@ -46,8 +46,9 @@ abstract class DescribeNetworkInsightsAccessScopeAnalysesResult
       payload;
 
   static const List<
-      _i3.SmithySerializer<
-          DescribeNetworkInsightsAccessScopeAnalysesResult>> serializers = [
+          _i3
+          .SmithySerializer<DescribeNetworkInsightsAccessScopeAnalysesResult>>
+      serializers = [
     DescribeNetworkInsightsAccessScopeAnalysesResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_reserved_instances_modifications_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_reserved_instances_modifications_request.dart
@@ -116,8 +116,8 @@ abstract class DescribeReservedInstancesModificationsRequest
 }
 
 class DescribeReservedInstancesModificationsRequestEc2QuerySerializer
-    extends _i1.StructuredSmithySerializer<
-        DescribeReservedInstancesModificationsRequest> {
+    extends _i1
+    .StructuredSmithySerializer<DescribeReservedInstancesModificationsRequest> {
   const DescribeReservedInstancesModificationsRequestEc2QuerySerializer()
       : super('DescribeReservedInstancesModificationsRequest');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_transit_gateway_multicast_domains_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_transit_gateway_multicast_domains_request.dart
@@ -124,8 +124,8 @@ abstract class DescribeTransitGatewayMulticastDomainsRequest
 }
 
 class DescribeTransitGatewayMulticastDomainsRequestEc2QuerySerializer
-    extends _i1.StructuredSmithySerializer<
-        DescribeTransitGatewayMulticastDomainsRequest> {
+    extends _i1
+    .StructuredSmithySerializer<DescribeTransitGatewayMulticastDomainsRequest> {
   const DescribeTransitGatewayMulticastDomainsRequestEc2QuerySerializer()
       : super('DescribeTransitGatewayMulticastDomainsRequest');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_verified_access_instance_logging_configurations_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_verified_access_instance_logging_configurations_request.dart
@@ -14,8 +14,8 @@ part 'describe_verified_access_instance_logging_configurations_request.g.dart';
 
 abstract class DescribeVerifiedAccessInstanceLoggingConfigurationsRequest
     with
-        _i1.HttpInput<
-            DescribeVerifiedAccessInstanceLoggingConfigurationsRequest>,
+        _i1
+        .HttpInput<DescribeVerifiedAccessInstanceLoggingConfigurationsRequest>,
         _i2.AWSEquatable<
             DescribeVerifiedAccessInstanceLoggingConfigurationsRequest>
     implements

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_verified_access_instance_logging_configurations_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_verified_access_instance_logging_configurations_result.dart
@@ -14,8 +14,8 @@ part 'describe_verified_access_instance_logging_configurations_result.g.dart';
 
 abstract class DescribeVerifiedAccessInstanceLoggingConfigurationsResult
     with
-        _i1.AWSEquatable<
-            DescribeVerifiedAccessInstanceLoggingConfigurationsResult>
+        _i1
+        .AWSEquatable<DescribeVerifiedAccessInstanceLoggingConfigurationsResult>
     implements
         Built<DescribeVerifiedAccessInstanceLoggingConfigurationsResult,
             DescribeVerifiedAccessInstanceLoggingConfigurationsResultBuilder> {

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_vpc_endpoint_connection_notifications_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_vpc_endpoint_connection_notifications_request.dart
@@ -51,8 +51,9 @@ abstract class DescribeVpcEndpointConnectionNotificationsRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          DescribeVpcEndpointConnectionNotificationsRequest>> serializers = [
+          _i1
+          .SmithySerializer<DescribeVpcEndpointConnectionNotificationsRequest>>
+      serializers = [
     DescribeVpcEndpointConnectionNotificationsRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_vpc_endpoint_connection_notifications_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/describe_vpc_endpoint_connection_notifications_result.dart
@@ -44,8 +44,9 @@ abstract class DescribeVpcEndpointConnectionNotificationsResult
       payload;
 
   static const List<
-      _i3.SmithySerializer<
-          DescribeVpcEndpointConnectionNotificationsResult>> serializers = [
+          _i3
+          .SmithySerializer<DescribeVpcEndpointConnectionNotificationsResult>>
+      serializers = [
     DescribeVpcEndpointConnectionNotificationsResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/disable_transit_gateway_route_table_propagation_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/disable_transit_gateway_route_table_propagation_request.dart
@@ -47,8 +47,9 @@ abstract class DisableTransitGatewayRouteTablePropagationRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          DisableTransitGatewayRouteTablePropagationRequest>> serializers = [
+          _i1
+          .SmithySerializer<DisableTransitGatewayRouteTablePropagationRequest>>
+      serializers = [
     DisableTransitGatewayRouteTablePropagationRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/disable_transit_gateway_route_table_propagation_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/disable_transit_gateway_route_table_propagation_result.dart
@@ -37,8 +37,9 @@ abstract class DisableTransitGatewayRouteTablePropagationResult
       payload;
 
   static const List<
-      _i2.SmithySerializer<
-          DisableTransitGatewayRouteTablePropagationResult>> serializers = [
+          _i2
+          .SmithySerializer<DisableTransitGatewayRouteTablePropagationResult>>
+      serializers = [
     DisableTransitGatewayRouteTablePropagationResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/disassociate_transit_gateway_multicast_domain_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/disassociate_transit_gateway_multicast_domain_request.dart
@@ -47,8 +47,9 @@ abstract class DisassociateTransitGatewayMulticastDomainRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          DisassociateTransitGatewayMulticastDomainRequest>> serializers = [
+          _i1
+          .SmithySerializer<DisassociateTransitGatewayMulticastDomainRequest>>
+      serializers = [
     DisassociateTransitGatewayMulticastDomainRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/enable_transit_gateway_route_table_propagation_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/enable_transit_gateway_route_table_propagation_request.dart
@@ -47,8 +47,9 @@ abstract class EnableTransitGatewayRouteTablePropagationRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          EnableTransitGatewayRouteTablePropagationRequest>> serializers = [
+          _i1
+          .SmithySerializer<EnableTransitGatewayRouteTablePropagationRequest>>
+      serializers = [
     EnableTransitGatewayRouteTablePropagationRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/failed_capacity_reservation_fleet_cancellation_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/failed_capacity_reservation_fleet_cancellation_result.dart
@@ -37,8 +37,9 @@ abstract class FailedCapacityReservationFleetCancellationResult
   const FailedCapacityReservationFleetCancellationResult._();
 
   static const List<
-      _i2.SmithySerializer<
-          FailedCapacityReservationFleetCancellationResult>> serializers = [
+          _i2
+          .SmithySerializer<FailedCapacityReservationFleetCancellationResult>>
+      serializers = [
     FailedCapacityReservationFleetCancellationResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/fast_launch_launch_template_specification_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/fast_launch_launch_template_specification_response.dart
@@ -78,8 +78,8 @@ abstract class FastLaunchLaunchTemplateSpecificationResponse
 }
 
 class FastLaunchLaunchTemplateSpecificationResponseEc2QuerySerializer
-    extends _i2.StructuredSmithySerializer<
-        FastLaunchLaunchTemplateSpecificationResponse> {
+    extends _i2
+    .StructuredSmithySerializer<FastLaunchLaunchTemplateSpecificationResponse> {
   const FastLaunchLaunchTemplateSpecificationResponseEc2QuerySerializer()
       : super('FastLaunchLaunchTemplateSpecificationResponse');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/get_associated_enclave_certificate_iam_roles_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/get_associated_enclave_certificate_iam_roles_result.dart
@@ -61,8 +61,8 @@ abstract class GetAssociatedEnclaveCertificateIamRolesResult
 }
 
 class GetAssociatedEnclaveCertificateIamRolesResultEc2QuerySerializer
-    extends _i3.StructuredSmithySerializer<
-        GetAssociatedEnclaveCertificateIamRolesResult> {
+    extends _i3
+    .StructuredSmithySerializer<GetAssociatedEnclaveCertificateIamRolesResult> {
   const GetAssociatedEnclaveCertificateIamRolesResultEc2QuerySerializer()
       : super('GetAssociatedEnclaveCertificateIamRolesResult');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/get_transit_gateway_attachment_propagations_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/get_transit_gateway_attachment_propagations_result.dart
@@ -79,8 +79,8 @@ abstract class GetTransitGatewayAttachmentPropagationsResult
 }
 
 class GetTransitGatewayAttachmentPropagationsResultEc2QuerySerializer
-    extends _i3.StructuredSmithySerializer<
-        GetTransitGatewayAttachmentPropagationsResult> {
+    extends _i3
+    .StructuredSmithySerializer<GetTransitGatewayAttachmentPropagationsResult> {
   const GetTransitGatewayAttachmentPropagationsResultEc2QuerySerializer()
       : super('GetTransitGatewayAttachmentPropagationsResult');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/get_transit_gateway_multicast_domain_associations_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/get_transit_gateway_multicast_domain_associations_result.dart
@@ -44,8 +44,9 @@ abstract class GetTransitGatewayMulticastDomainAssociationsResult
       payload;
 
   static const List<
-      _i3.SmithySerializer<
-          GetTransitGatewayMulticastDomainAssociationsResult>> serializers = [
+          _i3
+          .SmithySerializer<GetTransitGatewayMulticastDomainAssociationsResult>>
+      serializers = [
     GetTransitGatewayMulticastDomainAssociationsResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/get_transit_gateway_route_table_associations_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/get_transit_gateway_route_table_associations_result.dart
@@ -74,8 +74,8 @@ abstract class GetTransitGatewayRouteTableAssociationsResult
 }
 
 class GetTransitGatewayRouteTableAssociationsResultEc2QuerySerializer
-    extends _i3.StructuredSmithySerializer<
-        GetTransitGatewayRouteTableAssociationsResult> {
+    extends _i3
+    .StructuredSmithySerializer<GetTransitGatewayRouteTableAssociationsResult> {
   const GetTransitGatewayRouteTableAssociationsResultEc2QuerySerializer()
       : super('GetTransitGatewayRouteTableAssociationsResult');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/get_transit_gateway_route_table_propagations_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/get_transit_gateway_route_table_propagations_result.dart
@@ -79,8 +79,8 @@ abstract class GetTransitGatewayRouteTablePropagationsResult
 }
 
 class GetTransitGatewayRouteTablePropagationsResultEc2QuerySerializer
-    extends _i3.StructuredSmithySerializer<
-        GetTransitGatewayRouteTablePropagationsResult> {
+    extends _i3
+    .StructuredSmithySerializer<GetTransitGatewayRouteTablePropagationsResult> {
   const GetTransitGatewayRouteTablePropagationsResultEc2QuerySerializer()
       : super('GetTransitGatewayRouteTablePropagationsResult');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/get_vpn_connection_device_sample_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/get_vpn_connection_device_sample_configuration_request.dart
@@ -46,8 +46,9 @@ abstract class GetVpnConnectionDeviceSampleConfigurationRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          GetVpnConnectionDeviceSampleConfigurationRequest>> serializers = [
+          _i1
+          .SmithySerializer<GetVpnConnectionDeviceSampleConfigurationRequest>>
+      serializers = [
     GetVpnConnectionDeviceSampleConfigurationRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/launch_template_elastic_inference_accelerator_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/launch_template_elastic_inference_accelerator_response.dart
@@ -37,8 +37,9 @@ abstract class LaunchTemplateElasticInferenceAcceleratorResponse
   const LaunchTemplateElasticInferenceAcceleratorResponse._();
 
   static const List<
-      _i2.SmithySerializer<
-          LaunchTemplateElasticInferenceAcceleratorResponse>> serializers = [
+          _i2
+          .SmithySerializer<LaunchTemplateElasticInferenceAcceleratorResponse>>
+      serializers = [
     LaunchTemplateElasticInferenceAcceleratorResponseEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/launch_template_iam_instance_profile_specification.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/launch_template_iam_instance_profile_specification.dart
@@ -68,8 +68,8 @@ abstract class LaunchTemplateIamInstanceProfileSpecification
 }
 
 class LaunchTemplateIamInstanceProfileSpecificationEc2QuerySerializer
-    extends _i2.StructuredSmithySerializer<
-        LaunchTemplateIamInstanceProfileSpecification> {
+    extends _i2
+    .StructuredSmithySerializer<LaunchTemplateIamInstanceProfileSpecification> {
   const LaunchTemplateIamInstanceProfileSpecificationEc2QuerySerializer()
       : super('LaunchTemplateIamInstanceProfileSpecification');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_instance_capacity_reservation_attributes_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_instance_capacity_reservation_attributes_request.dart
@@ -45,8 +45,9 @@ abstract class ModifyInstanceCapacityReservationAttributesRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          ModifyInstanceCapacityReservationAttributesRequest>> serializers = [
+          _i1
+          .SmithySerializer<ModifyInstanceCapacityReservationAttributesRequest>>
+      serializers = [
     ModifyInstanceCapacityReservationAttributesRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_instance_capacity_reservation_attributes_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_instance_capacity_reservation_attributes_result.dart
@@ -36,8 +36,9 @@ abstract class ModifyInstanceCapacityReservationAttributesResult
       payload;
 
   static const List<
-      _i2.SmithySerializer<
-          ModifyInstanceCapacityReservationAttributesResult>> serializers = [
+          _i2
+          .SmithySerializer<ModifyInstanceCapacityReservationAttributesResult>>
+      serializers = [
     ModifyInstanceCapacityReservationAttributesResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_transit_gateway_prefix_list_reference_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_transit_gateway_prefix_list_reference_result.dart
@@ -59,8 +59,8 @@ abstract class ModifyTransitGatewayPrefixListReferenceResult
 }
 
 class ModifyTransitGatewayPrefixListReferenceResultEc2QuerySerializer
-    extends _i2.StructuredSmithySerializer<
-        ModifyTransitGatewayPrefixListReferenceResult> {
+    extends _i2
+    .StructuredSmithySerializer<ModifyTransitGatewayPrefixListReferenceResult> {
   const ModifyTransitGatewayPrefixListReferenceResultEc2QuerySerializer()
       : super('ModifyTransitGatewayPrefixListReferenceResult');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_verified_access_instance_logging_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_verified_access_instance_logging_configuration_request.dart
@@ -14,8 +14,8 @@ part 'modify_verified_access_instance_logging_configuration_request.g.dart';
 abstract class ModifyVerifiedAccessInstanceLoggingConfigurationRequest
     with
         _i1.HttpInput<ModifyVerifiedAccessInstanceLoggingConfigurationRequest>,
-        _i2.AWSEquatable<
-            ModifyVerifiedAccessInstanceLoggingConfigurationRequest>
+        _i2
+        .AWSEquatable<ModifyVerifiedAccessInstanceLoggingConfigurationRequest>
     implements
         Built<ModifyVerifiedAccessInstanceLoggingConfigurationRequest,
             ModifyVerifiedAccessInstanceLoggingConfigurationRequestBuilder> {

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_vpc_endpoint_connection_notification_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_vpc_endpoint_connection_notification_result.dart
@@ -63,8 +63,8 @@ abstract class ModifyVpcEndpointConnectionNotificationResult
 }
 
 class ModifyVpcEndpointConnectionNotificationResultEc2QuerySerializer
-    extends _i2.StructuredSmithySerializer<
-        ModifyVpcEndpointConnectionNotificationResult> {
+    extends _i2
+    .StructuredSmithySerializer<ModifyVpcEndpointConnectionNotificationResult> {
   const ModifyVpcEndpointConnectionNotificationResultEc2QuerySerializer()
       : super('ModifyVpcEndpointConnectionNotificationResult');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_vpc_endpoint_service_payer_responsibility_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_vpc_endpoint_service_payer_responsibility_request.dart
@@ -45,8 +45,9 @@ abstract class ModifyVpcEndpointServicePayerResponsibilityRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          ModifyVpcEndpointServicePayerResponsibilityRequest>> serializers = [
+          _i1
+          .SmithySerializer<ModifyVpcEndpointServicePayerResponsibilityRequest>>
+      serializers = [
     ModifyVpcEndpointServicePayerResponsibilityRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_vpc_endpoint_service_payer_responsibility_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/modify_vpc_endpoint_service_payer_responsibility_result.dart
@@ -37,8 +37,9 @@ abstract class ModifyVpcEndpointServicePayerResponsibilityResult
       payload;
 
   static const List<
-      _i2.SmithySerializer<
-          ModifyVpcEndpointServicePayerResponsibilityResult>> serializers = [
+          _i2
+          .SmithySerializer<ModifyVpcEndpointServicePayerResponsibilityResult>>
+      serializers = [
     ModifyVpcEndpointServicePayerResponsibilityResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/register_instance_event_notification_attributes_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/register_instance_event_notification_attributes_request.dart
@@ -43,8 +43,9 @@ abstract class RegisterInstanceEventNotificationAttributesRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          RegisterInstanceEventNotificationAttributesRequest>> serializers = [
+          _i1
+          .SmithySerializer<RegisterInstanceEventNotificationAttributesRequest>>
+      serializers = [
     RegisterInstanceEventNotificationAttributesRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/register_instance_event_notification_attributes_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/register_instance_event_notification_attributes_result.dart
@@ -37,8 +37,9 @@ abstract class RegisterInstanceEventNotificationAttributesResult
       payload;
 
   static const List<
-      _i2.SmithySerializer<
-          RegisterInstanceEventNotificationAttributesResult>> serializers = [
+          _i2
+          .SmithySerializer<RegisterInstanceEventNotificationAttributesResult>>
+      serializers = [
     RegisterInstanceEventNotificationAttributesResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/register_transit_gateway_multicast_group_members_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/register_transit_gateway_multicast_group_members_request.dart
@@ -49,8 +49,9 @@ abstract class RegisterTransitGatewayMulticastGroupMembersRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          RegisterTransitGatewayMulticastGroupMembersRequest>> serializers = [
+          _i1
+          .SmithySerializer<RegisterTransitGatewayMulticastGroupMembersRequest>>
+      serializers = [
     RegisterTransitGatewayMulticastGroupMembersRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/register_transit_gateway_multicast_group_members_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/register_transit_gateway_multicast_group_members_result.dart
@@ -38,8 +38,9 @@ abstract class RegisterTransitGatewayMulticastGroupMembersResult
       payload;
 
   static const List<
-      _i2.SmithySerializer<
-          RegisterTransitGatewayMulticastGroupMembersResult>> serializers = [
+          _i2
+          .SmithySerializer<RegisterTransitGatewayMulticastGroupMembersResult>>
+      serializers = [
     RegisterTransitGatewayMulticastGroupMembersResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/register_transit_gateway_multicast_group_sources_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/register_transit_gateway_multicast_group_sources_request.dart
@@ -49,8 +49,9 @@ abstract class RegisterTransitGatewayMulticastGroupSourcesRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          RegisterTransitGatewayMulticastGroupSourcesRequest>> serializers = [
+          _i1
+          .SmithySerializer<RegisterTransitGatewayMulticastGroupSourcesRequest>>
+      serializers = [
     RegisterTransitGatewayMulticastGroupSourcesRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/register_transit_gateway_multicast_group_sources_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/register_transit_gateway_multicast_group_sources_result.dart
@@ -38,8 +38,9 @@ abstract class RegisterTransitGatewayMulticastGroupSourcesResult
       payload;
 
   static const List<
-      _i2.SmithySerializer<
-          RegisterTransitGatewayMulticastGroupSourcesResult>> serializers = [
+          _i2
+          .SmithySerializer<RegisterTransitGatewayMulticastGroupSourcesResult>>
+      serializers = [
     RegisterTransitGatewayMulticastGroupSourcesResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/start_network_insights_access_scope_analysis_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/start_network_insights_access_scope_analysis_result.dart
@@ -60,8 +60,8 @@ abstract class StartNetworkInsightsAccessScopeAnalysisResult
 }
 
 class StartNetworkInsightsAccessScopeAnalysisResultEc2QuerySerializer
-    extends _i2.StructuredSmithySerializer<
-        StartNetworkInsightsAccessScopeAnalysisResult> {
+    extends _i2
+    .StructuredSmithySerializer<StartNetworkInsightsAccessScopeAnalysisResult> {
   const StartNetworkInsightsAccessScopeAnalysisResultEc2QuerySerializer()
       : super('StartNetworkInsightsAccessScopeAnalysisResult');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/transit_gateway_multicast_registered_group_members.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/transit_gateway_multicast_registered_group_members.dart
@@ -81,8 +81,8 @@ abstract class TransitGatewayMulticastRegisteredGroupMembers
 }
 
 class TransitGatewayMulticastRegisteredGroupMembersEc2QuerySerializer
-    extends _i3.StructuredSmithySerializer<
-        TransitGatewayMulticastRegisteredGroupMembers> {
+    extends _i3
+    .StructuredSmithySerializer<TransitGatewayMulticastRegisteredGroupMembers> {
   const TransitGatewayMulticastRegisteredGroupMembersEc2QuerySerializer()
       : super('TransitGatewayMulticastRegisteredGroupMembers');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/transit_gateway_multicast_registered_group_sources.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/transit_gateway_multicast_registered_group_sources.dart
@@ -81,8 +81,8 @@ abstract class TransitGatewayMulticastRegisteredGroupSources
 }
 
 class TransitGatewayMulticastRegisteredGroupSourcesEc2QuerySerializer
-    extends _i3.StructuredSmithySerializer<
-        TransitGatewayMulticastRegisteredGroupSources> {
+    extends _i3
+    .StructuredSmithySerializer<TransitGatewayMulticastRegisteredGroupSources> {
   const TransitGatewayMulticastRegisteredGroupSourcesEc2QuerySerializer()
       : super('TransitGatewayMulticastRegisteredGroupSources');
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/unsuccessful_instance_credit_specification_error_code.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/unsuccessful_instance_credit_specification_error_code.dart
@@ -55,8 +55,9 @@ class UnsuccessfulInstanceCreditSpecificationErrorCode
   ];
 
   static const List<
-      _i1.SmithySerializer<
-          UnsuccessfulInstanceCreditSpecificationErrorCode>> serializers = [
+          _i1
+          .SmithySerializer<UnsuccessfulInstanceCreditSpecificationErrorCode>>
+      serializers = [
     _i1.SmithyEnumSerializer(
       'UnsuccessfulInstanceCreditSpecificationErrorCode',
       values: values,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/unsuccessful_instance_credit_specification_item_error.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/unsuccessful_instance_credit_specification_item_error.dart
@@ -37,8 +37,9 @@ abstract class UnsuccessfulInstanceCreditSpecificationItemError
   const UnsuccessfulInstanceCreditSpecificationItemError._();
 
   static const List<
-      _i2.SmithySerializer<
-          UnsuccessfulInstanceCreditSpecificationItemError>> serializers = [
+          _i2
+          .SmithySerializer<UnsuccessfulInstanceCreditSpecificationItemError>>
+      serializers = [
     UnsuccessfulInstanceCreditSpecificationItemErrorEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/update_security_group_rule_descriptions_egress_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/update_security_group_rule_descriptions_egress_request.dart
@@ -54,8 +54,9 @@ abstract class UpdateSecurityGroupRuleDescriptionsEgressRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          UpdateSecurityGroupRuleDescriptionsEgressRequest>> serializers = [
+          _i1
+          .SmithySerializer<UpdateSecurityGroupRuleDescriptionsEgressRequest>>
+      serializers = [
     UpdateSecurityGroupRuleDescriptionsEgressRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/update_security_group_rule_descriptions_ingress_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/update_security_group_rule_descriptions_ingress_request.dart
@@ -54,8 +54,9 @@ abstract class UpdateSecurityGroupRuleDescriptionsIngressRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          UpdateSecurityGroupRuleDescriptionsIngressRequest>> serializers = [
+          _i1
+          .SmithySerializer<UpdateSecurityGroupRuleDescriptionsIngressRequest>>
+      serializers = [
     UpdateSecurityGroupRuleDescriptionsIngressRequestEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/update_security_group_rule_descriptions_ingress_result.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/update_security_group_rule_descriptions_ingress_result.dart
@@ -36,8 +36,9 @@ abstract class UpdateSecurityGroupRuleDescriptionsIngressResult
       payload;
 
   static const List<
-      _i2.SmithySerializer<
-          UpdateSecurityGroupRuleDescriptionsIngressResult>> serializers = [
+          _i2
+          .SmithySerializer<UpdateSecurityGroupRuleDescriptionsIngressResult>>
+      serializers = [
     UpdateSecurityGroupRuleDescriptionsIngressResultEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/verified_access_log_cloud_watch_logs_destination_options.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/model/verified_access_log_cloud_watch_logs_destination_options.dart
@@ -37,8 +37,9 @@ abstract class VerifiedAccessLogCloudWatchLogsDestinationOptions
   const VerifiedAccessLogCloudWatchLogsDestinationOptions._();
 
   static const List<
-      _i2.SmithySerializer<
-          VerifiedAccessLogCloudWatchLogsDestinationOptions>> serializers = [
+          _i2
+          .SmithySerializer<VerifiedAccessLogCloudWatchLogsDestinationOptions>>
+      serializers = [
     VerifiedAccessLogCloudWatchLogsDestinationOptionsEc2QuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/accept_transit_gateway_multicast_domain_associations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/accept_transit_gateway_multicast_domain_associations_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/accept_transit_gateway_multicas
 import 'package:smoke_test/src/sdk/src/ec2/model/accept_transit_gateway_multicast_domain_associations_result.dart';
 
 /// Accepts a request to associate subnets with a transit gateway multicast domain.
-class AcceptTransitGatewayMulticastDomainAssociationsOperation
-    extends _i1.HttpOperation<
+class AcceptTransitGatewayMulticastDomainAssociationsOperation extends _i1
+    .HttpOperation<
         AcceptTransitGatewayMulticastDomainAssociationsRequest,
         AcceptTransitGatewayMulticastDomainAssociationsRequest,
         AcceptTransitGatewayMulticastDomainAssociationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/apply_security_groups_to_client_vpn_target_network_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/apply_security_groups_to_client_vpn_target_network_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/apply_security_groups_to_client
 import 'package:smoke_test/src/sdk/src/ec2/model/apply_security_groups_to_client_vpn_target_network_result.dart';
 
 /// Applies a security group to the association between the target network and the Client VPN endpoint. This action replaces the existing security groups with the specified security groups.
-class ApplySecurityGroupsToClientVpnTargetNetworkOperation
-    extends _i1.HttpOperation<
+class ApplySecurityGroupsToClientVpnTargetNetworkOperation extends _i1
+    .HttpOperation<
         ApplySecurityGroupsToClientVpnTargetNetworkRequest,
         ApplySecurityGroupsToClientVpnTargetNetworkRequest,
         ApplySecurityGroupsToClientVpnTargetNetworkResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/create_local_gateway_route_table_vpc_association_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/create_local_gateway_route_table_vpc_association_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/create_local_gateway_route_tabl
 import 'package:smoke_test/src/sdk/src/ec2/model/create_local_gateway_route_table_vpc_association_result.dart';
 
 /// Associates the specified VPC with the specified local gateway route table.
-class CreateLocalGatewayRouteTableVpcAssociationOperation
-    extends _i1.HttpOperation<
+class CreateLocalGatewayRouteTableVpcAssociationOperation extends _i1
+    .HttpOperation<
         CreateLocalGatewayRouteTableVpcAssociationRequest,
         CreateLocalGatewayRouteTableVpcAssociationRequest,
         CreateLocalGatewayRouteTableVpcAssociationResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/create_transit_gateway_prefix_list_reference_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/create_transit_gateway_prefix_list_reference_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/create_transit_gateway_prefix_l
 import 'package:smoke_test/src/sdk/src/ec2/model/create_transit_gateway_prefix_list_reference_result.dart';
 
 /// Creates a reference (route) to a prefix list in a specified transit gateway route table.
-class CreateTransitGatewayPrefixListReferenceOperation
-    extends _i1.HttpOperation<
+class CreateTransitGatewayPrefixListReferenceOperation extends _i1
+    .HttpOperation<
         CreateTransitGatewayPrefixListReferenceRequest,
         CreateTransitGatewayPrefixListReferenceRequest,
         CreateTransitGatewayPrefixListReferenceResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/create_transit_gateway_route_table_announcement_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/create_transit_gateway_route_table_announcement_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/create_transit_gateway_route_ta
 import 'package:smoke_test/src/sdk/src/ec2/model/create_transit_gateway_route_table_announcement_result.dart';
 
 /// Advertises a new transit gateway route table.
-class CreateTransitGatewayRouteTableAnnouncementOperation
-    extends _i1.HttpOperation<
+class CreateTransitGatewayRouteTableAnnouncementOperation extends _i1
+    .HttpOperation<
         CreateTransitGatewayRouteTableAnnouncementRequest,
         CreateTransitGatewayRouteTableAnnouncementRequest,
         CreateTransitGatewayRouteTableAnnouncementResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/create_vpc_endpoint_connection_notification_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/create_vpc_endpoint_connection_notification_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/create_vpc_endpoint_connection_
 /// Creates a connection notification for a specified VPC endpoint or VPC endpoint service. A connection notification notifies you of specific endpoint events. You must create an SNS topic to receive notifications. For more information, see [Create a Topic](https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html) in the _Amazon Simple Notification Service Developer Guide_.
 ///
 /// You can create a connection notification for interface endpoints only.
-class CreateVpcEndpointConnectionNotificationOperation
-    extends _i1.HttpOperation<
+class CreateVpcEndpointConnectionNotificationOperation extends _i1
+    .HttpOperation<
         CreateVpcEndpointConnectionNotificationRequest,
         CreateVpcEndpointConnectionNotificationRequest,
         CreateVpcEndpointConnectionNotificationResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/delete_local_gateway_route_table_vpc_association_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/delete_local_gateway_route_table_vpc_association_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/delete_local_gateway_route_tabl
 import 'package:smoke_test/src/sdk/src/ec2/model/delete_local_gateway_route_table_vpc_association_result.dart';
 
 /// Deletes the specified association between a VPC and local gateway route table.
-class DeleteLocalGatewayRouteTableVpcAssociationOperation
-    extends _i1.HttpOperation<
+class DeleteLocalGatewayRouteTableVpcAssociationOperation extends _i1
+    .HttpOperation<
         DeleteLocalGatewayRouteTableVpcAssociationRequest,
         DeleteLocalGatewayRouteTableVpcAssociationRequest,
         DeleteLocalGatewayRouteTableVpcAssociationResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/delete_network_insights_access_scope_analysis_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/delete_network_insights_access_scope_analysis_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/delete_network_insights_access_
 import 'package:smoke_test/src/sdk/src/ec2/model/delete_network_insights_access_scope_analysis_result.dart';
 
 /// Deletes the specified Network Access Scope analysis.
-class DeleteNetworkInsightsAccessScopeAnalysisOperation
-    extends _i1.HttpOperation<
+class DeleteNetworkInsightsAccessScopeAnalysisOperation extends _i1
+    .HttpOperation<
         DeleteNetworkInsightsAccessScopeAnalysisRequest,
         DeleteNetworkInsightsAccessScopeAnalysisRequest,
         DeleteNetworkInsightsAccessScopeAnalysisResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/delete_transit_gateway_prefix_list_reference_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/delete_transit_gateway_prefix_list_reference_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/delete_transit_gateway_prefix_l
 import 'package:smoke_test/src/sdk/src/ec2/model/delete_transit_gateway_prefix_list_reference_result.dart';
 
 /// Deletes a reference (route) to a prefix list in a specified transit gateway route table.
-class DeleteTransitGatewayPrefixListReferenceOperation
-    extends _i1.HttpOperation<
+class DeleteTransitGatewayPrefixListReferenceOperation extends _i1
+    .HttpOperation<
         DeleteTransitGatewayPrefixListReferenceRequest,
         DeleteTransitGatewayPrefixListReferenceRequest,
         DeleteTransitGatewayPrefixListReferenceResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/delete_transit_gateway_route_table_announcement_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/delete_transit_gateway_route_table_announcement_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/delete_transit_gateway_route_ta
 import 'package:smoke_test/src/sdk/src/ec2/model/delete_transit_gateway_route_table_announcement_result.dart';
 
 /// Advertises to the transit gateway that a transit gateway route table is deleted.
-class DeleteTransitGatewayRouteTableAnnouncementOperation
-    extends _i1.HttpOperation<
+class DeleteTransitGatewayRouteTableAnnouncementOperation extends _i1
+    .HttpOperation<
         DeleteTransitGatewayRouteTableAnnouncementRequest,
         DeleteTransitGatewayRouteTableAnnouncementRequest,
         DeleteTransitGatewayRouteTableAnnouncementResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/delete_vpc_endpoint_connection_notifications_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/delete_vpc_endpoint_connection_notifications_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/delete_vpc_endpoint_connection_
 import 'package:smoke_test/src/sdk/src/ec2/model/delete_vpc_endpoint_connection_notifications_result.dart';
 
 /// Deletes the specified VPC endpoint connection notifications.
-class DeleteVpcEndpointConnectionNotificationsOperation
-    extends _i1.HttpOperation<
+class DeleteVpcEndpointConnectionNotificationsOperation extends _i1
+    .HttpOperation<
         DeleteVpcEndpointConnectionNotificationsRequest,
         DeleteVpcEndpointConnectionNotificationsRequest,
         DeleteVpcEndpointConnectionNotificationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/delete_vpc_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/delete_vpc_operation.dart
@@ -32,8 +32,9 @@ class DeleteVpcOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<DeleteVpcRequest, DeleteVpcRequest, _i1.Unit,
-          _i1.Unit>> protocols = [
+          _i1
+          .HttpProtocol<DeleteVpcRequest, DeleteVpcRequest, _i1.Unit, _i1.Unit>>
+      protocols = [
     _i3.Ec2QueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/deregister_instance_event_notification_attributes_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/deregister_instance_event_notification_attributes_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/deregister_instance_event_notif
 import 'package:smoke_test/src/sdk/src/ec2/model/deregister_instance_event_notification_attributes_result.dart';
 
 /// Deregisters tag keys to prevent tags that have the specified tag keys from being included in scheduled event notifications for resources in the Region.
-class DeregisterInstanceEventNotificationAttributesOperation
-    extends _i1.HttpOperation<
+class DeregisterInstanceEventNotificationAttributesOperation extends _i1
+    .HttpOperation<
         DeregisterInstanceEventNotificationAttributesRequest,
         DeregisterInstanceEventNotificationAttributesRequest,
         DeregisterInstanceEventNotificationAttributesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/deregister_transit_gateway_multicast_group_members_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/deregister_transit_gateway_multicast_group_members_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/deregister_transit_gateway_mult
 import 'package:smoke_test/src/sdk/src/ec2/model/deregister_transit_gateway_multicast_group_members_result.dart';
 
 /// Deregisters the specified members (network interfaces) from the transit gateway multicast group.
-class DeregisterTransitGatewayMulticastGroupMembersOperation
-    extends _i1.HttpOperation<
+class DeregisterTransitGatewayMulticastGroupMembersOperation extends _i1
+    .HttpOperation<
         DeregisterTransitGatewayMulticastGroupMembersRequest,
         DeregisterTransitGatewayMulticastGroupMembersRequest,
         DeregisterTransitGatewayMulticastGroupMembersResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/deregister_transit_gateway_multicast_group_sources_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/deregister_transit_gateway_multicast_group_sources_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/deregister_transit_gateway_mult
 import 'package:smoke_test/src/sdk/src/ec2/model/deregister_transit_gateway_multicast_group_sources_result.dart';
 
 /// Deregisters the specified sources (network interfaces) from the transit gateway multicast group.
-class DeregisterTransitGatewayMulticastGroupSourcesOperation
-    extends _i1.HttpOperation<
+class DeregisterTransitGatewayMulticastGroupSourcesOperation extends _i1
+    .HttpOperation<
         DeregisterTransitGatewayMulticastGroupSourcesRequest,
         DeregisterTransitGatewayMulticastGroupSourcesRequest,
         DeregisterTransitGatewayMulticastGroupSourcesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_aws_network_performance_metric_subscriptions_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_aws_network_performance_metric_subscriptions_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_aws_network_performanc
 import 'package:smoke_test/src/sdk/src/ec2/model/subscription.dart';
 
 /// Describes the current Infrastructure Performance metric subscriptions.
-class DescribeAwsNetworkPerformanceMetricSubscriptionsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeAwsNetworkPerformanceMetricSubscriptionsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeAwsNetworkPerformanceMetricSubscriptionsRequest,
         DescribeAwsNetworkPerformanceMetricSubscriptionsRequest,
         DescribeAwsNetworkPerformanceMetricSubscriptionsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_capacity_reservation_fleets_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_capacity_reservation_fleets_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_capacity_reservation_f
 import 'package:smoke_test/src/sdk/src/ec2/model/describe_capacity_reservation_fleets_result.dart';
 
 /// Describes one or more Capacity Reservation Fleets.
-class DescribeCapacityReservationFleetsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeCapacityReservationFleetsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeCapacityReservationFleetsRequest,
         DescribeCapacityReservationFleetsRequest,
         DescribeCapacityReservationFleetsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_client_vpn_authorization_rules_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_client_vpn_authorization_rules_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_client_vpn_authorizati
 import 'package:smoke_test/src/sdk/src/ec2/model/describe_client_vpn_authorization_rules_result.dart';
 
 /// Describes the authorization rules for a specified Client VPN endpoint.
-class DescribeClientVpnAuthorizationRulesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeClientVpnAuthorizationRulesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeClientVpnAuthorizationRulesRequest,
         DescribeClientVpnAuthorizationRulesRequest,
         DescribeClientVpnAuthorizationRulesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_client_vpn_target_networks_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_client_vpn_target_networks_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_client_vpn_target_netw
 import 'package:smoke_test/src/sdk/src/ec2/model/target_network.dart';
 
 /// Describes the target networks associated with the specified Client VPN endpoint.
-class DescribeClientVpnTargetNetworksOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeClientVpnTargetNetworksOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeClientVpnTargetNetworksRequest,
         DescribeClientVpnTargetNetworksRequest,
         DescribeClientVpnTargetNetworksResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_egress_only_internet_gateways_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_egress_only_internet_gateways_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_egress_only_internet_g
 import 'package:smoke_test/src/sdk/src/ec2/model/egress_only_internet_gateway.dart';
 
 /// Describes one or more of your egress-only internet gateways.
-class DescribeEgressOnlyInternetGatewaysOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeEgressOnlyInternetGatewaysOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeEgressOnlyInternetGatewaysRequest,
         DescribeEgressOnlyInternetGatewaysRequest,
         DescribeEgressOnlyInternetGatewaysResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_host_reservation_offerings_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_host_reservation_offerings_operation.dart
@@ -19,8 +19,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/host_offering.dart';
 /// Describes the Dedicated Host reservations that are available to purchase.
 ///
 /// The results describe all of the Dedicated Host reservation offerings, including offerings that might not match the instance family and Region of your Dedicated Hosts. When purchasing an offering, ensure that the instance family and Region of the offering matches that of the Dedicated Hosts with which it is to be associated. For more information about supported instance types, see [Dedicated Hosts](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-hosts-overview.html) in the _Amazon EC2 User Guide_.
-class DescribeHostReservationOfferingsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeHostReservationOfferingsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeHostReservationOfferingsRequest,
         DescribeHostReservationOfferingsRequest,
         DescribeHostReservationOfferingsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_iam_instance_profile_associations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_iam_instance_profile_associations_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_iam_instance_profile_a
 import 'package:smoke_test/src/sdk/src/ec2/model/iam_instance_profile_association.dart';
 
 /// Describes your IAM instance profile associations.
-class DescribeIamInstanceProfileAssociationsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeIamInstanceProfileAssociationsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeIamInstanceProfileAssociationsRequest,
         DescribeIamInstanceProfileAssociationsRequest,
         DescribeIamInstanceProfileAssociationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_instance_connect_endpoints_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_instance_connect_endpoints_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_instance_connect_endpo
 import 'package:smoke_test/src/sdk/src/ec2/model/ec2_instance_connect_endpoint.dart';
 
 /// Describes the specified EC2 Instance Connect Endpoints or all EC2 Instance Connect Endpoints.
-class DescribeInstanceConnectEndpointsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeInstanceConnectEndpointsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeInstanceConnectEndpointsRequest,
         DescribeInstanceConnectEndpointsRequest,
         DescribeInstanceConnectEndpointsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_instance_credit_specifications_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_instance_credit_specifications_operation.dart
@@ -27,8 +27,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/instance_credit_specification.d
 /// If an Availability Zone is experiencing a service disruption and you specify instance IDs in the affected zone, or do not specify any instance IDs at all, the call fails. If you specify only instance IDs in an unaffected zone, the call works normally.
 ///
 /// For more information, see [Burstable performance instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html) in the _Amazon EC2 User Guide_.
-class DescribeInstanceCreditSpecificationsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeInstanceCreditSpecificationsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeInstanceCreditSpecificationsRequest,
         DescribeInstanceCreditSpecificationsRequest,
         DescribeInstanceCreditSpecificationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_instance_event_notification_attributes_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_instance_event_notification_attributes_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_instance_event_notific
 import 'package:smoke_test/src/sdk/src/ec2/model/describe_instance_event_notification_attributes_result.dart';
 
 /// Describes the tag keys that are registered to appear in scheduled event notifications for resources in the current Region.
-class DescribeInstanceEventNotificationAttributesOperation
-    extends _i1.HttpOperation<
+class DescribeInstanceEventNotificationAttributesOperation extends _i1
+    .HttpOperation<
         DescribeInstanceEventNotificationAttributesRequest,
         DescribeInstanceEventNotificationAttributesRequest,
         DescribeInstanceEventNotificationAttributesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_ipam_resource_discoveries_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_ipam_resource_discoveries_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_ipam_resource_discover
 import 'package:smoke_test/src/sdk/src/ec2/model/ipam_resource_discovery.dart';
 
 /// Describes IPAM resource discoveries. A resource discovery is an IPAM component that enables IPAM to manage and monitor resources that belong to the owning account.
-class DescribeIpamResourceDiscoveriesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeIpamResourceDiscoveriesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeIpamResourceDiscoveriesRequest,
         DescribeIpamResourceDiscoveriesRequest,
         DescribeIpamResourceDiscoveriesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_ipam_resource_discovery_associations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_ipam_resource_discovery_associations_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_ipam_resource_discover
 import 'package:smoke_test/src/sdk/src/ec2/model/ipam_resource_discovery_association.dart';
 
 /// Describes resource discovery association with an Amazon VPC IPAM. An associated resource discovery is a resource discovery that has been associated with an IPAM..
-class DescribeIpamResourceDiscoveryAssociationsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeIpamResourceDiscoveryAssociationsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeIpamResourceDiscoveryAssociationsRequest,
         DescribeIpamResourceDiscoveryAssociationsRequest,
         DescribeIpamResourceDiscoveryAssociationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_launch_template_versions_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_launch_template_versions_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_launch_template_versio
 import 'package:smoke_test/src/sdk/src/ec2/model/launch_template_version.dart';
 
 /// Describes one or more versions of a specified launch template. You can describe all versions, individual versions, or a range of versions. You can also describe all the latest versions or all the default versions of all the launch templates in your account.
-class DescribeLaunchTemplateVersionsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeLaunchTemplateVersionsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeLaunchTemplateVersionsRequest,
         DescribeLaunchTemplateVersionsRequest,
         DescribeLaunchTemplateVersionsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_local_gateway_route_table_vpc_associations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_local_gateway_route_table_vpc_associations_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_local_gateway_route_ta
 import 'package:smoke_test/src/sdk/src/ec2/model/local_gateway_route_table_vpc_association.dart';
 
 /// Describes the specified associations between VPCs and local gateway route tables.
-class DescribeLocalGatewayRouteTableVpcAssociationsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeLocalGatewayRouteTableVpcAssociationsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeLocalGatewayRouteTableVpcAssociationsRequest,
         DescribeLocalGatewayRouteTableVpcAssociationsRequest,
         DescribeLocalGatewayRouteTableVpcAssociationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_local_gateway_route_tables_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_local_gateway_route_tables_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_local_gateway_route_ta
 import 'package:smoke_test/src/sdk/src/ec2/model/local_gateway_route_table.dart';
 
 /// Describes one or more local gateway route tables. By default, all local gateway route tables are described. Alternatively, you can filter the results.
-class DescribeLocalGatewayRouteTablesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeLocalGatewayRouteTablesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeLocalGatewayRouteTablesRequest,
         DescribeLocalGatewayRouteTablesRequest,
         DescribeLocalGatewayRouteTablesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_local_gateway_virtual_interface_groups_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_local_gateway_virtual_interface_groups_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_local_gateway_virtual_
 import 'package:smoke_test/src/sdk/src/ec2/model/local_gateway_virtual_interface_group.dart';
 
 /// Describes the specified local gateway virtual interface groups.
-class DescribeLocalGatewayVirtualInterfaceGroupsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeLocalGatewayVirtualInterfaceGroupsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeLocalGatewayVirtualInterfaceGroupsRequest,
         DescribeLocalGatewayVirtualInterfaceGroupsRequest,
         DescribeLocalGatewayVirtualInterfaceGroupsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_local_gateway_virtual_interfaces_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_local_gateway_virtual_interfaces_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_local_gateway_virtual_
 import 'package:smoke_test/src/sdk/src/ec2/model/local_gateway_virtual_interface.dart';
 
 /// Describes the specified local gateway virtual interfaces.
-class DescribeLocalGatewayVirtualInterfacesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeLocalGatewayVirtualInterfacesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeLocalGatewayVirtualInterfacesRequest,
         DescribeLocalGatewayVirtualInterfacesRequest,
         DescribeLocalGatewayVirtualInterfacesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_network_insights_access_scope_analyses_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_network_insights_access_scope_analyses_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_network_insights_acces
 import 'package:smoke_test/src/sdk/src/ec2/model/network_insights_access_scope_analysis.dart';
 
 /// Describes the specified Network Access Scope analyses.
-class DescribeNetworkInsightsAccessScopeAnalysesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeNetworkInsightsAccessScopeAnalysesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeNetworkInsightsAccessScopeAnalysesRequest,
         DescribeNetworkInsightsAccessScopeAnalysesRequest,
         DescribeNetworkInsightsAccessScopeAnalysesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_network_insights_access_scopes_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_network_insights_access_scopes_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_network_insights_acces
 import 'package:smoke_test/src/sdk/src/ec2/model/network_insights_access_scope.dart';
 
 /// Describes the specified Network Access Scopes.
-class DescribeNetworkInsightsAccessScopesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeNetworkInsightsAccessScopesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeNetworkInsightsAccessScopesRequest,
         DescribeNetworkInsightsAccessScopesRequest,
         DescribeNetworkInsightsAccessScopesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_network_insights_analyses_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_network_insights_analyses_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_network_insights_analy
 import 'package:smoke_test/src/sdk/src/ec2/model/network_insights_analysis.dart';
 
 /// Describes one or more of your network insights analyses.
-class DescribeNetworkInsightsAnalysesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeNetworkInsightsAnalysesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeNetworkInsightsAnalysesRequest,
         DescribeNetworkInsightsAnalysesRequest,
         DescribeNetworkInsightsAnalysesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_network_interface_permissions_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_network_interface_permissions_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_network_interface_perm
 import 'package:smoke_test/src/sdk/src/ec2/model/network_interface_permission.dart';
 
 /// Describes the permissions for your network interfaces.
-class DescribeNetworkInterfacePermissionsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeNetworkInterfacePermissionsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeNetworkInterfacePermissionsRequest,
         DescribeNetworkInterfacePermissionsRequest,
         DescribeNetworkInterfacePermissionsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_replace_root_volume_tasks_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_replace_root_volume_tasks_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_replace_root_volume_ta
 import 'package:smoke_test/src/sdk/src/ec2/model/replace_root_volume_task.dart';
 
 /// Describes a root volume replacement task. For more information, see [Replace a root volume](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/replace-root.html) in the _Amazon Elastic Compute Cloud User Guide_.
-class DescribeReplaceRootVolumeTasksOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeReplaceRootVolumeTasksOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeReplaceRootVolumeTasksRequest,
         DescribeReplaceRootVolumeTasksRequest,
         DescribeReplaceRootVolumeTasksResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_reserved_instances_modifications_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_reserved_instances_modifications_operation.dart
@@ -19,8 +19,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/reserved_instances_modification
 /// Describes the modifications made to your Reserved Instances. If no parameter is specified, information about all your Reserved Instances modification requests is returned. If a modification ID is specified, only information about the specific modification is returned.
 ///
 /// For more information, see [Modifying Reserved Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ri-modifying.html) in the _Amazon EC2 User Guide_.
-class DescribeReservedInstancesModificationsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeReservedInstancesModificationsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeReservedInstancesModificationsRequest,
         DescribeReservedInstancesModificationsRequest,
         DescribeReservedInstancesModificationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_reserved_instances_offerings_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_reserved_instances_offerings_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/reserved_instances_offering.dar
 /// If you have listed your own Reserved Instances for sale in the Reserved Instance Marketplace, they will be excluded from these results. This is to ensure that you do not purchase your own Reserved Instances.
 ///
 /// For more information, see [Reserved Instance Marketplace](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ri-market-general.html) in the _Amazon EC2 User Guide_.
-class DescribeReservedInstancesOfferingsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeReservedInstancesOfferingsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeReservedInstancesOfferingsRequest,
         DescribeReservedInstancesOfferingsRequest,
         DescribeReservedInstancesOfferingsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_scheduled_instance_availability_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_scheduled_instance_availability_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/scheduled_instance_availability
 /// You can search for an available schedule no more than 3 months in advance. You must meet the minimum required duration of 1,200 hours per year. For example, the minimum daily schedule is 4 hours, the minimum weekly schedule is 24 hours, and the minimum monthly schedule is 100 hours.
 ///
 /// After you find a schedule that meets your needs, call PurchaseScheduledInstances to purchase Scheduled Instances with that schedule.
-class DescribeScheduledInstanceAvailabilityOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeScheduledInstanceAvailabilityOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeScheduledInstanceAvailabilityRequest,
         DescribeScheduledInstanceAvailabilityRequest,
         DescribeScheduledInstanceAvailabilityResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_attachments_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_attachments_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_transit_gateway_attach
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_attachment.dart';
 
 /// Describes one or more attachments between resources and transit gateways. By default, all attachments are described. Alternatively, you can filter the results by attachment ID, attachment state, resource ID, or resource owner.
-class DescribeTransitGatewayAttachmentsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeTransitGatewayAttachmentsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeTransitGatewayAttachmentsRequest,
         DescribeTransitGatewayAttachmentsRequest,
         DescribeTransitGatewayAttachmentsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_connect_peers_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_connect_peers_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_transit_gateway_connec
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_connect_peer.dart';
 
 /// Describes one or more Connect peers.
-class DescribeTransitGatewayConnectPeersOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeTransitGatewayConnectPeersOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeTransitGatewayConnectPeersRequest,
         DescribeTransitGatewayConnectPeersRequest,
         DescribeTransitGatewayConnectPeersResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_connects_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_connects_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_transit_gateway_connec
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_connect.dart';
 
 /// Describes one or more Connect attachments.
-class DescribeTransitGatewayConnectsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeTransitGatewayConnectsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeTransitGatewayConnectsRequest,
         DescribeTransitGatewayConnectsRequest,
         DescribeTransitGatewayConnectsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_multicast_domains_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_multicast_domains_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_transit_gateway_multic
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_multicast_domain.dart';
 
 /// Describes one or more transit gateway multicast domains.
-class DescribeTransitGatewayMulticastDomainsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeTransitGatewayMulticastDomainsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeTransitGatewayMulticastDomainsRequest,
         DescribeTransitGatewayMulticastDomainsRequest,
         DescribeTransitGatewayMulticastDomainsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_peering_attachments_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_peering_attachments_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_transit_gateway_peerin
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_peering_attachment.dart';
 
 /// Describes your transit gateway peering attachments.
-class DescribeTransitGatewayPeeringAttachmentsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeTransitGatewayPeeringAttachmentsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeTransitGatewayPeeringAttachmentsRequest,
         DescribeTransitGatewayPeeringAttachmentsRequest,
         DescribeTransitGatewayPeeringAttachmentsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_policy_tables_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_policy_tables_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_transit_gateway_policy
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_policy_table.dart';
 
 /// Describes one or more transit gateway route policy tables.
-class DescribeTransitGatewayPolicyTablesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeTransitGatewayPolicyTablesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeTransitGatewayPolicyTablesRequest,
         DescribeTransitGatewayPolicyTablesRequest,
         DescribeTransitGatewayPolicyTablesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_route_table_announcements_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_route_table_announcements_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_transit_gateway_route_
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_route_table_announcement.dart';
 
 /// Describes one or more transit gateway route table advertisements.
-class DescribeTransitGatewayRouteTableAnnouncementsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeTransitGatewayRouteTableAnnouncementsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeTransitGatewayRouteTableAnnouncementsRequest,
         DescribeTransitGatewayRouteTableAnnouncementsRequest,
         DescribeTransitGatewayRouteTableAnnouncementsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_route_tables_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_route_tables_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_transit_gateway_route_
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_route_table.dart';
 
 /// Describes one or more transit gateway route tables. By default, all transit gateway route tables are described. Alternatively, you can filter the results.
-class DescribeTransitGatewayRouteTablesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeTransitGatewayRouteTablesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeTransitGatewayRouteTablesRequest,
         DescribeTransitGatewayRouteTablesRequest,
         DescribeTransitGatewayRouteTablesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_vpc_attachments_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_transit_gateway_vpc_attachments_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_transit_gateway_vpc_at
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_vpc_attachment.dart';
 
 /// Describes one or more VPC attachments. By default, all VPC attachments are described. Alternatively, you can filter the results.
-class DescribeTransitGatewayVpcAttachmentsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeTransitGatewayVpcAttachmentsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeTransitGatewayVpcAttachmentsRequest,
         DescribeTransitGatewayVpcAttachmentsRequest,
         DescribeTransitGatewayVpcAttachmentsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_trunk_interface_associations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_trunk_interface_associations_operation.dart
@@ -19,8 +19,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/trunk_interface_association.dar
 /// This API action is currently in **limited preview only**. If you are interested in using this feature, contact your account manager.
 ///
 /// Describes one or more network interface trunk associations.
-class DescribeTrunkInterfaceAssociationsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeTrunkInterfaceAssociationsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeTrunkInterfaceAssociationsRequest,
         DescribeTrunkInterfaceAssociationsRequest,
         DescribeTrunkInterfaceAssociationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_verified_access_endpoints_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_verified_access_endpoints_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_verified_access_endpoi
 import 'package:smoke_test/src/sdk/src/ec2/model/verified_access_endpoint.dart';
 
 /// Describes the specified Amazon Web Services Verified Access endpoints.
-class DescribeVerifiedAccessEndpointsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeVerifiedAccessEndpointsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeVerifiedAccessEndpointsRequest,
         DescribeVerifiedAccessEndpointsRequest,
         DescribeVerifiedAccessEndpointsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_verified_access_instance_logging_configurations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_verified_access_instance_logging_configurations_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_verified_access_instan
 import 'package:smoke_test/src/sdk/src/ec2/model/verified_access_instance_logging_configuration.dart';
 
 /// Describes the specified Amazon Web Services Verified Access instances.
-class DescribeVerifiedAccessInstanceLoggingConfigurationsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeVerifiedAccessInstanceLoggingConfigurationsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeVerifiedAccessInstanceLoggingConfigurationsRequest,
         DescribeVerifiedAccessInstanceLoggingConfigurationsRequest,
         DescribeVerifiedAccessInstanceLoggingConfigurationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_verified_access_instances_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_verified_access_instances_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_verified_access_instan
 import 'package:smoke_test/src/sdk/src/ec2/model/verified_access_instance.dart';
 
 /// Describes the specified Amazon Web Services Verified Access instances.
-class DescribeVerifiedAccessInstancesOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeVerifiedAccessInstancesOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeVerifiedAccessInstancesRequest,
         DescribeVerifiedAccessInstancesRequest,
         DescribeVerifiedAccessInstancesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_verified_access_trust_providers_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_verified_access_trust_providers_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_verified_access_trust_
 import 'package:smoke_test/src/sdk/src/ec2/model/verified_access_trust_provider.dart';
 
 /// Describes the specified Amazon Web Services Verified Access trust providers.
-class DescribeVerifiedAccessTrustProvidersOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeVerifiedAccessTrustProvidersOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeVerifiedAccessTrustProvidersRequest,
         DescribeVerifiedAccessTrustProvidersRequest,
         DescribeVerifiedAccessTrustProvidersResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_vpc_classic_link_dns_support_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_vpc_classic_link_dns_support_operation.dart
@@ -19,8 +19,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_vpc_classic_link_dns_s
 /// This action is deprecated.
 ///
 /// Describes the ClassicLink DNS support status of one or more VPCs. If enabled, the DNS hostname of a linked EC2-Classic instance resolves to its private IP address when addressed from an instance in the VPC to which it's linked. Similarly, the DNS hostname of an instance in a VPC resolves to its private IP address when addressed from a linked EC2-Classic instance.
-class DescribeVpcClassicLinkDnsSupportOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeVpcClassicLinkDnsSupportOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeVpcClassicLinkDnsSupportRequest,
         DescribeVpcClassicLinkDnsSupportRequest,
         DescribeVpcClassicLinkDnsSupportResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_vpc_endpoint_connection_notifications_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_vpc_endpoint_connection_notifications_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_vpc_endpoint_connectio
 import 'package:smoke_test/src/sdk/src/ec2/model/describe_vpc_endpoint_connection_notifications_result.dart';
 
 /// Describes the connection notifications for VPC endpoints and VPC endpoint services.
-class DescribeVpcEndpointConnectionNotificationsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeVpcEndpointConnectionNotificationsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeVpcEndpointConnectionNotificationsRequest,
         DescribeVpcEndpointConnectionNotificationsRequest,
         DescribeVpcEndpointConnectionNotificationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_vpc_endpoint_connections_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_vpc_endpoint_connections_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_vpc_endpoint_connectio
 import 'package:smoke_test/src/sdk/src/ec2/model/vpc_endpoint_connection.dart';
 
 /// Describes the VPC endpoint connections to your VPC endpoint services, including any endpoints that are pending your acceptance.
-class DescribeVpcEndpointConnectionsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeVpcEndpointConnectionsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeVpcEndpointConnectionsRequest,
         DescribeVpcEndpointConnectionsRequest,
         DescribeVpcEndpointConnectionsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_vpc_endpoint_service_configurations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_vpc_endpoint_service_configurations_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_vpc_endpoint_service_c
 import 'package:smoke_test/src/sdk/src/ec2/model/service_configuration.dart';
 
 /// Describes the VPC endpoint service configurations in your account (your services).
-class DescribeVpcEndpointServiceConfigurationsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeVpcEndpointServiceConfigurationsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeVpcEndpointServiceConfigurationsRequest,
         DescribeVpcEndpointServiceConfigurationsRequest,
         DescribeVpcEndpointServiceConfigurationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_vpc_endpoint_service_permissions_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/describe_vpc_endpoint_service_permissions_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/describe_vpc_endpoint_service_p
 import 'package:smoke_test/src/sdk/src/ec2/model/describe_vpc_endpoint_service_permissions_result.dart';
 
 /// Describes the principals (service consumers) that are permitted to discover your VPC endpoint service.
-class DescribeVpcEndpointServicePermissionsOperation
-    extends _i1.PaginatedHttpOperation<
+class DescribeVpcEndpointServicePermissionsOperation extends _i1
+    .PaginatedHttpOperation<
         DescribeVpcEndpointServicePermissionsRequest,
         DescribeVpcEndpointServicePermissionsRequest,
         DescribeVpcEndpointServicePermissionsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/disable_aws_network_performance_metric_subscription_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/disable_aws_network_performance_metric_subscription_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/disable_aws_network_performance
 import 'package:smoke_test/src/sdk/src/ec2/model/disable_aws_network_performance_metric_subscription_result.dart';
 
 /// Disables Infrastructure Performance metric subscriptions.
-class DisableAwsNetworkPerformanceMetricSubscriptionOperation
-    extends _i1.HttpOperation<
+class DisableAwsNetworkPerformanceMetricSubscriptionOperation extends _i1
+    .HttpOperation<
         DisableAwsNetworkPerformanceMetricSubscriptionRequest,
         DisableAwsNetworkPerformanceMetricSubscriptionRequest,
         DisableAwsNetworkPerformanceMetricSubscriptionResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/disable_transit_gateway_route_table_propagation_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/disable_transit_gateway_route_table_propagation_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/disable_transit_gateway_route_t
 import 'package:smoke_test/src/sdk/src/ec2/model/disable_transit_gateway_route_table_propagation_result.dart';
 
 /// Disables the specified resource attachment from propagating routes to the specified propagation route table.
-class DisableTransitGatewayRouteTablePropagationOperation
-    extends _i1.HttpOperation<
+class DisableTransitGatewayRouteTablePropagationOperation extends _i1
+    .HttpOperation<
         DisableTransitGatewayRouteTablePropagationRequest,
         DisableTransitGatewayRouteTablePropagationRequest,
         DisableTransitGatewayRouteTablePropagationResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/disassociate_transit_gateway_multicast_domain_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/disassociate_transit_gateway_multicast_domain_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/disassociate_transit_gateway_mu
 import 'package:smoke_test/src/sdk/src/ec2/model/disassociate_transit_gateway_multicast_domain_result.dart';
 
 /// Disassociates the specified subnets from the transit gateway multicast domain.
-class DisassociateTransitGatewayMulticastDomainOperation
-    extends _i1.HttpOperation<
+class DisassociateTransitGatewayMulticastDomainOperation extends _i1
+    .HttpOperation<
         DisassociateTransitGatewayMulticastDomainRequest,
         DisassociateTransitGatewayMulticastDomainRequest,
         DisassociateTransitGatewayMulticastDomainResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/enable_aws_network_performance_metric_subscription_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/enable_aws_network_performance_metric_subscription_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/enable_aws_network_performance_
 import 'package:smoke_test/src/sdk/src/ec2/model/enable_aws_network_performance_metric_subscription_result.dart';
 
 /// Enables Infrastructure Performance subscriptions.
-class EnableAwsNetworkPerformanceMetricSubscriptionOperation
-    extends _i1.HttpOperation<
+class EnableAwsNetworkPerformanceMetricSubscriptionOperation extends _i1
+    .HttpOperation<
         EnableAwsNetworkPerformanceMetricSubscriptionRequest,
         EnableAwsNetworkPerformanceMetricSubscriptionRequest,
         EnableAwsNetworkPerformanceMetricSubscriptionResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/enable_reachability_analyzer_organization_sharing_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/enable_reachability_analyzer_organization_sharing_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/enable_reachability_analyzer_or
 /// Establishes a trust relationship between Reachability Analyzer and Organizations. This operation must be performed by the management account for the organization.
 ///
 /// After you establish a trust relationship, a user in the management account or a delegated administrator account can run a cross-account analysis using resources from the member accounts.
-class EnableReachabilityAnalyzerOrganizationSharingOperation
-    extends _i1.HttpOperation<
+class EnableReachabilityAnalyzerOrganizationSharingOperation extends _i1
+    .HttpOperation<
         EnableReachabilityAnalyzerOrganizationSharingRequest,
         EnableReachabilityAnalyzerOrganizationSharingRequest,
         EnableReachabilityAnalyzerOrganizationSharingResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/enable_transit_gateway_route_table_propagation_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/enable_transit_gateway_route_table_propagation_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/enable_transit_gateway_route_ta
 import 'package:smoke_test/src/sdk/src/ec2/model/enable_transit_gateway_route_table_propagation_result.dart';
 
 /// Enables the specified attachment to propagate routes to the specified propagation route table.
-class EnableTransitGatewayRouteTablePropagationOperation
-    extends _i1.HttpOperation<
+class EnableTransitGatewayRouteTablePropagationOperation extends _i1
+    .HttpOperation<
         EnableTransitGatewayRouteTablePropagationRequest,
         EnableTransitGatewayRouteTablePropagationRequest,
         EnableTransitGatewayRouteTablePropagationResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/export_client_vpn_client_certificate_revocation_list_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/export_client_vpn_client_certificate_revocation_list_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/export_client_vpn_client_certif
 import 'package:smoke_test/src/sdk/src/ec2/model/export_client_vpn_client_certificate_revocation_list_result.dart';
 
 /// Downloads the client certificate revocation list for the specified Client VPN endpoint.
-class ExportClientVpnClientCertificateRevocationListOperation
-    extends _i1.HttpOperation<
+class ExportClientVpnClientCertificateRevocationListOperation extends _i1
+    .HttpOperation<
         ExportClientVpnClientCertificateRevocationListRequest,
         ExportClientVpnClientCertificateRevocationListRequest,
         ExportClientVpnClientCertificateRevocationListResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_associated_enclave_certificate_iam_roles_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_associated_enclave_certificate_iam_roles_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/get_associated_enclave_certific
 import 'package:smoke_test/src/sdk/src/ec2/model/get_associated_enclave_certificate_iam_roles_result.dart';
 
 /// Returns the IAM roles that are associated with the specified ACM (ACM) certificate. It also returns the name of the Amazon S3 bucket and the Amazon S3 object key where the certificate, certificate chain, and encrypted private key bundle are stored, and the ARN of the KMS key that's used to encrypt the private key.
-class GetAssociatedEnclaveCertificateIamRolesOperation
-    extends _i1.HttpOperation<
+class GetAssociatedEnclaveCertificateIamRolesOperation extends _i1
+    .HttpOperation<
         GetAssociatedEnclaveCertificateIamRolesRequest,
         GetAssociatedEnclaveCertificateIamRolesRequest,
         GetAssociatedEnclaveCertificateIamRolesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_groups_for_capacity_reservation_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_groups_for_capacity_reservation_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/get_groups_for_capacity_reserva
 import 'package:smoke_test/src/sdk/src/ec2/model/get_groups_for_capacity_reservation_result.dart';
 
 /// Lists the resource groups to which a Capacity Reservation has been added.
-class GetGroupsForCapacityReservationOperation
-    extends _i1.PaginatedHttpOperation<
+class GetGroupsForCapacityReservationOperation extends _i1
+    .PaginatedHttpOperation<
         GetGroupsForCapacityReservationRequest,
         GetGroupsForCapacityReservationRequest,
         GetGroupsForCapacityReservationResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_instance_types_from_instance_requirements_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_instance_types_from_instance_requirements_operation.dart
@@ -21,8 +21,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/instance_type_info_from_instanc
 /// When you specify multiple parameters, you get instance types that satisfy all of the specified parameters. If you specify multiple values for a parameter, you get instance types that satisfy any of the specified values.
 ///
 /// For more information, see [Preview instance types with specified attributes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet-attribute-based-instance-type-selection.html#spotfleet-get-instance-types-from-instance-requirements), [Attribute-based instance type selection for EC2 Fleet](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-attribute-based-instance-type-selection.html), [Attribute-based instance type selection for Spot Fleet](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet-attribute-based-instance-type-selection.html), and [Spot placement score](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-placement-score.html) in the _Amazon EC2 User Guide_, and [Creating an Auto Scaling group using attribute-based instance type selection](https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-asg-instance-type-requirements.html) in the _Amazon EC2 Auto Scaling User Guide_.
-class GetInstanceTypesFromInstanceRequirementsOperation
-    extends _i1.PaginatedHttpOperation<
+class GetInstanceTypesFromInstanceRequirementsOperation extends _i1
+    .PaginatedHttpOperation<
         GetInstanceTypesFromInstanceRequirementsRequest,
         GetInstanceTypesFromInstanceRequirementsRequest,
         GetInstanceTypesFromInstanceRequirementsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_ipam_discovered_resource_cidrs_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_ipam_discovered_resource_cidrs_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/get_ipam_discovered_resource_ci
 import 'package:smoke_test/src/sdk/src/ec2/model/ipam_discovered_resource_cidr.dart';
 
 /// Returns the resource CIDRs that are monitored as part of a resource discovery. A discovered resource is a resource CIDR monitored under a resource discovery. The following resources can be discovered: VPCs, Public IPv4 pools, VPC subnets, and Elastic IP addresses.
-class GetIpamDiscoveredResourceCidrsOperation
-    extends _i1.PaginatedHttpOperation<
+class GetIpamDiscoveredResourceCidrsOperation extends _i1
+    .PaginatedHttpOperation<
         GetIpamDiscoveredResourceCidrsRequest,
         GetIpamDiscoveredResourceCidrsRequest,
         GetIpamDiscoveredResourceCidrsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_managed_prefix_list_associations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_managed_prefix_list_associations_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/get_managed_prefix_list_associa
 import 'package:smoke_test/src/sdk/src/ec2/model/prefix_list_association.dart';
 
 /// Gets information about the resources that are associated with the specified managed prefix list.
-class GetManagedPrefixListAssociationsOperation
-    extends _i1.PaginatedHttpOperation<
+class GetManagedPrefixListAssociationsOperation extends _i1
+    .PaginatedHttpOperation<
         GetManagedPrefixListAssociationsRequest,
         GetManagedPrefixListAssociationsRequest,
         GetManagedPrefixListAssociationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_network_insights_access_scope_analysis_findings_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_network_insights_access_scope_analysis_findings_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/get_network_insights_access_sco
 import 'package:smoke_test/src/sdk/src/ec2/model/get_network_insights_access_scope_analysis_findings_result.dart';
 
 /// Gets the findings for the specified Network Access Scope analysis.
-class GetNetworkInsightsAccessScopeAnalysisFindingsOperation
-    extends _i1.PaginatedHttpOperation<
+class GetNetworkInsightsAccessScopeAnalysisFindingsOperation extends _i1
+    .PaginatedHttpOperation<
         GetNetworkInsightsAccessScopeAnalysisFindingsRequest,
         GetNetworkInsightsAccessScopeAnalysisFindingsRequest,
         GetNetworkInsightsAccessScopeAnalysisFindingsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_transit_gateway_attachment_propagations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_transit_gateway_attachment_propagations_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/get_transit_gateway_attachment_
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_attachment_propagation.dart';
 
 /// Lists the route tables to which the specified resource attachment propagates routes.
-class GetTransitGatewayAttachmentPropagationsOperation
-    extends _i1.PaginatedHttpOperation<
+class GetTransitGatewayAttachmentPropagationsOperation extends _i1
+    .PaginatedHttpOperation<
         GetTransitGatewayAttachmentPropagationsRequest,
         GetTransitGatewayAttachmentPropagationsRequest,
         GetTransitGatewayAttachmentPropagationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_transit_gateway_multicast_domain_associations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_transit_gateway_multicast_domain_associations_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/get_transit_gateway_multicast_d
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_multicast_domain_association.dart';
 
 /// Gets information about the associations for the transit gateway multicast domain.
-class GetTransitGatewayMulticastDomainAssociationsOperation
-    extends _i1.PaginatedHttpOperation<
+class GetTransitGatewayMulticastDomainAssociationsOperation extends _i1
+    .PaginatedHttpOperation<
         GetTransitGatewayMulticastDomainAssociationsRequest,
         GetTransitGatewayMulticastDomainAssociationsRequest,
         GetTransitGatewayMulticastDomainAssociationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_transit_gateway_policy_table_associations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_transit_gateway_policy_table_associations_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/get_transit_gateway_policy_tabl
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_policy_table_association.dart';
 
 /// Gets a list of the transit gateway policy table associations.
-class GetTransitGatewayPolicyTableAssociationsOperation
-    extends _i1.PaginatedHttpOperation<
+class GetTransitGatewayPolicyTableAssociationsOperation extends _i1
+    .PaginatedHttpOperation<
         GetTransitGatewayPolicyTableAssociationsRequest,
         GetTransitGatewayPolicyTableAssociationsRequest,
         GetTransitGatewayPolicyTableAssociationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_transit_gateway_prefix_list_references_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_transit_gateway_prefix_list_references_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/get_transit_gateway_prefix_list
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_prefix_list_reference.dart';
 
 /// Gets information about the prefix list references in a specified transit gateway route table.
-class GetTransitGatewayPrefixListReferencesOperation
-    extends _i1.PaginatedHttpOperation<
+class GetTransitGatewayPrefixListReferencesOperation extends _i1
+    .PaginatedHttpOperation<
         GetTransitGatewayPrefixListReferencesRequest,
         GetTransitGatewayPrefixListReferencesRequest,
         GetTransitGatewayPrefixListReferencesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_transit_gateway_route_table_associations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_transit_gateway_route_table_associations_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/get_transit_gateway_route_table
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_route_table_association.dart';
 
 /// Gets information about the associations for the specified transit gateway route table.
-class GetTransitGatewayRouteTableAssociationsOperation
-    extends _i1.PaginatedHttpOperation<
+class GetTransitGatewayRouteTableAssociationsOperation extends _i1
+    .PaginatedHttpOperation<
         GetTransitGatewayRouteTableAssociationsRequest,
         GetTransitGatewayRouteTableAssociationsRequest,
         GetTransitGatewayRouteTableAssociationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_transit_gateway_route_table_propagations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_transit_gateway_route_table_propagations_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/get_transit_gateway_route_table
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_route_table_propagation.dart';
 
 /// Gets information about the route table propagations for the specified transit gateway route table.
-class GetTransitGatewayRouteTablePropagationsOperation
-    extends _i1.PaginatedHttpOperation<
+class GetTransitGatewayRouteTablePropagationsOperation extends _i1
+    .PaginatedHttpOperation<
         GetTransitGatewayRouteTablePropagationsRequest,
         GetTransitGatewayRouteTablePropagationsRequest,
         GetTransitGatewayRouteTablePropagationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_vpn_connection_device_sample_configuration_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/get_vpn_connection_device_sample_configuration_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/get_vpn_connection_device_sampl
 import 'package:smoke_test/src/sdk/src/ec2/model/get_vpn_connection_device_sample_configuration_result.dart';
 
 /// Download an Amazon Web Services-provided sample configuration file to be used with the customer gateway device specified for your Site-to-Site VPN connection.
-class GetVpnConnectionDeviceSampleConfigurationOperation
-    extends _i1.HttpOperation<
+class GetVpnConnectionDeviceSampleConfigurationOperation extends _i1
+    .HttpOperation<
         GetVpnConnectionDeviceSampleConfigurationRequest,
         GetVpnConnectionDeviceSampleConfigurationRequest,
         GetVpnConnectionDeviceSampleConfigurationResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/import_client_vpn_client_certificate_revocation_list_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/import_client_vpn_client_certificate_revocation_list_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/import_client_vpn_client_certif
 /// Uploads a client certificate revocation list to the specified Client VPN endpoint. Uploading a client certificate revocation list overwrites the existing client certificate revocation list.
 ///
 /// Uploading a client certificate revocation list resets existing client connections.
-class ImportClientVpnClientCertificateRevocationListOperation
-    extends _i1.HttpOperation<
+class ImportClientVpnClientCertificateRevocationListOperation extends _i1
+    .HttpOperation<
         ImportClientVpnClientCertificateRevocationListRequest,
         ImportClientVpnClientCertificateRevocationListRequest,
         ImportClientVpnClientCertificateRevocationListResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/modify_instance_capacity_reservation_attributes_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/modify_instance_capacity_reservation_attributes_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/modify_instance_capacity_reserv
 import 'package:smoke_test/src/sdk/src/ec2/model/modify_instance_capacity_reservation_attributes_result.dart';
 
 /// Modifies the Capacity Reservation settings for a stopped instance. Use this action to configure an instance to target a specific Capacity Reservation, run in any `open` Capacity Reservation with matching attributes, or run On-Demand Instance capacity.
-class ModifyInstanceCapacityReservationAttributesOperation
-    extends _i1.HttpOperation<
+class ModifyInstanceCapacityReservationAttributesOperation extends _i1
+    .HttpOperation<
         ModifyInstanceCapacityReservationAttributesRequest,
         ModifyInstanceCapacityReservationAttributesRequest,
         ModifyInstanceCapacityReservationAttributesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/modify_traffic_mirror_filter_network_services_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/modify_traffic_mirror_filter_network_services_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/modify_traffic_mirror_filter_ne
 /// Allows or restricts mirroring network services.
 ///
 /// By default, Amazon DNS network services are not eligible for Traffic Mirror. Use `AddNetworkServices` to add network services to a Traffic Mirror filter. When a network service is added to the Traffic Mirror filter, all traffic related to that network service will be mirrored. When you no longer want to mirror network services, use `RemoveNetworkServices` to remove the network services from the Traffic Mirror filter.
-class ModifyTrafficMirrorFilterNetworkServicesOperation
-    extends _i1.HttpOperation<
+class ModifyTrafficMirrorFilterNetworkServicesOperation extends _i1
+    .HttpOperation<
         ModifyTrafficMirrorFilterNetworkServicesRequest,
         ModifyTrafficMirrorFilterNetworkServicesRequest,
         ModifyTrafficMirrorFilterNetworkServicesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/modify_transit_gateway_prefix_list_reference_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/modify_transit_gateway_prefix_list_reference_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/modify_transit_gateway_prefix_l
 import 'package:smoke_test/src/sdk/src/ec2/model/modify_transit_gateway_prefix_list_reference_result.dart';
 
 /// Modifies a reference (route) to a prefix list in a specified transit gateway route table.
-class ModifyTransitGatewayPrefixListReferenceOperation
-    extends _i1.HttpOperation<
+class ModifyTransitGatewayPrefixListReferenceOperation extends _i1
+    .HttpOperation<
         ModifyTransitGatewayPrefixListReferenceRequest,
         ModifyTransitGatewayPrefixListReferenceRequest,
         ModifyTransitGatewayPrefixListReferenceResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/modify_verified_access_instance_logging_configuration_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/modify_verified_access_instance_logging_configuration_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/modify_verified_access_instance
 import 'package:smoke_test/src/sdk/src/ec2/model/modify_verified_access_instance_logging_configuration_result.dart';
 
 /// Modifies the logging configuration for the specified Amazon Web Services Verified Access instance.
-class ModifyVerifiedAccessInstanceLoggingConfigurationOperation
-    extends _i1.HttpOperation<
+class ModifyVerifiedAccessInstanceLoggingConfigurationOperation extends _i1
+    .HttpOperation<
         ModifyVerifiedAccessInstanceLoggingConfigurationRequest,
         ModifyVerifiedAccessInstanceLoggingConfigurationRequest,
         ModifyVerifiedAccessInstanceLoggingConfigurationResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/modify_vpc_endpoint_connection_notification_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/modify_vpc_endpoint_connection_notification_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/modify_vpc_endpoint_connection_
 import 'package:smoke_test/src/sdk/src/ec2/model/modify_vpc_endpoint_connection_notification_result.dart';
 
 /// Modifies a connection notification for VPC endpoint or VPC endpoint service. You can change the SNS topic for the notification, or the events for which to be notified.
-class ModifyVpcEndpointConnectionNotificationOperation
-    extends _i1.HttpOperation<
+class ModifyVpcEndpointConnectionNotificationOperation extends _i1
+    .HttpOperation<
         ModifyVpcEndpointConnectionNotificationRequest,
         ModifyVpcEndpointConnectionNotificationRequest,
         ModifyVpcEndpointConnectionNotificationResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/modify_vpc_endpoint_service_payer_responsibility_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/modify_vpc_endpoint_service_payer_responsibility_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/modify_vpc_endpoint_service_pay
 import 'package:smoke_test/src/sdk/src/ec2/model/modify_vpc_endpoint_service_payer_responsibility_result.dart';
 
 /// Modifies the payer responsibility for your VPC endpoint service.
-class ModifyVpcEndpointServicePayerResponsibilityOperation
-    extends _i1.HttpOperation<
+class ModifyVpcEndpointServicePayerResponsibilityOperation extends _i1
+    .HttpOperation<
         ModifyVpcEndpointServicePayerResponsibilityRequest,
         ModifyVpcEndpointServicePayerResponsibilityRequest,
         ModifyVpcEndpointServicePayerResponsibilityResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/register_instance_event_notification_attributes_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/register_instance_event_notification_attributes_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/register_instance_event_notific
 /// Registers a set of tag keys to include in scheduled event notifications for your resources.
 ///
 /// To remove tags, use [DeregisterInstanceEventNotificationAttributes](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeregisterInstanceEventNotificationAttributes.html).
-class RegisterInstanceEventNotificationAttributesOperation
-    extends _i1.HttpOperation<
+class RegisterInstanceEventNotificationAttributesOperation extends _i1
+    .HttpOperation<
         RegisterInstanceEventNotificationAttributesRequest,
         RegisterInstanceEventNotificationAttributesRequest,
         RegisterInstanceEventNotificationAttributesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/register_transit_gateway_multicast_group_members_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/register_transit_gateway_multicast_group_members_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/register_transit_gateway_multic
 /// Registers members (network interfaces) with the transit gateway multicast group. A member is a network interface associated with a supported EC2 instance that receives multicast traffic. For information about supported instances, see [Multicast Consideration](https://docs.aws.amazon.com/vpc/latest/tgw/transit-gateway-limits.html#multicast-limits) in _Amazon VPC Transit Gateways_.
 ///
 /// After you add the members, use [SearchTransitGatewayMulticastGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SearchTransitGatewayMulticastGroups.html) to verify that the members were added to the transit gateway multicast group.
-class RegisterTransitGatewayMulticastGroupMembersOperation
-    extends _i1.HttpOperation<
+class RegisterTransitGatewayMulticastGroupMembersOperation extends _i1
+    .HttpOperation<
         RegisterTransitGatewayMulticastGroupMembersRequest,
         RegisterTransitGatewayMulticastGroupMembersRequest,
         RegisterTransitGatewayMulticastGroupMembersResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/register_transit_gateway_multicast_group_sources_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/register_transit_gateway_multicast_group_sources_operation.dart
@@ -19,8 +19,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/register_transit_gateway_multic
 /// A multicast source is a network interface attached to a supported instance that sends multicast traffic. For information about supported instances, see [Multicast Considerations](https://docs.aws.amazon.com/vpc/latest/tgw/transit-gateway-limits.html#multicast-limits) in _Amazon VPC Transit Gateways_.
 ///
 /// After you add the source, use [SearchTransitGatewayMulticastGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SearchTransitGatewayMulticastGroups.html) to verify that the source was added to the multicast group.
-class RegisterTransitGatewayMulticastGroupSourcesOperation
-    extends _i1.HttpOperation<
+class RegisterTransitGatewayMulticastGroupSourcesOperation extends _i1
+    .HttpOperation<
         RegisterTransitGatewayMulticastGroupSourcesRequest,
         RegisterTransitGatewayMulticastGroupSourcesRequest,
         RegisterTransitGatewayMulticastGroupSourcesResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/reject_transit_gateway_multicast_domain_associations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/reject_transit_gateway_multicast_domain_associations_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/reject_transit_gateway_multicas
 import 'package:smoke_test/src/sdk/src/ec2/model/reject_transit_gateway_multicast_domain_associations_result.dart';
 
 /// Rejects a request to associate cross-account subnets with a transit gateway multicast domain.
-class RejectTransitGatewayMulticastDomainAssociationsOperation
-    extends _i1.HttpOperation<
+class RejectTransitGatewayMulticastDomainAssociationsOperation extends _i1
+    .HttpOperation<
         RejectTransitGatewayMulticastDomainAssociationsRequest,
         RejectTransitGatewayMulticastDomainAssociationsRequest,
         RejectTransitGatewayMulticastDomainAssociationsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/search_transit_gateway_multicast_groups_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/search_transit_gateway_multicast_groups_operation.dart
@@ -17,8 +17,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/search_transit_gateway_multicas
 import 'package:smoke_test/src/sdk/src/ec2/model/transit_gateway_multicast_group.dart';
 
 /// Searches one or more transit gateway multicast groups and returns the group membership information.
-class SearchTransitGatewayMulticastGroupsOperation
-    extends _i1.PaginatedHttpOperation<
+class SearchTransitGatewayMulticastGroupsOperation extends _i1
+    .PaginatedHttpOperation<
         SearchTransitGatewayMulticastGroupsRequest,
         SearchTransitGatewayMulticastGroupsRequest,
         SearchTransitGatewayMulticastGroupsResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/start_network_insights_access_scope_analysis_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/start_network_insights_access_scope_analysis_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/start_network_insights_access_s
 import 'package:smoke_test/src/sdk/src/ec2/model/start_network_insights_access_scope_analysis_result.dart';
 
 /// Starts analyzing the specified Network Access Scope.
-class StartNetworkInsightsAccessScopeAnalysisOperation
-    extends _i1.HttpOperation<
+class StartNetworkInsightsAccessScopeAnalysisOperation extends _i1
+    .HttpOperation<
         StartNetworkInsightsAccessScopeAnalysisRequest,
         StartNetworkInsightsAccessScopeAnalysisRequest,
         StartNetworkInsightsAccessScopeAnalysisResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/start_vpc_endpoint_service_private_dns_verification_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/start_vpc_endpoint_service_private_dns_verification_operation.dart
@@ -19,8 +19,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/start_vpc_endpoint_service_priv
 /// The service provider must successfully perform the verification before the consumer can use the name to access the service.
 ///
 /// Before the service provider runs this command, they must add a record to the DNS server.
-class StartVpcEndpointServicePrivateDnsVerificationOperation
-    extends _i1.HttpOperation<
+class StartVpcEndpointServicePrivateDnsVerificationOperation extends _i1
+    .HttpOperation<
         StartVpcEndpointServicePrivateDnsVerificationRequest,
         StartVpcEndpointServicePrivateDnsVerificationRequest,
         StartVpcEndpointServicePrivateDnsVerificationResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/update_security_group_rule_descriptions_egress_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/update_security_group_rule_descriptions_egress_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/update_security_group_rule_desc
 import 'package:smoke_test/src/sdk/src/ec2/model/update_security_group_rule_descriptions_egress_result.dart';
 
 /// Updates the description of an egress (outbound) security group rule. You can replace an existing description, or add a description to a rule that did not have one previously. You can remove a description for a security group rule by omitting the description parameter in the request.
-class UpdateSecurityGroupRuleDescriptionsEgressOperation
-    extends _i1.HttpOperation<
+class UpdateSecurityGroupRuleDescriptionsEgressOperation extends _i1
+    .HttpOperation<
         UpdateSecurityGroupRuleDescriptionsEgressRequest,
         UpdateSecurityGroupRuleDescriptionsEgressRequest,
         UpdateSecurityGroupRuleDescriptionsEgressResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/update_security_group_rule_descriptions_ingress_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/ec2/operation/update_security_group_rule_descriptions_ingress_operation.dart
@@ -15,8 +15,8 @@ import 'package:smoke_test/src/sdk/src/ec2/model/update_security_group_rule_desc
 import 'package:smoke_test/src/sdk/src/ec2/model/update_security_group_rule_descriptions_ingress_result.dart';
 
 /// Updates the description of an ingress (inbound) security group rule. You can replace an existing description, or add a description to a rule that did not have one previously. You can remove a description for a security group rule by omitting the description parameter in the request.
-class UpdateSecurityGroupRuleDescriptionsIngressOperation
-    extends _i1.HttpOperation<
+class UpdateSecurityGroupRuleDescriptionsIngressOperation extends _i1
+    .HttpOperation<
         UpdateSecurityGroupRuleDescriptionsIngressRequest,
         UpdateSecurityGroupRuleDescriptionsIngressRequest,
         UpdateSecurityGroupRuleDescriptionsIngressResult,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/iam_client.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/iam_client.dart
@@ -1636,8 +1636,9 @@ class IamClient {
   ///
   /// You can optionally filter the results using the `Filter` parameter. You can paginate the results using the `MaxItems` and `Marker` parameters.
   _i3.SmithyOperation<
-      _i3.PaginatedResult<GetAccountAuthorizationDetailsResponse, int,
-          String>> getAccountAuthorizationDetails(
+          _i3
+          .PaginatedResult<GetAccountAuthorizationDetailsResponse, int, String>>
+      getAccountAuthorizationDetails(
     GetAccountAuthorizationDetailsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/get_service_last_accessed_details_with_entities_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/get_service_last_accessed_details_with_entities_request.dart
@@ -45,8 +45,9 @@ abstract class GetServiceLastAccessedDetailsWithEntitiesRequest
       payload;
 
   static const List<
-      _i1.SmithySerializer<
-          GetServiceLastAccessedDetailsWithEntitiesRequest>> serializers = [
+          _i1
+          .SmithySerializer<GetServiceLastAccessedDetailsWithEntitiesRequest>>
+      serializers = [
     GetServiceLastAccessedDetailsWithEntitiesRequestAwsQuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/get_service_last_accessed_details_with_entities_response.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/model/get_service_last_accessed_details_with_entities_response.dart
@@ -55,8 +55,9 @@ abstract class GetServiceLastAccessedDetailsWithEntitiesResponse
       payload;
 
   static const List<
-      _i3.SmithySerializer<
-          GetServiceLastAccessedDetailsWithEntitiesResponse>> serializers = [
+          _i3
+          .SmithySerializer<GetServiceLastAccessedDetailsWithEntitiesResponse>>
+      serializers = [
     GetServiceLastAccessedDetailsWithEntitiesResponseAwsQuerySerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/get_account_authorization_details_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/get_account_authorization_details_operation.dart
@@ -20,8 +20,8 @@ import 'package:smoke_test/src/sdk/src/iam/model/service_failure_exception.dart'
 /// Policies returned by this operation are URL-encoded compliant with [RFC 3986](https://tools.ietf.org/html/rfc3986). You can use a URL decoding method to convert the policy back to plain JSON text. For example, if you use Java, you can use the `decode` method of the `java.net.URLDecoder` utility class in the Java SDK. Other languages and SDKs provide similar functionality.
 ///
 /// You can optionally filter the results using the `Filter` parameter. You can paginate the results using the `MaxItems` and `Marker` parameters.
-class GetAccountAuthorizationDetailsOperation
-    extends _i1.PaginatedHttpOperation<
+class GetAccountAuthorizationDetailsOperation extends _i1
+    .PaginatedHttpOperation<
         GetAccountAuthorizationDetailsRequest,
         GetAccountAuthorizationDetailsRequest,
         GetAccountAuthorizationDetailsResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/get_service_last_accessed_details_with_entities_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/get_service_last_accessed_details_with_entities_operation.dart
@@ -28,8 +28,8 @@ import 'package:smoke_test/src/sdk/src/iam/model/no_such_entity_exception.dart';
 /// If the operation fails, the `GetServiceLastAccessedDetailsWithEntities` operation returns the reason that it failed.
 ///
 /// By default, the list of associated entities is sorted by date, with the most recent access listed first.
-class GetServiceLastAccessedDetailsWithEntitiesOperation
-    extends _i1.HttpOperation<
+class GetServiceLastAccessedDetailsWithEntitiesOperation extends _i1
+    .HttpOperation<
         GetServiceLastAccessedDetailsWithEntitiesRequest,
         GetServiceLastAccessedDetailsWithEntitiesRequest,
         GetServiceLastAccessedDetailsWithEntitiesResponse,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/remove_client_id_from_open_id_connect_provider_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/remove_client_id_from_open_id_connect_provider_operation.dart
@@ -19,8 +19,8 @@ import 'package:smoke_test/src/sdk/src/iam/model/service_failure_exception.dart'
 /// Removes the specified client ID (also known as audience) from the list of client IDs registered for the specified IAM OpenID Connect (OIDC) provider resource object.
 ///
 /// This operation is idempotent; it does not fail or return an error if you try to remove a client ID that does not exist.
-class RemoveClientIdFromOpenIdConnectProviderOperation
-    extends _i1.HttpOperation<RemoveClientIdFromOpenIdConnectProviderRequest,
+class RemoveClientIdFromOpenIdConnectProviderOperation extends _i1
+    .HttpOperation<RemoveClientIdFromOpenIdConnectProviderRequest,
         RemoveClientIdFromOpenIdConnectProviderRequest, _i1.Unit, _i1.Unit> {
   /// Removes the specified client ID (also known as audience) from the list of client IDs registered for the specified IAM OpenID Connect (OIDC) provider resource object.
   ///

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/tag_policy_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/tag_policy_operation.dart
@@ -59,8 +59,9 @@ class TagPolicyOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<TagPolicyRequest, TagPolicyRequest, _i1.Unit,
-          _i1.Unit>> protocols = [
+          _i1
+          .HttpProtocol<TagPolicyRequest, TagPolicyRequest, _i1.Unit, _i1.Unit>>
+      protocols = [
     _i3.AwsQueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/untag_role_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/untag_role_operation.dart
@@ -35,8 +35,9 @@ class UntagRoleOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<UntagRoleRequest, UntagRoleRequest, _i1.Unit,
-          _i1.Unit>> protocols = [
+          _i1
+          .HttpProtocol<UntagRoleRequest, UntagRoleRequest, _i1.Unit, _i1.Unit>>
+      protocols = [
     _i3.AwsQueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/untag_user_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/iam/operation/untag_user_operation.dart
@@ -35,8 +35,9 @@ class UntagUserOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<UntagUserRequest, UntagUserRequest, _i1.Unit,
-          _i1.Unit>> protocols = [
+          _i1
+          .HttpProtocol<UntagUserRequest, UntagUserRequest, _i1.Unit, _i1.Unit>>
+      protocols = [
     _i3.AwsQueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_analytics_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_analytics_configuration_request.dart
@@ -57,8 +57,9 @@ abstract class DeleteBucketAnalyticsConfigurationRequest
       });
 
   static const List<
-      _i1.SmithySerializer<
-          DeleteBucketAnalyticsConfigurationRequestPayload>> serializers = [
+          _i1
+          .SmithySerializer<DeleteBucketAnalyticsConfigurationRequestPayload>>
+      serializers = [
     DeleteBucketAnalyticsConfigurationRequestRestXmlSerializer()
   ];
 
@@ -135,8 +136,8 @@ abstract class DeleteBucketAnalyticsConfigurationRequestPayload
   }
 }
 
-class DeleteBucketAnalyticsConfigurationRequestRestXmlSerializer
-    extends _i1.StructuredSmithySerializer<
+class DeleteBucketAnalyticsConfigurationRequestRestXmlSerializer extends _i1
+    .StructuredSmithySerializer<
         DeleteBucketAnalyticsConfigurationRequestPayload> {
   const DeleteBucketAnalyticsConfigurationRequestRestXmlSerializer()
       : super('DeleteBucketAnalyticsConfigurationRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_intelligent_tiering_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_intelligent_tiering_configuration_request.dart
@@ -13,15 +13,15 @@ part 'delete_bucket_intelligent_tiering_configuration_request.g.dart';
 
 abstract class DeleteBucketIntelligentTieringConfigurationRequest
     with
-        _i1.HttpInput<
-            DeleteBucketIntelligentTieringConfigurationRequestPayload>,
+        _i1
+        .HttpInput<DeleteBucketIntelligentTieringConfigurationRequestPayload>,
         _i2.AWSEquatable<DeleteBucketIntelligentTieringConfigurationRequest>
     implements
         Built<DeleteBucketIntelligentTieringConfigurationRequest,
             DeleteBucketIntelligentTieringConfigurationRequestBuilder>,
         _i1.EmptyPayload,
-        _i1.HasPayload<
-            DeleteBucketIntelligentTieringConfigurationRequestPayload> {
+        _i1
+        .HasPayload<DeleteBucketIntelligentTieringConfigurationRequestPayload> {
   factory DeleteBucketIntelligentTieringConfigurationRequest({
     required String bucket,
     required String id,
@@ -103,8 +103,8 @@ abstract class DeleteBucketIntelligentTieringConfigurationRequest
 @_i3.internal
 abstract class DeleteBucketIntelligentTieringConfigurationRequestPayload
     with
-        _i2.AWSEquatable<
-            DeleteBucketIntelligentTieringConfigurationRequestPayload>
+        _i2
+        .AWSEquatable<DeleteBucketIntelligentTieringConfigurationRequestPayload>
     implements
         Built<DeleteBucketIntelligentTieringConfigurationRequestPayload,
             DeleteBucketIntelligentTieringConfigurationRequestPayloadBuilder>,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_inventory_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_inventory_configuration_request.dart
@@ -57,8 +57,9 @@ abstract class DeleteBucketInventoryConfigurationRequest
       });
 
   static const List<
-      _i1.SmithySerializer<
-          DeleteBucketInventoryConfigurationRequestPayload>> serializers = [
+          _i1
+          .SmithySerializer<DeleteBucketInventoryConfigurationRequestPayload>>
+      serializers = [
     DeleteBucketInventoryConfigurationRequestRestXmlSerializer()
   ];
 
@@ -135,8 +136,8 @@ abstract class DeleteBucketInventoryConfigurationRequestPayload
   }
 }
 
-class DeleteBucketInventoryConfigurationRequestRestXmlSerializer
-    extends _i1.StructuredSmithySerializer<
+class DeleteBucketInventoryConfigurationRequestRestXmlSerializer extends _i1
+    .StructuredSmithySerializer<
         DeleteBucketInventoryConfigurationRequestPayload> {
   const DeleteBucketInventoryConfigurationRequestRestXmlSerializer()
       : super('DeleteBucketInventoryConfigurationRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_metrics_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/delete_bucket_metrics_configuration_request.dart
@@ -135,8 +135,8 @@ abstract class DeleteBucketMetricsConfigurationRequestPayload
   }
 }
 
-class DeleteBucketMetricsConfigurationRequestRestXmlSerializer
-    extends _i1.StructuredSmithySerializer<
+class DeleteBucketMetricsConfigurationRequestRestXmlSerializer extends _i1
+    .StructuredSmithySerializer<
         DeleteBucketMetricsConfigurationRequestPayload> {
   const DeleteBucketMetricsConfigurationRequestRestXmlSerializer()
       : super('DeleteBucketMetricsConfigurationRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/get_bucket_accelerate_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/get_bucket_accelerate_configuration_request.dart
@@ -137,8 +137,8 @@ abstract class GetBucketAccelerateConfigurationRequestPayload
   }
 }
 
-class GetBucketAccelerateConfigurationRequestRestXmlSerializer
-    extends _i1.StructuredSmithySerializer<
+class GetBucketAccelerateConfigurationRequestRestXmlSerializer extends _i1
+    .StructuredSmithySerializer<
         GetBucketAccelerateConfigurationRequestPayload> {
   const GetBucketAccelerateConfigurationRequestRestXmlSerializer()
       : super('GetBucketAccelerateConfigurationRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/get_bucket_notification_configuration_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/get_bucket_notification_configuration_request.dart
@@ -52,8 +52,9 @@ abstract class GetBucketNotificationConfigurationRequest
       });
 
   static const List<
-      _i1.SmithySerializer<
-          GetBucketNotificationConfigurationRequestPayload>> serializers = [
+          _i1
+          .SmithySerializer<GetBucketNotificationConfigurationRequestPayload>>
+      serializers = [
     GetBucketNotificationConfigurationRequestRestXmlSerializer()
   ];
 
@@ -126,8 +127,8 @@ abstract class GetBucketNotificationConfigurationRequestPayload
   }
 }
 
-class GetBucketNotificationConfigurationRequestRestXmlSerializer
-    extends _i1.StructuredSmithySerializer<
+class GetBucketNotificationConfigurationRequestRestXmlSerializer extends _i1
+    .StructuredSmithySerializer<
         GetBucketNotificationConfigurationRequestPayload> {
   const GetBucketNotificationConfigurationRequestRestXmlSerializer()
       : super('GetBucketNotificationConfigurationRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/lifecycle_rule.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/lifecycle_rule.dart
@@ -30,8 +30,9 @@ abstract class LifecycleRule
   factory LifecycleRule({
     LifecycleExpiration? expiration,
     String? id,
-    @Deprecated('No longer recommended for use. See API documentation for more details.')
-        String? prefix,
+    @Deprecated(
+        'No longer recommended for use. See API documentation for more details.')
+    String? prefix,
     LifecycleRuleFilter? filter,
     required ExpirationStatus status,
     List<Transition>? transitions,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_analytics_configurations_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_analytics_configurations_request.dart
@@ -135,8 +135,8 @@ abstract class ListBucketAnalyticsConfigurationsRequestPayload
   }
 }
 
-class ListBucketAnalyticsConfigurationsRequestRestXmlSerializer
-    extends _i1.StructuredSmithySerializer<
+class ListBucketAnalyticsConfigurationsRequestRestXmlSerializer extends _i1
+    .StructuredSmithySerializer<
         ListBucketAnalyticsConfigurationsRequestPayload> {
   const ListBucketAnalyticsConfigurationsRequestRestXmlSerializer()
       : super('ListBucketAnalyticsConfigurationsRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_intelligent_tiering_configurations_output.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_intelligent_tiering_configurations_output.dart
@@ -49,8 +49,9 @@ abstract class ListBucketIntelligentTieringConfigurationsOutput
       payload;
 
   static const List<
-      _i3.SmithySerializer<
-          ListBucketIntelligentTieringConfigurationsOutput>> serializers = [
+          _i3
+          .SmithySerializer<ListBucketIntelligentTieringConfigurationsOutput>>
+      serializers = [
     ListBucketIntelligentTieringConfigurationsOutputRestXmlSerializer()
   ];
 

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_intelligent_tiering_configurations_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_intelligent_tiering_configurations_request.dart
@@ -19,8 +19,8 @@ abstract class ListBucketIntelligentTieringConfigurationsRequest
         Built<ListBucketIntelligentTieringConfigurationsRequest,
             ListBucketIntelligentTieringConfigurationsRequestBuilder>,
         _i1.EmptyPayload,
-        _i1.HasPayload<
-            ListBucketIntelligentTieringConfigurationsRequestPayload> {
+        _i1
+        .HasPayload<ListBucketIntelligentTieringConfigurationsRequestPayload> {
   factory ListBucketIntelligentTieringConfigurationsRequest({
     required String bucket,
     String? continuationToken,
@@ -102,8 +102,8 @@ abstract class ListBucketIntelligentTieringConfigurationsRequest
 @_i3.internal
 abstract class ListBucketIntelligentTieringConfigurationsRequestPayload
     with
-        _i2.AWSEquatable<
-            ListBucketIntelligentTieringConfigurationsRequestPayload>
+        _i2
+        .AWSEquatable<ListBucketIntelligentTieringConfigurationsRequestPayload>
     implements
         Built<ListBucketIntelligentTieringConfigurationsRequestPayload,
             ListBucketIntelligentTieringConfigurationsRequestPayloadBuilder>,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_inventory_configurations_request.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/list_bucket_inventory_configurations_request.dart
@@ -135,8 +135,8 @@ abstract class ListBucketInventoryConfigurationsRequestPayload
   }
 }
 
-class ListBucketInventoryConfigurationsRequestRestXmlSerializer
-    extends _i1.StructuredSmithySerializer<
+class ListBucketInventoryConfigurationsRequestRestXmlSerializer extends _i1
+    .StructuredSmithySerializer<
         ListBucketInventoryConfigurationsRequestPayload> {
   const ListBucketInventoryConfigurationsRequestRestXmlSerializer()
       : super('ListBucketInventoryConfigurationsRequest');

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/replication_rule.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/model/replication_rule.dart
@@ -24,8 +24,9 @@ abstract class ReplicationRule
   factory ReplicationRule({
     String? id,
     int? priority,
-    @Deprecated('No longer recommended for use. See API documentation for more details.')
-        String? prefix,
+    @Deprecated(
+        'No longer recommended for use. See API documentation for more details.')
+    String? prefix,
     ReplicationRuleFilter? filter,
     required ReplicationRuleStatus status,
     SourceSelectionCriteria? sourceSelectionCriteria,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/delete_bucket_intelligent_tiering_configuration_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/delete_bucket_intelligent_tiering_configuration_operation.dart
@@ -28,8 +28,8 @@ import 'package:smoke_test/src/sdk/src/s3/model/delete_bucket_intelligent_tierin
 /// *   [PutBucketIntelligentTieringConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html)
 ///
 /// *   [ListBucketIntelligentTieringConfigurations](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html)
-class DeleteBucketIntelligentTieringConfigurationOperation
-    extends _i1.HttpOperation<
+class DeleteBucketIntelligentTieringConfigurationOperation extends _i1
+    .HttpOperation<
         DeleteBucketIntelligentTieringConfigurationRequestPayload,
         DeleteBucketIntelligentTieringConfigurationRequest,
         _i1.Unit,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/get_bucket_intelligent_tiering_configuration_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/get_bucket_intelligent_tiering_configuration_operation.dart
@@ -30,8 +30,8 @@ import 'package:smoke_test/src/sdk/src/s3/model/intelligent_tiering_configuratio
 /// *   [PutBucketIntelligentTieringConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html)
 ///
 /// *   [ListBucketIntelligentTieringConfigurations](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html)
-class GetBucketIntelligentTieringConfigurationOperation
-    extends _i1.HttpOperation<
+class GetBucketIntelligentTieringConfigurationOperation extends _i1
+    .HttpOperation<
         GetBucketIntelligentTieringConfigurationRequestPayload,
         GetBucketIntelligentTieringConfigurationRequest,
         IntelligentTieringConfiguration,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/list_bucket_intelligent_tiering_configurations_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/list_bucket_intelligent_tiering_configurations_operation.dart
@@ -29,8 +29,8 @@ import 'package:smoke_test/src/sdk/src/s3/model/list_bucket_intelligent_tiering_
 /// *   [PutBucketIntelligentTieringConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html)
 ///
 /// *   [GetBucketIntelligentTieringConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html)
-class ListBucketIntelligentTieringConfigurationsOperation
-    extends _i1.HttpOperation<
+class ListBucketIntelligentTieringConfigurationsOperation extends _i1
+    .HttpOperation<
         ListBucketIntelligentTieringConfigurationsRequestPayload,
         ListBucketIntelligentTieringConfigurationsRequest,
         ListBucketIntelligentTieringConfigurationsOutput,

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/put_bucket_intelligent_tiering_configuration_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/put_bucket_intelligent_tiering_configuration_operation.dart
@@ -50,8 +50,8 @@ import 'package:smoke_test/src/sdk/src/s3/model/put_bucket_intelligent_tiering_c
 /// HTTP 403 Forbidden Error
 ///
 /// _Cause:_ You are not the owner of the specified bucket, or you do not have the `s3:PutIntelligentTieringConfiguration` bucket permission to set the configuration on the bucket.
-class PutBucketIntelligentTieringConfigurationOperation
-    extends _i1.HttpOperation<IntelligentTieringConfiguration,
+class PutBucketIntelligentTieringConfigurationOperation extends _i1
+    .HttpOperation<IntelligentTieringConfiguration,
         PutBucketIntelligentTieringConfigurationRequest, _i1.Unit, _i1.Unit> {
   /// Puts a S3 Intelligent-Tiering configuration to the specified bucket. You can have up to 1,000 S3 Intelligent-Tiering configurations per bucket.
   ///

--- a/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/put_bucket_tagging_operation.dart
+++ b/packages/aws_sdk/smoke_test/lib/src/sdk/src/s3/operation/put_bucket_tagging_operation.dart
@@ -97,8 +97,9 @@ class PutBucketTaggingOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<Tagging, PutBucketTaggingRequest, _i1.Unit,
-          _i1.Unit>> protocols = [
+          _i1
+          .HttpProtocol<Tagging, PutBucketTaggingRequest, _i1.Unit, _i1.Unit>>
+      protocols = [
     _i2.RestXmlProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/cupertino/security.bindings.g.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/cupertino/security.bindings.g.dart
@@ -268,8 +268,9 @@ class Security {
   }
 
   late final _SecItemDeletePtr = _lookup<
-      ffi.NativeFunction<
-          OSStatus Function(coreFoundation.CFDictionaryRef)>>('SecItemDelete');
+          ffi
+          .NativeFunction<OSStatus Function(coreFoundation.CFDictionaryRef)>>(
+      'SecItemDelete');
   late final _SecItemDelete = _SecItemDeletePtr.asFunction<
       int Function(coreFoundation.CFDictionaryRef)>();
 }

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/data_protection.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/data_protection.dart
@@ -14,7 +14,7 @@ import 'package:win32/win32.dart'
 
 /// Encrypts the provided string as a [Uint8List].
 Uint8List encryptString(String value) {
-  final encodedValue = utf8.encode(value) as Uint8List;
+  final encodedValue = const Utf8Encoder().convert(value);
   return encrypt(encodedValue);
 }
 

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/json_protocol_server.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/json_protocol/json_protocol_server.dart
@@ -165,7 +165,7 @@ class _JsonProtocolServer extends _i1.HttpServer<JsonProtocolServerBase> {
   );
 
   late final _i1
-          .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
+      .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
       _endpointWithHostLabelOperationProtocol = _i2.AwsJson1_1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -219,7 +219,7 @@ class _JsonProtocolServer extends _i1.HttpServer<JsonProtocolServerBase> {
   );
 
   late final _i1
-          .HttpProtocol<KitchenSink, KitchenSink, KitchenSink, KitchenSink>
+      .HttpProtocol<KitchenSink, KitchenSink, KitchenSink, KitchenSink>
       _kitchenSinkOperationProtocol = _i2.AwsJson1_1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/machine_learning_server.dart
+++ b/packages/smithy/goldens/lib/awsJson1_1/lib/src/machine_learning/machine_learning_server.dart
@@ -53,8 +53,9 @@ class _MachineLearningServer extends _i1.HttpServer<MachineLearningServerBase> {
   @override
   final MachineLearningServerBase service;
 
-  late final _i1.HttpProtocol<PredictInput, PredictInput, PredictOutput,
-      PredictOutput> _predictProtocol = _i2.AwsJson1_1Protocol(
+  late final _i1
+      .HttpProtocol<PredictInput, PredictInput, PredictOutput, PredictOutput>
+      _predictProtocol = _i2.AwsJson1_1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );

--- a/packages/smithy/goldens/lib/awsQuery/lib/src/query_protocol/operation/query_lists_operation.dart
+++ b/packages/smithy/goldens/lib/awsQuery/lib/src/query_protocol/operation/query_lists_operation.dart
@@ -28,8 +28,9 @@ class QueryListsOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<QueryListsInput, QueryListsInput, _i1.Unit,
-          _i1.Unit>> protocols = [
+          _i1
+          .HttpProtocol<QueryListsInput, QueryListsInput, _i1.Unit, _i1.Unit>>
+      protocols = [
     _i2.AwsQueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib/ec2Query/lib/src/ec2_protocol/operation/query_lists_operation.dart
+++ b/packages/smithy/goldens/lib/ec2Query/lib/src/ec2_protocol/operation/query_lists_operation.dart
@@ -28,8 +28,9 @@ class QueryListsOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<QueryListsInput, QueryListsInput, _i1.Unit,
-          _i1.Unit>> protocols = [
+          _i1
+          .HttpProtocol<QueryListsInput, QueryListsInput, _i1.Unit, _i1.Unit>>
+      protocols = [
     _i2.Ec2QueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
@@ -13,12 +13,9 @@ import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
 /// The example tests how requests serialize different timestamp formats in the URI path.
-class HttpRequestWithLabelsAndTimestampFormatOperation
-    extends _i1.HttpOperation<
-        HttpRequestWithLabelsAndTimestampFormatInputPayload,
-        HttpRequestWithLabelsAndTimestampFormatInput,
-        _i1.Unit,
-        _i1.Unit> {
+class HttpRequestWithLabelsAndTimestampFormatOperation extends _i1
+    .HttpOperation<HttpRequestWithLabelsAndTimestampFormatInputPayload,
+        HttpRequestWithLabelsAndTimestampFormatInput, _i1.Unit, _i1.Unit> {
   /// The example tests how requests serialize different timestamp formats in the URI path.
   HttpRequestWithLabelsAndTimestampFormatOperation({
     required String region,

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/operation/http_string_payload_operation.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/operation/http_string_payload_operation.dart
@@ -26,8 +26,9 @@ class HttpStringPayloadOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<String, StringPayloadInput, String,
-          StringPayloadInput>> protocols = [
+          _i1
+          .HttpProtocol<String, StringPayloadInput, String, StringPayloadInput>>
+      protocols = [
     _i2.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/operation/malformed_content_type_without_body_empty_input_operation.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/operation/malformed_content_type_without_body_empty_input_operation.dart
@@ -12,12 +12,9 @@ import 'package:rest_json1_v1/src/rest_json_protocol/model/malformed_content_typ
 import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
-class MalformedContentTypeWithoutBodyEmptyInputOperation
-    extends _i1.HttpOperation<
-        MalformedContentTypeWithoutBodyEmptyInputInputPayload,
-        MalformedContentTypeWithoutBodyEmptyInputInput,
-        _i1.Unit,
-        _i1.Unit> {
+class MalformedContentTypeWithoutBodyEmptyInputOperation extends _i1
+    .HttpOperation<MalformedContentTypeWithoutBodyEmptyInputInputPayload,
+        MalformedContentTypeWithoutBodyEmptyInputInput, _i1.Unit, _i1.Unit> {
   MalformedContentTypeWithoutBodyEmptyInputOperation({
     required String region,
     Uri? baseUri,

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/rest_json_protocol_server.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_protocol/rest_json_protocol_server.dart
@@ -1051,7 +1051,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-          .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
+      .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
       _endpointWithHostLabelOperationProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1087,8 +1087,9 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1.HttpProtocol<StringEnum, EnumPayloadInput, StringEnum,
-      EnumPayloadInput> _httpEnumPayloadProtocol = _i2.RestJson1Protocol(
+  late final _i1
+      .HttpProtocol<StringEnum, EnumPayloadInput, StringEnum, EnumPayloadInput>
+      _httpEnumPayloadProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );
@@ -1192,7 +1193,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-          .HttpProtocol<String, StringPayloadInput, String, StringPayloadInput>
+      .HttpProtocol<String, StringPayloadInput, String, StringPayloadInput>
       _httpStringPayloadProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1280,7 +1281,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-          .HttpProtocol<_i1.Unit, _i1.Unit, GreetingStruct, GreetingStruct>
+      .HttpProtocol<_i1.Unit, _i1.Unit, GreetingStruct, GreetingStruct>
       _malformedAcceptWithBodyProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1300,8 +1301,9 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1.HttpProtocol<MalformedBlobInput, MalformedBlobInput, _i1.Unit,
-      _i1.Unit> _malformedBlobProtocol = _i2.RestJson1Protocol(
+  late final _i1
+      .HttpProtocol<MalformedBlobInput, MalformedBlobInput, _i1.Unit, _i1.Unit>
+      _malformedBlobProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );
@@ -1322,7 +1324,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-          .HttpProtocol<GreetingStruct, GreetingStruct, _i1.Unit, _i1.Unit>
+      .HttpProtocol<GreetingStruct, GreetingStruct, _i1.Unit, _i1.Unit>
       _malformedContentTypeWithBodyProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1380,8 +1382,9 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1.HttpProtocol<MalformedListInput, MalformedListInput, _i1.Unit,
-      _i1.Unit> _malformedListProtocol = _i2.RestJson1Protocol(
+  late final _i1
+      .HttpProtocol<MalformedListInput, MalformedListInput, _i1.Unit, _i1.Unit>
+      _malformedListProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );
@@ -1392,8 +1395,9 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1.HttpProtocol<MalformedMapInput, MalformedMapInput, _i1.Unit,
-      _i1.Unit> _malformedMapProtocol = _i2.RestJson1Protocol(
+  late final _i1
+      .HttpProtocol<MalformedMapInput, MalformedMapInput, _i1.Unit, _i1.Unit>
+      _malformedMapProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );

--- a/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/rest_json_validation_protocol_server.dart
+++ b/packages/smithy/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/rest_json_validation_protocol_server.dart
@@ -156,8 +156,9 @@ class _RestJsonValidationProtocolServer
   @override
   final RestJsonValidationProtocolServerBase service;
 
-  late final _i1.HttpProtocol<MalformedEnumInput, MalformedEnumInput, _i1.Unit,
-      _i1.Unit> _malformedEnumProtocol = _i2.RestJson1Protocol(
+  late final _i1
+      .HttpProtocol<MalformedEnumInput, MalformedEnumInput, _i1.Unit, _i1.Unit>
+      _malformedEnumProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );

--- a/packages/smithy/goldens/lib/restJson1/test/rest_json_protocol/http_request_with_labels_and_timestamp_format_operation_test.dart
+++ b/packages/smithy/goldens/lib/restJson1/test/rest_json_protocol/http_request_with_labels_and_timestamp_format_operation_test.dart
@@ -64,8 +64,8 @@ void main() {
 }
 
 class HttpRequestWithLabelsAndTimestampFormatInputRestJson1Serializer
-    extends _i3.StructuredSmithySerializer<
-        HttpRequestWithLabelsAndTimestampFormatInput> {
+    extends _i3
+    .StructuredSmithySerializer<HttpRequestWithLabelsAndTimestampFormatInput> {
   const HttpRequestWithLabelsAndTimestampFormatInputRestJson1Serializer()
       : super('HttpRequestWithLabelsAndTimestampFormatInput');
 

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/http_request_with_labels_and_timestamp_format_input.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/http_request_with_labels_and_timestamp_format_input.dart
@@ -220,8 +220,8 @@ abstract class HttpRequestWithLabelsAndTimestampFormatInputPayload
   }
 }
 
-class HttpRequestWithLabelsAndTimestampFormatInputRestXmlSerializer
-    extends _i1.StructuredSmithySerializer<
+class HttpRequestWithLabelsAndTimestampFormatInputRestXmlSerializer extends _i1
+    .StructuredSmithySerializer<
         HttpRequestWithLabelsAndTimestampFormatInputPayload> {
   const HttpRequestWithLabelsAndTimestampFormatInputRestXmlSerializer()
       : super('HttpRequestWithLabelsAndTimestampFormatInput');

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
@@ -13,12 +13,9 @@ import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
 /// The example tests how requests serialize different timestamp formats in the URI path.
-class HttpRequestWithLabelsAndTimestampFormatOperation
-    extends _i1.HttpOperation<
-        HttpRequestWithLabelsAndTimestampFormatInputPayload,
-        HttpRequestWithLabelsAndTimestampFormatInput,
-        _i1.Unit,
-        _i1.Unit> {
+class HttpRequestWithLabelsAndTimestampFormatOperation extends _i1
+    .HttpOperation<HttpRequestWithLabelsAndTimestampFormatInputPayload,
+        HttpRequestWithLabelsAndTimestampFormatInput, _i1.Unit, _i1.Unit> {
   /// The example tests how requests serialize different timestamp formats in the URI path.
   HttpRequestWithLabelsAndTimestampFormatOperation({
     required String region,

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/rest_xml_protocol_server.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/rest_xml_protocol_server.dart
@@ -686,7 +686,7 @@ class _RestXmlProtocolServer extends _i1.HttpServer<RestXmlProtocolServerBase> {
   );
 
   late final _i1
-          .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
+      .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
       _endpointWithHostLabelOperationProtocol = _i2.RestXmlProtocol(
     serializers: serializers,
     builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/json_protocol_server.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/json_protocol/json_protocol_server.dart
@@ -165,7 +165,7 @@ class _JsonProtocolServer extends _i1.HttpServer<JsonProtocolServerBase> {
   );
 
   late final _i1
-          .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
+      .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
       _endpointWithHostLabelOperationProtocol = _i2.AwsJson1_1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -219,7 +219,7 @@ class _JsonProtocolServer extends _i1.HttpServer<JsonProtocolServerBase> {
   );
 
   late final _i1
-          .HttpProtocol<KitchenSink, KitchenSink, KitchenSink, KitchenSink>
+      .HttpProtocol<KitchenSink, KitchenSink, KitchenSink, KitchenSink>
       _kitchenSinkOperationProtocol = _i2.AwsJson1_1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/machine_learning_server.dart
+++ b/packages/smithy/goldens/lib2/awsJson1_1/lib/src/machine_learning/machine_learning_server.dart
@@ -53,8 +53,9 @@ class _MachineLearningServer extends _i1.HttpServer<MachineLearningServerBase> {
   @override
   final MachineLearningServerBase service;
 
-  late final _i1.HttpProtocol<PredictInput, PredictInput, PredictOutput,
-      PredictOutput> _predictProtocol = _i2.AwsJson1_1Protocol(
+  late final _i1
+      .HttpProtocol<PredictInput, PredictInput, PredictOutput, PredictOutput>
+      _predictProtocol = _i2.AwsJson1_1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );

--- a/packages/smithy/goldens/lib2/awsQuery/lib/src/query_protocol/operation/query_lists_operation.dart
+++ b/packages/smithy/goldens/lib2/awsQuery/lib/src/query_protocol/operation/query_lists_operation.dart
@@ -28,8 +28,9 @@ class QueryListsOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<QueryListsInput, QueryListsInput, _i1.Unit,
-          _i1.Unit>> protocols = [
+          _i1
+          .HttpProtocol<QueryListsInput, QueryListsInput, _i1.Unit, _i1.Unit>>
+      protocols = [
     _i2.AwsQueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib2/ec2Query/lib/src/ec2_protocol/operation/query_lists_operation.dart
+++ b/packages/smithy/goldens/lib2/ec2Query/lib/src/ec2_protocol/operation/query_lists_operation.dart
@@ -28,8 +28,9 @@ class QueryListsOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<QueryListsInput, QueryListsInput, _i1.Unit,
-          _i1.Unit>> protocols = [
+          _i1
+          .HttpProtocol<QueryListsInput, QueryListsInput, _i1.Unit, _i1.Unit>>
+      protocols = [
     _i2.Ec2QueryProtocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
@@ -13,12 +13,9 @@ import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
 /// The example tests how requests serialize different timestamp formats in the URI path.
-class HttpRequestWithLabelsAndTimestampFormatOperation
-    extends _i1.HttpOperation<
-        HttpRequestWithLabelsAndTimestampFormatInputPayload,
-        HttpRequestWithLabelsAndTimestampFormatInput,
-        _i1.Unit,
-        _i1.Unit> {
+class HttpRequestWithLabelsAndTimestampFormatOperation extends _i1
+    .HttpOperation<HttpRequestWithLabelsAndTimestampFormatInputPayload,
+        HttpRequestWithLabelsAndTimestampFormatInput, _i1.Unit, _i1.Unit> {
   /// The example tests how requests serialize different timestamp formats in the URI path.
   HttpRequestWithLabelsAndTimestampFormatOperation({
     required String region,

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/operation/http_string_payload_operation.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/operation/http_string_payload_operation.dart
@@ -26,8 +26,9 @@ class HttpStringPayloadOperation extends _i1
 
   @override
   late final List<
-      _i1.HttpProtocol<String, StringPayloadInput, String,
-          StringPayloadInput>> protocols = [
+          _i1
+          .HttpProtocol<String, StringPayloadInput, String, StringPayloadInput>>
+      protocols = [
     _i2.RestJson1Protocol(
       serializers: serializers,
       builderFactories: builderFactories,

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/operation/malformed_content_type_without_body_empty_input_operation.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/operation/malformed_content_type_without_body_empty_input_operation.dart
@@ -12,12 +12,9 @@ import 'package:rest_json1_v2/src/rest_json_protocol/model/malformed_content_typ
 import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
-class MalformedContentTypeWithoutBodyEmptyInputOperation
-    extends _i1.HttpOperation<
-        MalformedContentTypeWithoutBodyEmptyInputInputPayload,
-        MalformedContentTypeWithoutBodyEmptyInputInput,
-        _i1.Unit,
-        _i1.Unit> {
+class MalformedContentTypeWithoutBodyEmptyInputOperation extends _i1
+    .HttpOperation<MalformedContentTypeWithoutBodyEmptyInputInputPayload,
+        MalformedContentTypeWithoutBodyEmptyInputInput, _i1.Unit, _i1.Unit> {
   MalformedContentTypeWithoutBodyEmptyInputOperation({
     required String region,
     Uri? baseUri,

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/rest_json_protocol_server.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_protocol/rest_json_protocol_server.dart
@@ -1051,7 +1051,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-          .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
+      .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
       _endpointWithHostLabelOperationProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1087,8 +1087,9 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1.HttpProtocol<StringEnum, EnumPayloadInput, StringEnum,
-      EnumPayloadInput> _httpEnumPayloadProtocol = _i2.RestJson1Protocol(
+  late final _i1
+      .HttpProtocol<StringEnum, EnumPayloadInput, StringEnum, EnumPayloadInput>
+      _httpEnumPayloadProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );
@@ -1192,7 +1193,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-          .HttpProtocol<String, StringPayloadInput, String, StringPayloadInput>
+      .HttpProtocol<String, StringPayloadInput, String, StringPayloadInput>
       _httpStringPayloadProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1280,7 +1281,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-          .HttpProtocol<_i1.Unit, _i1.Unit, GreetingStruct, GreetingStruct>
+      .HttpProtocol<_i1.Unit, _i1.Unit, GreetingStruct, GreetingStruct>
       _malformedAcceptWithBodyProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1300,8 +1301,9 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1.HttpProtocol<MalformedBlobInput, MalformedBlobInput, _i1.Unit,
-      _i1.Unit> _malformedBlobProtocol = _i2.RestJson1Protocol(
+  late final _i1
+      .HttpProtocol<MalformedBlobInput, MalformedBlobInput, _i1.Unit, _i1.Unit>
+      _malformedBlobProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );
@@ -1322,7 +1324,7 @@ class _RestJsonProtocolServer
   );
 
   late final _i1
-          .HttpProtocol<GreetingStruct, GreetingStruct, _i1.Unit, _i1.Unit>
+      .HttpProtocol<GreetingStruct, GreetingStruct, _i1.Unit, _i1.Unit>
       _malformedContentTypeWithBodyProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
@@ -1380,8 +1382,9 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1.HttpProtocol<MalformedListInput, MalformedListInput, _i1.Unit,
-      _i1.Unit> _malformedListProtocol = _i2.RestJson1Protocol(
+  late final _i1
+      .HttpProtocol<MalformedListInput, MalformedListInput, _i1.Unit, _i1.Unit>
+      _malformedListProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );
@@ -1392,8 +1395,9 @@ class _RestJsonProtocolServer
     builderFactories: builderFactories,
   );
 
-  late final _i1.HttpProtocol<MalformedMapInput, MalformedMapInput, _i1.Unit,
-      _i1.Unit> _malformedMapProtocol = _i2.RestJson1Protocol(
+  late final _i1
+      .HttpProtocol<MalformedMapInput, MalformedMapInput, _i1.Unit, _i1.Unit>
+      _malformedMapProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );

--- a/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/rest_json_validation_protocol_server.dart
+++ b/packages/smithy/goldens/lib2/restJson1/lib/src/rest_json_validation_protocol/rest_json_validation_protocol_server.dart
@@ -156,8 +156,9 @@ class _RestJsonValidationProtocolServer
   @override
   final RestJsonValidationProtocolServerBase service;
 
-  late final _i1.HttpProtocol<MalformedEnumInput, MalformedEnumInput, _i1.Unit,
-      _i1.Unit> _malformedEnumProtocol = _i2.RestJson1Protocol(
+  late final _i1
+      .HttpProtocol<MalformedEnumInput, MalformedEnumInput, _i1.Unit, _i1.Unit>
+      _malformedEnumProtocol = _i2.RestJson1Protocol(
     serializers: serializers,
     builderFactories: builderFactories,
   );

--- a/packages/smithy/goldens/lib2/restJson1/test/rest_json_protocol/http_request_with_labels_and_timestamp_format_operation_test.dart
+++ b/packages/smithy/goldens/lib2/restJson1/test/rest_json_protocol/http_request_with_labels_and_timestamp_format_operation_test.dart
@@ -64,8 +64,8 @@ void main() {
 }
 
 class HttpRequestWithLabelsAndTimestampFormatInputRestJson1Serializer
-    extends _i3.StructuredSmithySerializer<
-        HttpRequestWithLabelsAndTimestampFormatInput> {
+    extends _i3
+    .StructuredSmithySerializer<HttpRequestWithLabelsAndTimestampFormatInput> {
   const HttpRequestWithLabelsAndTimestampFormatInputRestJson1Serializer()
       : super('HttpRequestWithLabelsAndTimestampFormatInput');
 

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/http_request_with_labels_and_timestamp_format_input.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/http_request_with_labels_and_timestamp_format_input.dart
@@ -220,8 +220,8 @@ abstract class HttpRequestWithLabelsAndTimestampFormatInputPayload
   }
 }
 
-class HttpRequestWithLabelsAndTimestampFormatInputRestXmlSerializer
-    extends _i1.StructuredSmithySerializer<
+class HttpRequestWithLabelsAndTimestampFormatInputRestXmlSerializer extends _i1
+    .StructuredSmithySerializer<
         HttpRequestWithLabelsAndTimestampFormatInputPayload> {
   const HttpRequestWithLabelsAndTimestampFormatInputRestXmlSerializer()
       : super('HttpRequestWithLabelsAndTimestampFormatInput');

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/operation/http_request_with_labels_and_timestamp_format_operation.dart
@@ -13,12 +13,9 @@ import 'package:smithy/smithy.dart' as _i1;
 import 'package:smithy_aws/smithy_aws.dart' as _i2;
 
 /// The example tests how requests serialize different timestamp formats in the URI path.
-class HttpRequestWithLabelsAndTimestampFormatOperation
-    extends _i1.HttpOperation<
-        HttpRequestWithLabelsAndTimestampFormatInputPayload,
-        HttpRequestWithLabelsAndTimestampFormatInput,
-        _i1.Unit,
-        _i1.Unit> {
+class HttpRequestWithLabelsAndTimestampFormatOperation extends _i1
+    .HttpOperation<HttpRequestWithLabelsAndTimestampFormatInputPayload,
+        HttpRequestWithLabelsAndTimestampFormatInput, _i1.Unit, _i1.Unit> {
   /// The example tests how requests serialize different timestamp formats in the URI path.
   HttpRequestWithLabelsAndTimestampFormatOperation({
     required String region,

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/rest_xml_protocol_server.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/rest_xml_protocol_server.dart
@@ -686,7 +686,7 @@ class _RestXmlProtocolServer extends _i1.HttpServer<RestXmlProtocolServerBase> {
   );
 
   late final _i1
-          .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
+      .HttpProtocol<HostLabelInput, HostLabelInput, _i1.Unit, _i1.Unit>
       _endpointWithHostLabelOperationProtocol = _i2.RestXmlProtocol(
     serializers: serializers,
     builderFactories: builderFactories,

--- a/packages/smithy/smithy_codegen/lib/src/util/shape_ext.dart
+++ b/packages/smithy/smithy_codegen/lib/src/util/shape_ext.dart
@@ -621,7 +621,7 @@ extension OperationShapeUtil on OperationShape {
       AwsJson1_0Trait.id,
       AwsJson1_1Trait.id,
       AwsQueryTrait.id,
-      Ec2QueryTrait.id
+      Ec2QueryTrait.id,
     ];
     if (rpcProtocols.contains(protocol.singleOrNull?.shapeId)) {
       return const HttpTrait(method: 'POST', uri: '/');

--- a/packages/smithy/smithy_codegen/pubspec.yaml
+++ b/packages/smithy/smithy_codegen/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   code_builder: 4.5.0
   collection: ^1.15.0
   crclib: ^3.0.0
-  dart_style: 2.3.1
+  dart_style: 2.3.2
   fixnum: ^1.0.0
   grpc: ^3.0.2
   html2md: ^1.2.5

--- a/packages/worker_bee/worker_bee_builder/pubspec.yaml
+++ b/packages/worker_bee/worker_bee_builder/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   build: ^2.2.1
   code_builder: 4.5.0
   collection: ^1.15.0
-  dart_style: 2.3.1
+  dart_style: 2.3.2
   meta: ^1.7.0
   path: ^1.8.0
   source_gen: ^1.3.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   connectivity_plus: ^4.0.1
   # This must exactly match what's included in `dart format`
   # on stable so that CI checks pass for generated code.
-  dart_style: 2.3.1
+  dart_style: 2.3.2
   device_info_plus: ^9.0.0
   drift: ">=2.11.0 <2.12.0"
   ffigen: ^9.0.0


### PR DESCRIPTION
To match Dart 3.1 (stable), bumps `dart_style` and updates formatting throughout so that stable CI workflows pass.
