### PR TITLE
chore(logging): example app to use different keys for home page for guest and auth user

### DIFF
--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/example/lib/main.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/example/lib/main.dart
@@ -40,18 +40,23 @@ class MyApp extends StatelessWidget {
         initialRoute: '/',
         routes: {
           '/': (BuildContext context) {
-            return const InitPage(
+            return InitPage(
+              key: GlobalKey(),
               title: 'Amplify Logging Cloudwatch Example',
             );
           },
           '/home': (BuildContext context) {
-            return const MyHomePage(
+            return MyHomePage(
+              key: GlobalKey(),
               title: 'Amplify Logging Cloudwatch Example',
             );
           },
           '/login': (BuildContext context) {
-            return const AuthenticatedView(
-              child: MyHomePage(title: 'Amplify Logging Cloudwatch Example'),
+            return AuthenticatedView(
+              child: MyHomePage(
+                key: GlobalKey(),
+                title: 'Amplify Logging Cloudwatch Example',
+              ),
             );
           },
         },

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/example/lib/main.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/example/lib/main.dart
@@ -65,6 +65,7 @@ class InitPage extends StatelessWidget {
   final String title;
   @override
   Widget build(BuildContext context) {
+    Amplify.Auth.signOut();
     return Scaffold(
       appBar: AppBar(
         title: Text(title),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- example app to use different keys for home page for guest and auth user
- to fix exception because of Multiple widgets used the same GlobalKey.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
