### PR TITLE
fix(api): Paginated GraphQL preserve request params

### DIFF
--- a/packages/api/amplify_api_dart/lib/src/graphql/helpers/graphql_response_decoder.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/helpers/graphql_response_decoder.dart
@@ -99,6 +99,8 @@ class GraphQLResponseDecoder {
           decodePath: request.decodePath,
           variables: variablesWithNextToken,
           modelType: request.modelType,
+          authorizationMode: request.authorizationMode,
+          apiName: request.apiName,
         );
       }
       decodedData = modelType.fromJson(

--- a/packages/api/amplify_api_dart/test/graphql_helpers_test.dart
+++ b/packages/api/amplify_api_dart/test/graphql_helpers_test.dart
@@ -231,7 +231,11 @@ void main() {
           () async {
         const limit = 2;
         final GraphQLRequest<PaginatedResult<Blog>> req =
-            ModelQueries.list<Blog>(Blog.classType, limit: limit);
+            ModelQueries.list<Blog>(
+          Blog.classType,
+          limit: limit,
+          authorizationMode: APIAuthorizationType.iam,
+        );
 
         const data = '''{
           "listBlogs": {
@@ -263,6 +267,8 @@ void main() {
           response.data?.nextToken,
         );
         expect(resultRequest?.variables['limit'], limit);
+        expect(resultRequest?.authorizationMode, req.authorizationMode);
+        expect(resultRequest?.apiName, req.apiName);
       });
 
       test(


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/4585

*Description of changes:*
`requestForNextResult ` now preserves the auth mode and api name if provided in the original request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
