### PR TITLE
chore(deps): Bump the drift window 2.13.0

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   built_collection: ^5.0.0
   built_value: ">=8.6.0 <8.7.0"
   collection: ^1.15.0
-  drift: ">=2.11.0 <2.12.0"
+  drift: ">=2.12.0 <2.13.0"
   intl: ">=0.18.0 <1.0.0"
   meta: ^1.7.0
   path: ^1.8.0
@@ -33,7 +33,7 @@ dev_dependencies:
   build_version: ^2.0.0
   build_web_compilers: ^4.0.0
   built_value_generator: 8.6.1
-  drift_dev: ">=2.11.0 <2.12.0"
+  drift_dev: ">=2.12.0 <2.13.0"
   mocktail: ^1.0.0
   test: ^1.22.1
 

--- a/packages/common/amplify_db_common/example/pubspec.yaml
+++ b/packages/common/amplify_db_common/example/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
 
 dependencies:
   amplify_db_common: ">=0.1.2+5 <0.2.0"
-  drift: ">=2.11.0 <2.12.0"
+  drift: ">=2.12.0 <2.13.0"
   flutter:
     sdk: flutter
 
 dev_dependencies:
   amplify_lints: ^2.0.0
-  drift_dev: ">=2.11.0 <2.12.0"
+  drift_dev: ">=2.12.0 <2.13.0"
   build_runner: ^2.4.0
   flutter_test:
     sdk: flutter

--- a/packages/common/amplify_db_common/pubspec.yaml
+++ b/packages/common/amplify_db_common/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   amplify_db_common_dart: ">=0.3.1 <0.4.0"
-  drift: ">=2.11.0 <2.12.0"
+  drift: ">=2.12.0 <2.13.0"
   flutter:
     sdk: flutter
   path: ^1.8.2

--- a/packages/common/amplify_db_common_dart/example/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/example/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   amplify_db_common_dart: ">=0.2.0+5 <0.3.0"
-  drift: ">=2.11.0 <2.12.0"
+  drift: ">=2.12.0 <2.13.0"
   example_common:
     path: ../../../example_common
 
@@ -20,4 +20,4 @@ dev_dependencies:
     path: ../../../amplify_lints
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
-  drift_dev: ">=2.11.0 <2.12.0"
+  drift_dev: ">=2.12.0 <2.13.0"

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   amplify_core: ">=1.4.0 <1.5.0"
   async: ^2.10.0
   aws_common: ">=0.6.0 <0.7.0"
-  drift: ">=2.11.0 <2.12.0"
+  drift: ">=2.12.0 <2.13.0"
   meta: ^1.7.0
   path: ^1.8.0
   sqlite3: ^2.0.0
@@ -22,5 +22,5 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_test: ^2.0.0
   build_web_compilers: ^4.0.0
-  drift_dev: ">=2.11.0 <2.12.0"
+  drift_dev: ">=2.12.0 <2.13.0"
   test: ^1.22.1

--- a/packages/storage/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/example/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
     path: ../../../amplify_lints
   amplify_storage_s3_dart: any
   aws_common: any
-  drift: ">=2.11.0 <2.12.0"
+  drift: ">=2.12.0 <2.13.0"
   flutter_driver:
     sdk: flutter
   flutter_test:

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/database_io.g.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/database_io.g.dart
@@ -39,9 +39,10 @@ class $TransferRecordsTable extends TransferRecords
   @override
   List<GeneratedColumn> get $columns => [id, uploadId, objectKey, createdAt];
   @override
-  String get aliasedName => _alias ?? 'transfer_records';
+  String get aliasedName => _alias ?? actualTableName;
   @override
-  String get actualTableName => 'transfer_records';
+  String get actualTableName => $name;
+  static const String $name = 'transfer_records';
   @override
   VerificationContext validateIntegrity(Insertable<TransferRecord> instance,
       {bool isInserting = false}) {

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   aws_signature_v4: ">=0.5.0 <0.6.0"
   built_collection: ^5.0.0
   built_value: ">=8.6.0 <8.7.0"
-  drift: ">=2.11.0 <2.12.0"
+  drift: ">=2.12.0 <2.13.0"
   fixnum: ^1.0.0
   json_annotation: ">=4.8.1 <4.9.0"
   meta: ^1.7.0
@@ -29,7 +29,7 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_verify: ^3.0.0
   built_value_generator: 8.6.1
-  drift_dev: ">=2.11.0 <2.12.0"
+  drift_dev: ">=2.12.0 <2.13.0"
   json_serializable: 6.7.1
   mocktail: ^1.0.0
   test: ^1.22.1

--- a/packages/test/pub_server/pubspec.yaml
+++ b/packages/test/pub_server/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   async: ^2.10.0
   aws_common: any
   collection: ^1.15.0
-  drift: ">=2.11.0 <2.12.0"
+  drift: ">=2.12.0 <2.13.0"
   file: ">=6.0.0 <8.0.0"
   git: ^2.2.0
   graphs: ^2.1.0
@@ -31,7 +31,7 @@ dependencies:
 dev_dependencies:
   amplify_lints: ">=2.0.3 <2.1.0"
   build_runner: ^2.4.0
-  drift_dev: ">=2.11.0 <2.12.0"
+  drift_dev: ">=2.12.0 <2.13.0"
   json_serializable: 6.7.1
   pub_api_client: ^2.4.0
   shelf_router_generator: ^1.0.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,8 +25,8 @@ dependencies:
   # on stable so that CI checks pass for generated code.
   dart_style: 2.3.2
   device_info_plus: ^9.0.0
-  drift: ">=2.11.0 <2.12.0"
-  drift_dev: ">=2.11.0 <2.12.0"
+  drift: ">=2.12.0 <2.13.0"
+  drift_dev: ">=2.12.0 <2.13.0"
   ffigen: ^9.0.0
   file: ">=6.0.0 <8.0.0"
   flutter_plugin_android_lifecycle: ^2.0.9


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/pull/3976

*Description of changes:*
Slide drift window to: 
- `drift: ">=2.12.0 <2.13.0"`
- `drift_dev: ">=2.12.0 <2.13.0"`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
