### PR TITLE
fix(aft): Don't use build numbers (`+`) for 0-based patch versions

### DIFF
--- a/packages/aft/lib/src/models.dart
+++ b/packages/aft/lib/src/models.dart
@@ -81,7 +81,7 @@ extension AmplifyVersion on Version {
     if (preRelease.isEmpty) {
       switch (type) {
         case VersionBumpType.patch:
-          return major == 0 ? replace(build: [newBuild]) : nextPatch;
+          return nextPatch;
         case VersionBumpType.nonBreaking:
           return major == 0 ? nextPatch : nextMinor;
         case VersionBumpType.breaking:

--- a/packages/aft/test/e2e_test.dart
+++ b/packages/aft/test/e2e_test.dart
@@ -292,17 +292,17 @@ void main() {
         final finalRepo = d.repo([
           d.package(
             'aws_common',
-            version: '0.1.0+1',
+            version: '0.1.1',
             contents: [
               d.pubspec('''
 name: aws_common
-version: 0.1.0+1
+version: 0.1.1
 
 environment:
   sdk: ^3.0.0
 '''),
               d.file('CHANGELOG.md', '''
-## 0.1.0+1
+## 0.1.1
 
 ### Fixes
 - fix(aws_common): Fix type

--- a/packages/aft/test/model_test.dart
+++ b/packages/aft/test/model_test.dart
@@ -28,11 +28,11 @@ void main() {
       final version = Version(0, 1, 0);
 
       final patch = version.nextAmplifyVersion(VersionBumpType.patch);
-      expect(patch, Version(0, 1, 0, build: '1'));
+      expect(patch, Version(0, 1, 1));
       expect(proagation.propagateToComponent(version, patch), false);
 
       final nextPatch = patch.nextAmplifyVersion(VersionBumpType.patch);
-      expect(nextPatch, Version(0, 1, 0, build: '2'));
+      expect(nextPatch, Version(0, 1, 2));
       expect(proagation.propagateToComponent(version, nextPatch), false);
 
       final nonBreaking =


### PR DESCRIPTION
There is a seeming bug in `pub` which causes issues publishing 0-based patch versions with `+` in their versions. For now, we can just stop publishing these and prefer true SemVer patch bumps instead.
