### PR TITLE
chore(api): added unit test for GraphQL custom types

### DIFF
--- a/packages/amplify_datastore/example/lib/models/CustomTypeWithAppsyncScalarTypes.dart
+++ b/packages/amplify_datastore/example/lib/models/CustomTypeWithAppsyncScalarTypes.dart
@@ -19,9 +19,10 @@
 
 // ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, override_on_non_overriding_member, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
 
-import 'ModelProvider.dart';
 import 'package:amplify_core/amplify_core.dart' as amplify_core;
 import 'package:collection/collection.dart';
+
+import 'ModelProvider.dart';
 
 /** This is an auto generated class representing the CustomTypeWithAppsyncScalarTypes type in your schema. */
 class CustomTypeWithAppsyncScalarTypes {
@@ -738,14 +739,17 @@ class CustomTypeWithAppsyncScalarTypes {
                 .toList()
             : null,
         _customTypeValue = json['customTypeValue'] != null
-            ? SimpleCustomType.fromJson(
-                new Map<String, dynamic>.from(json['customTypeValue']))
+            ? json['customTypeValue']['serializedData'] != null
+                ? SimpleCustomType.fromJson(new Map<String, dynamic>.from(
+                    json['customTypeValue']['serializedData']))
+                : SimpleCustomType.fromJson(
+                    new Map<String, dynamic>.from(json['customTypeValue']))
             : null,
         _listOfCustomTypeValue = json['listOfCustomTypeValue'] is List
             ? (json['listOfCustomTypeValue'] as List)
                 .where((e) => e != null)
-                .map((e) =>
-                    SimpleCustomType.fromJson(new Map<String, dynamic>.from(e)))
+                .map((e) => SimpleCustomType.fromJson(
+                    new Map<String, dynamic>.from(e['serializedData'] ?? e)))
                 .toList()
             : null;
 

--- a/packages/amplify_datastore/example/lib/models/ModelWithCustomType.dart
+++ b/packages/amplify_datastore/example/lib/models/ModelWithCustomType.dart
@@ -19,9 +19,10 @@
 
 // ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, override_on_non_overriding_member, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
 
-import 'ModelProvider.dart';
 import 'package:amplify_core/amplify_core.dart' as amplify_core;
 import 'package:collection/collection.dart';
+
+import 'ModelProvider.dart';
 
 /** This is an auto generated class representing the ModelWithCustomType type in your schema. */
 class ModelWithCustomType extends amplify_core.Model {
@@ -152,14 +153,18 @@ class ModelWithCustomType extends amplify_core.Model {
   ModelWithCustomType.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         _customTypeValue = json['customTypeValue'] != null
-            ? CustomTypeWithAppsyncScalarTypes.fromJson(
-                new Map<String, dynamic>.from(json['customTypeValue']))
+            ? json['customTypeValue']['serializedData'] != null
+                ? CustomTypeWithAppsyncScalarTypes.fromJson(
+                    new Map<String, dynamic>.from(
+                        json['customTypeValue']['serializedData']))
+                : CustomTypeWithAppsyncScalarTypes.fromJson(
+                    new Map<String, dynamic>.from(json['customTypeValue']))
             : null,
         _listOfCustomTypeValue = json['listOfCustomTypeValue'] is List
             ? (json['listOfCustomTypeValue'] as List)
                 .where((e) => e != null)
                 .map((e) => CustomTypeWithAppsyncScalarTypes.fromJson(
-                    new Map<String, dynamic>.from(e)))
+                    new Map<String, dynamic>.from(e['serializedData'] ?? e)))
                 .toList()
             : null,
         _createdAt = json['createdAt'] != null

--- a/packages/api/amplify_api_dart/test/mocks.dart
+++ b/packages/api/amplify_api_dart/test/mocks.dart
@@ -1,0 +1,347 @@
+import 'package:amplify_core/amplify_core.dart';
+
+import 'test_models/ModelProvider.dart';
+
+// Mock requests
+const modelWithCustomTypeDocument =
+    r'mutation createModelWithCustomType($input: CreateModelWithCustomTypeInput!, $condition:  ModelModelWithCustomTypeConditionInput) { createModelWithCustomType(input: $input, condition: $condition) { id customTypeValue { stringValue listOfStringValue intValue listOfIntValue floatValue listOfFloatValue booleanValue listOfBooleanValue awsDateValue listOfAWSDateValue awsDateTimeValue listOfAWSDateTimeValue awsTimeValue listOfAWSTimeValue awsTimestampValue listOfAWSTimestampValue awsEmailValue listOfAWSEmailValue awsJsonValue listOfAWSJsonValue awsPhoneValue listOfAWSPhoneValue awsURLValue listOfAWSURLValue awsIPAddressValue listOfAWSIPAddressValue enumValue listOfEnumValue customTypeValue { foo } listOfCustomTypeValue { foo } } listOfCustomTypeValue { stringValue listOfStringValue intValue listOfIntValue floatValue listOfFloatValue booleanValue listOfBooleanValue awsDateValue listOfAWSDateValue awsDateTimeValue listOfAWSDateTimeValue awsTimeValue listOfAWSTimeValue awsTimestampValue listOfAWSTimestampValue awsEmailValue listOfAWSEmailValue awsJsonValue listOfAWSJsonValue awsPhoneValue listOfAWSPhoneValue awsURLValue listOfAWSURLValue awsIPAddressValue listOfAWSIPAddressValue enumValue listOfEnumValue customTypeValue { foo } listOfCustomTypeValue { foo } } createdAt updatedAt } }';
+final modelCustomTypeId = uuid();
+final modelWithCustomTypeVariables = {
+  'input': {
+    'id': modelCustomTypeId,
+    'customTypeValue': {
+      'stringValue': 'foo',
+      'listOfStringValue': ['foo', 'bar'],
+      'intValue': 42,
+      'listOfIntValue': [1, 2, 3],
+      'floatValue': 3.14,
+      'listOfFloatValue': [3.14, 6.28],
+      'booleanValue': true,
+      'listOfBooleanValue': [true, false],
+      'awsDateValue': '2021-07-07',
+      'listOfAWSDateValue': ['2021-07-07', '2021-07-08'],
+      'awsDateTimeValue': '2021-07-07T20:20:20.000000000Z',
+      'listOfAWSDateTimeValue': [
+        '2021-07-07T20:20:20.000000000Z',
+        '2021-07-08T20:20:20.000000000Z',
+      ],
+      'awsTimeValue': '20:20:20Z',
+      'listOfAWSTimeValue': ['20:20:20Z', '21:21:21Z'],
+      'awsTimestampValue': 1625660420,
+      'listOfAWSTimestampValue': [1625660420, 1625746820],
+      'awsEmailValue': 'example@amazon.com',
+      'listOfAWSEmailValue': [
+        'example+foo@amazon.com',
+        'example+bar@amazon.com',
+      ],
+      'awsJsonValue': '{"a":1,"b":3,"string":234}',
+      'listOfAWSJsonValue': [
+        '{"a":1,"b":3,"string":234}',
+        '{"a":2,"b":4,"string":567}',
+      ],
+      'awsPhoneValue': '2234567890',
+      'listOfAWSPhoneValue': ['2234567890', '2234567891'],
+      'awsURLValue': 'https://aws.amazon.com',
+      'listOfAWSURLValue': ['https://aws.amazon.com', 'https://flutter.dev'],
+      'awsIPAddressValue': '1.0.0.1',
+      'listOfAWSIPAddressValue': ['1.0.0.1', '1.0.0.2'],
+      'enumValue': 'yes',
+      'listOfEnumValue': ['yes', 'no'],
+      'customTypeValue': {
+        'foo': 'bar',
+      },
+      'listOfCustomTypeValue': [
+        {
+          'foo': 'bar',
+        },
+        {
+          'foo': 'baz',
+        }
+      ],
+    },
+    'listOfCustomTypeValue': [
+      {
+        'stringValue': 'foo',
+        'listOfStringValue': ['foo', 'bar'],
+        'intValue': 42,
+        'listOfIntValue': [1, 2, 3],
+        'floatValue': 3.14,
+        'listOfFloatValue': [3.14, 6.28],
+        'booleanValue': true,
+        'listOfBooleanValue': [true, false],
+        'awsDateValue': '2021-07-07',
+        'listOfAWSDateValue': ['2021-07-07', '2021-07-08'],
+        'awsDateTimeValue': '2021-07-07T20:20:20.000000000Z',
+        'listOfAWSDateTimeValue': [
+          '2021-07-07T20:20:20.000000000Z',
+          '2021-07-08T20:20:20.000000000Z',
+        ],
+        'awsTimeValue': '20:20:20Z',
+        'listOfAWSTimeValue': ['20:20:20Z', '21:21:21Z'],
+        'awsTimestampValue': 1625660420,
+        'listOfAWSTimestampValue': [1625660420, 1625746820],
+        'awsEmailValue': 'example@amazon.com',
+        'listOfAWSEmailValue': [
+          'example+foo@amazon.com',
+          'example+bar@amazon.com',
+        ],
+        'awsJsonValue': '{"a":1,"b":3,"string":234}',
+        'listOfAWSJsonValue': [
+          '{"a":1,"b":3,"string":234}',
+          '{"a":2,"b":4,"string":567}',
+        ],
+        'awsPhoneValue': '2234567890',
+        'listOfAWSPhoneValue': ['2234567890', '2234567891'],
+        'awsURLValue': 'https://aws.amazon.com',
+        'listOfAWSURLValue': ['https://aws.amazon.com', 'https://flutter.dev'],
+        'awsIPAddressValue': '1.0.0.1',
+        'listOfAWSIPAddressValue': ['1.0.0.1', '1.0.0.2'],
+        'enumValue': 'yes',
+        'listOfEnumValue': ['yes', 'no'],
+        'customTypeValue': {
+          'foo': 'bar',
+        },
+        'listOfCustomTypeValue': [
+          {
+            'foo': 'bar',
+          },
+          {
+            'foo': 'baz',
+          }
+        ],
+      }
+    ],
+  },
+};
+
+// Success Mocks
+const expectedQuerySuccessResponseBody = {
+  'data': {
+    'listBlogs': {
+      'items': [
+        {
+          'id': 'TEST_ID',
+          'name': 'Test App Blog',
+          'createdAt': '2022-06-28T17:36:52.460Z',
+        }
+      ],
+    },
+  },
+};
+
+final modelQueryId = uuid();
+final expectedModelQueryResult = {
+  'data': {
+    'getBlog': {
+      'createdAt': '2021-07-21T22:23:33.707Z',
+      'id': modelQueryId,
+      'name': 'Test App Blog',
+    },
+  },
+};
+const expectedMutateSuccessResponseBody = {
+  'data': {
+    'createBlog': {
+      'id': 'TEST_ID',
+      'name': 'Test App Blog',
+      'createdAt': '2022-07-06T18:42:26.126Z',
+    },
+  },
+};
+final expectedModelWithCustomTypeSuccessResponseBody = {
+  'data': {
+    'createModelWithCustomType': {
+      'id': modelCustomTypeId,
+      'customTypeValue': {
+        'stringValue': 'foo',
+        'listOfStringValue': ['foo', 'bar'],
+        'intValue': 42,
+        'listOfIntValue': [1, 2, 3],
+        'floatValue': 3.14,
+        'listOfFloatValue': [3.14, 6.28],
+        'booleanValue': true,
+        'listOfBooleanValue': [true, false],
+        'awsDateValue': '2021-07-07',
+        'listOfAWSDateValue': ['2021-07-07', '2021-07-08'],
+        'awsDateTimeValue': '2021-07-07T20:20:20.000000000Z',
+        'listOfAWSDateTimeValue': [
+          '2021-07-07T20:20:20.000000000Z',
+          '2021-07-08T20:20:20.000000000Z',
+        ],
+        'awsTimeValue': '20:20:20Z',
+        'listOfAWSTimeValue': ['20:20:20Z', '21:21:21Z'],
+        'awsTimestampValue': 1625660420,
+        'listOfAWSTimestampValue': [1625660420, 1625746820],
+        'awsEmailValue': 'example@amazon.com',
+        'listOfAWSEmailValue': [
+          'example+foo@amazon.com',
+          'example+bar@amazon.com',
+        ],
+        'awsJsonValue': '{"a":1,"b":3,"string":234}',
+        'listOfAWSJsonValue': [
+          '{"a":1,"b":3,"string":234}',
+          '{"a":2,"b":4,"string":567}',
+        ],
+        'awsPhoneValue': '2234567890',
+        'listOfAWSPhoneValue': ['2234567890', '2234567891'],
+        'awsURLValue': 'https://aws.amazon.com',
+        'listOfAWSURLValue': ['https://aws.amazon.com', 'https://flutter.dev'],
+        'awsIPAddressValue': '1.0.0.1',
+        'listOfAWSIPAddressValue': ['1.0.0.1', '1.0.0.2'],
+        'enumValue': 'yes',
+        'listOfEnumValue': ['yes', 'no'],
+        'customTypeValue': {'foo': 'bar'},
+        'listOfCustomTypeValue': [
+          {'foo': 'bar'},
+          {'foo': 'baz'},
+        ],
+      },
+      'listOfCustomTypeValue': [
+        {
+          'stringValue': 'foo',
+          'listOfStringValue': ['foo', 'bar'],
+          'intValue': 42,
+          'listOfIntValue': [1, 2, 3],
+          'floatValue': 3.14,
+          'listOfFloatValue': [3.14, 6.28],
+          'booleanValue': true,
+          'listOfBooleanValue': [true, false],
+          'awsDateValue': '2021-07-07',
+          'listOfAWSDateValue': ['2021-07-07', '2021-07-08'],
+          'awsDateTimeValue': '2021-07-07T20:20:20.000000000Z',
+          'listOfAWSDateTimeValue': [
+            '2021-07-07T20:20:20.000000000Z',
+            '2021-07-08T20:20:20.000000000Z',
+          ],
+          'awsTimeValue': '20:20:20Z',
+          'listOfAWSTimeValue': ['20:20:20Z', '21:21:21Z'],
+          'awsTimestampValue': 1625660420,
+          'listOfAWSTimestampValue': [1625660420, 1625746820],
+          'awsEmailValue': 'example@amazon.com',
+          'listOfAWSEmailValue': [
+            'example+foo@amazon.com',
+            'example+bar@amazon.com',
+          ],
+          'awsJsonValue': '{"a":1,"b":3,"string":234}',
+          'listOfAWSJsonValue': [
+            '{"a":1,"b":3,"string":234}',
+            '{"a":2,"b":4,"string":567}',
+          ],
+          'awsPhoneValue': '2234567890',
+          'listOfAWSPhoneValue': ['2234567890', '2234567891'],
+          'awsURLValue': 'https://aws.amazon.com',
+          'listOfAWSURLValue': [
+            'https://aws.amazon.com',
+            'https://flutter.dev',
+          ],
+          'awsIPAddressValue': '1.0.0.1',
+          'listOfAWSIPAddressValue': ['1.0.0.1', '1.0.0.2'],
+          'enumValue': 'yes',
+          'listOfEnumValue': ['yes', 'no'],
+          'customTypeValue': {'foo': 'bar'},
+          'listOfCustomTypeValue': [
+            {'foo': 'bar'},
+            {'foo': 'baz'},
+          ],
+        }
+      ],
+      'createdAt': '2024-05-14T22:00:30.605Z',
+      'updatedAt': '2024-05-14T22:00:30.605Z',
+    },
+  },
+};
+
+// Error Mocks
+const errorMessage = 'Unable to parse GraphQL query.';
+const errorLocations = [
+  {'line': 2, 'column': 3},
+  {'line': 4, 'column': 5},
+];
+const errorPath = ['a', 1, 'b'];
+const errorExtensions = {
+  'a': 'blah',
+  'b': {'c': 'd'},
+};
+const errorType = 'DynamoDB:ConditionalCheckFailedException';
+const errorInfo = {'a': 'b'};
+const expectedErrorResponseBody = {
+  'data': null,
+  'errors': [
+    {
+      'message': errorMessage,
+      'locations': errorLocations,
+      'path': errorPath,
+      'extensions': errorExtensions,
+      'errorType': errorType,
+      'errorInfo': errorInfo,
+    },
+  ],
+};
+
+const authErrorMessage = 'Not authorized';
+const expectedAuthErrorResponseBody = {
+  'data': null,
+  'errors': [
+    {
+      'message': authErrorMessage,
+    },
+  ],
+};
+
+/// Models
+final customTypesSubModel1 = CustomTypeWithAppsyncScalarTypes(
+  stringValue: 'foo',
+  listOfStringValue: ['foo', 'bar'],
+  intValue: 42,
+  listOfIntValue: [1, 2, 3],
+  floatValue: 3.14,
+  listOfFloatValue: [3.14, 6.28],
+  booleanValue: true,
+  listOfBooleanValue: [true, false],
+  awsDateValue: TemporalDate.fromString('2021-07-07'),
+  listOfAWSDateValue: [
+    TemporalDate.fromString('2021-07-07'),
+    TemporalDate.fromString('2021-07-08'),
+  ],
+  awsDateTimeValue: TemporalDateTime.fromString('2021-07-07T20:20:20Z'),
+  listOfAWSDateTimeValue: [
+    TemporalDateTime.fromString('2021-07-07T20:20:20Z'),
+    TemporalDateTime.fromString('2021-07-08T20:20:20Z'),
+  ],
+  awsTimeValue: TemporalTime.fromString('20:20:20Z'),
+  listOfAWSTimeValue: [
+    TemporalTime.fromString('20:20:20Z'),
+    TemporalTime.fromString('21:21:21Z'),
+  ],
+  awsTimestampValue: TemporalTimestamp.fromSeconds(1625660420),
+  listOfAWSTimestampValue: [
+    TemporalTimestamp.fromSeconds(1625660420),
+    TemporalTimestamp.fromSeconds(1625746820),
+  ],
+  awsEmailValue: 'example@amazon.com',
+  listOfAWSEmailValue: ['example+foo@amazon.com', 'example+bar@amazon.com'],
+  awsJsonValue: '{"a":1,"b":3,"string":234}',
+  listOfAWSJsonValue: [
+    '{"a":1,"b":3,"string":234}',
+    '{"a":2,"b":4,"string":567}',
+  ],
+  awsPhoneValue: '2234567890',
+  listOfAWSPhoneValue: ['2234567890', '2234567891'],
+  awsURLValue: 'https://aws.amazon.com',
+  listOfAWSURLValue: ['https://aws.amazon.com', 'https://flutter.dev'],
+  awsIPAddressValue: '1.0.0.1',
+  listOfAWSIPAddressValue: ['1.0.0.1', '1.0.0.2'],
+  enumValue: EnumField.yes,
+  listOfEnumValue: [EnumField.yes, EnumField.no],
+  customTypeValue: SimpleCustomType(foo: 'bar'),
+  listOfCustomTypeValue: [
+    SimpleCustomType(foo: 'bar'),
+    SimpleCustomType(foo: 'baz'),
+  ],
+);
+final customTypesSubModel2 = customTypesSubModel1.copyWith();
+final modelWithCustomType = ModelWithCustomType(
+  id: modelCustomTypeId,
+  customTypeValue: customTypesSubModel1,
+  listOfCustomTypeValue: [customTypesSubModel2],
+);

--- a/packages/api/amplify_api_dart/test/test_models/CustomTypeWithAppsyncScalarTypes.dart
+++ b/packages/api/amplify_api_dart/test/test_models/CustomTypeWithAppsyncScalarTypes.dart
@@ -738,14 +738,17 @@ class CustomTypeWithAppsyncScalarTypes {
                 .toList()
             : null,
         _customTypeValue = json['customTypeValue'] != null
-            ? SimpleCustomType.fromJson(
-                new Map<String, dynamic>.from(json['customTypeValue']))
+            ? json['customTypeValue']['serializedData'] != null
+                ? SimpleCustomType.fromJson(new Map<String, dynamic>.from(
+                    json['customTypeValue']['serializedData']))
+                : SimpleCustomType.fromJson(
+                    new Map<String, dynamic>.from(json['customTypeValue']))
             : null,
         _listOfCustomTypeValue = json['listOfCustomTypeValue'] is List
             ? (json['listOfCustomTypeValue'] as List)
                 .where((e) => e != null)
-                .map((e) =>
-                    SimpleCustomType.fromJson(new Map<String, dynamic>.from(e)))
+                .map((e) => SimpleCustomType.fromJson(
+                    new Map<String, dynamic>.from(e['serializedData'] ?? e)))
                 .toList()
             : null;
 

--- a/packages/api/amplify_api_dart/test/test_models/ModelWithCustomType.dart
+++ b/packages/api/amplify_api_dart/test/test_models/ModelWithCustomType.dart
@@ -152,14 +152,18 @@ class ModelWithCustomType extends amplify_core.Model {
   ModelWithCustomType.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         _customTypeValue = json['customTypeValue'] != null
-            ? CustomTypeWithAppsyncScalarTypes.fromJson(
-                new Map<String, dynamic>.from(json['customTypeValue']))
+            ? json['customTypeValue']['serializedData'] != null
+                ? CustomTypeWithAppsyncScalarTypes.fromJson(
+                    new Map<String, dynamic>.from(
+                        json['customTypeValue']['serializedData']))
+                : CustomTypeWithAppsyncScalarTypes.fromJson(
+                    new Map<String, dynamic>.from(json['customTypeValue']))
             : null,
         _listOfCustomTypeValue = json['listOfCustomTypeValue'] is List
             ? (json['listOfCustomTypeValue'] as List)
                 .where((e) => e != null)
                 .map((e) => CustomTypeWithAppsyncScalarTypes.fromJson(
-                    new Map<String, dynamic>.from(e)))
+                    new Map<String, dynamic>.from(e['serializedData'] ?? e)))
                 .toList()
             : null,
         _createdAt = json['createdAt'] != null


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/4872

*Description of changes:*

- Adds a unit test for model decoding AppSync Scalar types.
- Regenerates models based off https://github.com/aws-amplify/amplify-codegen/pull/843 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
