### PR TITLE
chore(version): Bump version

### DIFF
--- a/packages/common/amplify_db_common_dart/CHANGELOG.md
+++ b/packages/common/amplify_db_common_dart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1
+
+### Fixes
+- fix(common): set upper bound limit for sqlite version for `drift` compatibility ([#4884](https://github.com/aws-amplify/amplify-flutter/pull/4884))
+
 ## 0.4.0
 
 - Minor bug fixes and improvements

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_db_common_dart
 description: Common utilities for working with databases such as sqlite. Used throughout Amplify packages.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/common/amplify_db_common_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues


### PR DESCRIPTION
### Fixes
- fix(common): set upper bound limit for sqlite version for `drift` compatibility ([#4884](https://github.com/aws-amplify/amplify-flutter/pull/4884))

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
