### PR TITLE
chore(storage): add e2e tests for `uploadData`, `uploadFile`, `getUrl`, `getProperties`

### DIFF
--- a/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'utils/configure.dart';
+import 'utils/sign_in_new_user.dart';
+import 'utils/tear_down.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('getProperties()', () {
+    final path = 'public/get-properties-${uuid()}';
+    final data = 'get properties data'.codeUnits;
+    final metadata = {'foo': 'bar'};
+    setUpAll(() async {
+      await configure(amplifyEnvironments['main']!);
+      addTearDownPath(StoragePath.fromString(path));
+      await Amplify.Storage.uploadData(
+        data: HttpPayload.bytes(data),
+        path: StoragePath.fromString(path),
+        options: StorageUploadDataOptions(metadata: metadata),
+      ).result;
+    });
+
+    test('String StoragePath', () async {
+      final result = await Amplify.Storage.getProperties(
+        path: StoragePath.fromString(path),
+      ).result;
+      expect(result.storageItem.path, path);
+      expect(result.storageItem.metadata, metadata);
+      expect(result.storageItem.eTag, isNotNull);
+      expect(result.storageItem.size, data.length);
+    });
+
+    test('with identity ID', () async {
+      final userIdentityId = await signInNewUser();
+      final name = 'get-properties-with-identity-id-${uuid()}';
+      final data = 'with identity ID'.codeUnits;
+      final expectedResolvedPath = 'private/$userIdentityId/$name';
+      addTearDownPath(StoragePath.fromString(expectedResolvedPath));
+      final result = await Amplify.Storage.getProperties(
+        path: StoragePath.fromIdentityId(
+          ((identityId) => 'private/$identityId/$name'),
+        ),
+      ).result;
+      expect(result.storageItem.path, path);
+      expect(result.storageItem.metadata, metadata);
+      expect(result.storageItem.eTag, isNotNull);
+      expect(result.storageItem.size, data.length);
+    });
+
+    test('unauthorized path', () async {
+      expect(
+        () => Amplify.Storage.getProperties(
+          path: const StoragePath.fromString('unauthorized/path'),
+        ).result,
+        throwsA(isA<StorageAccessDeniedException>()),
+      );
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
@@ -45,9 +45,7 @@ void main() {
       addTearDownPath(StoragePath.fromString(expectedResolvedPath));
       await Amplify.Storage.uploadData(
         data: HttpPayload.bytes(data),
-        path: StoragePath.fromIdentityId(
-          (identityId) => 'private/$identityId/$name',
-        ),
+        path: StoragePath.fromString(expectedResolvedPath),
         options: const StorageUploadDataOptions(metadata: metadata),
       ).result;
       final result = await Amplify.Storage.getProperties(

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
@@ -27,7 +27,7 @@ void main() {
       ).result;
     });
 
-    test('String StoragePath', () async {
+    testWidgets('String StoragePath', (_) async {
       final result = await Amplify.Storage.getProperties(
         path: StoragePath.fromString(path),
       ).result;
@@ -37,7 +37,7 @@ void main() {
       expect(result.storageItem.size, data.length);
     });
 
-    test('with identity ID', () async {
+    testWidgets('with identity ID', (_) async {
       final userIdentityId = await signInNewUser();
       final name = 'get-properties-with-identity-id-${uuid()}';
       final data = 'with identity ID'.codeUnits;
@@ -61,7 +61,7 @@ void main() {
       expect(result.storageItem.size, data.length);
     });
 
-    test('unauthorized path', () async {
+    testWidgets('unauthorized path', (_) async {
       expect(
         () => Amplify.Storage.getProperties(
           path: const StoragePath.fromString('unauthorized/path'),

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
@@ -43,12 +43,19 @@ void main() {
       final data = 'with identity ID'.codeUnits;
       final expectedResolvedPath = 'private/$userIdentityId/$name';
       addTearDownPath(StoragePath.fromString(expectedResolvedPath));
+      await Amplify.Storage.uploadData(
+        data: HttpPayload.bytes(data),
+        path: StoragePath.fromIdentityId(
+          (identityId) => 'private/$identityId/$name',
+        ),
+        options: StorageUploadDataOptions(metadata: metadata),
+      ).result;
       final result = await Amplify.Storage.getProperties(
         path: StoragePath.fromIdentityId(
           ((identityId) => 'private/$identityId/$name'),
         ),
       ).result;
-      expect(result.storageItem.path, path);
+      expect(result.storageItem.path, expectedResolvedPath);
       expect(result.storageItem.metadata, metadata);
       expect(result.storageItem.eTag, isNotNull);
       expect(result.storageItem.size, data.length);

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
@@ -16,14 +16,14 @@ void main() {
   group('getProperties()', () {
     final path = 'public/get-properties-${uuid()}';
     final data = 'get properties data'.codeUnits;
-    final metadata = {'foo': 'bar'};
+    const metadata = {'description': 'foo'};
     setUpAll(() async {
       await configure(amplifyEnvironments['main']!);
       addTearDownPath(StoragePath.fromString(path));
       await Amplify.Storage.uploadData(
         data: HttpPayload.bytes(data),
         path: StoragePath.fromString(path),
-        options: StorageUploadDataOptions(metadata: metadata),
+        options: const StorageUploadDataOptions(metadata: metadata),
       ).result;
     });
 
@@ -48,7 +48,7 @@ void main() {
         path: StoragePath.fromIdentityId(
           (identityId) => 'private/$identityId/$name',
         ),
-        options: StorageUploadDataOptions(metadata: metadata),
+        options: const StorageUploadDataOptions(metadata: metadata),
       ).result;
       final result = await Amplify.Storage.getProperties(
         path: StoragePath.fromIdentityId(

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
@@ -31,7 +31,7 @@ void main() {
       ).result;
     });
 
-    test('String StoragePath', () async {
+    testWidgets('String StoragePath', (_) async {
       final result = await Amplify.Storage.getUrl(
         path: StoragePath.fromString(path),
       ).result;
@@ -40,7 +40,7 @@ void main() {
       expect(actualData, data);
     });
 
-    test('with identity ID', () async {
+    testWidgets('with identity ID', (_) async {
       final userIdentityId = await signInNewUser();
       final name = 'get-url-with-identity-id-${uuid()}';
       final data = 'with identity ID'.codeUnits;
@@ -64,7 +64,7 @@ void main() {
     });
 
     group('unauthorized path', () {
-      test('validateObjectExistence true', () async {
+      testWidgets('validateObjectExistence true', (_) async {
         expect(
           () => Amplify.Storage.getUrl(
             path: const StoragePath.fromString('unauthorized/path'),
@@ -78,7 +78,7 @@ void main() {
         );
       });
 
-      test('validateObjectExistence false', () async {
+      testWidgets('validateObjectExistence false', (_) async {
         final result = await Amplify.Storage.getUrl(
           path: const StoragePath.fromString('unauthorized/path'),
           options: const StorageGetUrlOptions(
@@ -95,7 +95,7 @@ void main() {
     });
 
     group('with options', () {
-      test('expiresIn', () async {
+      testWidgets('expiresIn', (_) async {
         const duration = Duration(seconds: 10);
         final result = await Amplify.Storage.getUrl(
           path: StoragePath.fromString(path),
@@ -115,7 +115,7 @@ void main() {
         );
       });
 
-      test('validateObjectExistence true', () async {
+      testWidgets('validateObjectExistence true', (_) async {
         expect(
           () => Amplify.Storage.getUrl(
             path: const StoragePath.fromString('public/non-existent-path'),
@@ -129,7 +129,7 @@ void main() {
         );
       });
 
-      test('validateObjectExistence false', () async {
+      testWidgets('validateObjectExistence false', (_) async {
         expect(
           Amplify.Storage.getUrl(
             path: const StoragePath.fromString('public/non-existent-path'),
@@ -143,7 +143,7 @@ void main() {
         );
       });
 
-      test('useAccelerateEndpoint', () async {
+      testWidgets('useAccelerateEndpoint', (_) async {
         final result = await Amplify.Storage.getUrl(
           path: StoragePath.fromString(path),
           options: const StorageGetUrlOptions(

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
@@ -48,9 +48,7 @@ void main() {
       addTearDownPath(StoragePath.fromString(expectedResolvedPath));
       await Amplify.Storage.uploadData(
         data: HttpPayload.bytes(data),
-        path: StoragePath.fromIdentityId(
-          (identityId) => 'private/$identityId/$name',
-        ),
+        path: StoragePath.fromString(expectedResolvedPath),
       ).result;
 
       final result = await Amplify.Storage.getUrl(

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
@@ -20,12 +20,10 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('getUrl()', () {
-    late String path;
-    late List<int> data;
+    final path = 'public/get-url-${uuid()}';
+    final data = 'get url data'.codeUnits;
     setUpAll(() async {
       await configure(amplifyEnvironments['main']!);
-      path = 'public/get-url-${uuid()}';
-      data = 'get url data'.codeUnits;
       addTearDownPath(StoragePath.fromString(path));
       await Amplify.Storage.uploadData(
         data: HttpPayload.bytes(data),

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
@@ -1,0 +1,163 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3/amplify_storage_s3.dart';
+import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'utils/configure.dart';
+import 'utils/sign_in_new_user.dart';
+import 'utils/tear_down.dart';
+
+Future<List<int>> readData(Uri uri) async {
+  return (await read(uri)).codeUnits;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('getUrl()', () {
+    late String path;
+    late List<int> data;
+    setUpAll(() async {
+      await configure(amplifyEnvironments['main']!);
+      path = 'public/get-url-${uuid()}';
+      data = 'get url data'.codeUnits;
+      addTearDownPath(StoragePath.fromString(path));
+      await Amplify.Storage.uploadData(
+        data: HttpPayload.bytes(data),
+        path: StoragePath.fromString(path),
+      ).result;
+    });
+
+    test('String StoragePath', () async {
+      final result = await Amplify.Storage.getUrl(
+        path: StoragePath.fromString(path),
+      ).result;
+      expect(result.url.path, '/$path');
+      final actualData = await readData(result.url);
+      expect(actualData, data);
+    });
+
+    test('with identity ID', () async {
+      final userIdentityId = await signInNewUser();
+      final name = 'get-url-with-identity-id-${uuid()}';
+      final data = 'with identity ID'.codeUnits;
+      final expectedResolvedPath = 'private/$userIdentityId/$name';
+      addTearDownPath(StoragePath.fromString(expectedResolvedPath));
+      await Amplify.Storage.uploadData(
+        data: HttpPayload.bytes(data),
+        path: StoragePath.fromIdentityId(
+          (identityId) => 'private/$identityId/$name',
+        ),
+      ).result;
+
+      final result = await Amplify.Storage.getUrl(
+        path: StoragePath.fromIdentityId(
+          (identityId) => 'private/$identityId/$name',
+        ),
+      ).result;
+      expect(result.url.path, '/$expectedResolvedPath');
+      final actualData = await readData(result.url);
+      expect(actualData, data);
+    });
+
+    group('unauthorized path', () {
+      test('validateObjectExistence true', () async {
+        expect(
+          () => Amplify.Storage.getUrl(
+            path: const StoragePath.fromString('unauthorized/path'),
+            options: const StorageGetUrlOptions(
+              pluginOptions: S3GetUrlPluginOptions(
+                validateObjectExistence: true,
+              ),
+            ),
+          ).result,
+          throwsA(isA<StorageAccessDeniedException>()),
+        );
+      });
+
+      test('validateObjectExistence false', () async {
+        final result = await Amplify.Storage.getUrl(
+          path: const StoragePath.fromString('unauthorized/path'),
+          options: const StorageGetUrlOptions(
+            pluginOptions: S3GetUrlPluginOptions(
+              validateObjectExistence: false,
+            ),
+          ),
+        ).result;
+        expect(
+          () => readData(result.url),
+          throwsA(isA<ClientException>()),
+        );
+      });
+    });
+
+    group('with options', () {
+      test('expiresIn', () async {
+        const duration = Duration(seconds: 10);
+        final result = await Amplify.Storage.getUrl(
+          path: StoragePath.fromString(path),
+          options: const StorageGetUrlOptions(
+            pluginOptions: S3GetUrlPluginOptions(
+              expiresIn: duration,
+            ),
+          ),
+        ).result;
+        expect(result.url.path, '/$path');
+        final actualData = await readData(result.url);
+        expect(actualData, data);
+        await Future<void>.delayed(duration);
+        expect(
+          () => readData(result.url),
+          throwsA(isA<ClientException>()),
+        );
+      });
+
+      test('validateObjectExistence true', () async {
+        expect(
+          () => Amplify.Storage.getUrl(
+            path: const StoragePath.fromString('public/non-existent-path'),
+            options: const StorageGetUrlOptions(
+              pluginOptions: S3GetUrlPluginOptions(
+                validateObjectExistence: true,
+              ),
+            ),
+          ).result,
+          throwsA(isA<StorageKeyNotFoundException>()),
+        );
+      });
+
+      test('validateObjectExistence false', () async {
+        expect(
+          Amplify.Storage.getUrl(
+            path: const StoragePath.fromString('public/non-existent-path'),
+            options: const StorageGetUrlOptions(
+              pluginOptions: S3GetUrlPluginOptions(
+                validateObjectExistence: false,
+              ),
+            ),
+          ).result,
+          completes,
+        );
+      });
+
+      test('useAccelerateEndpoint', () async {
+        final result = await Amplify.Storage.getUrl(
+          path: StoragePath.fromString(path),
+          options: const StorageGetUrlOptions(
+            pluginOptions: S3GetUrlPluginOptions(
+              useAccelerateEndpoint: true,
+            ),
+          ),
+        ).result;
+        expect(result.url.path, '/$path');
+        final actualData = await readData(result.url);
+        expect(actualData, data);
+      });
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'get_url_test.dart' as get_url_test;
 import 'issues/get_url_special_characters_test.dart'
     as get_url_special_characters_tests;
 import 'upload_data_test.dart' as upload_data_test;
@@ -16,6 +17,7 @@ void main() {
   group('amplify_storage_s3', () {
     get_url_special_characters_tests.main();
     use_case_tests.main();
+    get_url_test.main();
     upload_file_test.main();
     upload_data_test.main();
   });

--- a/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
@@ -6,6 +6,8 @@ import 'package:integration_test/integration_test.dart';
 
 import 'issues/get_url_special_characters_test.dart'
     as get_url_special_characters_tests;
+import 'upload_data_test.dart' as upload_data_test;
+import 'upload_file_test.dart' as upload_file_test;
 import 'use_case_test.dart' as use_case_tests;
 
 void main() {
@@ -14,5 +16,7 @@ void main() {
   group('amplify_storage_s3', () {
     get_url_special_characters_tests.main();
     use_case_tests.main();
+    upload_file_test.main();
+    upload_data_test.main();
   });
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'get_properties_test.dart' as get_properties_test;
 import 'get_url_test.dart' as get_url_test;
 import 'issues/get_url_special_characters_test.dart'
     as get_url_special_characters_tests;
@@ -18,6 +19,7 @@ void main() {
     get_url_special_characters_tests.main();
     use_case_tests.main();
     get_url_test.main();
+    get_properties_test.main();
     upload_file_test.main();
     upload_data_test.main();
   });

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
@@ -163,7 +163,7 @@ void main() {
       );
       final result = await Amplify.Storage.uploadData(
         data: HttpPayload.bytes(data),
-        path: StoragePath.withIdentityId(
+        path: StoragePath.fromIdentityId(
           (identityId) => 'private/$identityId/$name',
         ),
       ).result;

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
@@ -1,0 +1,243 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:convert';
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3/amplify_storage_s3.dart';
+import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'utils/configure.dart';
+import 'utils/sign_in_new_user.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('uploadData()', () {
+    setUpAll(() async {
+      await configure(amplifyEnvironments['main']!);
+    });
+    group('for data type', () {
+      test('bytes', () async {
+        final path = 'public/upload-data-from-bytes-${uuid()}';
+        final data = 'from bytes'.codeUnits;
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadData(
+          data: HttpPayload.bytes(data),
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final downloadResult = await Amplify.Storage.downloadData(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(downloadResult.bytes, data);
+      });
+
+      test('dataUrl', () async {
+        final path = 'public/upload-data-url-${uuid()}';
+        final data = 'dataUrl'.codeUnits;
+        final dataUrl =
+            'data:text/plain;charset=utf-8;base64,${base64Encode(data)}';
+
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadData(
+          data: HttpPayload.dataUrl(dataUrl),
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final downloadResult = await Amplify.Storage.downloadData(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(downloadResult.bytes, data);
+      });
+
+      test('json', () async {
+        final path = 'public/upload-data-from-stream-${uuid()}';
+        final json = {'foo': 'bar'};
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadData(
+          data: HttpPayload.json(json),
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final downloadResult = await Amplify.Storage.downloadData(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(downloadResult.bytes, jsonEncode(json).toString().codeUnits);
+      });
+
+      test('formFields', () async {
+        final path = 'public/upload-data-form-fields-${uuid()}';
+        const key = 'foo';
+        const value = 'bar';
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadData(
+          data: HttpPayload.formFields({key: value}),
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final downloadResult = await Amplify.Storage.downloadData(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(downloadResult.bytes, '$key=$value'.codeUnits);
+      });
+
+      test('string', () async {
+        final path = 'public/upload-data-string-${uuid()}';
+        const data = 'string';
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadData(
+          data: HttpPayload.string(data),
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final downloadResult = await Amplify.Storage.downloadData(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(downloadResult.bytes, data.codeUnits);
+      });
+
+      test('empty', () async {
+        final path = 'public/upload-data-empty-${uuid()}';
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadData(
+          data: const HttpPayload.empty(),
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final downloadResult = await Amplify.Storage.downloadData(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(downloadResult.bytes, <int>[]);
+      });
+
+      test('stream', () async {
+        final path = 'public/upload-data-stream-${uuid()}';
+        final data = [1, 2, 3];
+        final stream = Stream<List<int>>.value(data);
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadData(
+          data: HttpPayload.streaming(stream),
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final downloadResult = await Amplify.Storage.downloadData(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(downloadResult.bytes, data);
+      });
+    });
+
+    test('with identity ID', () async {
+      final userIdentityId = await signInNewUser();
+      final name = 'upload-data-with-identity-id-${uuid()}';
+      final data = 'with identity ID'.codeUnits;
+      final expectedResolvedPath = 'private/$userIdentityId/$name';
+      addTearDown(
+        () => Amplify.Storage.remove(
+          path: StoragePath.fromString(expectedResolvedPath),
+        ),
+      );
+      final result = await Amplify.Storage.uploadData(
+        data: HttpPayload.bytes(data),
+        path: StoragePath.withIdentityId(
+          (identityId) => 'private/$identityId/$name',
+        ),
+      ).result;
+
+      expect(result.uploadedItem.path, expectedResolvedPath);
+
+      final downloadResult = await Amplify.Storage.downloadData(
+        path: StoragePath.fromString(expectedResolvedPath),
+      ).result;
+      expect(downloadResult.bytes, data);
+    });
+
+    group('with options', () {
+      test('metadata', () async {
+        final path = 'public/upload-data-with-metadata-${uuid()}';
+        final data = 'metadata'.codeUnits;
+        const metadata = {'foo': 'bar'};
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadData(
+          data: HttpPayload.bytes(data),
+          path: StoragePath.fromString(path),
+          options: const StorageUploadDataOptions(metadata: metadata),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final propertiesResult = await Amplify.Storage.getProperties(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(propertiesResult.storageItem.metadata, metadata);
+      });
+
+      test('getProperties', () async {
+        final path = 'public/upload-data-get-properties-${uuid()}';
+        final data = 'getProperties'.codeUnits;
+        const metadata = {'foo': 'bar'};
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadData(
+          data: HttpPayload.bytes(data),
+          path: StoragePath.fromString(path),
+          options: const StorageUploadDataOptions(
+            metadata: metadata,
+            pluginOptions: S3UploadDataPluginOptions(getProperties: true),
+          ),
+        ).result;
+        expect(result.uploadedItem.path, path);
+        expect(result.uploadedItem.metadata, metadata);
+      });
+
+      test('useAccelerateEndpoint', () async {
+        final path = 'public/upload-data-acceleration-${uuid()}';
+        final data = 'useAccelerateEndpoint'.codeUnits;
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadData(
+          data: HttpPayload.bytes(data),
+          path: StoragePath.fromString(path),
+          options: const StorageUploadDataOptions(
+            pluginOptions: S3UploadDataPluginOptions(
+              useAccelerateEndpoint: true,
+            ),
+          ),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final downloadResult = await Amplify.Storage.downloadData(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(downloadResult.bytes, data);
+      });
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
@@ -172,7 +172,7 @@ void main() {
       testWidgets('metadata', (_) async {
         final path = 'public/upload-data-with-metadata-${uuid()}';
         final data = 'metadata'.codeUnits;
-        const metadata = {'foo': 'bar'};
+        const metadata = {'description': 'foo'};
         addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
           data: HttpPayload.bytes(data),
@@ -190,7 +190,7 @@ void main() {
       testWidgets('getProperties', (_) async {
         final path = 'public/upload-data-get-properties-${uuid()}';
         final data = 'getProperties'.codeUnits;
-        const metadata = {'foo': 'bar'};
+        const metadata = {'description': 'foo'};
         addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
           data: HttpPayload.bytes(data),

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
@@ -158,6 +158,16 @@ void main() {
       expect(downloadResult.bytes, data);
     });
 
+    test('unauthorized path', () async {
+      expect(
+        () => Amplify.Storage.uploadData(
+          data: HttpPayload.bytes('unauthorized path'.codeUnits),
+          path: const StoragePath.fromString('unauthorized/path'),
+        ).result,
+        throwsA(isA<StorageAccessDeniedException>()),
+      );
+    });
+
     group('with options', () {
       test('metadata', () async {
         final path = 'public/upload-data-with-metadata-${uuid()}';

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
@@ -21,7 +21,7 @@ void main() {
       await configure(amplifyEnvironments['main']!);
     });
     group('for data type', () {
-      test('bytes', () async {
+      testWidgets('bytes', (_) async {
         final path = 'public/upload-data-from-bytes-${uuid()}';
         final data = 'from bytes'.codeUnits;
         addTearDownPath(StoragePath.fromString(path));
@@ -37,7 +37,7 @@ void main() {
         expect(downloadResult.bytes, data);
       });
 
-      test('dataUrl', () async {
+      testWidgets('dataUrl', (_) async {
         final path = 'public/upload-data-url-${uuid()}';
         final data = 'dataUrl'.codeUnits;
         final dataUrl =
@@ -55,7 +55,7 @@ void main() {
         expect(downloadResult.bytes, data);
       });
 
-      test('json', () async {
+      testWidgets('json', (_) async {
         final path = 'public/upload-data-from-stream-${uuid()}';
         final json = {'foo': 'bar'};
         addTearDownPath(StoragePath.fromString(path));
@@ -71,7 +71,7 @@ void main() {
         expect(downloadResult.bytes, jsonEncode(json).toString().codeUnits);
       });
 
-      test('formFields', () async {
+      testWidgets('formFields', (_) async {
         final path = 'public/upload-data-form-fields-${uuid()}';
         const key = 'foo';
         const value = 'bar';
@@ -88,7 +88,7 @@ void main() {
         expect(downloadResult.bytes, '$key=$value'.codeUnits);
       });
 
-      test('string', () async {
+      testWidgets('string', (_) async {
         final path = 'public/upload-data-string-${uuid()}';
         const data = 'string';
         addTearDownPath(StoragePath.fromString(path));
@@ -104,7 +104,7 @@ void main() {
         expect(downloadResult.bytes, data.codeUnits);
       });
 
-      test('empty', () async {
+      testWidgets('empty', (_) async {
         final path = 'public/upload-data-empty-${uuid()}';
         addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
@@ -119,7 +119,7 @@ void main() {
         expect(downloadResult.bytes, <int>[]);
       });
 
-      test('stream', () async {
+      testWidgets('stream', (_) async {
         final path = 'public/upload-data-stream-${uuid()}';
         final data = [1, 2, 3];
         final stream = Stream<List<int>>.value(data);
@@ -137,7 +137,7 @@ void main() {
       });
     });
 
-    test('with identity ID', () async {
+    testWidgets('with identity ID', (_) async {
       final userIdentityId = await signInNewUser();
       final name = 'upload-data-with-identity-id-${uuid()}';
       final data = 'with identity ID'.codeUnits;
@@ -158,7 +158,7 @@ void main() {
       expect(downloadResult.bytes, data);
     });
 
-    test('unauthorized path', () async {
+    testWidgets('unauthorized path', (_) async {
       expect(
         () => Amplify.Storage.uploadData(
           data: HttpPayload.bytes('unauthorized path'.codeUnits),
@@ -169,7 +169,7 @@ void main() {
     });
 
     group('with options', () {
-      test('metadata', () async {
+      testWidgets('metadata', (_) async {
         final path = 'public/upload-data-with-metadata-${uuid()}';
         final data = 'metadata'.codeUnits;
         const metadata = {'foo': 'bar'};
@@ -187,7 +187,7 @@ void main() {
         expect(propertiesResult.storageItem.metadata, metadata);
       });
 
-      test('getProperties', () async {
+      testWidgets('getProperties', (_) async {
         final path = 'public/upload-data-get-properties-${uuid()}';
         final data = 'getProperties'.codeUnits;
         const metadata = {'foo': 'bar'};
@@ -204,7 +204,7 @@ void main() {
         expect(result.uploadedItem.metadata, metadata);
       });
 
-      test('useAccelerateEndpoint', () async {
+      testWidgets('useAccelerateEndpoint', (_) async {
         final path = 'public/upload-data-acceleration-${uuid()}';
         final data = 'useAccelerateEndpoint'.codeUnits;
         addTearDownPath(StoragePath.fromString(path));

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
@@ -11,6 +11,7 @@ import 'package:integration_test/integration_test.dart';
 
 import 'utils/configure.dart';
 import 'utils/sign_in_new_user.dart';
+import 'utils/tear_down.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -23,9 +24,7 @@ void main() {
       test('bytes', () async {
         final path = 'public/upload-data-from-bytes-${uuid()}';
         final data = 'from bytes'.codeUnits;
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
           data: HttpPayload.bytes(data),
           path: StoragePath.fromString(path),
@@ -43,10 +42,7 @@ void main() {
         final data = 'dataUrl'.codeUnits;
         final dataUrl =
             'data:text/plain;charset=utf-8;base64,${base64Encode(data)}';
-
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
           data: HttpPayload.dataUrl(dataUrl),
           path: StoragePath.fromString(path),
@@ -62,9 +58,7 @@ void main() {
       test('json', () async {
         final path = 'public/upload-data-from-stream-${uuid()}';
         final json = {'foo': 'bar'};
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
           data: HttpPayload.json(json),
           path: StoragePath.fromString(path),
@@ -81,9 +75,7 @@ void main() {
         final path = 'public/upload-data-form-fields-${uuid()}';
         const key = 'foo';
         const value = 'bar';
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
           data: HttpPayload.formFields({key: value}),
           path: StoragePath.fromString(path),
@@ -99,9 +91,7 @@ void main() {
       test('string', () async {
         final path = 'public/upload-data-string-${uuid()}';
         const data = 'string';
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
           data: HttpPayload.string(data),
           path: StoragePath.fromString(path),
@@ -116,9 +106,7 @@ void main() {
 
       test('empty', () async {
         final path = 'public/upload-data-empty-${uuid()}';
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
           data: const HttpPayload.empty(),
           path: StoragePath.fromString(path),
@@ -135,9 +123,7 @@ void main() {
         final path = 'public/upload-data-stream-${uuid()}';
         final data = [1, 2, 3];
         final stream = Stream<List<int>>.value(data);
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
           data: HttpPayload.streaming(stream),
           path: StoragePath.fromString(path),
@@ -156,11 +142,7 @@ void main() {
       final name = 'upload-data-with-identity-id-${uuid()}';
       final data = 'with identity ID'.codeUnits;
       final expectedResolvedPath = 'private/$userIdentityId/$name';
-      addTearDown(
-        () => Amplify.Storage.remove(
-          path: StoragePath.fromString(expectedResolvedPath),
-        ),
-      );
+      addTearDownPath(StoragePath.fromString(expectedResolvedPath));
       final result = await Amplify.Storage.uploadData(
         data: HttpPayload.bytes(data),
         path: StoragePath.fromIdentityId(
@@ -181,9 +163,7 @@ void main() {
         final path = 'public/upload-data-with-metadata-${uuid()}';
         final data = 'metadata'.codeUnits;
         const metadata = {'foo': 'bar'};
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
           data: HttpPayload.bytes(data),
           path: StoragePath.fromString(path),
@@ -201,9 +181,7 @@ void main() {
         final path = 'public/upload-data-get-properties-${uuid()}';
         final data = 'getProperties'.codeUnits;
         const metadata = {'foo': 'bar'};
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
           data: HttpPayload.bytes(data),
           path: StoragePath.fromString(path),
@@ -219,9 +197,7 @@ void main() {
       test('useAccelerateEndpoint', () async {
         final path = 'public/upload-data-acceleration-${uuid()}';
         final data = 'useAccelerateEndpoint'.codeUnits;
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadData(
           data: HttpPayload.bytes(data),
           path: StoragePath.fromString(path),

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
@@ -44,10 +44,11 @@ void main() {
       );
 
       testWidgets('from path', (_) async {
-        final path = 'public/upload-file-from-path-${uuid()}';
+        final fileId = uuid();
+        final path = 'public/upload-file-from-path-$fileId';
         const content = 'upload data';
         final data = content.codeUnits;
-        final filePath = await createFile(path: path, content: content);
+        final filePath = await createFile(path: fileId, content: content);
         addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadFile(
           localFile: AWSFile.fromPath(filePath),
@@ -79,15 +80,13 @@ void main() {
     });
 
     testWidgets('with identity ID', (_) async {
+      final fileId = uuid();
       final userIdentityId = await signInNewUser();
-      final name = 'upload-file-with-identity-id-${uuid()}';
+      final name = 'upload-file-with-identity-id-$fileId';
       const content = 'upload data';
       final data = content.codeUnits;
       final expectedResolvedPath = 'private/$userIdentityId/$name';
-      final filePath = await createFile(
-        path: expectedResolvedPath,
-        content: content,
-      );
+      final filePath = await createFile(path: fileId, content: content);
       addTearDownPath(StoragePath.fromString(expectedResolvedPath));
       final result = await Amplify.Storage.uploadFile(
         localFile: AWSFile.fromPath(filePath),
@@ -151,10 +150,11 @@ void main() {
       });
 
       testWidgets('useAccelerateEndpoint', (_) async {
-        final path = 'public/upload-file-acceleration-${uuid()}';
+        final fileId = uuid();
+        final path = 'public/upload-file-acceleration-$fileId';
         const content = 'upload data';
         final data = content.codeUnits;
-        final filePath = await createFile(path: path, content: content);
+        final filePath = await createFile(path: fileId, content: content);
         addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadFile(
           localFile: AWSFile.fromPath(filePath),

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
@@ -91,6 +91,16 @@ void main() {
       expect(downloadResult.bytes, data);
     });
 
+    test('unauthorized path', () async {
+      expect(
+        () => Amplify.Storage.uploadFile(
+          localFile: AWSFile.fromData('unauthorized path'.codeUnits),
+          path: const StoragePath.fromString('unauthorized/path'),
+        ).result,
+        throwsA(isA<StorageAccessDeniedException>()),
+      );
+    });
+
     group('with options', () {
       test('metadata', () async {
         final path = 'public/upload-file-with-metadata-${uuid()}';

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
@@ -20,7 +20,7 @@ void main() {
       await configure(amplifyEnvironments['main']!);
     });
     group('for file type', () {
-      test('from data', () async {
+      testWidgets('from data', (_) async {
         final path = 'public/upload-file-from-data-${uuid()}';
         final data = 'from data'.codeUnits;
         addTearDownPath(StoragePath.fromString(path));
@@ -36,7 +36,7 @@ void main() {
         expect(downloadResult.bytes, data);
       });
 
-      test('from path', () async {
+      testWidgets('from path', (_) async {
         final path = 'public/upload-file-from-path-${uuid()}';
         final data = 'from path'.codeUnits;
         final filePath = await createFile(path, data);
@@ -53,7 +53,7 @@ void main() {
         expect(downloadResult.bytes, data);
       });
 
-      test('from stream', () async {
+      testWidgets('from stream', (_) async {
         final path = 'public/upload-file-from-stream-${uuid()}';
         final stream = Stream<List<int>>.value([1, 2, 3]);
         addTearDownPath(StoragePath.fromString(path));
@@ -70,7 +70,7 @@ void main() {
       });
     });
 
-    test('with identity ID', () async {
+    testWidgets('with identity ID', (_) async {
       final userIdentityId = await signInNewUser();
       final name = 'upload-file-with-identity-id-${uuid()}';
       final data = 'with identity ID'.codeUnits;
@@ -91,7 +91,7 @@ void main() {
       expect(downloadResult.bytes, data);
     });
 
-    test('unauthorized path', () async {
+    testWidgets('unauthorized path', (_) async {
       expect(
         () => Amplify.Storage.uploadFile(
           localFile: AWSFile.fromData('unauthorized path'.codeUnits),
@@ -102,7 +102,7 @@ void main() {
     });
 
     group('with options', () {
-      test('metadata', () async {
+      testWidgets('metadata', (_) async {
         final path = 'public/upload-file-with-metadata-${uuid()}';
         final data = 'metadata'.codeUnits;
         const metadata = {'foo': 'bar'};
@@ -120,7 +120,7 @@ void main() {
         expect(propertiesResult.storageItem.metadata, metadata);
       });
 
-      test('getProperties', () async {
+      testWidgets('getProperties', (_) async {
         final path = 'public/upload-file-get-properties-${uuid()}';
         final data = 'getProperties'.codeUnits;
         const metadata = {'foo': 'bar'};
@@ -137,7 +137,7 @@ void main() {
         expect(result.uploadedItem.metadata, metadata);
       });
 
-      test('useAccelerateEndpoint', () async {
+      testWidgets('useAccelerateEndpoint', (_) async {
         final path = 'public/upload-file-acceleration-${uuid()}';
         final data = 'useAccelerateEndpoint'.codeUnits;
         addTearDownPath(StoragePath.fromString(path));

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
@@ -10,6 +10,7 @@ import 'package:integration_test/integration_test.dart';
 import 'utils/configure.dart';
 import 'utils/create_file/create_file.dart';
 import 'utils/sign_in_new_user.dart';
+import 'utils/tear_down.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -22,9 +23,7 @@ void main() {
       test('from data', () async {
         final path = 'public/upload-file-from-data-${uuid()}';
         final data = 'from data'.codeUnits;
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadFile(
           localFile: AWSFile.fromData(data),
           path: StoragePath.fromString(path),
@@ -41,9 +40,7 @@ void main() {
         final path = 'public/upload-file-from-path-${uuid()}';
         final data = 'from path'.codeUnits;
         final filePath = await createFile(path, data);
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadFile(
           localFile: AWSFile.fromPath(filePath),
           path: StoragePath.fromString(path),
@@ -59,9 +56,7 @@ void main() {
       test('from stream', () async {
         final path = 'public/upload-file-from-stream-${uuid()}';
         final stream = Stream<List<int>>.value([1, 2, 3]);
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadFile(
           localFile: AWSFile.fromStream(stream, size: 3),
           path: StoragePath.fromString(path),
@@ -80,11 +75,7 @@ void main() {
       final name = 'upload-file-with-identity-id-${uuid()}';
       final data = 'with identity ID'.codeUnits;
       final expectedResolvedPath = 'private/$userIdentityId/$name';
-      addTearDown(
-        () => Amplify.Storage.remove(
-          path: StoragePath.fromString(expectedResolvedPath),
-        ),
-      );
+      addTearDownPath(StoragePath.fromString(expectedResolvedPath));
       final result = await Amplify.Storage.uploadFile(
         localFile: AWSFile.fromData(data),
         path: StoragePath.fromIdentityId(
@@ -105,9 +96,7 @@ void main() {
         final path = 'public/upload-file-with-metadata-${uuid()}';
         final data = 'metadata'.codeUnits;
         const metadata = {'foo': 'bar'};
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadFile(
           localFile: AWSFile.fromData(data),
           path: StoragePath.fromString(path),
@@ -125,9 +114,7 @@ void main() {
         final path = 'public/upload-file-get-properties-${uuid()}';
         final data = 'getProperties'.codeUnits;
         const metadata = {'foo': 'bar'};
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadFile(
           localFile: AWSFile.fromData(data),
           path: StoragePath.fromString(path),
@@ -143,9 +130,7 @@ void main() {
       test('useAccelerateEndpoint', () async {
         final path = 'public/upload-file-acceleration-${uuid()}';
         final data = 'useAccelerateEndpoint'.codeUnits;
-        addTearDown(
-          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
-        );
+        addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadFile(
           localFile: AWSFile.fromData(data),
           path: StoragePath.fromString(path),

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
@@ -1,0 +1,167 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3/amplify_storage_s3.dart';
+import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'utils/configure.dart';
+import 'utils/create_file/create_file.dart';
+import 'utils/sign_in_new_user.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('uploadFile()', () {
+    setUpAll(() async {
+      await configure(amplifyEnvironments['main']!);
+    });
+    group('for file type', () {
+      test('from data', () async {
+        final path = 'public/upload-file-from-data-${uuid()}';
+        final data = 'from data'.codeUnits;
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadFile(
+          localFile: AWSFile.fromData(data),
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final downloadResult = await Amplify.Storage.downloadData(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(downloadResult.bytes, data);
+      });
+
+      test('from path', () async {
+        final path = 'public/upload-file-from-path-${uuid()}';
+        final data = 'from path'.codeUnits;
+        final filePath = await createFile(path, data);
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadFile(
+          localFile: AWSFile.fromPath(filePath),
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final downloadResult = await Amplify.Storage.downloadData(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(downloadResult.bytes, data);
+      });
+
+      test('from stream', () async {
+        final path = 'public/upload-file-from-stream-${uuid()}';
+        final stream = Stream<List<int>>.value([1, 2, 3]);
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadFile(
+          localFile: AWSFile.fromStream(stream, size: 3),
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final downloadResult = await Amplify.Storage.downloadData(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(downloadResult.bytes, [1, 2, 3]);
+      });
+    });
+
+    test('with identity ID', () async {
+      final userIdentityId = await signInNewUser();
+      final name = 'upload-file-with-identity-id-${uuid()}';
+      final data = 'with identity ID'.codeUnits;
+      final expectedResolvedPath = 'private/$userIdentityId/$name';
+      addTearDown(
+        () => Amplify.Storage.remove(
+          path: StoragePath.fromString(expectedResolvedPath),
+        ),
+      );
+      final result = await Amplify.Storage.uploadFile(
+        localFile: AWSFile.fromData(data),
+        path: StoragePath.withIdentityId(
+          (identityId) => 'private/$identityId/$name',
+        ),
+      ).result;
+
+      expect(result.uploadedItem.path, expectedResolvedPath);
+
+      final downloadResult = await Amplify.Storage.downloadData(
+        path: StoragePath.fromString(expectedResolvedPath),
+      ).result;
+      expect(downloadResult.bytes, data);
+    });
+
+    group('with options', () {
+      test('metadata', () async {
+        final path = 'public/upload-file-with-metadata-${uuid()}';
+        final data = 'metadata'.codeUnits;
+        const metadata = {'foo': 'bar'};
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadFile(
+          localFile: AWSFile.fromData(data),
+          path: StoragePath.fromString(path),
+          options: const StorageUploadFileOptions(metadata: metadata),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final propertiesResult = await Amplify.Storage.getProperties(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(propertiesResult.storageItem.metadata, metadata);
+      });
+
+      test('getProperties', () async {
+        final path = 'public/upload-file-get-properties-${uuid()}';
+        final data = 'getProperties'.codeUnits;
+        const metadata = {'foo': 'bar'};
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadFile(
+          localFile: AWSFile.fromData(data),
+          path: StoragePath.fromString(path),
+          options: const StorageUploadFileOptions(
+            metadata: metadata,
+            pluginOptions: S3UploadFilePluginOptions(getProperties: true),
+          ),
+        ).result;
+        expect(result.uploadedItem.path, path);
+        expect(result.uploadedItem.metadata, metadata);
+      });
+
+      test('useAccelerateEndpoint', () async {
+        final path = 'public/upload-file-acceleration-${uuid()}';
+        final data = 'useAccelerateEndpoint'.codeUnits;
+        addTearDown(
+          () => Amplify.Storage.remove(path: StoragePath.fromString(path)),
+        );
+        final result = await Amplify.Storage.uploadFile(
+          localFile: AWSFile.fromData(data),
+          path: StoragePath.fromString(path),
+          options: const StorageUploadFileOptions(
+            pluginOptions: S3UploadFilePluginOptions(
+              useAccelerateEndpoint: true,
+            ),
+          ),
+        ).result;
+        expect(result.uploadedItem.path, path);
+
+        final downloadResult = await Amplify.Storage.downloadData(
+          path: StoragePath.fromString(path),
+        ).result;
+        expect(downloadResult.bytes, data);
+      });
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'utils/configure.dart';
-import 'utils/create_file/create_file_io.dart';
+import 'utils/create_file/create_file.dart';
 import 'utils/sign_in_new_user.dart';
 import 'utils/tear_down.dart';
 
@@ -39,7 +39,7 @@ void main() {
           ).result;
           expect(downloadResult.bytes, data);
         },
-        // TODO(Jordan-Nelson): Resolve bu with `AWSFile.fromData` on web.
+        // TODO(Jordan-Nelson): Resolve bug with `AWSFile.fromData` on web.
         skip: kIsWeb,
       );
 
@@ -81,11 +81,16 @@ void main() {
     testWidgets('with identity ID', (_) async {
       final userIdentityId = await signInNewUser();
       final name = 'upload-file-with-identity-id-${uuid()}';
-      final data = 'upload data'.codeUnits;
+      const content = 'upload data';
+      final data = content.codeUnits;
       final expectedResolvedPath = 'private/$userIdentityId/$name';
+      final filePath = await createFile(
+        path: expectedResolvedPath,
+        content: content,
+      );
       addTearDownPath(StoragePath.fromString(expectedResolvedPath));
       final result = await Amplify.Storage.uploadFile(
-        localFile: AWSFile.fromData(data),
+        localFile: AWSFile.fromPath(filePath),
         path: StoragePath.fromIdentityId(
           (identityId) => 'private/$identityId/$name',
         ),
@@ -147,10 +152,12 @@ void main() {
 
       testWidgets('useAccelerateEndpoint', (_) async {
         final path = 'public/upload-file-acceleration-${uuid()}';
-        final data = 'useAccelerateEndpoint'.codeUnits;
+        const content = 'upload data';
+        final data = content.codeUnits;
+        final filePath = await createFile(path: path, content: content);
         addTearDownPath(StoragePath.fromString(path));
         final result = await Amplify.Storage.uploadFile(
-          localFile: AWSFile.fromData(data),
+          localFile: AWSFile.fromPath(filePath),
           path: StoragePath.fromString(path),
           options: const StorageUploadFileOptions(
             pluginOptions: S3UploadFilePluginOptions(

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
@@ -87,7 +87,7 @@ void main() {
       );
       final result = await Amplify.Storage.uploadFile(
         localFile: AWSFile.fromData(data),
-        path: StoragePath.withIdentityId(
+        path: StoragePath.fromIdentityId(
           (identityId) => 'private/$identityId/$name',
         ),
       ).result;

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/configure.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/configure.dart
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
+import 'package:amplify_storage_s3/amplify_storage_s3.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> configure(String config) async {
+  final authPlugin = AmplifyAuthCognito(
+    secureStorageFactory: AmplifySecureStorage.factoryFrom(
+      macOSOptions: MacOSSecureStorageOptions(useDataProtection: false),
+    ),
+  );
+  final storagePlugin = AmplifyStorageS3();
+
+  await Amplify.addPlugins([authPlugin, storagePlugin]);
+  await Amplify.configure(config);
+  // addTearDown(Amplify.reset);
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/configure.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/configure.dart
@@ -16,5 +16,5 @@ Future<void> configure(String config) async {
 
   await Amplify.addPlugins([authPlugin, storagePlugin]);
   await Amplify.configure(config);
-  // addTearDown(Amplify.reset);
+  addTearDown(Amplify.reset);
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file.dart
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export 'create_file_stub.dart'
+    if (dart.library.html) 'create_file_html.dart'
+    if (dart.library.io) 'create_file_io.dart';

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_html.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_html.dart
@@ -4,8 +4,11 @@
 // ignore: avoid_web_libraries_in_flutter
 import 'dart:html' as html;
 
-Future<String> createFile(String path, List<int> bytes) async {
-  final fileBlob = html.Blob(bytes);
+Future<String> createFile({
+  required String path,
+  required String content,
+}) async {
+  final fileBlob = html.Blob([content], 'text/plain');
   final file = html.File([fileBlob], path);
   return html.Url.createObjectUrl(file);
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_html.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_html.dart
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html;
+
+Future<String> createFile(String path, List<int> bytes) async {
+  final fileBlob = html.Blob(bytes);
+  final file = html.File([fileBlob], path);
+  return html.Url.createObjectUrl(file);
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_io.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_io.dart
@@ -5,10 +5,13 @@ import 'dart:io' as io;
 
 import 'package:path/path.dart' as p;
 
-Future<String> createFile(String path, List<int> bytes) async {
+Future<String> createFile({
+  required String path,
+  required String content,
+}) async {
   final tempPath = io.Directory.systemTemp.path;
   final file = io.File(p.join(tempPath, path));
   await file.create(recursive: true);
-  await file.writeAsBytes(bytes);
+  await file.writeAsBytes(content.codeUnits);
   return file.path;
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_io.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_io.dart
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:io' as io;
+
+import 'package:path/path.dart' as p;
+
+Future<String> createFile(String path, List<int> bytes) async {
+  final tempPath = io.Directory.systemTemp.path;
+  final file = io.File(p.join(tempPath, path));
+  await file.create(recursive: true);
+  await file.writeAsBytes(bytes);
+  return file.path;
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_stub.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_stub.dart
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+Future<String> createFile(String path, List<int> bytes) async {
+  throw UnimplementedError();
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_stub.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_stub.dart
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-Future<String> createFile(String path, List<int> bytes) async {
+Future<String> createFile({
+  required String path,
+  required String content,
+}) async {
   throw UnimplementedError();
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/sign_in_new_user.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/sign_in_new_user.dart
@@ -10,6 +10,8 @@ import 'tear_down.dart';
 /// Creates a new user and signs them in.
 ///
 /// Returns the users identityId.
+///
+/// A tear down will be added to delete the user after the test completes.
 Future<String> signInNewUser() async {
   addTearDownCurrentUser();
   final username = 'test-user-1-${uuid()}';

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/sign_in_new_user.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/sign_in_new_user.dart
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Creates a new user and signs them in.
+///
+/// Returns the users identityId.
+Future<String> signInNewUser() async {
+  addTearDown(() {
+    try {
+      return Amplify.Auth.deleteUser();
+    } on Exception {
+      // do nothing;
+    }
+  });
+  final username = 'test-user-1-${uuid()}';
+  const password = 'TestUser1!';
+  await Amplify.Auth.signUp(
+    username: username,
+    password: password,
+  );
+  await Amplify.Auth.signIn(
+    username: username,
+    password: password,
+  );
+  final session = await Amplify.Auth.getPlugin(AmplifyAuthCognito.pluginKey)
+      .fetchAuthSession();
+  return session.identityIdResult.value;
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/sign_in_new_user.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/sign_in_new_user.dart
@@ -5,17 +5,13 @@ import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'tear_down.dart';
+
 /// Creates a new user and signs them in.
 ///
 /// Returns the users identityId.
 Future<String> signInNewUser() async {
-  addTearDown(() {
-    try {
-      return Amplify.Auth.deleteUser();
-    } on Exception {
-      // do nothing;
-    }
-  });
+  addTearDownCurrentUser();
   final username = 'test-user-1-${uuid()}';
   const password = 'TestUser1!';
   await Amplify.Auth.signUp(

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/sign_in_new_user.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/sign_in_new_user.dart
@@ -3,6 +3,7 @@
 
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
+import 'package:amplify_integration_test/amplify_integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'tear_down.dart';
@@ -14,8 +15,8 @@ import 'tear_down.dart';
 /// A tear down will be added to delete the user after the test completes.
 Future<String> signInNewUser() async {
   addTearDownCurrentUser();
-  final username = 'test-user-1-${uuid()}';
-  const password = 'TestUser1!';
+  final username = generateUsername();
+  final password = generatePassword();
   await Amplify.Auth.signUp(
     username: username,
     password: password,

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/tear_down.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/tear_down.dart
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Adds a tear down to remove the object at [path].
+void addTearDownPath(StoragePath path) {
+  addTearDown(
+    () {
+      try {
+        return Amplify.Storage.remove(path: path).result;
+      } on Exception catch (e) {
+        AmplifyLogger()
+            .createChild('StorageTests')
+            .warn('Failed to remove file after test', e);
+      }
+    },
+  );
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/tear_down.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/tear_down.dart
@@ -4,6 +4,8 @@
 import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+final _logger = AmplifyLogger().createChild('StorageTests');
+
 /// Adds a tear down to remove the object at [path].
 void addTearDownPath(StoragePath path) {
   addTearDown(
@@ -11,10 +13,18 @@ void addTearDownPath(StoragePath path) {
       try {
         return Amplify.Storage.remove(path: path).result;
       } on Exception catch (e) {
-        AmplifyLogger()
-            .createChild('StorageTests')
-            .warn('Failed to remove file after test', e);
+        _logger.warn('Failed to remove file after test', e);
       }
     },
   );
+}
+
+void addTearDownCurrentUser() {
+  addTearDown(() {
+    try {
+      return Amplify.Auth.deleteUser();
+    } on Exception catch (e) {
+      _logger.warn('Failed to delete user after test', e);
+    }
+  });
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/tear_down.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/tear_down.dart
@@ -14,6 +14,7 @@ void addTearDownPath(StoragePath path) {
         return Amplify.Storage.remove(path: path).result;
       } on Exception catch (e) {
         _logger.warn('Failed to remove file after test', e);
+        rethrow;
       }
     },
   );
@@ -26,6 +27,7 @@ void addTearDownCurrentUser() {
       return Amplify.Auth.deleteUser();
     } on Exception catch (e) {
       _logger.warn('Failed to delete user after test', e);
+      rethrow;
     }
   });
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/tear_down.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/tear_down.dart
@@ -19,6 +19,7 @@ void addTearDownPath(StoragePath path) {
   );
 }
 
+/// Adds a tear down to delete the current user.
 void addTearDownCurrentUser() {
   addTearDown(() {
     try {

--- a/packages/storage/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/example/pubspec.yaml
@@ -25,6 +25,8 @@ dev_dependencies:
   amplify_lints:
     path: ../../../amplify_lints
   amplify_storage_s3_dart: any
+  amplify_test:
+    path: ../../../test/amplify_test
   aws_common: any
   drift: ">=2.14.0 <2.15.0"
   flutter_driver:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add e2e test for `uploadData`, `uploadFile`, `getUrl`, and `getProperties` APIs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
