### PR TITLE
ci: Use large Windows runner

### DIFF
--- a/.github/workflows/amplify_integration_tests.yaml
+++ b/.github/workflows/amplify_integration_tests.yaml
@@ -259,7 +259,8 @@ jobs:
           aft exec --include=${{ matrix.scope }} -- "<AFT_ROOT>/build-support/integ_test.sh" -d linux
 
   windows:
-    runs-on: windows-latest
+    runs-on:
+      labels: amplify-flutter_windows-latest_8-core
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write


### PR DESCRIPTION
Use the large Windows runner in e2e tests