### PR TITLE
chore: remove exception for auth integ tests

### DIFF
--- a/.github/workflows/e2e_android.yaml
+++ b/.github/workflows/e2e_android.yaml
@@ -32,10 +32,9 @@ jobs:
         channel:
           - beta
           - stable
-        # Skips e2e tests against beta on PRs, except for auth
-        # Todo(Jordan-Nelson): Update tests to skip beta for auth once flutter 3.16.0 becomes stable.
+        # Skips e2e tests against beta on PRs
         exclude:
-          - channel: ${{ (github.event_name == 'pull_request' && inputs.package-name != 'amplify_auth_cognito_example' && 'beta') || 'NONE' }}
+          - channel: ${{ (github.event_name == 'pull_request' && 'beta') || 'NONE' }}
 
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # 3.5.3

--- a/.github/workflows/e2e_ios.yaml
+++ b/.github/workflows/e2e_ios.yaml
@@ -25,10 +25,9 @@ jobs:
         channel:
           - beta
           - stable
-        # Skips e2e tests against beta on PRs, except for auth
-        # Todo(Jordan-Nelson): Update tests to skip beta for auth once flutter 3.16.0 becomes stable.
+        # Skips e2e tests against beta on PRs
         exclude:
-          - channel: ${{ (github.event_name == 'pull_request' && inputs.package-name != 'amplify_auth_cognito_example' && 'beta') || 'NONE' }}
+          - channel: ${{ (github.event_name == 'pull_request' && 'beta') || 'NONE' }}
 
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:

--- a/.github/workflows/e2e_linux.yaml
+++ b/.github/workflows/e2e_linux.yaml
@@ -26,10 +26,9 @@ jobs:
         channel:
           - beta
           - stable
-        # Skips e2e tests against beta on PRs, except for auth
-        # Todo(Jordan-Nelson): Update tests to skip beta for auth once flutter 3.16.0 becomes stable.
+        # Skips e2e tests against beta on PRs
         exclude:
-          - channel: ${{ (github.event_name == 'pull_request' && inputs.package-name != 'amplify_auth_cognito_example' && 'beta') || 'NONE' }}
+          - channel: ${{ (github.event_name == 'pull_request' && 'beta') || 'NONE' }}
 
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:

--- a/.github/workflows/e2e_web.yaml
+++ b/.github/workflows/e2e_web.yaml
@@ -26,10 +26,9 @@ jobs:
         channel:
           - beta
           - stable
-        # Skips e2e tests against beta on PRs, except for auth
-        # Todo(Jordan-Nelson): Update tests to skip beta for auth once flutter 3.16.0 becomes stable.
+        # Skips e2e tests against beta on PRs
         exclude:
-          - channel: ${{ (github.event_name == 'pull_request' && inputs.package-name != 'amplify_auth_cognito_example' && 'beta') || 'NONE' }}
+          - channel: ${{ (github.event_name == 'pull_request' && 'beta') || 'NONE' }}
 
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:

--- a/.github/workflows/e2e_windows.yaml
+++ b/.github/workflows/e2e_windows.yaml
@@ -26,10 +26,9 @@ jobs:
         channel:
           - beta
           - stable
-        # Skips e2e tests against beta on PRs, except for auth
-        # Todo(Jordan-Nelson): Update tests to skip beta for auth once flutter 3.16.0 becomes stable.
+        # Skips e2e tests against beta on PRs
         exclude:
-          - channel: ${{ (github.event_name == 'pull_request' && inputs.package-name != 'amplify_auth_cognito_example' && 'beta') || 'NONE' }}
+          - channel: ${{ (github.event_name == 'pull_request' && 'beta') || 'NONE' }}
 
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Removes an exception for auth integration tests that was added in https://github.com/aws-amplify/amplify-flutter/pull/4030.

Auth integration tests were flaky when running against flutter 3.13 due https://github.com/flutter/flutter/issues/134548. That bug was resolved in flutter 3.16. We temporarily added an exception to run auth integration tests against beta when 3.16 was still in beta so that we could get integ tests passing on PRs. Now that 3.16 is stable that exception is not needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
