### PR TITLE
feat(aft): Allow `aft link` to work outside the repo

### DIFF
--- a/packages/aft/lib/src/commands/amplify_command.dart
+++ b/packages/aft/lib/src/commands/amplify_command.dart
@@ -78,8 +78,21 @@ abstract class AmplifyCommand extends Command<void>
     return Directory(directory);
   }();
 
+  /// The override for the Amplify Flutter root directory.
+  ///
+  /// Useful for running commands `aft link` from outside the repo.
+  ///
+  /// **NOTE**: Not all commands support this.
+  late final _rootDirectoryOverride = () {
+    if (argParser.findByNameOrAlias('root') != null) {
+      return argResults?['root'] as String?;
+    }
+    return null;
+  }();
+
   late final AftConfigLoader aftConfigLoader = AftConfigLoader(
     workingDirectory: workingDirectory,
+    rootDirectoryOverride: _rootDirectoryOverride,
   );
 
   /// The processed `aft` configuration for the repo with packages and

--- a/packages/aft/lib/src/commands/link_command.dart
+++ b/packages/aft/lib/src/commands/link_command.dart
@@ -13,6 +13,16 @@ import 'package:yaml_edit/yaml_edit.dart';
 /// Command to link all Dart/Flutter packages in the repo together using
 /// `pubspec_overrides.yaml`.
 class LinkCommand extends AmplifyCommand {
+  LinkCommand() {
+    argParser.addOption(
+      'root',
+      abbr: 'r',
+      help:
+          'The root of the Amplify Flutter repo. Defaults to automatic determination '
+          'but must be set when linking outside the repo.',
+    );
+  }
+
   @override
   String get description => 'Links all packages in the Amplify Flutter repo';
 
@@ -115,7 +125,12 @@ extension LinkPackages on AmplifyCommand {
   /// Links [commandPackages] together using `pubspec_overrides.yaml`.
   Future<void> linkPackages() async {
     final futureGroup = FutureGroup<void>();
-    for (final package in repoPackages.values) {
+    final packagesToLink = [
+      ...repoPackages.values,
+      if (!path.isWithin(rootDir.path, workingDirectory.path))
+        PackageInfo.fromDirectory(workingDirectory)!,
+    ];
+    for (final package in packagesToLink) {
       final dependencyPaths = _collectDependencies(package, repoPackages);
       futureGroup.add(
         _createPubspecOverride(

--- a/packages/aft/test/config/config_loader_test.dart
+++ b/packages/aft/test/config/config_loader_test.dart
@@ -29,6 +29,7 @@ dependencies:
       final rootDirectory = p.normalize(d.path('repo'));
       final workingDirectory = rootDirectory;
       final configLoader = AftConfigLoader(
+        rootPackageName: 'my_repo',
         workingDirectory: Directory(workingDirectory),
       );
       check(configLoader.load).returnsNormally()
@@ -87,8 +88,8 @@ aft:
         d.dir('packages', [
           d.dir('my_pkg', [
             d.file('pubspec.yaml', packagePubspec),
-          ])
-        ])
+          ]),
+        ]),
       ]).create();
 
       final rootDirectory = p.normalize(d.path('repo'));
@@ -96,6 +97,7 @@ aft:
         d.path('repo/packages/my_pkg'),
       );
       final configLoader = AftConfigLoader(
+        rootPackageName: 'my_repo',
         workingDirectory: Directory(workingDirectory),
       );
       check(configLoader.load).returnsNormally()


### PR DESCRIPTION
The use case for this is improving the experience of working on issues and features from apps which live outside the repo. It adds a `--root/-r` option to `aft link` which can overrides the default logic for finding the root directory.

Assume my `amplify-flutter` repo is cloned at `~/amplify-flutter`. I can now do the following:

```console
$ flutter create my_app
$ cd my_app && flutter pub add amplify_flutter amplify_auth_cognito
$ aft link -r ~/amplify-flutter
```

This will create a `pubspec_overrides.yaml` file in `my_app` which links all Amplify Flutter dependencies back to the repo so changes can be worked on live.
