### PR TITLE
ci: Fix dependabot groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,71 +17,27 @@ updates:
     directory: "infra"
     schedule:
       interval: "weekly"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-
-  - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    ignore:
-      # Ignore Kotlin updates since we should always match Flutter stable
-      # to ensure users can have Kt versions >= Flutter stable.
-      - dependency-name: "kotlin_version"
-      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
-
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
     groups:
-      amplify-android:
+      cdk:
         patterns:
-          - "com.amplifyframework:*"
-          - "com.amazonaws:*"
-      mockito:
+          - "aws-cdk"
+          - "aws-cdk-lib"
+          - "@aws-cdk/*"
+          - "constructs"
+      aws-sdk-js:
         patterns:
-          - "org.mockito:*"
-
+          - "@aws-sdk/*"
+          - "@aws-crypto/*"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
   - package-ecosystem: "pub"
     directory: "/"
     schedule:
       interval: "daily"
-
-    # Ignore all repo packages
-    ignore:
-      - dependency-name: "amplify_flutter"
-      - dependency-name: "amplify_core"
-      - dependency-name: "amplify_datastore"
-      - dependency-name: "amplify_datastore_plugin_interface"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "amplify_analytics_pinpoint"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_api"
-      - dependency-name: "amplify_api_dart"
-      - dependency-name: "amplify_auth_cognito"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "amplify_authenticator"
-      - dependency-name: "aws_common"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_push_notifications"
-      - dependency-name: "amplify_push_notifications_pinpoint"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_storage_s3"
-      - dependency-name: "amplify_storage_s3_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-
-    # Group dependencies which have a constraint set in the global
-    # "pubspec.yaml"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
     groups:
       async:
         patterns:
@@ -170,3 +126,2725 @@ updates:
       test:
         patterns:
           - "test"
