### PR TITLE
chore(version): Bump version

### DIFF
--- a/packages/common/amplify_db_common_dart/CHANGELOG.md
+++ b/packages/common/amplify_db_common_dart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1
+
+### Fixes
+- fix(common): set upper bound limit for sqlite version for `drift` compatibility ([#4884](https://github.com/aws-amplify/amplify-flutter/pull/4884))
+
 ## 0.4.0
 
 - Minor bug fixes and improvements

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   drift: ">=2.14.0 <2.15.0"
   meta: ^1.7.0
   path: ">=1.8.0 <2.0.0"
-  sqlite3: ^2.0.0
+  sqlite3: ">=2.0.0 <2.4.3"
 
 dev_dependencies:
   amplify_lints: ">=3.1.0 <3.2.0"

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_db_common_dart
 description: Common utilities for working with databases such as sqlite. Used throughout Amplify packages.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/common/amplify_db_common_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   oauth2: ^2.0.2
   package_info_plus: ^6.0.0
   pigeon: ^11.0.0
-  sqlite3: ^2.0.0
+  sqlite3: ">=2.0.0 <2.4.3"
   source_gen: ^1.3.2
   stack_trace: ^1.10.0
   uuid: ">=3.0.6 <5.0.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
### Fixes
- fix(common): set upper bound limit for sqlite version for `drift` compatibility ([#4884](https://github.com/aws-amplify/amplify-flutter/pull/4884))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
