### PR TITLE
feat(logging): enable log rotation and set retry on full log store sync

### DIFF
--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.stub.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.stub.dart
@@ -42,7 +42,7 @@ class DartQueuedItemStore implements QueuedItemStore, Closeable {
   }
 
   @override
-  FutureOr<bool> isFull(int maxSizeInMB) {
+  bool isFull(int maxSizeInMB) {
     throw UnimplementedError('isFull() has not been implemented.');
   }
 

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.vm.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.vm.dart
@@ -53,7 +53,7 @@ class DartQueuedItemStore implements QueuedItemStore, Closeable {
   }
 
   @override
-  Future<bool> isFull(int maxSizeInMB) {
+  bool isFull(int maxSizeInMB) {
     return _database.isFull(maxSizeInMB);
   }
 

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.web.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.web.dart
@@ -14,8 +14,8 @@ class DartQueuedItemStore
   // ignore: avoid_unused_constructor_parameters
   DartQueuedItemStore(String? storagePath);
 
-  late final Future<QueuedItemStore> _database = () async {
-    if (await IndexedDbAdapter.checkIsIndexedDBSupported()) {
+  late final QueuedItemStore _database = () {
+    if (IndexedDbAdapter.checkIsIndexedDBSupported()) {
       return IndexedDbAdapter();
     }
     logger.warn(
@@ -34,7 +34,7 @@ class DartQueuedItemStore
     String timestamp, {
     bool enableQueueRotation = false,
   }) async {
-    final db = await _database;
+    final db = _database;
     await db.addItem(
       string,
       timestamp,
@@ -44,25 +44,25 @@ class DartQueuedItemStore
 
   @override
   Future<void> deleteItems(Iterable<QueuedItem> items) async {
-    final db = await _database;
+    final db = _database;
     await db.deleteItems(items);
   }
 
   @override
   Future<Iterable<QueuedItem>> getCount(int count) async {
-    final db = await _database;
+    final db = _database;
     return db.getCount(count);
   }
 
   @override
   Future<Iterable<QueuedItem>> getAll() async {
-    final db = await _database;
+    final db = _database;
     return db.getAll();
   }
 
   @override
-  Future<bool> isFull(int maxSizeInMB) async {
-    final db = await _database;
+  bool isFull(int maxSizeInMB) {
+    final db = _database;
     return db.isFull(maxSizeInMB);
   }
 
@@ -70,7 +70,7 @@ class DartQueuedItemStore
   @override
   @visibleForTesting
   Future<void> clear() async {
-    final db = await _database;
+    final db = _database;
     return db.clear();
   }
 

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.web.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.web.dart
@@ -34,8 +34,7 @@ class DartQueuedItemStore
     String timestamp, {
     bool enableQueueRotation = false,
   }) async {
-    final db = _database;
-    await db.addItem(
+    await _database.addItem(
       string,
       timestamp,
       enableQueueRotation: enableQueueRotation,
@@ -44,34 +43,29 @@ class DartQueuedItemStore
 
   @override
   Future<void> deleteItems(Iterable<QueuedItem> items) async {
-    final db = _database;
-    await db.deleteItems(items);
+    await _database.deleteItems(items);
   }
 
   @override
   Future<Iterable<QueuedItem>> getCount(int count) async {
-    final db = _database;
-    return db.getCount(count);
+    return _database.getCount(count);
   }
 
   @override
   Future<Iterable<QueuedItem>> getAll() async {
-    final db = _database;
-    return db.getAll();
+    return _database.getAll();
   }
 
   @override
   bool isFull(int maxSizeInMB) {
-    final db = _database;
-    return db.isFull(maxSizeInMB);
+    return _database.isFull(maxSizeInMB);
   }
 
   /// Clear IndexedDB data.
   @override
   @visibleForTesting
   Future<void> clear() async {
-    final db = _database;
-    return db.clear();
+    return _database.clear();
   }
 
   @override

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/drift/drift_queued_item_store.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/drift/drift_queued_item_store.dart
@@ -104,7 +104,7 @@ class DriftQueuedItemStore extends _$DriftQueuedItemStore
   }
 
   @override
-  Future<bool> isFull(int maxSizeInMB) async {
+  bool isFull(int maxSizeInMB) {
     final maxBytes = maxSizeInMB * 1024 * 1024;
     return _currentTotalByteSize >= maxBytes;
   }

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/index_db/indexed_db_adapter.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/index_db/indexed_db_adapter.dart
@@ -150,7 +150,7 @@ class IndexedDbAdapter implements QueuedItemStore {
   }
 
   @override
-  Future<bool> isFull(int maxSizeInMB) async {
+  bool isFull(int maxSizeInMB) {
     final maxBytes = maxSizeInMB * 1024 * 1024;
     return _currentTotalByteSize >= maxBytes;
   }
@@ -167,15 +167,14 @@ class IndexedDbAdapter implements QueuedItemStore {
   void close() {}
 
   /// Check that IndexDB will work on this device.
-  static Future<bool> checkIsIndexedDBSupported() async {
+  static bool checkIsIndexedDBSupported() {
     if (indexedDB == null) {
       return false;
     }
     // indexedDB will be non-null in Firefox private browsing,
     // but will fail to open.
     try {
-      final openRequest = indexedDB!.open('test', 1);
-      await openRequest.future;
+      indexedDB!.open('test', 1).result;
       return true;
     } on Object {
       return false;

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/test/queued_item_store_test.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/test/queued_item_store_test.dart
@@ -233,14 +233,14 @@ void main() {
           await db.addItem(largeItem, DateTime.now().toIso8601String());
         }
 
-        var result = await db.isFull(capacityLimit);
+        var result = db.isFull(capacityLimit);
         expect(result, isFalse);
 
         for (var i = 0; i < 100; i++) {
           await db.addItem(largeItem, DateTime.now().toIso8601String());
         }
 
-        result = await db.isFull(capacityLimit);
+        result = db.isFull(capacityLimit);
         expect(result, isTrue);
       },
     );

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/queued_item_store/queued_item_store.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/queued_item_store/queued_item_store.dart
@@ -24,7 +24,7 @@ abstract interface class QueuedItemStore {
   FutureOr<Iterable<QueuedItem>> getAll();
 
   /// Whether the queue size is reached [maxSizeInMB].
-  FutureOr<bool> isFull(int maxSizeInMB);
+  bool isFull(int maxSizeInMB);
 
   /// Clear the queue of items.
   FutureOr<void> clear();

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/test/cloudwatch_logger_plugin_test.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/test/cloudwatch_logger_plugin_test.dart
@@ -62,17 +62,34 @@ void main() {
         logStreamProvider: mockCloudWatchLogStreamProvider,
       );
     });
+
     test('when enabled, logs are added to the item store', () async {
-      when(() => mockQueuedItemStore.addItem(any(), any()))
-          .thenAnswer((_) async => {});
+      when(
+        () => mockQueuedItemStore.addItem(
+          any(),
+          any(),
+          enableQueueRotation: false,
+        ),
+      ).thenAnswer((_) async => {});
+
       when(() => mockQueuedItemStore.isFull(pluginConfig.localStoreMaxSizeInMB))
-          .thenAnswer((_) async => Future<bool>.value(false));
+          .thenReturn(false);
+
       plugin.enable();
+
       await expectLater(
         plugin.handleLogEntry(errorLog),
         completes,
       );
-      verify(() => mockQueuedItemStore.addItem(any(), any())).called(1);
+
+      verify(
+        () => mockQueuedItemStore.addItem(
+          any(),
+          any(),
+          enableQueueRotation: false,
+        ),
+      ).called(1);
+
       verify(
         () => mockQueuedItemStore.isFull(pluginConfig.localStoreMaxSizeInMB),
       ).called(1);
@@ -138,8 +155,8 @@ void main() {
       when(() => mockCloudWatchLogStreamProvider.defaultLogStream)
           .thenAnswer((_) async => Future<String>.value('log stream name'));
 
-      when(() => mockQueuedItemStore.addItem(any(), any()))
-          .thenAnswer((_) async => {});
+      when(() => mockQueuedItemStore.isFull(pluginConfig.localStoreMaxSizeInMB))
+          .thenReturn(false);
 
       when(() => mockQueuedItemStore.deleteItems(any()))
           .thenAnswer((_) async => {});
@@ -184,8 +201,8 @@ void main() {
       when(() => mockCloudWatchLogStreamProvider.defaultLogStream)
           .thenAnswer((_) async => Future<String>.value('log stream name'));
 
-      when(() => mockQueuedItemStore.addItem(any(), any()))
-          .thenAnswer((_) async => {});
+      when(() => mockQueuedItemStore.isFull(pluginConfig.localStoreMaxSizeInMB))
+          .thenReturn(false);
 
       when(() => mockQueuedItemStore.getAll()).thenAnswer(
         (_) async => Future<Iterable<QueuedItem>>.value(queuedItems),
@@ -239,6 +256,9 @@ void main() {
         (_) async => Future<Iterable<QueuedItem>>.value(queuedItems),
       );
 
+      when(() => mockQueuedItemStore.isFull(pluginConfig.localStoreMaxSizeInMB))
+          .thenReturn(false);
+
       await expectLater(
         plugin.flushLogs(),
         completes,
@@ -276,6 +296,9 @@ void main() {
         (_) async => Future<Iterable<QueuedItem>>.value(queuedItems),
       );
 
+      when(() => mockQueuedItemStore.isFull(pluginConfig.localStoreMaxSizeInMB))
+          .thenReturn(false);
+
       await expectLater(
         plugin.flushLogs(),
         completes,
@@ -288,6 +311,338 @@ void main() {
       verify(
         () => mockCloudWatchLogStreamProvider.createLogStream(any()),
       ).called(1);
+    });
+
+    test('it enables log rotation when log store is full and retry is set',
+        () async {
+      when(
+        () => mockPutLogEventsOperation.result,
+      ).thenAnswer(
+        (_) async => Future<PutLogEventsResponse>.value(PutLogEventsResponse()),
+      );
+
+      when(() => mockCloudWatchLogsClient.putLogEvents(any())).thenAnswer(
+        (_) => mockPutLogEventsOperation,
+      );
+
+      when(() => mockCloudWatchLogStreamProvider.defaultLogStream)
+          .thenAnswer((_) async => Future<String>.value('log stream name'));
+
+      when(() => mockQueuedItemStore.isFull(pluginConfig.localStoreMaxSizeInMB))
+          .thenReturn(true);
+
+      when(() => mockQueuedItemStore.deleteItems(any()))
+          .thenAnswer((_) async => {});
+
+      when(() => mockQueuedItemStore.getAll()).thenAnswer(
+        (_) async => Future<Iterable<QueuedItem>>.value(queuedItems),
+      );
+      plugin.enable();
+
+      await expectLater(
+        plugin.flushLogs(),
+        completes,
+      );
+
+      await expectLater(
+        plugin.handleLogEntry(errorLog),
+        completes,
+      );
+
+      verify(
+        () => mockQueuedItemStore.addItem(
+          any(),
+          any(),
+          enableQueueRotation: true,
+        ),
+      ).called(1);
+    });
+
+    test(
+      'it does not enable log rotation when log store is full if retry is not '
+      'set. it start sync on full log store.',
+      () async {
+        final isFullResponse = [false, true, false];
+        when(
+          () => mockQueuedItemStore.isFull(pluginConfig.localStoreMaxSizeInMB),
+        ).thenAnswer((_) => isFullResponse.removeAt(0));
+
+        when(
+          () => mockPutLogEventsOperation.result,
+        ).thenAnswer(
+          (_) async =>
+              Future<PutLogEventsResponse>.value(PutLogEventsResponse()),
+        );
+
+        when(() => mockCloudWatchLogsClient.putLogEvents(any())).thenAnswer(
+          (_) => mockPutLogEventsOperation,
+        );
+
+        when(() => mockCloudWatchLogStreamProvider.defaultLogStream)
+            .thenAnswer((_) async => Future<String>.value('log stream name'));
+
+        when(() => mockQueuedItemStore.deleteItems(any()))
+            .thenAnswer((_) async => {});
+
+        when(() => mockQueuedItemStore.getAll()).thenAnswer(
+          (_) async => Future<Iterable<QueuedItem>>.value(queuedItems),
+        );
+
+        plugin.enable();
+
+        await expectLater(
+          plugin.flushLogs(),
+          completes,
+        );
+
+        await expectLater(
+          plugin.handleLogEntry(errorLog),
+          completes,
+        );
+
+        verify(
+          () => mockCloudWatchLogsClient.putLogEvents(any()),
+        ).called(2);
+
+        verify(() => mockQueuedItemStore.deleteItems(queuedItems)).called(2);
+
+        verify(
+          () => mockQueuedItemStore.addItem(
+            any(),
+            any(),
+            enableQueueRotation: false,
+          ),
+        ).called(1);
+      },
+    );
+
+    test('it does not sync on full log store if retry time not reached',
+        () async {
+      when(
+        () => mockPutLogEventsOperation.result,
+      ).thenAnswer(
+        (_) async => Future<PutLogEventsResponse>.value(PutLogEventsResponse()),
+      );
+
+      when(() => mockCloudWatchLogsClient.putLogEvents(any())).thenAnswer(
+        (_) => mockPutLogEventsOperation,
+      );
+
+      when(() => mockCloudWatchLogStreamProvider.defaultLogStream)
+          .thenAnswer((_) async => Future<String>.value('log stream name'));
+
+      when(() => mockQueuedItemStore.isFull(pluginConfig.localStoreMaxSizeInMB))
+          .thenReturn(true);
+
+      when(() => mockQueuedItemStore.deleteItems(any()))
+          .thenAnswer((_) async => {});
+
+      when(() => mockQueuedItemStore.getAll()).thenAnswer(
+        (_) async => Future<Iterable<QueuedItem>>.value(queuedItems),
+      );
+      plugin.enable();
+
+      await expectLater(
+        plugin.flushLogs(),
+        completes,
+      );
+
+      await expectLater(
+        plugin.handleLogEntry(errorLog),
+        completes,
+      );
+
+      verify(
+        () => mockCloudWatchLogsClient.putLogEvents(any()),
+      ).called(1);
+
+      verify(() => mockQueuedItemStore.deleteItems(queuedItems)).called(1);
+    });
+
+    test(
+      'it deletes too old logs in the batch and sync the rest',
+      () async {
+        final responses = [
+          PutLogEventsResponse(
+            rejectedLogEventsInfo:
+                RejectedLogEventsInfo(tooOldLogEventEndIndex: 0),
+          ),
+          PutLogEventsResponse(),
+        ];
+
+        when(
+          () => mockPutLogEventsOperation.result,
+        ).thenAnswer(
+          (_) async {
+            final response = responses.removeAt(0);
+            return Future<PutLogEventsResponse>.value(response);
+          },
+        );
+
+        when(() => mockCloudWatchLogsClient.putLogEvents(any())).thenAnswer(
+          (_) => mockPutLogEventsOperation,
+        );
+
+        when(() => mockCloudWatchLogStreamProvider.defaultLogStream)
+            .thenAnswer((_) async => Future<String>.value('log stream name'));
+
+        when(
+          () => mockQueuedItemStore.isFull(pluginConfig.localStoreMaxSizeInMB),
+        ).thenReturn(false);
+
+        when(() => mockQueuedItemStore.deleteItems(any()))
+            .thenAnswer((_) async => {});
+
+        when(() => mockQueuedItemStore.getAll()).thenAnswer(
+          (_) async => Future<Iterable<QueuedItem>>.value(queuedItems),
+        );
+        plugin.enable();
+
+        await expectLater(
+          plugin.flushLogs(),
+          completes,
+        );
+
+        verify(
+          () => mockCloudWatchLogsClient.putLogEvents(any()),
+        ).called(2);
+
+        final captures = verify(
+          () => mockQueuedItemStore
+              .deleteItems(captureAny<Iterable<QueuedItem>>()),
+        );
+
+        expect(captures.callCount, 2);
+        expect(
+          (captures.captured.first as Iterable<QueuedItem>).first,
+          queuedItems.first,
+        );
+        expect(
+          (captures.captured.last as Iterable<QueuedItem>).first,
+          queuedItems.last,
+        );
+      },
+    );
+
+    test('it deletes expired logs in the batch and sync the rest', () async {
+      final responses = [
+        PutLogEventsResponse(
+          rejectedLogEventsInfo:
+              RejectedLogEventsInfo(expiredLogEventEndIndex: 0),
+        ),
+        PutLogEventsResponse(),
+      ];
+
+      when(
+        () => mockPutLogEventsOperation.result,
+      ).thenAnswer(
+        (_) async {
+          final response = responses.removeAt(0);
+          return Future<PutLogEventsResponse>.value(response);
+        },
+      );
+
+      when(() => mockCloudWatchLogsClient.putLogEvents(any())).thenAnswer(
+        (_) => mockPutLogEventsOperation,
+      );
+
+      when(() => mockCloudWatchLogStreamProvider.defaultLogStream)
+          .thenAnswer((_) async => Future<String>.value('log stream name'));
+
+      when(
+        () => mockQueuedItemStore.isFull(pluginConfig.localStoreMaxSizeInMB),
+      ).thenReturn(false);
+
+      when(() => mockQueuedItemStore.deleteItems(any()))
+          .thenAnswer((_) async => {});
+
+      when(() => mockQueuedItemStore.getAll()).thenAnswer(
+        (_) async => Future<Iterable<QueuedItem>>.value(queuedItems),
+      );
+      plugin.enable();
+
+      await expectLater(
+        plugin.flushLogs(),
+        completes,
+      );
+
+      verify(
+        () => mockCloudWatchLogsClient.putLogEvents(any()),
+      ).called(2);
+
+      final captures = verify(
+        () =>
+            mockQueuedItemStore.deleteItems(captureAny<Iterable<QueuedItem>>()),
+      );
+
+      expect(captures.callCount, 2);
+      expect(
+        (captures.captured.first as Iterable<QueuedItem>).first,
+        queuedItems.first,
+      );
+      expect(
+        (captures.captured.last as Iterable<QueuedItem>).first,
+        queuedItems.last,
+      );
+    });
+
+    test('it leaves too new logs in the batch and sync the rest', () async {
+      final responses = [
+        PutLogEventsResponse(
+          rejectedLogEventsInfo:
+              RejectedLogEventsInfo(tooNewLogEventStartIndex: 1),
+        ),
+        PutLogEventsResponse(),
+      ];
+
+      when(
+        () => mockPutLogEventsOperation.result,
+      ).thenAnswer(
+        (_) async {
+          final response = responses.removeAt(0);
+          return Future<PutLogEventsResponse>.value(response);
+        },
+      );
+
+      when(() => mockCloudWatchLogsClient.putLogEvents(any())).thenAnswer(
+        (_) => mockPutLogEventsOperation,
+      );
+
+      when(() => mockCloudWatchLogStreamProvider.defaultLogStream)
+          .thenAnswer((_) async => Future<String>.value('log stream name'));
+
+      when(
+        () => mockQueuedItemStore.isFull(pluginConfig.localStoreMaxSizeInMB),
+      ).thenReturn(false);
+
+      when(() => mockQueuedItemStore.deleteItems(any()))
+          .thenAnswer((_) async => {});
+
+      when(() => mockQueuedItemStore.getAll()).thenAnswer(
+        (_) async => Future<Iterable<QueuedItem>>.value(queuedItems),
+      );
+      plugin.enable();
+
+      await expectLater(
+        plugin.flushLogs(),
+        completes,
+      );
+
+      verify(
+        () => mockCloudWatchLogsClient.putLogEvents(any()),
+      ).called(2);
+
+      final captures = verify(
+        () =>
+            mockQueuedItemStore.deleteItems(captureAny<Iterable<QueuedItem>>()),
+      );
+
+      expect(captures.callCount, 1);
+      expect(captures.captured.length, 1);
+      expect(
+        (captures.captured.last as Iterable<QueuedItem>).first,
+        queuedItems.first,
+      );
     });
   });
 }

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/test/queued_item_store/queued_item_store_test.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/test/queued_item_store/queued_item_store_test.dart
@@ -231,7 +231,7 @@ void main() {
           await db.addItem('0', DateTime.now().toIso8601String());
         }
 
-        var result = await db.isFull(capacityLimit);
+        var result = db.isFull(capacityLimit);
         expect(result, isFalse);
 
         // add enough items to exceed capacity limit of 1mb
@@ -239,7 +239,7 @@ void main() {
           await db.addItem('0', DateTime.now().toIso8601String());
         }
 
-        result = await db.isFull(capacityLimit);
+        result = db.isFull(capacityLimit);
         expect(result, isTrue);
       },
     );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- make QueuedItemStore.isFull() sync
- enable log rotation when log store is full
- set retry on full log store sync
- handle rejectedLogEventsInfo response and do partial sync


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
