### PR TITLE
fix: uncaught exception in smithy code

### DIFF
--- a/packages/smithy/smithy/lib/src/http/http_operation.dart
+++ b/packages/smithy/smithy/lib/src/http/http_operation.dart
@@ -220,14 +220,7 @@ abstract class HttpOperation<InputPayload, Input, OutputPayload, Output>
           (response) => deserializeOutput(
             protocol: protocol,
             response: response,
-            // Prevents errors thrown from registering as "Uncaught Exceptions"
-            // in the Dart debugger.
-            //
-            // This is a false positive because we do catch errors in the
-            // retryer which wraps this. Likely this is due to the use of
-            // completers in `CancelableOperation` or some other Zone-related
-            // nonsense.
-          ).catchError(Error.throwWithStackTrace),
+          ),
         );
       },
       onCancel: () {

--- a/packages/smithy/smithy_aws/lib/src/http/retry/aws_retryer.dart
+++ b/packages/smithy/smithy_aws/lib/src/http/retry/aws_retryer.dart
@@ -193,21 +193,21 @@ class AWSRetryer implements Retryer {
           return completer.complete(result);
         } on Exception catch (e) {
           if (!isRetryable(e)) {
-            rethrow;
+            return completer.completeError(e);
           }
           retryToken = _retrieveRetryToken(e);
           if (retryToken == null) {
-            rethrow;
+            return completer.completeError(e);
           }
           final delay = _delayFor(e, attempts);
           if (++attempts >= _maxAttempts) {
-            rethrow;
+            return completer.completeError(e);
           }
           await onRetry?.call(e, delay);
           await Future<void>.delayed(delay);
         }
       }
-    }).catchError(completer.completeError);
+    });
     return completer.operation;
   }
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/4345

*Description of changes:*
- Replace `rethrow`/`catchError(completer.completeError)` with `return completer.completeError(e)`
- Remove a previous fix that was put in place for this that is no longer required

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
