### PR TITLE
test(auth): Fix flaky test

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_io.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform_io.dart
@@ -156,8 +156,7 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
   /// of the ports may be blocked.
   @visibleForTesting
   Future<LocalServer> localConnect(Iterable<Uri> uris) async {
-    final localServer = _localServer;
-    if (localServer != null) {
+    if (_localServer case final localServer?) {
       return localServer;
     }
 
@@ -182,7 +181,7 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
             'All ports were blocked: [${uris.map((uri) => uri.port).join(',')}]',
       );
     }
-    return LocalServer(server, selectedUri);
+    return _localServer = LocalServer(server, selectedUri);
   }
 
   Future<void> _respond(
@@ -212,20 +211,16 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
       _noSuitableRedirect(signIn: true);
     }
 
-    _localServer = await localConnect(signInUris);
+    final localServer = await localConnect(signInUris);
     try {
       final signInUrl = (await getSignInUri(
         provider: provider,
-        redirectUri: _localServer!.uri,
+        redirectUri: localServer.uri,
       ))
           .toString();
       await launchUrl(signInUrl);
 
-      final server = _localServer?.server;
-      if (server == null) {
-        return;
-      }
-      await for (final request in server) {
+      await for (final request in localServer.server) {
         final method = request.method;
         if (method != 'GET') {
           await _respond(
@@ -288,17 +283,12 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
       _noSuitableRedirect(signIn: false);
     }
 
-    _localServer = await localConnect(signOutUris);
+    final localServer = await localConnect(signOutUris);
     try {
-      final signOutUri =
-          getSignOutUri(redirectUri: _localServer!.uri).toString();
+      final signOutUri = getSignOutUri(redirectUri: localServer.uri).toString();
       await launchUrl(signOutUri);
 
-      final server = _localServer?.server;
-      if (server == null) {
-        return;
-      }
-      await for (final request in server) {
+      await for (final request in localServer.server) {
         final method = request.method;
         if (method != 'GET') {
           await _respond(
@@ -331,8 +321,9 @@ class HostedUiPlatformImpl extends HostedUiPlatform {
   /// Closes the open server, if any.
   @override
   Future<void> close() async {
-    await _localServer?.server.close();
+    final localServer = _localServer;
     _localServer = null;
+    await localServer?.server.close();
   }
 }
 


### PR DESCRIPTION
Fixes flaky HostedUI test by updating expectations and not relying on the timings of the event loop.
