### PR TITLE
chore(core):mark asyncConfig api as deprecated and to be removed in 2.0.0

### DIFF
--- a/packages/amplify_core/lib/src/amplify_class.dart
+++ b/packages/amplify_core/lib/src/amplify_class.dart
@@ -92,6 +92,7 @@ abstract class AmplifyClass {
   bool get isConfigured => _configCompleter.isCompleted;
 
   /// A future when completes when Amplify has been successfully configured.
+  @Deprecated('Will be removed in 2.0.0')
   Future<AmplifyConfig> get asyncConfig => _configCompleter.future;
 
   /// Configures Amplify with the provided configuration string.

--- a/packages/amplify_core/test/amplify_class_test.dart
+++ b/packages/amplify_core/test/amplify_class_test.dart
@@ -19,12 +19,16 @@ void main() {
       });
 
       test('completes', () async {
+        // TODO(nikahsn): remove after making the api internal in 2.0.0.
+        // ignore: deprecated_member_use_from_same_package
         expect(Amplify.asyncConfig, completes);
         await Amplify.addPlugin(SuccessPlugin());
         expect(Amplify.configure(dummyConfiguration), completes);
       });
 
       test('plugin is configured even if addPlugin is not awaited', () async {
+        // TODO(nikahsn): remove after making the api internal in 2.0.0.
+        // ignore: deprecated_member_use_from_same_package
         expect(Amplify.asyncConfig, completes);
         final plugin = AsyncAddPlugin();
         unawaited(Amplify.addPlugin(plugin));
@@ -36,6 +40,8 @@ void main() {
 
       test('throws for invalid JSON', () async {
         expect(
+          // TODO(nikahsn): remove after making the api internal in 2.0.0.
+          // ignore: deprecated_member_use_from_same_package
           Amplify.asyncConfig,
           throwsA(isA<ConfigurationError>()),
         );
@@ -47,6 +53,8 @@ void main() {
 
       test('throws for configuration exceptions', () async {
         expect(
+          // TODO(nikahsn): remove after making the api internal in 2.0.0.
+          // ignore: deprecated_member_use_from_same_package
           Amplify.asyncConfig,
           throwsA(isA<ConfigurationError>()),
         );
@@ -58,6 +66,8 @@ void main() {
       });
 
       test('throws non-configuration exceptions', () async {
+        // TODO(nikahsn): remove after making the api internal in 2.0.0.
+        // ignore: deprecated_member_use_from_same_package
         expect(Amplify.asyncConfig, completes);
         await Amplify.addPlugin(NonConfigErrorPlugin());
         expect(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_out_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_out_test.dart
@@ -49,6 +49,8 @@ void main() {
             environmentName: environmentName,
           );
 
+          // TODO(nikahsn): remove after making the api internal in 2.0.0.
+          // ignore: deprecated_member_use
           final config = await Amplify.asyncConfig;
           final authConfig = config.auth!.awsPlugin!.cognitoUserPool!.default$!;
           client = AWSHttpClient()

--- a/packages/auth/amplify_auth_cognito_dart/example/web/components/app_component.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/web/components/app_component.dart
@@ -62,10 +62,14 @@ class AppComponent extends StatefulComponent {
     if (Amplify.isConfigured) return;
     try {
       await configure();
+      // TODO(nikahsn): remove after making the api internal in 2.0.0.
+      // ignore: deprecated_member_use
       config = await Amplify.asyncConfig;
 
       Amplify.Hub.listen(HubChannel.Auth, (AuthHubEvent event) {
         if (event.type == AuthHubEventType.signedIn) {
+          // TODO(nikahsn): remove after making the api internal in 2.0.0.
+          // ignore: deprecated_member_use
           Amplify.asyncConfig.then((_) {
             if (!appState.authState.isAuthenticatedRoute) {
               setState(

--- a/packages/authenticator/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/authenticator/amplify_authenticator/lib/amplify_authenticator.dart
@@ -633,6 +633,8 @@ class _AuthenticatorState extends State<Authenticator> {
   }
 
   Future<void> _waitForConfiguration() async {
+    // TODO(nikahsn): remove after making the api internal in 2.0.0.
+    // ignore: deprecated_member_use
     final config = await Amplify.asyncConfig;
     if (!mounted) return;
     setState(() {

--- a/packages/authenticator/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -332,6 +332,8 @@ class AmplifyAuthService
       );
     });
     try {
+      // TODO(nikahsn): remove after making the api internal in 2.0.0.
+      // ignore: deprecated_member_use
       return await Amplify.asyncConfig;
     } finally {
       timer.cancel();

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -123,6 +123,8 @@ class AmplifyStorageS3Dart extends StoragePluginInterface
       );
 
     scheduleMicrotask(() async {
+      // TODO(nikahsn): remove after making the api internal in 2.0.0.
+      // ignore: deprecated_member_use
       await Amplify.asyncConfig;
       if (_zIsTest) {
         return;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- mark asyncConfig api as deprecated and to be removed in 2.0.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
