### PR TITLE
chore(storage): fix progress for upload, add e2e for progress, pause, resume, and cancel

### DIFF
--- a/packages/amplify_core/lib/src/types/storage/data_payload.dart
+++ b/packages/amplify_core/lib/src/types/storage/data_payload.dart
@@ -1,9 +1,131 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_core/amplify_core.dart';
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:aws_common/aws_common.dart';
+import 'package:meta/meta.dart';
 
 /// {@template amplify_core.storage.data_payload}
-/// A data payload to be uploaded by a plugin of the Storage category.
+/// A data payload to be uploaded by the Storage category.
+///
+/// Create a [StorageDataPayload] from various data types using one of the
+/// following constructors:
+/// - [StorageDataPayload.empty]
+/// - [StorageDataPayload.bytes]
+/// - [StorageDataPayload.string]
+/// - [StorageDataPayload.formFields]
+/// - [StorageDataPayload.json]
+/// - [StorageDataPayload.streaming]
+/// - [StorageDataPayload.dataUrl]
 /// {@endtemplate}
-typedef StorageDataPayload = HttpPayload;
+
+// The implementation is based on HttpPayload from aws_common. StorageDataPayload
+// converts all payloads other than streams to byte data when the object is
+// constructed in order to read the length of the byte data. HttpPayload does not
+// convert the data to byte data until th data is read. Monitoring storage
+// upload progress requires knowing the length of the data prior to the start
+// of the upload.
+//
+class StorageDataPayload extends StreamView<List<int>> {
+  /// An empty [StorageDataPayload].
+  const StorageDataPayload.empty({this.contentType})
+      : size = 0,
+        super(const Stream.empty());
+
+  /// A byte buffer [StorageDataPayload].
+  StorageDataPayload.bytes(
+    List<int> body, {
+    this.contentType,
+  })  : size = body.length,
+        super(Stream.value(body));
+
+  /// A [StorageDataPayload].
+  ///
+  /// Defaults to UTF-8 encoding.
+  ///
+  /// The Content-Type defaults to 'text/plain'.
+  factory StorageDataPayload.string(
+    String body, {
+    Encoding encoding = utf8,
+    String? contentType,
+  }) {
+    return StorageDataPayload.bytes(
+      encoding.encode(body),
+      contentType: contentType ?? 'text/plain; charset=${encoding.name}',
+    );
+  }
+
+  /// A form-encoded [StorageDataPayload].
+  ///
+  /// The Content-Type defaults to 'application/x-www-form-urlencoded'.
+  factory StorageDataPayload.formFields(
+    Map<String, String> body, {
+    Encoding encoding = utf8,
+    String? contentType,
+  }) {
+    return StorageDataPayload.bytes(
+      // ignore: invalid_use_of_internal_member
+      encoding.encode(HttpPayload.encodeFormValues(body, encoding: encoding)),
+      contentType: contentType ??
+          'application/x-www-form-urlencoded; charset=${encoding.name}',
+    );
+  }
+
+  /// A JSON [StorageDataPayload]
+  ///
+  /// The Content-Type defaults to 'application/json'.
+  factory StorageDataPayload.json(
+    Object? body, {
+    Encoding encoding = utf8,
+    String? contentType,
+  }) {
+    return StorageDataPayload.bytes(
+      encoding.encode(json.encode(body)),
+      contentType: contentType ?? 'application/json; charset=${encoding.name}',
+    );
+  }
+
+  /// A streaming [StorageDataPayload].
+  const StorageDataPayload.streaming(
+    super.body, {
+    this.contentType,
+  }) : size = -1;
+
+  /// A data url [StorageDataPayload].
+  factory StorageDataPayload.dataUrl(String dataUrl) {
+    // ignore: invalid_use_of_internal_member
+    if (!dataUrl.startsWith(HttpPayload.dataUrlMatcher)) {
+      throw ArgumentError('Invalid data url: $dataUrl');
+    }
+
+    final dataUrlParts = dataUrl.split(',');
+    final mediaTypeEncoding = dataUrlParts.first.replaceFirst('data:', '');
+    final body = dataUrlParts.skip(1).join(',');
+
+    if (mediaTypeEncoding.endsWith(';base64')) {
+      return StorageDataPayload.bytes(
+        base64Decode(body),
+        contentType: mediaTypeEncoding.replaceFirst(';base64', ''),
+      );
+    }
+
+    return StorageDataPayload.bytes(
+      // data url encodes body, need to decode before converting it into bytes
+      utf8.encode(Uri.decodeComponent(body)),
+      contentType: mediaTypeEncoding,
+    );
+  }
+
+  /// The content type of the body.
+  final String? contentType;
+
+  /// The size of the content of the data payload.
+  ///
+  /// If this payload was created using the  [StorageDataPayload.streaming]
+  /// constructor the size will be unknown until the stream completes. This
+  /// value will return -1 in that case.
+  @internal
+  final int size;
+}