+  - package-ecosystem: "pub"
+    directory: "actions"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      stack_trace:
+        patterns:
+          - "stack_trace"
+      build_runner:
+        patterns:
+          - "build_runner"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "canaries"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_authenticator"
+      - dependency-name: "amplify_datastore"
+      - dependency-name: "amplify_datastore_plugin_interface"
+      - dependency-name: "amplify_storage_s3"
+      - dependency-name: "amplify_storage_s3_dart"
+  - package-ecosystem: "pub"
+    directory: "infra"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+  - package-ecosystem: "pub"
+    directory: "packages/aft"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "pub_server"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "smithy_aws"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      code_builder:
+        patterns:
+          - "code_builder"
+      file:
+        patterns:
+          - "file"
+      graphs:
+        patterns:
+          - "graphs"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify/amplify_flutter"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify/amplify_flutter/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_datastore"
+      - dependency-name: "amplify_datastore_plugin_interface"
+      - dependency-name: "amplify_storage_s3"
+      - dependency-name: "amplify_storage_s3_dart"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify_core"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      graphs:
+        patterns:
+          - "graphs"
+      intl:
+        patterns:
+          - "intl"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      stack_trace:
+        patterns:
+          - "stack_trace"
+      uuid:
+        patterns:
+          - "uuid"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify_core/doc"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_datastore"
+      - dependency-name: "amplify_datastore_plugin_interface"
+      - dependency-name: "amplify_storage_s3"
+      - dependency-name: "amplify_storage_s3_dart"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify_datastore"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_datastore_plugin_interface"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      pigeon:
+        patterns:
+          - "pigeon"
+  - package-ecosystem: "gradle"
+    directory: "packages/amplify_datastore/android"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore Kotlin updates since we should always match Flutter stable
+      # to ensure users can have Kt versions >= Flutter stable.
+      - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
+      
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+    groups:
+      amplify-android:
+        patterns:
+          - "com.amplifyframework:*"
+          - "com.amazonaws:*"
+      mockito:
+        patterns:
+          - "org.mockito:*"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify_datastore/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "amplify_datastore"
+      - dependency-name: "amplify_datastore_plugin_interface"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "smithy_codegen"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify_datastore_plugin_interface"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify_lints"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify_native_legacy_wrapper"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      pigeon:
+        patterns:
+          - "pigeon"
+  - package-ecosystem: "gradle"
+    directory: "packages/amplify_native_legacy_wrapper/android"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore Kotlin updates since we should always match Flutter stable
+      # to ensure users can have Kt versions >= Flutter stable.
+      - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
+      
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+    groups:
+      amplify-android:
+        patterns:
+          - "com.amplifyframework:*"
+          - "com.amazonaws:*"
+      mockito:
+        patterns:
+          - "org.mockito:*"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify_native_legacy_wrapper/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_native_legacy_wrapper"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_common"
+  - package-ecosystem: "pub"
+    directory: "packages/analytics/amplify_analytics_pinpoint"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      device_info_plus:
+        patterns:
+          - "device_info_plus"
+      package_info_plus:
+        patterns:
+          - "package_info_plus"
+      pigeon:
+        patterns:
+          - "pigeon"
+  - package-ecosystem: "gradle"
+    directory: "packages/analytics/amplify_analytics_pinpoint/android"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore Kotlin updates since we should always match Flutter stable
+      # to ensure users can have Kt versions >= Flutter stable.
+      - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
+      
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+    groups:
+      amplify-android:
+        patterns:
+          - "com.amplifyframework:*"
+          - "com.amazonaws:*"
+      mockito:
+        patterns:
+          - "org.mockito:*"
+  - package-ecosystem: "pub"
+    directory: "packages/analytics/amplify_analytics_pinpoint/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value:
+        patterns:
+          - "built_value"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+  - package-ecosystem: "pub"
+    directory: "packages/analytics/amplify_analytics_pinpoint_dart"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      drift:
+        patterns:
+          - "drift"
+      intl:
+        patterns:
+          - "intl"
+      uuid:
+        patterns:
+          - "uuid"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/api/amplify_api"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      connectivity_plus:
+        patterns:
+          - "connectivity_plus"
+      build_runner:
+        patterns:
+          - "build_runner"
+  - package-ecosystem: "pub"
+    directory: "packages/api/amplify_api/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_authenticator"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+  - package-ecosystem: "pub"
+    directory: "packages/api/amplify_api_dart"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/auth/amplify_auth_cognito"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_flutter"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      pigeon:
+        patterns:
+          - "pigeon"
+  - package-ecosystem: "gradle"
+    directory: "packages/auth/amplify_auth_cognito/android"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore Kotlin updates since we should always match Flutter stable
+      # to ensure users can have Kt versions >= Flutter stable.
+      - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
+      
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+    groups:
+      amplify-android:
+        patterns:
+          - "com.amplifyframework:*"
+          - "com.amazonaws:*"
+      mockito:
+        patterns:
+          - "org.mockito:*"
+  - package-ecosystem: "pub"
+    directory: "packages/auth/amplify_auth_cognito/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_authenticator"
+      - dependency-name: "amplify_native_legacy_wrapper"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      http:
+        patterns:
+          - "http"
+      stack_trace:
+        patterns:
+          - "stack_trace"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/auth/amplify_auth_cognito_dart"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "smithy_codegen"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      http:
+        patterns:
+          - "http"
+      intl:
+        patterns:
+          - "intl"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      oauth2:
+        patterns:
+          - "oauth2"
+      uuid:
+        patterns:
+          - "uuid"
+      win32:
+        patterns:
+          - "win32"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      ffigen:
+        patterns:
+          - "ffigen"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/auth/amplify_auth_cognito_dart/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "example_common"
+      - dependency-name: "amplify_api_dart"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      mime:
+        patterns:
+          - "mime"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/auth/amplify_auth_cognito_test"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      http:
+        patterns:
+          - "http"
+      test:
+        patterns:
+          - "test"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+  - package-ecosystem: "pub"
+    directory: "packages/authenticator/amplify_authenticator"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_flutter"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      intl:
+        patterns:
+          - "intl"
+      package_info_plus:
+        patterns:
+          - "package_info_plus"
+      build_runner:
+        patterns:
+          - "build_runner"
+  - package-ecosystem: "pub"
+    directory: "packages/authenticator/amplify_authenticator/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_authenticator"
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      uuid:
+        patterns:
+          - "uuid"
+  - package-ecosystem: "pub"
+    directory: "packages/authenticator/amplify_authenticator_test"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_authenticator"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_flutter"
+  - package-ecosystem: "pub"
+    directory: "packages/aws_common"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      mime:
+        patterns:
+          - "mime"
+      uuid:
+        patterns:
+          - "uuid"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/aws_sdk/smoke_test"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      xml:
+        patterns:
+          - "xml"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/aws_signature_v4"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/aws_signature_v4/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+  - package-ecosystem: "pub"
+    directory: "packages/common/amplify_db_common"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      drift:
+        patterns:
+          - "drift"
+  - package-ecosystem: "gradle"
+    directory: "packages/common/amplify_db_common/android"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore Kotlin updates since we should always match Flutter stable
+      # to ensure users can have Kt versions >= Flutter stable.
+      - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
+      
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+    groups:
+      amplify-android:
+        patterns:
+          - "com.amplifyframework:*"
+          - "com.amazonaws:*"
+      mockito:
+        patterns:
+          - "org.mockito:*"
+  - package-ecosystem: "pub"
+    directory: "packages/common/amplify_db_common/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      drift:
+        patterns:
+          - "drift"
+      build_runner:
+        patterns:
+          - "build_runner"
+  - package-ecosystem: "pub"
+    directory: "packages/common/amplify_db_common_dart"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      drift:
+        patterns:
+          - "drift"
+      sqlite3:
+        patterns:
+          - "sqlite3"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/common/amplify_db_common_dart/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "example_common"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      drift:
+        patterns:
+          - "drift"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+  - package-ecosystem: "pub"
+    directory: "packages/example_common"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/example_common/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "example_common"
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+  - package-ecosystem: "pub"
+    directory: "packages/notifications/push/amplify_push_notifications"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      flutter_plugin_android_lifecycle:
+        patterns:
+          - "flutter_plugin_android_lifecycle"
+      build_runner:
+        patterns:
+          - "build_runner"
+      pigeon:
+        patterns:
+          - "pigeon"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "gradle"
+    directory: "packages/notifications/push/amplify_push_notifications/android"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore Kotlin updates since we should always match Flutter stable
+      # to ensure users can have Kt versions >= Flutter stable.
+      - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
+      
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+    groups:
+      amplify-android:
+        patterns:
+          - "com.amplifyframework:*"
+          - "com.amazonaws:*"
+      mockito:
+        patterns:
+          - "org.mockito:*"
+  - package-ecosystem: "pub"
+    directory: "packages/notifications/push/amplify_push_notifications/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_push_notifications"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+  - package-ecosystem: "pub"
+    directory: "packages/notifications/push/amplify_push_notifications_pinpoint"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_push_notifications"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      flutter_plugin_android_lifecycle:
+        patterns:
+          - "flutter_plugin_android_lifecycle"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+  - package-ecosystem: "pub"
+    directory: "packages/notifications/push/amplify_push_notifications_pinpoint/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_push_notifications_pinpoint"
+      - dependency-name: "amplify_push_notifications"
+  - package-ecosystem: "pub"
+    directory: "packages/secure_storage/amplify_secure_storage"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      file:
+        patterns:
+          - "file"
+      pigeon:
+        patterns:
+          - "pigeon"
+  - package-ecosystem: "gradle"
+    directory: "packages/secure_storage/amplify_secure_storage/android"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore Kotlin updates since we should always match Flutter stable
+      # to ensure users can have Kt versions >= Flutter stable.
+      - dependency-name: "kotlin_version"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
+      
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+    groups:
+      amplify-android:
+        patterns:
+          - "com.amplifyframework:*"
+          - "com.amazonaws:*"
+      mockito:
+        patterns:
+          - "org.mockito:*"
+  - package-ecosystem: "pub"
+    directory: "packages/secure_storage/amplify_secure_storage/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+  - package-ecosystem: "pub"
+    directory: "packages/secure_storage/amplify_secure_storage_dart"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      file:
+        patterns:
+          - "file"
+      win32:
+        patterns:
+          - "win32"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      ffigen:
+        patterns:
+          - "ffigen"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/secure_storage/amplify_secure_storage_dart/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "example_common"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+  - package-ecosystem: "pub"
+    directory: "packages/secure_storage/amplify_secure_storage_test"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      file:
+        patterns:
+          - "file"
+      test:
+        patterns:
+          - "test"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "smithy_aws"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      file:
+        patterns:
+          - "file"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib/awsJson1_0"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib/awsJson1_1"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "smithy_aws"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib/awsQuery"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib/ec2Query"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib/restJson1"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib/restXml"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      xml:
+        patterns:
+          - "xml"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib/restXmlWithNamespace"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      xml:
+        patterns:
+          - "xml"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib2/awsJson1_0"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib2/awsJson1_1"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "smithy_aws"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib2/awsQuery"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib2/custom"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib2/ec2Query"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib2/restJson1"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib2/restXml"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      xml:
+        patterns:
+          - "xml"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/goldens/lib2/restXmlWithNamespace"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "smithy"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      xml:
+        patterns:
+          - "xml"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/smithy"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      intl:
+        patterns:
+          - "intl"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      xml:
+        patterns:
+          - "xml"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      stack_trace:
+        patterns:
+          - "stack_trace"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/smithy_aws"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "smithy"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      intl:
+        patterns:
+          - "intl"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      xml:
+        patterns:
+          - "xml"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      file:
+        patterns:
+          - "file"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/smithy_codegen"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      code_builder:
+        patterns:
+          - "code_builder"
+      dart_style:
+        patterns:
+          - "dart_style"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      xml:
+        patterns:
+          - "xml"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/smithy_test"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "smithy"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      test:
+        patterns:
+          - "test"
+      xml:
+        patterns:
+          - "xml"
+  - package-ecosystem: "pub"
+    directory: "packages/storage/amplify_storage_s3"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_storage_s3_dart"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+  - package-ecosystem: "pub"
+    directory: "packages/storage/amplify_storage_s3/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_authenticator"
+      - dependency-name: "amplify_storage_s3"
+      - dependency-name: "amplify_storage_s3_dart"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      drift:
+        patterns:
+          - "drift"
+      http:
+        patterns:
+          - "http"
+      stack_trace:
+        patterns:
+          - "stack_trace"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/storage/amplify_storage_s3_dart"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      drift:
+        patterns:
+          - "drift"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/storage/amplify_storage_s3_dart/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_storage_s3_dart"
+      - dependency-name: "example_common"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+  - package-ecosystem: "pub"
+    directory: "packages/test/amplify_auth_integration_test"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      stack_trace:
+        patterns:
+          - "stack_trace"
+  - package-ecosystem: "pub"
+    directory: "packages/test/amplify_integration_test"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "smithy_codegen"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      test:
+        patterns:
+          - "test"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+  - package-ecosystem: "pub"
+    directory: "packages/test/amplify_test"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+  - package-ecosystem: "pub"
+    directory: "packages/test/pub_server"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      drift:
+        patterns:
+          - "drift"
+      file:
+        patterns:
+          - "file"
+      graphs:
+        patterns:
+          - "graphs"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      build_runner:
+        patterns:
+          - "build_runner"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/worker_bee/e2e"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      test:
+        patterns:
+          - "test"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+  - package-ecosystem: "pub"
+    directory: "packages/worker_bee/e2e_flutter_test"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+  - package-ecosystem: "pub"
+    directory: "packages/worker_bee/e2e_test"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_common"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value:
+        patterns:
+          - "built_value"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/worker_bee/worker_bee"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      stack_trace:
+        patterns:
+          - "stack_trace"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/worker_bee/worker_bee_builder"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "worker_bee"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      code_builder:
+        patterns:
+          - "code_builder"
+      dart_style:
+        patterns:
+          - "dart_style"
+      source_gen:
+        patterns:
+          - "source_gen"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "templates/dart-package/hooks"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+  - package-ecosystem: "pub"
+    directory: "templates/flutter-package/hooks"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"


### PR DESCRIPTION
The use of the root (`/`) as the directory only has recursive behavior for some package managers. Pub + Gradle apparently don't support this 🫠

Reverts the consolidation in https://github.com/aws-amplify/amplify-flutter/pull/3668 in favor of individual package entries but leaves the groups work. The docs are not super explicit but it seems that if each entry defines the same group, that is enough to group them all together.