### PR TITLE
chore(smithy,auth): Dart 3.3.0 Beta Analysis Errors

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_device_info_collector.windows.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_device_info_collector.windows.dart
@@ -102,6 +102,8 @@ final class ASFDeviceInfoWindows extends ASFDeviceInfoPlatform {
       final langCodepageArr = lpTranslate.value;
       final n = lenTranslate.value / sizeOf<_LANGANDCODEPAGE>();
       final langCodepages = [
+        // TODO(equartey): Use `(langCodepageArr + 1).ref` when Dart 3.30 is released.
+        // ignore: deprecated_member_use
         for (var i = 0; i < n; i++) langCodepageArr.elementAt(i).ref,
       ];
       for (final _LANGANDCODEPAGE(:wLanguage, :wCodepage) in langCodepages) {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_device_info_collector.windows.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_device_info_collector.windows.dart
@@ -102,7 +102,7 @@ final class ASFDeviceInfoWindows extends ASFDeviceInfoPlatform {
       final langCodepageArr = lpTranslate.value;
       final n = lenTranslate.value / sizeOf<_LANGANDCODEPAGE>();
       final langCodepages = [
-        // TODO(equartey): Use `(langCodepageArr + 1).ref` when Dart 3.30 is released.
+        // TODO(equartey): Use `(langCodepageArr + i).ref` when Dart 3.30 is released.
         // ignore: deprecated_member_use
         for (var i = 0; i < n; i++) langCodepageArr.elementAt(i).ref,
       ];

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_device_info_collector.windows.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_device_info_collector.windows.dart
@@ -102,7 +102,7 @@ final class ASFDeviceInfoWindows extends ASFDeviceInfoPlatform {
       final langCodepageArr = lpTranslate.value;
       final n = lenTranslate.value / sizeOf<_LANGANDCODEPAGE>();
       final langCodepages = [
-        // TODO(equartey): `.elementAt(i)` is depreciated in Dart 3.3.0. Eventually use `(langCodepageArr + i).ref`
+        // TODO(equartey): `.elementAt(i)` is depreciated in Dart 3.3.0. Use `(langCodepageArr + i).ref` when min Dart version is 3.3.0 or higher
         // ignore: deprecated_member_use
         for (var i = 0; i < n; i++) langCodepageArr.elementAt(i).ref,
       ];

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_device_info_collector.windows.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_device_info_collector.windows.dart
@@ -102,7 +102,7 @@ final class ASFDeviceInfoWindows extends ASFDeviceInfoPlatform {
       final langCodepageArr = lpTranslate.value;
       final n = lenTranslate.value / sizeOf<_LANGANDCODEPAGE>();
       final langCodepages = [
-        // TODO(equartey): Use `(langCodepageArr + i).ref` when Dart 3.30 is released.
+        // TODO(equartey): `.elementAt(i)` is depreciated in Dart 3.3.0. Eventually use `(langCodepageArr + i).ref`
         // ignore: deprecated_member_use
         for (var i = 0; i < n; i++) langCodepageArr.elementAt(i).ref,
       ];

--- a/packages/smithy/smithy/lib/src/ast/shapes/collection_shape.dart
+++ b/packages/smithy/smithy/lib/src/ast/shapes/collection_shape.dart
@@ -23,7 +23,7 @@ class NamedMembersMap extends DelegatingMap<String, MemberShape> {
   NamedMembersMap(super.members);
 
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       identical(this, other) ||
       other is NamedMembersMap &&
           const MapEquality<String, MemberShape>().equals(this, other);

--- a/packages/smithy/smithy/lib/src/ast/shapes/shape_map.dart
+++ b/packages/smithy/smithy/lib/src/ast/shapes/shape_map.dart
@@ -12,7 +12,7 @@ class ShapeMap extends DelegatingMap<ShapeId, Shape> {
   ShapeMap(super.shapes);
 
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       identical(this, other) ||
       other is ShapeMap &&
           const MapEquality<ShapeId, Shape>().equals(this, other);

--- a/packages/smithy/smithy/lib/src/ast/shapes/trait_map.dart
+++ b/packages/smithy/smithy/lib/src/ast/shapes/trait_map.dart
@@ -27,7 +27,7 @@ class TraitMap extends DelegatingMap<ShapeId, Trait> {
   T expectTrait<T extends Trait>() => values.firstWhere((t) => t is T) as T;
 
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       identical(this, other) ||
       other is TraitMap &&
           const MapEquality<ShapeId, Trait>().equals(this, other);

--- a/packages/smithy/smithy_codegen/lib/src/util/config_parameter.dart
+++ b/packages/smithy/smithy_codegen/lib/src/util/config_parameter.dart
@@ -34,7 +34,7 @@ class ParameterLocation {
       ParameterLocation._(val & other.val);
 
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       identical(this, other) || other is ParameterLocation && val == other.val;
 
   @override


### PR DESCRIPTION
*Description of changes:*
Dart 3.30 beta introduces new lint failures. This provides fixes for failing tests:

- https://github.com/aws-amplify/amplify-flutter/actions/runs/7556134956/job/20572507702
- https://github.com/aws-amplify/amplify-flutter/actions/runs/7556125826/job/20572480545
- https://github.com/aws-amplify/amplify-flutter/actions/runs/7556149774/job/20572552398

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
