### PR TITLE
chore(deps): bump xml range to 6.5.0

### DIFF
--- a/packages/smithy/goldens/lib/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXml/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   fixnum: ^1.0.0
   built_collection: ^5.0.0
   meta: ^1.7.0
-  xml: 6.5.0
+  xml: ">=6.3.0 <=6.5.0"
   shelf_router: ^1.1.0
   shelf: ^1.4.0
   aws_signature_v4:

--- a/packages/smithy/goldens/lib/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXml/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   fixnum: ^1.0.0
   built_collection: ^5.0.0
   meta: ^1.7.0
-  xml: 6.3.0
+  xml: 6.5.0
   shelf_router: ^1.1.0
   shelf: ^1.4.0
   aws_signature_v4:

--- a/packages/smithy/goldens/lib/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXml/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   fixnum: ^1.0.0
   built_collection: ^5.0.0
   meta: ^1.7.0
-  xml: 6.5.0
+  xml: 6.4.0
   shelf_router: ^1.1.0
   shelf: ^1.4.0
   aws_signature_v4:

--- a/packages/smithy/goldens/lib/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXml/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   fixnum: ^1.0.0
   built_collection: ^5.0.0
   meta: ^1.7.0
-  xml: 6.4.0
+  xml: 6.5.0
   shelf_router: ^1.1.0
   shelf: ^1.4.0
   aws_signature_v4:

--- a/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   aws_common:
     path: ../../../../aws_common
   built_value: ">=8.6.0 <8.8.0"
-  xml: 6.3.0
+  xml: 6.5.0
   fixnum: ^1.0.0
   meta: ^1.7.0
   built_collection: ^5.0.0

--- a/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   aws_common:
     path: ../../../../aws_common
   built_value: ">=8.6.0 <8.8.0"
-  xml: 6.5.0
+  xml: ">=6.3.0 <=6.5.0"
   fixnum: ^1.0.0
   meta: ^1.7.0
   built_collection: ^5.0.0

--- a/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   aws_common:
     path: ../../../../aws_common
   built_value: ">=8.6.0 <8.8.0"
-  xml: 6.5.0
+  xml: 6.4.0
   fixnum: ^1.0.0
   meta: ^1.7.0
   built_collection: ^5.0.0

--- a/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   aws_common:
     path: ../../../../aws_common
   built_value: ">=8.6.0 <8.8.0"
-  xml: 6.4.0
+  xml: 6.5.0
   fixnum: ^1.0.0
   meta: ^1.7.0
   built_collection: ^5.0.0

--- a/packages/smithy/goldens/lib2/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXml/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   fixnum: ^1.0.0
   built_collection: ^5.0.0
   meta: ^1.7.0
-  xml: 6.5.0
+  xml: ">=6.3.0 <=6.5.0"
   shelf_router: ^1.1.0
   shelf: ^1.4.0
   aws_signature_v4:

--- a/packages/smithy/goldens/lib2/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXml/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   fixnum: ^1.0.0
   built_collection: ^5.0.0
   meta: ^1.7.0
-  xml: 6.3.0
+  xml: 6.5.0
   shelf_router: ^1.1.0
   shelf: ^1.4.0
   aws_signature_v4:

--- a/packages/smithy/goldens/lib2/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXml/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   fixnum: ^1.0.0
   built_collection: ^5.0.0
   meta: ^1.7.0
-  xml: 6.5.0
+  xml: 6.4.0
   shelf_router: ^1.1.0
   shelf: ^1.4.0
   aws_signature_v4:

--- a/packages/smithy/goldens/lib2/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXml/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   fixnum: ^1.0.0
   built_collection: ^5.0.0
   meta: ^1.7.0
-  xml: 6.4.0
+  xml: 6.5.0
   shelf_router: ^1.1.0
   shelf: ^1.4.0
   aws_signature_v4:

--- a/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   aws_common:
     path: ../../../../aws_common
   built_value: ">=8.6.0 <8.8.0"
-  xml: 6.3.0
+  xml: 6.5.0
   fixnum: ^1.0.0
   meta: ^1.7.0
   built_collection: ^5.0.0

--- a/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   aws_common:
     path: ../../../../aws_common
   built_value: ">=8.6.0 <8.8.0"
-  xml: 6.5.0
+  xml: ">=6.3.0 <=6.5.0"
   fixnum: ^1.0.0
   meta: ^1.7.0
   built_collection: ^5.0.0

--- a/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   aws_common:
     path: ../../../../aws_common
   built_value: ">=8.6.0 <8.8.0"
-  xml: 6.5.0
+  xml: 6.4.0
   fixnum: ^1.0.0
   meta: ^1.7.0
   built_collection: ^5.0.0

--- a/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   aws_common:
     path: ../../../../aws_common
   built_value: ">=8.6.0 <8.8.0"
-  xml: 6.4.0
+  xml: 6.5.0
   fixnum: ^1.0.0
   meta: ^1.7.0
   built_collection: ^5.0.0

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   retry: ^3.1.0
   shelf: ^1.1.0
   typed_data: ^1.3.0
-  xml: 6.4.0
+  xml: 6.5.0
 
 dev_dependencies:
   amplify_lints: ">=3.0.2 <3.1.0"

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   retry: ^3.1.0
   shelf: ^1.1.0
   typed_data: ^1.3.0
-  xml: 6.5.0
+  xml: ">=6.3.0 <=6.5.0"
 
 dev_dependencies:
   amplify_lints: ">=3.0.2 <3.1.0"

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   retry: ^3.1.0
   shelf: ^1.1.0
   typed_data: ^1.3.0
