### PR TITLE
chore: remove `UserAttributeKey`, `serializeAsMap()`

### DIFF
--- a/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute.dart
@@ -31,10 +31,6 @@ class AuthUserAttribute
   @override
   List<Object> get props => [userAttributeKey, value];
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   String get runtimeTypeName => 'AuthUserAttribute';
 

--- a/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute_key.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/auth_user_attribute_key.dart
@@ -5,10 +5,6 @@ import 'package:amplify_core/amplify_core.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 
-/// @nodoc
-@Deprecated('Use AuthUserAttributeKey instead')
-typedef UserAttributeKey = AuthUserAttributeKey;
-
 /// {@category Auth}
 /// {@template amplify_core.auth_user_attribute_key}
 /// A user attribute identifier.

--- a/packages/amplify_core/lib/src/types/auth/attribute/confirm_user_attribute_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/confirm_user_attribute_options.dart
@@ -26,10 +26,6 @@ class ConfirmUserAttributeOptions
   @override
   String get runtimeTypeName => 'ConfirmUserAttributeOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/attribute/fetch_user_attributes_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/fetch_user_attributes_options.dart
@@ -26,10 +26,6 @@ class FetchUserAttributesOptions
   @override
   String get runtimeTypeName => 'FetchUserAttributesOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/attribute/send_user_attribute_verification_code_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/send_user_attribute_verification_code_options.dart
@@ -27,10 +27,6 @@ class SendUserAttributeVerificationCodeOptions
   @override
   String get runtimeTypeName => 'SendUserAttributeVerificationCodeOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attribute_options.dart
@@ -26,10 +26,6 @@ class UpdateUserAttributeOptions
   @override
   String get runtimeTypeName => 'UpdateUserAttributeOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/attribute/update_user_attributes_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/attribute/update_user_attributes_options.dart
@@ -26,10 +26,6 @@ class UpdateUserAttributesOptions
   @override
   String get runtimeTypeName => 'UpdateUserAttributesOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/password/confirm_reset_password_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/confirm_reset_password_options.dart
@@ -26,10 +26,6 @@ class ConfirmResetPasswordOptions
   @override
   String get runtimeTypeName => 'ConfirmResetPasswordOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/password/reset_password_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/reset_password_options.dart
@@ -26,10 +26,6 @@ class ResetPasswordOptions
   @override
   String get runtimeTypeName => 'ResetPasswordOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/password/update_password_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/password/update_password_options.dart
@@ -26,10 +26,6 @@ class UpdatePasswordOptions
   @override
   String get runtimeTypeName => 'UpdatePasswordOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/session/fetch_auth_session_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/session/fetch_auth_session_options.dart
@@ -33,10 +33,6 @@ class FetchAuthSessionOptions
   @override
   String get runtimeTypeName => 'FetchAuthSessionOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'forceRefresh': forceRefresh,

--- a/packages/amplify_core/lib/src/types/auth/session/get_current_user_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/session/get_current_user_options.dart
@@ -25,10 +25,6 @@ class GetCurrentUserOptions
   @override
   String get runtimeTypeName => 'GetCurrentUserOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/sign_in/confirm_sign_in_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/confirm_sign_in_options.dart
@@ -26,10 +26,6 @@ class ConfirmSignInOptions
   @override
   String get runtimeTypeName => 'ConfirmSignInOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_options.dart
@@ -26,10 +26,6 @@ class SignInOptions
   @override
   String get runtimeTypeName => 'SignInOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_with_web_ui_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/sign_in_with_web_ui_options.dart
@@ -26,10 +26,6 @@ class SignInWithWebUIOptions
   @override
   String get runtimeTypeName => 'SignInWithWebUIOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/sign_out/sign_out_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_out/sign_out_options.dart
@@ -33,10 +33,6 @@ class SignOutOptions
   @override
   String get runtimeTypeName => 'SignOutOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'globalSignOut': globalSignOut,

--- a/packages/amplify_core/lib/src/types/auth/sign_up/confirm_sign_up_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/confirm_sign_up_options.dart
@@ -26,10 +26,6 @@ class ConfirmSignUpOptions
   @override
   String get runtimeTypeName => 'ConfirmSignUpOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/sign_up/resend_sign_up_code_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/resend_sign_up_code_options.dart
@@ -26,10 +26,6 @@ class ResendSignUpCodeOptions
   @override
   String get runtimeTypeName => 'ResendSignUpCodeOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),

--- a/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_options.dart
@@ -41,10 +41,6 @@ class SignUpOptions
   @override
   String get runtimeTypeName => 'SignUpOptions';
 
-  /// @nodoc
-  @Deprecated('Use toJson instead')
-  Map<String, Object?> serializeAsMap() => toJson();
-
   @override
   Map<String, Object?> toJson() => {
         'userAttributes': userAttributes,

--- a/packages/amplify_core/lib/src/types/models/model_field_definition.dart
+++ b/packages/amplify_core/lib/src/types/models/model_field_definition.dart
@@ -147,10 +147,6 @@ class ModelFieldDefinition {
     bool isRequired = true,
     required String ofModelName,
     QueryField<Object?>? associatedKey,
-    @Deprecated(
-      'Please use the latest version of Amplify CLI to regenerate models',
-    )
-    String? targetName,
     List<String>? targetNames,
   }) {
     // Extra code needed due to lack of nullability support


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- remove `UserAttributeKey`
- remove `serializeAsMap()` from auth types


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
