### PR TITLE
initial commit for password policy display

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/widgets/form.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/widgets/form.dart
@@ -219,6 +219,7 @@ class SignUpForm extends AuthenticatorForm {
   SignUpForm({
     super.key,
   })  : _includeDefaultFields = true,
+        passwordPolicyWidget = null,
         super._(
           fields: [
             SignUpFormField.username(),
@@ -234,6 +235,7 @@ class SignUpForm extends AuthenticatorForm {
   const SignUpForm.custom({
     super.key,
     required List<SignUpFormField> super.fields,
+    this.passwordPolicyWidget,
   })  : _includeDefaultFields = false,
         super._(
           actions: const [
@@ -244,6 +246,11 @@ class SignUpForm extends AuthenticatorForm {
   /// Controls whether the default form fields are included, based on settings in
   /// the Auth plugin configuration.
   final bool _includeDefaultFields;
+
+  /// Widget to show for displaying a password policy.
+  ///
+  /// Typically a [TextBox]
+  final Widget? passwordPolicyWidget;
 
   @override
   AuthenticatorFormState<SignUpForm> createState() => _SignUpFormState();

--- a/packages/authenticator/amplify_authenticator/lib/src/widgets/form_fields/sign_up_form_field.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/widgets/form_fields/sign_up_form_field.dart
@@ -55,7 +55,7 @@ abstract class SignUpFormField<FieldValue extends Object>
     FormFieldValidator<String>? validator,
     Iterable<String>? autofillHints,
   }) =>
-      _SignUpTextField(
+      _SignUpPasswordField(
         key: key ?? keyPasswordSignUpFormField,
         titleKey: InputResolverKey.passwordTitle,
         hintTextKey: InputResolverKey.passwordHint,
@@ -508,8 +508,6 @@ class _SignUpTextFieldState extends _SignUpFormFieldState<String>
     switch (widget.field) {
       case SignUpField.username:
         return state.username;
-      case SignUpField.password:
-        return state.password;
       case SignUpField.passwordConfirmation:
         return state.passwordConfirmation;
       case SignUpField.address:
@@ -535,8 +533,6 @@ class _SignUpTextFieldState extends _SignUpFormFieldState<String>
     switch (widget.field) {
       case SignUpField.username:
         return (v) => state.username = v;
-      case SignUpField.password:
-        return (v) => state.password = v;
       case SignUpField.passwordConfirmation:
         return (v) => state.passwordConfirmation = v;
       case SignUpField.address:
@@ -585,11 +581,6 @@ class _SignUpTextFieldState extends _SignUpFormFieldState<String>
           ),
           isOptional: isOptional,
         );
-      case SignUpField.password:
-        return validateNewPassword(
-          amplifyConfig: config.amplifyConfig,
-          inputResolver: stringResolver.inputs,
-        )(context);
       case SignUpField.passwordConfirmation:
         return validatePasswordConfirmation(
           () => state.password,
@@ -787,5 +778,63 @@ class _SignUpDateFieldState extends _SignUpFormFieldState<String>
       ),
       isOptional: isOptional,
     );
+  }
+}
+
+class _SignUpPasswordField extends SignUpFormField<String> {
+  const _SignUpPasswordField({
+    super.key,
+    required super.field,
+    super.titleKey,
+    super.hintTextKey,
+    CognitoUserAttributeKey? attributeKey,
+    super.validator,
+    super.required,
+    super.autofillHints,
+  }) : super._(
+          customAttributeKey: attributeKey,
+        );
+
+  @override
+  _SignUpPasswordFieldState createState() => _SignUpPasswordFieldState();
+}
+
+class _SignUpPasswordFieldState extends _SignUpTextFieldState {
+  @override
+  String? get initialValue {
+    return state.password;
+  }
+
+  @override
+  ValueChanged<String> get onChanged {
+    return (v) => state.password = v;
+  }
+
+  @override
+  Widget? get companionWidget {
+    final policyWidget =
+        InheritedForms.of(context).signUpForm.passwordPolicyWidget;
+    if (policyWidget != null) {
+      return policyWidget;
+    }
+
+    if (state.password.isEmpty) {
+      return null;
+    }
+
+    final validatorResult = validator(state.password);
+    if (validatorResult == null) {
+      return null;
+    }
+
+    return Text(validatorResult);
+  }
+
+  @override
+  FormFieldValidator<String> get validator {
+    return validateNewPassword(
+      amplifyConfig: config.amplifyConfig,
+      inputResolver: stringResolver.inputs,
+    )(context);
   }
 }


### PR DESCRIPTION
Resolves #3522 

Updates the password field in the signup form to display the password policy as a companion widget. The policy text comes straight from the validator. Further, the SignUp form now accepts a widget, likely a `Text` box, for custom policy displays.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
