### PR TITLE
Feature: search in ModelQueries

### DIFF
--- a/packages/amplify_core/lib/src/types/query/query_field.dart
+++ b/packages/amplify_core/lib/src/types/query/query_field.dart
@@ -285,4 +285,26 @@ class QueryField<T> {
   QuerySortBy descending() {
     return QuerySortBy(field: fieldName, order: QuerySortOrder.descending);
   }
+
+  /// A **matchPhrasePrefix** operation.
+  ///
+  /// Matches models where the given field phase prefix with the provided value.
+  /// It's only for GraphQL API with Amplify.API.query()
+  /// You should've already created a search resolver in your GraphQL API.
+  /// See https://docs.amplify.aws/flutter/build-a-backend/graphqlapi/search-and-result-aggregations/
+  ///
+  /// ### Example:
+  /// The example returns Todos where the title phrase prefix with "fo".
+  /// If you have a Todo model with a title "foo", it will be returned as a result.
+  ///
+  /// ```dart
+  /// ModelQueries.search(
+  ///  Todo.classType,
+  ///  where: Todo.TITLE.matchPhrasePrefix("fo"),
+  ///  limit: 10
+  /// );
+  /// ```
+  QueryPredicateOperation matchPhrasePrefix(String value) =>
+      QueryPredicateOperation(
+          fieldName, MatchPhrasePrefixWithQueryOperator(value));
 }

--- a/packages/amplify_core/lib/src/types/query/query_field_operators.dart
+++ b/packages/amplify_core/lib/src/types/query/query_field_operators.dart
@@ -380,3 +380,29 @@ class BeginsWithQueryOperator extends QueryFieldOperatorSingleValue<String> {
   @override
   bool evaluateSerialized(String? other) => evaluate(other);
 }
+
+class MatchPhrasePrefixWithQueryOperator
+    extends QueryFieldOperatorSingleValue<String> {
+  const MatchPhrasePrefixWithQueryOperator(String value)
+      : super(value, QueryFieldOperatorType.match_phrase_prefix);
+
+  @override
+  bool evaluate(String? other) {
+    if (other == null) {
+      return false;
+    }
+    return other == value;
+  }
+
+  @override
+  bool evaluateSerialized(String? other) => evaluate(other);
+
+  @override
+  Map<String, dynamic> serializeAsMap() {
+    return <String, dynamic>{
+      'operatorName':
+          QueryFieldOperatorType.match_phrase_prefix.toShortString(),
+      'value': serializeDynamicValue(value),
+    };
+  }
+}

--- a/packages/api/amplify_api_dart/lib/src/graphql/factories/graphql_request_factory.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/factories/graphql_request_factory.dart
@@ -471,6 +471,7 @@ String _getGraphQLFilterExpression(QueryFieldOperatorType operatorType) {
     QueryFieldOperatorType.between: 'between',
     QueryFieldOperatorType.contains: 'contains',
     QueryFieldOperatorType.begins_with: 'beginsWith',
+    QueryFieldOperatorType.match_phrase_prefix: 'matchPhrasePrefix',
   };
   final result = dictionary[operatorType];
   if (result == null) {

--- a/packages/api/amplify_api_dart/lib/src/graphql/factories/model_queries_factory.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/factories/model_queries_factory.dart
@@ -58,4 +58,28 @@ class ModelQueriesFactory {
       headers: headers,
     );
   }
+
+   GraphQLRequest<PaginatedResult<T>> search<T extends Model>(
+    ModelType<T> modelType, {
+    int? limit,
+    QueryPredicate? where,
+    String? apiName,
+    APIAuthorizationType? authorizationMode,
+    Map<String, String>? headers,
+  }) {
+    final filter = GraphQLRequestFactory.instance
+        .queryPredicateToGraphQLFilter(where, modelType);
+    final variables = GraphQLRequestFactory.instance
+        .buildVariablesForListRequest(limit: limit, filter: filter);
+
+    return GraphQLRequestFactory.instance.buildRequest<PaginatedResult<T>>(
+      modelType: PaginatedModelType(modelType),
+      variables: variables,
+      requestType: GraphQLRequestType.query,
+      requestOperation: GraphQLRequestOperation.search,
+      apiName: apiName,
+      authorizationMode: authorizationMode,
+      headers: headers,
+    );
+  }
 }

--- a/packages/api/amplify_api_dart/lib/src/graphql/model_helpers/model_queries.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/model_helpers/model_queries.dart
@@ -59,6 +59,31 @@ class ModelQueries {
       headers: headers,
     );
   }
+
+  /// Generates a request for a search of model instances.
+  /// ```dart
+  /// final request = ModelQueries.search(
+  ///   Todo.classType,
+  ///   where: Todo.NAME.matchPhrasePrefix("Jo"),
+  ///   limit: 10);
+  /// ```
+  static GraphQLRequest<PaginatedResult<T>> search<T extends Model>(
+    ModelType<T> modelType, {
+    int? limit,
+    QueryPredicate? where,
+    String? apiName,
+    APIAuthorizationType? authorizationMode,
+    Map<String, String>? headers,
+  }) {
+    return ModelQueriesFactory.instance.search<T>(
+      modelType,
+      limit: limit,
+      where: where,
+      apiName: apiName,
+      authorizationMode: authorizationMode,
+      headers: headers,
+    );
+  }
 }
 
 // TODO(ragingsquirrel3): remove when https://github.com/dart-lang/sdk/issues/50748 addressed


### PR DESCRIPTION
**Issue:**
#4189 

**Description of changes:**
I created ModelQueries.search which based on ModelQueries.list, it's the same with .list except where operations, please check if it's looks good for you, I only added matchPhrasePrefix as a operation, I noted as  `/// It's only for GraphQL API with Amplify.API.query()`

There are DataStore operations like `QuerySortBy` and it's not a creating any issue that only using Amplify.API users. So I just added `matchPhrasePrefix` as a `QueryPredicateOperation`.

If it's looks good, I can add other operations using on search in GraphQL. These are: `matchPhrase, match, multiMatch, ne, range, regexp, eq, exists, gt, gte, lt, lte, wildcard`

but I think it's already enough with `matchPhrasePrefix`.