### PR TITLE
feat(aws_common): replace package:js to js_interop

### DIFF
--- a/packages/aws_common/lib/src/js/abort.dart
+++ b/packages/aws_common/lib/src/js/abort.dart
@@ -3,8 +3,11 @@
 
 // ignore_for_file: avoid_classes_with_only_static_members
 
-import 'package:js/js.dart';
-import 'package:js/js_util.dart' as js_util;
+// import 'package:js/js.dart';
+// import 'package:js/js_util.dart' as js_util;
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe' as js_interop_unsafe;
 
 /// {@template aws_http.js.abort_signal}
 /// A signal object that allows you to communicate with a DOM request (such as
@@ -29,7 +32,7 @@ extension PropsAbortSignal on AbortSignal {
 
   /// The abort reason, once the signal has aborted.
   String? get reason =>
-      js_util.getProperty<Object?>(this, 'reason')?.toString();
+      globalContext.getProperty('reason'.toJS);
 }
 
 /// {@template aws_http.js.abort_controller}

--- a/packages/aws_common/lib/src/js/fetch.dart
+++ b/packages/aws_common/lib/src/js/fetch.dart
@@ -1,13 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// import 'package:js/js.dart';
+// import 'package:js/js_util.dart' as js_util;
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
 import 'package:aws_common/aws_common.dart';
 import 'package:aws_common/src/js/abort.dart';
 import 'package:aws_common/src/js/common.dart';
 import 'package:aws_common/src/js/promise.dart';
 import 'package:aws_common/src/js/readable_stream.dart';
