### PR TITLE
fix(workflows): dart browser workflows

### DIFF
--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -82,5 +82,5 @@ jobs:
 
       - name: Run Tests
         if: "always() && steps.bootstrap.conclusion == 'success'"
-        run: dart run build_runner test --release --delete-conflicting-outputs -- -p ${{ matrix.browser }}
+        run: dart run build_runner build test --release --delete-conflicting-outputs && dart test -p ${{ matrix.browser }}
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Run Tests
         if: "always() && steps.bootstrap.conclusion == 'success'"
-        run: dart run build_runner test --delete-conflicting-outputs -- -p ${{ matrix.browser }}
+        run: dart run build_runner build test --delete-conflicting-outputs && dart test -p ${{ matrix.browser }}
         working-directory: ${{ inputs.working-directory }}
 
       - name: Log success/failure


### PR DESCRIPTION
This fixes an error of browser tests not being found when using the one liner `dart run build_runner test -- -p chrome`

Broke run command into two parts. 

1. Build the test directory with args: `dart run build_runner build test`
2. Then run tests given a platform: `dart test -p`

Context: 

Dart test browser suite was failing in CI after no changes to code base. Nor any external changes were identified.

<details>
  <summary>Original error log</summary>

```
$ dart run build_runner test -- -p chrome
[INFO] Generating build script completed, took 192ms
[INFO] Reading cached asset graph completed, took 185ms
[INFO] Checking for updates since last build completed, took 583ms
[INFO] Running build completed, took 115ms
[INFO] Caching finalized dependency graph completed, took 171ms
[INFO] Creating merged output dir `/var/folders/jn/qqs9x2394pv1vg9gz8g77[INFO] Creating merged output dir `/var/folders/jn/qqs9x2394pv1vg9gz8g77y1r0000gr/T/build_runner_testSfcoaM/` completed, took 249ms
[INFO] Writing asset manifest completed, took 4ms
[INFO] Succeeded after 565ms with 0 outputs (0 actions)
Running tests...

00:30 +0 -1: loading test/web_test.dart [E]
  Failed to load "test/web_test.dart":
  Timed out waiting for browser to load test suite. Browser output:
  DevTools listening on ws://127.0.0.1:59560/devtools/browser/bcd54593-11ac-439c-992f-f877ec2afc60
  [1222/120743.551809:INFO:CONSOLE(7705)] "Dart test runner browser host running", source: http://localhost:59557/e23aT5xFkV7itXvRgzcmQu2X3EK9ucEj/packages/test/src/runner/browser/static/host.dart.js (7705)
  [1222/120743.575677:INFO:CONSOLE(7733)] "Starting suite http://localhost:59557/e23aT5xFkV7itXvRgzcmQu2X3EK9ucEj/test/web_test.html", source: http://localhost:59557/e23aT5xFkV7itXvRgzcmQu2X3EK9ucEj/packages/test/src/runner/browser/static/host.dart.js (7733)

To run this test again: /opt/homebrew/Cellar/dart/3.2.4/libexec/bin/dart test test/web_test.dart -p chrome --plain-name 'loading test/web_test.dart'
00:30 +0 -1: Some tests failed.
```

</details>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
