### PR TITLE
ci: Update composite action deps

### DIFF
--- a/.github/composite_actions/fetch_backends/action.yaml
+++ b/.github/composite_actions/fetch_backends/action.yaml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # 1.7.0
+      uses: aws-actions/configure-aws-credentials@ef93a73b1313f148011965ef7361f667f371f58b # 3.0.0
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
@@ -33,7 +33,7 @@ runs:
       shell: bash
 
     - name: Get Amplify App IDs / bucket ARNs from Secrets Manager
-      uses: aws-actions/aws-secretsmanager-get-secrets@bafac38d78b5f679d35ef3f36f9842a63de59564 # 1.0.0
+      uses: aws-actions/aws-secretsmanager-get-secrets@022e8919774ecb75e8e375656d7b1898936ab878 # 1.0.4
       with:
         secret-ids: |
           ${{ inputs.secret-identifier }}

--- a/.github/composite_actions/install_dependencies/action.yaml
+++ b/.github/composite_actions/install_dependencies/action.yaml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d # 2.8.0
+    - uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa # 2.10.0
       with:
         cache: true
         channel: ${{ inputs.channel }}

--- a/.github/composite_actions/log_metric/action.yaml
+++ b/.github/composite_actions/log_metric/action.yaml
@@ -22,10 +22,10 @@ inputs:
     description: Dimensions of metric to track in Cloudwatch, in format dimensionName1=value,dimensionName2=value,...
     required: false
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # 1.7.0
+      uses: aws-actions/configure-aws-credentials@ef93a73b1313f148011965ef7361f667f371f58b # 3.0.0
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/composite_actions/setup_firefox/action.yaml
+++ b/.github/composite_actions/setup_firefox/action.yaml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: browser-actions/setup-firefox@c990ef23a9bedbbe657b163aaf0f3b7c608ea9f0 # master
+    - uses: browser-actions/setup-firefox@2904820ff2e2cfeadf033d26ce136d65509ce7fc # 1.1.0
     - shell: bash
       run: firefox --version
     - shell: bash
@@ -23,7 +23,7 @@ runs:
         sudo mv geckodriver /usr/local/bin
     - shell: bash
       run: geckodriver --version
-    - name: Virtual X Display 
+    - name: Virtual X Display
       shell: bash
       if: ${{ runner.os == 'Linux' }}
       run: |

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: ".github/composite_actions"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "pub"
     directory: "actions"
     schedule:

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -35,6 +35,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: ".github/composite_actions"
+    schedule:
+      interval: "weekly"
 ''');
 
   @override


### PR DESCRIPTION
Dependabot doesn't check this directory, by default.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#enabling-dependabot-version-updates-for-actions
