### PR TITLE
feat(smithy)!: remove error match on http status code

### DIFF
--- a/packages/smithy/smithy/lib/src/http/http_operation.dart
+++ b/packages/smithy/smithy/lib/src/http/http_operation.dart
@@ -287,9 +287,6 @@ abstract class HttpOperation<InputPayload, Input, OutputPayload, Output>
         smithyError =
             errorTypes.firstWhereOrNull((t) => t.shapeId.shape == resolvedType);
       }
-      smithyError ??= errorTypes.singleWhereOrNull(
-        (t) => t.statusCode == response.statusCode,
-      );
       if (smithyError == null) {
         throw SmithyHttpException(
           statusCode: response.statusCode,

--- a/packages/smithy/smithy_aws/test/http/sdk_request_test.dart
+++ b/packages/smithy/smithy_aws/test/http/sdk_request_test.dart
@@ -24,7 +24,10 @@ void main() {
           return AWSHttpResponse(statusCode: 200, body: '{}'.codeUnits);
         }
         attempt++;
-        return AWSHttpResponse(statusCode: 500, body: '{}'.codeUnits);
+        return AWSHttpResponse(
+          statusCode: 500,
+          body: '{"error":"DummySmithyException"}'.codeUnits,
+        );
       });
       final retryer = AWSRetryer();
       final op = DummyHttpOperation(retryer);
@@ -57,7 +60,10 @@ void main() {
         return AWSHttpResponse(statusCode: 200, body: '{}'.codeUnits);
       }
       attempt++;
-      return AWSHttpResponse(statusCode: 500, body: '{}'.codeUnits);
+      return AWSHttpResponse(
+        statusCode: 500,
+        body: '{"error":"DummySmithyException"}'.codeUnits,
+      );
     });
     final retryer = AWSRetryer();
     final op = DummyHttpOperation(retryer);

--- a/packages/storage/amplify_storage_s3/example/integration_test/copy_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/copy_test.dart
@@ -3,7 +3,6 @@
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3/amplify_storage_s3.dart';
-import 'package:amplify_storage_s3_dart/src/sdk/src/s3/model/object_not_in_active_tier_error.dart';
 import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -92,8 +91,7 @@ void main() {
             source: const StoragePath.fromString('unauthorized/path'),
             destination: const StoragePath.fromString('public/foo'),
           ).result,
-          // TODO(Jordan-Nelson): update to StorageAccessDeniedException when SDK error mapping is fixed
-          throwsA(isA<ObjectNotInActiveTierError>()),
+          throwsA(isA<StorageAccessDeniedException>()),
         );
       });
 
@@ -103,8 +101,7 @@ void main() {
             source: srcStoragePath,
             destination: const StoragePath.fromString('unauthorized/path'),
           ).result,
-          // TODO(Jordan-Nelson): update to StorageAccessDeniedException when SDK error mapping is fixed
-          throwsA(isA<ObjectNotInActiveTierError>()),
+          throwsA(isA<StorageAccessDeniedException>()),
         );
       });
 

--- a/packages/storage/amplify_storage_s3/example/integration_test/download_data_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/download_data_test.dart
@@ -5,7 +5,6 @@ import 'dart:convert';
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3/amplify_storage_s3.dart';
-import 'package:amplify_storage_s3_dart/src/sdk/src/s3/model/invalid_object_state.dart';
 import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -83,8 +82,7 @@ void main() {
             () => Amplify.Storage.downloadData(
               path: const StoragePath.fromString('unauthorized/path'),
             ).result,
-            // TODO(khatruong2009): update to access denied exception when S3 exception mapping is fixed
-            throwsA(isA<InvalidObjectState>()),
+            throwsA(isA<StorageAccessDeniedException>()),
           );
         });
       });

--- a/packages/storage/amplify_storage_s3/example/integration_test/download_file_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/download_file_test.dart
@@ -5,7 +5,6 @@ import 'dart:io';
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3/amplify_storage_s3.dart';
-import 'package:amplify_storage_s3_dart/src/sdk/src/s3/model/invalid_object_state.dart';
 import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -157,13 +156,12 @@ void main() {
         testWidgets('unauthorized path', (_) async {
           final downloadFilePath = '${tempDir.path}/downloaded-file.txt';
 
-          // TODO(khatruong2009): update to access denied exception when bug is fixed
           await expectLater(
             () => Amplify.Storage.downloadFile(
               path: const StoragePath.fromString('unauthorized/path'),
               localFile: AWSFile.fromPath(downloadFilePath),
             ).result,
-            throwsA(isA<InvalidObjectState>()),
+            throwsA(isA<StorageAccessDeniedException>()),
           );
         });
       });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove logic in smithy's http operation that maps exceptions based on the http status code alone 
- Update Storage e2e tests to check for the correct exception

Prior to this change smithy contains logic to attempt to determine what type of exception should be thrown based on first the error name/shape (Ex: Access Denied) and then the http status code (ex: 403). The issue with this is that some services (S3) have operations that can return multiple errors for a single status code. For example, a 403 http status code during a GetObject operation can mean AccessDenied OR InvalidObjectState. By mapping based on the http status alone the first exception gets thrown.

With the changes smithy will throw a generic SmithyHttpException when it cannot match the error type based on the name/shape. This allows the consumer (Amplify) to handle the exception as appropriate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
