### PR TITLE
feat: deprecate `Storage.move()` API

### DIFF
--- a/packages/amplify_core/lib/src/category/amplify_storage_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_storage_category.dart
@@ -218,6 +218,14 @@ class StorageCategory extends AmplifyCategory<StoragePluginInterface> {
   ///
   /// {@macro amplify_core.amplify_storage_category.copy_source}
   /// {@endtemplate}
+  @Deprecated(
+    'This API will be removed in the next major version. '
+    'This API calls Amplify.Storage.copy() to create a copy of the file in the '
+    'destination directory and then calls Amplify.Storage.remove() to remove '
+    'the source file. '
+    'Please use Amplify.Storage.copy() and Amplify.Storage.remove() directly '
+    'instead.',
+  )
   StorageMoveOperation move({
     required StorageItemWithAccessLevel<StorageItem> source,
     required StorageItemWithAccessLevel<StorageItem> destination,

--- a/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/use_case_test.dart
@@ -412,6 +412,7 @@ void main() {
         testWidgets(
             'move object with access level private for the currently signed in user',
             (WidgetTester tester) async {
+          // ignore: deprecated_member_use
           final result = await Amplify.Storage.move(
             source: S3ItemWithAccessLevel(
               storageItem: S3Item(key: testObject3CopyKey),
@@ -685,6 +686,7 @@ void main() {
           testWidgets(
               'move object with access level guest for the currently signed in user',
               (WidgetTester tester) async {
+            // ignore: deprecated_member_use
             final result = await Amplify.Storage.move(
               source: S3ItemWithAccessLevel(
                 storageItem: S3Item(key: testObjectKey1),
@@ -862,6 +864,7 @@ void main() {
 
         testWidgets('move object with access level protected as object owner',
             (WidgetTester tester) async {
+          // ignore: deprecated_member_use
           final result = await Amplify.Storage.move(
             source: S3ItemWithAccessLevel.forIdentity(
               user1IdentityId,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Deprecate the Storage.move() API
- Updates tests to ignore deprecation warning

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
