### PR TITLE
fix(auth): Crash with EXC_BAD_ACCESS

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/ffigen.macos.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/ffigen.macos.yaml
@@ -78,6 +78,7 @@ enums:
 macros:
   include:
     - kIOPlatformUUIDKey
+    - IO_OBJECT_NULL
 typedefs:
   include:
     - CFTypeRef

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/platform/macos_bindings.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/platform/macos_bindings.g.dart
@@ -10366,18 +10366,23 @@ class NativeMacOsFramework {
 }
 
 final class utsname extends ffi.Struct {
+  /// [XSI] Name of OS
   @ffi.Array.multi([256])
   external ffi.Array<ffi.Char> sysname;
 
+  /// [XSI] Name of this network node
   @ffi.Array.multi([256])
   external ffi.Array<ffi.Char> nodename;
 
+  /// [XSI] Release level
   @ffi.Array.multi([256])
   external ffi.Array<ffi.Char> release;
 
+  /// [XSI] Version level
   @ffi.Array.multi([256])
   external ffi.Array<ffi.Char> version;
 
+  /// [XSI] Hardware type
   @ffi.Array.multi([256])
   external ffi.Array<ffi.Char> machine;
 }
@@ -20023,3 +20028,5 @@ abstract class NSAlignmentOptions {
 typedef CFTypeRef1 = ffi.Pointer<ffi.Void>;
 
 const String kIOPlatformUUIDKey = 'IOPlatformUUID';
+
+const int IO_OBJECT_NULL = 0;


### PR DESCRIPTION
- Adds checks to results of `IOServiceGetMatchingService` and `IORegistryEntryCreateCFProperty` FFI calls to prevent trying to access bad data in cast or free calls.
- Removes accesses to `NSScreen` due to potential ffigen bug