### PR TITLE
test(auth): MFA preference tests

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_totp_optional_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_totp_optional_test.dart
@@ -243,6 +243,35 @@ void main() {
           check(confirmRes.nextStep.signInStep).equals(AuthSignInStep.done);
         }
 
+        // Verify marking enabled does not change preference.
+        await cognitoPlugin.updateMfaPreference(
+          sms: MfaPreference.enabled,
+          totp: MfaPreference.enabled,
+        );
+        check(
+          await cognitoPlugin.fetchMfaPreference(),
+          because: 'SMS should still be marked preferred',
+        ).equals(
+          const UserMfaPreference(
+            enabled: {MfaType.sms, MfaType.totp},
+            preferred: MfaType.sms,
+          ),
+        );
+
+        // Verify we can mark neither as preferred
+        await cognitoPlugin.updateMfaPreference(
+          sms: MfaPreference.notPreferred,
+        );
+        check(
+          await cognitoPlugin.fetchMfaPreference(),
+          because: 'SMS should be marked not preferred',
+        ).equals(
+          const UserMfaPreference(
+            enabled: {MfaType.sms, MfaType.totp},
+            preferred: null,
+          ),
+        );
+
         // Verify that we can disable both
         await check(
           because: 'MFA can be disabled when optional',
@@ -415,6 +444,35 @@ void main() {
           );
           check(confirmRes.nextStep.signInStep).equals(AuthSignInStep.done);
         }
+
+        // Verify marking enabled does not change preference.
+        await cognitoPlugin.updateMfaPreference(
+          sms: MfaPreference.enabled,
+          totp: MfaPreference.enabled,
+        );
+        check(
+          await cognitoPlugin.fetchMfaPreference(),
+          because: 'TOTP should still be marked preferred',
+        ).equals(
+          const UserMfaPreference(
+            enabled: {MfaType.sms, MfaType.totp},
+            preferred: MfaType.totp,
+          ),
+        );
+
+        // Verify we can mark neither as preferred
+        await cognitoPlugin.updateMfaPreference(
+          totp: MfaPreference.notPreferred,
+        );
+        check(
+          await cognitoPlugin.fetchMfaPreference(),
+          because: 'TOTP should be marked not preferred',
+        ).equals(
+          const UserMfaPreference(
+            enabled: {MfaType.sms, MfaType.totp},
+            preferred: null,
+          ),
+        );
 
         // Verify that we can disable both
         await check(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_totp_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_totp_required_test.dart
@@ -238,8 +238,36 @@ void main() {
           check(confirmRes.nextStep.signInStep).equals(AuthSignInStep.done);
         }
 
-        // Verify that we can disable MFA
+        // Verify marking enabled does not change preference.
+        await cognitoPlugin.updateMfaPreference(
+          sms: MfaPreference.enabled,
+          totp: MfaPreference.enabled,
+        );
+        check(
+          await cognitoPlugin.fetchMfaPreference(),
+          because: 'SMS should still be marked preferred',
+        ).equals(
+          const UserMfaPreference(
+            enabled: {MfaType.sms, MfaType.totp},
+            preferred: MfaType.sms,
+          ),
+        );
 
+        // Verify we can mark neither as preferred
+        await cognitoPlugin.updateMfaPreference(
+          sms: MfaPreference.notPreferred,
+        );
+        check(
+          await cognitoPlugin.fetchMfaPreference(),
+          because: 'SMS should be marked not preferred',
+        ).equals(
+          const UserMfaPreference(
+            enabled: {MfaType.sms, MfaType.totp},
+            preferred: null,
+          ),
+        );
+
+        // Verify that we can disable MFA
         {
           await check(
             because: 'Interestingly, Cognito does not throw and allows '
@@ -426,8 +454,36 @@ void main() {
           check(confirmRes.nextStep.signInStep).equals(AuthSignInStep.done);
         }
 
-        // Verify that we can disable MFA
+        // Verify marking enabled does not change preference.
+        await cognitoPlugin.updateMfaPreference(
+          sms: MfaPreference.enabled,
+          totp: MfaPreference.enabled,
+        );
+        check(
+          await cognitoPlugin.fetchMfaPreference(),
+          because: 'TOTP should still be marked preferred',
+        ).equals(
+          const UserMfaPreference(
+            enabled: {MfaType.sms, MfaType.totp},
+            preferred: MfaType.totp,
+          ),
+        );
 
+        // Verify we can mark neither as preferred
+        await cognitoPlugin.updateMfaPreference(
+          totp: MfaPreference.notPreferred,
+        );
+        check(
+          await cognitoPlugin.fetchMfaPreference(),
+          because: 'TOTP should be marked not preferred',
+        ).equals(
+          const UserMfaPreference(
+            enabled: {MfaType.sms, MfaType.totp},
+            preferred: null,
+          ),
+        );
+
+        // Verify that we can disable MFA
         {
           await check(
             because: 'Interestingly, Cognito does not throw and allows '


### PR DESCRIPTION
Adds some more e2e tests for the `updateMfaPreference` API
