### PR TITLE
fix(datastore): Use platform thread

### DIFF
--- a/packages/amplify_datastore/ios/Classes/CognitoPlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/CognitoPlugin.swift
@@ -62,9 +62,11 @@ public class CognitoPlugin: AuthCategoryPlugin {
             request: AuthFetchSessionRequest(options: options ?? AuthFetchSessionRequest.Options()),
             resultListener: listener
         )
-        nativeAuthPlugin.fetchAuthSession { session in
-            let result = NativeAWSAuthCognitoSession(from: session)
-            operation.dispatch(result: .success(result))
+        DispatchQueue.main.async {
+            self.nativeAuthPlugin.fetchAuthSession { session in
+                let result = NativeAWSAuthCognitoSession(from: session)
+                operation.dispatch(result: .success(result))
+            }
         }
         return operation
     }


### PR DESCRIPTION
The call from Native -> Dart to retrieve Auth credentials is being performed on a background thread which results in the following warning message.

```
The 'dev.flutter.pigeon.NativeAuthPlugin.fetchAuthSession' channel sent a message from native to Flutter on a non-platform thread. Platform channel messages must be sent on the platform thread. Failure to do so may result in data loss or crashes, and must be fixed in the plugin or application code creating that channel.
```
