### PR TITLE
chore(workflows): Use ubuntu-latest

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -109,8 +109,7 @@ jobs:
 
   test_launch_android_emulator:
     name: Test Action (launch_android_emulator)
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # 3.5.3

--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -73,8 +73,7 @@ jobs:
           flutter-version: ${{ matrix.flutter-version }}
 
   e2e-android:
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -14,8 +14,7 @@ on:
 jobs:
   test-dart-2js:
     # These tests heavily leverage build_runner which benefits from faster runners
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       # Allows other matrix items to run if one fails

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -14,8 +14,7 @@ on:
 jobs:
   test-dart-ddc:
     # These tests heavily leverage build_runner which benefits from faster runners
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       # Allows other matrix items to run if one fails

--- a/.github/workflows/e2e_android.yaml
+++ b/.github/workflows/e2e_android.yaml
@@ -17,8 +17,7 @@ on:
 
 jobs:
   e2e-test-android:
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write

--- a/.github/workflows/e2e_linux.yaml
+++ b/.github/workflows/e2e_linux.yaml
@@ -17,8 +17,7 @@ on:
 
 jobs:
   e2e-test-linux:
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     strategy:
       # Allows other matrix items to run if one fails
       fail-fast: false

--- a/.github/workflows/flutter_android.yaml
+++ b/.github/workflows/flutter_android.yaml
@@ -18,8 +18,7 @@ on:
 
 jobs:
   flutter-android-build-and-test:
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       # Allows other matrix items to run if one fails


### PR DESCRIPTION
*Description of changes:*
Moves our ubuntu runners to use the now equivalent `ubuntu-latest`.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
