### PR TITLE
chore(core): relax .pubignore

### DIFF
--- a/packages/amplify_core/.pubignore
+++ b/packages/amplify_core/.pubignore
@@ -1,6 +1,1 @@
-# Ignore
-doc/*
-
-# Allow
-!doc/lib/*
-!doc/static/*
+doc/api/*


### PR DESCRIPTION
*Description of changes:*
Relaxes the `.pubignore` for amplify core docs folder. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
