### PR TITLE
[flutter-datastore-v2] port graphql error decoding logic

### DIFF
--- a/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
+++ b/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
@@ -29,42 +29,122 @@ extension GraphQLResponse {
         guard let data = string.data(using: .utf8) else {
             return .failure(.transformationError(
                 string,
-                .operationError("Unable to deserialize json data", "Check the event structure.", nil)
+                .unknown("Unable to deserialize json data", "Check the event structure.")
             ))
         }
-        return fromAppSyncResponse(data: data, decodePath: decodePath, modelName: modelName)
+
+        let result: Result<GraphQLResponse<R>, APIError> = toJson(data: data).flatMap {
+            fromAppSyncResponse(json: $0, decodePath: decodePath, modelName: modelName)
+        }
+
+        switch result {
+        case .success(let response): return response
+        case .failure(let error): return .failure(.transformationError(string, error))
+        }
     }
 
-    public static func fromAppSyncResponse<R: Decodable>(
-        data: Data,
+    public static func fromAppSyncSubscriptionResponse<R: Decodable>(
+        string: String,
         decodePath: String?,
         modelName: String? = nil
     ) -> GraphQLResponse<R> {
-        toJson(data: data)
-            .flatMap { fromAppSyncResponse(json: $0, decodePath: decodePath, modelName: modelName) }
-            .mapError {
-                if let response = String(data: data, encoding: .utf8) {
-                    return .transformationError(response, $0)
+        guard let data = string.data(using: .utf8) else {
+            return .failure(.transformationError(
+                string,
+                .unknown("Unable to deserialize json data", "Check the event structure.")
+            ))
+        }
+
+        return toJson(data: data)
+            .flatMap {
+                if let decodePath, let data = $0.value(at: decodePath) {
+                    return .success(data)
                 } else {
-                    return .transformationError("Response is not string encodable", $0)
+                    return .failure(APIError.unknown("Failed to get data from AppSync response", ""))
                 }
             }
+            .flatMap { decodeDataPayload($0, modelName: modelName) }
+            .mapError { .transformationError(string, $0) }
     }
 
+    public static func fromAppSyncSubscriptionErrorResponse<R: Decodable>(
+        string: String
+    ) -> GraphQLResponse<R> {
+        guard let data = string.data(using: .utf8) else {
+            return .failure(.transformationError(
+                string,
+                .unknown("Unable to deserialize json data", "Check the event structure.")
+            ))
+        }
+
+        let result = toJson(data: data)
+            .flatMap {
+                let errors = $0.errors
+                if errors != nil {
+                    return .success(errors?.asArray ?? [errors!])
+                } else {
+                    return .failure(.unknown("Failed to get errors from AppSync response", ""))
+                }
+            }
+            .map { $0.compactMap(parseGraphQLError(error:)) }
+
+        switch result {
+        case .success(let errors): return .failure(.error(errors))
+        case .failure(let apiError): return .failure(.transformationError(string, apiError))
+        }
+    }
+
+// MARK: - internal methods
+    // following logic in
+    // https://github.com/aws-amplify/amplify-swift/blob/main/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Internal/AWSAppSyncGraphQLResponse.swift#L18-L38
     static func fromAppSyncResponse<R: Decodable>(
         json: JSONValue,
         decodePath: String?,
         modelName: String?
-    ) -> Result<R, APIError> {
-        if let decodePath {
-            if let payload = json.value(at: decodePath) {
-                return decodeDataPayload(payload, modelName: modelName)
-            } else {
-                return .failure(.operationError("Empty data on decode path \(decodePath)", "", nil))
+    ) -> Result<GraphQLResponse<R>, APIError> {
+        let data = decodePath != nil ? json.value(at: decodePath!) : json
+        let errors = json.errors?.asArray
+        switch (data, errors) {
+        case (.some(let data), .none):
+            return decodeDataPayload(data, modelName: modelName).map { .success($0) }
+        case (.none, .some(let errors)):
+            return .success(.failure(.error(errors.compactMap(parseGraphQLError(error:)))))
+        case (.some(let data), .some(let errors)):
+            return decodeDataPayload(data, modelName: modelName).map {
+                .failure(.partial($0, errors.compactMap(parseGraphQLError(error:))))
             }
-        } else {
-            return decodeDataPayload(json, modelName: modelName)
+        case (.none, .none):
+            return .failure(.unknown(
+                "Failed to get data object or errors from GraphQL response",
+                "The AppSync service returned a malformed GraphQL response"
+            ))
         }
+    }
+
+    // folowing logic in
+    // https://github.com/aws-amplify/amplify-swift/blob/main/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Decode/GraphQLErrorDecoder.swift
+    static func parseGraphQLError(
+        error: JSONValue
+    ) -> GraphQLError? {
+        guard let errorObject = error.asObject else {
+            return nil
+        }
+
+        let extensions = errorObject.enumerated().filter { !["message", "locations", "path", "extensions"].contains($0.element.key) }
+            .reduce([String: JSONValue]()) { partialResult, item in
+                partialResult.merging([item.element.key: item.element.value]) { $1 }
+            }
+
+        return (try? jsonEncoder.encode(error))
+            .flatMap { try? jsonDecoder.decode(GraphQLError.self, from: $0) }
+            .map {
+                GraphQLError(
+                    message: $0.message,
+                    locations: $0.locations,
+                    path: $0.path,
+                    extensions: extensions.isEmpty ? nil : extensions
+                )
+            }
     }
 
     static func decodeDataPayload<R: Decodable>(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- add error decoding for GraphQL response and GraphQL subscription event


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
