### PR TITLE
chore(version): Bump version 1.7.2

### DIFF
--- a/packages/auth/amplify_auth_cognito/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito/CHANGELOG.md
@@ -1,8 +1,13 @@
-## 1.7.1
+## 1.7.2
 
 ### Fixes
 - fix(auth): Allow retries with verifyTotpSetup() ([#4532](https://github.com/aws-amplify/amplify-flutter/pull/4532))
 - fix(auth): device metadata migration ([#4503](https://github.com/aws-amplify/amplify-flutter/pull/4503))
+- fix(auth): verifyTotp throw EnableSoftwareTokenMfaException ([#4558](https://github.com/aws-amplify/amplify-flutter/pull/4558))
+
+## 1.7.1
+
+- This version was retracted to avoid a breaking change introduced in ([#4532](https://github.com/aws-amplify/amplify-flutter/pull/4532))
 
 ## 1.7.0
 

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito
 description: The Amplify Flutter Auth category plugin using the AWS Cognito provider.
-version: 1.7.1
+version: 1.7.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/auth/amplify_auth_cognito
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -21,7 +21,7 @@ platforms:
 dependencies:
   amplify_analytics_pinpoint: ">=1.7.0 <1.8.0"
   amplify_analytics_pinpoint_dart: ">=0.3.6 <0.4.0"
-  amplify_auth_cognito_dart: ">=0.10.11 <0.11.0"
+  amplify_auth_cognito_dart: ">=0.10.12 <0.11.0"
   amplify_core: ">=1.7.0 <1.8.0"
   amplify_flutter: ">=1.7.0 <1.8.0"
   amplify_secure_storage: ">=0.4.1 <0.5.0"

--- a/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
@@ -1,8 +1,13 @@
-## 0.10.11
+## 0.10.12
 
 ### Fixes
 - fix(auth): Allow retries with verifyTotpSetup() ([#4532](https://github.com/aws-amplify/amplify-flutter/pull/4532))
 - fix(auth): device metadata migration ([#4503](https://github.com/aws-amplify/amplify-flutter/pull/4503))
+- fix(auth): verifyTotp throw EnableSoftwareTokenMfaException ([#4558](https://github.com/aws-amplify/amplify-flutter/pull/4558))
+
+## 0.10.11
+
+- This version was retracted to avoid a breaking change introduced in ([#4532](https://github.com/aws-amplify/amplify-flutter/pull/4532))
 
 ## 0.10.10
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -932,12 +932,24 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
       defaultPluginOptions: const CognitoVerifyTotpSetupPluginOptions(),
     );
     final machine = _stateMachine.getOrCreate(TotpSetupStateMachine.type);
-    await machine.dispatchAndComplete<TotpSetupState>(
+    final state = await machine.dispatchAndComplete<TotpSetupState>(
       TotpSetupEvent.verify(
         code: totpCode,
         friendlyDeviceName: pluginOptions.friendlyDeviceName,
       ),
     );
+
+    switch (state) {
+      case TotpSetupRequiresVerification _:
+        // TODO(equartey): Change to `CodeMismatchException` in next major version as breaking change
+        throw const EnableSoftwareTokenMfaException(
+          'The code provided was incorrect, try again',
+        );
+      case TotpSetupFailure(:final exception, :final stackTrace):
+        Error.throwWithStackTrace(exception, stackTrace);
+      default:
+        return;
+    }
   }
 
   @override

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_dart
 description: A Dart-only implementation of the Amplify Auth plugin for Cognito.
-version: 0.10.11
+version: 0.10.12
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues


### PR DESCRIPTION
chore(version): Bump version
### Fixes
- fix(auth): Allow retries with verifyTotpSetup() ([https://github.com/aws-amplify/amplify-flutter/pull/4532](https://github.com/aws-amplify/amplify-flutter/pull/4532))
- fix(auth): device metadata migration ([https://github.com/aws-amplify/amplify-flutter/pull/4503](https://github.com/aws-amplify/amplify-flutter/pull/4503))
- fix(auth): verifyTotp throw EnableSoftwareTokenMfaException ([https://github.com/aws-amplify/amplify-flutter/pull/4558](https://github.com/aws-amplify/amplify-flutter/pull/4558))

Updated-Components: amplify_lints, Amplify Flutter, Amplify Dart, Amplify UI, DB Common, Secure Storage, AWS Common, Smithy, Worker Bee


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
