### PR TITLE
chore: remove delay to start datastore in tests

### DIFF
--- a/packages/amplify_datastore/example/integration_test/clear_test.dart
+++ b/packages/amplify_datastore/example/integration_test/clear_test.dart
@@ -22,7 +22,7 @@ void main() {
       await Amplify.DataStore.save(blog);
       var resultOne = await Amplify.DataStore.query(Blog.classType);
       expect(resultOne, isNotEmpty);
-      await Amplify.DataStore.clear();
+      await clearDataStore();
       var resultTwo = await Amplify.DataStore.query(Blog.classType);
       expect(resultTwo, isEmpty);
     });

--- a/packages/amplify_datastore/example/integration_test/utils/setup_utils.dart
+++ b/packages/amplify_datastore/example/integration_test/utils/setup_utils.dart
@@ -12,7 +12,6 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 const ENABLE_CLOUD_SYNC =
     bool.fromEnvironment('ENABLE_CLOUD_SYNC', defaultValue: false);
 const DATASTORE_READY_EVENT_TIMEOUT = const Duration(minutes: 10);
-const DELAY_TO_START_DATASTORE = const Duration(milliseconds: 500);
 const DELAY_TO_CLEAR_DATASTORE = const Duration(seconds: 2);
 const DELAY_FOR_OBSERVE = const Duration(milliseconds: 100);
 
@@ -106,7 +105,6 @@ class DataStoreStarter {
 }
 
 Future<void> startDataStore() async {
-  await Future.delayed(DELAY_TO_START_DATASTORE);
   await DataStoreStarter().startDataStore();
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove the delay prior to starting datastore from our integration test suite. This delay is no longer needed with https://github.com/aws-amplify/amplify-android/issues/1690 resolved.

See passing test run (with all the cloud sync tests running): https://github.com/aws-amplify/amplify-flutter/actions/runs/6188100758/job/16799548931?pr=3738

Note: As mentioned in https://github.com/aws-amplify/amplify-android/issues/1690#issuecomment-1692358164, and https://github.com/aws-amplify/amplify-android/issues/1464, calling stop and then start multiple times in a row, or calling stop/clear multiple times in a row will still result in issues.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
