### PR TITLE
feat(logging):send amplify library logs to cloudwatch

### DIFF
--- a/packages/amplify/amplify_flutter/lib/src/amplify_logging_cloudwatch.dart
+++ b/packages/amplify/amplify_flutter/lib/src/amplify_logging_cloudwatch.dart
@@ -14,7 +14,7 @@ import 'package:meta/meta.dart';
 /// {@macro amplify_core.logger.amplify_logging_cloudwatch}
 class AmplifyFlutterLogging extends AmplifyLogging {
   static AmplifyCloudWatchLoggerPlugin? _plugin;
-  static final _logger = AmplifyLogger();
+  static final _logger = AWSLogger();
 
   @override
   void configure(
@@ -44,7 +44,9 @@ class AmplifyFlutterLogging extends AmplifyLogging {
       credentialsProvider: credentialsProvider,
       pluginConfig: pluginConfig,
     );
-    _logger.registerPlugin(_plugin!);
+    _logger
+      ..registerPlugin(_plugin!)
+      ..logLevel = LogLevel.verbose;
   }
 
   @override

--- a/packages/amplify_core/lib/src/logger/amplify_logging_cloudwatch.dart
+++ b/packages/amplify_core/lib/src/logger/amplify_logging_cloudwatch.dart
@@ -10,11 +10,11 @@ import 'package:meta/meta.dart';
 
 /// {@template amplify_core.logger.amplify_logging_cloudwatch}
 /// It configures the [CloudWatchLoggerPlugin] from [AmplifyConfig] to sends
-/// [AmplifyLogger]'s logs to the CloudWatch.
+/// [AWSLogger]'s logs to the CloudWatch.
 /// {@endtemplate}
 class AmplifyLogging {
   static CloudWatchLoggerPlugin? _plugin;
-  static final _logger = AmplifyLogger();
+  static final _logger = AWSLogger();
 
   void configure(
     AmplifyConfig amplifyConfig,
@@ -43,7 +43,9 @@ class AmplifyLogging {
       credentialsProvider: credentialsProvider,
       pluginConfig: pluginConfig,
     );
-    _logger.registerPlugin(_plugin!);
+    _logger
+      ..registerPlugin(_plugin!)
+      ..logLevel = LogLevel.verbose;
   }
 
   @visibleForTesting

--- a/packages/amplify_core/lib/src/state_machine/state_machine.dart
+++ b/packages/amplify_core/lib/src/state_machine/state_machine.dart
@@ -68,7 +68,7 @@ abstract class StateMachineManager<
         E extends StateMachineEvent,
         S extends StateMachineState,
         Manager extends StateMachineManager<E, S, Manager>>
-    with Dispatcher<E, S>, AWSDebuggable, AWSLoggerMixin
+    with Dispatcher<E, S>, AWSDebuggable, AmplifyLoggerMixin
     implements DependencyManager, Closeable {
   /// {@macro amplify_core.state_machinedispatcher}
   StateMachineManager(

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -252,6 +252,9 @@ class AmplifyDataStore extends DataStorePluginInterface
 
   @override
   String get runtimeTypeName => 'AmplifyDataStore';
+
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.dataStore);
 }
 
 class _NativeAmplifyAuthCognito
@@ -296,6 +299,9 @@ class _NativeAmplifyAuthCognito
 
   @override
   String get runtimeTypeName => '_NativeAmplifyAuthCognito';
+
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.dataStore);
 }
 
 class _NativeAmplifyApi
@@ -325,4 +331,7 @@ class _NativeAmplifyApi
 
   @override
   String get runtimeTypeName => '_NativeAmplifyApi';
+
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.dataStore);
 }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/dart_queued_item_store.web.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/queued_item_store/dart_queued_item_store.web.dart
@@ -3,14 +3,13 @@
 
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/queued_item_store/index_db/in_memory_queued_item_store.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/queued_item_store/index_db/indexed_db_adapter.dart';
-
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/event_client/queued_item_store/queued_item_store.dart';
-import 'package:aws_common/aws_common.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:meta/meta.dart';
 
 /// {@macro amplify_analytics_pinpoint_dart.dart_queued_item_store}
 class DartQueuedItemStore
