### PR TITLE
fix(aft): Don't write changelog updates if version was not bumped.

### DIFF
--- a/packages/aft/lib/src/commands/version_bump_command.dart
+++ b/packages/aft/lib/src/commands/version_bump_command.dart
@@ -90,19 +90,20 @@ class VersionBumpCommand extends AmplifyCommand
     final bumpedPackages = <PackageInfo>[];
     for (final package in repo.publishablePackages()) {
       final edits = package.pubspecInfo.pubspecYamlEditor.edits;
-      if (edits.isNotEmpty) {
-        bumpedPackages.add(package);
-        if (preview) {
-          logger.info('pubspec.yaml');
-          for (final edit in edits) {
-            final originalText = package.pubspecInfo.pubspecYaml
-                .substring(edit.offset, edit.offset + edit.length);
-            logger.info('$originalText --> ${edit.replacement}');
-          }
-        } else {
-          await File(p.join(package.path, 'pubspec.yaml'))
-              .writeAsString(package.pubspecInfo.pubspecYamlEditor.toString());
+      if (edits.isEmpty) {
+        continue;
+      }
+      bumpedPackages.add(package);
+      if (preview) {
+        logger.info('pubspec.yaml');
+        for (final edit in edits) {
+          final originalText = package.pubspecInfo.pubspecYaml
+              .substring(edit.offset, edit.offset + edit.length);
+          logger.info('$originalText --> ${edit.replacement}');
         }
+      } else {
+        await File(p.join(package.path, 'pubspec.yaml'))
+            .writeAsString(package.pubspecInfo.pubspecYamlEditor.toString());
       }
       final changelogUpdate = changelogUpdates[package];
       if (changelogUpdate != null && changelogUpdate.hasUpdate) {


### PR DESCRIPTION
Fixes issue in `version-bump` where a changelog may be updated without a corresponding version bump. For example, `amplify_flutter` consolidates updates from all packages, and can collect changelog updates when its version has not been bumped causing a ghost `## NEXT` entry.
