### PR TITLE
feat(logging): add amplify cloudwatch logger plugin base implementation

### DIFF
--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/amplify_cloudwatch_logger_plugin.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/amplify_cloudwatch_logger_plugin.dart
@@ -1,0 +1,19 @@
+import 'package:amplify_logging_cloudwatch/src/amplify_log_stream_name_provider.dart';
+import 'package:aws_logging_cloudwatch/aws_logging_cloudwatch.dart';
+
+/// {@macro aws_logging_cloudwatch.cloudwatch_logger_plugin}
+class AmplifyCloudWatchLoggerPlugin extends CloudWatchLoggerPlugin {
+  /// {@macro aws_logging_cloudwatch.cloudwatch_logger_plugin}
+  AmplifyCloudWatchLoggerPlugin({
+    required super.credentialsProvider,
+    required super.pluginConfig,
+  }) : super(
+          logStreamProvider: DefaultCloudWatchLogStreamProvider(
+            credentialsProvider: credentialsProvider,
+            region: pluginConfig.region,
+            logGroupName: pluginConfig.logGroupName,
+            defaultLogStreamNameProvider:
+                AmplifyLogStreamNameProvider().defaultLogStreamName,
+          ),
+        );
+}

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/amplify_log_stream_name_provider.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/amplify_log_stream_name_provider.dart
@@ -1,0 +1,39 @@
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_logging_cloudwatch/src/device_info/device_info.dart';
+import 'package:intl/intl.dart';
+
+const _guestUserId = 'guest';
+
+/// {@template amplify_logging_cloudwatch.amplify_log_stream_name_provider}
+/// It uses {mm-dd-yyyy}.{deviceId}.{userId|guest} format for log stream name.
+///
+/// It gets deviceId from platform inforamtion or uuid if it is `null`.
+/// It gets userId from `Amplify.Auth.getCurrentUser()).userId` or uses `guest`
+/// if userId is not available.
+/// {@endtemplate}
+class AmplifyLogStreamNameProvider {
+  /// {@macro amplify_logging_cloudwatch.amplify_log_stream_name_provider}
+  AmplifyLogStreamNameProvider();
+  static final DateFormat _dateFormat = DateFormat('yyyy-MM-dd');
+  String? _deviceID;
+
+  /// Returns log stream name in `{mm-dd-yyyy}.{deviceId}.{userId|guest}` format
+  Future<String> defaultLogStreamName() async {
+    _deviceID ??= await getDeviceId() ?? UUID.getUUID();
+    String userId;
+    userId = await _getUserId();
+    return '${_dateFormat.format(DateTime.timestamp())}.$_deviceID.$userId';
+  }
+
+  Future<String> _getUserId() async {
+    String userId;
+    try {
+      userId = (await Amplify.Auth.getCurrentUser()).userId;
+    } on Error {
+      userId = _guestUserId;
+    } on Exception {
+      userId = _guestUserId;
+    }
+    return userId;
+  }
+}

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/device_info/device_info.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/device_info/device_info.dart
@@ -1,0 +1,3 @@
+export 'device_info.stub.dart'
+    if (dart.library.io) 'device_info.vm.dart'
+    if (dart.library.html) 'device_info.web.dart';

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/device_info/device_info.stub.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/device_info/device_info.stub.dart
@@ -1,0 +1,7 @@
+/// {@template amplify_logging_cloudwatch.device_info}
+/// Returns device Id from platform information on `vm`.
+/// Returns a UUID across browser sessions for web.
+/// {@endtemplate}
+Future<String?> getDeviceId() {
+  throw UnimplementedError('getDeviceId() has not been implemented.');
+}

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/device_info/device_info.vm.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/device_info/device_info.vm.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+
+/// {@macro amplify_logging_cloudwatch.device_info}
+Future<String?> getDeviceId() async {
+  final deviceInfo = DeviceInfoPlugin();
+  String? deviceID;
+  try {
+    if (Platform.isAndroid) {
+      final androidInfo = await deviceInfo.androidInfo;
+      deviceID = androidInfo.id;
+    } else if (Platform.isIOS) {
+      final iosInfo = await deviceInfo.iosInfo;
+      deviceID = iosInfo.identifierForVendor ?? '';
+    } else if (Platform.isLinux) {
+      final linuxInfo = await deviceInfo.linuxInfo;
+      deviceID = linuxInfo.machineId ?? '';
+    } else if (Platform.isMacOS) {
+      final macInfo = await deviceInfo.macOsInfo;
+      deviceID = macInfo.systemGUID ?? '';
+    } else if (Platform.isWindows) {
+      final windowsInfo = await deviceInfo.windowsInfo;
+      deviceID = windowsInfo.deviceId;
+    }
+  } on Exception {
+    return null;
+  }
+  return deviceID;
+}

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/device_info/device_info.web.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/device_info/device_info.web.dart
@@ -1,0 +1,16 @@
+import 'dart:html';
+
+import 'package:amplify_core/amplify_core.dart';
+
+const _localStorageKey = 'amplify-cloudwatch-logger-device-id';
+
+/// {@macro amplify_logging_cloudwatch.device_info}
+Future<String?> getDeviceId() async {
+  var deviceID = window.localStorage[_localStorageKey];
+  if (deviceID != null) {
+    return deviceID;
+  }
+  deviceID = UUID.getUUID();
+  window.localStorage.putIfAbsent(_localStorageKey, () => deviceID!);
+  return deviceID;
+}

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/pubspec.yaml
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/pubspec.yaml
@@ -15,9 +15,11 @@ dependencies:
   aws_common: ">=0.6.0 <0.7.0"
   aws_logging_cloudwatch: ^0.1.0
   collection: ^1.15.0
