### PR TITLE
fix(datastore): Pin `Starscream`

### DIFF
--- a/build-support/build_canary.sh
+++ b/build-support/build_canary.sh
@@ -4,6 +4,7 @@ set -e
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 
 PROJECT_DIR=$(mktemp -d)
+echo "Building in $PROJECT_DIR"
 cd $PROJECT_DIR
 
 # generate
@@ -23,11 +24,13 @@ cp -r $ROOT_DIR/canaries/lib .
 cp $ROOT_DIR/build-support/dummy_amplifyconfiguration.dart lib/amplifyconfiguration.dart
 
 # Android
-sed -i'' -e "s/ext.kotlin_version = .*/ext.kotlin_version = \"1.8.21\"/" ./android/build.gradle
-sed -i'' -e "s/minSdkVersion .*/minSdkVersion 24/" ./android/app/build.gradle
-sed -i'' -e "s/compileSdkVersion .*/compileSdkVersion 33/" ./android/app/build.gradle
+sed -i '' -e "s/ext.kotlin_version = .*/ext.kotlin_version = \"1.8.21\"/" ./android/build.gradle
+sed -i '' -e "s/minSdkVersion .*/minSdkVersion 24/" ./android/app/build.gradle
+sed -i '' -e "s/compileSdkVersion .*/compileSdkVersion 33/" ./android/app/build.gradle
 cat ./android/app/build.gradle
 # iOS
-sed -i'' -e "s/# platform .*/platform :ios, '13.0'/" ./ios/Podfile && cat ./ios/Podfile
+sed -i '' -e "s/# platform .*/platform :ios, '13.0'/" ./ios/Podfile
+cat ./ios/Podfile
+pod repo update
 
 flutter build $@

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -18,6 +18,7 @@ The DataStore module for Amplify Flutter.
   s.dependency 'Amplify', '1.30.4'
   s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.30.4'
   s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.30.4'
+  s.dependency 'Starscream', '4.0.4'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.


### PR DESCRIPTION
The repo added a new enum case (https://github.com/daltoniam/Starscream/commit/f900d67759cdd11df3dcca34af21f40f59fe4e79) which is not handled by Amplify's `AppSyncRealTimeClient` causing build failures for Starscream >4.0.4.

Build failures: https://github.com/aws-amplify/amplify-flutter/actions/runs/5917560965
