### PR TITLE
feat(api): add listByIndex to ModelQueries

### DIFF
--- a/packages/amplify_core/lib/src/types/api/graphql/graphql_request_type.dart
+++ b/packages/amplify_core/lib/src/types/api/graphql/graphql_request_type.dart
@@ -6,6 +6,7 @@ enum GraphQLRequestType { query, mutation, subscription }
 enum GraphQLRequestOperation {
   get,
   list,
+  listWithIndex,
   create,
   update,
   delete,

--- a/packages/api/amplify_api_dart/lib/src/graphql/factories/model_queries_factory.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/factories/model_queries_factory.dart
@@ -58,4 +58,37 @@ class ModelQueriesFactory {
       headers: headers,
     );
   }
+
+  GraphQLRequest<PaginatedResult<T>> listByIndex<T extends Model>(
+    ModelType<T> modelType, {
+    int? limit,
+    QueryPredicate? where,
+    String? apiName,
+    APIAuthorizationType? authorizationMode,
+    Map<String, String>? headers,
+    String? queryField,
+    String? sortDirection,
+    String? indexName,
+    String? overrideQueryFieldType,
+  }) {
+    final filter = GraphQLRequestFactory.instance
+        .queryPredicateToGraphQLFilter(where, modelType);
+    final variables = GraphQLRequestFactory.instance
+        .buildVariablesForListRequest(limit: limit, filter: filter);
+
+    return GraphQLRequestFactory.instance
+        .buildRequestForSecondaryIndex<PaginatedResult<T>>(
+      modelType: PaginatedModelType(modelType),
+      variables: variables,
+      requestType: GraphQLRequestType.query,
+      requestOperation: GraphQLRequestOperation.listWithIndex,
+      apiName: apiName,
+      authorizationMode: authorizationMode,
+      headers: headers,
+      queryField: queryField,
+      sortDirection: sortDirection,
+      indexName: indexName,
+      overrideQueryFieldType: overrideQueryFieldType,
+    );
+  }
 }

--- a/packages/api/amplify_api_dart/lib/src/graphql/model_helpers/model_queries.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/model_helpers/model_queries.dart
@@ -59,6 +59,52 @@ class ModelQueries {
       headers: headers,
     );
   }
+
+  /// Generates a request for a list of model instances from
+  /// secondary index. The `modelType` must have a secondary index defined.
+  /// Check out the Amplify documentation for more information on how to define
+  /// secondary indexes. https://docs.amplify.aws/gen1/react/build-a-backend/graphqlapi/best-practice/query-with-sorting/
+  ///
+  /// ```dart
+  /// final request = ModelQueries.listByIndex(Todo.classType, queryField: parentId);
+  /// ```
+  /// or optional parameters:
+  /// ```dart
+  /// final request = ModelQueries.listByIndex(
+  ///   Todo.classType,
+  ///   queryField: parentId,
+  ///   sortDirection: "DESC", // ASC or DESC, default is DESC
+  ///   indexName: "todosByDate", // default is the first secondary index
+  ///   overrideQueryFieldType: "ID!", // override the query field type, default is "ID!", e.g. "String!"
+  ///   where: Todo.TASK.eq(taskId), // If your query parameter is taskId, you cannot use in where at the same time
+  /// );
+  /// ```
+  
+  static GraphQLRequest<PaginatedResult<T>> listByIndex<T extends Model>(
+    ModelType<T> modelType, {
+    int? limit,
+    String? queryField,
+    String? sortDirection,
+    String? indexName,
+    String? overrideQueryFieldType,
+    QueryPredicate? where,
+    String? apiName,
+    APIAuthorizationType? authorizationMode,
+    Map<String, String>? headers,
+  }) {
+    return ModelQueriesFactory.instance.listByIndex<T>(
+      modelType,
+      limit: limit,
+      where: where,
+      apiName: apiName,
+      authorizationMode: authorizationMode,
+      headers: headers,
+      queryField: queryField,
+      sortDirection: sortDirection ?? 'DESC',
+      indexName: indexName,
+      overrideQueryFieldType: overrideQueryFieldType,
+    );
+  }
 }
 
 // TODO(ragingsquirrel3): remove when https://github.com/dart-lang/sdk/issues/50748 addressed


### PR DESCRIPTION
*Issue* #4942

*Description of changes:*
- Add listByIndex to ModelQueries, it's build on `list`, required parameters are: `classType` and `queryField`, optional fields are `sortDirection`, `indexName`, `overrideQueryFieldType`.

Usage:

```
ModelQueries.listByIndex(
  TaskComment.classType,
  queryField: taskId,
  /// sortDirection: "ASC",  /// ASC or DESC, default is DESC
  /// indexName: "taskCommentsByDate",  ///  It's getting first secondary index in schema, if you have more, specify secondary index name
  /// overrideQueryFieldType: "String!",  /// It's for queryField's type, it should be match for GraphQL validation, autogenerated gen1 belongsTo fields are `ID!`
  /// where: TaskComment.TASK.eq(taskId), /// It cannot be used, if secondary index's queryField is taskId, you cannot use where taskId at the same time
);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
