### PR TITLE
fix(analytics): event client flush events to do not discard events from cache on auth exception

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/event_client.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/event_client/event_client.dart
@@ -204,6 +204,11 @@ class EventClient implements Closeable {
       // Due to no internet or unable to reach server.
       // These exceptions are always retryable.
       eventsToDelete.clear();
+    } on AuthException {
+      // AuthException indicates request did not complete
+      // Due to Authentication error.
+      // These exceptions are always retryable.
+      eventsToDelete.clear();
     } on SmithyHttpException catch (e) {
       if (e.statusCode != null && _isRetryable(e.statusCode)) {
         eventsToDelete.removeWhere((eventId, _) {


### PR DESCRIPTION
*Issue #, if available:*
- when unauthenticated access is disabled, Analytics can record events when user is not logged-in but flush events fails due to auth exception and events are cleared from cache.

*Description of changes:*
- if flush events (PutEvents request) fails due to Auth exception, do not clear cache as these events are always retryable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
