### PR TITLE
fix(smithy): casts output to fix beta tests

### DIFF
--- a/packages/smithy/smithy/lib/src/http/http_operation.dart
+++ b/packages/smithy/smithy/lib/src/http/http_operation.dart
@@ -268,7 +268,6 @@ abstract class HttpOperation<InputPayload, Input, OutputPayload, Output>
     var successCode = this.successCode();
     try {
       final payload = await protocol.deserialize(response.split());
-      // ignore: unnecessary_cast
       output = switch (payload) {
         final Output p => p,
         _ => buildOutput(payload, response),

--- a/packages/smithy/smithy/lib/src/http/http_operation.dart
+++ b/packages/smithy/smithy/lib/src/http/http_operation.dart
@@ -268,10 +268,11 @@ abstract class HttpOperation<InputPayload, Input, OutputPayload, Output>
     var successCode = this.successCode();
     try {
       final payload = await protocol.deserialize(response.split());
+      // ignore: unnecessary_cast
       output = switch (payload) {
         Output _ => payload,
         _ => buildOutput(payload, response),
-      };
+      } as Output;
       successCode = this.successCode(output);
     } on Object catch (e, st) {
       error = e;

--- a/packages/smithy/smithy/lib/src/http/http_operation.dart
+++ b/packages/smithy/smithy/lib/src/http/http_operation.dart
@@ -270,9 +270,9 @@ abstract class HttpOperation<InputPayload, Input, OutputPayload, Output>
       final payload = await protocol.deserialize(response.split());
       // ignore: unnecessary_cast
       output = switch (payload) {
-        Output _ => payload,
+        final Output p => p,
         _ => buildOutput(payload, response),
-      } as Output;
+      };
       successCode = this.successCode(output);
     } on Object catch (e, st) {
       error = e;


### PR DESCRIPTION
*Description of changes:*
Casts output to fix the following `beta` test failure:

```
Failed to build aft:aft:
packages/smithy/smithy/lib/src/http/http_operation.dart:271:16: Error: A value of type 'Object?' can't be assigned to a variable of type 'Output?'.
 - 'Object' is from 'dart:core'.
      output = switch (payload) {
               ^
```
            

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
