### PR TITLE
fix(aft): removed 'has-goldens' check from dart_vm.yaml workflows

### DIFF
--- a/.github/workflows/amplify_analytics_pinpoint_dart.yaml
+++ b/.github/workflows/amplify_analytics_pinpoint_dart.yaml
@@ -88,7 +88,6 @@ jobs:
     with:
       package-name: amplify_analytics_pinpoint_dart
       working-directory: packages/analytics/amplify_analytics_pinpoint_dart
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/amplify_api_dart.yaml
+++ b/.github/workflows/amplify_api_dart.yaml
@@ -64,7 +64,6 @@ jobs:
     with:
       package-name: amplify_api_dart
       working-directory: packages/api/amplify_api_dart
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/amplify_auth_cognito_dart.yaml
+++ b/.github/workflows/amplify_auth_cognito_dart.yaml
@@ -90,7 +90,6 @@ jobs:
     with:
       package-name: amplify_auth_cognito_dart
       working-directory: packages/auth/amplify_auth_cognito_dart
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/amplify_auth_cognito_test.yaml
+++ b/.github/workflows/amplify_auth_cognito_test.yaml
@@ -100,7 +100,6 @@ jobs:
     with:
       package-name: amplify_auth_cognito_test
       working-directory: packages/auth/amplify_auth_cognito_test
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/amplify_core.yaml
+++ b/.github/workflows/amplify_core.yaml
@@ -60,7 +60,6 @@ jobs:
     with:
       package-name: amplify_core
       working-directory: packages/amplify_core
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/amplify_db_common_dart.yaml
+++ b/.github/workflows/amplify_db_common_dart.yaml
@@ -64,7 +64,6 @@ jobs:
     with:
       package-name: amplify_db_common_dart
       working-directory: packages/common/amplify_db_common_dart
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/amplify_lints.yaml
+++ b/.github/workflows/amplify_lints.yaml
@@ -40,4 +40,3 @@ jobs:
     with:
       package-name: amplify_lints
       working-directory: packages/amplify_lints
-      has-goldens: false

--- a/.github/workflows/amplify_secure_storage_dart.yaml
+++ b/.github/workflows/amplify_secure_storage_dart.yaml
@@ -56,4 +56,3 @@ jobs:
     with:
       package-name: amplify_secure_storage_dart
       working-directory: packages/secure_storage/amplify_secure_storage_dart
-      has-goldens: false

--- a/.github/workflows/amplify_secure_storage_test.yaml
+++ b/.github/workflows/amplify_secure_storage_test.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: amplify_secure_storage_test
       working-directory: packages/secure_storage/amplify_secure_storage_test
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/amplify_storage_s3_dart.yaml
+++ b/.github/workflows/amplify_storage_s3_dart.yaml
@@ -70,7 +70,6 @@ jobs:
     with:
       package-name: amplify_storage_s3_dart
       working-directory: packages/storage/amplify_storage_s3_dart
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/aws_common.yaml
+++ b/.github/workflows/aws_common.yaml
@@ -52,7 +52,6 @@ jobs:
     with:
       package-name: aws_common
       working-directory: packages/aws_common
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/aws_json1_0_v1.yaml
+++ b/.github/workflows/aws_json1_0_v1.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: aws_json1_0_v1
       working-directory: packages/smithy/goldens/lib/awsJson1_0
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/aws_json1_0_v2.yaml
+++ b/.github/workflows/aws_json1_0_v2.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: aws_json1_0_v2
       working-directory: packages/smithy/goldens/lib2/awsJson1_0
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/aws_json1_1_v1.yaml
+++ b/.github/workflows/aws_json1_1_v1.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: aws_json1_1_v1
       working-directory: packages/smithy/goldens/lib/awsJson1_1
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/aws_json1_1_v2.yaml
+++ b/.github/workflows/aws_json1_1_v2.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: aws_json1_1_v2
       working-directory: packages/smithy/goldens/lib2/awsJson1_1
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/aws_query_v1.yaml
+++ b/.github/workflows/aws_query_v1.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: aws_query_v1
       working-directory: packages/smithy/goldens/lib/awsQuery
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/aws_query_v2.yaml
+++ b/.github/workflows/aws_query_v2.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: aws_query_v2
       working-directory: packages/smithy/goldens/lib2/awsQuery
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/aws_signature_v4.yaml
+++ b/.github/workflows/aws_signature_v4.yaml
@@ -56,7 +56,6 @@ jobs:
     with:
       package-name: aws_signature_v4
       working-directory: packages/aws_signature_v4
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/cognito_example.yaml
+++ b/.github/workflows/cognito_example.yaml
@@ -100,4 +100,3 @@ jobs:
     with:
       package-name: cognito_example
       working-directory: packages/auth/amplify_auth_cognito_dart/example
