### PR TITLE
test(swift-datastore): add unit tests for GraphQLResposne decoding logic

### DIFF
--- a/packages/amplify_datastore/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/amplify_datastore/example/ios/Runner.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		4B4F4F612982D1E100204FE6 /* model_name_with_all_query_parameters.json in Resources */ = {isa = PBXBuildFile; fileRef = 4B4F4F472982D1E000204FE6 /* model_name_with_all_query_parameters.json */; };
 		4B4F4F622982D1E100204FE6 /* 1_result.json in Resources */ = {isa = PBXBuildFile; fileRef = 4B4F4F482982D1E000204FE6 /* 1_result.json */; };
 		4B4F4F632982D1E100204FE6 /* instance_without_predicate.json in Resources */ = {isa = PBXBuildFile; fileRef = 4B4F4F4A2982D1E000204FE6 /* instance_without_predicate.json */; };
+		600B4A792BED53E4007AA1EA /* GraphQLResponse+DecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600B4A782BED53E4007AA1EA /* GraphQLResponse+DecodeTests.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -118,6 +119,7 @@
 		4B4F4F482982D1E000204FE6 /* 1_result.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 1_result.json; sourceTree = "<group>"; };
 		4B4F4F4A2982D1E000204FE6 /* instance_without_predicate.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = instance_without_predicate.json; sourceTree = "<group>"; };
 		513D66DA8B182E3FFDF8750D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		600B4A782BED53E4007AA1EA /* GraphQLResponse+DecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLResponse+DecodeTests.swift"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7A205B25C076AD0D2D0AEBA9 /* Pods-unit_tests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-unit_tests.profile.xcconfig"; path = "Target Support Files/Pods-unit_tests/Pods-unit_tests.profile.xcconfig"; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 				4B4F4F1E2982D0CA00204FE6 /* QuerySortBuilderUnitTests.swift */,
 				4B4F4F162982D0C400204FE6 /* unit_tests-Bridging-Header.h */,
 				119A9D2529F997A6008BD2A8 /* NativeAuthPluginTests.swift */,
+				600B4A782BED53E4007AA1EA /* GraphQLResponse+DecodeTests.swift */,
 			);
 			path = unit_tests;
 			sourceTree = "<group>";
@@ -576,6 +579,7 @@
 				4B4F4F502982D1E000204FE6 /* FlutterSerializedModelData.swift in Sources */,
 				4B4F4F282982D0CB00204FE6 /* DataStorePluginUnitTests.swift in Sources */,
 				119A9D2629F997A6008BD2A8 /* NativeAuthPluginTests.swift in Sources */,
+				600B4A792BED53E4007AA1EA /* GraphQLResponse+DecodeTests.swift in Sources */,
 				4B4F4F272982D0CB00204FE6 /* QuerySortBuilderUnitTests.swift in Sources */,
 				4B4F4F202982D0CB00204FE6 /* DataStoreHubEventStreamHandlerTests.swift in Sources */,
 				4B4F4F242982D0CB00204FE6 /* GetJsonFromFileUtil.swift in Sources */,

