### PR TITLE
chore(version): Bump version 1.7.0

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -109,8 +109,7 @@ jobs:
 
   test_launch_android_emulator:
     name: Test Action (launch_android_emulator)
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # 3.5.3

--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -73,8 +73,7 @@ jobs:
           flutter-version: ${{ matrix.flutter-version }}
 
   e2e-android:
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -14,8 +14,7 @@ on:
 jobs:
   test-dart-2js:
     # These tests heavily leverage build_runner which benefits from faster runners
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       # Allows other matrix items to run if one fails

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -14,8 +14,7 @@ on:
 jobs:
   test-dart-ddc:
     # These tests heavily leverage build_runner which benefits from faster runners
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       # Allows other matrix items to run if one fails

--- a/.github/workflows/e2e_android.yaml
+++ b/.github/workflows/e2e_android.yaml
@@ -17,8 +17,7 @@ on:
 
 jobs:
   e2e-test-android:
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write

--- a/.github/workflows/e2e_linux.yaml
+++ b/.github/workflows/e2e_linux.yaml
@@ -17,8 +17,7 @@ on:
 
 jobs:
   e2e-test-linux:
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     strategy:
       # Allows other matrix items to run if one fails
       fail-fast: false

--- a/.github/workflows/e2e_windows.yaml
+++ b/.github/workflows/e2e_windows.yaml
@@ -17,8 +17,7 @@ on:
 
 jobs:
   e2e-test-windows:
-    runs-on:
-      labels: amplify-flutter_windows-latest_8-core
+    runs-on: windows-latest
     strategy:
       # Allows other matrix items to run if one fails
       fail-fast: false

--- a/.github/workflows/flutter_android.yaml
+++ b/.github/workflows/flutter_android.yaml
@@ -18,8 +18,7 @@ on:
 
 jobs:
   flutter-android-build-and-test:
-    runs-on:
-      labels: amplify-flutter_ubuntu-latest_4-core
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       # Allows other matrix items to run if one fails

--- a/build-support/build_canary.sh
+++ b/build-support/build_canary.sh
@@ -25,7 +25,9 @@ cp $ROOT_DIR/build-support/dummy_amplifyconfiguration.dart lib/amplifyconfigurat
 
 # Android
 sed -i '' -e "s/ext.kotlin_version = .*/ext.kotlin_version = \"1.8.21\"/" ./android/build.gradle
+# TODO(khatruong2009): remove this line after the next stable release (3.22.0 or 4.0)
 sed -i '' -e "s/minSdkVersion .*/minSdkVersion 24/" ./android/app/build.gradle
+sed -i '' -e "s/minSdk .*/minSdk 24/" ./android/app/build.gradle
 sed -i '' -e "s/compileSdkVersion .*/compileSdkVersion 33/" ./android/app/build.gradle
 cat ./android/app/build.gradle
 # iOS

