### PR TITLE
chore(dep): update uuid dependency version range

### DIFF
--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   meta: ^1.7.0
   retry: ^3.1.0
   stack_trace: ^1.10.0
-  uuid: ">=3.0.6 <=3.0.7"
+  uuid: ">=3.0.6 <5.0.0"
 
 dev_dependencies:
   amplify_lints: ">=3.0.1 <3.1.0"

--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   path: ^1.8.0
   smithy: ">=0.6.1 <0.7.0"
   smithy_aws: ">=0.6.0 <0.7.0"
-  uuid: ">=3.0.6 <=3.0.7"
+  uuid: ">=3.0.6 <5.0.0"
 
 dev_dependencies:
   amplify_lints: ">=3.0.0 <3.1.0"

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   smithy: ">=0.6.0 <0.7.0"
   smithy_aws: ">=0.6.0 <0.7.0"
   stream_transform: ^2.0.0
-  uuid: ">=3.0.6 <=3.0.7"
+  uuid: ">=3.0.6 <5.0.0"
   win32: ">=4.1.2 <6.0.0"
   win32_registry: ^1.1.0
   worker_bee: ">=0.2.0+5 <0.3.0"

--- a/packages/authenticator/amplify_authenticator/example/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/example/pubspec.yaml
@@ -55,7 +55,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   stream_transform: ^2.0.0
-  uuid: ">=3.0.6 <=3.0.7"
+  uuid: ">=3.0.6 <5.0.0"
 
 flutter:
   uses-material-design: true

--- a/packages/aws_common/lib/src/util/uuid.dart
+++ b/packages/aws_common/lib/src/util/uuid.dart
@@ -1,19 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'dart:math';
+
 import 'package:uuid/uuid.dart';
-import 'package:uuid/uuid_util.dart';
 
 /// Generates a UUID (v4).
 ///
 /// If [secure] is `true`, uses a crypto-secure RNG at the cost of worse
 /// performance (5-100x, depending on the platform).
 String uuid({bool secure = false}) => const Uuid().v4(
+      // ignore: deprecated_member_use
       options: !secure
           ? null
-          // Use the crypto-secure RNG per `package:uuid` docs:
-          // https://github.com/Daegalus/dart-uuid/blob/d7bc930942afc752edd0fd15f8bf8234d81dfeda/example/example.dart#L21
           : const <String, Object>{
-              'rng': UuidUtil.cryptoRNG,
+              'rng': _cryptoRNG,
             },
     );
+
+/// Creates 16 digit cryptographically secure random number.
+List<int> _cryptoRNG() {
+  return List<int>.generate(16, (i) => Random.secure().nextInt(256));
+}

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   os_detect: ^2.0.0
   path: ^1.8.0
   stream_transform: ^2.0.0
-  uuid: ">=3.0.6 <=3.0.7"
+  uuid: ">=3.0.6 <5.0.0"
 
 dev_dependencies:
   amplify_lints: ">=3.0.0 <3.1.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   sqlite3: ^2.0.0
   source_gen: ^1.3.2
   stack_trace: ^1.10.0
-  uuid: ">=3.0.6 <=3.0.7"
+  uuid: ">=3.0.6 <5.0.0"
   win32: ">=4.1.2 <6.0.0"
   xml: 6.3.0
   test: ^1.22.1


### PR DESCRIPTION
*Issue #, if available:*
#4162 
*Description of changes:*
- use custom crypto rng function and remove dependency on UuidUtil.cryptoRNG because the uuid_util.dart is removed in v4.
- update the uuid dependency range to support v4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
