### PR TITLE
fix(logging): queued item store to use path provider on vm

### DIFF
--- a/.github/workflows/amplify_logging_cloudwatch.yaml
+++ b/.github/workflows/amplify_logging_cloudwatch.yaml
@@ -11,8 +11,7 @@ on:
       - '.github/workflows/amplify_logging_cloudwatch.yaml'
       - '.github/workflows/dart_dart2js.yaml'
       - '.github/workflows/dart_ddc.yaml'
-      - '.github/workflows/dart_native.yaml'
-      - '.github/workflows/dart_vm.yaml'
+      - '.github/workflows/flutter_vm.yaml'
       - 'packages/amplify_core/lib/**/*.dart'
       - 'packages/amplify_core/pubspec.yaml'
       - 'packages/amplify_lints/lib/**/*.yaml'
@@ -42,25 +41,7 @@ permissions: read-all
 
 jobs:
   test:
-    uses: ./.github/workflows/dart_vm.yaml
-    with:
-      package-name: amplify_logging_cloudwatch
-      working-directory: packages/logging_cloudwatch/amplify_logging_cloudwatch
-  native_test:
-    needs: test
-    uses: ./.github/workflows/dart_native.yaml
-    with:
-      package-name: amplify_logging_cloudwatch
-      working-directory: packages/logging_cloudwatch/amplify_logging_cloudwatch
-  ddc_test:
-    needs: test
-    uses: ./.github/workflows/dart_ddc.yaml
-    with:
-      package-name: amplify_logging_cloudwatch
-      working-directory: packages/logging_cloudwatch/amplify_logging_cloudwatch
-  dart2js_test:
-    needs: test
-    uses: ./.github/workflows/dart_dart2js.yaml
+    uses: ./.github/workflows/flutter_vm.yaml
     with:
       package-name: amplify_logging_cloudwatch
       working-directory: packages/logging_cloudwatch/amplify_logging_cloudwatch

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.vm.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.vm.dart
@@ -7,16 +7,19 @@ import 'package:amplify_logging_cloudwatch/src/queued_item_store/drift/drift_que
 import 'package:aws_common/aws_common.dart';
 import 'package:aws_logging_cloudwatch/aws_logging_cloudwatch.dart';
 import 'package:meta/meta.dart';
