### PR TITLE
chore: update removeMany API, add tests for `remove`, `removeMany`, `copy`

### DIFF
--- a/packages/amplify_core/lib/src/types/storage/remove_many_result.dart
+++ b/packages/amplify_core/lib/src/types/storage/remove_many_result.dart
@@ -6,12 +6,16 @@ import 'package:amplify_core/amplify_core.dart';
 /// {@template amplify_core.storage.remove_many_result}
 /// Presents the result of a [StorageRemoveManyOperation].
 /// {@endtemplate}
-class StorageRemoveManyResult<Item extends StorageItem> {
+class StorageRemoveManyResult<Item extends StorageItem, Error extends Object> {
   /// {@macro amplify_core.storage.remove_many_result}
   const StorageRemoveManyResult({
     required this.removedItems,
+    required this.errors,
   });
 
   /// The removed objects of the [StorageRemoveManyOperation].
   final List<Item> removedItems;
+
+  /// The errors that occurred when removing the specified items.
+  final List<Error> errors;
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/copy_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/copy_test.dart
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3/amplify_storage_s3.dart';
+import 'package:amplify_storage_s3_dart/src/sdk/src/s3/model/object_not_in_active_tier_error.dart';
+import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'utils/configure.dart';
+import 'utils/object_exists.dart';
+import 'utils/sign_in_new_user.dart';
+import 'utils/tear_down.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('copy()', () {
+    final srcPath = 'public/copy-source-${uuid()}';
+    final srcStoragePath = StoragePath.fromString(srcPath);
+    const metadata = {'description': 'foo'};
+    setUpAll(() async {
+      await configure(amplifyEnvironments['main']!);
+      addTearDownPath(srcStoragePath);
+      await Amplify.Storage.uploadData(
+        data: HttpPayload.bytes('data'.codeUnits),
+        path: srcStoragePath,
+        options: const StorageUploadDataOptions(metadata: metadata),
+      ).result;
+    });
+
+    testWidgets('StoragePath from string', (_) async {
+      final destinationPath = 'public/copy-dest-${uuid()}';
+      final destinationStoragePath = StoragePath.fromString(destinationPath);
+      addTearDownPath(destinationStoragePath);
+      final result = await Amplify.Storage.copy(
+        source: srcStoragePath,
+        destination: destinationStoragePath,
+      ).result;
+      expect(await objectExists(destinationStoragePath), true);
+      expect(result.copiedItem.path, destinationPath);
+    });
+
+    testWidgets('StoragePath from identity Id', (_) async {
+      final srcFileName = 'copy-source-identityId-${uuid()}';
+      final srcStoragePath = StoragePath.fromIdentityId(
+        ((identityId) => 'private/$identityId/$srcFileName'),
+      );
+      final identityId = await signInNewUser();
+      addTearDownPath(srcStoragePath);
+      await Amplify.Storage.uploadData(
+        data: HttpPayload.bytes('data'.codeUnits),
+        path: srcStoragePath,
+      ).result;
+      final destinationFileName = 'copy-source-${uuid()}';
+      final destinationStoragePath = StoragePath.fromIdentityId(
+        ((identityId) => 'private/$identityId/$destinationFileName'),
+      );
+      final expectedDestinationPath =
+          'private/$identityId/$destinationFileName';
+      addTearDownPath(destinationStoragePath);
+      final result = await Amplify.Storage.copy(
+        source: srcStoragePath,
+        destination: destinationStoragePath,
+      ).result;
+      expect(await objectExists(destinationStoragePath), true);
+      expect(result.copiedItem.path, expectedDestinationPath);
+    });
+
+    group('with options', () {
+      testWidgets('getProperties', (_) async {
+        final destinationPath = 'public/copy-dest-metadata-${uuid()}';
+        final destinationStoragePath = StoragePath.fromString(destinationPath);
+        addTearDownPath(destinationStoragePath);
+        final result = await Amplify.Storage.copy(
+          source: srcStoragePath,
+          destination: destinationStoragePath,
+          options: const StorageCopyOptions(
+            pluginOptions: S3CopyPluginOptions(getProperties: true),
+          ),
+        ).result;
+        expect(result.copiedItem.metadata, metadata);
+      });
+    });
+
+    testWidgets('unauthorized path (src)', (_) async {
+      await expectLater(
+        () => Amplify.Storage.copy(
+          source: const StoragePath.fromString('unauthorized/path'),
+          destination: const StoragePath.fromString('public/foo'),
+        ).result,
+        // TODO(Jordan-Nelson): update to StorageAccessDeniedException when SDK error mapping is fixed
+        throwsA(isA<ObjectNotInActiveTierError>()),
+      );
+    });
+
+    testWidgets('unauthorized path (destination)', (_) async {
+      await expectLater(
+        () => Amplify.Storage.copy(
+          source: srcStoragePath,
+          destination: const StoragePath.fromString('unauthorized/path'),
+        ).result,
+        // TODO(Jordan-Nelson): update to StorageAccessDeniedException when SDK error mapping is fixed
+        throwsA(isA<ObjectNotInActiveTierError>()),
+      );
+    });
+
+    testWidgets('non existent path', (_) async {
+      await expectLater(
+        () => Amplify.Storage.copy(
+          source: const StoragePath.fromString('public/non-existent-path'),
+          destination: const StoragePath.fromString('public/foo'),
+        ).result,
+        throwsA(isA<StorageKeyNotFoundException>()),
+      );
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
@@ -60,11 +60,20 @@ void main() {
     });
 
     testWidgets('unauthorized path', (_) async {
-      expect(
+      await expectLater(
         () => Amplify.Storage.getProperties(
           path: const StoragePath.fromString('unauthorized/path'),
         ).result,
         throwsA(isA<StorageAccessDeniedException>()),
+      );
+    });
+
+    testWidgets('not existent path', (_) async {
+      await expectLater(
+        () => Amplify.Storage.getProperties(
+          path: const StoragePath.fromString('public/not-existent-path'),
+        ).result,
+        throwsA(isA<StorageKeyNotFoundException>()),
       );
     });
   });

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
@@ -63,7 +63,7 @@ void main() {
 
     group('unauthorized path', () {
       testWidgets('validateObjectExistence true', (_) async {
-        expect(
+        await expectLater(
           () => Amplify.Storage.getUrl(
             path: const StoragePath.fromString('unauthorized/path'),
             options: const StorageGetUrlOptions(
@@ -85,7 +85,7 @@ void main() {
             ),
           ),
         ).result;
-        expect(
+        await expectLater(
           () => readData(result.url),
           throwsA(isA<ClientException>()),
         );
@@ -107,14 +107,14 @@ void main() {
         final actualData = await readData(result.url);
         expect(actualData, data);
         await Future<void>.delayed(duration);
-        expect(
+        await expectLater(
           () => readData(result.url),
           throwsA(isA<ClientException>()),
         );
       });
 
       testWidgets('validateObjectExistence true', (_) async {
-        expect(
+        await expectLater(
           () => Amplify.Storage.getUrl(
             path: const StoragePath.fromString('public/non-existent-path'),
             options: const StorageGetUrlOptions(
@@ -128,7 +128,7 @@ void main() {
       });
 
       testWidgets('validateObjectExistence false', (_) async {
-        expect(
+        await expectLater(
           Amplify.Storage.getUrl(
             path: const StoragePath.fromString('public/non-existent-path'),
             options: const StorageGetUrlOptions(

--- a/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
@@ -4,10 +4,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'copy_test.dart' as copy_test;
 import 'get_properties_test.dart' as get_properties_test;
 import 'get_url_test.dart' as get_url_test;
 import 'issues/get_url_special_characters_test.dart'
     as get_url_special_characters_tests;
+import 'remove_many_test.dart' as remove_many_test;
+import 'remove_test.dart' as remove_test;
 import 'upload_data_test.dart' as upload_data_test;
 import 'upload_file_test.dart' as upload_file_test;
 import 'use_case_test.dart' as use_case_tests;
@@ -18,9 +21,12 @@ void main() {
   group('amplify_storage_s3', () {
     get_url_special_characters_tests.main();
     use_case_tests.main();
+    copy_test.main();
     get_url_test.main();
     get_properties_test.main();
     upload_file_test.main();
     upload_data_test.main();
+    remove_many_test.main();
+    remove_test.main();
   });
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/remove_many_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/remove_many_test.dart
@@ -1,0 +1,132 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3/amplify_storage_s3.dart';
+import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'utils/configure.dart';
+import 'utils/sign_in_new_user.dart';
+
+/// Returns true if an object exists at the given [path].
+Future<bool> objectExists(StoragePath path) async {
+  try {
+    await Amplify.Storage.getProperties(path: path).result;
+    return true;
+  } on StorageKeyNotFoundException {
+    return false;
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('removeMany()', () {
+    setUpAll(() async {
+      await configure(amplifyEnvironments['main']!);
+    });
+
+    group('StoragePath from string', () {
+      final path1 = 'public/remove-${uuid()}';
+      final path2 = 'public/remove-${uuid()}';
+      final storagePath1 = StoragePath.fromString(path1);
+      final storagePath2 = StoragePath.fromString(path2);
+      setUp(() async {
+        await Amplify.Storage.uploadData(
+          data: HttpPayload.bytes('data'.codeUnits),
+          path: storagePath1,
+        ).result;
+        await Amplify.Storage.uploadData(
+          data: HttpPayload.bytes('data'.codeUnits),
+          path: storagePath2,
+        ).result;
+      });
+
+      testWidgets('removes objects', (_) async {
+        expect(await objectExists(storagePath1), true);
+        expect(await objectExists(storagePath2), true);
+        final result = await Amplify.Storage.removeMany(
+          paths: [storagePath1, storagePath2],
+        ).result;
+        expect(await objectExists(storagePath1), false);
+        expect(await objectExists(storagePath2), false);
+        final removedPaths = result.removedItems.map((i) => i.path).toList();
+        expect(removedPaths, unorderedEquals([path1, path2]));
+      });
+    });
+
+    group('StoragePath from identity Id', () {
+      final fileName1 = 'remove-${uuid()}';
+      final fileName2 = 'remove-${uuid()}';
+      final storagePath1 = StoragePath.fromIdentityId(
+        ((identityId) => 'private/$identityId/$fileName1'),
+      );
+      final storagePath2 = StoragePath.fromIdentityId(
+        ((identityId) => 'private/$identityId/$fileName2'),
+      );
+      late String expectedResolvedPath1;
+      late String expectedResolvedPath2;
+      setUp(() async {
+        final identityId = await signInNewUser();
+        expectedResolvedPath1 = 'private/$identityId/$fileName1';
+        expectedResolvedPath2 = 'private/$identityId/$fileName2';
+        await Amplify.Storage.uploadData(
+          data: HttpPayload.bytes('data'.codeUnits),
+          path: StoragePath.fromString(expectedResolvedPath1),
+        ).result;
+        await Amplify.Storage.uploadData(
+          data: HttpPayload.bytes('data'.codeUnits),
+          path: StoragePath.fromString(expectedResolvedPath2),
+        ).result;
+      });
+
+      testWidgets('removes objects', (_) async {
+        expect(await objectExists(storagePath1), true);
+        expect(await objectExists(storagePath2), true);
+        final result = await Amplify.Storage.removeMany(
+          paths: [storagePath1, storagePath2],
+        ).result;
+        expect(await objectExists(storagePath1), false);
+        expect(await objectExists(storagePath2), false);
+        final removedPaths = result.removedItems.map((i) => i.path).toList();
+        expect(
+          removedPaths,
+          unorderedEquals([expectedResolvedPath1, expectedResolvedPath2]),
+        );
+      });
+    });
+
+    testWidgets('unauthorized path', (_) async {
+      final result = await Amplify.Storage.removeMany(
+        paths: [const StoragePath.fromString('unauthorized/path')],
+      ).result as S3RemoveManyResult;
+
+      expect(result.errors.first.code, 'AccessDenied');
+    });
+
+    testWidgets('non existent path', (_) async {
+      await expectLater(
+        Amplify.Storage.removeMany(
+          paths: [const StoragePath.fromString('public/not-existent-path')],
+        ).result,
+        completes,
+      );
+    });
+
+    testWidgets('partial success', (_) async {
+      final result = await Amplify.Storage.removeMany(
+        paths: [
+          const StoragePath.fromString('unauthorized/path'),
+          const StoragePath.fromString('public/path'),
+        ],
+      ).result as S3RemoveManyResult;
+
+      expect(result.removedItems.length, 1);
+      expect(result.removedItems.first.path, 'public/path');
+      expect(result.errors.length, 1);
+      expect(result.errors.first.code, 'AccessDenied');
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/remove_many_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/remove_many_test.dart
@@ -8,17 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'utils/configure.dart';
+import 'utils/object_exists.dart';
 import 'utils/sign_in_new_user.dart';
-
-/// Returns true if an object exists at the given [path].
-Future<bool> objectExists(StoragePath path) async {
-  try {
-    await Amplify.Storage.getProperties(path: path).result;
-    return true;
-  } on StorageKeyNotFoundException {
-    return false;
-  }
-}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/storage/amplify_storage_s3/example/integration_test/remove_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/remove_test.dart
@@ -7,17 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'utils/configure.dart';
+import 'utils/object_exists.dart';
 import 'utils/sign_in_new_user.dart';
-
-/// Returns true if an object exists at the given [path].
-Future<bool> objectExists(StoragePath path) async {
-  try {
-    await Amplify.Storage.getProperties(path: path).result;
-    return true;
-  } on StorageKeyNotFoundException {
-    return false;
-  }
-}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/storage/amplify_storage_s3/example/integration_test/remove_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/remove_test.dart
@@ -1,0 +1,93 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'utils/configure.dart';
+import 'utils/sign_in_new_user.dart';
+
+/// Returns true if an object exists at the given [path].
+Future<bool> objectExists(StoragePath path) async {
+  try {
+    await Amplify.Storage.getProperties(path: path).result;
+    return true;
+  } on StorageKeyNotFoundException {
+    return false;
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('remove()', () {
+    setUpAll(() async {
+      await configure(amplifyEnvironments['main']!);
+    });
+
+    group('StoragePath from string', () {
+      final path = 'public/remove-${uuid()}';
+      final storagePath = StoragePath.fromString(path);
+      setUp(() async {
+        await Amplify.Storage.uploadData(
+          data: HttpPayload.bytes('data'.codeUnits),
+          path: storagePath,
+        ).result;
+      });
+
+      testWidgets('removes object', (_) async {
+        expect(await objectExists(storagePath), true);
+        final result = await Amplify.Storage.remove(
+          path: storagePath,
+        ).result;
+        expect(await objectExists(storagePath), false);
+        expect(result.removedItem.path, path);
+      });
+    });
+
+    group('StoragePath from identity Id', () {
+      final fileName = 'remove-${uuid()}';
+      final storagePath = StoragePath.fromIdentityId(
+        ((identityId) => 'private/$identityId/$fileName'),
+      );
+      late String expectedResolvedPath;
+      setUp(() async {
+        final identityId = await signInNewUser();
+        expectedResolvedPath = 'private/$identityId/$fileName';
+        await Amplify.Storage.uploadData(
+          data: HttpPayload.bytes('data'.codeUnits),
+          path: StoragePath.fromString(expectedResolvedPath),
+        ).result;
+      });
+
+      testWidgets('removes object', (_) async {
+        expect(await objectExists(storagePath), true);
+        final result = await Amplify.Storage.remove(
+          path: storagePath,
+        ).result;
+        expect(await objectExists(storagePath), false);
+        expect(result.removedItem.path, expectedResolvedPath);
+      });
+    });
+
+    testWidgets('unauthorized path', (_) async {
+      await expectLater(
+        () => Amplify.Storage.remove(
+          path: const StoragePath.fromString('unauthorized/path'),
+        ).result,
+        throwsA(isA<StorageAccessDeniedException>()),
+      );
+    });
+
+    testWidgets('non existent path', (_) async {
+      await expectLater(
+        Amplify.Storage.remove(
+          path: const StoragePath.fromString('public/not-existent-path'),
+        ).result,
+        completes,
+      );
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
@@ -159,7 +159,7 @@ void main() {
     });
 
     testWidgets('unauthorized path', (_) async {
-      expect(
+      await expectLater(
         () => Amplify.Storage.uploadData(
           data: HttpPayload.bytes('unauthorized path'.codeUnits),
           path: const StoragePath.fromString('unauthorized/path'),

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_file_test.dart
@@ -104,7 +104,7 @@ void main() {
     });
 
     testWidgets('unauthorized path', (_) async {
-      expect(
+      await expectLater(
         () => Amplify.Storage.uploadFile(
           localFile: AWSFile.fromData('unauthorized path'.codeUnits),
           path: const StoragePath.fromString('unauthorized/path'),

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/object_exists.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/object_exists.dart
@@ -1,0 +1,11 @@
+import 'package:amplify_core/amplify_core.dart';
+
+/// Returns true if an object exists at the given [path].
+Future<bool> objectExists(StoragePath path) async {
+  try {
+    await Amplify.Storage.getProperties(path: path).result;
+    return true;
+  } on StorageKeyNotFoundException {
+    return false;
+  }
+}

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_remove_many_result.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_remove_many_result.dart
@@ -8,16 +8,10 @@ import 'package:amplify_storage_s3_dart/src/sdk/s3.dart' as s3;
 /// {@template storage.amplify_storage_s3.remove_many_result}
 /// The result returned by the Storage S3 plugin `removeMany` API.
 /// {@endtemplate}
-class S3RemoveManyResult extends StorageRemoveManyResult<S3Item> {
+class S3RemoveManyResult extends StorageRemoveManyResult<S3Item, s3.Error> {
   /// {@macro storage.amplify_storage_s3.remove_many_result}
   const S3RemoveManyResult({
     required super.removedItems,
-    this.removeErrors = const [],
+    super.errors = const [],
   });
-
-  /// A list of [s3.Error] that represents objects that failed to remove.
-  ///
-  /// Please review the details of an [s3.Error] to learn about the reason of
-  /// a failure.
-  final List<s3.Error> removeErrors;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -519,7 +519,7 @@ class StorageS3Service {
 
     return S3RemoveManyResult(
       removedItems: removedItems,
-      removeErrors: removedErrors,
+      errors: removedErrors,
     );
   }
 

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
@@ -1299,7 +1299,7 @@ void main() {
           containsAllInOrder(expectedKeysForRequest2),
         );
         final removedItems = removeManyResult.removedItems;
-        final removeErrors = removeManyResult.removeErrors;
+        final removeErrors = removeManyResult.errors;
 
         expect(removedItems, hasLength(testNumOfRemovedItems));
         expect(removeErrors, hasLength(testNumOfRemoveErrors));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update `StorageRemoveManyResult` and `S3RemoveManyResult` to include errors in `StorageRemoveManyResult`
- Add e2e tests for `remove`, `removeMany`, `copy` APIs
- Update previous tests to use `expectLater` when appropriate

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
