### PR TITLE
fix(api): GraphQL Model Helpers support lowercase model names

### DIFF
--- a/packages/api/amplify_api/example/amplify/backend/api/apiintegmultiauth/schema.graphql
+++ b/packages/api/amplify_api/example/amplify/backend/api/apiintegmultiauth/schema.graphql
@@ -67,3 +67,18 @@ type OwnerOnly @model @auth(rules: [{allow: owner}]) {
   id: ID!
   name: String!
 } 
+
+type lowerCase
+  @model
+  @auth(
+    rules: [
+      { allow: public, operations: [read], provider: apiKey },
+      { allow: public, operations: [read], provider: iam },
+      { allow: private, operations: [read], provider: iam },
+      { allow: private, operations: [read], provider: userPools },
+      { allow: owner, operations: [create, read, update, delete] }
+    ]
+  ) {
+  id: ID!
+  name: String!
+}

--- a/packages/api/amplify_api/example/integration_test/graphql/user_pools_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/user_pools_test.dart
@@ -122,6 +122,24 @@ void main({bool useExistingTestUser = false}) {
         expect(data.rating, equals(rating));
       });
 
+      testWidgets('should CREATE a lower case model name with Model helper',
+          (WidgetTester tester) async {
+        final name = 'Integration Test lowercase - ${uuid()}';
+        final model = lowerCase(name: name);
+
+        final req = ModelMutations.create(
+          model,
+          authorizationMode: APIAuthorizationType.userPools,
+        );
+        final res = await Amplify.API.mutate(request: req).response;
+        expect(res, hasNoGraphQLErrors);
+        final data = res.data;
+        if (data != null) lowerCaseCache.add(data);
+
+        expect(data?.name, equals(model.name));
+        expect(data?.id, equals(model.id));
+      });
+
       testWidgets('should UPDATE a blog with Model helper',
           (WidgetTester tester) async {
         const oldName = 'Integration Test Blog to update';

--- a/packages/api/amplify_api/example/integration_test/util.dart
+++ b/packages/api/amplify_api/example/integration_test/util.dart
@@ -19,6 +19,7 @@ TestUser? testUser;
 final blogCache = <Blog>[];
 final postCache = <Post>[];
 final ownerOnlyCache = <OwnerOnly>[];
+final lowerCaseCache = <lowerCase>[];
 final cpkParentCache = <CpkOneToOneBidirectionalParentCD>[];
 final cpkExplicitChildCache = <CpkOneToOneBidirectionalChildExplicitCD>[];
 final cpkImplicitChildCache = <CpkOneToOneBidirectionalChildImplicitCD>[];
@@ -297,12 +298,25 @@ Future<OwnerOnly?> deleteOwnerOnly(OwnerOnly model) async {
   return res.data;
 }
 
+Future<lowerCase?> deleteLowerCase(lowerCase model) async {
+  final request = ModelMutations.deleteById(
+    lowerCase.classType,
+    model.modelIdentifier,
+    authorizationMode: APIAuthorizationType.userPools,
+  );
+  final res = await Amplify.API.mutate(request: request).response;
+  expect(res, hasNoGraphQLErrors);
+  lowerCaseCache.removeWhere((modelFromCache) => modelFromCache.id == model.id);
+  return res.data;
+}
+
 Future<void> deleteTestModels() async {
   await Future.wait(blogCache.map(deleteBlog));
   await Future.wait(postCache.map(deletePost));
   await Future.wait(cpkExplicitChildCache.map(deleteCpkExplicitChild));
   await Future.wait(cpkImplicitChildCache.map(deleteCpkImplicitChild));
   await Future.wait(ownerOnlyCache.map(deleteOwnerOnly));
+  await Future.wait(lowerCaseCache.map(deleteLowerCase));
 }
 
 /// Wait for subscription established for given request.

--- a/packages/api/amplify_api/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/api/amplify_api/example/ios/Runner.xcodeproj/project.pbxproj
@@ -155,7 +155,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -226,6 +226,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (

--- a/packages/api/amplify_api/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/api/amplify_api/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/api/amplify_api/example/lib/models/Blog.dart
+++ b/packages/api/amplify_api/example/lib/models/Blog.dart
@@ -20,19 +20,17 @@
 // ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/amplify_core.dart' as amplify_core;
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
 
-/// This is an auto generated class representing the Blog type in your schema.
-@immutable
-class Blog extends Model {
-  static const classType = _BlogModelType();
+/** This is an auto generated class representing the Blog type in your schema. */
+class Blog extends amplify_core.Model {
+  static const classType = const _BlogModelType();
   final String id;
   final String? _name;
   final List<Post>? _posts;
-  final TemporalDateTime? _createdAt;
-  final TemporalDateTime? _updatedAt;
+  final amplify_core.TemporalDateTime? _createdAt;
+  final amplify_core.TemporalDateTime? _updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -50,10 +48,10 @@ class Blog extends Model {
     try {
       return _name!;
     } catch (e) {
-      throw AmplifyCodeGenModelException(
-          AmplifyExceptionMessages
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion: AmplifyExceptionMessages
+          recoverySuggestion: amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastRecoverySuggestion,
           underlyingException: e.toString());
     }
@@ -63,11 +61,11 @@ class Blog extends Model {
     return _posts;
   }
 
-  TemporalDateTime? get createdAt {
+  amplify_core.TemporalDateTime? get createdAt {
     return _createdAt;
   }
 
-  TemporalDateTime? get updatedAt {
+  amplify_core.TemporalDateTime? get updatedAt {
     return _updatedAt;
   }
 
@@ -80,7 +78,7 @@ class Blog extends Model {
 
   factory Blog({String? id, required String name, List<Post>? posts}) {
     return Blog._internal(
-        id: id == null ? UUID.getUUID() : id,
+        id: id == null ? amplify_core.UUID.getUUID() : id,
         name: name,
         posts: posts != null ? List<Post>.unmodifiable(posts) : posts);
   }
@@ -103,7 +101,7 @@ class Blog extends Model {
 
   @override
   String toString() {
-    var buffer = StringBuffer();
+    var buffer = new StringBuffer();
 
     buffer.write("Blog {");
     buffer.write("id=" + "$id" + ", ");
@@ -123,6 +121,14 @@ class Blog extends Model {
         id: id, name: name ?? this.name, posts: posts ?? this.posts);
   }
 
+  Blog copyWithModelFieldValues(
+      {ModelFieldValue<String>? name, ModelFieldValue<List<Post>?>? posts}) {
+    return Blog._internal(
+        id: id,
+        name: name == null ? this.name : name.value,
+        posts: posts == null ? this.posts : posts.value);
+  }
+
   Blog.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         _name = json['name'],
@@ -130,14 +136,14 @@ class Blog extends Model {
             ? (json['posts'] as List)
                 .where((e) => e?['serializedData'] != null)
                 .map((e) => Post.fromJson(
-                    Map<String, dynamic>.from(e['serializedData'])))
+                    new Map<String, dynamic>.from(e['serializedData'])))
                 .toList()
             : null,
         _createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
+            ? amplify_core.TemporalDateTime.fromString(json['createdAt'])
             : null,
         _updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
+            ? amplify_core.TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
   Map<String, dynamic> toJson() => {
@@ -156,76 +162,84 @@ class Blog extends Model {
         'updatedAt': _updatedAt
       };
 
-  static final QueryModelIdentifier<BlogModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<BlogModelIdentifier>();
-  static final QueryField ID = QueryField(fieldName: "id");
-  static final QueryField NAME = QueryField(fieldName: "name");
-  static final QueryField POSTS = QueryField(
+  static final amplify_core.QueryModelIdentifier<BlogModelIdentifier>
+      MODEL_IDENTIFIER =
+      amplify_core.QueryModelIdentifier<BlogModelIdentifier>();
+  static final ID = amplify_core.QueryField(fieldName: "id");
+  static final NAME = amplify_core.QueryField(fieldName: "name");
+  static final POSTS = amplify_core.QueryField(
       fieldName: "posts",
-      fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: 'Post'));
-  static var schema =
-      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+      fieldType: amplify_core.ModelFieldType(
+          amplify_core.ModelFieldTypeEnum.model,
+          ofModelName: 'Post'));
+  static var schema = amplify_core.Model.defineSchema(
+      define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = "Blog";
     modelSchemaDefinition.pluralName = "Blogs";
 
     modelSchemaDefinition.authRules = [
-      AuthRule(
-          authStrategy: AuthStrategy.PUBLIC,
-          provider: AuthRuleProvider.APIKEY,
-          operations: [ModelOperation.READ]),
-      AuthRule(
-          authStrategy: AuthStrategy.PUBLIC,
-          provider: AuthRuleProvider.IAM,
-          operations: [ModelOperation.READ]),
-      AuthRule(
-          authStrategy: AuthStrategy.PRIVATE,
-          provider: AuthRuleProvider.IAM,
-          operations: [ModelOperation.READ]),
-      AuthRule(
-          authStrategy: AuthStrategy.PRIVATE,
-          provider: AuthRuleProvider.USERPOOLS,
-          operations: [ModelOperation.READ]),
-      AuthRule(
-          authStrategy: AuthStrategy.OWNER,
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PUBLIC,
+          provider: amplify_core.AuthRuleProvider.APIKEY,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PUBLIC,
+          provider: amplify_core.AuthRuleProvider.IAM,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PRIVATE,
+          provider: amplify_core.AuthRuleProvider.IAM,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PRIVATE,
+          provider: amplify_core.AuthRuleProvider.USERPOOLS,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.OWNER,
           ownerField: "owner",
           identityClaim: "cognito:username",
-          provider: AuthRuleProvider.USERPOOLS,
-          operations: [
-            ModelOperation.CREATE,
-            ModelOperation.READ,
-            ModelOperation.UPDATE,
-            ModelOperation.DELETE
+          provider: amplify_core.AuthRuleProvider.USERPOOLS,
+          operations: const [
+            amplify_core.ModelOperation.CREATE,
+            amplify_core.ModelOperation.READ,
+            amplify_core.ModelOperation.UPDATE,
+            amplify_core.ModelOperation.DELETE
           ])
     ];
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.id());
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
         key: Blog.NAME,
         isRequired: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+        ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.string)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.hasMany(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.hasMany(
         key: Blog.POSTS,
         isRequired: false,
         ofModelName: 'Post',
         associatedKey: Post.BLOG));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
-        fieldName: 'createdAt',
-        isRequired: false,
-        isReadOnly: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+    modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.nonQueryField(
+            fieldName: 'createdAt',
+            isRequired: false,
+            isReadOnly: true,
+            ofType: amplify_core.ModelFieldType(
+                amplify_core.ModelFieldTypeEnum.dateTime)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
-        fieldName: 'updatedAt',
-        isRequired: false,
-        isReadOnly: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+    modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.nonQueryField(
+            fieldName: 'updatedAt',
+            isRequired: false,
+            isReadOnly: true,
+            ofType: amplify_core.ModelFieldType(
+                amplify_core.ModelFieldTypeEnum.dateTime)));
   });
 }
 
-class _BlogModelType extends ModelType<Blog> {
+class _BlogModelType extends amplify_core.ModelType<Blog> {
   const _BlogModelType();
 
   @override
@@ -239,13 +253,14 @@ class _BlogModelType extends ModelType<Blog> {
   }
 }
 
-/// This is an auto generated class representing the model identifier
-/// of [Blog] in your schema.
-@immutable
-class BlogModelIdentifier implements ModelIdentifier<Blog> {
+/**
+ * This is an auto generated class representing the model identifier
+ * of [Blog] in your schema.
+ */
+class BlogModelIdentifier implements amplify_core.ModelIdentifier<Blog> {
   final String id;
 
-  /// Create an instance of BlogModelIdentifier using [id] the primary key.
+  /** Create an instance of BlogModelIdentifier using [id] the primary key. */
   const BlogModelIdentifier({required this.id});
 
   @override

--- a/packages/api/amplify_api/example/lib/models/Comment.dart
+++ b/packages/api/amplify_api/example/lib/models/Comment.dart
@@ -20,18 +20,16 @@
 // ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
-import 'package:flutter/foundation.dart';
+import 'package:amplify_core/amplify_core.dart' as amplify_core;
 
-/// This is an auto generated class representing the Comment type in your schema.
-@immutable
-class Comment extends Model {
-  static const classType = _CommentModelType();
+/** This is an auto generated class representing the Comment type in your schema. */
+class Comment extends amplify_core.Model {
+  static const classType = const _CommentModelType();
   final String id;
   final Post? _post;
   final String? _content;
-  final TemporalDateTime? _createdAt;
-  final TemporalDateTime? _updatedAt;
+  final amplify_core.TemporalDateTime? _createdAt;
+  final amplify_core.TemporalDateTime? _updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -53,20 +51,20 @@ class Comment extends Model {
     try {
       return _content!;
     } catch (e) {
-      throw AmplifyCodeGenModelException(
-          AmplifyExceptionMessages
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion: AmplifyExceptionMessages
+          recoverySuggestion: amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastRecoverySuggestion,
           underlyingException: e.toString());
     }
   }
 
-  TemporalDateTime? get createdAt {
+  amplify_core.TemporalDateTime? get createdAt {
     return _createdAt;
   }
 
-  TemporalDateTime? get updatedAt {
+  amplify_core.TemporalDateTime? get updatedAt {
     return _updatedAt;
   }
 
@@ -79,7 +77,9 @@ class Comment extends Model {
 
   factory Comment({String? id, Post? post, required String content}) {
     return Comment._internal(
-        id: id == null ? UUID.getUUID() : id, post: post, content: content);
+        id: id == null ? amplify_core.UUID.getUUID() : id,
+        post: post,
+        content: content);
   }
 
   bool equals(Object other) {
@@ -100,7 +100,7 @@ class Comment extends Model {
 
   @override
   String toString() {
-    var buffer = StringBuffer();
+    var buffer = new StringBuffer();
 
     buffer.write("Comment {");
     buffer.write("id=" + "$id" + ", ");
@@ -121,18 +121,26 @@ class Comment extends Model {
         id: id, post: post ?? this.post, content: content ?? this.content);
   }
 
+  Comment copyWithModelFieldValues(
+      {ModelFieldValue<Post?>? post, ModelFieldValue<String>? content}) {
+    return Comment._internal(
+        id: id,
+        post: post == null ? this.post : post.value,
+        content: content == null ? this.content : content.value);
+  }
+
   Comment.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         _post = json['post']?['serializedData'] != null
             ? Post.fromJson(
-                Map<String, dynamic>.from(json['post']['serializedData']))
+                new Map<String, dynamic>.from(json['post']['serializedData']))
             : null,
         _content = json['content'],
         _createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
+            ? amplify_core.TemporalDateTime.fromString(json['createdAt'])
             : null,
         _updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
+            ? amplify_core.TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
   Map<String, dynamic> toJson() => {
@@ -151,72 +159,80 @@ class Comment extends Model {
         'updatedAt': _updatedAt
       };
 
-  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<CommentModelIdentifier>();
-  static final QueryField ID = QueryField(fieldName: "id");
-  static final QueryField POST = QueryField(
+  static final amplify_core.QueryModelIdentifier<CommentModelIdentifier>
+      MODEL_IDENTIFIER =
+      amplify_core.QueryModelIdentifier<CommentModelIdentifier>();
+  static final ID = amplify_core.QueryField(fieldName: "id");
+  static final POST = amplify_core.QueryField(
       fieldName: "post",
-      fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: 'Post'));
-  static final QueryField CONTENT = QueryField(fieldName: "content");
-  static var schema =
-      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+      fieldType: amplify_core.ModelFieldType(
+          amplify_core.ModelFieldTypeEnum.model,
+          ofModelName: 'Post'));
+  static final CONTENT = amplify_core.QueryField(fieldName: "content");
+  static var schema = amplify_core.Model.defineSchema(
+      define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = "Comment";
     modelSchemaDefinition.pluralName = "Comments";
 
     modelSchemaDefinition.authRules = [
-      AuthRule(
-          authStrategy: AuthStrategy.PRIVATE,
-          provider: AuthRuleProvider.IAM,
-          operations: [ModelOperation.READ]),
-      AuthRule(
-          authStrategy: AuthStrategy.PRIVATE,
-          provider: AuthRuleProvider.USERPOOLS,
-          operations: [ModelOperation.READ]),
-      AuthRule(
-          authStrategy: AuthStrategy.OWNER,
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PRIVATE,
+          provider: amplify_core.AuthRuleProvider.IAM,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PRIVATE,
+          provider: amplify_core.AuthRuleProvider.USERPOOLS,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.OWNER,
           ownerField: "owner",
           identityClaim: "cognito:username",
-          provider: AuthRuleProvider.USERPOOLS,
-          operations: [
-            ModelOperation.CREATE,
-            ModelOperation.READ,
-            ModelOperation.UPDATE,
-            ModelOperation.DELETE
+          provider: amplify_core.AuthRuleProvider.USERPOOLS,
+          operations: const [
+            amplify_core.ModelOperation.CREATE,
+            amplify_core.ModelOperation.READ,
+            amplify_core.ModelOperation.UPDATE,
+            amplify_core.ModelOperation.DELETE
           ])
     ];
 
     modelSchemaDefinition.indexes = [
-      ModelIndex(fields: const ["postID"], name: "byPost")
+      amplify_core.ModelIndex(fields: const ["postID"], name: "byPost")
     ];
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.id());
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
         key: Comment.POST,
         isRequired: false,
         targetNames: ['postID'],
         ofModelName: 'Post'));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
         key: Comment.CONTENT,
         isRequired: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+        ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.string)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
-        fieldName: 'createdAt',
-        isRequired: false,
-        isReadOnly: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+    modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.nonQueryField(
+            fieldName: 'createdAt',
+            isRequired: false,
+            isReadOnly: true,
+            ofType: amplify_core.ModelFieldType(
+                amplify_core.ModelFieldTypeEnum.dateTime)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
-        fieldName: 'updatedAt',
-        isRequired: false,
-        isReadOnly: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+    modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.nonQueryField(
+            fieldName: 'updatedAt',
+            isRequired: false,
+            isReadOnly: true,
+            ofType: amplify_core.ModelFieldType(
+                amplify_core.ModelFieldTypeEnum.dateTime)));
   });
 }
 
-class _CommentModelType extends ModelType<Comment> {
+class _CommentModelType extends amplify_core.ModelType<Comment> {
   const _CommentModelType();
 
   @override
@@ -230,13 +246,14 @@ class _CommentModelType extends ModelType<Comment> {
   }
 }
 
-/// This is an auto generated class representing the model identifier
-/// of [Comment] in your schema.
-@immutable
-class CommentModelIdentifier implements ModelIdentifier<Comment> {
+/**
+ * This is an auto generated class representing the model identifier
+ * of [Comment] in your schema.
+ */
+class CommentModelIdentifier implements amplify_core.ModelIdentifier<Comment> {
   final String id;
 
-  /// Create an instance of CommentModelIdentifier using [id] the primary key.
+  /** Create an instance of CommentModelIdentifier using [id] the primary key. */
   const CommentModelIdentifier({required this.id});
 
   @override

--- a/packages/api/amplify_api/example/lib/models/CpkOneToOneBidirectionalChildImplicitCD.dart
+++ b/packages/api/amplify_api/example/lib/models/CpkOneToOneBidirectionalChildImplicitCD.dart
@@ -20,18 +20,17 @@
 // ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
-import 'package:flutter/foundation.dart';
+import 'package:amplify_core/amplify_core.dart' as amplify_core;
 
-/// This is an auto generated class representing the CpkOneToOneBidirectionalChildImplicitCD type in your schema.
-@immutable
-class CpkOneToOneBidirectionalChildImplicitCD extends Model {
-  static const classType = _CpkOneToOneBidirectionalChildImplicitCDModelType();
+/** This is an auto generated class representing the CpkOneToOneBidirectionalChildImplicitCD type in your schema. */
+class CpkOneToOneBidirectionalChildImplicitCD extends amplify_core.Model {
+  static const classType =
+      const _CpkOneToOneBidirectionalChildImplicitCDModelType();
   final String id;
   final String? _name;
   final CpkOneToOneBidirectionalParentCD? _belongsToParent;
-  final TemporalDateTime? _createdAt;
-  final TemporalDateTime? _updatedAt;
+  final amplify_core.TemporalDateTime? _createdAt;
+  final amplify_core.TemporalDateTime? _updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -46,10 +45,10 @@ class CpkOneToOneBidirectionalChildImplicitCD extends Model {
       return CpkOneToOneBidirectionalChildImplicitCDModelIdentifier(
           id: id, name: _name!);
     } catch (e) {
-      throw AmplifyCodeGenModelException(
-          AmplifyExceptionMessages
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion: AmplifyExceptionMessages
+          recoverySuggestion: amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastRecoverySuggestion,
           underlyingException: e.toString());
     }
@@ -59,10 +58,10 @@ class CpkOneToOneBidirectionalChildImplicitCD extends Model {
     try {
       return _name!;
     } catch (e) {
-      throw AmplifyCodeGenModelException(
-          AmplifyExceptionMessages
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion: AmplifyExceptionMessages
+          recoverySuggestion: amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastRecoverySuggestion,
           underlyingException: e.toString());
     }
@@ -72,11 +71,11 @@ class CpkOneToOneBidirectionalChildImplicitCD extends Model {
     return _belongsToParent;
   }
 
-  TemporalDateTime? get createdAt {
+  amplify_core.TemporalDateTime? get createdAt {
     return _createdAt;
   }
 
-  TemporalDateTime? get updatedAt {
+  amplify_core.TemporalDateTime? get updatedAt {
     return _updatedAt;
   }
 
@@ -92,7 +91,7 @@ class CpkOneToOneBidirectionalChildImplicitCD extends Model {
       required String name,
       CpkOneToOneBidirectionalParentCD? belongsToParent}) {
     return CpkOneToOneBidirectionalChildImplicitCD._internal(
-        id: id == null ? UUID.getUUID() : id,
+        id: id == null ? amplify_core.UUID.getUUID() : id,
         name: name,
         belongsToParent: belongsToParent);
   }
@@ -115,7 +114,7 @@ class CpkOneToOneBidirectionalChildImplicitCD extends Model {
 
   @override
   String toString() {
-    var buffer = StringBuffer();
+    var buffer = new StringBuffer();
 
     buffer.write("CpkOneToOneBidirectionalChildImplicitCD {");
     buffer.write("id=" + "$id" + ", ");
@@ -141,19 +140,29 @@ class CpkOneToOneBidirectionalChildImplicitCD extends Model {
         belongsToParent: belongsToParent ?? this.belongsToParent);
   }
 
+  CpkOneToOneBidirectionalChildImplicitCD copyWithModelFieldValues(
+      {ModelFieldValue<CpkOneToOneBidirectionalParentCD?>? belongsToParent}) {
+    return CpkOneToOneBidirectionalChildImplicitCD._internal(
+        id: id,
+        name: name,
+        belongsToParent: belongsToParent == null
+            ? this.belongsToParent
+            : belongsToParent.value);
+  }
+
   CpkOneToOneBidirectionalChildImplicitCD.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         _name = json['name'],
         _belongsToParent = json['belongsToParent']?['serializedData'] != null
             ? CpkOneToOneBidirectionalParentCD.fromJson(
-                Map<String, dynamic>.from(
+                new Map<String, dynamic>.from(
                     json['belongsToParent']['serializedData']))
             : null,
         _createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
+            ? amplify_core.TemporalDateTime.fromString(json['createdAt'])
             : null,
         _updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
+            ? amplify_core.TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
   Map<String, dynamic> toJson() => {
@@ -172,41 +181,48 @@ class CpkOneToOneBidirectionalChildImplicitCD extends Model {
         'updatedAt': _updatedAt
       };
 
-  static final QueryModelIdentifier<
+  static final amplify_core.QueryModelIdentifier<
           CpkOneToOneBidirectionalChildImplicitCDModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<
+      MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<
           CpkOneToOneBidirectionalChildImplicitCDModelIdentifier>();
-  static final QueryField ID = QueryField(fieldName: "id");
-  static final QueryField NAME = QueryField(fieldName: "name");
-  static final QueryField BELONGSTOPARENT = QueryField(
+  static final ID = amplify_core.QueryField(fieldName: "id");
+  static final NAME = amplify_core.QueryField(fieldName: "name");
+  static final BELONGSTOPARENT = amplify_core.QueryField(
       fieldName: "belongsToParent",
-      fieldType: ModelFieldType(ModelFieldTypeEnum.model,
+      fieldType: amplify_core.ModelFieldType(
+          amplify_core.ModelFieldTypeEnum.model,
           ofModelName: 'CpkOneToOneBidirectionalParentCD'));
-  static var schema =
-      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+  static var schema = amplify_core.Model.defineSchema(
+      define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = "CpkOneToOneBidirectionalChildImplicitCD";
     modelSchemaDefinition.pluralName =
         "CpkOneToOneBidirectionalChildImplicitCDS";
 
     modelSchemaDefinition.authRules = [
-      AuthRule(
-          authStrategy: AuthStrategy.PRIVATE,
-          provider: AuthRuleProvider.IAM,
-          operations: [ModelOperation.READ])
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PRIVATE,
+          provider: amplify_core.AuthRuleProvider.IAM,
+          operations: const [
+            amplify_core.ModelOperation.CREATE,
+            amplify_core.ModelOperation.UPDATE,
+            amplify_core.ModelOperation.DELETE,
+            amplify_core.ModelOperation.READ
+          ])
     ];
 
     modelSchemaDefinition.indexes = [
-      ModelIndex(fields: const ["id", "name"], name: null)
+      amplify_core.ModelIndex(fields: const ["id", "name"], name: null)
     ];
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.id());
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
         key: CpkOneToOneBidirectionalChildImplicitCD.NAME,
         isRequired: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+        ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.string)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
         key: CpkOneToOneBidirectionalChildImplicitCD.BELONGSTOPARENT,
         isRequired: false,
         targetNames: [
@@ -215,22 +231,26 @@ class CpkOneToOneBidirectionalChildImplicitCD extends Model {
         ],
         ofModelName: 'CpkOneToOneBidirectionalParentCD'));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
-        fieldName: 'createdAt',
-        isRequired: false,
-        isReadOnly: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+    modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.nonQueryField(
+            fieldName: 'createdAt',
+            isRequired: false,
+            isReadOnly: true,
+            ofType: amplify_core.ModelFieldType(
+                amplify_core.ModelFieldTypeEnum.dateTime)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
-        fieldName: 'updatedAt',
-        isRequired: false,
-        isReadOnly: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+    modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.nonQueryField(
+            fieldName: 'updatedAt',
+            isRequired: false,
+            isReadOnly: true,
+            ofType: amplify_core.ModelFieldType(
+                amplify_core.ModelFieldTypeEnum.dateTime)));
   });
 }
 
 class _CpkOneToOneBidirectionalChildImplicitCDModelType
-    extends ModelType<CpkOneToOneBidirectionalChildImplicitCD> {
+    extends amplify_core.ModelType<CpkOneToOneBidirectionalChildImplicitCD> {
   const _CpkOneToOneBidirectionalChildImplicitCDModelType();
 
   @override
@@ -245,16 +265,20 @@ class _CpkOneToOneBidirectionalChildImplicitCDModelType
   }
 }
 
-/// This is an auto generated class representing the model identifier
-/// of [CpkOneToOneBidirectionalChildImplicitCD] in your schema.
-@immutable
+/**
+ * This is an auto generated class representing the model identifier
+ * of [CpkOneToOneBidirectionalChildImplicitCD] in your schema.
+ */
 class CpkOneToOneBidirectionalChildImplicitCDModelIdentifier
-    implements ModelIdentifier<CpkOneToOneBidirectionalChildImplicitCD> {
+    implements
+        amplify_core.ModelIdentifier<CpkOneToOneBidirectionalChildImplicitCD> {
   final String id;
   final String name;
 
-  /// Create an instance of CpkOneToOneBidirectionalChildImplicitCDModelIdentifier using [id] the primary key.
-  /// And [name] the sort key.
+  /**
+   * Create an instance of CpkOneToOneBidirectionalChildImplicitCDModelIdentifier using [id] the primary key.
+   * And [name] the sort key.
+   */
   const CpkOneToOneBidirectionalChildImplicitCDModelIdentifier(
       {required this.id, required this.name});
 

--- a/packages/api/amplify_api/example/lib/models/CpkOneToOneBidirectionalParentCD.dart
+++ b/packages/api/amplify_api/example/lib/models/CpkOneToOneBidirectionalParentCD.dart
@@ -20,19 +20,17 @@
 // ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
-import 'package:flutter/foundation.dart';
+import 'package:amplify_core/amplify_core.dart' as amplify_core;
 
-/// This is an auto generated class representing the CpkOneToOneBidirectionalParentCD type in your schema.
-@immutable
-class CpkOneToOneBidirectionalParentCD extends Model {
-  static const classType = _CpkOneToOneBidirectionalParentCDModelType();
+/** This is an auto generated class representing the CpkOneToOneBidirectionalParentCD type in your schema. */
+class CpkOneToOneBidirectionalParentCD extends amplify_core.Model {
+  static const classType = const _CpkOneToOneBidirectionalParentCDModelType();
   final String? _customId;
   final String? _name;
   final CpkOneToOneBidirectionalChildImplicitCD? _implicitChild;
   final CpkOneToOneBidirectionalChildExplicitCD? _explicitChild;
-  final TemporalDateTime? _createdAt;
-  final TemporalDateTime? _updatedAt;
+  final amplify_core.TemporalDateTime? _createdAt;
+  final amplify_core.TemporalDateTime? _updatedAt;
   final String? _cpkOneToOneBidirectionalParentCDImplicitChildId;
   final String? _cpkOneToOneBidirectionalParentCDImplicitChildName;
   final String? _cpkOneToOneBidirectionalParentCDExplicitChildId;
@@ -51,10 +49,10 @@ class CpkOneToOneBidirectionalParentCD extends Model {
       return CpkOneToOneBidirectionalParentCDModelIdentifier(
           customId: _customId!, name: _name!);
     } catch (e) {
-      throw AmplifyCodeGenModelException(
-          AmplifyExceptionMessages
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion: AmplifyExceptionMessages
+          recoverySuggestion: amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastRecoverySuggestion,
           underlyingException: e.toString());
     }
@@ -64,10 +62,10 @@ class CpkOneToOneBidirectionalParentCD extends Model {
     try {
       return _customId!;
     } catch (e) {
-      throw AmplifyCodeGenModelException(
-          AmplifyExceptionMessages
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion: AmplifyExceptionMessages
+          recoverySuggestion: amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastRecoverySuggestion,
           underlyingException: e.toString());
     }
@@ -77,10 +75,10 @@ class CpkOneToOneBidirectionalParentCD extends Model {
     try {
       return _name!;
     } catch (e) {
-      throw AmplifyCodeGenModelException(
-          AmplifyExceptionMessages
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion: AmplifyExceptionMessages
+          recoverySuggestion: amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastRecoverySuggestion,
           underlyingException: e.toString());
     }
@@ -94,11 +92,11 @@ class CpkOneToOneBidirectionalParentCD extends Model {
     return _explicitChild;
   }
 
-  TemporalDateTime? get createdAt {
+  amplify_core.TemporalDateTime? get createdAt {
     return _createdAt;
   }
 
-  TemporalDateTime? get updatedAt {
+  amplify_core.TemporalDateTime? get updatedAt {
     return _updatedAt;
   }
 
@@ -195,7 +193,7 @@ class CpkOneToOneBidirectionalParentCD extends Model {
 
   @override
   String toString() {
-    var buffer = StringBuffer();
+    var buffer = new StringBuffer();
 
     buffer.write("CpkOneToOneBidirectionalParentCD {");
     buffer.write("customId=" + "$_customId" + ", ");
@@ -248,24 +246,58 @@ class CpkOneToOneBidirectionalParentCD extends Model {
                 this.cpkOneToOneBidirectionalParentCDExplicitChildName);
   }
 
+  CpkOneToOneBidirectionalParentCD copyWithModelFieldValues(
+      {ModelFieldValue<CpkOneToOneBidirectionalChildImplicitCD?>? implicitChild,
+      ModelFieldValue<CpkOneToOneBidirectionalChildExplicitCD?>? explicitChild,
+      ModelFieldValue<String?>? cpkOneToOneBidirectionalParentCDImplicitChildId,
+      ModelFieldValue<String?>?
+          cpkOneToOneBidirectionalParentCDImplicitChildName,
+      ModelFieldValue<String?>? cpkOneToOneBidirectionalParentCDExplicitChildId,
+      ModelFieldValue<String?>?
+          cpkOneToOneBidirectionalParentCDExplicitChildName}) {
+    return CpkOneToOneBidirectionalParentCD._internal(
+        customId: customId,
+        name: name,
+        implicitChild:
+            implicitChild == null ? this.implicitChild : implicitChild.value,
+        explicitChild:
+            explicitChild == null ? this.explicitChild : explicitChild.value,
+        cpkOneToOneBidirectionalParentCDImplicitChildId:
+            cpkOneToOneBidirectionalParentCDImplicitChildId == null
+                ? this.cpkOneToOneBidirectionalParentCDImplicitChildId
+                : cpkOneToOneBidirectionalParentCDImplicitChildId.value,
+        cpkOneToOneBidirectionalParentCDImplicitChildName:
+            cpkOneToOneBidirectionalParentCDImplicitChildName == null
+                ? this.cpkOneToOneBidirectionalParentCDImplicitChildName
+                : cpkOneToOneBidirectionalParentCDImplicitChildName.value,
+        cpkOneToOneBidirectionalParentCDExplicitChildId:
+            cpkOneToOneBidirectionalParentCDExplicitChildId == null
+                ? this.cpkOneToOneBidirectionalParentCDExplicitChildId
+                : cpkOneToOneBidirectionalParentCDExplicitChildId.value,
+        cpkOneToOneBidirectionalParentCDExplicitChildName:
+            cpkOneToOneBidirectionalParentCDExplicitChildName == null
+                ? this.cpkOneToOneBidirectionalParentCDExplicitChildName
+                : cpkOneToOneBidirectionalParentCDExplicitChildName.value);
+  }
+
   CpkOneToOneBidirectionalParentCD.fromJson(Map<String, dynamic> json)
       : _customId = json['customId'],
         _name = json['name'],
         _implicitChild = json['implicitChild']?['serializedData'] != null
             ? CpkOneToOneBidirectionalChildImplicitCD.fromJson(
-                Map<String, dynamic>.from(
+                new Map<String, dynamic>.from(
                     json['implicitChild']['serializedData']))
             : null,
         _explicitChild = json['explicitChild']?['serializedData'] != null
             ? CpkOneToOneBidirectionalChildExplicitCD.fromJson(
-                Map<String, dynamic>.from(
+                new Map<String, dynamic>.from(
                     json['explicitChild']['serializedData']))
             : null,
         _createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
+            ? amplify_core.TemporalDateTime.fromString(json['createdAt'])
             : null,
         _updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
+            ? amplify_core.TemporalDateTime.fromString(json['updatedAt'])
             : null,
         _cpkOneToOneBidirectionalParentCDImplicitChildId =
             json['cpkOneToOneBidirectionalParentCDImplicitChildId'],
@@ -310,109 +342,129 @@ class CpkOneToOneBidirectionalParentCD extends Model {
             _cpkOneToOneBidirectionalParentCDExplicitChildName
       };
 
-  static final QueryModelIdentifier<
-          CpkOneToOneBidirectionalParentCDModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<CpkOneToOneBidirectionalParentCDModelIdentifier>();
-  static final QueryField CUSTOMID = QueryField(fieldName: "customId");
-  static final QueryField NAME = QueryField(fieldName: "name");
-  static final QueryField IMPLICITCHILD = QueryField(
+  static final amplify_core
+      .QueryModelIdentifier<CpkOneToOneBidirectionalParentCDModelIdentifier>
+      MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<
+          CpkOneToOneBidirectionalParentCDModelIdentifier>();
+  static final CUSTOMID = amplify_core.QueryField(fieldName: "customId");
+  static final NAME = amplify_core.QueryField(fieldName: "name");
+  static final IMPLICITCHILD = amplify_core.QueryField(
       fieldName: "implicitChild",
-      fieldType: ModelFieldType(ModelFieldTypeEnum.model,
+      fieldType: amplify_core.ModelFieldType(
+          amplify_core.ModelFieldTypeEnum.model,
           ofModelName: 'CpkOneToOneBidirectionalChildImplicitCD'));
-  static final QueryField EXPLICITCHILD = QueryField(
+  static final EXPLICITCHILD = amplify_core.QueryField(
       fieldName: "explicitChild",
-      fieldType: ModelFieldType(ModelFieldTypeEnum.model,
+      fieldType: amplify_core.ModelFieldType(
+          amplify_core.ModelFieldTypeEnum.model,
           ofModelName: 'CpkOneToOneBidirectionalChildExplicitCD'));
-  static final QueryField CPKONETOONEBIDIRECTIONALPARENTCDIMPLICITCHILDID =
-      QueryField(fieldName: "cpkOneToOneBidirectionalParentCDImplicitChildId");
-  static final QueryField CPKONETOONEBIDIRECTIONALPARENTCDIMPLICITCHILDNAME =
-      QueryField(
+  static final CPKONETOONEBIDIRECTIONALPARENTCDIMPLICITCHILDID =
+      amplify_core.QueryField(
+          fieldName: "cpkOneToOneBidirectionalParentCDImplicitChildId");
+  static final CPKONETOONEBIDIRECTIONALPARENTCDIMPLICITCHILDNAME =
+      amplify_core.QueryField(
           fieldName: "cpkOneToOneBidirectionalParentCDImplicitChildName");
-  static final QueryField CPKONETOONEBIDIRECTIONALPARENTCDEXPLICITCHILDID =
-      QueryField(fieldName: "cpkOneToOneBidirectionalParentCDExplicitChildId");
-  static final QueryField CPKONETOONEBIDIRECTIONALPARENTCDEXPLICITCHILDNAME =
-      QueryField(
+  static final CPKONETOONEBIDIRECTIONALPARENTCDEXPLICITCHILDID =
+      amplify_core.QueryField(
+          fieldName: "cpkOneToOneBidirectionalParentCDExplicitChildId");
+  static final CPKONETOONEBIDIRECTIONALPARENTCDEXPLICITCHILDNAME =
+      amplify_core.QueryField(
           fieldName: "cpkOneToOneBidirectionalParentCDExplicitChildName");
-  static var schema =
-      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+  static var schema = amplify_core.Model.defineSchema(
+      define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = "CpkOneToOneBidirectionalParentCD";
     modelSchemaDefinition.pluralName = "CpkOneToOneBidirectionalParentCDS";
 
     modelSchemaDefinition.authRules = [
-      AuthRule(
-          authStrategy: AuthStrategy.PRIVATE,
-          provider: AuthRuleProvider.IAM,
-          operations: [ModelOperation.READ])
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PRIVATE,
+          provider: amplify_core.AuthRuleProvider.IAM,
+          operations: const [
+            amplify_core.ModelOperation.CREATE,
+            amplify_core.ModelOperation.UPDATE,
+            amplify_core.ModelOperation.DELETE,
+            amplify_core.ModelOperation.READ
+          ])
     ];
 
     modelSchemaDefinition.indexes = [
-      ModelIndex(fields: const ["customId", "name"], name: null)
+      amplify_core.ModelIndex(fields: const ["customId", "name"], name: null)
     ];
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
         key: CpkOneToOneBidirectionalParentCD.CUSTOMID,
         isRequired: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+        ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.string)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
         key: CpkOneToOneBidirectionalParentCD.NAME,
         isRequired: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+        ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.string)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.hasOne(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.hasOne(
         key: CpkOneToOneBidirectionalParentCD.IMPLICITCHILD,
         isRequired: false,
         ofModelName: 'CpkOneToOneBidirectionalChildImplicitCD',
         associatedKey:
             CpkOneToOneBidirectionalChildImplicitCD.BELONGSTOPARENT));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.hasOne(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.hasOne(
         key: CpkOneToOneBidirectionalParentCD.EXPLICITCHILD,
         isRequired: false,
         ofModelName: 'CpkOneToOneBidirectionalChildExplicitCD',
         associatedKey:
             CpkOneToOneBidirectionalChildExplicitCD.BELONGSTOPARENT));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
-        fieldName: 'createdAt',
-        isRequired: false,
-        isReadOnly: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+    modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.nonQueryField(
+            fieldName: 'createdAt',
+            isRequired: false,
+            isReadOnly: true,
+            ofType: amplify_core.ModelFieldType(
+                amplify_core.ModelFieldTypeEnum.dateTime)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
-        fieldName: 'updatedAt',
-        isRequired: false,
-        isReadOnly: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+    modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.nonQueryField(
+            fieldName: 'updatedAt',
+            isRequired: false,
+            isReadOnly: true,
+            ofType: amplify_core.ModelFieldType(
+                amplify_core.ModelFieldTypeEnum.dateTime)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
         key: CpkOneToOneBidirectionalParentCD
             .CPKONETOONEBIDIRECTIONALPARENTCDIMPLICITCHILDID,
         isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+        ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.string)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
         key: CpkOneToOneBidirectionalParentCD
             .CPKONETOONEBIDIRECTIONALPARENTCDIMPLICITCHILDNAME,
         isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+        ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.string)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
         key: CpkOneToOneBidirectionalParentCD
             .CPKONETOONEBIDIRECTIONALPARENTCDEXPLICITCHILDID,
         isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+        ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.string)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
         key: CpkOneToOneBidirectionalParentCD
             .CPKONETOONEBIDIRECTIONALPARENTCDEXPLICITCHILDNAME,
         isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+        ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.string)));
   });
 }
 
 class _CpkOneToOneBidirectionalParentCDModelType
-    extends ModelType<CpkOneToOneBidirectionalParentCD> {
+    extends amplify_core.ModelType<CpkOneToOneBidirectionalParentCD> {
   const _CpkOneToOneBidirectionalParentCDModelType();
 
   @override
@@ -426,16 +478,19 @@ class _CpkOneToOneBidirectionalParentCDModelType
   }
 }
 
-/// This is an auto generated class representing the model identifier
-/// of [CpkOneToOneBidirectionalParentCD] in your schema.
-@immutable
+/**
+ * This is an auto generated class representing the model identifier
+ * of [CpkOneToOneBidirectionalParentCD] in your schema.
+ */
 class CpkOneToOneBidirectionalParentCDModelIdentifier
-    implements ModelIdentifier<CpkOneToOneBidirectionalParentCD> {
+    implements amplify_core.ModelIdentifier<CpkOneToOneBidirectionalParentCD> {
   final String customId;
   final String name;
 
-  /// Create an instance of CpkOneToOneBidirectionalParentCDModelIdentifier using [customId] the primary key.
-  /// And [name] the sort key.
+  /**
+   * Create an instance of CpkOneToOneBidirectionalParentCDModelIdentifier using [customId] the primary key.
+   * And [name] the sort key.
+   */
   const CpkOneToOneBidirectionalParentCDModelIdentifier(
       {required this.customId, required this.name});
 

--- a/packages/api/amplify_api/example/lib/models/ModelProvider.dart
+++ b/packages/api/amplify_api/example/lib/models/ModelProvider.dart
@@ -19,7 +19,7 @@
 
 // ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/amplify_core.dart' as amplify_core;
 import 'Blog.dart';
 import 'Comment.dart';
 import 'CpkOneToOneBidirectionalChildExplicitCD.dart';
@@ -27,6 +27,7 @@ import 'CpkOneToOneBidirectionalChildImplicitCD.dart';
 import 'CpkOneToOneBidirectionalParentCD.dart';
 import 'OwnerOnly.dart';
 import 'Post.dart';
+import 'lowerCase.dart';
 
 export 'Blog.dart';
 export 'Comment.dart';
@@ -35,27 +36,29 @@ export 'CpkOneToOneBidirectionalChildImplicitCD.dart';
 export 'CpkOneToOneBidirectionalParentCD.dart';
 export 'OwnerOnly.dart';
 export 'Post.dart';
+export 'lowerCase.dart';
 
-class ModelProvider implements ModelProviderInterface {
+class ModelProvider implements amplify_core.ModelProviderInterface {
   @override
-  String version = "a88eeb9e37e28459e7e16f3f2f218f9e";
+  String version = "76a7a7d8d3182c2fe17550068e585db7";
   @override
-  List<ModelSchema> modelSchemas = [
+  List<amplify_core.ModelSchema> modelSchemas = [
     Blog.schema,
     Comment.schema,
     CpkOneToOneBidirectionalChildExplicitCD.schema,
     CpkOneToOneBidirectionalChildImplicitCD.schema,
     CpkOneToOneBidirectionalParentCD.schema,
     OwnerOnly.schema,
-    Post.schema
+    Post.schema,
+    lowerCase.schema
   ];
-  static final ModelProvider _instance = ModelProvider();
   @override
-  List<ModelSchema> customTypeSchemas = [];
+  List<amplify_core.ModelSchema> customTypeSchemas = [];
+  static final ModelProvider _instance = ModelProvider();
 
   static ModelProvider get instance => _instance;
 
-  ModelType getModelTypeByModelName(String modelName) {
+  amplify_core.ModelType getModelTypeByModelName(String modelName) {
     switch (modelName) {
       case "Blog":
         return Blog.classType;
@@ -71,10 +74,18 @@ class ModelProvider implements ModelProviderInterface {
         return OwnerOnly.classType;
       case "Post":
         return Post.classType;
+      case "lowerCase":
+        return lowerCase.classType;
       default:
         throw Exception(
             "Failed to find model in model provider for model name: " +
                 modelName);
     }
   }
+}
+
+class ModelFieldValue<T> {
+  const ModelFieldValue.value(this.value);
+
+  final T value;
 }

--- a/packages/api/amplify_api/example/lib/models/OwnerOnly.dart
+++ b/packages/api/amplify_api/example/lib/models/OwnerOnly.dart
@@ -19,17 +19,16 @@
 
 // ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
 
-import 'package:amplify_core/amplify_core.dart';
-import 'package:flutter/foundation.dart';
+import 'ModelProvider.dart';
+import 'package:amplify_core/amplify_core.dart' as amplify_core;
 
-/// This is an auto generated class representing the OwnerOnly type in your schema.
-@immutable
-class OwnerOnly extends Model {
-  static const classType = _OwnerOnlyModelType();
+/** This is an auto generated class representing the OwnerOnly type in your schema. */
+class OwnerOnly extends amplify_core.Model {
+  static const classType = const _OwnerOnlyModelType();
   final String id;
   final String? _name;
-  final TemporalDateTime? _createdAt;
-  final TemporalDateTime? _updatedAt;
+  final amplify_core.TemporalDateTime? _createdAt;
+  final amplify_core.TemporalDateTime? _updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -47,20 +46,20 @@ class OwnerOnly extends Model {
     try {
       return _name!;
     } catch (e) {
-      throw AmplifyCodeGenModelException(
-          AmplifyExceptionMessages
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion: AmplifyExceptionMessages
+          recoverySuggestion: amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastRecoverySuggestion,
           underlyingException: e.toString());
     }
   }
 
-  TemporalDateTime? get createdAt {
+  amplify_core.TemporalDateTime? get createdAt {
     return _createdAt;
   }
 
-  TemporalDateTime? get updatedAt {
+  amplify_core.TemporalDateTime? get updatedAt {
     return _updatedAt;
   }
 
@@ -72,7 +71,7 @@ class OwnerOnly extends Model {
 
   factory OwnerOnly({String? id, required String name}) {
     return OwnerOnly._internal(
-        id: id == null ? UUID.getUUID() : id, name: name);
+        id: id == null ? amplify_core.UUID.getUUID() : id, name: name);
   }
 
   bool equals(Object other) {
@@ -90,7 +89,7 @@ class OwnerOnly extends Model {
 
   @override
   String toString() {
-    var buffer = StringBuffer();
+    var buffer = new StringBuffer();
 
     buffer.write("OwnerOnly {");
     buffer.write("id=" + "$id" + ", ");
@@ -109,14 +108,19 @@ class OwnerOnly extends Model {
     return OwnerOnly._internal(id: id, name: name ?? this.name);
   }
 
+  OwnerOnly copyWithModelFieldValues({ModelFieldValue<String>? name}) {
+    return OwnerOnly._internal(
+        id: id, name: name == null ? this.name : name.value);
+  }
+
   OwnerOnly.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         _name = json['name'],
         _createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
+            ? amplify_core.TemporalDateTime.fromString(json['createdAt'])
             : null,
         _updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
+            ? amplify_core.TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
   Map<String, dynamic> toJson() => {
@@ -133,51 +137,57 @@ class OwnerOnly extends Model {
         'updatedAt': _updatedAt
       };
 
-  static final QueryModelIdentifier<OwnerOnlyModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<OwnerOnlyModelIdentifier>();
-  static final QueryField ID = QueryField(fieldName: "id");
-  static final QueryField NAME = QueryField(fieldName: "name");
-  static var schema =
-      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+  static final amplify_core.QueryModelIdentifier<OwnerOnlyModelIdentifier>
+      MODEL_IDENTIFIER =
+      amplify_core.QueryModelIdentifier<OwnerOnlyModelIdentifier>();
+  static final ID = amplify_core.QueryField(fieldName: "id");
+  static final NAME = amplify_core.QueryField(fieldName: "name");
+  static var schema = amplify_core.Model.defineSchema(
+      define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = "OwnerOnly";
     modelSchemaDefinition.pluralName = "OwnerOnlies";
 
     modelSchemaDefinition.authRules = [
-      AuthRule(
-          authStrategy: AuthStrategy.OWNER,
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.OWNER,
           ownerField: "owner",
           identityClaim: "cognito:username",
-          provider: AuthRuleProvider.USERPOOLS,
-          operations: [
-            ModelOperation.CREATE,
-            ModelOperation.UPDATE,
-            ModelOperation.DELETE,
-            ModelOperation.READ
+          provider: amplify_core.AuthRuleProvider.USERPOOLS,
+          operations: const [
+            amplify_core.ModelOperation.CREATE,
+            amplify_core.ModelOperation.UPDATE,
+            amplify_core.ModelOperation.DELETE,
+            amplify_core.ModelOperation.READ
           ])
     ];
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.id());
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
         key: OwnerOnly.NAME,
         isRequired: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+        ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.string)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
-        fieldName: 'createdAt',
-        isRequired: false,
-        isReadOnly: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+    modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.nonQueryField(
+            fieldName: 'createdAt',
+            isRequired: false,
+            isReadOnly: true,
+            ofType: amplify_core.ModelFieldType(
+                amplify_core.ModelFieldTypeEnum.dateTime)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
-        fieldName: 'updatedAt',
-        isRequired: false,
-        isReadOnly: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+    modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.nonQueryField(
+            fieldName: 'updatedAt',
+            isRequired: false,
+            isReadOnly: true,
+            ofType: amplify_core.ModelFieldType(
+                amplify_core.ModelFieldTypeEnum.dateTime)));
   });
 }
 
-class _OwnerOnlyModelType extends ModelType<OwnerOnly> {
+class _OwnerOnlyModelType extends amplify_core.ModelType<OwnerOnly> {
   const _OwnerOnlyModelType();
 
   @override
@@ -191,13 +201,15 @@ class _OwnerOnlyModelType extends ModelType<OwnerOnly> {
   }
 }
 
-/// This is an auto generated class representing the model identifier
-/// of [OwnerOnly] in your schema.
-@immutable
-class OwnerOnlyModelIdentifier implements ModelIdentifier<OwnerOnly> {
+/**
+ * This is an auto generated class representing the model identifier
+ * of [OwnerOnly] in your schema.
+ */
+class OwnerOnlyModelIdentifier
+    implements amplify_core.ModelIdentifier<OwnerOnly> {
   final String id;
 
-  /// Create an instance of OwnerOnlyModelIdentifier using [id] the primary key.
+  /** Create an instance of OwnerOnlyModelIdentifier using [id] the primary key. */
   const OwnerOnlyModelIdentifier({required this.id});
 
   @override

--- a/packages/api/amplify_api/example/lib/models/Post.dart
+++ b/packages/api/amplify_api/example/lib/models/Post.dart
@@ -20,21 +20,19 @@
 // ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_core/amplify_core.dart' as amplify_core;
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
 
-/// This is an auto generated class representing the Post type in your schema.
-@immutable
-class Post extends Model {
-  static const classType = _PostModelType();
+/** This is an auto generated class representing the Post type in your schema. */
+class Post extends amplify_core.Model {
+  static const classType = const _PostModelType();
   final String id;
   final String? _title;
   final int? _rating;
   final Blog? _blog;
   final List<Comment>? _comments;
-  final TemporalDateTime? _createdAt;
-  final TemporalDateTime? _updatedAt;
+  final amplify_core.TemporalDateTime? _createdAt;
+  final amplify_core.TemporalDateTime? _updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -52,10 +50,10 @@ class Post extends Model {
     try {
       return _title!;
     } catch (e) {
-      throw AmplifyCodeGenModelException(
-          AmplifyExceptionMessages
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion: AmplifyExceptionMessages
+          recoverySuggestion: amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastRecoverySuggestion,
           underlyingException: e.toString());
     }
@@ -65,10 +63,10 @@ class Post extends Model {
     try {
       return _rating!;
     } catch (e) {
-      throw AmplifyCodeGenModelException(
-          AmplifyExceptionMessages
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion: AmplifyExceptionMessages
+          recoverySuggestion: amplify_core.AmplifyExceptionMessages
               .codeGenRequiredFieldForceCastRecoverySuggestion,
           underlyingException: e.toString());
     }
@@ -82,11 +80,11 @@ class Post extends Model {
     return _comments;
   }
 
-  TemporalDateTime? get createdAt {
+  amplify_core.TemporalDateTime? get createdAt {
     return _createdAt;
   }
 
-  TemporalDateTime? get updatedAt {
+  amplify_core.TemporalDateTime? get updatedAt {
     return _updatedAt;
   }
 
@@ -112,7 +110,7 @@ class Post extends Model {
       Blog? blog,
       List<Comment>? comments}) {
     return Post._internal(
-        id: id == null ? UUID.getUUID() : id,
+        id: id == null ? amplify_core.UUID.getUUID() : id,
         title: title,
         rating: rating,
         blog: blog,
@@ -140,7 +138,7 @@ class Post extends Model {
 
   @override
   String toString() {
-    var buffer = StringBuffer();
+    var buffer = new StringBuffer();
 
     buffer.write("Post {");
     buffer.write("id=" + "$id" + ", ");
@@ -168,26 +166,39 @@ class Post extends Model {
         comments: comments ?? this.comments);
   }
 
+  Post copyWithModelFieldValues(
+      {ModelFieldValue<String>? title,
+      ModelFieldValue<int>? rating,
+      ModelFieldValue<Blog?>? blog,
+      ModelFieldValue<List<Comment>?>? comments}) {
+    return Post._internal(
+        id: id,
+        title: title == null ? this.title : title.value,
+        rating: rating == null ? this.rating : rating.value,
+        blog: blog == null ? this.blog : blog.value,
+        comments: comments == null ? this.comments : comments.value);
+  }
+
   Post.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         _title = json['title'],
         _rating = (json['rating'] as num?)?.toInt(),
         _blog = json['blog']?['serializedData'] != null
             ? Blog.fromJson(
-                Map<String, dynamic>.from(json['blog']['serializedData']))
+                new Map<String, dynamic>.from(json['blog']['serializedData']))
             : null,
         _comments = json['comments'] is List
             ? (json['comments'] as List)
                 .where((e) => e?['serializedData'] != null)
                 .map((e) => Comment.fromJson(
-                    Map<String, dynamic>.from(e['serializedData'])))
+                    new Map<String, dynamic>.from(e['serializedData'])))
                 .toList()
             : null,
         _createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
+            ? amplify_core.TemporalDateTime.fromString(json['createdAt'])
             : null,
         _updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
+            ? amplify_core.TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
   Map<String, dynamic> toJson() => {
@@ -210,92 +221,102 @@ class Post extends Model {
         'updatedAt': _updatedAt
       };
 
-  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<PostModelIdentifier>();
-  static final QueryField ID = QueryField(fieldName: "id");
-  static final QueryField TITLE = QueryField(fieldName: "title");
-  static final QueryField RATING = QueryField(fieldName: "rating");
-  static final QueryField BLOG = QueryField(
+  static final amplify_core.QueryModelIdentifier<PostModelIdentifier>
+      MODEL_IDENTIFIER =
+      amplify_core.QueryModelIdentifier<PostModelIdentifier>();
+  static final ID = amplify_core.QueryField(fieldName: "id");
+  static final TITLE = amplify_core.QueryField(fieldName: "title");
+  static final RATING = amplify_core.QueryField(fieldName: "rating");
+  static final BLOG = amplify_core.QueryField(
       fieldName: "blog",
-      fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: 'Blog'));
-  static final QueryField COMMENTS = QueryField(
+      fieldType: amplify_core.ModelFieldType(
+          amplify_core.ModelFieldTypeEnum.model,
+          ofModelName: 'Blog'));
+  static final COMMENTS = amplify_core.QueryField(
       fieldName: "comments",
-      fieldType:
-          ModelFieldType(ModelFieldTypeEnum.model, ofModelName: 'Comment'));
-  static var schema =
-      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+      fieldType: amplify_core.ModelFieldType(
+          amplify_core.ModelFieldTypeEnum.model,
+          ofModelName: 'Comment'));
+  static var schema = amplify_core.Model.defineSchema(
+      define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = "Post";
     modelSchemaDefinition.pluralName = "Posts";
 
     modelSchemaDefinition.authRules = [
-      AuthRule(
-          authStrategy: AuthStrategy.PUBLIC,
-          provider: AuthRuleProvider.IAM,
-          operations: [ModelOperation.READ]),
-      AuthRule(
-          authStrategy: AuthStrategy.PRIVATE,
-          provider: AuthRuleProvider.IAM,
-          operations: [ModelOperation.READ]),
-      AuthRule(
-          authStrategy: AuthStrategy.PRIVATE,
-          provider: AuthRuleProvider.USERPOOLS,
-          operations: [ModelOperation.READ]),
-      AuthRule(
-          authStrategy: AuthStrategy.OWNER,
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PUBLIC,
+          provider: amplify_core.AuthRuleProvider.IAM,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PRIVATE,
+          provider: amplify_core.AuthRuleProvider.IAM,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PRIVATE,
+          provider: amplify_core.AuthRuleProvider.USERPOOLS,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.OWNER,
           ownerField: "owner",
           identityClaim: "cognito:username",
-          provider: AuthRuleProvider.USERPOOLS,
-          operations: [
-            ModelOperation.CREATE,
-            ModelOperation.READ,
-            ModelOperation.UPDATE,
-            ModelOperation.DELETE
+          provider: amplify_core.AuthRuleProvider.USERPOOLS,
+          operations: const [
+            amplify_core.ModelOperation.CREATE,
+            amplify_core.ModelOperation.READ,
+            amplify_core.ModelOperation.UPDATE,
+            amplify_core.ModelOperation.DELETE
           ])
     ];
 
     modelSchemaDefinition.indexes = [
-      ModelIndex(fields: const ["blogID"], name: "byBlog")
+      amplify_core.ModelIndex(fields: const ["blogID"], name: "byBlog")
     ];
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.id());
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
         key: Post.TITLE,
         isRequired: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+        ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.string)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
         key: Post.RATING,
         isRequired: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.int)));
+        ofType:
+            amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.int)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
         key: Post.BLOG,
         isRequired: false,
         targetNames: ['blogID'],
         ofModelName: 'Blog'));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.hasMany(
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.hasMany(
         key: Post.COMMENTS,
         isRequired: false,
         ofModelName: 'Comment',
         associatedKey: Comment.POST));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
-        fieldName: 'createdAt',
-        isRequired: false,
-        isReadOnly: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+    modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.nonQueryField(
+            fieldName: 'createdAt',
+            isRequired: false,
+            isReadOnly: true,
+            ofType: amplify_core.ModelFieldType(
+                amplify_core.ModelFieldTypeEnum.dateTime)));
 
-    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
-        fieldName: 'updatedAt',
-        isRequired: false,
-        isReadOnly: true,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+    modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.nonQueryField(
+            fieldName: 'updatedAt',
+            isRequired: false,
+            isReadOnly: true,
+            ofType: amplify_core.ModelFieldType(
+                amplify_core.ModelFieldTypeEnum.dateTime)));
   });
 }
 
-class _PostModelType extends ModelType<Post> {
+class _PostModelType extends amplify_core.ModelType<Post> {
   const _PostModelType();
 
   @override
@@ -309,13 +330,14 @@ class _PostModelType extends ModelType<Post> {
   }
 }
 
-/// This is an auto generated class representing the model identifier
-/// of [Post] in your schema.
-@immutable
-class PostModelIdentifier implements ModelIdentifier<Post> {
+/**
+ * This is an auto generated class representing the model identifier
+ * of [Post] in your schema.
+ */
+class PostModelIdentifier implements amplify_core.ModelIdentifier<Post> {
   final String id;
 
-  /// Create an instance of PostModelIdentifier using [id] the primary key.
+  /** Create an instance of PostModelIdentifier using [id] the primary key. */
   const PostModelIdentifier({required this.id});
 
   @override

--- a/packages/api/amplify_api/example/lib/models/lowerCase.dart
+++ b/packages/api/amplify_api/example/lib/models/lowerCase.dart
@@ -22,13 +22,11 @@
 import 'ModelProvider.dart';
 import 'package:amplify_core/amplify_core.dart' as amplify_core;
 
-/** This is an auto generated class representing the CpkOneToOneBidirectionalChildExplicitCD type in your schema. */
-class CpkOneToOneBidirectionalChildExplicitCD extends amplify_core.Model {
-  static const classType =
-      const _CpkOneToOneBidirectionalChildExplicitCDModelType();
+/** This is an auto generated class representing the lowerCase type in your schema. */
+class lowerCase extends amplify_core.Model {
+  static const classType = const _lowerCaseModelType();
   final String id;
   final String? _name;
-  final CpkOneToOneBidirectionalParentCD? _belongsToParent;
   final amplify_core.TemporalDateTime? _createdAt;
   final amplify_core.TemporalDateTime? _updatedAt;
 
@@ -40,18 +38,8 @@ class CpkOneToOneBidirectionalChildExplicitCD extends amplify_core.Model {
   @override
   String getId() => id;
 
-  CpkOneToOneBidirectionalChildExplicitCDModelIdentifier get modelIdentifier {
-    try {
-      return CpkOneToOneBidirectionalChildExplicitCDModelIdentifier(
-          id: id, name: _name!);
-    } catch (e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages
-              .codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion: amplify_core.AmplifyExceptionMessages
-              .codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString());
-    }
+  lowerCaseModelIdentifier get modelIdentifier {
+    return lowerCaseModelIdentifier(id: id);
   }
 
   String get name {
@@ -67,10 +55,6 @@ class CpkOneToOneBidirectionalChildExplicitCD extends amplify_core.Model {
     }
   }
 
-  CpkOneToOneBidirectionalParentCD? get belongsToParent {
-    return _belongsToParent;
-  }
-
   amplify_core.TemporalDateTime? get createdAt {
     return _createdAt;
   }
@@ -79,21 +63,15 @@ class CpkOneToOneBidirectionalChildExplicitCD extends amplify_core.Model {
     return _updatedAt;
   }
 
-  const CpkOneToOneBidirectionalChildExplicitCD._internal(
-      {required this.id, required name, belongsToParent, createdAt, updatedAt})
+  const lowerCase._internal(
+      {required this.id, required name, createdAt, updatedAt})
       : _name = name,
-        _belongsToParent = belongsToParent,
         _createdAt = createdAt,
         _updatedAt = updatedAt;
 
-  factory CpkOneToOneBidirectionalChildExplicitCD(
-      {String? id,
-      required String name,
-      CpkOneToOneBidirectionalParentCD? belongsToParent}) {
-    return CpkOneToOneBidirectionalChildExplicitCD._internal(
-        id: id == null ? amplify_core.UUID.getUUID() : id,
-        name: name,
-        belongsToParent: belongsToParent);
+  factory lowerCase({String? id, required String name}) {
+    return lowerCase._internal(
+        id: id == null ? amplify_core.UUID.getUUID() : id, name: name);
   }
 
   bool equals(Object other) {
@@ -103,10 +81,7 @@ class CpkOneToOneBidirectionalChildExplicitCD extends amplify_core.Model {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is CpkOneToOneBidirectionalChildExplicitCD &&
-        id == other.id &&
-        _name == other._name &&
-        _belongsToParent == other._belongsToParent;
+    return other is lowerCase && id == other.id && _name == other._name;
   }
 
   @override
@@ -116,12 +91,9 @@ class CpkOneToOneBidirectionalChildExplicitCD extends amplify_core.Model {
   String toString() {
     var buffer = new StringBuffer();
 
-    buffer.write("CpkOneToOneBidirectionalChildExplicitCD {");
+    buffer.write("lowerCase {");
     buffer.write("id=" + "$id" + ", ");
     buffer.write("name=" + "$_name" + ", ");
-    buffer.write("belongsToParent=" +
-        (_belongsToParent != null ? _belongsToParent!.toString() : "null") +
-        ", ");
     buffer.write("createdAt=" +
         (_createdAt != null ? _createdAt!.format() : "null") +
         ", ");
@@ -132,32 +104,18 @@ class CpkOneToOneBidirectionalChildExplicitCD extends amplify_core.Model {
     return buffer.toString();
   }
 
-  CpkOneToOneBidirectionalChildExplicitCD copyWith(
-      {CpkOneToOneBidirectionalParentCD? belongsToParent}) {
-    return CpkOneToOneBidirectionalChildExplicitCD._internal(
-        id: id,
-        name: name,
-        belongsToParent: belongsToParent ?? this.belongsToParent);
+  lowerCase copyWith({String? name}) {
+    return lowerCase._internal(id: id, name: name ?? this.name);
   }
 
-  CpkOneToOneBidirectionalChildExplicitCD copyWithModelFieldValues(
-      {ModelFieldValue<CpkOneToOneBidirectionalParentCD?>? belongsToParent}) {
-    return CpkOneToOneBidirectionalChildExplicitCD._internal(
-        id: id,
-        name: name,
-        belongsToParent: belongsToParent == null
-            ? this.belongsToParent
-            : belongsToParent.value);
+  lowerCase copyWithModelFieldValues({ModelFieldValue<String>? name}) {
+    return lowerCase._internal(
+        id: id, name: name == null ? this.name : name.value);
   }
 
-  CpkOneToOneBidirectionalChildExplicitCD.fromJson(Map<String, dynamic> json)
+  lowerCase.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         _name = json['name'],
-        _belongsToParent = json['belongsToParent']?['serializedData'] != null
-            ? CpkOneToOneBidirectionalParentCD.fromJson(
-                new Map<String, dynamic>.from(
-                    json['belongsToParent']['serializedData']))
-            : null,
         _createdAt = json['createdAt'] != null
             ? amplify_core.TemporalDateTime.fromString(json['createdAt'])
             : null,
@@ -168,7 +126,6 @@ class CpkOneToOneBidirectionalChildExplicitCD extends amplify_core.Model {
   Map<String, dynamic> toJson() => {
         'id': id,
         'name': _name,
-        'belongsToParent': _belongsToParent?.toJson(),
         'createdAt': _createdAt?.format(),
         'updatedAt': _updatedAt?.format()
       };
@@ -176,57 +133,57 @@ class CpkOneToOneBidirectionalChildExplicitCD extends amplify_core.Model {
   Map<String, Object?> toMap() => {
         'id': id,
         'name': _name,
-        'belongsToParent': _belongsToParent,
         'createdAt': _createdAt,
         'updatedAt': _updatedAt
       };
 
-  static final amplify_core.QueryModelIdentifier<
-          CpkOneToOneBidirectionalChildExplicitCDModelIdentifier>
-      MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<
-          CpkOneToOneBidirectionalChildExplicitCDModelIdentifier>();
+  static final amplify_core.QueryModelIdentifier<lowerCaseModelIdentifier>
+      MODEL_IDENTIFIER =
+      amplify_core.QueryModelIdentifier<lowerCaseModelIdentifier>();
   static final ID = amplify_core.QueryField(fieldName: "id");
   static final NAME = amplify_core.QueryField(fieldName: "name");
-  static final BELONGSTOPARENT = amplify_core.QueryField(
-      fieldName: "belongsToParent",
-      fieldType: amplify_core.ModelFieldType(
-          amplify_core.ModelFieldTypeEnum.model,
-          ofModelName: 'CpkOneToOneBidirectionalParentCD'));
   static var schema = amplify_core.Model.defineSchema(
       define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
-    modelSchemaDefinition.name = "CpkOneToOneBidirectionalChildExplicitCD";
-    modelSchemaDefinition.pluralName =
-        "CpkOneToOneBidirectionalChildExplicitCDS";
+    modelSchemaDefinition.name = "lowerCase";
+    modelSchemaDefinition.pluralName = "lowerCases";
 
     modelSchemaDefinition.authRules = [
       amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PUBLIC,
+          provider: amplify_core.AuthRuleProvider.APIKEY,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PUBLIC,
+          provider: amplify_core.AuthRuleProvider.IAM,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
           authStrategy: amplify_core.AuthStrategy.PRIVATE,
           provider: amplify_core.AuthRuleProvider.IAM,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.PRIVATE,
+          provider: amplify_core.AuthRuleProvider.USERPOOLS,
+          operations: const [amplify_core.ModelOperation.READ]),
+      amplify_core.AuthRule(
+          authStrategy: amplify_core.AuthStrategy.OWNER,
+          ownerField: "owner",
+          identityClaim: "cognito:username",
+          provider: amplify_core.AuthRuleProvider.USERPOOLS,
           operations: const [
             amplify_core.ModelOperation.CREATE,
+            amplify_core.ModelOperation.READ,
             amplify_core.ModelOperation.UPDATE,
-            amplify_core.ModelOperation.DELETE,
-            amplify_core.ModelOperation.READ
+            amplify_core.ModelOperation.DELETE
           ])
-    ];
-
-    modelSchemaDefinition.indexes = [
-      amplify_core.ModelIndex(fields: const ["id", "name"], name: null)
     ];
 
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.id());
 
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-        key: CpkOneToOneBidirectionalChildExplicitCD.NAME,
+        key: lowerCase.NAME,
         isRequired: true,
         ofType: amplify_core.ModelFieldType(
             amplify_core.ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
-        key: CpkOneToOneBidirectionalChildExplicitCD.BELONGSTOPARENT,
-        isRequired: false,
-        targetNames: ['belongsToParentID', 'belongsToParentName'],
-        ofModelName: 'CpkOneToOneBidirectionalParentCD'));
 
     modelSchemaDefinition.addField(
         amplify_core.ModelFieldDefinition.nonQueryField(
@@ -246,42 +203,33 @@ class CpkOneToOneBidirectionalChildExplicitCD extends amplify_core.Model {
   });
 }
 
-class _CpkOneToOneBidirectionalChildExplicitCDModelType
-    extends amplify_core.ModelType<CpkOneToOneBidirectionalChildExplicitCD> {
-  const _CpkOneToOneBidirectionalChildExplicitCDModelType();
+class _lowerCaseModelType extends amplify_core.ModelType<lowerCase> {
+  const _lowerCaseModelType();
 
   @override
-  CpkOneToOneBidirectionalChildExplicitCD fromJson(
-      Map<String, dynamic> jsonData) {
-    return CpkOneToOneBidirectionalChildExplicitCD.fromJson(jsonData);
+  lowerCase fromJson(Map<String, dynamic> jsonData) {
+    return lowerCase.fromJson(jsonData);
   }
 
   @override
   String modelName() {
-    return 'CpkOneToOneBidirectionalChildExplicitCD';
+    return 'lowerCase';
   }
 }
 
 /**
  * This is an auto generated class representing the model identifier
- * of [CpkOneToOneBidirectionalChildExplicitCD] in your schema.
+ * of [lowerCase] in your schema.
  */
-class CpkOneToOneBidirectionalChildExplicitCDModelIdentifier
-    implements
-        amplify_core.ModelIdentifier<CpkOneToOneBidirectionalChildExplicitCD> {
+class lowerCaseModelIdentifier
+    implements amplify_core.ModelIdentifier<lowerCase> {
   final String id;
-  final String name;
 
-  /**
-   * Create an instance of CpkOneToOneBidirectionalChildExplicitCDModelIdentifier using [id] the primary key.
-   * And [name] the sort key.
-   */
-  const CpkOneToOneBidirectionalChildExplicitCDModelIdentifier(
-      {required this.id, required this.name});
+  /** Create an instance of lowerCaseModelIdentifier using [id] the primary key. */
+  const lowerCaseModelIdentifier({required this.id});
 
   @override
-  Map<String, dynamic> serializeAsMap() =>
-      (<String, dynamic>{'id': id, 'name': name});
+  Map<String, dynamic> serializeAsMap() => (<String, dynamic>{'id': id});
 
   @override
   List<Map<String, dynamic>> serializeAsList() => serializeAsMap()
@@ -293,8 +241,7 @@ class CpkOneToOneBidirectionalChildExplicitCDModelIdentifier
   String serializeAsString() => serializeAsMap().values.join('#');
 
   @override
-  String toString() =>
-      'CpkOneToOneBidirectionalChildExplicitCDModelIdentifier(id: $id, name: $name)';
+  String toString() => 'lowerCaseModelIdentifier(id: $id)';
 
   @override
   bool operator ==(Object other) {
@@ -302,11 +249,9 @@ class CpkOneToOneBidirectionalChildExplicitCDModelIdentifier
       return true;
     }
 
-    return other is CpkOneToOneBidirectionalChildExplicitCDModelIdentifier &&
-        id == other.id &&
-        name == other.name;
+    return other is lowerCaseModelIdentifier && id == other.id;
   }
 
   @override
-  int get hashCode => id.hashCode ^ name.hashCode;
+  int get hashCode => id.hashCode;
 }

--- a/packages/api/amplify_api_dart/lib/src/graphql/factories/graphql_request_factory.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/factories/graphql_request_factory.dart
@@ -126,7 +126,7 @@ class GraphQLRequestFactory {
   ) {
     var upperOutput = '';
     var lowerOutput = '';
-    final modelName = schema.name;
+    final modelName = _capitalize(schema.name);
 
     // build inputs based on request operation
     switch (operation) {
@@ -209,7 +209,7 @@ class GraphQLRequestFactory {
         getModelSchemaByModelName(modelType.modelName(), requestOperation);
 
     // e.g. "Blog" or "Blogs"
-    final name = _getName(schema, requestOperation);
+    final name = _capitalize(_getName(schema, requestOperation));
     // e.g. "query" or "mutation"
     final requestTypeVal = requestType.name;
     // e.g. "get" or "list"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/4109

*Description of changes:*
Fixes a bug where model names with lowercase names would not build the correct GraphQL request document

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