+import 'package:path_provider/path_provider.dart';
 
 /// {@macro amplify_logging_cloudwatch.dart_queued_item_store}
 class DartQueuedItemStore implements QueuedItemStore, Closeable {
   /// {@macro amplify_logging_cloudwatch.dart_queued_item_store}
   factory DartQueuedItemStore(String? storagePath) {
-    assert(
-      storagePath != null,
-      'A storage path is required on VM for locating the DB',
-    );
-    final database = DriftQueuedItemStore(storagePath!);
+    final FutureOr<String> path;
+    if (storagePath == null) {
+      path = getApplicationSupportDirectory().then((value) => value.path);
+    } else {
+      path = storagePath;
+    }
+    final database = DriftQueuedItemStore(path);
     return DartQueuedItemStore._(database);
   }
 

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/drift/drift_queued_item_store.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/drift/drift_queued_item_store.dart
@@ -28,7 +28,7 @@ class DriftQueuedItems extends Table {
 class DriftQueuedItemStore extends _$DriftQueuedItemStore
     implements QueuedItemStore {
   /// {@macro amplify_logging_cloudwatch.drift_queued_item_store}
-  factory DriftQueuedItemStore(String storagePath) {
+  factory DriftQueuedItemStore(FutureOr<String> storagePath) {
     final driftQueryExecutor = connect(
       name: 'logging_cached_logs',
       path: storagePath,

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/pubspec.yaml
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/pubspec.yaml
@@ -6,6 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/amplify_log
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
+  flutter: ">=3.10.0"
   sdk: "^3.0.0"
 
 dependencies:
@@ -15,7 +16,10 @@ dependencies:
   aws_logging_cloudwatch: ^0.1.0
   collection: ^1.15.0
   drift: ">=2.11.0 <2.12.0"
+  flutter:
+    sdk: flutter
   meta: ^1.7.0
+  path_provider: ^2.0.0
 
 dev_dependencies:
   amplify_lints: ">=3.0.0 <3.1.0"

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/cloudwatch_logger_plugin.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/cloudwatch_logger_plugin.dart
@@ -44,46 +44,16 @@ typedef _LogBatch = (List<QueuedItem> logQueues, List<InputLogEvent> logEvents);
 class CloudWatchLoggerPlugin extends AWSLoggerPlugin
     with AWSDebuggable, AWSLoggerMixin {
   /// {@macro aws_logging_cloudwatch.cloudwatch_logger_plugin}
-  factory CloudWatchLoggerPlugin({
+  CloudWatchLoggerPlugin({
     required AWSCredentialsProvider credentialsProvider,
     required CloudWatchLoggerPluginConfiguration pluginConfig,
     RemoteLoggingConstraintProvider? remoteLoggingConstraintProvider,
     CloudWatchLogStreamProvider? logStreamProvider,
-  }) {
-    return CloudWatchLoggerPlugin._(
-      credentialsProvider: credentialsProvider,
-      pluginConfig: pluginConfig,
-      remoteLoggingConstraintProvider: remoteLoggingConstraintProvider,
-      logStreamProvider: logStreamProvider,
-      logStore: InMemoryQueuedItemStore(),
-    );
-  }
-
-  /// An [AWSLoggerPlugin] to use only for testing.
-  @protected
-  @visibleForTesting
-  CloudWatchLoggerPlugin.testPlugin({
-    required CloudWatchLogsClient client,
-    required CloudWatchLoggerPluginConfiguration pluginConfig,
-    required CloudWatchLogStreamProvider logStreamProvider,
-    required QueuedItemStore logStore,
-    RemoteLoggingConstraintProvider? remoteLoggingConstraintProvider,
+    // TODO(nikahsn): remove after moving queued item store implementation from
+    // amplify_logging_cloudwath to aws_logging_cloudwatch
+    @protected QueuedItemStore? logStore,
   })  : _enabled = pluginConfig.enable,
         _pluginConfig = pluginConfig,
-        _logStore = logStore,
-        _remoteLoggingConstraintProvider = remoteLoggingConstraintProvider,
-        _logStreamProvider = logStreamProvider,
-        _client = client;
-
-  CloudWatchLoggerPlugin._({
-    required AWSCredentialsProvider credentialsProvider,
-    required CloudWatchLoggerPluginConfiguration pluginConfig,
-    RemoteLoggingConstraintProvider? remoteLoggingConstraintProvider,
-    CloudWatchLogStreamProvider? logStreamProvider,
-    QueuedItemStore? logStore,
-  })  : _enabled = pluginConfig.enable,
-        _pluginConfig = pluginConfig,
-        _logStore = logStore ?? InMemoryQueuedItemStore(),
         _remoteLoggingConstraintProvider = remoteLoggingConstraintProvider ??
             (pluginConfig.defaultRemoteConfiguration != null
                 ? DefaultRemoteLoggingConstraintProvider(
@@ -95,6 +65,10 @@ class CloudWatchLoggerPlugin extends AWSLoggerPlugin
           region: pluginConfig.region,
           credentialsProvider: credentialsProvider,
         ),
+        // TODO(nikahsn): move queued item store implementation from
+        // amplify_logging_cloudwath to aws_logging_cloudwatch and use
+        // DartQueueItemStore instead of InMemoryQueuedItemStore
+        _logStore = logStore ?? InMemoryQueuedItemStore(),
         _logStreamProvider = logStreamProvider ??
             DefaultCloudWatchLogStreamProvider(
               logGroupName: pluginConfig.logGroupName,
@@ -114,6 +88,22 @@ class CloudWatchLoggerPlugin extends AWSLoggerPlugin
       _timer?.stop();
     }
   }
+
+  /// An [AWSLoggerPlugin] to use only for testing.
+  @protected
+  @visibleForTesting
+  CloudWatchLoggerPlugin.testPlugin({
+    required CloudWatchLogsClient client,
+    required CloudWatchLoggerPluginConfiguration pluginConfig,
+    required CloudWatchLogStreamProvider logStreamProvider,
+    required QueuedItemStore logStore,
+    RemoteLoggingConstraintProvider? remoteLoggingConstraintProvider,
+  })  : _enabled = pluginConfig.enable,
+        _pluginConfig = pluginConfig,
+        _logStore = logStore,
+        _remoteLoggingConstraintProvider = remoteLoggingConstraintProvider,
+        _logStreamProvider = logStreamProvider,
+        _client = client;
 
   final CloudWatchLoggerPluginConfiguration _pluginConfig;
   final CloudWatchLogsClient _client;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- queued item store to use path provider on vm if storage path is empty. so cloudwatch logger plugin can init the log store in the construct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