-      has-goldens: false

--- a/.github/workflows/custom_v2.yaml
+++ b/.github/workflows/custom_v2.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: custom_v2
       working-directory: packages/smithy/goldens/lib2/custom
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/ec2_query_v1.yaml
+++ b/.github/workflows/ec2_query_v1.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: ec2_query_v1
       working-directory: packages/smithy/goldens/lib/ec2Query
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/ec2_query_v2.yaml
+++ b/.github/workflows/ec2_query_v2.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: ec2_query_v2
       working-directory: packages/smithy/goldens/lib2/ec2Query
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/pub_server.yaml
+++ b/.github/workflows/pub_server.yaml
@@ -50,7 +50,6 @@ jobs:
     with:
       package-name: pub_server
       working-directory: packages/test/pub_server
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/rest_json1_v1.yaml
+++ b/.github/workflows/rest_json1_v1.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: rest_json1_v1
       working-directory: packages/smithy/goldens/lib/restJson1
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/rest_json1_v2.yaml
+++ b/.github/workflows/rest_json1_v2.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: rest_json1_v2
       working-directory: packages/smithy/goldens/lib2/restJson1
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/rest_xml_v1.yaml
+++ b/.github/workflows/rest_xml_v1.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: rest_xml_v1
       working-directory: packages/smithy/goldens/lib/restXml
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/rest_xml_v2.yaml
+++ b/.github/workflows/rest_xml_v2.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: rest_xml_v2
       working-directory: packages/smithy/goldens/lib2/restXml
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/rest_xml_with_namespace_v1.yaml
+++ b/.github/workflows/rest_xml_with_namespace_v1.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: rest_xml_with_namespace_v1
       working-directory: packages/smithy/goldens/lib/restXmlWithNamespace
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/rest_xml_with_namespace_v2.yaml
+++ b/.github/workflows/rest_xml_with_namespace_v2.yaml
@@ -68,7 +68,6 @@ jobs:
     with:
       package-name: rest_xml_with_namespace_v2
       working-directory: packages/smithy/goldens/lib2/restXmlWithNamespace
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/smithy.yaml
+++ b/.github/workflows/smithy.yaml
@@ -50,7 +50,6 @@ jobs:
     with:
       package-name: smithy
       working-directory: packages/smithy/smithy
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/smithy_aws.yaml
+++ b/.github/workflows/smithy_aws.yaml
@@ -58,7 +58,6 @@ jobs:
     with:
       package-name: smithy_aws
       working-directory: packages/smithy/smithy_aws
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/smithy_codegen.yaml
+++ b/.github/workflows/smithy_codegen.yaml
@@ -62,7 +62,6 @@ jobs:
     with:
       package-name: smithy_codegen
       working-directory: packages/smithy/smithy_codegen
-      has-goldens: false
   native_test:
     needs: test
     uses: ./.github/workflows/dart_native.yaml

--- a/.github/workflows/storage_s3_example.yaml
+++ b/.github/workflows/storage_s3_example.yaml
@@ -100,4 +100,3 @@ jobs:
     with:
       package-name: storage_s3_example
       working-directory: packages/storage/amplify_storage_s3_dart/example
-      has-goldens: false

--- a/.github/workflows/worker_bee.yaml
+++ b/.github/workflows/worker_bee.yaml
@@ -48,4 +48,3 @@ jobs:
     with:
       package-name: worker_bee
       working-directory: packages/worker_bee/worker_bee
-      has-goldens: false

--- a/.github/workflows/worker_bee_builder.yaml
+++ b/.github/workflows/worker_bee_builder.yaml
@@ -52,4 +52,3 @@ jobs:
     with:
       package-name: worker_bee_builder
       working-directory: packages/worker_bee/worker_bee_builder
-      has-goldens: false

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -316,9 +316,15 @@ jobs:
     with:
       package-name: ${package.name}
       working-directory: $repoRelativePath
-      has-goldens: $hasGoldens
 ''',
     );
+    if (!isDartPackage) {
+      workflowContents.write(
+        '''
+      has-goldens: $hasGoldens
+''',
+      );
+    }
 
     if (needsNativeTest) {
       workflowContents.write(


### PR DESCRIPTION
*Description of changes:*
Fix for workflows trying to pass `has-goldens: false` to `dart_vm.yaml` runner. Dart runner should never have golden tests so we should not be passing this flag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
