### PR TITLE
fix(auth): Custom auth with device tracking, no SRP

### DIFF
--- a/infra/lib/stack.ts
+++ b/infra/lib/stack.ts
@@ -252,8 +252,15 @@ export class AmplifyFlutterIntegStack extends cdk.Stack {
       {
         associateWithWaf,
         type: "FULL",
-        environmentName: "custom-auth-device-srp",
+        environmentName: "custom-auth-device-with-srp",
         customAuth: "WITH_SRP",
+        deviceTracking: deviceTrackingAlways,
+      },
+      {
+        associateWithWaf,
+        type: "FULL",
+        environmentName: "custom-auth-device-without-srp",
+        customAuth: "WITHOUT_SRP",
         deviceTracking: deviceTrackingAlways,
       },
       {


### PR DESCRIPTION
The fix in https://github.com/aws-amplify/amplify-flutter/pull/3558 assumed that device SRP would only be performed when password SRP had previously been performed as part of a custom Auth workflow. However, this is not true. In custom auth workflows without password SRP, device SRP can still be required when device tracking is enabled, and in this case it is not a requirement that password SRP have been previously performed.