### PR TITLE
use of adaptive CircularProgressIndicator in LoadingScreen

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/screens/loading_screen.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/screens/loading_screen.dart
@@ -9,7 +9,7 @@ class LoadingScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Center(
-      child: CircularProgressIndicator(),
+      child: CircularProgressIndicator.adaptive(),
     );
   }
 }


### PR DESCRIPTION
*Issue #4438*

Simply use CircularProgressIndicator.adaptive() in place of CircularProgressIndicator() to better fit the platform Flutter is running on.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
