### PR TITLE
chore(repo): flutter version to use lower bound instead of upper bound

### DIFF
--- a/canaries/pubspec.yaml
+++ b/canaries/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_analytics_pinpoint: ^1.0.0

--- a/packages/amplify/amplify_flutter/example/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the Amplify Flutter client libraries.
 publish_to: none
 
 environment:
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
   sdk: ^3.3.0
 
 dependencies:

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/amplify_core/doc/pubspec.yaml
+++ b/packages/amplify_core/doc/pubspec.yaml
@@ -8,7 +8,7 @@ publish_to: none
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_analytics_pinpoint: any

--- a/packages/amplify_datastore/example/pubspec.yaml
+++ b/packages/amplify_datastore/example/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/packages/amplify_datastore_plugin_interface/pubspec.yaml
+++ b/packages/amplify_datastore_plugin_interface/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_core: ">=1.7.0 <1.8.0"

--- a/packages/amplify_native_legacy_wrapper/example/pubspec.yaml
+++ b/packages/amplify_native_legacy_wrapper/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_native_legacy_wrapper: ^0.1.0

--- a/packages/amplify_native_legacy_wrapper/pubspec.yaml
+++ b/packages/amplify_native_legacy_wrapper/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_analytics_pinpoint: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/api/amplify_api/example/pubspec.yaml
+++ b/packages/api/amplify_api/example/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/auth/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_api: any

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/authenticator/amplify_authenticator/example/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/example/pubspec.yaml
@@ -19,7 +19,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_auth_cognito: ">=1.7.0 <1.8.0"

--- a/packages/authenticator/amplify_authenticator_test/example/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator_test/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_authenticator: any

--- a/packages/authenticator/amplify_authenticator_test/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator_test/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_authenticator: any

--- a/packages/common/amplify_db_common/example/pubspec.yaml
+++ b/packages/common/amplify_db_common/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the amplify_db_common plugin.
 publish_to: "none"
 
 environment:
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
   sdk: ^3.3.0
 
 dependencies:

--- a/packages/common/amplify_db_common/pubspec.yaml
+++ b/packages/common/amplify_db_common/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_db_common_dart: ">=0.3.5 <0.4.0"

--- a/packages/notifications/push/amplify_push_notifications/example/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 version: 0.1.0
 
 environment:
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
   sdk: ^3.3.0
 
 dependencies:

--- a/packages/notifications/push/amplify_push_notifications/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications/pubspec.yaml
@@ -6,7 +6,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_core: ">=1.7.0 <1.8.0"

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/example/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
@@ -6,7 +6,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 # Helps `pana` since it does not detect Android support.
 platforms:

--- a/packages/secure_storage/amplify_secure_storage/example/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_secure_storage: ">=0.3.0 <0.4.0"

--- a/packages/secure_storage/amplify_secure_storage/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_secure_storage_dart: ">=0.4.3 <0.5.0"

--- a/packages/storage/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_auth_cognito: any

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/test/amplify_auth_integration_test/pubspec.yaml
+++ b/packages/test/amplify_auth_integration_test/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   amplify_api: any

--- a/packages/worker_bee/e2e_flutter_test/pubspec.yaml
+++ b/packages/worker_bee/e2e_flutter_test/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
   sdk: ^3.3.0
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 # The current constraints for Dart and Flutter SDKs.
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: '>=3.19.0'
 
 # Global dependency versions for third-party dependencies of
 # Amplify Flutter projects. These represent the values which


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- pub publish fails due to use of upper bound for flutter version with a fix message to use lower bound instead
- use flutter: ">=3.19.0" instead of flutter: ^3.19.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
