### PR TITLE
chore(analytics): trim key/value before logging

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_global_fields_manager.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/lib/src/impl/analytics_client/endpoint_client/endpoint_global_fields_manager.dart
@@ -76,22 +76,24 @@ class EndpointGlobalFieldsManager {
 
   String _processKey(String key) {
     if (key.length > maxKeyLength) {
+      final trimmedKey = key.substring(0, maxKeyLength);
       _logger.warn(
-        'The key: "$key" ',
+        'The key beginning with: "$trimmedKey" ',
         'has been trimmed to a length of $maxKeyLength characters.',
       );
-      return key.substring(0, maxKeyLength);
+      return trimmedKey;
     }
     return key;
   }
 
   String _processAttributeValue(String value) {
     if (value.length > maxAttributeValueLength) {
+      final trimmedValue = value.substring(0, maxAttributeValueLength);
       _logger.warn(
-        'The attribute value: "$value" ',
+        'The attribute value beginning with: "$trimmedValue" ',
         'has been trimmed to a length of $maxAttributeValueLength characters.',
       );
-      return value.substring(0, maxAttributeValueLength);
+      return trimmedValue;
     }
     return value;
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Trim key/values before logging warning to avoid the potential of excessively large values getting included in logs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
