### PR TITLE
fix(authenticator): TOTP Setup typo

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/l10n/generated/instructions_localizations.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/l10n/generated/instructions_localizations.dart
@@ -68,9 +68,7 @@ abstract class AuthenticatorInstructionsLocalizations {
 
   static AuthenticatorInstructionsLocalizations? of(BuildContext context) {
     return Localizations.of<AuthenticatorInstructionsLocalizations>(
-      context,
-      AuthenticatorInstructionsLocalizations,
-    );
+        context, AuthenticatorInstructionsLocalizations);
   }
 
   static const LocalizationsDelegate<AuthenticatorInstructionsLocalizations>
@@ -99,37 +97,37 @@ abstract class AuthenticatorInstructionsLocalizations {
     Locale('en'),
   ];
 
-  /// The header for the first step of TOTP setup
+  /// The title for the first step of TOTP setup
   ///
   /// In en, this message translates to:
   /// **'Step 1: Download an Authenticator app'**
   String get totpStep1Title;
 
-  /// The header for the second step of TOTP setup
+  /// The title for the second step of TOTP setup
   ///
   /// In en, this message translates to:
-  /// **'Step 2: Enter the QR code'**
+  /// **'Step 2: Scan the QR code'**
   String get totpStep2Title;
 
-  /// The header for the third step of TOTP setup
+  /// The title for the third step of TOTP setup
   ///
   /// In en, this message translates to:
   /// **'Step 3: Verify your code'**
   String get totpStep3Title;
 
-  /// The instructional text for step one of TOTP setup
+  /// The body text for step one of TOTP setup
   ///
   /// In en, this message translates to:
   /// **'Authenticator apps generate one-time codes that can be used to verify your identity'**
   String get totpStep1Body;
 
-  /// The instructional text for step two of TOTP setup
+  /// The body text for step two of TOTP setup
   ///
   /// In en, this message translates to:
   /// **'Open then Authenticator app and scan the QR code or enter the key to get your verification code'**
   String get totpStep2Body;
 
-  /// The instructional text for step three of TOTP setup
+  /// The body text for step three of TOTP setup
   ///
   /// In en, this message translates to:
   /// **'Enter the 6 digit code from your Authenticator app'**
@@ -159,10 +157,9 @@ Future<AuthenticatorInstructionsLocalizations>
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
     case 'en':
-      return instructions_localizations_en.loadLibrary().then(
-            (dynamic _) => instructions_localizations_en
-                .AuthenticatorInstructionsLocalizationsEn(),
-          );
+      return instructions_localizations_en.loadLibrary().then((dynamic _) =>
+          instructions_localizations_en
+              .AuthenticatorInstructionsLocalizationsEn());
   }
 
   throw FlutterError(

--- a/packages/authenticator/amplify_authenticator/lib/src/l10n/generated/instructions_localizations_en.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/l10n/generated/instructions_localizations_en.dart
@@ -12,7 +12,7 @@ class AuthenticatorInstructionsLocalizationsEn
   String get totpStep1Title => 'Step 1: Download an Authenticator app';
 
   @override
-  String get totpStep2Title => 'Step 2: Enter the QR code';
+  String get totpStep2Title => 'Step 2: Scan the QR code';
 
   @override
   String get totpStep3Title => 'Step 3: Verify your code';

--- a/packages/authenticator/amplify_authenticator/lib/src/l10n/src/instructions/instructions_en.arb
+++ b/packages/authenticator/amplify_authenticator/lib/src/l10n/src/instructions/instructions_en.arb
@@ -5,7 +5,7 @@
     "@totpStep1Title": {
         "description": "The title for the first step of TOTP setup"
     },
-    "totpStep2Title": "Step 2: Enter the QR code",
+    "totpStep2Title": "Step 2: Scan the QR code",
     "@totpStep2Title": {
         "description": "The title for the second step of TOTP setup"
     },


### PR DESCRIPTION
*Description of changes:*
Fixed typo in the setup instructions: `Enter` => `Scan`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
