### PR TITLE
chore(workflows): Use windows-latest

### DIFF
--- a/.github/workflows/e2e_windows.yaml
+++ b/.github/workflows/e2e_windows.yaml
@@ -17,8 +17,7 @@ on:
 
 jobs:
   e2e-test-windows:
-    runs-on:
-      labels: amplify-flutter_windows-latest_8-core
+    runs-on: windows-latest
     strategy:
       # Allows other matrix items to run if one fails
       fail-fast: false


### PR DESCRIPTION
*Description of changes:*
Moves our windows e2e runner to use the windows 4 core runner, `windows-latest`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
