### PR TITLE
chore(api)!: Removed deprecated members …

### DIFF
--- a/packages/amplify_core/lib/src/types/api/graphql/graphql_request.dart
+++ b/packages/amplify_core/lib/src/types/api/graphql/graphql_request.dart
@@ -59,9 +59,6 @@ class GraphQLRequest<T> with AWSSerializable<Map<String, Object?>> {
   /// See https://docs.amplify.aws/lib/graphqlapi/advanced-workflows/q/platform/flutter/.
   final ModelType? modelType;
 
-  @Deprecated('Use toJson instead')
-  Map<String, dynamic> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'id': id,

--- a/packages/amplify_core/lib/src/types/exception/api/http_status_exception.dart
+++ b/packages/amplify_core/lib/src/types/exception/api/http_status_exception.dart
@@ -3,9 +3,6 @@
 
 part of '../amplify_exception.dart';
 
-@Deprecated('Use HttpStatusException instead')
-typedef RestException = HttpStatusException;
-
 /// {@template amplify_core.api.http_status_exception}
 /// An HTTP error encountered during a REST API call, i.e. for calls returning
 /// non-2xx status codes.

--- a/packages/amplify_core/lib/src/types/query/query_field.dart
+++ b/packages/amplify_core/lib/src/types/query/query_field.dart
@@ -4,7 +4,6 @@
 library query_field;
 
 import 'package:amplify_core/amplify_core.dart';
-import 'package:amplify_core/src/types/temporal/datetime_parse.dart';
 
 part 'query_field_operators.dart';
 part 'query_pagination.dart';

--- a/packages/amplify_core/lib/src/types/query/query_field_operators.dart
+++ b/packages/amplify_core/lib/src/types/query/query_field_operators.dart
@@ -32,15 +32,6 @@ abstract class QueryFieldOperator<T> {
   /// where [other] is a field on the model.
   bool evaluate(T? other);
 
-  /// Similar to `evaluate`, except `other` should be the
-  /// *serialized* value of a field on the model.
-  ///
-  /// This should be used to support comparisons with models
-  /// that were generated prior to `toMap()` being added.
-  // TODO(Jordan-Nelson): remove at next major version bump
-  @Deprecated('Regenerate models with latest CLI and use `evaluate` instead.')
-  bool evaluateSerialized(T? other);
-
   Map<String, dynamic> serializeAsMap();
 
   Map<String, dynamic> serializeAsMapWithOperator(
@@ -117,18 +108,6 @@ class EqualQueryOperator<T> extends QueryFieldOperatorSingleValue<T> {
 
     return value == other;
   }
-
-  @override
-  bool evaluateSerialized(T? other) {
-    // if `other` is a Map and has an "id" field, the query predicate is on a
-    // nested model, such as `Post.BLOG.eq(myBlog.modelIdentifier))`,
-    // and the value should be compared against the model ID.
-    if (other is Map && other['id'] != null && value is String) {
-      return value == other['id'];
-    }
-    final serializedValue = serializeDynamicValue(value);
-    return other == serializedValue;
-  }
 }
 
 class EqualModelIdentifierQueryOperator<T extends ModelIdentifier>
@@ -139,13 +118,6 @@ class EqualModelIdentifierQueryOperator<T extends ModelIdentifier>
   @override
   bool evaluate(T? other) {
     return other == value;
-  }
-
-  @override
-  bool evaluateSerialized(T? other) {
-    throw UnimplementedError(
-      'evaluateSerialized is not implemented for EqualModelIdentifierQueryOperator',
-    );
   }
 
   @override
@@ -175,18 +147,6 @@ class NotEqualQueryOperator<T> extends QueryFieldOperatorSingleValue<T> {
     }
     return other != value;
   }
-
-  @override
-  bool evaluateSerialized(T? other) {
-    // if `other` is a Map and has an "id" field, the query predicate is on a
-    // nested model, such as `Post.BLOG.eq(myBlog.modelIdentifier))`,
-    // and the value should be compared against the model ID.
-    if (other is Map && other['id'] != null && value is String) {
-      return value != other['id'];
-    }
-    final serializedValue = serializeDynamicValue(value);
-    return other != serializedValue;
-  }
 }
 
 class NotEqualModelIdentifierQueryOperator<T extends ModelIdentifier>
