### PR TITLE
chore: update `expectLater` to use callback

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/integration_test/custom_auth_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/custom_auth_test.dart
@@ -181,7 +181,7 @@ void main() {
           'passes client metadata to signIn',
           (_) async {
             await expectLater(
-              Amplify.Auth.signIn(
+              () => Amplify.Auth.signIn(
                 username: username,
                 options: const SignInOptions(
                   pluginOptions: CognitoSignInPluginOptions(
@@ -347,7 +347,7 @@ void main() {
 
         asyncTest('passes client metadata to signIn', (_) async {
           await expectLater(
-            Amplify.Auth.signIn(
+            () => Amplify.Auth.signIn(
               username: username,
               password: password,
               options: const SignInOptions(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update `expectLater` to use a callback

The updated tests are skipped, but are causing failures when run with flutter beta. The failures occur because although the `expectLater` matchers are skipped, the code still executes and results in an error. There must have been a change in behavior in a recent version of flutter_test in how async exceptions are handled. However, using a cb seems like a good best practice even if not required in most cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
