### PR TITLE
chore: bump amplify android to 2.12.0

### DIFF
--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -72,10 +72,10 @@ dependencies {
     // Support for Java 8 features
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 
-    implementation 'com.amplifyframework:aws-auth-cognito:2.11.2'
-    implementation "com.amplifyframework:aws-api:2.11.2"
-    implementation "com.amplifyframework:aws-datastore:2.11.2"
-    implementation "com.amplifyframework:aws-api-appsync:2.11.2"
+    implementation 'com.amplifyframework:aws-auth-cognito:2.12.0'
+    implementation "com.amplifyframework:aws-api:2.12.0"
+    implementation "com.amplifyframework:aws-datastore:2.12.0"
+    implementation "com.amplifyframework:aws-api-appsync:2.12.0"
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1'
 

--- a/packages/amplify_datastore/example/android/build.gradle
+++ b/packages/amplify_datastore/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/packages/amplify_datastore/example/integration_test/utils/setup_utils.dart
+++ b/packages/amplify_datastore/example/integration_test/utils/setup_utils.dart
@@ -11,7 +11,7 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 
 const ENABLE_CLOUD_SYNC =
     bool.fromEnvironment('ENABLE_CLOUD_SYNC', defaultValue: false);
-const DATASTORE_READY_EVENT_TIMEOUT = const Duration(minutes: 2);
+const DATASTORE_READY_EVENT_TIMEOUT = const Duration(minutes: 10);
 const DELAY_TO_START_DATASTORE = const Duration(milliseconds: 500);
 const DELAY_TO_CLEAR_DATASTORE = const Duration(seconds: 2);
 const DELAY_FOR_OBSERVE = const Duration(milliseconds: 100);

--- a/packages/notifications/push/amplify_push_notifications/android/build.gradle
+++ b/packages/notifications/push/amplify_push_notifications/android/build.gradle
@@ -65,7 +65,7 @@ android {
 dependencies {
     api "com.google.firebase:firebase-messaging:23.2.0"
     // Import support library for Amplify push utils
-    implementation 'com.amplifyframework:aws-push-notifications-pinpoint-common:2.11.2'
+    implementation 'com.amplifyframework:aws-push-notifications-pinpoint-common:2.12.0'
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
     implementation project(path: ':flutter_plugin_android_lifecycle')
     implementation 'androidx.test:core-ktx:1.5.0'


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-amplify/amplify-flutter/issues/3575 (fixed by https://github.com/aws-amplify/amplify-android/pull/2565)
- https://github.com/aws-amplify/amplify-flutter/issues/1693 (fixed by https://github.com/aws-amplify/amplify-android/pull/2561)
- https://github.com/aws-amplify/amplify-flutter/issues/3017 (fixed by https://github.com/aws-amplify/amplify-android/pull/2551)

*Description of changes:*
- Bump Amplify Android to v2.12.0
- Increase cloud sync timeout from 2 minutes to 10 minutes. This is currently a frequent source of integ test failure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