@@ -197,13 +157,6 @@ class NotEqualModelIdentifierQueryOperator<T extends ModelIdentifier>
   @override
   bool evaluate(T? other) {
     return other != value;
-  }
-
-  @override
-  bool evaluateSerialized(T? other) {
-    throw UnimplementedError(
-      'evaluateSerialized is not implemented for NotEqualModelIdentifierQueryOperator',
-    );
   }
 
   @override
@@ -224,15 +177,6 @@ class LessOrEqualQueryOperator<T extends Comparable<Object?>>
     }
     return other.compareTo(value) <= 0;
   }
-
-  @override
-  bool evaluateSerialized(T? other) {
-    if (other == null) {
-      return false;
-    }
-    final serializedValue = serializeDynamicValue(value);
-    return other.compareTo(serializedValue) <= 0;
-  }
 }
 
 class LessThanQueryOperator<T extends Comparable<Object?>>
@@ -246,15 +190,6 @@ class LessThanQueryOperator<T extends Comparable<Object?>>
       return false;
     }
     return other.compareTo(value) < 0;
-  }
-
-  @override
-  bool evaluateSerialized(T? other) {
-    if (other == null) {
-      return false;
-    }
-    final serializedValue = serializeDynamicValue(value);
-    return other.compareTo(serializedValue) < 0;
   }
 }
 
@@ -270,15 +205,6 @@ class GreaterOrEqualQueryOperator<T extends Comparable<Object?>>
     }
     return other.compareTo(value) >= 0;
   }
-
-  @override
-  bool evaluateSerialized(T? other) {
-    if (other == null) {
-      return false;
-    }
-    final serializedValue = serializeDynamicValue(value);
-    return other.compareTo(serializedValue) >= 0;
-  }
 }
 
 class GreaterThanQueryOperator<T extends Comparable<Object?>>
@@ -292,15 +218,6 @@ class GreaterThanQueryOperator<T extends Comparable<Object?>>
       return false;
     }
     return other.compareTo(value) > 0;
-  }
-
-  @override
-  bool evaluateSerialized(T? other) {
-    if (other == null) {
-      return false;
-    }
-    final serializedValue = serializeDynamicValue(value);
-    return other.compareTo(serializedValue) > 0;
   }
 }
 
@@ -323,9 +240,6 @@ class ContainsQueryOperator extends QueryFieldOperatorSingleValue<String> {
       );
     }
   }
-
-  @override
-  bool evaluateSerialized(dynamic other) => evaluate(other);
 }
 
 class BetweenQueryOperator<T extends Comparable<Object?>>
@@ -342,17 +256,6 @@ class BetweenQueryOperator<T extends Comparable<Object?>>
       return false;
     }
     return other.compareTo(start) >= 0 && other.compareTo(end) <= 0;
-  }
-
-  @override
-  bool evaluateSerialized(T? other) {
-    if (other == null) {
-      return false;
-    }
-    final serializedStart = serializeDynamicValue(start);
-    final serializedEnd = serializeDynamicValue(end);
-    return other.compareTo(serializedStart) >= 0 &&
-        other.compareTo(serializedEnd) <= 0;
   }
 
   @override
@@ -376,7 +279,4 @@ class BeginsWithQueryOperator extends QueryFieldOperatorSingleValue<String> {
     }
     return other.startsWith(value);
   }
-
-  @override
-  bool evaluateSerialized(String? other) => evaluate(other);
 }

