### PR TITLE
chore: fix flaky api e2e test

### DIFF
--- a/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
@@ -129,6 +129,7 @@ void main({bool useExistingTestUser = false}) {
         final req = ModelQueries.list<Blog>(
           Blog.classType,
           where: Blog.NAME.eq(blogName) & Blog.ID.eq(blog.id),
+          limit: 100000,
         );
         final res = await Amplify.API.query(request: req).response;
         final data = res.data;

--- a/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
@@ -122,14 +122,15 @@ void main({bool useExistingTestUser = false}) {
 
       testWidgets('should LIST blogs with Model helper with query predicate',
           (WidgetTester tester) async {
-        // test
         final blogName = 'Integration Test Blog ${uuid()}';
         final blog = await addBlog(blogName);
 
         final req = ModelQueries.list<Blog>(
           Blog.classType,
           where: Blog.NAME.eq(blogName) & Blog.ID.eq(blog.id),
-          limit: 100000,
+          // a high limit ensures that blogs created by other tests do not cause
+          // this test to fail.
+          limit: 5000,
         );
         final res = await Amplify.API.query(request: req).response;
         final data = res.data;

--- a/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
@@ -12,6 +12,14 @@ import 'package:integration_test/integration_test.dart';
 
 import '../util.dart';
 
+/// A limit to use in [ModelQueries.list] operations.
+///
+/// Tests that use [ModelQueries.list] and expect certain models in the response
+/// can fail if the DB has a large number of items in it. Models are cleaned up
+/// after tests complete, but during test execution the number of models can
+/// increase past the default limit.
+const _limit = 10000;
+
 void main({bool useExistingTestUser = false}) {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -128,9 +136,7 @@ void main({bool useExistingTestUser = false}) {
         final req = ModelQueries.list<Blog>(
           Blog.classType,
           where: Blog.NAME.eq(blogName) & Blog.ID.eq(blog.id),
-          // a high limit ensures that blogs created by other tests do not cause
-          // this test to fail.
-          limit: 5000,
+          limit: _limit,
         );
         final res = await Amplify.API.query(request: req).response;
         final data = res.data;
@@ -148,8 +154,11 @@ void main({bool useExistingTestUser = false}) {
         const rating = 0;
         final createdPost = await addPostAndBlog(title, rating);
 
-        final req =
-            ModelQueries.list(Post.classType, where: Post.TITLE.eq(title));
+        final req = ModelQueries.list(
+          Post.classType,
+          where: Post.TITLE.eq(title),
+          limit: _limit,
+        );
         final res = await Amplify.API.query(request: req).response;
         final postFromResponse = res.data?.items[0];
 
@@ -165,8 +174,11 @@ void main({bool useExistingTestUser = false}) {
         final createdPost = await addPostAndBlog(title, rating);
         final blogId = createdPost.blog?.id;
 
-        final req =
-            ModelQueries.list(Post.classType, where: Post.BLOG.eq(blogId));
+        final req = ModelQueries.list(
+          Post.classType,
+          where: Post.BLOG.eq(blogId),
+          limit: _limit,
+        );
         final res = await Amplify.API.query(request: req).response;
         final postFromResponse = res.data?.items[0];
 

--- a/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
@@ -122,6 +122,7 @@ void main({bool useExistingTestUser = false}) {
 
       testWidgets('should LIST blogs with Model helper with query predicate',
           (WidgetTester tester) async {
+        // test
         final blogName = 'Integration Test Blog ${uuid()}';
         final blog = await addBlog(blogName);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add a `limit` to `ModelQueries.list` operations that expect a certain model in the response.

Tests that use `ModelQueries.list` and expect certain models in the response can fail if the DB has a large number of items in it. Models are cleaned up after tests complete, but during test execution the number of models can increase past the default limit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