-import 'package:js/js.dart';
-import 'package:js/js_util.dart' as js_util;
 
 /// How a [Request] will interact with the browser's HTTP cache.
 enum RequestCache with JSEnum {
@@ -228,7 +231,7 @@ abstract class RequestInit {
       destination: destination.jsValue,
       redirect: redirect.jsValue,
       referrer: referrer ?? undefined,
-      headers: headers != null ? js_util.jsify(headers) : undefined,
+      headers: headers != null ? headers.jsify() : undefined,
       integrity: integrity ?? undefined,
       keepalive: keepalive ?? undefined,
       method: method.value,
@@ -302,7 +305,7 @@ extension PropsHeaders on Headers {
   void forEach(
     void Function(String value, String key, Headers parent) callback,
   ) =>
-      js_util.callMethod(this, 'forEach', [allowInterop(callback)]);
+      globalContext.callMethod('forEach'.toJS, callback.toJS);
 }
 
 /// {@template aws_common.js.request}
@@ -334,13 +337,13 @@ final Expando<ReadableStreamView> _responseStreams = Expando('ResponseStreams');
 extension PropsResponse on Response {
   /// The response's body as a Dart [Stream].
   ReadableStreamView get body => _responseStreams[this] ??=
-      js_util.getProperty<ReadableStream?>(this, 'body')?.stream ??
+      (globalContext.getProperty('body'.toJS) as ReadableStream?)?.stream ??
           const ReadableStreamView.empty();
 
   /// The response's headers.
   Map<String, String> get headers {
     final Map<String, String> headers = CaseInsensitiveMap({});
-    js_util.getProperty<Headers>(this, 'headers').forEach((value, key, _) {
+    (globalContext.getProperty('headers'.toJS) as Headers?)?.forEach((value, key, _) {
       headers[key] = value;
     });
     return headers;

--- a/packages/aws_common/lib/src/js/indexed_db.dart
+++ b/packages/aws_common/lib/src/js/indexed_db.dart
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
-import 'dart:js_util' as js_util;
+// import 'package:js/js.dart';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+// import 'dart:js_util' as js_util;
 
 import 'package:aws_common/src/js/common.dart';
-import 'package:js/js.dart';
 
 /// The global read-only [IDBFactory] instance.
 @JS()
@@ -22,7 +25,7 @@ abstract class DOMStringList {}
 extension PropsDOMStringList on DOMStringList {
   /// Checks if the given string is in the list.
   bool contains(String string) =>
-      js_util.callMethod(this, 'contains', [string]);
+      globalContext.callMethod('contains'.toJS, string.toJS);
 }
 
 /// {@template amplify_secure_storage_dart.idb_version_change_event}
@@ -37,7 +40,7 @@ abstract class IDBVersionChangeEvent extends Event {}
 /// {@macro amplify_secure_storage_dart.idb_version_change_event}
 extension PropsIDBVersionChangeEvent on IDBVersionChangeEvent {
   /// The target of this event, the DB open request.
-  IDBOpenDBRequest get target => js_util.getProperty(this, 'target');
+  IDBOpenDBRequest get target => globalContext.getProperty('target'.toJS);
 }
 
 /// {@template amplify_secure_storage_dart.idb_request}
@@ -57,16 +60,16 @@ extension PropsIDBRequest<T> on IDBRequest<T> {
   ///
   /// If the request failed and the result is not available, an
   /// `InvalidStateError` exception is thrown.
-  T get result => js_util.getProperty(this, 'result');
+  T get result => globalContext.getProperty('result'.toJS);
 
   /// Fired when an IDBRequest succeeds.
   set onsuccess(EventHandler newValue) {
-    js_util.setProperty(this, 'onsuccess', allowInterop(newValue));
+    globalContext.setProperty('onsuccess'.toJS, newValue.toJS);
   }
 
   /// Fired when an error caused a request to fail.
   set onerror(EventHandler newValue) {
-    js_util.setProperty(this, 'onerror', allowInterop(newValue));
+    globalContext.setProperty('onerror'.toJS, newValue.toJS);
   }
 
   /// Returns a [Future] which completes with the [result] of this request.
@@ -97,7 +100,7 @@ extension PropsIDBOpenDBRequest on IDBOpenDBRequest {
   /// Fired when an attempt was made to open a database with a version number
   /// higher than its current version.
   set onupgradeneeded(EventHandler<IDBVersionChangeEvent> newValue) {
-    js_util.setProperty(this, 'onupgradeneeded', allowInterop(newValue));
+    globalContext.setProperty('onupgradeneeded'.toJS, newValue.toJS);
   }
 }
 
@@ -113,10 +116,10 @@ abstract class IDBFactory {}
 extension PropsIDBFactory on IDBFactory {
   /// The current method to request opening a connection to a database.
   IDBOpenDBRequest open(String name, [int? version]) =>
-      js_util.callMethod(this, 'open', [
-        name,
-        if (version != null) version,
-      ]);
+      globalContext.callMethod('open'.toJS, 
+        name.toJS,
+        (version != null) ? version.toJS : null,
+      );
 }
 
 /// {@template amplify_secure_storage_dart.idb_database}
@@ -133,7 +136,7 @@ abstract class IDBDatabase {}
 extension PropsIDBDatabase on IDBDatabase {
   /// The list of the names of object stores in the database.
   DOMStringList get objectStoreNames =>
-      js_util.getProperty(this, 'objectStoreNames');
+      globalContext.getProperty('objectStoreNames'.toJS);
 
   /// Returns a new transaction with the given mode (`readonly` or `readwrite`)
   /// and scope which can be a single object store name or an array of names.
@@ -141,7 +144,7 @@ extension PropsIDBDatabase on IDBDatabase {
     String storeNames, {
     IDBTransactionMode mode = IDBTransactionMode.readonly,
   }) =>
-      js_util.callMethod(this, 'transaction', [storeNames, mode.name]);
+      globalContext.callMethod('transaction'.toJS, storeNames.toJS, mode.jsify());
 
   /// Creates a new object store with the given name and options and returns a
   /// new [IDBObjectStore].
@@ -161,10 +164,10 @@ extension PropsIDBDatabase on IDBDatabase {
       params['autoIncrement'] = autoIncrement;
     }
 
-    return js_util.callMethod(
-      this,
-      'createObjectStore',
-      [name, js_util.jsify(params)],
+    return globalContext.callMethod(
+      'createObjectStore'.toJS,
+      name.toJS,
+      params.jsify(),
     );
   }
 
@@ -198,7 +201,7 @@ extension PropsIDBObjectStore on IDBObjectStore {
   /// This is for updating existing records in an object store when the
   /// transaction's mode is `readwrite`.
   IDBRequest<void> put(String value, String key) =>
-      js_util.callMethod(this, 'put', [value, key]);
+      globalContext.callMethod('put'.toJS, value.toJS, key.toJS);
 
   /// Returns an [IDBRequest] object, and, in a separate thread, creates a
   /// structured clone of the value, and stores the cloned value in the object
@@ -206,7 +209,7 @@ extension PropsIDBObjectStore on IDBObjectStore {
   ///
   /// This is for adding new records to an object store.
   IDBRequest<void> add(String value, String key) =>
-      js_util.callMethod(this, 'add', [value, key]);
+      globalContext.callMethod('add'.toJS, value.toJS, key.toJS);
 
   /// Returns an [IDBRequest] object, and, in a separate thread, creates a
   /// structured clone of the value, and stores the cloned value in the object
@@ -214,41 +217,41 @@ extension PropsIDBObjectStore on IDBObjectStore {
   ///
   /// This is for adding new records to an object store created with keyPath set and autoincrement = true
   IDBRequest<void> push(Map<Object, Object> item) =>
-      js_util.callMethod(this, 'add', [js_util.jsify(item)]);
+      globalContext.callMethod('add'.toJS, item.jsify());
 
   /// Returns an [IDBRequest] object, and, in a separate thread, deletes the
   /// store object selected by the specified key.
   ///
   /// This is for deleting individual records out of an object store.
   IDBRequest<void> delete(String query) =>
-      js_util.callMethod(this, 'delete', [query]);
+      globalContext.callMethod('delete'.toJS, query.toJS);
 
   /// Returns an [IDBRequest] object, and, in a separate thread, deletes the
   /// store objects within the provided [IDBKeyRange].
   ///
   /// This is for deleting ranges of records out of an object store.
   IDBRequest<void> deleteByKeyRange(IDBKeyRange range) =>
-      js_util.callMethod(this, 'delete', [range]);
+      globalContext.callMethod('delete'.toJS, range.jsify());
 
   /// Returns an [IDBRequest] object, and, in a separate thread, deletes all
   /// store objects.
   ///
   /// This is for deleting all records in an object store.
-  IDBRequest<void> clear() => js_util.callMethod(this, 'clear', []);
+  IDBRequest<void> clear() => globalContext.callMethod('clear'.toJS, null);
 
   /// Returns an [IDBRequest] object, and, in a separate thread, returns the
   /// store object store selected by the specified key.
   ///
   /// This is for retrieving specific records from an object store.
   IDBRequest<String?> getObject(String query) =>
-      js_util.callMethod(this, 'get', [query]);
+      globalContext.callMethod('get'.toJS, query.toJS);
 
   /// Returns an [IDBRequest] object, and, in a separate thread, returns
   /// [count] records from the object store.
   ///
   /// This is for retrieving a specific [count] of records from the object store.
   IDBRequest<List<dynamic>> getAll(String? query, int? count) =>
-      js_util.callMethod(this, 'getAll', [query, count]);
+      globalContext.callMethod('getAll'.toJS, query?.toJS, count?.toJS);
 }
 
 /// {@template amplify_secure_storage_dart.idb_transaction}
@@ -265,7 +268,7 @@ abstract class IDBTransaction {}
 extension PropsIDBTransaction on IDBTransaction {
   /// Returns an [IDBObjectStore] in the transaction's scope.
   IDBObjectStore objectStore(String name) =>
-      js_util.callMethod(this, 'objectStore', [name]);
+      globalContext.callMethod('objectStore'.toJS, name.toJS);
 }
 
 /// The mode for isolating access to data in the object stores that are in the

--- a/packages/aws_common/lib/src/js/promise.dart
+++ b/packages/aws_common/lib/src/js/promise.dart
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
+// import 'package:js/js.dart';
+// import 'package:js/js_util.dart' as js_util;
 
-import 'package:js/js.dart';
-import 'package:js/js_util.dart' as js_util;
+import 'dart:js_interop';
 
 /// A [Promise] executor callback.
 typedef Executor<T> = void Function(
@@ -20,7 +21,7 @@ typedef Executor<T> = void Function(
 @staticInterop
 abstract class Promise<T> {
   /// Creates a JS Promise.
-  factory Promise(Executor<T> executor) => Promise._(allowInterop(executor));
+  factory Promise(Executor<T> executor) => Promise._(executor);
 
   external factory Promise._(Executor<T> executor);
 
@@ -49,5 +50,5 @@ abstract class Promise<T> {
 /// {@macro aws_common.js.promise}
 extension PropsPromise<T> on Promise<T> {
   /// Resolves `this` as a Dart [Future].
-  Future<T> get future => js_util.promiseToFuture(this);
+  Future<T> get future => this.future;
 }

--- a/packages/aws_common/lib/src/js/readable_stream.dart
+++ b/packages/aws_common/lib/src/js/readable_stream.dart
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
+// import 'package:js/js.dart';
+// import 'package:js/js_util.dart' as js_util;
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 import 'dart:typed_data';
 
 import 'package:async/async.dart';
 import 'package:aws_common/src/js/common.dart';
 import 'package:aws_common/src/js/promise.dart';
-import 'package:js/js.dart';
-import 'package:js/js_util.dart' as js_util;
+
 
 /// {@template aws_common.js.readable_stream}
 /// An object containing methods and properties that define how the constructed
@@ -75,30 +78,30 @@ abstract class UnderlyingSource {
     final startFn = start == null
         ? undefined
         : start is Future<void> Function(ReadableStreamController)
-            ? allowInterop((ReadableStreamController controller) {
+            ? ((ReadableStreamController controller) {
                 return Promise.fromFuture(start(controller));
-              })
-            : allowInterop(start);
+              }).jsify()
+            : start.toJS;
     final pullFn = pull == null
         ? undefined
         : pull is Future<void> Function(ReadableStreamController)
-            ? allowInterop((ReadableStreamController controller) {
+            ? ((ReadableStreamController controller) {
                 return Promise.fromFuture(pull(controller));
-              })
-            : allowInterop(pull);
+              }).jsify()
+            : pull.toJS;
     final cancelFn = cancel == null
         ? undefined
         : cancel is Future<void> Function([
             String? reason,
             ReadableStreamController? controller,
           ])
-            ? allowInterop((
+            ? ((
                 String? reason,
                 ReadableStreamController? controller,
               ) {
                 return Promise.fromFuture(cancel(reason, controller));
-              })
-            : allowInterop(cancel);
+              }).jsify()
+            : cancel.toJS;
     return UnderlyingSource._(
       start: startFn,
       pull: pullFn,
@@ -194,7 +197,7 @@ extension PropsReadableStream on ReadableStream {
   /// consumer. The supplied reason argument will be given to the underlying
   /// source, which may or may not use it.
   Future<void> cancel([String? reason]) =>
-      js_util.promiseToFuture(js_util.callMethod(this, 'cancel', [reason]));
+      globalContext.callMethod('cancel'.toJS, reason.jsify());
 
   /// Creates a reader and locks the stream to it.
   ///
@@ -203,7 +206,7 @@ extension PropsReadableStream on ReadableStream {
   ReadableStreamReader getReader({
     ReadableStreamReaderMode mode = ReadableStreamReaderMode.default$,
   }) =>
-      js_util.callMethod(this, 'getReader', [mode.jsValue]);
+      globalContext.callMethod('getReader'.toJS, mode.jsValue.jsify());
 
   /// Creates a Dart [Stream] from `this`.
   ReadableStreamView get stream =>
@@ -229,7 +232,7 @@ extension PropsReadableStreamReader on ReadableStreamReader {
   /// This property enables you to write code that responds to an end to the
   /// streaming process.
   Future<void> get closed =>
-      js_util.promiseToFuture(js_util.getProperty(this, 'closed'));
+      (globalContext.getProperty('closed'.toJS));
 
   /// Returns a Promise that resolves when the stream is canceled.
   ///
@@ -237,7 +240,7 @@ extension PropsReadableStreamReader on ReadableStreamReader {
   /// consumer. The supplied reason argument will be given to the underlying
   /// source, which may or may not use it.
   Future<void> cancel([String? reason]) =>
-      js_util.promiseToFuture(js_util.callMethod(this, 'cancel', [reason]));
+     globalContext.callMethod('cancel'.toJS, reason.jsify());
 
   /// Releases the reader's lock on the stream.
   external void releaseLock();
@@ -269,7 +272,7 @@ extension PropsReadableStreamDefaultReader on ReadableStreamDefaultReader {
   /// Returns a promise providing access to the next chunk in the stream's
   /// internal queue.
   Future<ReadableStreamChunk> read() =>
-      js_util.promiseToFuture(js_util.callMethod(this, 'read', []));
+      globalContext.callMethod('read'.toJS, null);
 }
 
 /// Specifies the type of [ReadableStreamReader] to create.


### PR DESCRIPTION
*Issue*
#4807 

*Description of changes:*
I tried to change `package:js` and `package:js/js_util.dart` to `dart:js_interop` and `dart:js_interop_unsafe`.

Still there are these errors, so I couldn't test fully build. Maybe it can be starter for us:

Still need changes on these files with this error log like I said in issue #4807:

```
../../../../../.pub-cache/hosted/pub.dev/aws_common-0.6.4/lib/src/js/readable_stream.dart:10:1: Error: JS interop library 'package:js/js.dart' can't be imported when compiling to
Wasm.
Try using 'dart:js_interop' or 'dart:js_interop_unsafe' instead.
import 'package:js/js.dart';
^
../../../../../.pub-cache/hosted/pub.dev/aws_common-0.6.4/lib/src/js/readable_stream.dart:11:1: Error: JS interop library 'package:js/js_util.dart' can't be imported when compiling
to Wasm.
Try using 'dart:js_interop' or 'dart:js_interop_unsafe' instead.
import 'package:js/js_util.dart' as js_util;
^
../../../../../.pub-cache/hosted/pub.dev/aws_common-0.6.4/lib/src/js/fetch.dart:9:1: Error: JS interop library 'package:js/js.dart' can't be imported when compiling to Wasm.
Try using 'dart:js_interop' or 'dart:js_interop_unsafe' instead.
import 'package:js/js.dart';
^
../../../../../.pub-cache/hosted/pub.dev/aws_common-0.6.4/lib/src/js/fetch.dart:10:1: Error: JS interop library 'package:js/js_util.dart' can't be imported when compiling to Wasm.
Try using 'dart:js_interop' or 'dart:js_interop_unsafe' instead.
import 'package:js/js_util.dart' as js_util;
^
../../../../../.pub-cache/hosted/pub.dev/amplify_auth_cognito_dart-0.10.13/lib/src/asf/asf_device_info_collector.js.dart:15:1: Error: JS interop library 'package:js/js.dart' can't be
imported when compiling to Wasm.
Try using 'dart:js_interop' or 'dart:js_interop_unsafe' instead.
import 'package:js/js.dart';
^
../../../../../.pub-cache/hosted/pub.dev/aws_common-0.6.4/lib/src/js/promise.dart:6:1: Error: JS interop library 'package:js/js.dart' can't be imported when compiling to Wasm.
Try using 'dart:js_interop' or 'dart:js_interop_unsafe' instead.
import 'package:js/js.dart';
^
../../../../../.pub-cache/hosted/pub.dev/aws_common-0.6.4/lib/src/js/promise.dart:7:1: Error: JS interop library 'package:js/js_util.dart' can't be imported when compiling to Wasm.
Try using 'dart:js_interop' or 'dart:js_interop_unsafe' instead.
import 'package:js/js_util.dart' as js_util;
^
../../../../../.pub-cache/hosted/pub.dev/worker_bee-0.2.4/lib/src/worker_bee_js.dart:4:1: Error: JS interop library 'package:js/js.dart' can't be imported when compiling to Wasm.
Try using 'dart:js_interop' or 'dart:js_interop_unsafe' instead.
export 'package:js/js.dart';
^
../../../../../.pub-cache/hosted/pub.dev/aws_common-0.6.4/lib/src/js/abort.dart:6:1: Error: JS interop library 'package:js/js.dart' can't be imported when compiling to Wasm.
Try using 'dart:js_interop' or 'dart:js_interop_unsafe' instead.
import 'package:js/js.dart';
^
../../../../../.pub-cache/hosted/pub.dev/aws_common-0.6.4/lib/src/js/abort.dart:7:1: Error: JS interop library 'package:js/js_util.dart' can't be imported when compiling to Wasm.
Try using 'dart:js_interop' or 'dart:js_interop_unsafe' instead.
import 'package:js/js_util.dart' as js_util;
^
../../../../../.pub-cache/hosted/pub.dev/aws_common-0.6.4/lib/src/js/common.dart:7:1: Error: JS interop library 'dart:js_util' can't be imported when compiling to Wasm.
Try using 'dart:js_interop' or 'dart:js_interop_unsafe' instead.
import 'dart:js_util' as js_util;
../../../../../.pub-cache/hosted/pub.dev/aws_common-0.6.4/lib/src/js/common.dart:10:1: Error: JS interop library 'package:js/js.dart' can't be imported when compiling to Wasm.
Try using 'dart:js_interop' or 'dart:js_interop_unsafe' instead.
import 'package:js/js.dart';
```
