### PR TITLE
chore(logging): update the sdk yaml definition for cloudwatch logs and regenerate the sdks

### DIFF
--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/cloud_watch_logs_client.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/cloud_watch_logs_client.dart
@@ -4,16 +4,11 @@
 library aws_logging_cloudwatch.cloud_watch_logs.cloud_watch_logs_client; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/create_log_stream_request.dart'
-    as _i4;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart'
-    as _i7;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart'
-    as _i6;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/operation/create_log_stream_operation.dart'
-    as _i5;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/operation/put_log_events_operation.dart'
-    as _i8;
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/create_log_stream_request.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/operation/create_log_stream_operation.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/operation/put_log_events_operation.dart';
 import 'package:aws_signature_v4/aws_signature_v4.dart' as _i2;
 import 'package:smithy/smithy.dart' as _i3;
 
@@ -41,7 +36,7 @@ class CloudWatchLogsClient {
     required String region,
     Uri? baseUri,
     _i2.AWSCredentialsProvider credentialsProvider =
-        const _i2.AWSCredentialsProvider.environment(),
+        const _i2.AWSCredentialsProvider.defaultChain(),
     List<_i3.HttpRequestInterceptor> requestInterceptors = const [],
     List<_i3.HttpResponseInterceptor> responseInterceptors = const [],
   })  : _client = client,
