### PR TITLE
ci: Unset AWS credentials

### DIFF
--- a/.github/composite_actions/fetch_backends/action.yaml
+++ b/.github/composite_actions/fetch_backends/action.yaml
@@ -24,6 +24,7 @@ runs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 # 3.0.1
       with:
+        unset-current-credentials: true
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
         role-duration-seconds: 900

--- a/.github/composite_actions/log_metric/action.yaml
+++ b/.github/composite_actions/log_metric/action.yaml
@@ -27,6 +27,7 @@ runs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 # 3.0.1
       with:
+        unset-current-credentials: true
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
         role-duration-seconds: 900


### PR DESCRIPTION
Basically, force a refresh. Some composite actions are failing due to stale credentials.

https://github.com/aws-actions/configure-aws-credentials#unset-current-credentials