### PR TITLE
fix(logging): use indexedDB on web if it is supported

### DIFF
--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.web.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/dart_queued_item_store.web.dart
@@ -3,6 +3,8 @@
 
 // ignore_for_file: implementation_imports
 
+import 'dart:async';
+
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_logging_cloudwatch/src/queued_item_store/index_db/indexed_db_adapter.dart';
 import 'package:aws_logging_cloudwatch/src/queued_item_store/in_memory_queued_item_store.dart';
@@ -17,8 +19,8 @@ class DartQueuedItemStore
   // ignore: avoid_unused_constructor_parameters
   DartQueuedItemStore(String? storagePath);
 
-  late final QueuedItemStore _database = () {
-    if (IndexedDbAdapter.checkIsIndexedDBSupported()) {
+  late final Future<QueuedItemStore> _database = () async {
+    if (await IndexedDbAdapter.checkIsIndexedDBSupported()) {
       return IndexedDbAdapter();
     }
     logger.warn(
@@ -40,7 +42,8 @@ class DartQueuedItemStore
     String timestamp, {
     bool enableQueueRotation = false,
   }) async {
-    await _database.addItem(
+    final db = await _database;
+    await db.addItem(
       string,
       timestamp,
       enableQueueRotation: enableQueueRotation,
@@ -49,29 +52,34 @@ class DartQueuedItemStore
 
   @override
   Future<void> deleteItems(Iterable<QueuedItem> items) async {
-    await _database.deleteItems(items);
+    final db = await _database;
+    await db.deleteItems(items);
   }
 
   @override
   Future<Iterable<QueuedItem>> getCount(int count) async {
-    return _database.getCount(count);
+    final db = await _database;
+    return db.getCount(count);
   }
 
   @override
   Future<Iterable<QueuedItem>> getAll() async {
-    return _database.getAll();
+    final db = await _database;
+    return db.getAll();
   }
 
   @override
-  bool isFull(int maxSizeInMB) {
-    return _database.isFull(maxSizeInMB);
+  Future<bool> isFull(int maxSizeInMB) async {
+    final db = await _database;
+    return db.isFull(maxSizeInMB);
   }
 
   /// Clear IndexedDB data.
   @override
   @visibleForTesting
   Future<void> clear() async {
-    return _database.clear();
+    final db = await _database;
+    return db.clear();
   }
 
   @override

--- a/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/index_db/indexed_db_adapter.dart
+++ b/packages/logging_cloudwatch/amplify_logging_cloudwatch/lib/src/queued_item_store/index_db/indexed_db_adapter.dart
@@ -97,10 +97,10 @@ class IndexedDbAdapter implements QueuedItemStore {
     for (final elem in request.result) {
       final value = elem as Object;
       final id = getProperty<int>(value, 'id');
-      final string = getProperty<String>(value, 'value');
+      final itemValue = getProperty<String>(value, 'value');
       final timestamp = getProperty<String>(value, 'timestamp');
       readValues.add(
-        QueuedItem(id: id, value: string, timestamp: timestamp),
+        QueuedItem(id: id, value: itemValue, timestamp: timestamp),
       );
     }
     return readValues;
@@ -129,25 +129,7 @@ class IndexedDbAdapter implements QueuedItemStore {
 
   @override
   Future<Iterable<QueuedItem>> getAll() async {
-    final readValues = <QueuedItem>[];
-
-    await _databaseOpenEvent;
-    final store = _getObjectStore();
-    final request = store.getAll(null, null);
-
-    await request.future;
-
-    for (final elem in request.result) {
-      final value = elem as Map<String, dynamic>;
-      final id = value['id'] as int;
-      final itemValue = value['value'] as String;
-      final timestamp = value['timestamp'] as String;
-      readValues.add(
-        QueuedItem(id: id, value: itemValue, timestamp: timestamp),
-      );
-    }
-
-    return readValues;
+    return getCount();
   }
 
   @override
@@ -168,14 +150,14 @@ class IndexedDbAdapter implements QueuedItemStore {
   void close() {}
 
   /// Check that IndexDB will work on this device.
-  static bool checkIsIndexedDBSupported() {
+  static Future<bool> checkIsIndexedDBSupported() async {
     if (indexedDB == null) {
       return false;
     }
     // indexedDB will be non-null in Firefox private browsing,
     // but will fail to open.
     try {
-      indexedDB!.open('test', 1).result;
+      await indexedDB!.open('test', 1).future;
       return true;
     } on Object {
       return false;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/cloudwatch_logger_plugin.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/cloudwatch_logger_plugin.dart
@@ -219,7 +219,7 @@ class CloudWatchLoggerPlugin extends AWSLoggerPlugin
       } on Exception catch (e) {
         logger.error('Failed to sync logs to CloudWatch.', e);
       } finally {
-        _handleFullLogStoreAfterSync(
+        await _handleFullLogStoreAfterSync(
           retryTime: nextRetry,
         );
         _syncing = false;
@@ -227,11 +227,11 @@ class CloudWatchLoggerPlugin extends AWSLoggerPlugin
     }
   }
 
-  void _handleFullLogStoreAfterSync({
+  Future<void> _handleFullLogStoreAfterSync({
     DateTime? retryTime,
-  }) {
+  }) async {
     final isLogStoreFull =
-        _logStore.isFull(_pluginConfig.localStoreMaxSizeInMB);
+        await _logStore.isFull(_pluginConfig.localStoreMaxSizeInMB);
     if (!isLogStoreFull) {
       _retryCount = 0;
       _retryTime = null;
@@ -347,7 +347,7 @@ class CloudWatchLoggerPlugin extends AWSLoggerPlugin
     }
     final item = logEntry.toQueuedItem();
     final isLogStoreFull =
-        _logStore.isFull(_pluginConfig.localStoreMaxSizeInMB);
+        await _logStore.isFull(_pluginConfig.localStoreMaxSizeInMB);
     final shouldEnableQueueRotation = isLogStoreFull && _retryTime != null;
 
     await _logStore.addItem(

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/queued_item_store/queued_item_store.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/queued_item_store/queued_item_store.dart
@@ -24,7 +24,7 @@ abstract interface class QueuedItemStore {
   FutureOr<Iterable<QueuedItem>> getAll();
 
   /// Whether the queue size is reached [maxSizeInMB].
-  bool isFull(int maxSizeInMB);
+  FutureOr<bool> isFull(int maxSizeInMB);
 
   /// Clear the queue of items.
   FutureOr<void> clear();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- indexedDb adapter to wait for the test DB open result when checking if indexedDB is supported.
- DartQueuedItemStore web implementation to wait for indexedDb adapter and fall back to in memory if indexedDb is not supported
- indexedDb adapter getAll method to read result as Object instead of Map


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