--- a/packages/amplify/amplify_flutter/CHANGELOG.md
+++ b/packages/amplify/amplify_flutter/CHANGELOG.md
@@ -1,6 +1,21 @@
+## 1.7.0
+
+### Features
+
+- feat(api): add copyWith to GraphQLRequest ([#4365](https://github.com/aws-amplify/amplify-flutter/pull/4365))
+
+### Fixes
+
+- fix: `google.crypto.tink` version constraint ([#4434](https://github.com/aws-amplify/amplify-flutter/pull/4434))
+
+### Chores
+
+- chore(datastore): Amplify Swift version bump to 1.30.7 ([#4454](https://github.com/aws-amplify/amplify-flutter/pull/4454))
+
 ## 1.6.1
 
 ### Fixes
+
 - fix(api): GraphQL Model Helpers support lowercase model names #4143 (#4144)
 - fix(core): pub docs ([#4049](https://github.com/aws-amplify/amplify-flutter/pull/4049))
 - fix(datastore): emit observeQuery snapshot when model create mutation results in an updated model ([#4084](https://github.com/aws-amplify/amplify-flutter/pull/4084))
@@ -8,9 +23,11 @@
 ## 1.6.0
 
 ### Features
+
 - feat: rename sendUserAttributeVerificationCode ([#3759](https://github.com/aws-amplify/amplify-flutter/pull/3759))
 
 ### Fixes
+
 - fix(analytics): allow nullable userProfile
 - fix(pub): ignore templates folder during analysis ([#4009](https://github.com/aws-amplify/amplify-flutter/pull/4009))
 - fix: remove exception during token timeout ([#3939](https://github.com/aws-amplify/amplify-flutter/pull/3939))

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_flutter
 description: The top level Flutter package for the AWS Amplify libraries.
-version: 1.6.1
+version: 1.7.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify/amplify_flutter
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,7 +19,7 @@ platforms:
   web:
 
 dependencies:
-  amplify_core: ">=1.6.0 <1.7.0"
+  amplify_core: ">=1.7.0 <1.8.0"
   amplify_secure_storage: ">=0.4.0+6 <0.5.0"
   aws_common: ">=0.6.0 <0.7.0"
   collection: ^1.15.0

--- a/packages/amplify_core/CHANGELOG.md
+++ b/packages/amplify_core/CHANGELOG.md
@@ -1,6 +1,21 @@
+## 1.7.0
+
+### Features
+
+- feat(api): add copyWith to GraphQLRequest ([#4365](https://github.com/aws-amplify/amplify-flutter/pull/4365))
+
+### Fixes
+
+- fix: `google.crypto.tink` version constraint ([#4434](https://github.com/aws-amplify/amplify-flutter/pull/4434))
+
+### Chores
+
+- chore(datastore): Amplify Swift version bump to 1.30.7 ([#4454](https://github.com/aws-amplify/amplify-flutter/pull/4454))
+
 ## 1.6.3
 
 ### Fixes
+
 - fix(auth): forget local device only if matches ([#4060](https://github.com/aws-amplify/amplify-flutter/pull/4060))
 - fix: Bumped built_value to ">=8.6.0 <8.9.0" and built_value_generator to 8.8.1
 - fix: Bumped drift to ">=2.14.0 <2.15.0" and drift_dev to ">=2.14.0 <2.15.0".
@@ -9,6 +24,7 @@
 ## 1.6.2
 
 ### Fixes
+
 - fix(api): GraphQL Model Helpers support lowercase model names #4143 (#4144)
 - fix(core): pub docs ([#4049](https://github.com/aws-amplify/amplify-flutter/pull/4049))
 - fix(datastore): emit observeQuery snapshot when model create mutation results in an updated model ([#4084](https://github.com/aws-amplify/amplify-flutter/pull/4084))
@@ -16,14 +32,17 @@
 ## 1.6.1
 
 ### Fixes
+
 - fix(core): pub docs ([#4049](https://github.com/aws-amplify/amplify-flutter/pull/4049))
 
 ## 1.6.0
 
 ### Features
+
 - feat: rename sendUserAttributeVerificationCode ([#3759](https://github.com/aws-amplify/amplify-flutter/pull/3759))
 
 ### Fixes
+
 - fix(analytics): allow nullable userProfile
 - fix(auth): use loadCredentials to check login state
 - fix(pub): ignore templates folder during analysis ([#4009](https://github.com/aws-amplify/amplify-flutter/pull/4009))

--- a/packages/amplify_core/lib/src/types/api/graphql/graphql_request.dart
+++ b/packages/amplify_core/lib/src/types/api/graphql/graphql_request.dart
@@ -74,4 +74,39 @@ class GraphQLRequest<T> with AWSSerializable<Map<String, Object?>> {
           'authorizationMode': authorizationMode!.name,
         if (decodePath != null) 'decodePath': decodePath,
       };
+
+  /// Creates a copy of this request with the given fields replaced with the new values.
+  /// If no new value is given, the old value is used.
+  ///
+  /// ```dart
+  /// final original = ModelQueries.list(
+  ///   Blog.classType,
+  /// );
+  /// final modified = original.copyWith(
+  ///   document: yourCustomQuery,
+  /// );
+  /// ```
+  ///
+  /// Useful in advanced scenarios where you want to modify the request before sending it.
+  ///
+  /// See https://docs.amplify.aws/lib/graphqlapi/advanced-workflows/q/platform/flutter/.
+  GraphQLRequest<T> copyWith({
+    String? document,
+    String? apiName,
+    Map<String, String>? headers,
+    APIAuthorizationType? authorizationMode,
+    Map<String, dynamic>? variables,
+    String? decodePath,
+    ModelType? modelType,
+  }) {
+    return GraphQLRequest<T>(
+      document: document ?? this.document,
+      apiName: apiName ?? this.apiName,
+      headers: headers ?? this.headers,
+      authorizationMode: authorizationMode ?? this.authorizationMode,
+      variables: variables ?? this.variables,
+      decodePath: decodePath ?? this.decodePath,
+      modelType: modelType ?? this.modelType,
+    );
+  }
 }

--- a/packages/amplify_core/lib/src/version.dart
+++ b/packages/amplify_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.6.3';
+const packageVersion = '1.7.0';

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_core
 description: The base package containing common types and utilities that are shared across the Amplify Flutter packages.
-version: 1.6.3
+version: 1.7.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_core
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/amplify_datastore/CHANGELOG.md
+++ b/packages/amplify_datastore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0
+
+- chore(datastore): Amplify Swift version bump to 1.30.7 ([#4454](https://github.com/aws-amplify/amplify-flutter/pull/4454))
+
 ## 1.6.0
 
 - Minor bug fixes and improvements
@@ -17,11 +21,13 @@
 ## 1.4.0
 
 ### Fixes
+
 - fix(datastore): Use platform thread ([#3607](https://github.com/aws-amplify/amplify-flutter/pull/3607))
 
 ## 1.3.4
 
 ### Fixes
+
 - fix(datastore): Pin `Starscream`
 
 ## 1.3.3
@@ -31,17 +37,20 @@
 ## 1.3.2
 
 ### Fixes
+
 - fix(datastore): Custom list serde ([#3544](https://github.com/aws-amplify/amplify-flutter/pull/3544))
 
 ## 1.3.1
 
 ### Fixes
+
 - fix(datastore): hot restart ([#3497](https://github.com/aws-amplify/amplify-flutter/pull/3497))
 - fix(datastore): make event history list thread safe ([#3509](https://github.com/aws-amplify/amplify-flutter/pull/3509))
 
 ## 1.3.0
 
 ### Features
+
 - feat(datastore): Adds DataStoreHubEventType to DataStoreHubEvents ([#3454](https://github.com/aws-amplify/amplify-flutter/pull/3454))
 
 ### Chores
@@ -59,27 +68,31 @@
 ## 1.1.0-supports-only-mobile+1
 
 ### Fixes
+
 - fix(datastore): support nested predicates for observe and observeQuery ([#3029](https://github.com/aws-amplify/amplify-flutter/pull/3029))
 
 ## 1.1.0-supports-only-mobile
 
 ### Features
+
 - Dart 3 support (must update Dart SDK constraint to `^3.0.0`)
 
 ### Fixes
+
 - fix(repo): AGP 8.0 compatibility ([#2942](https://github.com/aws-amplify/amplify-flutter/pull/2942))
 
 ## 1.0.0-supports-only-mobile.0+1
 
 ### Fixes
+
 - fix(repo): Flutter 3.3 support
 
 ## 1.0.0-supports-only-mobile.0
 
-Version 1 of the Amplify libraries have been released to support all the platforms Flutter supports. 
-When interacting with GraphQL APIs, use the API category for all platforms or DataStore for iOS and Android. 
-This is because we retained DataStore on the original Android & iOS implementation. We’re 
-looking to bring data synchronization and offline-first experiences to the web and desktop in the 
+Version 1 of the Amplify libraries have been released to support all the platforms Flutter supports.
+When interacting with GraphQL APIs, use the API category for all platforms or DataStore for iOS and Android.
+This is because we retained DataStore on the original Android & iOS implementation. We’re
+looking to bring data synchronization and offline-first experiences to the web and desktop in the
 future and would love to get your feedback on [this GitHub issue](https://github.com/aws-amplify/amplify-flutter/issues/234).
 
 As always, you can find us on [GitHub](https://github.com/aws-amplify/amplify-flutter/) and
@@ -96,11 +109,13 @@ As always, you can find us on [GitHub](https://github.com/aws-amplify/amplify-fl
 ## 1.0.0-next.7
 
 ### Fixes
+
 - fix(android): Bump Amplify Android to 2.4.1
 - fix(datastore): support use of java8 features in the example App
 - fix(ios): Bump Amplify iOS to 1.29.1
 
 ### Breaking Changes
+
 - chore(datastore)!: Reorganize + import cleanup ([#2760](https://github.com/aws-amplify/amplify-flutter/pull/2760))
 
 ## 1.0.0-next.6
@@ -114,11 +129,13 @@ As always, you can find us on [GitHub](https://github.com/aws-amplify/amplify-fl
 ## 1.0.0-next.4
 
 ### Fixes
+
 - fix(datastore): prevent unhandled exception crashing App rebuilding sync expression
 
 ## 1.0.0-next.3
 
 ### Breaking Changes
+
 - refactor(core)!: Migrate exception types
 
 ## 1.0.0-next.2
@@ -128,6 +145,7 @@ As always, you can find us on [GitHub](https://github.com/aws-amplify/amplify-fl
 ## 1.0.0-next.1+1
 
 ### Fixes
+
 - fix(datastore): adapt amplify-ios CPK fix breaking change
 - fix(datastore): cpk errors on a custom type ([#2134](https://github.com/aws-amplify/amplify-flutter/pull/2134))
 - fix(datastore): enable java8 desugaring for amplify-android datastore plugin
@@ -135,6 +153,7 @@ As always, you can find us on [GitHub](https://github.com/aws-amplify/amplify-fl
 - fix(datastore): update dependency importing paths
 
 ### Features
+
 - feat(datastore): add targetNames support for codegen
 - feat(datastore): custom primary key Flutter native implementation
 

--- a/packages/amplify_datastore/ios/Classes/types/temporal/FlutterTemporal.swift
+++ b/packages/amplify_datastore/ios/Classes/types/temporal/FlutterTemporal.swift
@@ -8,9 +8,11 @@ import Foundation
 // Stores an ISO 8601 String to be saved to Appsync
 struct FlutterTemporal: TemporalSpec {
     let iso8601: String
+    var timeZone: TimeZone?
     init(iso8601String: String) {
         self.iso8601 = iso8601String
         self.foundationDate = Date()
+        self.timeZone = TimeZone.current
     }
 
     var iso8601String: String {
@@ -21,9 +23,10 @@ struct FlutterTemporal: TemporalSpec {
     // In order to properly adhere to "TemporalSpec" these functions must be implemented
     // This class is solely for transmitting a ISO 8601 Date String to Appsync so these other functions are not needed
     var foundationDate: Date
-    init(_ date: Date) {
+    init(_ date: Date, timeZone: TimeZone? = TimeZone.current) {
         self.iso8601 = ""
         self.foundationDate = date
+        self.timeZone = timeZone
     }
 
     static func now() -> FlutterTemporal {

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,9 +15,9 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.30.4'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.30.4'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.30.4'
+  s.dependency 'Amplify', '1.30.7'
+  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.30.7'
+  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.30.7'
   s.dependency 'Starscream', '4.0.4'
   s.platform = :ios, '13.0'
 

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore
 description: The Amplify Flutter DataStore category plugin, providing a queryable, on-device data store.
-version: 1.6.0
+version: 1.7.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_datastore
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  amplify_datastore_plugin_interface: ">=1.6.0 <1.7.0"
-  amplify_core: ">=1.6.0 <1.7.0"
+  amplify_datastore_plugin_interface: ">=1.7.0 <1.8.0"
+  amplify_core: ">=1.7.0 <1.8.0"
   plugin_platform_interface: ^2.0.0
   meta: ^1.7.0
   collection: ^1.14.13

--- a/packages/amplify_datastore_plugin_interface/CHANGELOG.md
+++ b/packages/amplify_datastore_plugin_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0
+
+- Minor bug fixes and improvements
+
 ## 1.6.1
 
 ### Fixes

--- a/packages/amplify_datastore_plugin_interface/pubspec.yaml
+++ b/packages/amplify_datastore_plugin_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore_plugin_interface
 description: The platform interface for the DataStore module of Amplify Flutter.
-version: 1.6.1
+version: 1.7.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_datastore_plugin_interface
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  amplify_core: ">=1.6.2 <1.7.0"
+  amplify_core: ">=1.7.0 <1.8.0"
   collection: ^1.15.0
   flutter:
     sdk: flutter

--- a/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0
+
+- Minor bug fixes and improvements
+
 ## 1.6.3
 
 ### Fixes

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint
 description: The Amplify Flutter Analytics category plugin using the AWS Pinpoint provider.
-version: 1.6.3
+version: 1.7.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/analytics/amplify_analytics_pinpoint
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,8 +19,8 @@ platforms:
   web:
 
 dependencies:
-  amplify_analytics_pinpoint_dart: ">=0.3.6 <0.4.0"
-  amplify_core: ">=1.6.2 <1.7.0"
+  amplify_analytics_pinpoint_dart: ">=0.3.7 <0.4.0"
+  amplify_core: ">=1.7.0 <1.8.0"
   amplify_db_common: ">=0.3.3 <0.4.0"
   amplify_secure_storage: ">=0.4.0+6 <0.5.0"
   aws_common: ">=0.6.3 <0.7.0"

--- a/packages/analytics/amplify_analytics_pinpoint_dart/CHANGELOG.md
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.7
+
+- Minor bug fixes and improvements
+
 ## 0.3.6
 
 ### Fixes

--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/version.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.3.6';
+const packageVersion = '0.3.7';

--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint_dart
 description: A Dart-only implementation of the Amplify Analytics plugin for Pinpoint.
-version: 0.3.6
+version: 0.3.7
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/analytics/amplify_analytics_pinpoint_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  amplify_core: ">=1.6.2 <1.7.0"
+  amplify_core: ">=1.7.0 <1.8.0"
   amplify_db_common_dart: ">=0.3.5 <0.4.0"
   amplify_secure_storage_dart: ">=0.4.3 <0.5.0"
   aws_common: ">=0.6.3 <0.7.0"

--- a/packages/api/amplify_api/CHANGELOG.md
+++ b/packages/api/amplify_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.7.0
+
+### Features
+- feat(api): add copyWith to GraphQLRequest ([#4365](https://github.com/aws-amplify/amplify-flutter/pull/4365))
+
 ## 1.6.2
 
 ### Fixes

--- a/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
+++ b/packages/api/amplify_api/example/integration_test/graphql/iam_test.dart
@@ -188,6 +188,37 @@ void main({bool useExistingTestUser = false}) {
         expect(postFromResponse?.title, title);
       });
 
+      testWidgets('should copyWith request', (WidgetTester tester) async {
+        final title = 'Lorem Ipsum Test Post: ${uuid()}';
+        const rating = 0;
+        final createdPost = await addPostAndBlog(title, rating);
+        final blogId = createdPost.blog?.id;
+
+        // Original request with mock id
+        final req = ModelQueries.list(
+          Post.classType,
+          where: Post.BLOG.eq(uuid()),
+          limit: _limit,
+        );
+
+        // Copy request with actual blog id
+        final copiedRequest = req.copyWith(
+          variables: {
+            ...req.variables,
+            'filter': {
+              'blogID': {'eq': blogId},
+            },
+          },
+        );
+        final res = await Amplify.API.query(request: copiedRequest).response;
+        final postFromResponse = res.data?.items[0];
+
+        expect(res, hasNoGraphQLErrors);
+        expect(postFromResponse?.blog?.id, isNotNull);
+        expect(postFromResponse?.blog?.id, blogId);
+        expect(postFromResponse?.title, title);
+      });
+
       testWidgets('should decode a custom list request',
           (WidgetTester tester) async {
         final name = 'Lorem Ipsum Test Blog: ${uuid()}';

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api
 description: The Amplify Flutter API category plugin, supporting GraphQL and REST operations.
-version: 1.6.2
+version: 1.7.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/api/amplify_api
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,9 +19,9 @@ platforms:
   web:
 
 dependencies:
-  amplify_api_dart: ">=0.3.4 <0.4.0"
-  amplify_core: ">=1.6.2 <1.7.0"
-  amplify_flutter: ">=1.6.1 <1.7.0"
+  amplify_api_dart: ">=0.4.0 <0.5.0"
+  amplify_core: ">=1.7.0 <1.8.0"
+  amplify_flutter: ">=1.7.0 <1.8.0"
   connectivity_plus: ">=4.0.1 <6.0.0"
   flutter:
     sdk: flutter

--- a/packages/api/amplify_api_dart/CHANGELOG.md
+++ b/packages/api/amplify_api_dart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+### Features
+- feat(api): add copyWith to GraphQLRequest ([#4365](https://github.com/aws-amplify/amplify-flutter/pull/4365))
+
 ## 0.3.4
 
 ### Fixes

--- a/packages/api/amplify_api_dart/pubspec.yaml
+++ b/packages/api/amplify_api_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_dart
 description: The Amplify API category plugin in Dart-only, supporting GraphQL and REST operations.
-version: 0.3.4
+version: 0.4.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/api/amplify_api_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  amplify_core: ">=1.6.0 <1.7.0"
+  amplify_core: ">=1.7.0 <1.8.0"
   async: ^2.10.0
   aws_common: ">=0.6.0 <0.7.0"
   collection: ^1.15.0

--- a/packages/auth/amplify_auth_cognito/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0
+
+- Minor bug fixes and improvements
+
 ## 1.6.2
 
 ### Fixes

--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_out_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_out_test.dart
@@ -144,7 +144,7 @@ void main() {
             because: 'Sign out should succeed even if user is deleted',
             cognitoPlugin.signOut(),
           ).completes(
-            it()
+            (it) => it
               ..has((res) => res.signedOutLocally, 'signedOutLocally').isTrue(),
           );
         });
@@ -178,8 +178,9 @@ void main() {
                 'credentials are expired',
             cognitoPlugin.signOut(),
           ).completes(
-            it()
-              ..has((res) => res.signedOutLocally, 'signedOutLocally').isTrue(),
+            (it) => it
+                .has((res) => res.signedOutLocally, 'signedOutLocally')
+                .isTrue(),
           );
         });
       });

--- a/packages/auth/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
     path: ../../../amplify_lints
   async: ^2.10.0
   aws_signature_v4: any
-  checks: ^0.2.0
+  checks: ^0.3.0
   collection: any
   flutter_driver:
     sdk: flutter

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito
 description: The Amplify Flutter Auth category plugin using the AWS Cognito provider.
-version: 1.6.2
+version: 1.7.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/auth/amplify_auth_cognito
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,11 +19,11 @@ platforms:
   web:
 
 dependencies:
-  amplify_analytics_pinpoint: ">=1.6.2 <1.7.0"
+  amplify_analytics_pinpoint: ">=1.7.0 <1.8.0"
   amplify_analytics_pinpoint_dart: ">=0.3.6 <0.4.0"
-  amplify_auth_cognito_dart: ">=0.10.9 <0.11.0"
-  amplify_core: ">=1.6.0 <1.7.0"
-  amplify_flutter: ">=1.6.1 <1.7.0"
+  amplify_auth_cognito_dart: ">=0.10.10 <0.11.0"
+  amplify_core: ">=1.7.0 <1.8.0"
+  amplify_flutter: ">=1.7.0 <1.8.0"
   amplify_secure_storage: ">=0.4.1 <0.5.0"
   async: ^2.10.0
   flutter:

--- a/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.10
+
+- Minor bug fixes and improvements
+
 ## 0.10.9
 
 ### Fixes

--- a/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
@@ -25,7 +25,7 @@ dev_dependencies:
   browser_launcher: ^1.1.1
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
-  checks: ^0.2.0
+  checks: ^0.3.0
   cli_script: ^0.3.0
   io: ^1.0.0
   mime: ^1.0.0

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_dart
 description: A Dart-only implementation of the Amplify Auth plugin for Cognito.
-version: 0.10.9
+version: 0.10.10
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   amplify_analytics_pinpoint_dart: ">=0.3.6 <0.4.0"
-  amplify_core: ">=1.6.2 <1.7.0"
+  amplify_core: ">=1.7.0 <1.8.0"
   amplify_secure_storage_dart: ">=0.4.3 <0.5.0"
   async: ^2.10.0
   aws_common: ">=0.6.3 <0.7.0"

--- a/packages/authenticator/amplify_authenticator/CHANGELOG.md
+++ b/packages/authenticator/amplify_authenticator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.4
+
+- Minor bug fixes and improvements## 1.5.3
+
 ## 1.5.3
 
 ### Fixes

--- a/packages/authenticator/amplify_authenticator/lib/src/version.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.5.3';
+const packageVersion = '1.5.4';

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_authenticator
 description: A prebuilt Sign In and Sign Up experience for the Amplify Auth category
-version: 1.5.3
+version: 1.5.4
 homepage: https://ui.docs.amplify.aws/flutter/connected-components/authenticator
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/authenticator/amplify_authenticator
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,9 +10,9 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  amplify_auth_cognito: ">=1.6.1 <1.7.0"
-  amplify_core: ">=1.6.2 <1.7.0"
-  amplify_flutter: ">=1.6.1 <1.7.0"
+  amplify_auth_cognito: ">=1.7.0 <1.8.0"
+  amplify_core: ">=1.7.0 <1.8.0"
+  amplify_flutter: ">=1.7.0 <1.8.0"
   async: ^2.10.0
   aws_common: ">=0.6.2 <0.7.0"
   collection: ^1.15.0

--- a/packages/common/amplify_db_common_dart/CHANGELOG.md
+++ b/packages/common/amplify_db_common_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.6
+
+- Minor bug fixes and improvements
+
 ## 0.3.5
 
 ### Fixes

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_db_common_dart
 description: Common utilities for working with databases such as sqlite. Used throughout Amplify packages.
-version: 0.3.5
+version: 0.3.6
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/common/amplify_db_common_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  amplify_core: ">=1.6.0 <1.7.0"
+  amplify_core: ">=1.7.0 <1.8.0"
   async: ^2.10.0
   aws_common: ">=0.6.3 <0.7.0"
   drift: ">=2.14.0 <2.15.0"

--- a/packages/notifications/push/amplify_push_notifications/CHANGELOG.md
+++ b/packages/notifications/push/amplify_push_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0
+
+- Minor bug fixes and improvements
+
 ## 1.6.0
 
 ### Fixes

--- a/packages/notifications/push/amplify_push_notifications/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_push_notifications
 description: The Amplify Flutter Push Notifications package implementing features agnostic of an AWS Service such as Pinpoint.
-version: 1.6.0
+version: 1.7.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  amplify_core: ">=1.6.0 <1.7.0"
+  amplify_core: ">=1.7.0 <1.8.0"
   amplify_secure_storage: ">=0.4.0+6 <0.5.0"
   async: ^2.10.0
   flutter:

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/CHANGELOG.md
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0
+
+- Minor bug fixes and improvements
+
 ## 1.6.2
 
 ### Fixes

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_push_notifications_pinpoint
 description: The Amplify Flutter Push Notifications category plugin using the AWS Pinpoint provider.
-version: 1.6.2
+version: 1.7.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
@@ -14,12 +14,12 @@ platforms:
   android:
 
 dependencies:
-  amplify_analytics_pinpoint: ">=1.6.3 <1.7.0"
+  amplify_analytics_pinpoint: ">=1.7.0 <1.8.0"
   amplify_analytics_pinpoint_dart: ">=0.3.6 <0.4.0"
-  amplify_auth_cognito: ">=1.6.0 <1.7.0"
-  amplify_core: ">=1.6.0 <1.7.0"
-  amplify_flutter: ">=1.6.0 <1.7.0"
-  amplify_push_notifications: ">=1.6.0 <1.7.0"
+  amplify_auth_cognito: ">=1.7.0 <1.8.0"
+  amplify_core: ">=1.7.0 <1.8.0"
+  amplify_flutter: ">=1.7.0 <1.8.0"
+  amplify_push_notifications: ">=1.7.0 <1.8.0"
   amplify_secure_storage: ">=0.4.0+5 <0.5.0"
   flutter:
     sdk: flutter

--- a/packages/secure_storage/amplify_secure_storage/CHANGELOG.md
+++ b/packages/secure_storage/amplify_secure_storage/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2
+
+### Fixes
+- fix: `google.crypto.tink` version constraint ([#4434](https://github.com/aws-amplify/amplify-flutter/pull/4434))
+
 ## 0.4.1
 
 ### Fixes

--- a/packages/secure_storage/amplify_secure_storage/android/build.gradle
+++ b/packages/secure_storage/amplify_secure_storage/android/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'androidx.security:security-crypto:1.0.0'
     // TODO(Jordan-Nelson): remove once security-crypto:1.1.0 is stable.
     // See https://github.com/aws-amplify/amplify-flutter/issues/2640
-    implementation 'com.google.crypto.tink:tink-android:[1.8.0'
+    implementation 'com.google.crypto.tink:tink-android:[1.8.0, )'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.10.3'
     testImplementation 'androidx.test:core-ktx:1.5.0'

--- a/packages/secure_storage/amplify_secure_storage/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_secure_storage
 description: A package for storing secrets, intended for use in Amplify libraries.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/secure_storage/amplify_secure_storage
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/storage/amplify_storage_s3/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0
+
+- Minor bug fixes and improvements
+
 ## 1.6.2
 
 ### Fixes

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3
 description: The Amplify Flutter Storage category plugin using the AWS S3 provider.
-version: 1.6.2
+version: 1.7.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/storage/amplify_storage_s3
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,9 +19,9 @@ platforms:
   web:
 
 dependencies:
-  amplify_core: ">=1.6.0 <1.7.0"
+  amplify_core: ">=1.7.0 <1.8.0"
   amplify_db_common: ">=0.3.5 <0.4.0"
-  amplify_storage_s3_dart: ">=0.3.9 <0.4.0"
+  amplify_storage_s3_dart: ">=0.3.10 <0.4.0"
   aws_common: ">=0.6.0 <0.7.0"
   flutter:
     sdk: flutter

--- a/packages/storage/amplify_storage_s3_dart/CHANGELOG.md
+++ b/packages/storage/amplify_storage_s3_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.10
+
+- Minor bug fixes and improvements
+
 ## 0.3.9
 
 ### Fixes

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_storage_s3_dart
 description: A Dart-only implementation of the Amplify Storage plugin for S3.
-version: 0.3.9
+version: 0.3.10
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/storage/amplify_storage_s3_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  amplify_core: ">=1.6.2 <1.7.0"
+  amplify_core: ">=1.7.0 <1.8.0"
   amplify_db_common_dart: ">=0.3.5 <0.4.0"
   async: ^2.10.0
   aws_common: ">=0.6.3 <0.7.0"


### PR DESCRIPTION
chore(version): Bump version

### Features
- feat(api): add copyWith to GraphQLRequest ([#4365](https://github.com/aws-amplify/amplify-flutter/pull/4365))

### Fixes
- fix: `google.crypto.tink` version constraint ([#4434](https://github.com/aws-amplify/amplify-flutter/pull/4434))

### Chores
- chore(datastore): Amplify Swift version bump to 1.30.7 ([#4454](https://github.com/aws-amplify/amplify-flutter/pull/4454))

Updated-Components: amplify_lints, Amplify Flutter, Amplify Dart, Amplify UI, DB Common, Secure Storage, AWS Common, Smithy, Worker Bee


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
