### PR TITLE
ci: Fix AWS credentials retrieval

### DIFF
--- a/.github/composite_actions/fetch_backends/action.yaml
+++ b/.github/composite_actions/fetch_backends/action.yaml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@ef93a73b1313f148011965ef7361f667f371f58b # 3.0.0
+      uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 # 3.0.1
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/composite_actions/log_metric/action.yaml
+++ b/.github/composite_actions/log_metric/action.yaml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@ef93a73b1313f148011965ef7361f667f371f58b # 3.0.0
+      uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 # 3.0.1
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}


### PR DESCRIPTION
Bumps the `configure-aws-credentials` action so that we no longer receive this error:

```
Assuming role with OIDC
Error: Could not assume role with OIDC: SecretAccessKey contains special characters.
```