+  device_info_plus: ^9.0.0
   drift: ">=2.11.0 <2.12.0"
   flutter:
     sdk: flutter
+  intl: ">=0.18.0 <1.0.0"
   meta: ^1.7.0
   path_provider: ^2.0.0
 
@@ -27,4 +29,6 @@ dev_dependencies:
   build_test: ^2.0.0
   build_web_compilers: ^4.0.0
   drift_dev: ^2.2.0+1
+  flutter_test:
+    sdk: flutter
   test: ^1.22.1

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/test/amplify_log_stream_provider_test.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/test/amplify_log_stream_provider_test.dart
@@ -1,0 +1,21 @@
+@TestOn('vm')
+
+import 'package:amplify_logging_cloudwatch/src/amplify_log_stream_name_provider.dart';
+import 'package:flutter_test/flutter_test.dart' as flutter;
+import 'package:test/test.dart';
+
+void main() {
+  flutter.TestWidgetsFlutterBinding.ensureInitialized();
+  test('it uses uuid and guest when their values are not provided', () async {
+    final logStreamNameProvider = AmplifyLogStreamNameProvider();
+    await expectLater(logStreamNameProvider.defaultLogStreamName(), completes);
+  });
+
+  test('it caches the device Id', () async {
+    final logStreamNameProvider = AmplifyLogStreamNameProvider();
+    final logStreamName1 = await logStreamNameProvider.defaultLogStreamName();
+    final logStreamName2 = await logStreamNameProvider.defaultLogStreamName();
+
+    expect(logStreamName1, logStreamName2);
+  });
+}

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/cloudwatch_logger_plugin.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/cloudwatch_logger_plugin.dart
@@ -72,10 +72,8 @@ class CloudWatchLoggerPlugin extends AWSLoggerPlugin
         _logStreamProvider = logStreamProvider ??
             DefaultCloudWatchLogStreamProvider(
               logGroupName: pluginConfig.logGroupName,
-              client: CloudWatchLogsClient(
-                region: pluginConfig.region,
-                credentialsProvider: credentialsProvider,
-              ),
+              region: pluginConfig.region,
+              credentialsProvider: credentialsProvider,
             ) {
     _timer = pluginConfig.flushIntervalInSeconds > Duration.zero
         ? StoppableTimer(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- add amplify cloudwatch logger plugin
- update DefaultCloudWatchLogStreamProvider to accept a Function for `defaultLogStreamNameProvider` instead of String value
Next: after remote config provider is ready apply category and user level constraints
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