-    with AWSDebuggable, AWSLoggerMixin
+    with AWSDebuggable, AmplifyLoggerMixin
     implements QueuedItemStore, Closeable {
   /// {@macro amplify_analytics_pinpoint_dart.index_db_queued_item_store}
   // ignore: avoid_unused_constructor_parameters
@@ -29,6 +28,9 @@ class DartQueuedItemStore
 
   @override
   String get runtimeTypeName => 'DartQueuedItemStore';
+
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.analytics);
 
   @override
   Future<void> addItem(String string) async {

--- a/packages/api/amplify_api_dart/lib/src/graphql/web_socket/blocs/subscriptions_bloc.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/web_socket/blocs/subscriptions_bloc.dart
@@ -120,6 +120,9 @@ class SubscriptionBloc<T>
   @override
   String get runtimeTypeName => 'WsSubscriptionBloc';
 
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.api);
+
   Stream<WsSubscriptionState<T>> _startAck(
     SubscriptionStartAckEvent event,
   ) async* {

--- a/packages/api/amplify_api_dart/lib/src/graphql/web_socket/blocs/web_socket_bloc.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/web_socket/blocs/web_socket_bloc.dart
@@ -54,6 +54,9 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
   @override
   String get runtimeTypeName => 'WebSocketBloc';
 
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.api);
+
   /// Default timeout response for polling
   static const Duration _pollResponseTimeout = Duration(seconds: 5);
 

--- a/packages/api/amplify_api_dart/lib/src/graphql/web_socket/services/web_socket_service.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/web_socket/services/web_socket_service.dart
@@ -201,4 +201,7 @@ class AmplifyWebSocketService
 
   @override
   String get runtimeTypeName => 'WebSocketService';
+
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.api);
 }

--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -153,6 +153,9 @@ class _NativeAmplifyAuthCognito
 
   @override
   String get runtimeTypeName => '_NativeAmplifyAuthCognito';
