### PR TITLE
[TEST] fix(auth): forget local device only if matches

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -981,7 +981,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
     if (deviceKey == null) {
       throw const DeviceNotTrackedException();
     }
-    await _deviceRepo.remove(username);
+    if (device == null || device.id == deviceSecrets?.deviceKey) {
+      await _deviceRepo.remove(username);
+    }
     await _cognitoIdp
         .forgetDevice(
           cognito.ForgetDeviceRequest(


### PR DESCRIPTION
Pushing to upstream to run e2e tests