### PR TITLE
fix(notifications): allow offline configuration

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint_dart/test/endpoint_client_test.dart
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/test/endpoint_client_test.dart
@@ -333,5 +333,22 @@ void main() {
         ),
       );
     });
+
+    test(
+        'updateEndpoint throws NetworkException for AWSHttpException exceptions',
+        () async {
+      when(() => pinpointClient.updateEndpoint(any())).thenThrow(
+        AWSHttpException(
+          AWSHttpRequest(method: AWSHttpMethod.post, uri: Uri()),
+        ),
+      );
+
+      expect(
+        endpointClient.updateEndpoint(),
+        throwsA(
+          isA<NetworkException>(),
+        ),
+      );
+    });
   });
 }

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/test/pinpoint_provider_test.dart
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/test/pinpoint_provider_test.dart
@@ -274,6 +274,48 @@ void main() {
       verify(mockEndpointClient.updateEndpoint);
     });
 
+    test('registerDevice should run successfully when device is offline',
+        () async {
+      when(
+        () => mockAmplifyAuthProviderRepository.getAuthProvider(
+          APIAuthorizationType.iam.authProviderToken,
+        ),
+      ).thenReturn(awsIamAmplifyAuthProvider);
+      when(
+        () => mockAnalyticsClient.init(
+          pinpointAppId: any(named: 'pinpointAppId'),
+          region: any(named: 'region'),
+          authProvider: any(named: 'authProvider'),
+        ),
+      ).thenAnswer((realInvocation) async {});
+
+      final mockEndpointClient = MockEndpointClient();
+
+      when(mockEndpointClient.updateEndpoint)
+          .thenThrow(const NetworkException('message'));
+
+      when(
+        () => mockAnalyticsClient.endpointClient,
+      ).thenReturn(mockEndpointClient);
+
+      await expectLater(
+        pinpointProvider.init(
+          config: notificationsPinpointConfig,
+          authProviderRepo: mockAmplifyAuthProviderRepository,
+          analyticsClient: mockAnalyticsClient,
+        ),
+        completes,
+      );
+
+      expect(
+        pinpointProvider.registerDevice(
+          '',
+        ),
+        completes,
+      );
+      verify(mockEndpointClient.updateEndpoint);
+    });
+
     test('recordEvent should run successfully', () async {
       when(
         () => mockAmplifyAuthProviderRepository.getAuthProvider(


### PR DESCRIPTION
*Issue #, if available:* #4688

*Description of changes:*
- updated to catch to handle `NetworkException` instead of `AWSHttpException`, since the endpoint client does not throw `AWSHttpException`; it throws `NetworkException` instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
