### PR TITLE
chore(datastore): Regenerate Amplify Swift Plugins

### DIFF
--- a/packages/amplify_datastore/ios/internal/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/packages/amplify_datastore/ios/internal/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -56,7 +56,7 @@ class SyncMutationToCloudOperation: AsynchronousOperation {
     override func main() {
         log.verbose(#function)
 
-        sendMutationToCloud(withAuthType: authTypesIterator?.next())
+        sendMutationToCloud(withAuthType: authTypesIterator?.next()?.awsAuthType)
     }
 
     override func cancel() {
@@ -251,7 +251,7 @@ class SyncMutationToCloudOperation: AsynchronousOperation {
             resolveReachabilityPublisher(request: request)
             if let pluginOptions = request.options?.pluginOptions as? AWSAPIPluginDataStoreOptions, pluginOptions.authType != nil,
                let nextAuthType = authTypesIterator?.next() {
-                scheduleRetry(advice: advice, withAuthType: nextAuthType)
+                scheduleRetry(advice: advice, withAuthType: nextAuthType.awsAuthType)
             } else {
                 scheduleRetry(advice: advice)
             }

--- a/packages/amplify_datastore/ios/internal/AWSPluginsCore/Auth/AmplifyAuthorizationType.swift
+++ b/packages/amplify_datastore/ios/internal/AWSPluginsCore/Auth/AmplifyAuthorizationType.swift
@@ -1,0 +1,29 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+
+/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+///   by host applications. The behavior of this may change without warning.
+public enum AmplifyAuthorizationType {
+
+    /// Determine the authorization method based on the amplifyconfiguration.
+    case inferred
+
+    /// Specify the authentication method.
+    case designated(AWSAuthorizationType)
+
+    public var awsAuthType: AWSAuthorizationType? {
+        switch self {
+        case .inferred: return nil
+        case .designated(let authType): return authType
+        }
+    }
+}
+
+extension AmplifyAuthorizationType: Equatable { }

--- a/packages/amplify_datastore/ios/internal/Amplify/Categories/API/Operation/RetryableGraphQLOperation.swift
+++ b/packages/amplify_datastore/ios/internal/Amplify/Categories/API/Operation/RetryableGraphQLOperation.swift
@@ -16,10 +16,10 @@ public final class RetryableGraphQLOperation<Payload: Decodable> {
     private let nondeterminsticOperation: NondeterminsticOperation<GraphQLTask<Payload>.Success>
 
     public init(
-        requestStream: AnyPublisher<() async throws -> GraphQLTask<Payload>.Success, Never>
+        requestStream: AsyncStream<() async throws -> GraphQLTask<Payload>.Success>
     ) {
         self.nondeterminsticOperation = NondeterminsticOperation(
-            operationStream: requestStream,
+            operations: requestStream,
             shouldTryNextOnError: Self.onError(_:)
         )
     }
@@ -80,9 +80,9 @@ public final class RetryableGraphQLSubscriptionOperation<Payload: Decodable> {
     private let nondeterminsticOperation: NondeterminsticOperation<AmplifyAsyncThrowingSequence<SubscriptionEvents>>
 
     public init(
-        requestStream: AnyPublisher<() async throws -> AmplifyAsyncThrowingSequence<SubscriptionEvents>, Never>
+        requestStream: AsyncStream<() async throws -> AmplifyAsyncThrowingSequence<SubscriptionEvents>>
     ) {
-        self.nondeterminsticOperation = NondeterminsticOperation(operationStream: requestStream)
+        self.nondeterminsticOperation = NondeterminsticOperation(operations: requestStream)
     }
 
     deinit {


### PR DESCRIPTION
*Description of changes:*
Regen Amplify Swift Plugin by running `aft generate amplify-swift -b flutter-datastore-v2`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