--- a/packages/amplify_core/lib/src/types/storage/transfer_progress.dart
+++ b/packages/amplify_core/lib/src/types/storage/transfer_progress.dart
@@ -46,6 +46,8 @@ class StorageTransferProgress {
 
   /// The fractional progress of the storage transfer operation.
   ///
-  /// 0 <= `fractionCompleted` <= 1
-  double get fractionCompleted => transferredBytes / totalBytes;
+  /// fractionCompleted will be between 0 and 1, unless the upload source size
+  /// cannot be determined in which case the fractionCompleted will be -1.
+  double get fractionCompleted =>
+      totalBytes == -1 ? -1 : transferredBytes / totalBytes;
 }

--- a/packages/aws_common/lib/src/http/http_payload.dart
+++ b/packages/aws_common/lib/src/http/http_payload.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:async/async.dart';
+import 'package:meta/meta.dart';
 
 /// {@template aws_common.http.http_payload}
 /// An HTTP request's payload.
@@ -61,7 +62,7 @@ final class HttpPayload extends StreamView<List<int>> {
         super(
           LazyStream(
             () => Stream.value(
-              encoding.encode(_encodeFormValues(body, encoding: encoding)),
+              encoding.encode(encodeFormValues(body, encoding: encoding)),
             ),
           ),
         );
@@ -87,7 +88,7 @@ final class HttpPayload extends StreamView<List<int>> {
 
   /// A data url HTTP body.
   factory HttpPayload.dataUrl(String dataUrl) {
-    if (!dataUrl.startsWith(_dataUrlMatcher)) {
+    if (!dataUrl.startsWith(dataUrlMatcher)) {
       throw ArgumentError('Invalid data url: $dataUrl');
     }
 
@@ -118,7 +119,8 @@ final class HttpPayload extends StreamView<List<int>> {
   ///     //=> "foo=bar&baz=bang"
   ///
   /// Similar util at https://github.com/dart-lang/http/blob/06649afbb5847dbb0293816ba8348766b116e419/pkgs/http/lib/src/utils.dart#L15
-  static String _encodeFormValues(
+  @internal
+  static String encodeFormValues(
     Map<String, String> params, {
     required Encoding encoding,
   }) =>
@@ -131,5 +133,7 @@ final class HttpPayload extends StreamView<List<int>> {
           )
           .join('&');
 
-  static final _dataUrlMatcher = RegExp(r'^data:.*,');
+  /// A [RegExp] matcher for data urls.
+  @internal
+  static final dataUrlMatcher = RegExp(r'^data:.*,');
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/copy_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/copy_test.dart
@@ -24,7 +24,7 @@ void main() {
         await configure(amplifyEnvironments['main']!);
         addTearDownPath(srcStoragePath);
         await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes('data'.codeUnits),
+          data: StorageDataPayload.bytes('data'.codeUnits),
           path: srcStoragePath,
           options: const StorageUploadDataOptions(metadata: metadata),
         ).result;
@@ -50,7 +50,7 @@ void main() {
         final identityId = await signInNewUser();
         addTearDownPath(srcStoragePath);
         await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes('data'.codeUnits),
+          data: StorageDataPayload.bytes('data'.codeUnits),
           path: srcStoragePath,
         ).result;
         final destinationFileName = 'copy-source-${uuid()}';
@@ -120,7 +120,7 @@ void main() {
         await configure(amplifyEnvironments['dots-in-name']!);
         addTearDownPath(srcStoragePath);
         await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes('data'.codeUnits),
+          data: StorageDataPayload.bytes('data'.codeUnits),
           path: srcStoragePath,
           options: const StorageUploadDataOptions(metadata: metadata),
         ).result;

--- a/packages/storage/amplify_storage_s3/example/integration_test/download_file_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/download_file_test.dart
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'dart:io';
-
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_storage_s3/amplify_storage_s3.dart';
 import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
@@ -21,7 +19,7 @@ void main() {
 
   group('downloadFile()', () {
     late String identityPath;
-    late Directory tempDir;
+    late String directory;
     late String userIdentityId;
     late String metadataDownloadFilePath;
     final publicPath = 'public/download-file-from-data-${uuid()}';
@@ -31,7 +29,7 @@ void main() {
     final metadata = {'description': 'foo'};
 
     setUpAll(() async {
-      tempDir = await getTemporaryDirectory();
+      directory = kIsWeb ? '/' : (await getTemporaryDirectory()).path;
     });
 
     group('standard config', () {
@@ -52,7 +50,7 @@ void main() {
           ),
         ).result;
 
-        metadataDownloadFilePath = '${tempDir.path}/downloaded-file.txt';
+        metadataDownloadFilePath = '$directory/downloaded-file.txt';
 
         await Amplify.Storage.uploadData(
           data: HttpPayload.bytes(data),
@@ -76,7 +74,7 @@ void main() {
 
       group('for file type', () {
         testWidgets('to file', (_) async {
-          final downloadFilePath = '${tempDir.path}/downloaded-file.txt';
+          final downloadFilePath = '$directory/downloaded-file.txt';
 
           final result = await Amplify.Storage.downloadFile(
             path: StoragePath.fromString(publicPath),
@@ -95,7 +93,7 @@ void main() {
       });
 
       testWidgets('from identity ID', (_) async {
-        final downloadFilePath = '${tempDir.path}/downloaded-file.txt';
+        final downloadFilePath = '$directory/downloaded-file.txt';
         final result = await Amplify.Storage.downloadFile(
           path: StoragePath.fromIdentityId(
             (identityId) => 'private/$identityId/$name',
@@ -113,7 +111,7 @@ void main() {
 
       group('with options', () {
         testWidgets('useAccelerateEndpoint', (_) async {
-          final downloadFilePath = '${tempDir.path}/downloaded-file.txt';
+          final downloadFilePath = '$directory/downloaded-file.txt';
 
           final result = await Amplify.Storage.downloadFile(
             path: StoragePath.fromString(publicPath),
@@ -154,7 +152,7 @@ void main() {
         });
 
         testWidgets('unauthorized path', (_) async {
-          final downloadFilePath = '${tempDir.path}/downloaded-file.txt';
+          final downloadFilePath = '$directory/downloaded-file.txt';
 
           await expectLater(
             () => Amplify.Storage.downloadFile(
@@ -179,7 +177,7 @@ void main() {
       testWidgets(
         'standard download works',
         (_) async {
-          final downloadFilePath = '${tempDir.path}/downloaded-file.txt';
+          final downloadFilePath = '$directory/downloaded-file.txt';
           final result = await Amplify.Storage.downloadFile(
             path: StoragePath.fromString(publicPath),
             localFile: AWSFile.fromPath(downloadFilePath),
@@ -192,7 +190,7 @@ void main() {
       testWidgets(
         'useAccelerateEndpoint throws',
         (_) async {
-          final downloadFilePath = '${tempDir.path}/downloaded-file.txt';
+          final downloadFilePath = '$directory/downloaded-file.txt';
           await expectLater(
             () => Amplify.Storage.downloadFile(
               path: StoragePath.fromString(publicPath),

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
@@ -23,7 +23,7 @@ void main() {
         await configure(amplifyEnvironments['main']!);
         addTearDownPath(StoragePath.fromString(path));
         await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes(data),
+          data: StorageDataPayload.bytes(data),
           path: StoragePath.fromString(path),
           options: const StorageUploadDataOptions(metadata: metadata),
         ).result;
@@ -46,7 +46,7 @@ void main() {
         final expectedResolvedPath = 'private/$userIdentityId/$name';
         addTearDownPath(StoragePath.fromString(expectedResolvedPath));
         await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes(data),
+          data: StorageDataPayload.bytes(data),
           path: StoragePath.fromString(expectedResolvedPath),
           options: const StorageUploadDataOptions(metadata: metadata),
         ).result;
@@ -85,7 +85,7 @@ void main() {
         await configure(amplifyEnvironments['dots-in-name']!);
         addTearDownPath(StoragePath.fromString(path));
         await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes(data),
+          data: StorageDataPayload.bytes(data),
           path: StoragePath.fromString(path),
           options: const StorageUploadDataOptions(metadata: metadata),
         ).result;

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
@@ -27,7 +27,7 @@ void main() {
         await configure(amplifyEnvironments['main']!);
         addTearDownPath(StoragePath.fromString(path));
         await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes(data),
+          data: StorageDataPayload.bytes(data),
           path: StoragePath.fromString(path),
         ).result;
       });
@@ -64,7 +64,7 @@ void main() {
         final expectedResolvedPath = 'private/$userIdentityId/$name';
         addTearDownPath(StoragePath.fromString(expectedResolvedPath));
         await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes(data),
+          data: StorageDataPayload.bytes(data),
           path: StoragePath.fromString(expectedResolvedPath),
         ).result;
 
@@ -179,7 +179,7 @@ void main() {
         await configure(amplifyEnvironments['dots-in-name']!);
         addTearDownPath(StoragePath.fromString(path));
         await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes(data),
+          data: StorageDataPayload.bytes(data),
           path: StoragePath.fromString(path),
         ).result;
       });

--- a/packages/storage/amplify_storage_s3/example/integration_test/list_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/list_test.dart
@@ -28,7 +28,7 @@ void main() {
         for (final path in uploadedPaths) {
           await Amplify.Storage.uploadData(
             path: StoragePath.fromString(path),
-            data: HttpPayload.bytes('test content'.codeUnits),
+            data: StorageDataPayload.bytes('test content'.codeUnits),
           ).result;
         }
 
@@ -169,7 +169,7 @@ void main() {
         for (final path in uploadedPaths) {
           await Amplify.Storage.uploadData(
             path: StoragePath.fromString(path),
-            data: HttpPayload.bytes('test content'.codeUnits),
+            data: StorageDataPayload.bytes('test content'.codeUnits),
           ).result;
         }
 

--- a/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/main_test.dart
@@ -10,6 +10,8 @@ import 'download_file_test.dart' as download_file_tests;
 import 'get_properties_test.dart' as get_properties_test;
 import 'get_url_test.dart' as get_url_test;
 import 'list_test.dart' as list_tests;
+import 'platform_test_io.dart' if (dart.library.html) 'platform_test_html.dart'
+    as platform_test;
 import 'remove_many_test.dart' as remove_many_test;
 import 'remove_test.dart' as remove_test;
 import 'upload_data_test.dart' as upload_data_test;
@@ -29,5 +31,6 @@ void main() {
     upload_data_test.main();
     remove_many_test.main();
     remove_test.main();
+    platform_test.main();
   });
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/platform_test_html.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/platform_test_html.dart
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
+import 'package:aws_common/web.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'utils/configure.dart';
+import 'utils/create_file/create_file_html.dart';
+import 'utils/tear_down.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('platform specific options', () {
+    setUpAll(() async {
+      await configure(amplifyEnvironments['main']!);
+    });
+    testWidgets('uploadFile() from html File', (_) async {
+      final fileId = uuid();
+      final path = 'public/upload-file-from-html-file-$fileId';
+      const content = 'upload data';
+      final data = content.codeUnits;
+      final file = await createHtmlFile(path: fileId, content: content);
+      addTearDownPath(StoragePath.fromString(path));
+      final result = await Amplify.Storage.uploadFile(
+        localFile: AWSFilePlatform.fromFile(file),
+        path: StoragePath.fromString(path),
+      ).result;
+      expect(result.uploadedItem.path, path);
+      final downloadResult = await Amplify.Storage.downloadData(
+        path: StoragePath.fromString(path),
+      ).result;
+      expect(downloadResult.bytes, data);
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/platform_test_io.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/platform_test_io.dart
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_storage_s3_example/amplifyconfiguration.dart';
+import 'package:aws_common/vm.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'utils/configure.dart';
+import 'utils/create_file/create_file_io.dart';
+import 'utils/tear_down.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('platform specific options', () {
+    setUpAll(() async {
+      await configure(amplifyEnvironments['main']!);
+    });
+    testWidgets('uploadFile() from io File', (_) async {
+      final fileId = uuid();
+      final path = 'public/upload-file-from-io-file-$fileId';
+      const content = 'upload data';
+      final data = content.codeUnits;
+      final file = await createIOFile(path: fileId, content: content);
+      addTearDownPath(StoragePath.fromString(path));
+      final result = await Amplify.Storage.uploadFile(
+        localFile: AWSFilePlatform.fromFile(file),
+        path: StoragePath.fromString(path),
+      ).result;
+      expect(result.uploadedItem.path, path);
+      final downloadResult = await Amplify.Storage.downloadData(
+        path: StoragePath.fromString(path),
+      ).result;
+      expect(downloadResult.bytes, data);
+    });
+  });
+}

--- a/packages/storage/amplify_storage_s3/example/integration_test/remove_many_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/remove_many_test.dart
@@ -27,11 +27,11 @@ void main() {
         final storagePath2 = StoragePath.fromString(path2);
         setUp(() async {
           await Amplify.Storage.uploadData(
-            data: HttpPayload.bytes('data'.codeUnits),
+            data: StorageDataPayload.bytes('data'.codeUnits),
             path: storagePath1,
           ).result;
           await Amplify.Storage.uploadData(
-            data: HttpPayload.bytes('data'.codeUnits),
+            data: StorageDataPayload.bytes('data'.codeUnits),
             path: storagePath2,
           ).result;
         });
@@ -65,11 +65,11 @@ void main() {
           expectedResolvedPath1 = 'private/$identityId/$fileName1';
           expectedResolvedPath2 = 'private/$identityId/$fileName2';
           await Amplify.Storage.uploadData(
-            data: HttpPayload.bytes('data'.codeUnits),
+            data: StorageDataPayload.bytes('data'.codeUnits),
             path: StoragePath.fromString(expectedResolvedPath1),
           ).result;
           await Amplify.Storage.uploadData(
-            data: HttpPayload.bytes('data'.codeUnits),
+            data: StorageDataPayload.bytes('data'.codeUnits),
             path: StoragePath.fromString(expectedResolvedPath2),
           ).result;
         });
@@ -132,11 +132,11 @@ void main() {
         final storagePath1 = StoragePath.fromString(path1);
         final storagePath2 = StoragePath.fromString(path2);
         await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes('data'.codeUnits),
+          data: StorageDataPayload.bytes('data'.codeUnits),
           path: storagePath1,
         ).result;
         await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes('data'.codeUnits),
+          data: StorageDataPayload.bytes('data'.codeUnits),
           path: storagePath2,
         ).result;
         expect(await objectExists(storagePath1), true);

--- a/packages/storage/amplify_storage_s3/example/integration_test/remove_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/remove_test.dart
@@ -24,7 +24,7 @@ void main() {
         final storagePath = StoragePath.fromString(path);
         setUp(() async {
           await Amplify.Storage.uploadData(
-            data: HttpPayload.bytes('data'.codeUnits),
+            data: StorageDataPayload.bytes('data'.codeUnits),
             path: storagePath,
           ).result;
         });
@@ -49,7 +49,7 @@ void main() {
           final identityId = await signInNewUser();
           expectedResolvedPath = 'private/$identityId/$fileName';
           await Amplify.Storage.uploadData(
-            data: HttpPayload.bytes('data'.codeUnits),
+            data: StorageDataPayload.bytes('data'.codeUnits),
             path: StoragePath.fromString(expectedResolvedPath),
           ).result;
         });
@@ -91,7 +91,7 @@ void main() {
         final path = 'public/remove-${uuid()}';
         final storagePath = StoragePath.fromString(path);
         await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes('data'.codeUnits),
+          data: StorageDataPayload.bytes('data'.codeUnits),
           path: storagePath,
         ).result;
         expect(await objectExists(storagePath), true);

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
@@ -325,6 +325,25 @@ void main() {
           expect(transferredBytes, data.length);
         });
       });
+
+      testWidgets('can cancel', (_) async {
+        const size = 1024 * 1024 * 6;
+        const chars = 'qwertyuiopasdfghjklzxcvbnm';
+        final content = List.generate(size, (i) => chars[i % 25]).join();
+        final fileId = uuid();
+        final path = 'public/upload-data-cancel-$fileId';
+        addTearDownPath(StoragePath.fromString(path));
+        final operation = Amplify.Storage.uploadData(
+          data: StorageDataPayload.string(content),
+          path: StoragePath.fromString(path),
+        );
+        final expectException = expectLater(
+          () => operation.result,
+          throwsA(isA<StorageOperationCanceledException>()),
+        );
+        await operation.cancel();
+        await expectException;
+      });
     });
     group('config with dots in name', () {
       setUpAll(() async {

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
@@ -27,7 +27,7 @@ void main() {
           final data = 'from bytes'.codeUnits;
           addTearDownPath(StoragePath.fromString(path));
           final result = await Amplify.Storage.uploadData(
-            data: HttpPayload.bytes(data),
+            data: StorageDataPayload.bytes(data),
             path: StoragePath.fromString(path),
           ).result;
           expect(result.uploadedItem.path, path);
@@ -41,14 +41,18 @@ void main() {
         testWidgets('dataUrl', (_) async {
           final path = 'public/upload-data-url-${uuid()}';
           final data = 'dataUrl'.codeUnits;
-          final dataUrl =
-              'data:text/plain;charset=utf-8;base64,${base64Encode(data)}';
+          const contentType = 'text/plain; charset=utf-8';
+          final dataUrl = 'data:$contentType;base64,${base64Encode(data)}';
           addTearDownPath(StoragePath.fromString(path));
           final result = await Amplify.Storage.uploadData(
-            data: HttpPayload.dataUrl(dataUrl),
+            data: StorageDataPayload.dataUrl(dataUrl),
             path: StoragePath.fromString(path),
+            options: const StorageUploadDataOptions(
+              pluginOptions: S3UploadDataPluginOptions(getProperties: true),
+            ),
           ).result;
           expect(result.uploadedItem.path, path);
+          expect((result.uploadedItem as S3Item).contentType, contentType);
 
           final downloadResult = await Amplify.Storage.downloadData(
             path: StoragePath.fromString(path),
@@ -61,10 +65,17 @@ void main() {
           final json = {'foo': 'bar'};
           addTearDownPath(StoragePath.fromString(path));
           final result = await Amplify.Storage.uploadData(
-            data: HttpPayload.json(json),
+            data: StorageDataPayload.json(json),
             path: StoragePath.fromString(path),
+            options: const StorageUploadDataOptions(
+              pluginOptions: S3UploadDataPluginOptions(getProperties: true),
+            ),
           ).result;
           expect(result.uploadedItem.path, path);
+          expect(
+            (result.uploadedItem as S3Item).contentType,
+            'application/json; charset=utf-8',
+          );
 
           final downloadResult = await Amplify.Storage.downloadData(
             path: StoragePath.fromString(path),
@@ -78,10 +89,17 @@ void main() {
           const value = 'bar';
           addTearDownPath(StoragePath.fromString(path));
           final result = await Amplify.Storage.uploadData(
-            data: HttpPayload.formFields({key: value}),
+            data: StorageDataPayload.formFields({key: value}),
             path: StoragePath.fromString(path),
+            options: const StorageUploadDataOptions(
+              pluginOptions: S3UploadDataPluginOptions(getProperties: true),
+            ),
           ).result;
           expect(result.uploadedItem.path, path);
+          expect(
+            (result.uploadedItem as S3Item).contentType,
+            'application/x-www-form-urlencoded; charset=utf-8',
+          );
 
           final downloadResult = await Amplify.Storage.downloadData(
             path: StoragePath.fromString(path),
@@ -94,10 +112,17 @@ void main() {
           const data = 'string';
           addTearDownPath(StoragePath.fromString(path));
           final result = await Amplify.Storage.uploadData(
-            data: HttpPayload.string(data),
+            data: StorageDataPayload.string(data),
             path: StoragePath.fromString(path),
+            options: const StorageUploadDataOptions(
+              pluginOptions: S3UploadDataPluginOptions(getProperties: true),
+            ),
           ).result;
           expect(result.uploadedItem.path, path);
+          expect(
+            (result.uploadedItem as S3Item).contentType,
+            'text/plain; charset=utf-8',
+          );
 
           final downloadResult = await Amplify.Storage.downloadData(
             path: StoragePath.fromString(path),
@@ -109,7 +134,7 @@ void main() {
           final path = 'public/upload-data-empty-${uuid()}';
           addTearDownPath(StoragePath.fromString(path));
           final result = await Amplify.Storage.uploadData(
-            data: const HttpPayload.empty(),
+            data: const StorageDataPayload.empty(),
             path: StoragePath.fromString(path),
           ).result;
           expect(result.uploadedItem.path, path);
@@ -126,7 +151,7 @@ void main() {
           final stream = Stream<List<int>>.value(data);
           addTearDownPath(StoragePath.fromString(path));
           final result = await Amplify.Storage.uploadData(
-            data: HttpPayload.streaming(stream),
+            data: StorageDataPayload.streaming(stream),
             path: StoragePath.fromString(path),
           ).result;
           expect(result.uploadedItem.path, path);
@@ -145,7 +170,7 @@ void main() {
         final expectedResolvedPath = 'private/$userIdentityId/$name';
         addTearDownPath(StoragePath.fromString(expectedResolvedPath));
         final result = await Amplify.Storage.uploadData(
-          data: HttpPayload.bytes(data),
+          data: StorageDataPayload.bytes(data),
           path: StoragePath.fromIdentityId(
             (identityId) => 'private/$identityId/$name',
           ),
@@ -162,7 +187,7 @@ void main() {
       testWidgets('unauthorized path', (_) async {
         await expectLater(
           () => Amplify.Storage.uploadData(
-            data: HttpPayload.bytes('unauthorized path'.codeUnits),
+            data: StorageDataPayload.bytes('unauthorized path'.codeUnits),
             path: const StoragePath.fromString('unauthorized/path'),
           ).result,
           throwsA(isA<StorageAccessDeniedException>()),
@@ -176,7 +201,7 @@ void main() {
           const metadata = {'description': 'foo'};
           addTearDownPath(StoragePath.fromString(path));
           final result = await Amplify.Storage.uploadData(
-            data: HttpPayload.bytes(data),
+            data: StorageDataPayload.bytes(data),
             path: StoragePath.fromString(path),
             options: const StorageUploadDataOptions(metadata: metadata),
           ).result;
@@ -194,7 +219,7 @@ void main() {
           const metadata = {'description': 'foo'};
           addTearDownPath(StoragePath.fromString(path));
           final result = await Amplify.Storage.uploadData(
-            data: HttpPayload.bytes(data),
+            data: StorageDataPayload.bytes(data),
             path: StoragePath.fromString(path),
             options: const StorageUploadDataOptions(
               metadata: metadata,
@@ -210,7 +235,7 @@ void main() {
           final data = 'useAccelerateEndpoint'.codeUnits;
           addTearDownPath(StoragePath.fromString(path));
           final result = await Amplify.Storage.uploadData(
-            data: HttpPayload.bytes(data),
+            data: StorageDataPayload.bytes(data),
             path: StoragePath.fromString(path),
             options: const StorageUploadDataOptions(
               pluginOptions: S3UploadDataPluginOptions(
@@ -226,6 +251,80 @@ void main() {
           expect(downloadResult.bytes, data);
         });
       });
+
+      group('upload progress', () {
+        testWidgets('reports progress for byte data', (_) async {
+          final path = 'public/upload-data-progress-bytes-${uuid()}';
+          final data = [1, 2, 3, 4, 5, 6];
+
+          var fractionCompleted = 0.0;
+          var totalBytes = 0;
+          var transferredBytes = 0;
+
+          addTearDownPath(StoragePath.fromString(path));
+          await Amplify.Storage.uploadData(
+            data: StorageDataPayload.bytes(data),
+            path: StoragePath.fromString(path),
+            onProgress: (StorageTransferProgress progress) {
+              fractionCompleted = progress.fractionCompleted;
+              totalBytes = progress.totalBytes;
+              transferredBytes = progress.transferredBytes;
+            },
+          ).result;
+          expect(fractionCompleted, 1.0);
+          expect(totalBytes, data.length);
+          expect(transferredBytes, data.length);
+        });
+
+        testWidgets('reports progress for string data', (_) async {
+          final path = 'public/upload-data-progress-bytes-${uuid()}';
+          const data = 'data to upload';
+          final encoded = utf8.encode(data);
+
+          var fractionCompleted = 0.0;
+          var totalBytes = 0;
+          var transferredBytes = 0;
+
+          addTearDownPath(StoragePath.fromString(path));
+          await Amplify.Storage.uploadData(
+            data: StorageDataPayload.string(data),
+            path: StoragePath.fromString(path),
+            onProgress: (StorageTransferProgress progress) {
+              fractionCompleted = progress.fractionCompleted;
+              totalBytes = progress.totalBytes;
+              transferredBytes = progress.transferredBytes;
+            },
+          ).result;
+          expect(fractionCompleted, 1.0);
+          expect(totalBytes, encoded.length);
+          expect(transferredBytes, encoded.length);
+        });
+
+        testWidgets(
+            'does not report fractionCompleted or totalBytes for streams',
+            (_) async {
+          final path = 'public/upload-data-progress-stream-${uuid()}';
+          final data = [1, 2, 3, 4, 5, 6];
+
+          var fractionCompleted = 0.0;
+          var totalBytes = 0;
+          var transferredBytes = 0;
+
+          addTearDownPath(StoragePath.fromString(path));
+          await Amplify.Storage.uploadData(
+            data: StorageDataPayload.streaming(Stream.value(data)),
+            path: StoragePath.fromString(path),
+            onProgress: (StorageTransferProgress progress) {
+              fractionCompleted = progress.fractionCompleted;
+              totalBytes = progress.totalBytes;
+              transferredBytes = progress.transferredBytes;
+            },
+          ).result;
+          expect(fractionCompleted, -1);
+          expect(totalBytes, -1);
+          expect(transferredBytes, data.length);
+        });
+      });
     });
     group('config with dots in name', () {
       setUpAll(() async {
@@ -238,7 +337,7 @@ void main() {
           final data = 'from bytes'.codeUnits;
           addTearDownPath(StoragePath.fromString(path));
           final result = await Amplify.Storage.uploadData(
-            data: HttpPayload.bytes(data),
+            data: StorageDataPayload.bytes(data),
             path: StoragePath.fromString(path),
           ).result;
           expect(result.uploadedItem.path, path);
@@ -257,7 +356,7 @@ void main() {
           final data = 'from bytes'.codeUnits;
           await expectLater(
             () => Amplify.Storage.uploadData(
-              data: HttpPayload.bytes(data),
+              data: StorageDataPayload.bytes(data),
               path: StoragePath.fromString(path),
               options: const StorageUploadDataOptions(
                 pluginOptions: S3UploadDataPluginOptions(

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_html.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_html.dart
@@ -9,7 +9,20 @@ Future<String> createFile({
   required String content,
   String contentType = 'text/plain',
 }) async {
+  final file = await createHtmlFile(
+    path: path,
+    content: content,
+    contentType: contentType,
+  );
+  return html.Url.createObjectUrl(file);
+}
+
+Future<html.File> createHtmlFile({
+  required String path,
+  required String content,
+  String contentType = 'text/plain',
+}) async {
   final fileBlob = html.Blob([content], contentType);
   final file = html.File([fileBlob], path, {'type': fileBlob.type});
-  return html.Url.createObjectUrl(file);
+  return file;
 }

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_io.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/create_file/create_file_io.dart
@@ -10,9 +10,22 @@ Future<String> createFile({
   required String content,
   String contentType = 'text/plain',
 }) async {
+  final file = await createIOFile(
+    path: path,
+    content: content,
+    contentType: contentType,
+  );
+  return file.path;
+}
+
+Future<io.File> createIOFile({
+  required String path,
+  required String content,
+  String contentType = 'text/plain',
+}) async {
   final tempPath = io.Directory.systemTemp.path;
   final file = io.File(p.join(tempPath, path));
   await file.create(recursive: true);
   await file.writeAsBytes(content.codeUnits);
-  return file.path;
+  return file;
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -210,7 +210,8 @@ class S3UploadTask {
     // size is unknown when uploading a stream of bytes and we cannot
     // determine whether to use multipart upload, so use putObject
     if (dataPayload != null) {
-      _fileSize = -1;
+      // ignore: invalid_use_of_internal_member
+      _fileSize = dataPayload.size;
       unawaited(_startPutObject(dataPayload));
       return;
     }

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -532,7 +532,7 @@ void main() {
         registerFallbackValue(
           const StorageUploadDataOptions(),
         );
-        registerFallbackValue(S3DataPayload());
+        registerFallbackValue(const S3DataPayload.empty());
       });
 
       test('should forward default options to StorageS3Service.uploadData API',
@@ -704,7 +704,7 @@ void main() {
         registerFallbackValue(
           const StorageUploadFileOptions(),
         );
-        registerFallbackValue(S3DataPayload());
+        registerFallbackValue(const S3DataPayload.empty());
         registerFallbackValue(AWSFile.fromData([]));
       });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- remove calls to `getTemporaryDirectory()` from web e2e tests. These were causing test setup to fail which leads to false positives due to https://github.com/flutter/flutter/issues/146763.
- fix progress reporting for `uploadData`. See note below for more info.
- Add platform specific e2e tests for upload to exercise the `AWSFilePlatform.fromFile()` constructor
- Add e2e tests for progress notifications and pause/resume/cancel. 

` upoadData` cannot report progress % for streams because the total size is unknown until the stream closes. Prior to this PR all `StorageDataPayload` are treated like streams even when they are created from string/json/etc. This PR converts the string/json/etc payload to byte data and reads the length when the object is constructed so that they can be uploaded with proper progress reporting. Fixing this also required creating a proper class for StorageDataPayload rather than a type alias of HttpPayload.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
