### PR TITLE
chore(authenticator): SocialSignInButtons to use textScaler instead of textScaleFactor

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/widgets/social/social_button.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/widgets/social/social_button.dart
@@ -45,10 +45,7 @@ class SocialSignInButtons extends StatelessAuthenticatorComponent {
                   ?.resolve({}) ??
               Theme.of(context).textTheme.labelLarge;
           final tp = TextPainter(
-            // TODO(dnys1): replace with textScaleFactor when min flutter version is bumped to 3.16.0
-            // see: https://docs.flutter.dev/release/breaking-changes/deprecate-textscalefactor#migrating-code-that-consumes-textscalefactor
-            // ignore: deprecated_member_use
-            textScaleFactor: MediaQuery.textScaleFactorOf(context),
+            textScaler: MediaQuery.textScalerOf(context),
             text: TextSpan(
               text: text,
               style: style,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- update SocialSignInButtons to use textScaler instead of textScaleFactor

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