@@ -75,11 +70,11 @@ class CloudWatchLogsClient {
   ///
   /// *   Don't use ':' (colon) or '*' (asterisk) characters.
   _i3.SmithyOperation<void> createLogStream(
-    _i4.CreateLogStreamRequest input, {
+    CreateLogStreamRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
   }) {
-    return _i5.CreateLogStreamOperation(
+    return CreateLogStreamOperation(
       region: _region,
       baseUri: _baseUri,
       credentialsProvider: credentialsProvider ?? _credentialsProvider,
@@ -107,18 +102,20 @@ class CloudWatchLogsClient {
   ///
   /// *   A batch of log events in a single request cannot span more than 24 hours. Otherwise, the operation fails.
   ///
+  /// *   Each log event can be no larger than 256 KB.
+  ///
   /// *   The maximum number of log events in a batch is 10,000.
   ///
   /// *   The quota of five requests per second per log stream has been removed. Instead, `PutLogEvents` actions are throttled based on a per-second per-account quota. You can request an increase to the per-second throttling quota by using the Service Quotas service.
   ///
   ///
   /// If a call to `PutLogEvents` returns "UnrecognizedClientException" the most likely cause is a non-valid Amazon Web Services access key ID or secret key.
-  _i3.SmithyOperation<_i6.PutLogEventsResponse> putLogEvents(
-    _i7.PutLogEventsRequest input, {
+  _i3.SmithyOperation<PutLogEventsResponse> putLogEvents(
+    PutLogEventsRequest input, {
     _i1.AWSHttpClient? client,
     _i2.AWSCredentialsProvider? credentialsProvider,
   }) {
-    return _i8.PutLogEventsOperation(
+    return PutLogEventsOperation(
       region: _region,
       baseUri: _baseUri,
       credentialsProvider: credentialsProvider ?? _credentialsProvider,

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/common/serializers.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/common/serializers.dart
@@ -3,51 +3,39 @@
 
 library aws_logging_cloudwatch.cloud_watch_logs.common.serializers; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/create_log_stream_request.dart'
-    as _i2;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.dart'
-    as _i11;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/input_log_event.dart'
-    as _i7;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart'
-    as _i3;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.dart'
-    as _i12;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart'
-    as _i8;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart'
-    as _i10;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.dart'
-    as _i9;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/resource_already_exists_exception.dart'
-    as _i4;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart'
-    as _i5;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart'
-    as _i6;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.dart'
-    as _i13;
-import 'package:built_collection/built_collection.dart' as _i14;
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/create_log_stream_request.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/input_log_event.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/resource_already_exists_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.dart';
+import 'package:built_collection/built_collection.dart' as _i2;
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i1;
 
 const List<_i1.SmithySerializer> serializers = [
-  ..._i2.CreateLogStreamRequest.serializers,
-  ..._i3.InvalidParameterException.serializers,
-  ..._i4.ResourceAlreadyExistsException.serializers,
-  ..._i5.ResourceNotFoundException.serializers,
-  ..._i6.ServiceUnavailableException.serializers,
-  ..._i7.InputLogEvent.serializers,
-  ..._i8.PutLogEventsRequest.serializers,
-  ..._i9.RejectedLogEventsInfo.serializers,
-  ..._i10.PutLogEventsResponse.serializers,
-  ..._i11.DataAlreadyAcceptedException.serializers,
-  ..._i12.InvalidSequenceTokenException.serializers,
-  ..._i13.UnrecognizedClientException.serializers,
+  ...CreateLogStreamRequest.serializers,
+  ...InvalidParameterException.serializers,
+  ...ResourceAlreadyExistsException.serializers,
+  ...ResourceNotFoundException.serializers,
+  ...ServiceUnavailableException.serializers,
+  ...InputLogEvent.serializers,
+  ...PutLogEventsRequest.serializers,
+  ...RejectedLogEventsInfo.serializers,
+  ...PutLogEventsResponse.serializers,
+  ...DataAlreadyAcceptedException.serializers,
+  ...InvalidSequenceTokenException.serializers,
+  ...UnrecognizedClientException.serializers,
 ];
 final Map<FullType, Function> builderFactories = {
   const FullType(
-    _i14.BuiltList,
-    [FullType(_i7.InputLogEvent)],
-  ): _i14.ListBuilder<_i7.InputLogEvent>.new
+    _i2.BuiltList,
+    [FullType(InputLogEvent)],
+  ): _i2.ListBuilder<InputLogEvent>.new
 };

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/create_log_stream_request.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/create_log_stream_request.dart
@@ -41,9 +41,6 @@ abstract class CreateLogStreamRequest
   static const List<_i1.SmithySerializer<CreateLogStreamRequest>> serializers =
       [CreateLogStreamRequestAwsJson11Serializer()];
 
-  @BuiltValueHook(initializeBuilder: true)
-  static void _init(CreateLogStreamRequestBuilder b) {}
-
   /// The name of the log group.
   String get logGroupName;
 
@@ -51,11 +48,13 @@ abstract class CreateLogStreamRequest
   String get logStreamName;
   @override
   CreateLogStreamRequest getPayload() => this;
+
   @override
   List<Object?> get props => [
         logGroupName,
         logStreamName,
       ];
+
   @override
   String toString() {
     final helper = newBuiltValueToStringHelper('CreateLogStreamRequest')
@@ -81,6 +80,7 @@ class CreateLogStreamRequestAwsJson11Serializer
         CreateLogStreamRequest,
         _$CreateLogStreamRequest,
       ];
+
   @override
   Iterable<_i1.ShapeId> get supportedProtocols => const [
         _i1.ShapeId(
@@ -88,6 +88,7 @@ class CreateLogStreamRequestAwsJson11Serializer
           shape: 'awsJson1_1',
         )
       ];
+
   @override
   CreateLogStreamRequest deserialize(
     Serializers serializers,

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/create_log_stream_request.g.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/create_log_stream_request.g.dart
@@ -65,9 +65,7 @@ class CreateLogStreamRequestBuilder
   set logStreamName(String? logStreamName) =>
       _$this._logStreamName = logStreamName;
 
-  CreateLogStreamRequestBuilder() {
-    CreateLogStreamRequest._init(this);
-  }
+  CreateLogStreamRequestBuilder();
 
   CreateLogStreamRequestBuilder get _$this {
     final $v = _$v;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.dart
@@ -55,8 +55,6 @@ abstract class DataAlreadyAcceptedException
   static const List<_i2.SmithySerializer<DataAlreadyAcceptedException>>
       serializers = [DataAlreadyAcceptedExceptionAwsJson11Serializer()];
 
-  @BuiltValueHook(initializeBuilder: true)
-  static void _init(DataAlreadyAcceptedExceptionBuilder b) {}
   String? get expectedSequenceToken;
   @override
   String? get message;
@@ -65,8 +63,10 @@ abstract class DataAlreadyAcceptedException
         namespace: 'com.amazonaws.cloudwatchlogs',
         shape: 'DataAlreadyAcceptedException',
       );
+
   @override
   _i2.RetryConfig? get retryConfig => null;
+
   @override
   @BuiltValueField(compare: false)
   int? get statusCode;
@@ -75,11 +75,13 @@ abstract class DataAlreadyAcceptedException
   Map<String, String>? get headers;
   @override
   Exception? get underlyingException => null;
+
   @override
   List<Object?> get props => [
         expectedSequenceToken,
         message,
       ];
+
   @override
   String toString() {
     final helper = newBuiltValueToStringHelper('DataAlreadyAcceptedException')
@@ -105,6 +107,7 @@ class DataAlreadyAcceptedExceptionAwsJson11Serializer
         DataAlreadyAcceptedException,
         _$DataAlreadyAcceptedException,
       ];
+
   @override
   Iterable<_i2.ShapeId> get supportedProtocols => const [
         _i2.ShapeId(
@@ -112,6 +115,7 @@ class DataAlreadyAcceptedExceptionAwsJson11Serializer
           shape: 'awsJson1_1',
         )
       ];
+
   @override
   DataAlreadyAcceptedException deserialize(
     Serializers serializers,

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.g.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.g.dart
@@ -74,9 +74,7 @@ class DataAlreadyAcceptedExceptionBuilder
   Map<String, String>? get headers => _$this._headers;
   set headers(Map<String, String>? headers) => _$this._headers = headers;
 
-  DataAlreadyAcceptedExceptionBuilder() {
-    DataAlreadyAcceptedException._init(this);
-  }
+  DataAlreadyAcceptedExceptionBuilder();
 
   DataAlreadyAcceptedExceptionBuilder get _$this {
     final $v = _$v;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/input_log_event.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/input_log_event.dart
@@ -17,10 +17,9 @@ abstract class InputLogEvent
     implements Built<InputLogEvent, InputLogEventBuilder> {
   /// Represents a log event, which is a record of activity that was recorded by the application or resource being monitored.
   factory InputLogEvent({
-    _i2.Int64? timestamp,
+    required _i2.Int64 timestamp,
     required String message,
   }) {
-    timestamp ??= _i2.Int64.ZERO;
     return _$InputLogEvent._(
       timestamp: timestamp,
       message: message,
@@ -37,21 +36,17 @@ abstract class InputLogEvent
     InputLogEventAwsJson11Serializer()
   ];
 
-  @BuiltValueHook(initializeBuilder: true)
-  static void _init(InputLogEventBuilder b) {
-    b.timestamp = _i2.Int64.ZERO;
-  }
-
   /// The time the event occurred, expressed as the number of milliseconds after `Jan 1, 1970 00:00:00 UTC`.
   _i2.Int64 get timestamp;
 
-  /// The raw event message.
+  /// The raw event message. Each log event can be no larger than 256 KB.
   String get message;
   @override
   List<Object?> get props => [
         timestamp,
         message,
       ];
+
   @override
   String toString() {
     final helper = newBuiltValueToStringHelper('InputLogEvent')
@@ -76,6 +71,7 @@ class InputLogEventAwsJson11Serializer
         InputLogEvent,
         _$InputLogEvent,
       ];
+
   @override
   Iterable<_i3.ShapeId> get supportedProtocols => const [
         _i3.ShapeId(
@@ -83,6 +79,7 @@ class InputLogEventAwsJson11Serializer
           shape: 'awsJson1_1',
         )
       ];
+
   @override
   InputLogEvent deserialize(
     Serializers serializers,

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/input_log_event.g.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/input_log_event.g.dart
@@ -59,9 +59,7 @@ class InputLogEventBuilder
   String? get message => _$this._message;
   set message(String? message) => _$this._message = message;
 
-  InputLogEventBuilder() {
-    InputLogEvent._init(this);
-  }
+  InputLogEventBuilder();
 
   InputLogEventBuilder get _$this {
     final $v = _$v;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart
@@ -41,8 +41,6 @@ abstract class InvalidParameterException
   static const List<_i2.SmithySerializer<InvalidParameterException>>
       serializers = [InvalidParameterExceptionAwsJson11Serializer()];
 
-  @BuiltValueHook(initializeBuilder: true)
-  static void _init(InvalidParameterExceptionBuilder b) {}
   @override
   String? get message;
   @override
@@ -50,8 +48,10 @@ abstract class InvalidParameterException
         namespace: 'com.amazonaws.cloudwatchlogs',
         shape: 'InvalidParameterException',
       );
+
   @override
   _i2.RetryConfig? get retryConfig => null;
+
   @override
   @BuiltValueField(compare: false)
   int? get statusCode;
@@ -60,8 +60,10 @@ abstract class InvalidParameterException
   Map<String, String>? get headers;
   @override
   Exception? get underlyingException => null;
+
   @override
   List<Object?> get props => [message];
+
   @override
   String toString() {
     final helper = newBuiltValueToStringHelper('InvalidParameterException')
@@ -83,6 +85,7 @@ class InvalidParameterExceptionAwsJson11Serializer
         InvalidParameterException,
         _$InvalidParameterException,
       ];
+
   @override
   Iterable<_i2.ShapeId> get supportedProtocols => const [
         _i2.ShapeId(
@@ -90,6 +93,7 @@ class InvalidParameterExceptionAwsJson11Serializer
           shape: 'awsJson1_1',
         )
       ];
+
   @override
   InvalidParameterException deserialize(
     Serializers serializers,

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.g.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.g.dart
@@ -62,9 +62,7 @@ class InvalidParameterExceptionBuilder
   Map<String, String>? get headers => _$this._headers;
   set headers(Map<String, String>? headers) => _$this._headers = headers;
 
-  InvalidParameterExceptionBuilder() {
-    InvalidParameterException._init(this);
-  }
+  InvalidParameterExceptionBuilder();
 
   InvalidParameterExceptionBuilder get _$this {
     final $v = _$v;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.dart
@@ -55,8 +55,6 @@ abstract class InvalidSequenceTokenException
   static const List<_i2.SmithySerializer<InvalidSequenceTokenException>>
       serializers = [InvalidSequenceTokenExceptionAwsJson11Serializer()];
 
-  @BuiltValueHook(initializeBuilder: true)
-  static void _init(InvalidSequenceTokenExceptionBuilder b) {}
   String? get expectedSequenceToken;
   @override
   String? get message;
@@ -65,8 +63,10 @@ abstract class InvalidSequenceTokenException
         namespace: 'com.amazonaws.cloudwatchlogs',
         shape: 'InvalidSequenceTokenException',
       );
+
   @override
   _i2.RetryConfig? get retryConfig => null;
+
   @override
   @BuiltValueField(compare: false)
   int? get statusCode;
@@ -75,11 +75,13 @@ abstract class InvalidSequenceTokenException
   Map<String, String>? get headers;
   @override
   Exception? get underlyingException => null;
+
   @override
   List<Object?> get props => [
         expectedSequenceToken,
         message,
       ];
+
   @override
   String toString() {
     final helper = newBuiltValueToStringHelper('InvalidSequenceTokenException')
@@ -105,6 +107,7 @@ class InvalidSequenceTokenExceptionAwsJson11Serializer
         InvalidSequenceTokenException,
         _$InvalidSequenceTokenException,
       ];
+
   @override
   Iterable<_i2.ShapeId> get supportedProtocols => const [
         _i2.ShapeId(
@@ -112,6 +115,7 @@ class InvalidSequenceTokenExceptionAwsJson11Serializer
           shape: 'awsJson1_1',
         )
       ];
+
   @override
   InvalidSequenceTokenException deserialize(
     Serializers serializers,

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.g.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.g.dart
@@ -74,9 +74,7 @@ class InvalidSequenceTokenExceptionBuilder
   Map<String, String>? get headers => _$this._headers;
   set headers(Map<String, String>? headers) => _$this._headers = headers;
 
-  InvalidSequenceTokenExceptionBuilder() {
-    InvalidSequenceTokenException._init(this);
-  }
+  InvalidSequenceTokenExceptionBuilder();
 
   InvalidSequenceTokenExceptionBuilder get _$this {
     final $v = _$v;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart
@@ -4,9 +4,8 @@
 library aws_logging_cloudwatch.cloud_watch_logs.model.put_log_events_request; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i2;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/input_log_event.dart'
-    as _i3;
-import 'package:built_collection/built_collection.dart' as _i4;
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/input_log_event.dart';
+import 'package:built_collection/built_collection.dart' as _i3;
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:smithy/smithy.dart' as _i1;
@@ -21,13 +20,13 @@ abstract class PutLogEventsRequest
   factory PutLogEventsRequest({
     required String logGroupName,
     required String logStreamName,
-    required List<_i3.InputLogEvent> logEvents,
+    required List<InputLogEvent> logEvents,
     String? sequenceToken,
   }) {
     return _$PutLogEventsRequest._(
       logGroupName: logGroupName,
       logStreamName: logStreamName,
-      logEvents: _i4.BuiltList(logEvents),
+      logEvents: _i3.BuiltList(logEvents),
       sequenceToken: sequenceToken,
     );
   }
@@ -49,9 +48,6 @@ abstract class PutLogEventsRequest
     PutLogEventsRequestAwsJson11Serializer()
   ];
 
-  @BuiltValueHook(initializeBuilder: true)
-  static void _init(PutLogEventsRequestBuilder b) {}
-
   /// The name of the log group.
   String get logGroupName;
 
@@ -59,7 +55,7 @@ abstract class PutLogEventsRequest
   String get logStreamName;
 
   /// The log events.
-  _i4.BuiltList<_i3.InputLogEvent> get logEvents;
+  _i3.BuiltList<InputLogEvent> get logEvents;
 
   /// The sequence token obtained from the response of the previous `PutLogEvents` call.
   ///
@@ -67,6 +63,7 @@ abstract class PutLogEventsRequest
   String? get sequenceToken;
   @override
   PutLogEventsRequest getPayload() => this;
+
   @override
   List<Object?> get props => [
         logGroupName,
@@ -74,6 +71,7 @@ abstract class PutLogEventsRequest
         logEvents,
         sequenceToken,
       ];
+
   @override
   String toString() {
     final helper = newBuiltValueToStringHelper('PutLogEventsRequest')
@@ -106,6 +104,7 @@ class PutLogEventsRequestAwsJson11Serializer
         PutLogEventsRequest,
         _$PutLogEventsRequest,
       ];
+
   @override
   Iterable<_i1.ShapeId> get supportedProtocols => const [
         _i1.ShapeId(
@@ -113,6 +112,7 @@ class PutLogEventsRequestAwsJson11Serializer
           shape: 'awsJson1_1',
         )
       ];
+
   @override
   PutLogEventsRequest deserialize(
     Serializers serializers,
@@ -143,10 +143,10 @@ class PutLogEventsRequestAwsJson11Serializer
           result.logEvents.replace((serializers.deserialize(
             value,
             specifiedType: const FullType(
-              _i4.BuiltList,
-              [FullType(_i3.InputLogEvent)],
+              _i3.BuiltList,
+              [FullType(InputLogEvent)],
             ),
-          ) as _i4.BuiltList<_i3.InputLogEvent>));
+          ) as _i3.BuiltList<InputLogEvent>));
         case 'sequenceToken':
           result.sequenceToken = (serializers.deserialize(
             value,
@@ -186,8 +186,8 @@ class PutLogEventsRequestAwsJson11Serializer
       serializers.serialize(
         logEvents,
         specifiedType: const FullType(
-          _i4.BuiltList,
-          [FullType(_i3.InputLogEvent)],
+          _i3.BuiltList,
+          [FullType(InputLogEvent)],
         ),
       ),
     ]);

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_request.g.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_request.g.dart
@@ -12,7 +12,7 @@ class _$PutLogEventsRequest extends PutLogEventsRequest {
   @override
   final String logStreamName;
   @override
-  final _i4.BuiltList<_i3.InputLogEvent> logEvents;
+  final _i3.BuiltList<InputLogEvent> logEvents;
   @override
   final String? sequenceToken;
 
@@ -78,10 +78,10 @@ class PutLogEventsRequestBuilder
   set logStreamName(String? logStreamName) =>
       _$this._logStreamName = logStreamName;
 
-  _i4.ListBuilder<_i3.InputLogEvent>? _logEvents;
-  _i4.ListBuilder<_i3.InputLogEvent> get logEvents =>
-      _$this._logEvents ??= new _i4.ListBuilder<_i3.InputLogEvent>();
-  set logEvents(_i4.ListBuilder<_i3.InputLogEvent>? logEvents) =>
+  _i3.ListBuilder<InputLogEvent>? _logEvents;
+  _i3.ListBuilder<InputLogEvent> get logEvents =>
+      _$this._logEvents ??= new _i3.ListBuilder<InputLogEvent>();
+  set logEvents(_i3.ListBuilder<InputLogEvent>? logEvents) =>
       _$this._logEvents = logEvents;
 
   String? _sequenceToken;
@@ -89,9 +89,7 @@ class PutLogEventsRequestBuilder
   set sequenceToken(String? sequenceToken) =>
       _$this._sequenceToken = sequenceToken;
 
-  PutLogEventsRequestBuilder() {
-    PutLogEventsRequest._init(this);
-  }
+  PutLogEventsRequestBuilder();
 
   PutLogEventsRequestBuilder get _$this {
     final $v = _$v;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart
@@ -4,11 +4,10 @@
 library aws_logging_cloudwatch.cloud_watch_logs.model.put_log_events_response; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:aws_common/aws_common.dart' as _i1;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.dart'
-    as _i2;
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:smithy/smithy.dart' as _i3;
+import 'package:smithy/smithy.dart' as _i2;
 
 part 'put_log_events_response.g.dart';
 
@@ -17,7 +16,7 @@ abstract class PutLogEventsResponse
     implements Built<PutLogEventsResponse, PutLogEventsResponseBuilder> {
   factory PutLogEventsResponse({
     String? nextSequenceToken,
-    _i2.RejectedLogEventsInfo? rejectedLogEventsInfo,
+    RejectedLogEventsInfo? rejectedLogEventsInfo,
   }) {
     return _$PutLogEventsResponse._(
       nextSequenceToken: nextSequenceToken,
@@ -38,12 +37,9 @@ abstract class PutLogEventsResponse
   ) =>
       payload;
 
-  static const List<_i3.SmithySerializer<PutLogEventsResponse>> serializers = [
+  static const List<_i2.SmithySerializer<PutLogEventsResponse>> serializers = [
     PutLogEventsResponseAwsJson11Serializer()
   ];
-
-  @BuiltValueHook(initializeBuilder: true)
-  static void _init(PutLogEventsResponseBuilder b) {}
 
   /// The next sequence token.
   ///
@@ -53,12 +49,13 @@ abstract class PutLogEventsResponse
   String? get nextSequenceToken;
 
   /// The rejected events.
-  _i2.RejectedLogEventsInfo? get rejectedLogEventsInfo;
+  RejectedLogEventsInfo? get rejectedLogEventsInfo;
   @override
   List<Object?> get props => [
         nextSequenceToken,
         rejectedLogEventsInfo,
       ];
+
   @override
   String toString() {
     final helper = newBuiltValueToStringHelper('PutLogEventsResponse')
@@ -75,7 +72,7 @@ abstract class PutLogEventsResponse
 }
 
 class PutLogEventsResponseAwsJson11Serializer
-    extends _i3.StructuredSmithySerializer<PutLogEventsResponse> {
+    extends _i2.StructuredSmithySerializer<PutLogEventsResponse> {
   const PutLogEventsResponseAwsJson11Serializer()
       : super('PutLogEventsResponse');
 
@@ -84,13 +81,15 @@ class PutLogEventsResponseAwsJson11Serializer
         PutLogEventsResponse,
         _$PutLogEventsResponse,
       ];
+
   @override
-  Iterable<_i3.ShapeId> get supportedProtocols => const [
-        _i3.ShapeId(
+  Iterable<_i2.ShapeId> get supportedProtocols => const [
+        _i2.ShapeId(
           namespace: 'aws.protocols',
           shape: 'awsJson1_1',
         )
       ];
+
   @override
   PutLogEventsResponse deserialize(
     Serializers serializers,
@@ -115,8 +114,8 @@ class PutLogEventsResponseAwsJson11Serializer
         case 'rejectedLogEventsInfo':
           result.rejectedLogEventsInfo.replace((serializers.deserialize(
             value,
-            specifiedType: const FullType(_i2.RejectedLogEventsInfo),
-          ) as _i2.RejectedLogEventsInfo));
+            specifiedType: const FullType(RejectedLogEventsInfo),
+          ) as RejectedLogEventsInfo));
       }
     }
 
@@ -145,7 +144,7 @@ class PutLogEventsResponseAwsJson11Serializer
         ..add('rejectedLogEventsInfo')
         ..add(serializers.serialize(
           rejectedLogEventsInfo,
-          specifiedType: const FullType(_i2.RejectedLogEventsInfo),
+          specifiedType: const FullType(RejectedLogEventsInfo),
         ));
     }
     return result$;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_response.g.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/put_log_events_response.g.dart
@@ -10,7 +10,7 @@ class _$PutLogEventsResponse extends PutLogEventsResponse {
   @override
   final String? nextSequenceToken;
   @override
-  final _i2.RejectedLogEventsInfo? rejectedLogEventsInfo;
+  final RejectedLogEventsInfo? rejectedLogEventsInfo;
 
   factory _$PutLogEventsResponse(
           [void Function(PutLogEventsResponseBuilder)? updates]) =>
@@ -55,16 +55,14 @@ class PutLogEventsResponseBuilder
   set nextSequenceToken(String? nextSequenceToken) =>
       _$this._nextSequenceToken = nextSequenceToken;
 
-  _i2.RejectedLogEventsInfoBuilder? _rejectedLogEventsInfo;
-  _i2.RejectedLogEventsInfoBuilder get rejectedLogEventsInfo =>
-      _$this._rejectedLogEventsInfo ??= new _i2.RejectedLogEventsInfoBuilder();
+  RejectedLogEventsInfoBuilder? _rejectedLogEventsInfo;
+  RejectedLogEventsInfoBuilder get rejectedLogEventsInfo =>
+      _$this._rejectedLogEventsInfo ??= new RejectedLogEventsInfoBuilder();
   set rejectedLogEventsInfo(
-          _i2.RejectedLogEventsInfoBuilder? rejectedLogEventsInfo) =>
+          RejectedLogEventsInfoBuilder? rejectedLogEventsInfo) =>
       _$this._rejectedLogEventsInfo = rejectedLogEventsInfo;
 
-  PutLogEventsResponseBuilder() {
-    PutLogEventsResponse._init(this);
-  }
+  PutLogEventsResponseBuilder();
 
   PutLogEventsResponseBuilder get _$this {
     final $v = _$v;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.dart
@@ -38,9 +38,6 @@ abstract class RejectedLogEventsInfo
     RejectedLogEventsInfoAwsJson11Serializer()
   ];
 
-  @BuiltValueHook(initializeBuilder: true)
-  static void _init(RejectedLogEventsInfoBuilder b) {}
-
   /// The log events that are too new.
   int? get tooNewLogEventStartIndex;
 
@@ -55,6 +52,7 @@ abstract class RejectedLogEventsInfo
         tooOldLogEventEndIndex,
         expiredLogEventEndIndex,
       ];
+
   @override
   String toString() {
     final helper = newBuiltValueToStringHelper('RejectedLogEventsInfo')
@@ -84,6 +82,7 @@ class RejectedLogEventsInfoAwsJson11Serializer
         RejectedLogEventsInfo,
         _$RejectedLogEventsInfo,
       ];
+
   @override
   Iterable<_i2.ShapeId> get supportedProtocols => const [
         _i2.ShapeId(
@@ -91,6 +90,7 @@ class RejectedLogEventsInfoAwsJson11Serializer
           shape: 'awsJson1_1',
         )
       ];
+
   @override
   RejectedLogEventsInfo deserialize(
     Serializers serializers,

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.g.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/rejected_log_events_info.g.dart
@@ -72,9 +72,7 @@ class RejectedLogEventsInfoBuilder
   set expiredLogEventEndIndex(int? expiredLogEventEndIndex) =>
       _$this._expiredLogEventEndIndex = expiredLogEventEndIndex;
 
-  RejectedLogEventsInfoBuilder() {
-    RejectedLogEventsInfo._init(this);
-  }
+  RejectedLogEventsInfoBuilder();
 
   RejectedLogEventsInfoBuilder get _$this {
     final $v = _$v;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/resource_already_exists_exception.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/resource_already_exists_exception.dart
@@ -43,8 +43,6 @@ abstract class ResourceAlreadyExistsException
   static const List<_i2.SmithySerializer<ResourceAlreadyExistsException>>
       serializers = [ResourceAlreadyExistsExceptionAwsJson11Serializer()];
 
-  @BuiltValueHook(initializeBuilder: true)
-  static void _init(ResourceAlreadyExistsExceptionBuilder b) {}
   @override
   String? get message;
   @override
@@ -52,8 +50,10 @@ abstract class ResourceAlreadyExistsException
         namespace: 'com.amazonaws.cloudwatchlogs',
         shape: 'ResourceAlreadyExistsException',
       );
+
   @override
   _i2.RetryConfig? get retryConfig => null;
+
   @override
   @BuiltValueField(compare: false)
   int? get statusCode;
@@ -62,8 +62,10 @@ abstract class ResourceAlreadyExistsException
   Map<String, String>? get headers;
   @override
   Exception? get underlyingException => null;
+
   @override
   List<Object?> get props => [message];
+
   @override
   String toString() {
     final helper = newBuiltValueToStringHelper('ResourceAlreadyExistsException')
@@ -85,6 +87,7 @@ class ResourceAlreadyExistsExceptionAwsJson11Serializer
         ResourceAlreadyExistsException,
         _$ResourceAlreadyExistsException,
       ];
+
   @override
   Iterable<_i2.ShapeId> get supportedProtocols => const [
         _i2.ShapeId(
@@ -92,6 +95,7 @@ class ResourceAlreadyExistsExceptionAwsJson11Serializer
           shape: 'awsJson1_1',
         )
       ];
+
   @override
   ResourceAlreadyExistsException deserialize(
     Serializers serializers,

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/resource_already_exists_exception.g.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/resource_already_exists_exception.g.dart
@@ -64,9 +64,7 @@ class ResourceAlreadyExistsExceptionBuilder
   Map<String, String>? get headers => _$this._headers;
   set headers(Map<String, String>? headers) => _$this._headers = headers;
 
-  ResourceAlreadyExistsExceptionBuilder() {
-    ResourceAlreadyExistsException._init(this);
-  }
+  ResourceAlreadyExistsExceptionBuilder();
 
   ResourceAlreadyExistsExceptionBuilder get _$this {
     final $v = _$v;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart
@@ -41,8 +41,6 @@ abstract class ResourceNotFoundException
   static const List<_i2.SmithySerializer<ResourceNotFoundException>>
       serializers = [ResourceNotFoundExceptionAwsJson11Serializer()];
 
-  @BuiltValueHook(initializeBuilder: true)
-  static void _init(ResourceNotFoundExceptionBuilder b) {}
   @override
   String? get message;
   @override
@@ -50,8 +48,10 @@ abstract class ResourceNotFoundException
         namespace: 'com.amazonaws.cloudwatchlogs',
         shape: 'ResourceNotFoundException',
       );
+
   @override
   _i2.RetryConfig? get retryConfig => null;
+
   @override
   @BuiltValueField(compare: false)
   int? get statusCode;
@@ -60,8 +60,10 @@ abstract class ResourceNotFoundException
   Map<String, String>? get headers;
   @override
   Exception? get underlyingException => null;
+
   @override
   List<Object?> get props => [message];
+
   @override
   String toString() {
     final helper = newBuiltValueToStringHelper('ResourceNotFoundException')
@@ -83,6 +85,7 @@ class ResourceNotFoundExceptionAwsJson11Serializer
         ResourceNotFoundException,
         _$ResourceNotFoundException,
       ];
+
   @override
   Iterable<_i2.ShapeId> get supportedProtocols => const [
         _i2.ShapeId(
@@ -90,6 +93,7 @@ class ResourceNotFoundExceptionAwsJson11Serializer
           shape: 'awsJson1_1',
         )
       ];
+
   @override
   ResourceNotFoundException deserialize(
     Serializers serializers,

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.g.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.g.dart
@@ -62,9 +62,7 @@ class ResourceNotFoundExceptionBuilder
   Map<String, String>? get headers => _$this._headers;
   set headers(Map<String, String>? headers) => _$this._headers = headers;
 
-  ResourceNotFoundExceptionBuilder() {
-    ResourceNotFoundException._init(this);
-  }
+  ResourceNotFoundExceptionBuilder();
 
   ResourceNotFoundExceptionBuilder get _$this {
     final $v = _$v;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart
@@ -41,8 +41,6 @@ abstract class ServiceUnavailableException
   static const List<_i2.SmithySerializer<ServiceUnavailableException>>
       serializers = [ServiceUnavailableExceptionAwsJson11Serializer()];
 
-  @BuiltValueHook(initializeBuilder: true)
-  static void _init(ServiceUnavailableExceptionBuilder b) {}
   @override
   String? get message;
   @override
@@ -50,8 +48,10 @@ abstract class ServiceUnavailableException
         namespace: 'com.amazonaws.cloudwatchlogs',
         shape: 'ServiceUnavailableException',
       );
+
   @override
   _i2.RetryConfig? get retryConfig => null;
+
   @override
   @BuiltValueField(compare: false)
   int? get statusCode;
@@ -60,8 +60,10 @@ abstract class ServiceUnavailableException
   Map<String, String>? get headers;
   @override
   Exception? get underlyingException => null;
+
   @override
   List<Object?> get props => [message];
+
   @override
   String toString() {
     final helper = newBuiltValueToStringHelper('ServiceUnavailableException')
@@ -83,6 +85,7 @@ class ServiceUnavailableExceptionAwsJson11Serializer
         ServiceUnavailableException,
         _$ServiceUnavailableException,
       ];
+
   @override
   Iterable<_i2.ShapeId> get supportedProtocols => const [
         _i2.ShapeId(
@@ -90,6 +93,7 @@ class ServiceUnavailableExceptionAwsJson11Serializer
           shape: 'awsJson1_1',
         )
       ];
+
   @override
   ServiceUnavailableException deserialize(
     Serializers serializers,

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.g.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.g.dart
@@ -63,9 +63,7 @@ class ServiceUnavailableExceptionBuilder
   Map<String, String>? get headers => _$this._headers;
   set headers(Map<String, String>? headers) => _$this._headers = headers;
 
-  ServiceUnavailableExceptionBuilder() {
-    ServiceUnavailableException._init(this);
-  }
+  ServiceUnavailableExceptionBuilder();
 
   ServiceUnavailableExceptionBuilder get _$this {
     final $v = _$v;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.dart
@@ -41,8 +41,6 @@ abstract class UnrecognizedClientException
   static const List<_i2.SmithySerializer<UnrecognizedClientException>>
       serializers = [UnrecognizedClientExceptionAwsJson11Serializer()];
 
-  @BuiltValueHook(initializeBuilder: true)
-  static void _init(UnrecognizedClientExceptionBuilder b) {}
   @override
   String? get message;
   @override
@@ -50,8 +48,10 @@ abstract class UnrecognizedClientException
         namespace: 'com.amazonaws.cloudwatchlogs',
         shape: 'UnrecognizedClientException',
       );
+
   @override
   _i2.RetryConfig? get retryConfig => null;
+
   @override
   @BuiltValueField(compare: false)
   int? get statusCode;
@@ -60,8 +60,10 @@ abstract class UnrecognizedClientException
   Map<String, String>? get headers;
   @override
   Exception? get underlyingException => null;
+
   @override
   List<Object?> get props => [message];
+
   @override
   String toString() {
     final helper = newBuiltValueToStringHelper('UnrecognizedClientException')
@@ -83,6 +85,7 @@ class UnrecognizedClientExceptionAwsJson11Serializer
         UnrecognizedClientException,
         _$UnrecognizedClientException,
       ];
+
   @override
   Iterable<_i2.ShapeId> get supportedProtocols => const [
         _i2.ShapeId(
@@ -90,6 +93,7 @@ class UnrecognizedClientExceptionAwsJson11Serializer
           shape: 'awsJson1_1',
         )
       ];
+
   @override
   UnrecognizedClientException deserialize(
     Serializers serializers,

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.g.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.g.dart
@@ -63,9 +63,7 @@ class UnrecognizedClientExceptionBuilder
   Map<String, String>? get headers => _$this._headers;
   set headers(Map<String, String>? headers) => _$this._headers = headers;
 
-  UnrecognizedClientExceptionBuilder() {
-    UnrecognizedClientException._init(this);
-  }
+  UnrecognizedClientExceptionBuilder();
 
   UnrecognizedClientExceptionBuilder get _$this {
     final $v = _$v;

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/operation/create_log_stream_operation.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/operation/create_log_stream_operation.dart
@@ -3,26 +3,19 @@
 
 library aws_logging_cloudwatch.cloud_watch_logs.operation.create_log_stream_operation; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
-import 'dart:async' as _i12;
+import 'dart:async' as _i5;
 
-import 'package:aws_common/aws_common.dart' as _i6;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/common/endpoint_resolver.dart'
-    as _i7;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/common/serializers.dart'
-    as _i5;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/create_log_stream_request.dart'
-    as _i2;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart'
-    as _i8;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/resource_already_exists_exception.dart'
-    as _i9;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart'
-    as _i10;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart'
-    as _i11;
-import 'package:aws_signature_v4/aws_signature_v4.dart' as _i3;
+import 'package:aws_common/aws_common.dart' as _i4;
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/common/endpoint_resolver.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/common/serializers.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/create_log_stream_request.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/resource_already_exists_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart';
+import 'package:aws_signature_v4/aws_signature_v4.dart' as _i2;
 import 'package:smithy/smithy.dart' as _i1;
-import 'package:smithy_aws/smithy_aws.dart' as _i4;
+import 'package:smithy_aws/smithy_aws.dart' as _i3;
 
 /// Creates a log stream for the specified log group. A log stream is a sequence of log events that originate from a single source, such as an application instance or a resource that is being monitored.
 ///
@@ -35,11 +28,8 @@ import 'package:smithy_aws/smithy_aws.dart' as _i4;
 /// *   Log stream names can be between 1 and 512 characters long.
 ///
 /// *   Don't use ':' (colon) or '*' (asterisk) characters.
-class CreateLogStreamOperation extends _i1.HttpOperation<
-    _i2.CreateLogStreamRequest,
-    _i2.CreateLogStreamRequest,
-    _i1.Unit,
-    _i1.Unit> {
+class CreateLogStreamOperation extends _i1.HttpOperation<CreateLogStreamRequest,
+    CreateLogStreamRequest, _i1.Unit, _i1.Unit> {
   /// Creates a log stream for the specified log group. A log stream is a sequence of log events that originate from a single source, such as an application instance or a resource that is being monitored.
   ///
   /// There is no limit on the number of log streams that you can create for a log group. There is a limit of 50 TPS on `CreateLogStream` operations, after which transactions are throttled.
@@ -54,8 +44,8 @@ class CreateLogStreamOperation extends _i1.HttpOperation<
   CreateLogStreamOperation({
     required String region,
     Uri? baseUri,
-    _i3.AWSCredentialsProvider credentialsProvider =
-        const _i3.AWSCredentialsProvider.environment(),
+    _i2.AWSCredentialsProvider credentialsProvider =
+        const _i2.AWSCredentialsProvider.defaultChain(),
     List<_i1.HttpRequestInterceptor> requestInterceptors = const [],
     List<_i1.HttpResponseInterceptor> responseInterceptors = const [],
   })  : _region = region,
@@ -66,11 +56,11 @@ class CreateLogStreamOperation extends _i1.HttpOperation<
 
   @override
   late final List<
-      _i1.HttpProtocol<_i2.CreateLogStreamRequest, _i2.CreateLogStreamRequest,
-          _i1.Unit, _i1.Unit>> protocols = [
-    _i4.AwsJson1_1Protocol(
-      serializers: _i5.serializers,
-      builderFactories: _i5.builderFactories,
+      _i1.HttpProtocol<CreateLogStreamRequest, CreateLogStreamRequest, _i1.Unit,
+          _i1.Unit>> protocols = [
+    _i3.AwsJson1_1Protocol(
+      serializers: serializers,
+      builderFactories: builderFactories,
       requestInterceptors: <_i1.HttpRequestInterceptor>[
             const _i1.WithHost(),
             const _i1.WithContentLength(),
@@ -78,14 +68,14 @@ class CreateLogStreamOperation extends _i1.HttpOperation<
               'X-Amz-Target',
               'Logs_20140328.CreateLogStream',
             ),
-            _i4.WithSigV4(
+            _i3.WithSigV4(
               region: _region,
-              service: _i6.AWSService.cloudWatchLogs,
+              service: _i4.AWSService.cloudWatchLogs,
               credentialsProvider: _credentialsProvider,
             ),
             const _i1.WithUserAgent('aws-sdk-dart/0.3.1'),
-            const _i4.WithSdkInvocationId(),
-            const _i4.WithSdkRequest(),
+            const _i3.WithSdkInvocationId(),
+            const _i3.WithSdkRequest(),
           ] +
           _requestInterceptors,
       responseInterceptors:
@@ -93,8 +83,8 @@ class CreateLogStreamOperation extends _i1.HttpOperation<
     )
   ];
 
-  late final _i4.AWSEndpoint _awsEndpoint = _i7.endpointResolver.resolve(
-    _i7.sdkId,
+  late final _i3.AWSEndpoint _awsEndpoint = endpointResolver.resolve(
+    sdkId,
     _region,
   );
 
@@ -102,84 +92,90 @@ class CreateLogStreamOperation extends _i1.HttpOperation<
 
   final Uri? _baseUri;
 
-  final _i3.AWSCredentialsProvider _credentialsProvider;
+  final _i2.AWSCredentialsProvider _credentialsProvider;
 
   final List<_i1.HttpRequestInterceptor> _requestInterceptors;
 
   final List<_i1.HttpResponseInterceptor> _responseInterceptors;
 
   @override
-  _i1.HttpRequest buildRequest(_i2.CreateLogStreamRequest input) =>
+  _i1.HttpRequest buildRequest(CreateLogStreamRequest input) =>
       _i1.HttpRequest((b) {
         b.method = 'POST';
         b.path = r'/';
       });
+
   @override
   int successCode([_i1.Unit? output]) => 200;
+
   @override
   _i1.Unit buildOutput(
     _i1.Unit payload,
-    _i6.AWSBaseHttpResponse response,
+    _i4.AWSBaseHttpResponse response,
   ) =>
       payload;
+
   @override
   List<_i1.SmithyError> get errorTypes => const [
-        _i1.SmithyError<_i8.InvalidParameterException,
-            _i8.InvalidParameterException>(
+        _i1.SmithyError<InvalidParameterException, InvalidParameterException>(
           _i1.ShapeId(
             namespace: 'com.amazonaws.cloudwatchlogs',
             shape: 'InvalidParameterException',
           ),
           _i1.ErrorKind.client,
-          _i8.InvalidParameterException,
-          builder: _i8.InvalidParameterException.fromResponse,
+          InvalidParameterException,
+          builder: InvalidParameterException.fromResponse,
         ),
-        _i1.SmithyError<_i9.ResourceAlreadyExistsException,
-            _i9.ResourceAlreadyExistsException>(
+        _i1.SmithyError<ResourceAlreadyExistsException,
+            ResourceAlreadyExistsException>(
           _i1.ShapeId(
             namespace: 'com.amazonaws.cloudwatchlogs',
             shape: 'ResourceAlreadyExistsException',
           ),
           _i1.ErrorKind.client,
-          _i9.ResourceAlreadyExistsException,
-          builder: _i9.ResourceAlreadyExistsException.fromResponse,
+          ResourceAlreadyExistsException,
+          builder: ResourceAlreadyExistsException.fromResponse,
         ),
-        _i1.SmithyError<_i10.ResourceNotFoundException,
-            _i10.ResourceNotFoundException>(
+        _i1.SmithyError<ResourceNotFoundException, ResourceNotFoundException>(
           _i1.ShapeId(
             namespace: 'com.amazonaws.cloudwatchlogs',
             shape: 'ResourceNotFoundException',
           ),
           _i1.ErrorKind.client,
-          _i10.ResourceNotFoundException,
-          builder: _i10.ResourceNotFoundException.fromResponse,
+          ResourceNotFoundException,
+          builder: ResourceNotFoundException.fromResponse,
         ),
-        _i1.SmithyError<_i11.ServiceUnavailableException,
-            _i11.ServiceUnavailableException>(
+        _i1.SmithyError<ServiceUnavailableException,
+            ServiceUnavailableException>(
           _i1.ShapeId(
             namespace: 'com.amazonaws.cloudwatchlogs',
             shape: 'ServiceUnavailableException',
           ),
           _i1.ErrorKind.server,
-          _i11.ServiceUnavailableException,
-          builder: _i11.ServiceUnavailableException.fromResponse,
+          ServiceUnavailableException,
+          builder: ServiceUnavailableException.fromResponse,
         ),
       ];
+
   @override
   String get runtimeTypeName => 'CreateLogStream';
+
   @override
-  _i4.AWSRetryer get retryer => _i4.AWSRetryer();
+  _i3.AWSRetryer get retryer => _i3.AWSRetryer();
+
   @override
   Uri get baseUri => _baseUri ?? endpoint.uri;
+
   @override
   _i1.Endpoint get endpoint => _awsEndpoint.endpoint;
+
   @override
   _i1.SmithyOperation<_i1.Unit> run(
-    _i2.CreateLogStreamRequest input, {
-    _i6.AWSHttpClient? client,
+    CreateLogStreamRequest input, {
+    _i4.AWSHttpClient? client,
     _i1.ShapeId? useProtocol,
   }) {
-    return _i12.runZoned(
+    return _i5.runZoned(
       () => super.run(
         input,
         client: client,
@@ -187,7 +183,7 @@ class CreateLogStreamOperation extends _i1.HttpOperation<
       ),
       zoneValues: {
         ...?_awsEndpoint.credentialScope?.zoneValues,
-        ...{_i6.AWSHeaders.sdkInvocationId: _i6.uuid(secure: true)},
+        ...{_i4.AWSHeaders.sdkInvocationId: _i4.uuid(secure: true)},
       },
     );
   }

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/operation/put_log_events_operation.dart
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/lib/src/sdk/src/cloud_watch_logs/operation/put_log_events_operation.dart
@@ -3,32 +3,22 @@
 
 library aws_logging_cloudwatch.cloud_watch_logs.operation.put_log_events_operation; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
-import 'dart:async' as _i15;
+import 'dart:async' as _i5;
 
-import 'package:aws_common/aws_common.dart' as _i7;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/common/endpoint_resolver.dart'
-    as _i8;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/common/serializers.dart'
-    as _i6;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.dart'
-    as _i9;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart'
-    as _i10;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.dart'
-    as _i11;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart'
-    as _i2;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart'
-    as _i3;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart'
-    as _i12;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart'
-    as _i13;
-import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.dart'
-    as _i14;
-import 'package:aws_signature_v4/aws_signature_v4.dart' as _i4;
+import 'package:aws_common/aws_common.dart' as _i4;
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/common/endpoint_resolver.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/common/serializers.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/data_already_accepted_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/invalid_parameter_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/invalid_sequence_token_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/put_log_events_request.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/put_log_events_response.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/resource_not_found_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/service_unavailable_exception.dart';
+import 'package:aws_logging_cloudwatch/src/sdk/src/cloud_watch_logs/model/unrecognized_client_exception.dart';
+import 'package:aws_signature_v4/aws_signature_v4.dart' as _i2;
 import 'package:smithy/smithy.dart' as _i1;
-import 'package:smithy_aws/smithy_aws.dart' as _i5;
+import 'package:smithy_aws/smithy_aws.dart' as _i3;
 
 /// Uploads a batch of log events to the specified log stream.
 ///
@@ -46,17 +36,16 @@ import 'package:smithy_aws/smithy_aws.dart' as _i5;
 ///
 /// *   A batch of log events in a single request cannot span more than 24 hours. Otherwise, the operation fails.
 ///
+/// *   Each log event can be no larger than 256 KB.
+///
 /// *   The maximum number of log events in a batch is 10,000.
 ///
 /// *   The quota of five requests per second per log stream has been removed. Instead, `PutLogEvents` actions are throttled based on a per-second per-account quota. You can request an increase to the per-second throttling quota by using the Service Quotas service.
 ///
 ///
 /// If a call to `PutLogEvents` returns "UnrecognizedClientException" the most likely cause is a non-valid Amazon Web Services access key ID or secret key.
-class PutLogEventsOperation extends _i1.HttpOperation<
-    _i2.PutLogEventsRequest,
-    _i2.PutLogEventsRequest,
-    _i3.PutLogEventsResponse,
-    _i3.PutLogEventsResponse> {
+class PutLogEventsOperation extends _i1.HttpOperation<PutLogEventsRequest,
+    PutLogEventsRequest, PutLogEventsResponse, PutLogEventsResponse> {
   /// Uploads a batch of log events to the specified log stream.
   ///
   /// The sequence token is now ignored in `PutLogEvents` actions. `PutLogEvents` actions are always accepted and never return `InvalidSequenceTokenException` or `DataAlreadyAcceptedException` even if the sequence token is not valid. You can use parallel `PutLogEvents` actions on the same log stream.
@@ -73,6 +62,8 @@ class PutLogEventsOperation extends _i1.HttpOperation<
   ///
   /// *   A batch of log events in a single request cannot span more than 24 hours. Otherwise, the operation fails.
   ///
+  /// *   Each log event can be no larger than 256 KB.
+  ///
   /// *   The maximum number of log events in a batch is 10,000.
   ///
   /// *   The quota of five requests per second per log stream has been removed. Instead, `PutLogEvents` actions are throttled based on a per-second per-account quota. You can request an increase to the per-second throttling quota by using the Service Quotas service.
@@ -82,8 +73,8 @@ class PutLogEventsOperation extends _i1.HttpOperation<
   PutLogEventsOperation({
     required String region,
     Uri? baseUri,
-    _i4.AWSCredentialsProvider credentialsProvider =
-        const _i4.AWSCredentialsProvider.environment(),
+    _i2.AWSCredentialsProvider credentialsProvider =
+        const _i2.AWSCredentialsProvider.defaultChain(),
     List<_i1.HttpRequestInterceptor> requestInterceptors = const [],
     List<_i1.HttpResponseInterceptor> responseInterceptors = const [],
   })  : _region = region,
@@ -94,11 +85,11 @@ class PutLogEventsOperation extends _i1.HttpOperation<
 
   @override
   late final List<
-      _i1.HttpProtocol<_i2.PutLogEventsRequest, _i2.PutLogEventsRequest,
-          _i3.PutLogEventsResponse, _i3.PutLogEventsResponse>> protocols = [
-    _i5.AwsJson1_1Protocol(
-      serializers: _i6.serializers,
-      builderFactories: _i6.builderFactories,
+      _i1.HttpProtocol<PutLogEventsRequest, PutLogEventsRequest,
+          PutLogEventsResponse, PutLogEventsResponse>> protocols = [
+    _i3.AwsJson1_1Protocol(
+      serializers: serializers,
+      builderFactories: builderFactories,
       requestInterceptors: <_i1.HttpRequestInterceptor>[
             const _i1.WithHost(),
             const _i1.WithContentLength(),
@@ -106,14 +97,14 @@ class PutLogEventsOperation extends _i1.HttpOperation<
               'X-Amz-Target',
               'Logs_20140328.PutLogEvents',
             ),
-            _i5.WithSigV4(
+            _i3.WithSigV4(
               region: _region,
-              service: _i7.AWSService.cloudWatchLogs,
+              service: _i4.AWSService.cloudWatchLogs,
               credentialsProvider: _credentialsProvider,
             ),
             const _i1.WithUserAgent('aws-sdk-dart/0.3.1'),
-            const _i5.WithSdkInvocationId(),
-            const _i5.WithSdkRequest(),
+            const _i3.WithSdkInvocationId(),
+            const _i3.WithSdkRequest(),
           ] +
           _requestInterceptors,
       responseInterceptors:
@@ -121,8 +112,8 @@ class PutLogEventsOperation extends _i1.HttpOperation<
     )
   ];
 
-  late final _i5.AWSEndpoint _awsEndpoint = _i8.endpointResolver.resolve(
-    _i8.sdkId,
+  late final _i3.AWSEndpoint _awsEndpoint = endpointResolver.resolve(
+    sdkId,
     _region,
   );
 
@@ -130,107 +121,113 @@ class PutLogEventsOperation extends _i1.HttpOperation<
 
   final Uri? _baseUri;
 
-  final _i4.AWSCredentialsProvider _credentialsProvider;
+  final _i2.AWSCredentialsProvider _credentialsProvider;
 
   final List<_i1.HttpRequestInterceptor> _requestInterceptors;
 
   final List<_i1.HttpResponseInterceptor> _responseInterceptors;
 
   @override
-  _i1.HttpRequest buildRequest(_i2.PutLogEventsRequest input) =>
+  _i1.HttpRequest buildRequest(PutLogEventsRequest input) =>
       _i1.HttpRequest((b) {
         b.method = 'POST';
         b.path = r'/';
       });
+
   @override
-  int successCode([_i3.PutLogEventsResponse? output]) => 200;
+  int successCode([PutLogEventsResponse? output]) => 200;
+
   @override
-  _i3.PutLogEventsResponse buildOutput(
-    _i3.PutLogEventsResponse payload,
-    _i7.AWSBaseHttpResponse response,
+  PutLogEventsResponse buildOutput(
+    PutLogEventsResponse payload,
+    _i4.AWSBaseHttpResponse response,
   ) =>
-      _i3.PutLogEventsResponse.fromResponse(
+      PutLogEventsResponse.fromResponse(
         payload,
         response,
       );
+
   @override
   List<_i1.SmithyError> get errorTypes => const [
-        _i1.SmithyError<_i9.DataAlreadyAcceptedException,
-            _i9.DataAlreadyAcceptedException>(
+        _i1.SmithyError<DataAlreadyAcceptedException,
+            DataAlreadyAcceptedException>(
           _i1.ShapeId(
             namespace: 'com.amazonaws.cloudwatchlogs',
             shape: 'DataAlreadyAcceptedException',
           ),
           _i1.ErrorKind.client,
-          _i9.DataAlreadyAcceptedException,
-          builder: _i9.DataAlreadyAcceptedException.fromResponse,
+          DataAlreadyAcceptedException,
+          builder: DataAlreadyAcceptedException.fromResponse,
         ),
-        _i1.SmithyError<_i10.InvalidParameterException,
-            _i10.InvalidParameterException>(
+        _i1.SmithyError<InvalidParameterException, InvalidParameterException>(
           _i1.ShapeId(
             namespace: 'com.amazonaws.cloudwatchlogs',
             shape: 'InvalidParameterException',
           ),
           _i1.ErrorKind.client,
-          _i10.InvalidParameterException,
-          builder: _i10.InvalidParameterException.fromResponse,
+          InvalidParameterException,
+          builder: InvalidParameterException.fromResponse,
         ),
-        _i1.SmithyError<_i11.InvalidSequenceTokenException,
-            _i11.InvalidSequenceTokenException>(
+        _i1.SmithyError<InvalidSequenceTokenException,
+            InvalidSequenceTokenException>(
           _i1.ShapeId(
             namespace: 'com.amazonaws.cloudwatchlogs',
             shape: 'InvalidSequenceTokenException',
           ),
           _i1.ErrorKind.client,
-          _i11.InvalidSequenceTokenException,
-          builder: _i11.InvalidSequenceTokenException.fromResponse,
+          InvalidSequenceTokenException,
+          builder: InvalidSequenceTokenException.fromResponse,
         ),
-        _i1.SmithyError<_i12.ResourceNotFoundException,
-            _i12.ResourceNotFoundException>(
+        _i1.SmithyError<ResourceNotFoundException, ResourceNotFoundException>(
           _i1.ShapeId(
             namespace: 'com.amazonaws.cloudwatchlogs',
             shape: 'ResourceNotFoundException',
           ),
           _i1.ErrorKind.client,
-          _i12.ResourceNotFoundException,
-          builder: _i12.ResourceNotFoundException.fromResponse,
+          ResourceNotFoundException,
+          builder: ResourceNotFoundException.fromResponse,
         ),
-        _i1.SmithyError<_i13.ServiceUnavailableException,
-            _i13.ServiceUnavailableException>(
+        _i1.SmithyError<ServiceUnavailableException,
+            ServiceUnavailableException>(
           _i1.ShapeId(
             namespace: 'com.amazonaws.cloudwatchlogs',
             shape: 'ServiceUnavailableException',
           ),
           _i1.ErrorKind.server,
-          _i13.ServiceUnavailableException,
-          builder: _i13.ServiceUnavailableException.fromResponse,
+          ServiceUnavailableException,
+          builder: ServiceUnavailableException.fromResponse,
         ),
-        _i1.SmithyError<_i14.UnrecognizedClientException,
-            _i14.UnrecognizedClientException>(
+        _i1.SmithyError<UnrecognizedClientException,
+            UnrecognizedClientException>(
           _i1.ShapeId(
             namespace: 'com.amazonaws.cloudwatchlogs',
             shape: 'UnrecognizedClientException',
           ),
           _i1.ErrorKind.client,
-          _i14.UnrecognizedClientException,
-          builder: _i14.UnrecognizedClientException.fromResponse,
+          UnrecognizedClientException,
+          builder: UnrecognizedClientException.fromResponse,
         ),
       ];
+
   @override
   String get runtimeTypeName => 'PutLogEvents';
+
   @override
-  _i5.AWSRetryer get retryer => _i5.AWSRetryer();
+  _i3.AWSRetryer get retryer => _i3.AWSRetryer();
+
   @override
   Uri get baseUri => _baseUri ?? endpoint.uri;
+
   @override
   _i1.Endpoint get endpoint => _awsEndpoint.endpoint;
+
   @override
-  _i1.SmithyOperation<_i3.PutLogEventsResponse> run(
-    _i2.PutLogEventsRequest input, {
-    _i7.AWSHttpClient? client,
+  _i1.SmithyOperation<PutLogEventsResponse> run(
+    PutLogEventsRequest input, {
+    _i4.AWSHttpClient? client,
     _i1.ShapeId? useProtocol,
   }) {
-    return _i15.runZoned(
+    return _i5.runZoned(
       () => super.run(
         input,
         client: client,
@@ -238,7 +235,7 @@ class PutLogEventsOperation extends _i1.HttpOperation<
       ),
       zoneValues: {
         ...?_awsEndpoint.credentialScope?.zoneValues,
-        ...{_i7.AWSHeaders.sdkInvocationId: _i7.uuid(secure: true)},
+        ...{_i4.AWSHeaders.sdkInvocationId: _i4.uuid(secure: true)},
       },
     );
   }

--- a/packages/logging_cloudwatch/aws_logging_cloudwatch/sdk.yaml
+++ b/packages/logging_cloudwatch/aws_logging_cloudwatch/sdk.yaml
@@ -1,4 +1,4 @@
 apis:
-  logs:
-  - com.amazonaws.cloudwatchlogs#PutLogEvents
-  - com.amazonaws.cloudwatchlogs#CreateLogStream
+  com.amazonaws.cloudwatchlogs:
+    - PutLogEvents
+    - CreateLogStream


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- the cloudwatch logs'  sdk.yaml file was based on the old aft generate command that uses the private repo and so we could not regenerate the cloudwatch logs sdks.
- update the sdk.yaml file to use the new format based on the public repo and ran aft generate sdk to regenerate the sdk files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