--- a/packages/amplify_datastore/example/ios/unit_tests/GraphQLResponse+DecodeTests.swift
+++ b/packages/amplify_datastore/example/ios/unit_tests/GraphQLResponse+DecodeTests.swift
@@ -1,0 +1,434 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import XCTest
+@testable import Amplify
+@testable import AWSPluginsCore
+@testable import amplify_datastore
+
+class GraphQLResponseDecodeTests: XCTestCase {
+
+    override func tearDown() async throws {
+        SchemaData.modelSchemaRegistry.modelSchemas = [:]
+        ModelRegistry.reset()
+    }
+
+    func testToJson_decodeDataToJSONValue_success() {
+        let testJson = """
+            {"a": "b", "c": ["d"]}
+        """
+        let expectedJson: JSONValue = [
+            "a": "b",
+            "c": ["d"]
+        ]
+        let testData = testJson.data(using: .utf8)
+        XCTAssertNotNil(testData)
+        let decodeJsonValue = GraphQLResponse<String>.toJson(data: testData!)
+        XCTAssertNoThrow(try decodeJsonValue.get())
+        XCTAssertEqual(expectedJson, try decodeJsonValue.get())
+    }
+
+    func testToJson_decodeWrongJsonDataToJSONValue_failure() {
+        let testJson = """
+            {"a": "b", "c": ["d"}
+        """
+        let testData = testJson.data(using: .utf8)
+        XCTAssertNotNil(testData)
+        let decodeJsonValue = GraphQLResponse<String>.toJson(data: testData!)
+        XCTAssertThrowsError(try decodeJsonValue.get())
+    }
+
+    func testFromJson_encodeJsonValueToData_success() {
+        let json: JSONValue = [
+            "a": ["b"]
+        ]
+
+        let expectedJsonData = "{\"a\":[\"b\"]}".data(using: .utf8)
+        let encodedJsonData = GraphQLResponse<String>.fromJson(json)
+        XCTAssertNoThrow(try encodedJsonData.get())
+        XCTAssertEqual(expectedJsonData, try encodedJsonData.get())
+    }
+
+    func testEncodeDataPayloadToString_withCorrectJSONValue_success() {
+        let json: JSONValue = [
+            "a": ["b"]
+        ]
+
+        let expectedJson = "{\"a\":[\"b\"]}"
+        let encodedJson = GraphQLResponse<String>.encodeDataPayloadToString(json)
+        XCTAssertNoThrow(try encodedJson.get())
+        XCTAssertEqual(expectedJson, try encodedJson.get())
+    }
+
+    func testDecodeDataPayloadToAnyModel_withCorrectJson_Success() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let json: JSONValue = [
+            "__typename": "Post",
+            "id": "123",
+            "title": "test",
+            "author": "authorId",
+        ]
+
+        let expectedModel: AnyModel = AnyModel(FlutterSerializedModel(map: [
+            "__typename": "Post",
+            "id": "123",
+            "title": "test",
+            "author": "authorId",
+        ], modelName: "Post"))
+
+        let result = GraphQLResponse<AnyModel>.decodeDataPayloadToAnyModel(json)
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(expectedModel.modelName, try result.get().modelName)
+        XCTAssertEqual(expectedModel.id, try result.get().id)
+    }
+
+    func testDecodeDataPayloadToAnyModel_withJsonWithoutTypename_failure() {
+        let json: JSONValue = [
+            "a": ["b"]
+        ]
+
+        let result = GraphQLResponse<AnyModel>.decodeDataPayloadToAnyModel(json)
+        XCTAssertThrowsError(try result.get()) { error in
+            XCTAssertTrue(error is APIError)
+            XCTAssertEqual((error as! APIError).errorDescription, "Could not retrieve __typename from object")
+        }
+    }
+
+    func testDecodeDataPayloadToAnyModel_withJsonWithWrongTypename_failure() {
+        let json: JSONValue = [
+            "a": ["b"],
+            "__typename": "Post"
+        ]
+
+        let result = GraphQLResponse<AnyModel>.decodeDataPayloadToAnyModel(json)
+        XCTAssertThrowsError(try result.get()) { error in
+            XCTAssertTrue(error is APIError)
+            XCTAssertTrue((error as! APIError).errorDescription.starts(with: "Could not decode to Post"))
+        }
+    }
+
+    func testDecodeDataPayload_withDecodableAsString_getString() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let json: JSONValue = [
+            "a": ["b"]
+        ]
+        let expectedJson = "{\"a\":[\"b\"]}"
+        let result: Result<String, APIError> = GraphQLResponse<String>.decodeDataPayload(json, modelName: nil)
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(expectedJson, try result.get())
+    }
+
+    func testDecodeDataPayload_withDecodableAsAnyModel_getAnyModel() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let json: JSONValue = [
+            "__typename": "Post",
+            "id": "123",
+            "title": "test",
+            "author": "authorId",
+        ]
+
+        let expectedModel: AnyModel = AnyModel(FlutterSerializedModel(map: [
+            "__typename": "Post",
+            "id": "123",
+            "title": "test",
+            "author": "authorId",
+        ], modelName: "Post"))
+
+        let result: Result<AnyModel, APIError> = GraphQLResponse<AnyModel>.decodeDataPayload(json, modelName: nil)
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(expectedModel.modelName, try result.get().modelName)
+        XCTAssertEqual(expectedModel.id, try result.get().id)
+    }
+
+    func testDecodeDataPayload_withSpecifiedModelName_decodedWithThatType() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let json: JSONValue = [
+            "id": "123",
+            "title": "test",
+            "author": "authorId",
+        ]
+
+        let expectedModel: AnyModel = AnyModel(FlutterSerializedModel(map: [
+            "__typename": "Post",
+            "id": "123",
+            "title": "test",
+            "author": "authorId",
+        ], modelName: "Post"))
+
+        let result: Result<AnyModel, APIError> = GraphQLResponse<AnyModel>.decodeDataPayload(json, modelName: "Post")
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(expectedModel.modelName, try result.get().modelName)
+        XCTAssertEqual(expectedModel.id, try result.get().id)
+    }
+
+    func testDecodeDataPayload_withTypeR_decodedToR() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let json: JSONValue = [
+            "__typename": "Post",
+            "id": "123",
+            "title": "test",
+            "author": "authorId",
+            "_version": 1,
+           "_deleted": nil,
+           "_lastChangedAt": 1707773705221
+        ]
+
+        let expectedModel: AnyModel = AnyModel(FlutterSerializedModel(map: [
+            "__typename": "Post",
+            "id": "123",
+            "title": "test",
+            "author": "authorId",
+        ], modelName: "Post"))
+
+        let result: Result<MutationSync<AnyModel>, APIError> = GraphQLResponse<AnyModel>.decodeDataPayload(json, modelName: "Post")
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(expectedModel.modelName, try result.get().model.modelName)
+        XCTAssertEqual(expectedModel.id, try result.get().model.identifier)
+    }
+
+    func testParseGraphQLError_withNonObjectJsonValue_returnNil() {
+        let errorJson: JSONValue = "test"
+        XCTAssertNil(GraphQLResponse<String>.parseGraphQLError(error: errorJson))
+    }
+
+    func testParseGraphQLError_withCorrectJsonValue_buildGraphQLErrorSuccessfully() {
+        let errorJson: JSONValue = [
+            "message": "test",
+            "errorType": "UnknownError"
+        ]
+
+        let result = GraphQLResponse<String>.parseGraphQLError(error: errorJson)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(errorJson.message?.stringValue, result?.message)
+        XCTAssertEqual(["errorType": "UnknownError"], result?.extensions)
+    }
+
+    func testFromAppSyncResponse_withOnlyData_decodePayload() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let json: JSONValue = [
+            "onCreatePost": [
+                "__typename": "Post",
+                "id": "123",
+                "title": "test",
+                "author": "authorId",
+                "_version": 1,
+               "_deleted": nil,
+               "_lastChangedAt": 1707773705221
+            ]
+        ]
+
+        let expectedModel: AnyModel = AnyModel(FlutterSerializedModel(map: [
+            "__typename": "Post",
+            "id": "123",
+            "title": "test",
+            "author": "authorId",
+        ], modelName: "Post"))
+
+        let result: Result<GraphQLResponse<MutationSync<AnyModel>>, APIError> = .fromAppSyncResponse(json: json, decodePath: "onCreatePost", modelName: nil)
+        XCTAssertNoThrow(try result.get())
+        let mutationSync = try! result.get()
+        XCTAssertNoThrow(try mutationSync.get())
+        XCTAssertEqual(expectedModel.modelName, try mutationSync.get().model.modelName)
+        XCTAssertEqual(expectedModel.id, try mutationSync.get().model.identifier)
+    }
+
+    func testFromAppSyncResponse_withOnlyErrors_decodePayload() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let json: JSONValue = [
+            "errors": [
+                ["message": "error1"],
+                ["message": "error2"]
+            ]
+        ]
+
+        let result: Result<GraphQLResponse<MutationSync<AnyModel>>, APIError> = .fromAppSyncResponse(json: json, decodePath: "onCreatePost", modelName: nil)
+        XCTAssertNoThrow(try result.get())
+        let mutationSync = try! result.get()
+        XCTAssertThrowsError(try mutationSync.get()) { error in
+            if let graphQLResponseError = error as? GraphQLResponseError<MutationSync<AnyModel>>,
+               case .error(let graphQLErrors) = graphQLResponseError
+            {
+                XCTAssertEqual(graphQLErrors.map(\.message), ["error1", "error2"])
+            } else {
+                XCTFail("Errors are not decoded correctly")
+            }
+        }
+    }
+
+    func testFromAppSyncResponse_withDataAndErrors_decodePayload() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let json: JSONValue = [
+            "onCreatePost": [
+                "__typename": "Post",
+                "id": "123",
+                "title": "test",
+                "author": "authorId",
+                "_version": 1,
+               "_deleted": nil,
+               "_lastChangedAt": 1707773705221
+            ],
+            "errors": [
+                ["message": "error1"],
+                ["message": "error2"]
+            ]
+        ]
+
+        let expectedModel: AnyModel = AnyModel(FlutterSerializedModel(map: [
+            "__typename": "Post",
+            "id": "123",
+            "title": "test",
+            "author": "authorId",
+        ], modelName: "Post"))
+
+        let result: Result<GraphQLResponse<MutationSync<AnyModel>>, APIError> = .fromAppSyncResponse(json: json, decodePath: "onCreatePost", modelName: nil)
+        XCTAssertNoThrow(try result.get())
+        let mutationSync = try! result.get()
+        XCTAssertThrowsError(try mutationSync.get()) { error in
+            if let graphQLResponseError = error as? GraphQLResponseError<MutationSync<AnyModel>>,
+               case .partial(let mutationSync, let graphQLErrors) = graphQLResponseError
+            {
+                XCTAssertEqual(graphQLErrors.map(\.message), ["error1", "error2"])
+                XCTAssertEqual(expectedModel.modelName, mutationSync.model.modelName)
+                XCTAssertEqual(expectedModel.id, mutationSync.model.identifier)
+            } else {
+                XCTFail("Errors are not decoded correctly")
+            }
+        }
+    }
+
+    func testFromAppSyncResponse_withNoDataNoErrors_decodePayload() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let json: JSONValue = [
+            "a": "b"
+        ]
+
+        let result: Result<GraphQLResponse<MutationSync<AnyModel>>, APIError> = .fromAppSyncResponse(json: json, decodePath: "onCreatePost", modelName: nil)
+        XCTAssertThrowsError(try result.get()) { error in
+            if case .unknown(let description, _, _) = (error as! APIError) {
+                XCTAssertEqual("Failed to get data object or errors from GraphQL response", description)
+            } else {
+                XCTFail("Should throw APIError.unknown")
+            }
+        }
+    }
+
+    func testFromAppSyncResponse_withJsonString_decodeCorrectly() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let json: JSONValue = [
+            "__typename": "Post",
+            "id": "123",
+            "title": "test",
+            "author": "authorId",
+        ]
+
+        let jsonString = String(data: try! JSONEncoder().encode(json), encoding: .utf8)!
+        let response: GraphQLResponse<AnyModel> = .fromAppSyncResponse(string: jsonString, decodePath: nil)
+        XCTAssertNoThrow(try response.get())
+        XCTAssertEqual(json.id?.stringValue, try response.get().identifier)
+        XCTAssertEqual(json.__typename?.stringValue, try response.get().modelName)
+    }
+
+    func testFromAppSyncResponse_withBrokenJsonString_failWithTransformationError() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let jsonString = "{"
+        let response: GraphQLResponse<AnyModel> = .fromAppSyncResponse(string: jsonString, decodePath: nil)
+        XCTAssertThrowsError(try response.get()) { error in
+            guard case .transformationError = error as! GraphQLResponseError<AnyModel> else {
+                XCTFail("Should failed with transformationError")
+                return
+            }
+        }
+    }
+
+    func testFromAppSyncSubscriptionResponse_withJsonString_decodeCorrectly() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let payloadJson: JSONValue = [
+            "onCreatePost": [
+                "__typename": "Post",
+                "id": "123",
+                "title": "test",
+                "author": "authorId",
+                "_version": 1,
+               "_deleted": nil,
+               "_lastChangedAt": 1707773705221
+            ]
+        ]
+
+        let jsonString = String(data: try! JSONEncoder().encode(payloadJson), encoding: .utf8)!
+        let response: GraphQLResponse<MutationSync<AnyModel>> = .fromAppSyncResponse(string: jsonString, decodePath: "onCreatePost")
+        XCTAssertNoThrow(try response.get())
+        let mutationSync = try! response.get()
+        XCTAssertEqual(payloadJson.onCreatePost?.id?.stringValue, mutationSync.model.identifier)
+        XCTAssertEqual(payloadJson.onCreatePost?.__typename?.stringValue, mutationSync.model.modelName)
+    }
+
+    func testFromAppSyncSubscriptionResponse_withWrongJsonString_failWithTransformationError() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let jsonString = "{"
+        let response: GraphQLResponse<MutationSync<AnyModel>> = .fromAppSyncSubscriptionResponse(string: jsonString, decodePath: nil)
+        XCTAssertThrowsError(try response.get()) { error in
+            guard case .transformationError = error as! GraphQLResponseError<MutationSync<AnyModel>> else {
+                XCTFail("Should failed with transformationError")
+                return
+            }
+        }
+    }
+
+    func testFromAppSyncSubscriptionErrorResponse_withErrorJsonPayload_decodeCorrectly() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let errorJsonPayload: JSONValue = [
+            "errors": [
+                ["message": "error1"],
+                ["message": "error2"]
+            ]
+        ]
+        let errorJsonPayloadString = String(data: try! JSONEncoder().encode(errorJsonPayload), encoding: .utf8)!
+        let result: GraphQLResponse<MutationSync<AnyModel>> = .fromAppSyncSubscriptionErrorResponse(string: errorJsonPayloadString)
+        XCTAssertThrowsError(try result.get()) { error in
+            if let graphQLResponseError = error as? GraphQLResponseError<MutationSync<AnyModel>>,
+               case .error(let graphQLErrors) = graphQLResponseError
+            {
+                XCTAssertEqual(graphQLErrors.map(\.message), ["error1", "error2"])
+            } else {
+                XCTFail("Errors are not decoded correctly")
+            }
+        }
+    }
+
+    func testFromAppSyncSubscriptionErrorResponse_withSingleErrorJsonPayload_decodeCorrectly() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let errorJsonPayload: JSONValue = [
+            "errors": [
+                "message": "error1"
+            ]
+        ]
+        let errorJsonPayloadString = String(data: try! JSONEncoder().encode(errorJsonPayload), encoding: .utf8)!
+        let result: GraphQLResponse<MutationSync<AnyModel>> = .fromAppSyncSubscriptionErrorResponse(string: errorJsonPayloadString)
+        XCTAssertThrowsError(try result.get()) { error in
+            if let graphQLResponseError = error as? GraphQLResponseError<MutationSync<AnyModel>>,
+               case .error(let graphQLErrors) = graphQLResponseError
+            {
+                XCTAssertEqual(graphQLErrors.map(\.message), ["error1"])
+            } else {
+                XCTFail("Errors are not decoded correctly")
+            }
+        }
+    }
+
+    func testFromAppSyncSubscriptionErrorResponse_withBrokenErrorJsonPayload_failWithTransformationError() {
+        SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
+        let errorJsonString = "{"
+        let response: GraphQLResponse<MutationSync<AnyModel>> = .fromAppSyncSubscriptionErrorResponse(string: errorJsonString)
+        XCTAssertThrowsError(try response.get()) { error in
+            guard case .transformationError = error as! GraphQLResponseError<MutationSync<AnyModel>> else {
+                XCTFail("Should failed with transformationError")
+                return
+            }
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- add unit tests for GraphQLResposne decoding logic
- 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
