### PR TITLE
test(auth): Resend user attribute confirmation code

### DIFF
--- a/infra/lib/auth/stack.ts
+++ b/infra/lib/auth/stack.ts
@@ -138,6 +138,12 @@ export interface AuthFullEnvironmentProps {
    * MFA settings for the user pool.
    */
   mfaConfiguration?: MfaConfiguration;
+
+  /**
+   * Whether to keep original attribute values while updating `email`
+   * and `phone_number` attributes.
+   */
+  keepOriginal?: cognito.KeepOriginalAttrs;
 }
 
 export interface AuthCustomAuthorizerEnvironmentProps {
@@ -227,6 +233,7 @@ class AuthIntegrationTestStackEnvironment extends IntegrationTestStackEnvironmen
       withClientSecret = false,
       advancedSecurityMode = cognito.AdvancedSecurityMode.OFF,
       mfaConfiguration,
+      keepOriginal,
     } = props;
 
     // Create the GraphQL API for admin actions
@@ -417,6 +424,7 @@ class AuthIntegrationTestStackEnvironment extends IntegrationTestStackEnvironmen
       deviceTracking,
       mfaSecondFactor,
       advancedSecurityMode,
+      keepOriginal
     });
     this.createUserCleanupJob(userPool);
 

--- a/infra/lib/stack.ts
+++ b/infra/lib/stack.ts
@@ -195,6 +195,26 @@ export class AmplifyFlutterIntegStack extends cdk.Stack {
       {
         associateWithWaf,
         type: "FULL",
+        environmentName: "keep-original-attributes",
+        autoConfirm: true,
+        standardAttributes: {
+          email: {
+            mutable: true,
+            required: true,
+          },
+          phoneNumber: {
+            mutable: true,
+            required: true,
+          }
+        },
+        keepOriginal: {
+          email: true,
+          phone: true,
+        }
+      },
+      {
+        associateWithWaf,
+        type: "FULL",
         environmentName: "hosted-ui",
         enableHostedUI: true,
       },


### PR DESCRIPTION
Adds tests which encode the behavior around `resendUserAttributeConfirmationCode` with and without the `keepOriginal` properties enabled in Cognito.