-  xml: 6.5.0
+  xml: 6.4.0
 
 dev_dependencies:
   amplify_lints: ">=3.0.2 <3.1.0"

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   retry: ^3.1.0
   shelf: ^1.1.0
   typed_data: ^1.3.0
-  xml: 6.3.0
+  xml: 6.5.0
 
 dev_dependencies:
   amplify_lints: ">=3.0.2 <3.1.0"

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   smithy: ">=0.6.2 <0.7.0"
-  xml: 6.5.0
+  xml: 6.4.0
 
 dev_dependencies:
   amplify_lints: ">=3.0.0 <3.1.0"

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   smithy: ">=0.6.2 <0.7.0"
-  xml: 6.4.0
+  xml: 6.5.0
 
 dev_dependencies:
   amplify_lints: ">=3.0.0 <3.1.0"

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   smithy: ">=0.6.2 <0.7.0"
-  xml: 6.3.0
+  xml: 6.5.0
 
 dev_dependencies:
   amplify_lints: ">=3.0.0 <3.1.0"

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   smithy: ">=0.6.2 <0.7.0"
-  xml: 6.5.0
+  xml: ">=6.3.0 <=6.5.0"
 
 dev_dependencies:
   amplify_lints: ">=3.0.0 <3.1.0"

--- a/packages/smithy/smithy_codegen/pubspec.yaml
+++ b/packages/smithy/smithy_codegen/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   smithy: ">=0.6.0 <0.7.0"
   smithy_aws: ">=0.6.0 <0.7.0"
   tuple: ^2.0.0
-  xml: 6.3.0
+  xml: 6.5.0
   yaml_edit: ^2.0.1
 
 dev_dependencies:

--- a/packages/smithy/smithy_codegen/pubspec.yaml
+++ b/packages/smithy/smithy_codegen/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   smithy: ">=0.6.0 <0.7.0"
   smithy_aws: ">=0.6.0 <0.7.0"
   tuple: ^2.0.0
-  xml: 6.5.0
+  xml: 6.4.0
   yaml_edit: ^2.0.1
 
 dev_dependencies:

--- a/packages/smithy/smithy_codegen/pubspec.yaml
+++ b/packages/smithy/smithy_codegen/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   smithy: ">=0.6.0 <0.7.0"
   smithy_aws: ">=0.6.0 <0.7.0"
   tuple: ^2.0.0
-  xml: 6.4.0
+  xml: 6.5.0
   yaml_edit: ^2.0.1
 
 dev_dependencies:

--- a/packages/smithy/smithy_codegen/pubspec.yaml
+++ b/packages/smithy/smithy_codegen/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   smithy: ">=0.6.0 <0.7.0"
   smithy_aws: ">=0.6.0 <0.7.0"
   tuple: ^2.0.0
-  xml: 6.5.0
+  xml: ">=6.3.0 <=6.5.0"
   yaml_edit: ^2.0.1
 
 dev_dependencies:

--- a/packages/smithy/smithy_test/pubspec.yaml
+++ b/packages/smithy/smithy_test/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   smithy: any
   test: ^1.22.1
   tuple: ^2.0.0
-  xml: 6.4.0
+  xml: 6.5.0
 
 dev_dependencies:
   amplify_lints:

--- a/packages/smithy/smithy_test/pubspec.yaml
+++ b/packages/smithy/smithy_test/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   smithy: any
   test: ^1.22.1
   tuple: ^2.0.0
-  xml: 6.5.0
+  xml: ">=6.3.0 <=6.5.0"
 
 dev_dependencies:
   amplify_lints:

--- a/packages/smithy/smithy_test/pubspec.yaml
+++ b/packages/smithy/smithy_test/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   smithy: any
   test: ^1.22.1
   tuple: ^2.0.0
-  xml: 6.3.0
+  xml: 6.5.0
 
 dev_dependencies:
   amplify_lints:

--- a/packages/smithy/smithy_test/pubspec.yaml
+++ b/packages/smithy/smithy_test/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   smithy: any
   test: ^1.22.1
   tuple: ^2.0.0
-  xml: 6.5.0
+  xml: 6.4.0
 
 dev_dependencies:
   amplify_lints:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   stack_trace: ^1.10.0
   uuid: ">=3.0.6 <5.0.0"
   win32: ">=4.1.2 <6.0.0"
-  xml: 6.5.0
+  xml: ">=6.3.0 <=6.5.0"
   test: ^1.22.1
 
 aft:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   stack_trace: ^1.10.0
   uuid: ">=3.0.6 <5.0.0"
   win32: ">=4.1.2 <6.0.0"
-  xml: 6.5.0
+  xml: 6.4.0
   test: ^1.22.1
 
 aft:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   stack_trace: ^1.10.0
   uuid: ">=3.0.6 <5.0.0"
   win32: ">=4.1.2 <6.0.0"
-  xml: 6.3.0
+  xml: 6.5.0
   test: ^1.22.1
 
 aft:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   stack_trace: ^1.10.0
   uuid: ">=3.0.6 <5.0.0"
   win32: ">=4.1.2 <6.0.0"
-  xml: 6.4.0
+  xml: 6.5.0
   test: ^1.22.1
 
 aft:


### PR DESCRIPTION
*Issue #, if available:*
fixes #4297 
*Description of changes:*
- Bumps xml range to 6.5.0
- The version is no longer pinned because version 6.3.0 contained a code change that required us to bump to 6.3.0 exclusively. We can return to the window since there are no code changes needed for 6.4.0-6.5.0. 
- We also want to use the window because xml 6.5.0 requires SDK version 3.2.0, which would break us as we're using 3.0.1. Xml 6.4.0 also requires Dart 3.0 so going back to the window will allow customers to be more flexible with their dart version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
