### PR TITLE
chore(version): Bump version

### DIFF
--- a/packages/amplify_core/CHANGELOG.md
+++ b/packages/amplify_core/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.6.3
+
+### Fixes
+- fix(auth): forget local device only if matches ([#4060](https://github.com/aws-amplify/amplify-flutter/pull/4060))
+- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
+- fix: Bumped drift to ">=2.14.0 <2.15.0" and drift_dev to ">=2.14.0 <2.15.0".
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 1.6.2
 
 ### Fixes

--- a/packages/amplify_core/lib/src/version.dart
+++ b/packages/amplify_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.6.2';
+const packageVersion = '1.6.3';

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_core
 description: The base package containing common types and utilities that are shared across the Amplify Flutter packages.
-version: 1.6.2
+version: 1.6.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_core
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.3
+
+### Fixes
+- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
+- fix: Bumped package_info_plus to ">=4.0.1 <=6.0.0"
+
 ## 1.6.2
 
 - Minor bug fixes and improvements

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint
 description: The Amplify Flutter Analytics category plugin using the AWS Pinpoint provider.
-version: 1.6.2
+version: 1.6.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/analytics/amplify_analytics_pinpoint
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,11 +19,11 @@ platforms:
   web:
 
 dependencies:
-  amplify_analytics_pinpoint_dart: ">=0.3.5 <0.4.0"
+  amplify_analytics_pinpoint_dart: ">=0.3.6 <0.4.0"
   amplify_core: ">=1.6.2 <1.7.0"
   amplify_db_common: ">=0.3.3 <0.4.0"
   amplify_secure_storage: ">=0.4.0+6 <0.5.0"
-  aws_common: ">=0.6.2 <0.7.0"
+  aws_common: ">=0.6.3 <0.7.0"
   device_info_plus: ^9.0.0
   flutter:
     sdk: flutter

--- a/packages/analytics/amplify_analytics_pinpoint_dart/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.6
+
+### Fixes
+- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
+- fix: Bumped drift to ">=2.14.0 <2.15.0" and drift_dev to ">=2.14.0 <2.15.0".
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 0.3.5
 
 - Minor bug fixes and improvements

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/version.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.3.5';
+const packageVersion = '0.3.6';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint_dart
 description: A Dart-only implementation of the Amplify Analytics plugin for Pinpoint.
-version: 0.3.5
+version: 0.3.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/analytics/amplify_analytics_pinpoint_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,10 +10,10 @@ environment:
 
 dependencies:
   amplify_core: ">=1.6.2 <1.7.0"
-  amplify_db_common_dart: ">=0.3.4 <0.4.0"
-  amplify_secure_storage_dart: ">=0.4.2 <0.5.0"
-  aws_common: ">=0.6.2 <0.7.0"
-  aws_signature_v4: ">=0.5.0 <0.6.0"
+  amplify_db_common_dart: ">=0.3.5 <0.4.0"
+  amplify_secure_storage_dart: ">=0.4.3 <0.5.0"
+  aws_common: ">=0.6.3 <0.7.0"
+  aws_signature_v4: ">=0.5.1 <0.6.0"
   built_collection: ^5.0.0
   built_value: ">=8.6.0 <8.9.0"
   collection: ^1.15.0
@@ -21,8 +21,8 @@ dependencies:
   intl: ">=0.18.0 <1.0.0"
   meta: ^1.7.0
   path: ">=1.8.0 <2.0.0"
-  smithy: ">=0.6.2 <0.7.0"
-  smithy_aws: ">=0.6.1 <0.7.0"
+  smithy: ">=0.6.3 <0.7.0"
+  smithy_aws: ">=0.6.2 <0.7.0"
   uuid: ">=3.0.6 <5.0.0"
 
 dev_dependencies:

--- a/packages/auth/amplify_auth_cognito/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.2
+
+### Fixes
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 1.6.1
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito
 description: The Amplify Flutter Auth category plugin using the AWS Cognito provider.
-version: 1.6.1
+version: 1.6.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/auth/amplify_auth_cognito
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -20,11 +20,11 @@ platforms:
 
 dependencies:
   amplify_analytics_pinpoint: ">=1.6.2 <1.7.0"
-  amplify_analytics_pinpoint_dart: ">=0.3.3 <0.4.0"
-  amplify_auth_cognito_dart: ">=0.10.6 <0.11.0"
+  amplify_analytics_pinpoint_dart: ">=0.3.6 <0.4.0"
+  amplify_auth_cognito_dart: ">=0.10.9 <0.11.0"
   amplify_core: ">=1.6.0 <1.7.0"
   amplify_flutter: ">=1.6.1 <1.7.0"
-  amplify_secure_storage: ">=0.4.0+6 <0.5.0"
+  amplify_secure_storage: ">=0.4.1 <0.5.0"
   async: ^2.10.0
   flutter:
     sdk: flutter

--- a/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.10.9
+
+### Fixes
+- fix(auth): forget local device only if matches ([#4060](https://github.com/aws-amplify/amplify-flutter/pull/4060))
+- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 0.10.8
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_dart
 description: A Dart-only implementation of the Amplify Auth plugin for Cognito.
-version: 0.10.8
+version: 0.10.9
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,12 +9,12 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  amplify_analytics_pinpoint_dart: ">=0.3.5 <0.4.0"
+  amplify_analytics_pinpoint_dart: ">=0.3.6 <0.4.0"
   amplify_core: ">=1.6.2 <1.7.0"
-  amplify_secure_storage_dart: ">=0.4.2 <0.5.0"
+  amplify_secure_storage_dart: ">=0.4.3 <0.5.0"
   async: ^2.10.0
-  aws_common: ">=0.6.2 <0.7.0"
-  aws_signature_v4: ">=0.5.0 <0.6.0"
+  aws_common: ">=0.6.3 <0.7.0"
+  aws_signature_v4: ">=0.5.1 <0.6.0"
   built_collection: ^5.0.0
   built_value: ">=8.6.0 <8.9.0"
   clock: ^1.1.1
@@ -30,13 +30,13 @@ dependencies:
   meta: ^1.7.0
   oauth2: ^2.0.2
   path: ">=1.8.0 <2.0.0"
-  smithy: ">=0.6.2 <0.7.0"
-  smithy_aws: ">=0.6.1 <0.7.0"
+  smithy: ">=0.6.3 <0.7.0"
+  smithy_aws: ">=0.6.2 <0.7.0"
   stream_transform: ^2.0.0
   uuid: ">=3.0.6 <5.0.0"
   win32: ">=4.1.2 <6.0.0"
   win32_registry: ^1.1.0
-  worker_bee: ">=0.2.2 <0.3.0"
+  worker_bee: ">=0.2.3 <0.3.0"
 
 dev_dependencies:
   amplify_lints: ">=3.0.2 <3.1.0"
@@ -51,7 +51,7 @@ dev_dependencies:
   smithy_codegen:
     path: ../../smithy/smithy_codegen
   test: ^1.22.1
-  worker_bee_builder: ">=0.2.2 <0.3.0"
+  worker_bee_builder: ">=0.2.3 <0.3.0"
 
 flutter:
   assets:

--- a/packages/authenticator/amplify_authenticator/CHANGELOG.md
+++ b/packages/authenticator/amplify_authenticator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.3
+
+### Fixes
+- fix: Bumped package_info_plus to ">=4.0.1 <=6.0.0"
+
 ## 1.5.2
 
 ### Fixes

--- a/packages/authenticator/amplify_authenticator/lib/src/version.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.5.2';
+const packageVersion = '1.5.3';

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_authenticator
 description: A prebuilt Sign In and Sign Up experience for the Amplify Auth category
-version: 1.5.2
+version: 1.5.3
 homepage: https://ui.docs.amplify.aws/flutter/connected-components/authenticator
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/authenticator/amplify_authenticator
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/aws_common/CHANGELOG.md
+++ b/packages/aws_common/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.3
+
+### Fixes
+- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 0.6.2
 
 - Minor bug fixes and improvements

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aws_common
 description: Common types and utilities used across AWS and Amplify packages.
-version: 0.6.2
+version: 0.6.3
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/aws_common
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/aws_signature_v4/CHANGELOG.md
+++ b/packages/aws_signature_v4/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.1
+
+### Fixes
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 0.5.0
 
 ### Breaking Changes

--- a/packages/aws_signature_v4/lib/src/version.dart
+++ b/packages/aws_signature_v4/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.5.0';
+const packageVersion = '0.5.1';

--- a/packages/aws_signature_v4/pubspec.yaml
+++ b/packages/aws_signature_v4/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aws_signature_v4
 description: Dart implementation of the AWS Signature Version 4 algorithm, for communication with AWS services.
-version: 0.5.0
+version: 0.5.1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/aws_signature_v4
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.10.0
-  aws_common: ">=0.6.0 <0.7.0"
+  aws_common: ">=0.6.3 <0.7.0"
   collection: ^1.15.0
   convert: ^3.0.0
   crypto: ^3.0.0

--- a/packages/common/amplify_db_common/CHANGELOG.md
+++ b/packages/common/amplify_db_common/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.5
+
+### Fixes
+- fix: Bumped drift to ">=2.14.0 <2.15.0" and drift_dev to ">=2.14.0 <2.15.0".
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 0.3.4
 
 - Minor bug fixes and improvements

--- a/packages/common/amplify_db_common/pubspec.yaml
+++ b/packages/common/amplify_db_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_db_common
 description: Common utilities for working with databases such as SQLite.
-version: 0.3.4
+version: 0.3.5
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/common/amplify_db_common
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  amplify_db_common_dart: ">=0.3.4 <0.4.0"
+  amplify_db_common_dart: ">=0.3.5 <0.4.0"
   drift: ">=2.14.0 <2.15.0"
   flutter:
     sdk: flutter

--- a/packages/common/amplify_db_common_dart/CHANGELOG.md
+++ b/packages/common/amplify_db_common_dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.5
+
+### Fixes
+- fix: Bumped drift to ">=2.14.0 <2.15.0" and drift_dev to ">=2.14.0 <2.15.0".
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 0.3.4
 
 - Minor bug fixes and improvements

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_db_common_dart
 description: Common utilities for working with databases such as sqlite. Used throughout Amplify packages.
-version: 0.3.4
+version: 0.3.5
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/common/amplify_db_common_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -11,7 +11,7 @@ environment:
 dependencies:
   amplify_core: ">=1.6.0 <1.7.0"
   async: ^2.10.0
-  aws_common: ">=0.6.0 <0.7.0"
+  aws_common: ">=0.6.3 <0.7.0"
   drift: ">=2.14.0 <2.15.0"
   meta: ^1.7.0
   path: ">=1.8.0 <2.0.0"

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/CHANGELOG.md
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.2
+
+### Fixes
+- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
+
 ## 1.6.1
 
 - Minor bug fixes and improvements

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_push_notifications_pinpoint
 description: The Amplify Flutter Push Notifications category plugin using the AWS Pinpoint provider.
-version: 1.6.1
+version: 1.6.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
@@ -14,8 +14,8 @@ platforms:
   android:
 
 dependencies:
-  amplify_analytics_pinpoint: ">=1.6.2 <1.7.0"
-  amplify_analytics_pinpoint_dart: ">=0.3.5 <0.4.0"
+  amplify_analytics_pinpoint: ">=1.6.3 <1.7.0"
+  amplify_analytics_pinpoint_dart: ">=0.3.6 <0.4.0"
   amplify_auth_cognito: ">=1.6.0 <1.7.0"
   amplify_core: ">=1.6.0 <1.7.0"
   amplify_flutter: ">=1.6.0 <1.7.0"
@@ -27,10 +27,10 @@ dependencies:
 
 dev_dependencies:
   amplify_lints: ">=3.0.0 <3.1.0"
-  amplify_secure_storage_dart: ">=0.4.2 <0.5.0"
+  amplify_secure_storage_dart: ">=0.4.3 <0.5.0"
   amplify_test:
     path: ../../../test/amplify_test
-  aws_common: ">=0.6.2 <0.7.0"
+  aws_common: ">=0.6.3 <0.7.0"
   aws_signature_v4: ">=0.5.0 <0.6.0"
   build_runner: ^2.4.0
   built_value_generator: 8.8.1

--- a/packages/secure_storage/amplify_secure_storage/CHANGELOG.md
+++ b/packages/secure_storage/amplify_secure_storage/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.1
+
+### Fixes
+- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 0.4.0+6
 
 - Minor bug fixes and improvements

--- a/packages/secure_storage/amplify_secure_storage/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_secure_storage
 description: A package for storing secrets, intended for use in Amplify libraries.
-version: 0.4.0+6
+version: 0.4.1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/secure_storage/amplify_secure_storage
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  amplify_secure_storage_dart: ">=0.4.0+7 <0.5.0"
+  amplify_secure_storage_dart: ">=0.4.3 <0.5.0"
   async: ^2.10.0
   file: ">=6.0.0 <8.0.0"
   flutter:

--- a/packages/secure_storage/amplify_secure_storage_dart/CHANGELOG.md
+++ b/packages/secure_storage/amplify_secure_storage_dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.3
+
+### Fixes
+- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 0.4.2
 
 - Minor bug fixes and improvements

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_secure_storage_dart
 description: A Dart-only implementation of `amplify_secure_storage`, using `dart:ffi` for Desktop and `dart:html` for Web.
-version: 0.4.2
+version: 0.4.3
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/secure_storage/amplify_secure_storage_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -21,7 +21,7 @@ platforms:
 
 dependencies:
   async: ^2.10.0
-  aws_common: ">=0.6.2 <0.7.0"
+  aws_common: ">=0.6.3 <0.7.0"
   built_collection: ^5.0.0
   built_value: ">=8.6.0 <8.9.0"
   ffi: ^2.0.0
@@ -30,7 +30,7 @@ dependencies:
   meta: ^1.7.0
   path: ">=1.8.0 <2.0.0"
   win32: ">=4.1.2 <6.0.0"
-  worker_bee: ">=0.2.2 <0.3.0"
+  worker_bee: ">=0.2.3 <0.3.0"
 
 dev_dependencies:
   amplify_lints: ">=3.0.2 <3.1.0"
@@ -42,7 +42,7 @@ dev_dependencies:
   built_value_generator: 8.8.1
   ffigen: ^9.0.0
   test: ^1.22.1
-  worker_bee_builder: ">=0.2.2 <0.3.0"
+  worker_bee_builder: ">=0.2.3 <0.3.0"
 
 flutter:
   assets:

--- a/packages/smithy/smithy/CHANGELOG.md
+++ b/packages/smithy/smithy/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.3
+
+### Fixes
+- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+- fix: uncaught exception in smithy code ([#4369](https://github.com/aws-amplify/amplify-flutter/pull/4369))
+
 ## 0.6.2
 
 - Minor bug fixes and improvements

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smithy
 description: Smithy client runtime for Dart with common utilities for I/O and serialization.
-version: 0.6.2
+version: 0.6.3
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/smithy/smithy
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.10.0
-  aws_common: ">=0.6.2 <0.7.0"
+  aws_common: ">=0.6.3 <0.7.0"
   built_collection: ^5.0.0
   built_value: ">=8.6.0 <8.9.0"
   collection: ^1.15.0

--- a/packages/smithy/smithy_aws/CHANGELOG.md
+++ b/packages/smithy/smithy_aws/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.2
+
+### Fixes
+- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+- fix: uncaught exception in smithy code ([#4369](https://github.com/aws-amplify/amplify-flutter/pull/4369))
+
 ## 0.6.1
 
 - Minor bug fixes and improvements

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smithy_aws
 description: Smithy runtime for AWS clients with utilities for endpoint resolution, retry behavior, and SigV4 signing.
-version: 0.6.1
+version: 0.6.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/smithy/smithy_aws
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,8 +9,8 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  aws_common: ">=0.6.2 <0.7.0"
-  aws_signature_v4: ">=0.5.0 <0.6.0"
+  aws_common: ">=0.6.3 <0.7.0"
+  aws_signature_v4: ">=0.5.1 <0.6.0"
   built_collection: ^5.0.0
   built_value: ">=8.6.0 <8.9.0"
   collection: ^1.15.0
@@ -21,7 +21,7 @@ dependencies:
   json_annotation: ">=4.8.1 <4.9.0"
   meta: ^1.7.0
   path: ">=1.8.0 <2.0.0"
-  smithy: ">=0.6.2 <0.7.0"
+  smithy: ">=0.6.3 <0.7.0"
   xml: ">=6.3.0 <=6.5.0"
 
 dev_dependencies:

--- a/packages/storage/amplify_storage_s3/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.2
+
+### Fixes
+- fix: Bumped drift to ">=2.14.0 <2.15.0" and drift_dev to ">=2.14.0 <2.15.0".
+
 ## 1.6.1
 
 - Minor bug fixes and improvements

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3
 description: The Amplify Flutter Storage category plugin using the AWS S3 provider.
-version: 1.6.1
+version: 1.6.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/storage/amplify_storage_s3
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -20,8 +20,8 @@ platforms:
 
 dependencies:
   amplify_core: ">=1.6.0 <1.7.0"
-  amplify_db_common: ">=0.3.4 <0.4.0"
-  amplify_storage_s3_dart: ">=0.3.8 <0.4.0"
+  amplify_db_common: ">=0.3.5 <0.4.0"
+  amplify_storage_s3_dart: ">=0.3.9 <0.4.0"
   aws_common: ">=0.6.0 <0.7.0"
   flutter:
     sdk: flutter

--- a/packages/storage/amplify_storage_s3_dart/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3_dart/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.9
+
+### Fixes
+- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
+- fix: Bumped drift to ">=2.14.0 <2.15.0" and drift_dev to ">=2.14.0 <2.15.0".
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 0.3.8
 
 - Minor bug fixes and improvements

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3_dart
 description: A Dart-only implementation of the Amplify Storage plugin for S3.
-version: 0.3.8
+version: 0.3.9
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/storage/amplify_storage_s3_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,10 +10,10 @@ environment:
 
 dependencies:
   amplify_core: ">=1.6.2 <1.7.0"
-  amplify_db_common_dart: ">=0.3.4 <0.4.0"
+  amplify_db_common_dart: ">=0.3.5 <0.4.0"
   async: ^2.10.0
-  aws_common: ">=0.6.2 <0.7.0"
-  aws_signature_v4: ">=0.5.0 <0.6.0"
+  aws_common: ">=0.6.3 <0.7.0"
+  aws_signature_v4: ">=0.5.1 <0.6.0"
   built_collection: ^5.0.0
   built_value: ">=8.6.0 <8.9.0"
   drift: ">=2.14.0 <2.15.0"
@@ -21,8 +21,8 @@ dependencies:
   json_annotation: ">=4.8.1 <4.9.0"
   meta: ^1.7.0
   path: ">=1.8.0 <2.0.0"
-  smithy: ">=0.6.2 <0.7.0"
-  smithy_aws: ">=0.6.1 <0.7.0"
+  smithy: ">=0.6.3 <0.7.0"
+  smithy_aws: ">=0.6.2 <0.7.0"
 
 dev_dependencies:
   amplify_lints: ">=3.0.2 <3.1.0"

--- a/packages/worker_bee/worker_bee/CHANGELOG.md
+++ b/packages/worker_bee/worker_bee/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.3
+
+### Fixes
+- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 0.2.2
 
 - Minor bug fixes and improvements

--- a/packages/worker_bee/worker_bee/pubspec.yaml
+++ b/packages/worker_bee/worker_bee/pubspec.yaml
@@ -1,6 +1,6 @@
 name: worker_bee
 description: A cross-platform isolated worker runtime for Dart Web, VM, and Flutter.
-version: 0.2.2
+version: 0.2.3
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/worker_bee/worker_bee
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.10.0
-  aws_common: ">=0.6.2 <0.7.0"
+  aws_common: ">=0.6.3 <0.7.0"
   built_collection: ^5.0.0
   built_value: ">=8.6.0 <8.9.0"
   collection: ^1.15.0

--- a/packages/worker_bee/worker_bee_builder/CHANGELOG.md
+++ b/packages/worker_bee/worker_bee_builder/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.3
+
+### Fixes
+- fix: Bumped path to ">=1.8.0 <2.0.0"
+
 ## 0.2.2
 
 - Minor bug fixes and improvements

--- a/packages/worker_bee/worker_bee_builder/pubspec.yaml
+++ b/packages/worker_bee/worker_bee_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: worker_bee_builder
 description: Builder package for worker_bee to quickly generate necessary boilerplate
-version: 0.2.2
+version: 0.2.3
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/worker_bee/worker_bee_builder
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -20,7 +20,7 @@ dependencies:
   source_gen: ^1.3.2
   stream_channel: ^2.1.0
   tuple: ^2.0.0
-  worker_bee: ">=0.2.2 <0.3.0"
+  worker_bee: ">=0.2.3 <0.3.0"
 
 dev_dependencies:
   amplify_lints: ">=3.0.2 <3.1.0"


### PR DESCRIPTION
*Issue #, if available:* #4345 #4056

*Description of changes:*
### Fixes
- fix(auth): forget local device only if matches ([#4060](https://github.com/aws-amplify/amplify-flutter/pull/4060))
- fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
- fix: Bumped drift to ">=2.14.0 <2.15.0" and drift_dev to ">=2.14.0 <2.15.0".
- fix: Bumped package_info_plus to ">=4.0.1 <=6.0.0"
- fix: Bumped path to ">=1.8.0 <2.0.0"
- fix: uncaught exception in smithy code ([#4369](https://github.com/aws-amplify/amplify-flutter/pull/4369))

Updated-Components: amplify_lints, Amplify Flutter, Amplify Dart, Amplify UI, DB Common, Secure Storage, AWS Common, Smithy, Worker Bee


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
