### PR TITLE
chore: use java 17 in android e2e tests

### DIFF
--- a/.github/workflows/e2e_android.yaml
+++ b/.github/workflows/e2e_android.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # 3.12.0
         with:
           distribution: "corretto" # Amazon Corretto Build of OpenJDK
-          java-version: "11"
+          java-version: "17"
 
       - name: Install dependencies
         uses: ./.github/composite_actions/install_dependencies


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update Android e2e test suite to use java 17

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
