### PR TITLE
fix(auth): verifyTotp throw EnableSoftwareTokenMfaException

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_totp_optional_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_totp_optional_test.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_auth_integration_test/amplify_auth_integration_test.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_integration_test/amplify_integration_test.dart';
@@ -117,9 +118,15 @@ void main() {
 
           final totpSetupResult = await Amplify.Auth.setUpTotp();
 
-          await Amplify.Auth.verifyTotpSetup(
-            '555555',
-          );
+          try {
+            await Amplify.Auth.verifyTotpSetup('555555');
+            fail('Expected to fail');
+          } on AuthException catch (e) {
+            check(
+              e,
+              because: 'Invalid TOTP code should fail verification',
+            ).isA<CodeMismatchException>();
+          }
 
           check(
             await cognitoPlugin.fetchMfaPreference(),
@@ -131,9 +138,13 @@ void main() {
             ),
           );
 
-          await Amplify.Auth.verifyTotpSetup(
-            await generateTotpCode(totpSetupResult.sharedSecret),
-          );
+          try {
+            await Amplify.Auth.verifyTotpSetup(
+              await generateTotpCode(totpSetupResult.sharedSecret),
+            );
+          } on Exception catch (e) {
+            fail('Expected to succeed, but got $e');
+          }
 
           check(await cognitoPlugin.fetchMfaPreference()).equals(
             const UserMfaPreference(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_totp_optional_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_totp_optional_test.dart
@@ -125,7 +125,7 @@ void main() {
             check(
               e,
               because: 'Invalid TOTP code should fail verification',
-            ).isA<CodeMismatchException>();
+            ).isA<EnableSoftwareTokenMfaException>();
           }
 
           check(

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -941,7 +941,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
 
     switch (state) {
       case TotpSetupRequiresVerification _:
-        throw const CodeMismatchException('The code provided was incorrect');
+        throw const EnableSoftwareTokenMfaException(
+          'The code provided was incorrect, try again',
+        );
       case TotpSetupFailure(:final exception, :final stackTrace):
         Error.throwWithStackTrace(exception, stackTrace);
       default:

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -941,6 +941,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
 
     switch (state) {
       case TotpSetupRequiresVerification _:
+        // TODO(equartey): Change to `CodeMismatchException` in next major version as breaking change
         throw const EnableSoftwareTokenMfaException(
           'The code provided was incorrect, try again',
         );

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -932,12 +932,21 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
       defaultPluginOptions: const CognitoVerifyTotpSetupPluginOptions(),
     );
     final machine = _stateMachine.getOrCreate(TotpSetupStateMachine.type);
-    await machine.dispatchAndComplete<TotpSetupState>(
+    final state = await machine.dispatchAndComplete<TotpSetupState>(
       TotpSetupEvent.verify(
         code: totpCode,
         friendlyDeviceName: pluginOptions.friendlyDeviceName,
       ),
     );
+
+    switch (state) {
+      case TotpSetupRequiresVerification _:
+        throw const CodeMismatchException('The code provided was incorrect');
+      case TotpSetupFailure(:final exception, :final stackTrace):
+        Error.throwWithStackTrace(exception, stackTrace);
+      default:
+        return;
+    }
   }
 
   @override


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/4490
*Description of changes:*
Throw exception when verifying the setup TOTP code for better DX/UX. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