+
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.auth);
 }
 
 final class _NativeASFDeviceInfoCollector extends ASFDeviceInfoCollector {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_context_data_provider.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_context_data_provider.dart
@@ -13,7 +13,7 @@ import 'package:async/async.dart';
 /// Provides user context data as required for Cognito's advanced security features
 /// (ASF) functionality.
 /// {@endtemplate}
-final class ASFContextDataProvider with AWSDebuggable, AWSLoggerMixin {
+final class ASFContextDataProvider with AWSDebuggable, AmplifyLoggerMixin {
   /// {@macro amplify_auth_cognito_dart.asf.asf_context_data_provider}
   ASFContextDataProvider(this._dependencyManager);
 
@@ -101,4 +101,7 @@ final class ASFContextDataProvider with AWSDebuggable, AWSLoggerMixin {
 
   @override
   String get runtimeTypeName => 'ASFContextDataProvider';
+
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.auth);
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_device_info_collector.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_device_info_collector.dart
@@ -57,7 +57,7 @@ abstract base class ASFDeviceInfoCollector {
 /// {@endtemplate}
 @internal
 abstract base class NativeASFDeviceInfoCollector extends ASFDeviceInfoCollector
-    with AWSDebuggable, AWSLoggerMixin {
+    with AWSDebuggable, AmplifyLoggerMixin {
   /// {@macro amplify_auth_cognito_dart.asf.asf_device_info}
   const NativeASFDeviceInfoCollector() : super.base();
 
@@ -158,4 +158,7 @@ abstract base class NativeASFDeviceInfoCollector extends ASFDeviceInfoCollector
 
   @override
   String get runtimeTypeName => 'NativeASFDeviceInfoCollector';
+
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.auth);
 }

--- a/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -46,6 +46,9 @@ class StateMachineBloc
   @override
   String get runtimeTypeName => 'StateMachineBloc';
 
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.auth);
+
   /// State controller.
   final StreamController<AuthState> _authStateController =
       StreamController<AuthState>.broadcast();

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/example/lib/main.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/example/lib/main.dart
@@ -25,7 +25,6 @@ Future<void> main() async {
 
   await Amplify.addPlugin(authPlugin);
   await Amplify.configure(amplifyConfig);
-  AmplifyLogger().logLevel = LogLevel.verbose;
 
   runApp(
     const MyApp(),

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.web.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.web.dart
@@ -3,15 +3,15 @@
 
 // ignore_for_file: implementation_imports
 
+import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_logging_cloudwatch/src/queued_item_store/index_db/indexed_db_adapter.dart';
-import 'package:aws_common/aws_common.dart';
 import 'package:aws_logging_cloudwatch/src/queued_item_store/in_memory_queued_item_store.dart';
 import 'package:aws_logging_cloudwatch/src/queued_item_store/queued_item_store.dart';
 import 'package:meta/meta.dart';
 
 /// {@macro amplify_logging_cloudwatch.dart_queued_item_store}
 class DartQueuedItemStore
-    with AWSDebuggable, AWSLoggerMixin
+    with AWSDebuggable, AmplifyLoggerMixin
     implements QueuedItemStore, Closeable {
   /// {@macro amplify_logging_cloudwatch.index_db_queued_item_store}
   // ignore: avoid_unused_constructor_parameters
@@ -30,6 +30,9 @@ class DartQueuedItemStore
 
   @override
   String get runtimeTypeName => 'DartQueuedItemStore';
+
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.logging);
 
   @override
   Future<void> addItem(

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/cloudwatch_logger_plugin.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/cloudwatch_logger_plugin.dart
@@ -47,7 +47,7 @@ typedef _LogBatch = (List<QueuedItem> logQueues, List<InputLogEvent> logEvents);
 /// An [AWSLoggerPlugin] for sending logs to AWS CloudWatch Logs.
 /// {@endtemplate}
 class CloudWatchLoggerPlugin extends AWSLoggerPlugin
-    with AWSDebuggable, AWSLoggerMixin {
+    with AWSDebuggable, AmplifyLoggerMixin {
   /// {@macro aws_logging_cloudwatch.cloudwatch_logger_plugin}
   CloudWatchLoggerPlugin({
     required AWSCredentialsProvider credentialsProvider,
@@ -369,6 +369,9 @@ class CloudWatchLoggerPlugin extends AWSLoggerPlugin
   Future<void> _clearLogs() async {
     await _logStore.clear();
   }
+
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.logging);
 }
 
 extension on QueuedItem {

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/remote_constraint_provider.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/remote_constraint_provider.dart
@@ -24,7 +24,7 @@ abstract class RemoteLoggingConstraintProvider {
 /// [LoggingConstraints] from a remote location and cache it.
 /// {@endtemplate}
 base class BaseRemoteLoggingConstraintProvider
-    with AWSDebuggable, AWSLoggerMixin
+    with AWSDebuggable, AmplifyLoggerMixin
     implements RemoteLoggingConstraintProvider, Closeable {
   /// {@macro aws_logging_cloudwatch.base_remote_constraints_provider}
   BaseRemoteLoggingConstraintProvider({
@@ -65,6 +65,9 @@ base class BaseRemoteLoggingConstraintProvider
   /// Retrives the runtime type name used for logging.
   @override
   String get runtimeTypeName => 'BaseRemoteConstraintsProvider';
+
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.logging);
 
   /// Initializes the [BaseRemoteLoggingConstraintProvider] by fetching
   /// the constraint from the endpoint initially and then

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -27,7 +27,7 @@ bool get _zIsTest => Zone.current[zIsTest] as bool? ?? false;
 /// The Dart Storage S3 plugin for the Amplify Storage Category.
 /// {@endtemplate}
 class AmplifyStorageS3Dart extends StoragePluginInterface
-    with AWSDebuggable, AWSLoggerMixin {
+    with AWSDebuggable, AmplifyLoggerMixin {
   /// {@macro amplify_storage_s3_dart.amplify_storage_s3_plugin_dart}
   AmplifyStorageS3Dart({
     String? delimiter,
@@ -478,6 +478,9 @@ class AmplifyStorageS3Dart extends StoragePluginInterface
 
   @override
   String get runtimeTypeName => 'AmplifyStorageS3Dart';
+
+  @override
+  AmplifyLogger get logger => AmplifyLogger.category(Category.storage);
 }
 
 class _AmplifyStorageS3DartPluginKey


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- register CloudWatchLoggerPlugin to AWSLogger. AWSLogger is the root logger and so all logs will be sent to cloudwatch
- set log level to verbose so CloudWatchLoggerPlugin gets all the logs and filters based on the logging constraints
- use AmplifyLoggerMixin for amplify libraries so they have the amplify namespace added to their logger full namespace
- override get logger to use category logger

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
