### PR TITLE
fix(repo): Schedule workflows at 6 am PST

### DIFF
--- a/.github/workflows/amplify_analytics_pinpoint.yaml
+++ b/.github/workflows/amplify_analytics_pinpoint.yaml
@@ -73,7 +73,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_analytics_pinpoint_dart.yaml
+++ b/.github/workflows/amplify_analytics_pinpoint_dart.yaml
@@ -69,7 +69,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_analytics_pinpoint_example.yaml
+++ b/.github/workflows/amplify_analytics_pinpoint_example.yaml
@@ -111,7 +111,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_api.yaml
+++ b/.github/workflows/amplify_api.yaml
@@ -61,7 +61,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_api_dart.yaml
+++ b/.github/workflows/amplify_api_dart.yaml
@@ -45,7 +45,7 @@ on:
       - 'packages/aws_signature_v4/lib/**/*.dart'
       - 'packages/aws_signature_v4/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_api_example.yaml
+++ b/.github/workflows/amplify_api_example.yaml
@@ -115,7 +115,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_auth_cognito.yaml
+++ b/.github/workflows/amplify_auth_cognito.yaml
@@ -89,7 +89,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_auth_cognito_dart.yaml
+++ b/.github/workflows/amplify_auth_cognito_dart.yaml
@@ -71,7 +71,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_auth_cognito_example.yaml
+++ b/.github/workflows/amplify_auth_cognito_example.yaml
@@ -119,7 +119,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_auth_cognito_test.yaml
+++ b/.github/workflows/amplify_auth_cognito_test.yaml
@@ -81,7 +81,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_authenticator.yaml
+++ b/.github/workflows/amplify_authenticator.yaml
@@ -93,7 +93,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_authenticator_example.yaml
+++ b/.github/workflows/amplify_authenticator_example.yaml
@@ -115,7 +115,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_core.yaml
+++ b/.github/workflows/amplify_core.yaml
@@ -41,7 +41,7 @@ on:
       - 'packages/aws_signature_v4/lib/**/*.dart'
       - 'packages/aws_signature_v4/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_datastore.yaml
+++ b/.github/workflows/amplify_datastore.yaml
@@ -41,7 +41,7 @@ on:
       - 'packages/aws_signature_v4/lib/**/*.dart'
       - 'packages/aws_signature_v4/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_datastore_example.yaml
+++ b/.github/workflows/amplify_datastore_example.yaml
@@ -101,7 +101,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_datastore_plugin_interface.yaml
+++ b/.github/workflows/amplify_datastore_plugin_interface.yaml
@@ -37,7 +37,7 @@ on:
       - 'packages/aws_signature_v4/lib/**/*.dart'
       - 'packages/aws_signature_v4/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_db_common.yaml
+++ b/.github/workflows/amplify_db_common.yaml
@@ -41,7 +41,7 @@ on:
       - 'packages/common/amplify_db_common_dart/lib/**/*.dart'
       - 'packages/common/amplify_db_common_dart/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_db_common_dart.yaml
+++ b/.github/workflows/amplify_db_common_dart.yaml
@@ -45,7 +45,7 @@ on:
       - 'packages/common/amplify_db_common_dart/lib/**/*'
       - 'packages/common/amplify_db_common_dart/test/**/*'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_db_common_example.yaml
+++ b/.github/workflows/amplify_db_common_example.yaml
@@ -55,7 +55,7 @@ on:
       - 'packages/common/amplify_db_common_dart/lib/**/*.dart'
       - 'packages/common/amplify_db_common_dart/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_flutter.yaml
+++ b/.github/workflows/amplify_flutter.yaml
@@ -53,7 +53,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_flutter_example.yaml
+++ b/.github/workflows/amplify_flutter_example.yaml
@@ -117,7 +117,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_lints.yaml
+++ b/.github/workflows/amplify_lints.yaml
@@ -21,7 +21,7 @@ on:
       - 'packages/amplify_lints/lib/**/*'
       - 'packages/amplify_lints/test/**/*'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_native_legacy_wrapper.yaml
+++ b/.github/workflows/amplify_native_legacy_wrapper.yaml
@@ -25,7 +25,7 @@ on:
       - 'packages/amplify_native_legacy_wrapper/lib/**/*'
       - 'packages/amplify_native_legacy_wrapper/test/**/*'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_native_legacy_wrapper_example.yaml
+++ b/.github/workflows/amplify_native_legacy_wrapper_example.yaml
@@ -33,7 +33,7 @@ on:
       - 'packages/aws_common/lib/**/*.dart'
       - 'packages/aws_common/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_push_notifications.yaml
+++ b/.github/workflows/amplify_push_notifications.yaml
@@ -59,7 +59,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_push_notifications_example.yaml
+++ b/.github/workflows/amplify_push_notifications_example.yaml
@@ -57,7 +57,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_push_notifications_pinpoint.yaml
+++ b/.github/workflows/amplify_push_notifications_pinpoint.yaml
@@ -97,7 +97,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_push_notifications_pinpoint_example.yaml
+++ b/.github/workflows/amplify_push_notifications_pinpoint_example.yaml
@@ -101,7 +101,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_secure_storage.yaml
+++ b/.github/workflows/amplify_secure_storage.yaml
@@ -41,7 +41,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_secure_storage_dart.yaml
+++ b/.github/workflows/amplify_secure_storage_dart.yaml
@@ -37,7 +37,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_secure_storage_example.yaml
+++ b/.github/workflows/amplify_secure_storage_example.yaml
@@ -55,7 +55,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_secure_storage_test.yaml
+++ b/.github/workflows/amplify_secure_storage_test.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_storage_s3.yaml
+++ b/.github/workflows/amplify_storage_s3.yaml
@@ -57,7 +57,7 @@ on:
       - 'packages/storage/amplify_storage_s3_dart/lib/**/*.dart'
       - 'packages/storage/amplify_storage_s3_dart/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_storage_s3_dart.yaml