--- a/packages/amplify_core/lib/src/types/query/query_field_operators.dart
+++ b/packages/amplify_core/lib/src/types/query/query_field_operators.dart
@@ -46,16 +46,7 @@ abstract class QueryFieldOperator<T> {
 
   /// check the type of [value] and invoke corresponding serialize method
   dynamic serializeDynamicValue(dynamic value) {
-    // DateTime is deprecated and will be removed in the next major version
-    if (value is DateTime) {
-      if (zDebugMode) {
-        safePrint(
-          'WARNING: Using DateTime types in a QueryPredicate is deprecated. '
-          'Use a Temporal Date/Time Type instead.',
-        );
-      }
-      return value.toDateTimeIso8601String();
-    } else if (value is TemporalDate) {
+    if (value is TemporalDate) {
       return value.format();
     } else if (value is TemporalDateTime) {
       return value.format();

--- a/packages/amplify_core/lib/src/types/query/query_predicate.dart
+++ b/packages/amplify_core/lib/src/types/query/query_predicate.dart
@@ -58,15 +58,8 @@ class QueryPredicateOperation extends QueryPredicate {
   @override
   bool evaluate(Model model) {
     final fieldName = getFieldName(field);
-    // TODO(Jordan-Nelson): Remove try/catch at next major version bump
-    try {
-      final value = model.toMap()[fieldName];
-      return queryFieldOperator.evaluate(value);
-    } on UnimplementedError {
-      final value = model.toJson()[fieldName];
-      // ignore: deprecated_member_use_from_same_package
-      return queryFieldOperator.evaluateSerialized(value);
-    }
+    final value = model.toMap()[fieldName];
+    return queryFieldOperator.evaluate(value);
   }
 
   @override

--- a/packages/amplify_core/lib/src/types/query/query_predicate.dart
+++ b/packages/amplify_core/lib/src/types/query/query_predicate.dart
@@ -58,7 +58,7 @@ class QueryPredicateOperation extends QueryPredicate {
   @override
   bool evaluate(Model model) {
     final fieldName = getFieldName(field);
-    final value = model.toMap()[fieldName];
+    final value = model.toJson()[fieldName];
     return queryFieldOperator.evaluate(value);
   }
 

--- a/packages/amplify_core/lib/src/types/query/query_predicate.dart
+++ b/packages/amplify_core/lib/src/types/query/query_predicate.dart
@@ -58,7 +58,7 @@ class QueryPredicateOperation extends QueryPredicate {
   @override
   bool evaluate(Model model) {
     final fieldName = getFieldName(field);
-    final value = model.toJson()[fieldName];
+    final value = model.toMap()[fieldName];
     return queryFieldOperator.evaluate(value);
   }
 

--- a/packages/amplify_datastore/test/query_predicate_test.dart
+++ b/packages/amplify_datastore/test/query_predicate_test.dart
@@ -8,33 +8,6 @@ import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_inte
 import 'package:amplify_test/test_models/ModelProvider.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-// TODO(Jordan-Nelson): Remove at next major version bump.
-/// A `Post` model that does not have a `toMap()` impl.
-class PostWithNoToMap extends Post {
-  PostWithNoToMap({
-    String? id,
-    required String title,
-    required int rating,
-    TemporalDateTime? created,
-    int? likeCount,
-    Blog? blog,
-    List<Comment>? comments,
-  }) : super.internal(
-          id: id == null ? UUID.getUUID() : id,
-          title: title,
-          rating: rating,
-          created: created,
-          likeCount: likeCount,
-          blog: blog,
-          comments: comments,
-        );
-
-  @override
-  Map<String, Object?> toMap() {
-    throw UnimplementedError('toMap has not been implemented');
-  }
-}
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -229,32 +202,6 @@ void main() {
       rating: 1000,
     );
 
-    PostWithNoToMap postWithNoToMap1 = PostWithNoToMap(
-      title: 'post one',
-      rating: 1,
-      likeCount: 1,
-      created: TemporalDateTime(DateTime(2020, 01, 01, 10, 30)),
-    );
-
-    PostWithNoToMap postWithNoToMap2 = PostWithNoToMap(
-      title: 'post two',
-      rating: 10,
-      likeCount: 10,
-      created: TemporalDateTime(DateTime(2020, 01, 01, 12, 00)),
-    );
-
-    PostWithNoToMap postWithNoToMap3 = PostWithNoToMap(
-      title: 'post three',
-      rating: 100,
-      likeCount: 100,
-      created: TemporalDateTime(DateTime(2021, 01, 01, 12, 00)),
-    );
-
-    PostWithNoToMap postWithNoToMap4 = PostWithNoToMap(
-      title: 'post four',
-      rating: 1000,
-    );
-
     StringListTypeModel stringListTypeModel1 = StringListTypeModel(
       value: ['abc'],
     );
@@ -274,25 +221,11 @@ void main() {
       expect(testPredicate.evaluate(post4), isFalse);
     });
 
-    test('equals (serialized)', () {
-      QueryPredicate testPredicate = Post.LIKECOUNT.eq(1);
-      expect(testPredicate.evaluate(postWithNoToMap1), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap2), isFalse);
-      expect(testPredicate.evaluate(postWithNoToMap4), isFalse);
-    });
-
     test('equals (ID)', () {
       QueryPredicate testPredicate = Post.ID.eq(post2.id);
       expect(testPredicate.evaluate(post1), isFalse);
       expect(testPredicate.evaluate(post2), isTrue);
       expect(testPredicate.evaluate(post4), isFalse);
-    });
-
-    test('equals (ID) (serialized)', () {
-      QueryPredicate testPredicate = Post.ID.eq(postWithNoToMap2.id);
-      expect(testPredicate.evaluate(postWithNoToMap1), isFalse);
-      expect(testPredicate.evaluate(postWithNoToMap2), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap4), isFalse);
     });
 
     test('equals (ModelIdentifier)', () {
@@ -311,25 +244,11 @@ void main() {
       expect(testPredicate.evaluate(post4), isTrue);
     });
 
-    test('not equals (serialized)', () {
-      QueryPredicate testPredicate = Post.LIKECOUNT.ne(1);
-      expect(testPredicate.evaluate(postWithNoToMap1), isFalse);
-      expect(testPredicate.evaluate(postWithNoToMap2), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap4), isTrue);
-    });
-
     test('less than', () {
       QueryPredicate testPredicate = Post.LIKECOUNT.lt(5);
       expect(testPredicate.evaluate(post1), isTrue);
       expect(testPredicate.evaluate(post2), isFalse);
       expect(testPredicate.evaluate(post4), isFalse);
-    });
-
-    test('less than (serialized)', () {
-      QueryPredicate testPredicate = Post.LIKECOUNT.lt(5);
-      expect(testPredicate.evaluate(postWithNoToMap1), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap2), isFalse);
-      expect(testPredicate.evaluate(postWithNoToMap4), isFalse);
     });
 
     test('less than or equal', () {
@@ -340,26 +259,11 @@ void main() {
       expect(testPredicate.evaluate(post4), isFalse);
     });
 
-    test('less than or equal (serialized)', () {
-      QueryPredicate testPredicate = Post.LIKECOUNT.le(10);
-      expect(testPredicate.evaluate(postWithNoToMap1), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap2), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap3), isFalse);
-      expect(testPredicate.evaluate(postWithNoToMap4), isFalse);
-    });
-
     test('greater than', () {
       QueryPredicate testPredicate = Post.LIKECOUNT.gt(5);
       expect(testPredicate.evaluate(post1), isFalse);
       expect(testPredicate.evaluate(post2), isTrue);
       expect(testPredicate.evaluate(post4), isFalse);
-    });
-
-    test('greater than (serialized)', () {
-      QueryPredicate testPredicate = Post.LIKECOUNT.gt(5);
-      expect(testPredicate.evaluate(postWithNoToMap1), isFalse);
-      expect(testPredicate.evaluate(postWithNoToMap2), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap4), isFalse);
     });
 
     test('greater than or equal', () {
@@ -370,14 +274,6 @@ void main() {
       expect(testPredicate.evaluate(post4), isFalse);
     });
 
-    test('greater than or equal (serialized)', () {
-      QueryPredicate testPredicate = Post.LIKECOUNT.ge(10);
-      expect(testPredicate.evaluate(postWithNoToMap1), isFalse);
-      expect(testPredicate.evaluate(postWithNoToMap2), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap3), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap4), isFalse);
-    });
-
     test('between', () {
       QueryPredicate testPredicate = Post.LIKECOUNT.between(5, 100);
       expect(testPredicate.evaluate(post1), isFalse);
@@ -386,36 +282,16 @@ void main() {
       expect(testPredicate.evaluate(post4), isFalse);
     });
 
-    test('between (serialized)', () {
-      QueryPredicate testPredicate = Post.LIKECOUNT.between(5, 100);
-      expect(testPredicate.evaluate(postWithNoToMap1), isFalse);
-      expect(testPredicate.evaluate(postWithNoToMap2), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap3), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap4), isFalse);
-    });
-
     test('contains', () {
       QueryPredicate testPredicate = Post.TITLE.contains("one");
       expect(testPredicate.evaluate(post1), isTrue);
       expect(testPredicate.evaluate(post2), isFalse);
     });
 
