### PR TITLE
chore(datastore): Amplify Swift version bump to 1.30.7

### DIFF
--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,9 +15,9 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.30.4'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.30.4'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.30.4'
+  s.dependency 'Amplify', '1.30.7'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.30.7'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.30.7'
   s.dependency 'Starscream', '4.0.4'
   s.platform = :ios, '13.0'
 


### PR DESCRIPTION
*Issue #, if available:*
- [3967](https://github.com/aws-amplify/amplify-flutter/issues/3967) 
*Description of changes:*
Bumps Amplify Swift version to 1.30.7.

Fixes an issue where DataStore sync fails on iOS with OIDC when IAM is specified as an additional provider.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
