### PR TITLE
 fix(datastore): Pin Starscream

### DIFF
--- a/packages/api/amplify_api_ios/ios/amplify_api_ios.podspec
+++ b/packages/api/amplify_api_ios/ios/amplify_api_ios.podspec
@@ -17,6 +17,7 @@ The API module for Amplify Flutter.
   s.dependency 'Flutter'
   s.dependency 'Amplify', '1.30.4'
   s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.30.4'
+  s.dependency 'Starscream', '4.0.4'
   s.dependency 'amplify_core'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
The repo added a new enum case (daltoniam/Starscream@f900d67) which is not handled by Amplify's AppSyncRealTimeClient causing build failures for Starscream >4.0.4.

Build failures: aws-amplify/amplify-flutter/actions/runs/5917560965