-    test('contains (serialized)', () {
-      QueryPredicate testPredicate = Post.TITLE.contains("one");
-      expect(testPredicate.evaluate(postWithNoToMap1), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap2), isFalse);
-    });
-
     test('beginsWith', () {
       QueryPredicate testPredicate = Post.TITLE.beginsWith("post o");
       expect(testPredicate.evaluate(post1), isTrue);
       expect(testPredicate.evaluate(post2), isFalse);
-    });
-
-    test('beginsWith (serialized)', () {
-      QueryPredicate testPredicate = Post.TITLE.beginsWith("post o");
-      expect(testPredicate.evaluate(postWithNoToMap1), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap2), isFalse);
     });
 
     test('and', () {
@@ -447,14 +323,6 @@ void main() {
       expect(testPredicate.evaluate(post2), isFalse);
     });
 
-    test('Temporal type (serialized)', () {
-      QueryPredicate testPredicate = Post.CREATED.lt(TemporalDateTime(
-        DateTime(2020, 01, 01, 12, 00),
-      ));
-      expect(testPredicate.evaluate(postWithNoToMap1), isTrue);
-      expect(testPredicate.evaluate(postWithNoToMap2), isFalse);
-    });
-
     group('List type', () {
       test('contains', () {
         QueryPredicate testPredicate = StringListTypeModel.VALUE.contains(
@@ -474,53 +342,6 @@ void main() {
       final post2 = Post(title: 'post 2', rating: 1, blog: blog1);
       final post3 = Post(title: 'post 3', rating: 1, blog: blog2);
 
-      final postWithNoToMap1 = PostWithNoToMap(
-        title: 'post 1',
-        rating: 1,
-        blog: blog1,
-      );
-      final postWithNoToMap2 = PostWithNoToMap(
-        title: 'post 2',
-        rating: 1,
-        blog: blog1,
-      );
-      final postWithNoToMap3 = PostWithNoToMap(
-        title: 'post 3',
-        rating: 1,
-        blog: blog2,
-      );
-
-      // TODO(Jordan-Nelson): Remove at next major version bump.
-      // can be removed when `getId()` is removed.
-      test('equals (id)', () {
-        final testPredicate = Post.BLOG.eq(blog1.id);
-        expect(testPredicate.evaluate(post1), isTrue);
-        expect(testPredicate.evaluate(post2), isTrue);
-        expect(testPredicate.evaluate(post3), isFalse);
-      });
-
-      // TODO(Jordan-Nelson): Remove at next major version bump.
-      // can be removed when `getId()` is removed.
-      test('not equals (id)', () {
-        final testPredicate = Post.BLOG.ne(blog1.id);
-        expect(testPredicate.evaluate(post1), isFalse);
-        expect(testPredicate.evaluate(post2), isFalse);
-        expect(testPredicate.evaluate(post3), isTrue);
-      });
-
-      test('equals (id) (serialized)', () {
-        final testPredicate = Post.BLOG.eq(blog1.id);
-        expect(testPredicate.evaluate(postWithNoToMap1), isTrue);
-        expect(testPredicate.evaluate(postWithNoToMap2), isTrue);
-        expect(testPredicate.evaluate(postWithNoToMap3), isFalse);
-      });
-
-      test('not equals (id) (serialized)', () {
-        final testPredicate = Post.BLOG.ne(blog1.id);
-        expect(testPredicate.evaluate(postWithNoToMap1), isFalse);
-        expect(testPredicate.evaluate(postWithNoToMap2), isFalse);
-        expect(testPredicate.evaluate(postWithNoToMap3), isTrue);
-      });
       test('equals', () {
         final testPredicate = Post.BLOG.eq(BlogModelIdentifier(id: blog1.id));
         expect(testPredicate.evaluate(post1), isTrue);

--- a/packages/amplify_datastore/test/query_sort_test.dart
+++ b/packages/amplify_datastore/test/query_sort_test.dart
@@ -8,53 +8,6 @@ import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_test/test_models/ModelProvider.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-// TODO(Jordan-Nelson): Remove at next major version bump.
-/// A `Post` model that does not have a `toMap()` impl.
-class PostWithNoToMap extends Post {
-  PostWithNoToMap({
-    String? id,
-    required String title,
-    required int rating,
-    TemporalDateTime? created,
-    int? likeCount,
-    Blog? blog,
-    List<Comment>? comments,
-  }) : super.internal(
-          id: id == null ? UUID.getUUID() : id,
-          title: title,
-          rating: rating,
-          created: created,
-          likeCount: likeCount,
-          blog: blog,
-          comments: comments,
-        );
-
-  @override
-  Map<String, Object?> toMap() {
-    throw UnimplementedError('toMap has not been implemented');
-  }
-
-  @override
-  PostWithNoToMap copyWith({
-    String? title,
-    int? rating,
-    TemporalDateTime? created,
-    int? likeCount,
-    Blog? blog,
-    List<Comment>? comments,
-  }) {
-    return PostWithNoToMap(
-      id: id,
-      title: title ?? this.title,
-      rating: rating ?? this.rating,
-      created: created ?? this.created,
-      likeCount: likeCount ?? this.likeCount,
-      blog: blog ?? this.blog,
-      comments: comments ?? this.comments,
-    );
-  }
-}
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -117,28 +70,6 @@ void main() {
 
     Post post4Copy = post4.copyWith();
 
-    PostWithNoToMap postWithNoToMap1 = PostWithNoToMap(
-      id: '123e4567-e89b-12d3-a456-426614174000',
-      title: 'post1',
-      rating: 1,
-      created: TemporalDateTime(DateTime(2020, 01, 01, 10, 30)),
-    );
-
-    PostWithNoToMap postWithNoToMap2 = PostWithNoToMap(
-      id: '123e4567-e89b-12d3-a456-426614174001',
-      title: 'post2',
-      rating: 2,
-      created: TemporalDateTime(DateTime(2020, 01, 01, 12, 30)),
-    );
-
-    PostWithNoToMap postWithNoToMap2Copy = postWithNoToMap2.copyWith();
-
-    PostWithNoToMap postWithNoToMap3 = postWithNoToMap1.copyWith(likeCount: 0);
-
-    PostWithNoToMap postWithNoToMap4 = postWithNoToMap1.copyWith(likeCount: 1);
-
-    PostWithNoToMap postWithNoToMap4Copy = postWithNoToMap4.copyWith();
-
     test('should compare ID fields', () {
       QuerySortBy sortByAsc = Post.ID.ascending();
       QuerySortBy sortByDesc = Post.ID.descending();
@@ -150,19 +81,6 @@ void main() {
       expect(sortByDesc.compare(post1, post2), 1);
       expect(sortByDesc.compare(post2, post1), -1);
       expect(sortByDesc.compare(post2, post2Copy), 0);
-    });
-
-    test('should compare ID fields (serialized)', () {
-      QuerySortBy sortByAsc = Post.ID.ascending();
-      QuerySortBy sortByDesc = Post.ID.descending();
-
-      expect(sortByAsc.compare(postWithNoToMap1, postWithNoToMap2), -1);
-      expect(sortByAsc.compare(postWithNoToMap2, postWithNoToMap1), 1);
-      expect(sortByAsc.compare(postWithNoToMap2, postWithNoToMap2Copy), 0);
-
-      expect(sortByDesc.compare(postWithNoToMap1, postWithNoToMap2), 1);
-      expect(sortByDesc.compare(postWithNoToMap2, postWithNoToMap1), -1);
-      expect(sortByDesc.compare(postWithNoToMap2, postWithNoToMap2Copy), 0);
     });
 
     test('should compare int fields', () {
@@ -178,19 +96,6 @@ void main() {
       expect(sortByDesc.compare(post2, post2Copy), 0);
     });
 
-    test('should compare int fields (serialized)', () {
-      QuerySortBy sortByAsc = Post.RATING.ascending();
-      QuerySortBy sortByDesc = Post.RATING.descending();
-
-      expect(sortByAsc.compare(postWithNoToMap1, postWithNoToMap2), -1);
-      expect(sortByAsc.compare(postWithNoToMap2, postWithNoToMap1), 1);
-      expect(sortByAsc.compare(postWithNoToMap2, postWithNoToMap2Copy), 0);
-
-      expect(sortByDesc.compare(postWithNoToMap1, postWithNoToMap2), 1);
-      expect(sortByDesc.compare(postWithNoToMap2, postWithNoToMap1), -1);
-      expect(sortByDesc.compare(postWithNoToMap2, postWithNoToMap2Copy), 0);
-    });
-
     test('should compare bool fields', () {
       QuerySortBy sortByAsc = Post.LIKECOUNT.ascending();
       QuerySortBy sortByDesc = Post.LIKECOUNT.descending();
@@ -202,19 +107,6 @@ void main() {
       expect(sortByDesc.compare(post3, post4), 1);
       expect(sortByDesc.compare(post4, post3), -1);
       expect(sortByDesc.compare(post4, post4Copy), 0);
-    });
-
-    test('should compare bool fields (serialized)', () {
-      QuerySortBy sortByAsc = Post.LIKECOUNT.ascending();
-      QuerySortBy sortByDesc = Post.LIKECOUNT.descending();
-
-      expect(sortByAsc.compare(postWithNoToMap3, postWithNoToMap4), -1);
-      expect(sortByAsc.compare(postWithNoToMap4, postWithNoToMap3), 1);
-      expect(sortByAsc.compare(postWithNoToMap4, postWithNoToMap4Copy), 0);
-
-      expect(sortByDesc.compare(postWithNoToMap3, postWithNoToMap4), 1);
-      expect(sortByDesc.compare(postWithNoToMap4, postWithNoToMap3), -1);
-      expect(sortByDesc.compare(postWithNoToMap4, postWithNoToMap4Copy), 0);
     });
 
     test('should compare string fields', () {
@@ -230,19 +122,6 @@ void main() {
       expect(sortByDesc.compare(post2, post2Copy), 0);
     });
 
-    test('should compare string fields (serialized)', () {
-      QuerySortBy sortByAsc = Post.TITLE.ascending();
-      QuerySortBy sortByDesc = Post.TITLE.descending();
-
-      expect(sortByAsc.compare(postWithNoToMap1, postWithNoToMap2), -1);
-      expect(sortByAsc.compare(postWithNoToMap2, postWithNoToMap1), 1);
-      expect(sortByAsc.compare(postWithNoToMap2, postWithNoToMap2Copy), 0);
-
-      expect(sortByDesc.compare(postWithNoToMap1, postWithNoToMap2), 1);
-      expect(sortByDesc.compare(postWithNoToMap2, postWithNoToMap1), -1);
-      expect(sortByDesc.compare(postWithNoToMap2, postWithNoToMap2Copy), 0);
-    });
-
     test('should compare date/time fields', () {
       QuerySortBy sortByAsc = Post.CREATED.ascending();
       QuerySortBy sortByDesc = Post.CREATED.descending();
@@ -256,19 +135,6 @@ void main() {
       expect(sortByDesc.compare(post2, post2Copy), 0);
     });
 
-    test('should compare date/time fields (serialized)', () {
-      QuerySortBy sortByAsc = Post.CREATED.ascending();
-      QuerySortBy sortByDesc = Post.CREATED.descending();
-
-      expect(sortByAsc.compare(postWithNoToMap1, postWithNoToMap2), -1);
-      expect(sortByAsc.compare(postWithNoToMap2, postWithNoToMap1), 1);
-      expect(sortByAsc.compare(postWithNoToMap2, postWithNoToMap2Copy), 0);
-
-      expect(sortByDesc.compare(postWithNoToMap1, postWithNoToMap2), 1);
-      expect(sortByDesc.compare(postWithNoToMap2, postWithNoToMap1), -1);
-      expect(sortByDesc.compare(postWithNoToMap2, postWithNoToMap2Copy), 0);
-    });
-
     test('should handle null values', () {
       QuerySortBy sortByAsc = Post.LIKECOUNT.ascending();
       QuerySortBy sortByDesc = Post.LIKECOUNT.descending();
@@ -280,19 +146,6 @@ void main() {
       expect(sortByDesc.compare(post1, post3), 1);
       expect(sortByDesc.compare(post1, post4), 1);
       expect(sortByDesc.compare(post1, post2), 0);
-    });
-
-    test('should handle null values (serialized)', () {
-      QuerySortBy sortByAsc = Post.LIKECOUNT.ascending();
-      QuerySortBy sortByDesc = Post.LIKECOUNT.descending();
-
-      expect(sortByAsc.compare(postWithNoToMap1, postWithNoToMap3), -1);
-      expect(sortByAsc.compare(postWithNoToMap1, postWithNoToMap4), -1);
-      expect(sortByAsc.compare(postWithNoToMap1, postWithNoToMap2), 0);
-
-      expect(sortByDesc.compare(postWithNoToMap1, postWithNoToMap3), 1);
-      expect(sortByDesc.compare(postWithNoToMap1, postWithNoToMap4), 1);
-      expect(sortByDesc.compare(postWithNoToMap1, postWithNoToMap2), 0);
     });
   });
 }

--- a/packages/api/amplify_api/example/integration_test/rest_test.dart
+++ b/packages/api/amplify_api/example/integration_test/rest_test.dart
@@ -61,7 +61,7 @@ void main({bool useExistingTestUser = false}) {
         skip: zIsWeb,
       );
 
-      testWidgets('should throw a RestException for POST',
+      testWidgets('should throw a HttpStatusException for POST',
           (WidgetTester tester) async {
         final operation = Amplify.API.post(path);
         await expectLater(

--- a/packages/api/amplify_api_dart/lib/src/util/amplify_authorization_rest_client.dart
+++ b/packages/api/amplify_api_dart/lib/src/util/amplify_authorization_rest_client.dart
@@ -55,7 +55,7 @@ class AmplifyAuthorizationRestClient extends AWSBaseHttpClient {
   Future<AWSBaseHttpResponse> transformResponse(
     AWSBaseHttpResponse response,
   ) async {
-    // For REST endpoints, throw [RestException] on non-successful responses.
+    // For REST endpoints, throw [HttpStatusException] on non-successful responses.
     if (endpointConfig.endpointType == EndpointType.rest &&
         (response.statusCode < 200 || response.statusCode >= 300)) {
       final responseForException = switch (response) {


### PR DESCRIPTION
*Description of changes:*
Removed GraphQLRequest.serializeAsMap(), QueryFieldOperator.evaluateSerialized(), and RestException.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
