### PR TITLE
chore(aft): Added generate amplify-swift

### DIFF
--- a/packages/aft/lib/src/commands/generate/generate_amplify_swift_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_amplify_swift_command.dart
@@ -16,7 +16,11 @@ class PluginConfig {
     required this.name,
     required this.remotePathToSource,
   });
+
+  /// The name of the plugin.
   final String name;
+
+  /// The path to the plugin source files in the Amplify Swift repo.
   final String remotePathToSource;
 }
 
@@ -160,7 +164,7 @@ class GenerateAmplifySwiftCommand extends AmplifyCommand with GlobOptions {
   Future<void> _generatePlugin(PluginConfig plugin) async {
     logger.info('Selecting source files for ${plugin.name}...');
 
-    final repoDir = await _pluginDirForPath(plugin.remotePathToSource);
+    final remotePluginDir = await _pluginDirForPath(plugin.remotePathToSource);
 
     final outputDir = Directory(p.join(outputPath, plugin.name));
 
@@ -177,8 +181,8 @@ class GenerateAmplifySwiftCommand extends AmplifyCommand with GlobOptions {
     // Copy the files from the repo to the plugin directory.
     logger
       ..info('Copying plugin files for ${plugin.name}...')
-      ..verbose('From $repoDir to $outputDir');
-    await copyPath(repoDir.path, outputDir.path);
+      ..verbose('From $remotePluginDir to $outputDir');
+    await copyPath(remotePluginDir.path, outputDir.path);
   }
 
   Future<void> checkDiff(PluginConfig plugin) async {

--- a/packages/aft/lib/src/commands/generate/generate_amplify_swift_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_amplify_swift_command.dart
@@ -1,0 +1,288 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:aft/aft.dart';
+import 'package:aft/src/options/glob_options.dart';
+import 'package:async/async.dart';
+import 'package:git/git.dart';
+import 'package:path/path.dart' as p;
+
+enum PermissionScope {
+  readExecuteWrite('777'),
+  readExecute('555');
+
+  const PermissionScope(this.value);
+  final String value;
+}
+
+class PluginConfig {
+  const PluginConfig({
+    required this.name,
+    required this.remotePathToSource,
+  });
+  final String name;
+  final String remotePathToSource;
+}
+
+/// Command for generating the Amplify Swift plugins for the DataStore plugin.
+class GenerateAmplifySwiftCommand extends AmplifyCommand with GlobOptions {
+  GenerateAmplifySwiftCommand() {
+    argParser
+      ..addOption(
+        'branch',
+        abbr: 'b',
+        help: 'The branch of Amplify Swift to target',
+        defaultsTo: 'release',
+      )
+      ..addOption(
+        'output',
+        abbr: 'o',
+        help: 'The lib/-relative output directory for the plugins',
+        defaultsTo: 'packages/amplify_datastore/ios/internal',
+      )
+      ..addFlag(
+        'diff',
+        abbr: 'd',
+        help: 'Show the diff of the generated files',
+        negatable: false,
+        defaultsTo: false,
+      );
+  }
+
+  @override
+  String get description =>
+      'Generates Amplify Swift DataStore for the DataStore plugin.';
+
+  @override
+  String get name => 'amplify-swift';
+
+  @override
+  bool get hidden => true;
+
+  /// The branch of Amplify Swift to target.
+  ///
+  /// If not provided, defaults to `release`.
+  late final branchTarget = argResults!['branch'] as String? ?? 'release';
+
+  /// The lib/-relative output path for the generated plugins.
+  late final outputPath = argResults!['output'] as String? ??
+      'packages/amplify_datastore/ios/internal';
+
+  /// Whether to check the diff of the generated files.
+  /// If not provided, defaults to `false`.
+  late final isDiff = argResults!['diff'] as bool? ?? false;
+
+  /// Cache of repos by git ref.
+  final _repoCache = <String, Directory>{};
+  final _cloneMemo = AsyncMemoizer<Directory>();
+
+  final _amplifySwiftPlugins = [
+    const PluginConfig(
+      name: 'AWSDataStorePlugin',
+      remotePathToSource: 'AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin',
+    ),
+    const PluginConfig(
+      name: 'AWSPluginsCore',
+      remotePathToSource: 'AmplifyPlugins/Core/AWSPluginsCore',
+    ),
+    const PluginConfig(
+      name: 'Amplify',
+      remotePathToSource: 'Amplify',
+    ),
+  ];
+
+  /// Downloads Amplify Swift from GitHub into a temporary directory.
+  Future<Directory> _downloadRepository() => _cloneMemo.runOnce(() async {
+        final cloneDir =
+            await Directory.systemTemp.createTemp('amplify_swift_');
+        logger
+          ..info('Downloading Amplify Swift...')
+          ..verbose('Cloning repo to ${cloneDir.path}');
+        await runGit(
+          [
+            'clone',
+            // https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
+            '--filter=tree:0',
+            'https://github.com/aws-amplify/amplify-swift.git',
+            cloneDir.path,
+          ],
+          echoOutput: verbose,
+        );
+        logger.info('Successfully cloned Amplify Swift Repo');
+        return cloneDir;
+      });
+
+  /// Checks out [ref] in [pluginDir].
+  Future<Directory> _checkoutRepositoryRef(
+    Directory pluginDir,
+    String ref,
+  ) async {
+    logger
+      ..info('Checking out target branch: $ref')
+      ..verbose('Creating git work tree in $pluginDir');
+    final worktreeDir =
+        await Directory.systemTemp.createTemp('amplify_swift_worktree_');
+    try {
+      await runGit(
+        ['worktree', 'add', worktreeDir.path, ref],
+        processWorkingDir: pluginDir.path,
+      );
+    } on Exception catch (e) {
+      if (e.toString().contains('already checked out')) {
+        return pluginDir;
+      }
+      rethrow;
+    }
+    return worktreeDir;
+  }
+
+  /// Sets up the Amplify Swift repo for use later
+  Future<void> _setupRepo() async {
+    if (_repoCache[branchTarget] != null) {
+      return;
+    }
+    Directory repoDir;
+    repoDir = await _downloadRepository();
+    repoDir = await _checkoutRepositoryRef(repoDir, branchTarget);
+
+    _repoCache[branchTarget] = repoDir;
+  }
+
+  /// Returns the directory for the plugin at [path].
+  Future<Directory> _pluginDirForPath(String path) async {
+    final repoDir = _repoCache[branchTarget];
+    if (repoDir == null) {
+      exitError('No cached repo for branch $branchTarget');
+    }
+
+    return Directory.fromUri(
+      repoDir.uri.resolve(path),
+    );
+  }
+
+  /// Generates the Amplify Swift plugin for [plugin].
+  Future<void> _generatePlugin(PluginConfig plugin) async {
+    logger.info('Selecting source files for ${plugin.name}...');
+
+    final repoDir = await _pluginDirForPath(plugin.remotePathToSource);
+
+    final outputDir = Directory(p.join(outputPath, plugin.name));
+
+    // Clear out the directory if it already exists.
+    // This is to ensure that we don't have any stale files.
+    if (await outputDir.exists()) {
+      logger.verbose(
+        'Clearing out existing plugin directory for ${plugin.name}...',
+      );
+      await _setPermissions(outputDir.path, PermissionScope.readExecuteWrite);
+      await outputDir.delete(recursive: true);
+    }
+    await outputDir.create(recursive: true);
+
+    // Copy the files from the repo to the plugin directory.
+    logger
+      ..info('Copying plugin files for ${plugin.name}...')
+      ..verbose('From $repoDir to $outputDir');
+    await copyPath(repoDir.path, outputDir.path);
+    await _setPermissions(outputDir.path, PermissionScope.readExecute);
+  }
+
+  Future<void> checkDiff(PluginConfig plugin) async {
+    logger.info('Checking diff for ${plugin.name}...');
+    final incoming = (await _pluginDirForPath(plugin.remotePathToSource)).path;
+    // Set the permissions of the incoming files to readExecute (fails otherwise)
+    await _setPermissions(incoming, PermissionScope.readExecute);
+    final current = '$outputPath/${plugin.name}';
+    final diffCmd = await Process.start(
+      'git',
+      [
+        'diff',
+        '--no-index',
+        '--exit-code',
+        incoming,
+        current,
+      ],
+      mode: verbose ? ProcessStartMode.inheritStdio : ProcessStartMode.normal,
+    );
+    final exitCode = await diffCmd.exitCode;
+    if (exitCode != 0) {
+      exitError(
+        '`diff` failed: $exitCode. There are differences between $incoming and $current',
+      );
+    }
+    logger.info(
+      'No differences between incoming and current for ${plugin.name}.',
+    );
+  }
+
+  /// Sets the permissions of all files in [path]  to
+  Future<void> _setPermissions(String path, PermissionScope scope) async {
+    const scope = '777';
+    logger.verbose('Setting files in $path to $scope...');
+    final readOnlyCmd = await Process.start(
+      'chmod',
+      [
+        '-R',
+        scope,
+        path,
+      ],
+      mode: verbose ? ProcessStartMode.inheritStdio : ProcessStartMode.normal,
+    );
+    final exitCode = await readOnlyCmd.exitCode;
+    if (exitCode != 0) {
+      exitError('`pod install` failed: $exitCode.');
+    }
+  }
+
+  /// Runs pod install after copying files to the plugin directory.
+  Future<void> _podInstall() async {
+    logger.info('Running pod install in datastore/example/ios...');
+
+    final podInstallCmd = await Process.start(
+      'pod',
+      [
+        'install',
+      ],
+      mode: verbose ? ProcessStartMode.inheritStdio : ProcessStartMode.normal,
+      workingDirectory: 'packages/amplify_datastore/example/ios',
+    );
+    final exitCode = await podInstallCmd.exitCode;
+    if (exitCode != 0) {
+      exitError('`pod install` failed: $exitCode.');
+    }
+  }
+
+  Future<void> _runDiff() async {
+    await _setupRepo();
+    for (final plugin in _amplifySwiftPlugins) {
+      await checkDiff(plugin);
+    }
+    logger.info(
+      'Successfully checked diff for Amplify Swift plugins',
+    );
+  }
+
+  Future<void> _runGenerate() async {
+    await _setupRepo();
+    for (final plugin in _amplifySwiftPlugins) {
+      await _generatePlugin(plugin);
+    }
+    await _podInstall();
+    logger.info('Successfully generated Amplify Swift plugins');
+  }
+
+  @override
+  Future<void> run() async {
+    await super.run();
+    switch (isDiff) {
+      case true:
+        await _runDiff();
+      default:
+        await _runGenerate();
+        break;
+    }
+  }
+}

--- a/packages/aft/lib/src/commands/generate/generate_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_command.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:aft/aft.dart';
+import 'package:aft/src/commands/generate/generate_amplify_swift_command.dart';
 import 'package:aft/src/commands/generate/generate_goldens_command.dart';
 import 'package:aft/src/commands/generate/generate_sdk_command.dart';
 import 'package:aft/src/commands/generate/generate_workflows_command.dart';
@@ -12,6 +13,7 @@ class GenerateCommand extends AmplifyCommand {
     addSubcommand(GenerateSdkCommand());
     addSubcommand(GenerateWorkflowsCommand());
     addSubcommand(GenerateGoldensCommand());
+    addSubcommand(GenerateAmplifySwiftCommand());
   }
 
   @override

--- a/packages/aft/lib/src/util.dart
+++ b/packages/aft/lib/src/util.dart
@@ -6,7 +6,6 @@ import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:graphs/graphs.dart';
-import 'package:path/path.dart' as p;
 import 'package:pubspec_parse/pubspec_parse.dart';
 
 String? getEnv(String envName) {
@@ -115,35 +114,4 @@ void sortPackagesTopologically<T>(
         .indexOf(getPubspec(b).name)
         .compareTo(ordered.indexOf(getPubspec(a).name));
   });
-}
-
-// Copyright 2017, the Dart project authors.
-// Copied from io.dart https://pub.dev/documentation/io/latest/io/copyPath.html
-bool _doNothing(String from, String to) {
-  if (p.canonicalize(from) == p.canonicalize(to)) {
-    return true;
-  }
-  if (p.isWithin(from, to)) {
-    throw ArgumentError('Cannot copy from $from to $to');
-  }
-  return false;
-}
-
-// Copyright 2017, the Dart project authors.
-// Copied from io.dart https://pub.dev/documentation/io/latest/io/copyPath.html
-Future<void> copyPath(String from, String to) async {
-  if (_doNothing(from, to)) {
-    return;
-  }
-  await Directory(to).create(recursive: true);
-  await for (final file in Directory(from).list(recursive: true)) {
-    final copyTo = p.join(to, p.relative(file.path, from: from));
-    if (file is Directory) {
-      await Directory(copyTo).create(recursive: true);
-    } else if (file is File) {
-      await File(file.path).copy(copyTo);
-    } else if (file is Link) {
-      await Link(copyTo).create(await file.target(), recursive: true);
-    }
-  }
 }

--- a/packages/aft/pubspec.yaml
+++ b/packages/aft/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   git: any # override
   glob: ^2.1.0
   graphs: ^2.1.0
+  io: ^1.0.4
   json_annotation: ">=4.8.1 <4.9.0"
   markdown: ^5.0.0
   mason: ^0.1.0-dev.40

--- a/packages/amplify_datastore/example/ios/Podfile
+++ b/packages/amplify_datastore/example/ios/Podfile
@@ -31,6 +31,11 @@ target 'Runner' do
   use_frameworks!
   use_modular_headers!
 
+  # Point pods to internal source files
+  pod 'Amplify', path: '../../ios/internal/'
+  pod 'AWSPluginsCore', path: '../../ios/internal/'
+  pod 'AWSDataStorePlugin', path: '../../ios/internal/'
+
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 

--- a/packages/amplify_datastore/ios/.gitignore
+++ b/packages/amplify_datastore/ios/.gitignore
@@ -29,9 +29,10 @@ xcuserdata
 *.moved-aside
 
 *.pyc
-*sync/
+*sync/*
 Icon?
 .tags*
 
 /Flutter/Generated.xcconfig
 /Flutter/flutter_export_environment.sh
+!internal/*

--- a/packages/amplify_datastore/ios/amplify_datastore.podspec
+++ b/packages/amplify_datastore/ios/amplify_datastore.podspec
@@ -15,12 +15,9 @@ The DataStore module for Amplify Flutter.
   s.source = { :git => 'https://github.com/aws-amplify/amplify-flutter.git' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Amplify', '1.30.7'
-  s.dependency 'AmplifyPlugins/AWSAPIPlugin', '1.30.7'
-  s.dependency 'AmplifyPlugins/AWSDataStorePlugin', '1.30.7'
+  s.dependency 'AWSDataStorePlugin', '0.0.1'
   s.dependency 'Starscream', '4.0.4'
   s.platform = :ios, '13.0'
-
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
   s.swift_version = '5.0'

--- a/packages/amplify_datastore/ios/internal/AWSDataStorePlugin.podspec
+++ b/packages/amplify_datastore/ios/internal/AWSDataStorePlugin.podspec
@@ -1,0 +1,35 @@
+#
+#  Be sure to run `pod spec lint AWSS3StoragePlugin.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+# Version definitions
+$AMPLIFY_VERSION = '0.0.1'
+$AMPLIFY_RELEASE_TAG = "#{$AMPLIFY_VERSION}"
+
+$AWS_SDK_VERSION = '2.33.0'
+$OPTIMISTIC_AWS_SDK_VERSION = "~> #{$AWS_SDK_VERSION}"
+
+Pod::Spec.new do |s|
+  s.name         = 'AWSDataStorePlugin'
+  s.version      = $AMPLIFY_VERSION
+  s.summary      = 'Amazon Web Services Amplify for iOS.'
+
+  s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
+
+  s.homepage     = 'https://github.com/aws-amplify/amplify-ios'
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-swift.git', :tag => $AMPLIFY_RELEASE_TAG }
+
+  s.platform = :ios, '13.0'
+  s.swift_version = '5.0'
+
+  s.source_files = 'AWSDataStorePlugin/**/*.swift'
+  s.dependency 'Amplify', $AMPLIFY_VERSION
+  s.dependency 'AWSPluginsCore', $AMPLIFY_VERSION
+  s.dependency 'SQLite.swift', '0.13.2'
+end

--- a/packages/amplify_datastore/ios/internal/AWSPluginsCore.podspec
+++ b/packages/amplify_datastore/ios/internal/AWSPluginsCore.podspec
@@ -1,0 +1,32 @@
+#
+#  Be sure to run `pod spec lint Amplify.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+# Version definitions
+$AMPLIFY_VERSION = '0.0.1'
+$AMPLIFY_RELEASE_TAG = "#{$AMPLIFY_VERSION}"
+
+Pod::Spec.new do |s|
+  s.name         = 'AWSPluginsCore'
+
+  s.version      = $AMPLIFY_VERSION
+  s.summary      = 'Amazon Web Services Amplify for Swift.'
+
+  s.description  = 'Internal Amplify PluginsCore for Swift module for Amplify Flutter.'
+
+  s.homepage     = 'https://github.com/aws-amplify/amplify-ios'
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-swift.git', :tag => $AMPLIFY_RELEASE_TAG }
+
+  s.platform     = :ios, '13.0'
+  s.swift_version = '5.0'
+
+  s.source_files = 'AWSPluginsCore/**/*.swift'
+
+  s.dependency 'Amplify', $AMPLIFY_VERSION
+end

--- a/packages/amplify_datastore/ios/internal/Amplify.podspec
+++ b/packages/amplify_datastore/ios/internal/Amplify.podspec
@@ -1,0 +1,29 @@
+#
+#  Be sure to run `pod spec lint Amplify.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+# Version definitions
+$AMPLIFY_VERSION = '0.0.1'
+$AMPLIFY_RELEASE_TAG = "#{$AMPLIFY_VERSION}"
+
+Pod::Spec.new do |s|
+  s.name         = 'Amplify'
+  s.version      = $AMPLIFY_VERSION
+  s.summary      = 'Amazon Web Services Amplify for Swift.'
+
+  s.description  = 'Internal AWS Amplify for Swift module for Amplify Flutter.'
+
+  s.homepage     = 'https://github.com/aws-amplify/amplify-swift'
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-swift.git', :tag => $AMPLIFY_RELEASE_TAG }
+
+  s.platform     = :ios, '13.0'
+  s.swift_version = '5.0'
+
+  s.source_files = 'Amplify/**/*.swift'
+end


### PR DESCRIPTION
*Description of changes:*
Adds `aft generate amplify-swift` command
- `-b` to change target branch
- `-o` to change output
- `-d` to run a diff of current vs incoming
- Sets cloned files to read-execute. This prevents modifications, but allows `pod install`
- Added internal definitions for pods

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
