### PR TITLE
fix: catch and log updateEndpoint error during configure

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint/example/integration_test/no_unauth_test.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/example/integration_test/no_unauth_test.dart
@@ -14,7 +14,9 @@ import 'utils/mock_secure_storage.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  group('unathenticated access restricted', () {
+  group(
+      'Amplify.configure should complete even when unauthenticated access is disabled.',
+      () {
     tearDown(Amplify.reset);
 
     for (final environmentName in const [
@@ -34,7 +36,7 @@ void main() {
         ]);
         await expectLater(
           Amplify.configure(amplifyEnvironments[environmentName]!),
-          throwsA(isA<UnknownException>()),
+          completes,
         );
       });
     }

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/analytics_plugin_impl.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/analytics_plugin_impl.dart
@@ -128,7 +128,11 @@ class AmplifyAnalyticsPinpointDart extends AnalyticsPluginInterface {
     _endpointClient = analyticsClient.endpointClient;
     _eventClient = analyticsClient.eventClient;
 
-    await _endpointClient.updateEndpoint();
+    try {
+      await _endpointClient.updateEndpoint();
+    } on Exception catch (e) {
+      _logger.warn('Could not update endpoint: $e');
+    }
 
     _sessionManager = SessionManager(
       fixedEndpointId: _endpointClient.fixedEndpointId,


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/3950

*Description of changes:*
- Catch and log updateEndpoint errors during configure

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
