### PR TITLE
chore: moved user agent to logging category api

### DIFF
--- a/packages/amplify_core/lib/src/category/amplify_logging_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_logging_category.dart
@@ -61,6 +61,9 @@ class LoggingCategory extends AmplifyCategory<LoggingPluginInterface> {
   /// Sends recorded logs to the output and remove them from the local storage.
   /// {@endtemplate}
   void flushLogs() {
-    return identifyCall(LoggingCategoryMethod.flush, () => defaultPlugin.flushLogs(),);
+    return identifyCall(
+      LoggingCategoryMethod.flush,
+      () => defaultPlugin.flushLogs(),
+    );
   }
 }

--- a/packages/amplify_core/lib/src/category/amplify_logging_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_logging_category.dart
@@ -61,6 +61,6 @@ class LoggingCategory extends AmplifyCategory<LoggingPluginInterface> {
   /// Sends recorded logs to the output and remove them from the local storage.
   /// {@endtemplate}
   void flushLogs() {
-    return defaultPlugin.flushLogs();
+    return identifyCall(LoggingCategoryMethod.flush, () => defaultPlugin.flushLogs());
   }
 }

--- a/packages/amplify_core/lib/src/category/amplify_logging_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_logging_category.dart
@@ -61,6 +61,6 @@ class LoggingCategory extends AmplifyCategory<LoggingPluginInterface> {
   /// Sends recorded logs to the output and remove them from the local storage.
   /// {@endtemplate}
   void flushLogs() {
-    return identifyCall(LoggingCategoryMethod.flush, () => defaultPlugin.flushLogs());
+    return identifyCall(LoggingCategoryMethod.flush, () => defaultPlugin.flushLogs(),);
   }
 }

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/cloudwatch_logger_plugin.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/cloudwatch_logger_plugin.dart
@@ -389,10 +389,7 @@ class CloudWatchLoggerPlugin extends AWSLoggerPlugin
 
   /// Sends logs on-demand to CloudWatch.
   Future<void> flushLogs() async {
-    await identifyCall(
-      LoggingCategoryMethod.flush,
-      _startSyncingIfNotInProgress,
-    );
+    await _startSyncingIfNotInProgress();
   }
 
   @override


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Moved user agent for `flushLogs` out of `cloudwatch_logger_plugin` and into amplify logging category.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
