### PR TITLE
chore(repo): Pin `drift_dev`

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -33,7 +33,7 @@ dev_dependencies:
   build_version: ^2.0.0
   build_web_compilers: ^4.0.0
   built_value_generator: 8.6.1
-  drift_dev: ^2.2.0+1
+  drift_dev: ">=2.11.0 <2.12.0"
   mocktail: ^1.0.0
   test: ^1.22.1
 

--- a/packages/common/amplify_db_common/example/pubspec.yaml
+++ b/packages/common/amplify_db_common/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
 dev_dependencies:
   amplify_lints: ^2.0.0
-  drift_dev: ^2.2.0+1
+  drift_dev: ">=2.11.0 <2.12.0"
   build_runner: ^2.4.0
   flutter_test:
     sdk: flutter

--- a/packages/common/amplify_db_common_dart/example/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/example/pubspec.yaml
@@ -20,4 +20,4 @@ dev_dependencies:
     path: ../../../amplify_lints
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
-  drift_dev: ^2.2.0+1
+  drift_dev: ">=2.11.0 <2.12.0"

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -22,5 +22,5 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_test: ^2.0.0
   build_web_compilers: ^4.0.0
-  drift_dev: ^2.0.0
+  drift_dev: ">=2.11.0 <2.12.0"
   test: ^1.22.1

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_verify: ^3.0.0
   built_value_generator: 8.6.1
-  drift_dev: ^2.2.0+1
+  drift_dev: ">=2.11.0 <2.12.0"
   json_serializable: 6.7.1
   mocktail: ^1.0.0
   test: ^1.22.1

--- a/packages/test/pub_server/pubspec.yaml
+++ b/packages/test/pub_server/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
 dev_dependencies:
   amplify_lints: ">=2.0.3 <2.1.0"
   build_runner: ^2.4.0
-  drift_dev: ^2.4.0
+  drift_dev: ">=2.11.0 <2.12.0"
   json_serializable: 6.7.1
   pub_api_client: ^2.4.0
   shelf_router_generator: ^1.0.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   dart_style: 2.3.2
   device_info_plus: ^9.0.0
   drift: ">=2.11.0 <2.12.0"
+  drift_dev: ">=2.11.0 <2.12.0"
   ffigen: ^9.0.0
   file: ">=6.0.0 <8.0.0"
   flutter_plugin_android_lifecycle: ^2.0.9


### PR DESCRIPTION
The `drift_dev` dependency follows the same versioning as `drift`. Pinning to the same range enables better awareness of when to re-run table generation.
