### PR TITLE
fix(logging): fix log levels to have none as the lowest level in the log level enum

### DIFF
--- a/packages/aws_common/lib/src/logging/log_level.dart
+++ b/packages/aws_common/lib/src/logging/log_level.dart
@@ -7,6 +7,10 @@ import 'package:json_annotation/json_annotation.dart';
 
 /// The different levels of logging.
 enum LogLevel implements Comparable<LogLevel> {
+  /// Prevents any logs from being emitted.
+  @JsonValue('NONE')
+  none,
+
   /// Logs for showing behavior of particular components/flows.
   ///
   /// **Note**: May contain information inappropriate for emission into
@@ -31,11 +35,7 @@ enum LogLevel implements Comparable<LogLevel> {
 
   /// Logs when system is not operating as expected.
   @JsonValue('ERROR')
-  error,
-
-  /// Prevents any logs from being emitted.
-  @JsonValue('NONE')
-  none;
+  error;
 
   @override
   int compareTo(LogLevel other) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- having the none log level as the last value in the enum list cause the logs with none level to be logged. this fixes the enum value list to have the none as the lowest index so the compareTo method works as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