+++ b/.github/workflows/amplify_storage_s3_dart.yaml
@@ -51,7 +51,7 @@ on:
       - 'packages/storage/amplify_storage_s3_dart/lib/**/*'
       - 'packages/storage/amplify_storage_s3_dart/test/**/*'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/amplify_storage_s3_example.yaml
+++ b/.github/workflows/amplify_storage_s3_example.yaml
@@ -115,7 +115,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/aws_common.yaml
+++ b/.github/workflows/aws_common.yaml
@@ -33,7 +33,7 @@ on:
       - 'packages/aws_common/lib/**/*'
       - 'packages/aws_common/test/**/*'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/aws_json1_0_v1.yaml
+++ b/.github/workflows/aws_json1_0_v1.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/aws_json1_0_v2.yaml
+++ b/.github/workflows/aws_json1_0_v2.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/aws_json1_1_v1.yaml
+++ b/.github/workflows/aws_json1_1_v1.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/aws_json1_1_v2.yaml
+++ b/.github/workflows/aws_json1_1_v2.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/aws_query_v1.yaml
+++ b/.github/workflows/aws_query_v1.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/aws_query_v2.yaml
+++ b/.github/workflows/aws_query_v2.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/aws_signature_v4.yaml
+++ b/.github/workflows/aws_signature_v4.yaml
@@ -37,7 +37,7 @@ on:
       - 'packages/aws_signature_v4/lib/**/*'
       - 'packages/aws_signature_v4/test/**/*'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/cognito_example.yaml
+++ b/.github/workflows/cognito_example.yaml
@@ -81,7 +81,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/custom_v2.yaml
+++ b/.github/workflows/custom_v2.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/ec2_query_v1.yaml
+++ b/.github/workflows/ec2_query_v1.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/ec2_query_v2.yaml
+++ b/.github/workflows/ec2_query_v2.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/pub_server.yaml
+++ b/.github/workflows/pub_server.yaml
@@ -31,7 +31,7 @@ on:
       - 'packages/test/pub_server/lib/**/*'
       - 'packages/test/pub_server/test/**/*'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/rest_json1_v1.yaml
+++ b/.github/workflows/rest_json1_v1.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/rest_json1_v2.yaml
+++ b/.github/workflows/rest_json1_v2.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/rest_xml_v1.yaml
+++ b/.github/workflows/rest_xml_v1.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/rest_xml_v2.yaml
+++ b/.github/workflows/rest_xml_v2.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/rest_xml_with_namespace_v1.yaml
+++ b/.github/workflows/rest_xml_with_namespace_v1.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/rest_xml_with_namespace_v2.yaml
+++ b/.github/workflows/rest_xml_with_namespace_v2.yaml
@@ -49,7 +49,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*.dart'
       - 'packages/smithy/smithy_aws/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/smithy.yaml
+++ b/.github/workflows/smithy.yaml
@@ -31,7 +31,7 @@ on:
       - 'packages/smithy/smithy/lib/**/*'
       - 'packages/smithy/smithy/test/**/*'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/smithy_aws.yaml
+++ b/.github/workflows/smithy_aws.yaml
@@ -39,7 +39,7 @@ on:
       - 'packages/smithy/smithy_aws/lib/**/*'
       - 'packages/smithy/smithy_aws/test/**/*'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/smithy_codegen.yaml
+++ b/.github/workflows/smithy_codegen.yaml
@@ -43,7 +43,7 @@ on:
       - 'packages/smithy/smithy_codegen/lib/**/*'
       - 'packages/smithy/smithy_codegen/test/**/*'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/storage_s3_example.yaml
+++ b/.github/workflows/storage_s3_example.yaml
@@ -81,7 +81,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*.dart'
       - 'packages/worker_bee/worker_bee_builder/pubspec.yaml'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/worker_bee.yaml
+++ b/.github/workflows/worker_bee.yaml
@@ -29,7 +29,7 @@ on:
       - 'packages/worker_bee/worker_bee/lib/**/*'
       - 'packages/worker_bee/worker_bee/test/**/*'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/.github/workflows/worker_bee_builder.yaml
+++ b/.github/workflows/worker_bee_builder.yaml
@@ -33,7 +33,7 @@ on:
       - 'packages/worker_bee/worker_bee_builder/lib/**/*'
       - 'packages/worker_bee/worker_bee_builder/test/**/*'
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -290,7 +290,7 @@ ${workflowPaths.map((path) => "      - '$path'").join('\n')}
     paths:
 ${workflowPaths.map((path) => "      - '$path'").join('\n')}
   schedule:
-    - cron: "0 6 * * *" # Every day at 06:00
+    - cron: "0 13 * * *" # Everyday at 06:00 PST
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Github schedule is based on UTC.  6 am UTC = 11 pm PST.  We should use PST instead.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
