### PR TITLE
fix(datastore): Various integration bug fixes

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/pigeons/NativePluginBindings.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/pigeons/NativePluginBindings.kt
@@ -158,22 +158,19 @@ data class NativeAWSCredentials (
 
 /** Generated class from Pigeon that represents data sent in messages. */
 data class NativeGraphQLResponse (
-  val payloadJson: String? = null,
-  val errorsJson: String? = null
+  val payloadJson: String? = null
 
 ) {
   companion object {
     @Suppress("UNCHECKED_CAST")
     fun fromList(list: List<Any?>): NativeGraphQLResponse {
       val payloadJson = list[0] as String?
-      val errorsJson = list[1] as String?
-      return NativeGraphQLResponse(payloadJson, errorsJson)
+      return NativeGraphQLResponse(payloadJson)
     }
   }
   fun toList(): List<Any?> {
     return listOf<Any?>(
       payloadJson,
-      errorsJson,
     )
   }
 }

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/pigeons/NativePluginBindings.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/pigeons/NativePluginBindings.kt
@@ -210,7 +210,8 @@ data class NativeGraphQLRequest (
   val variablesJson: String? = null,
   val responseType: String? = null,
   val decodePath: String? = null,
-  val options: String? = null
+  val options: String? = null,
+  val authMode: String? = null
 
 ) {
   companion object {
@@ -222,7 +223,8 @@ data class NativeGraphQLRequest (
       val responseType = list[3] as String?
       val decodePath = list[4] as String?
       val options = list[5] as String?
-      return NativeGraphQLRequest(document, apiName, variablesJson, responseType, decodePath, options)
+      val authMode = list[6] as String?
+      return NativeGraphQLRequest(document, apiName, variablesJson, responseType, decodePath, options, authMode)
     }
   }
   fun toList(): List<Any?> {
@@ -233,6 +235,7 @@ data class NativeGraphQLRequest (
       responseType,
       decodePath,
       options,
+      authMode,
     )
   }
 }

--- a/packages/amplify_datastore/example/ios/unit_tests/GraphQLResponse+DecodeTests.swift
+++ b/packages/amplify_datastore/example/ios/unit_tests/GraphQLResponse+DecodeTests.swift
@@ -209,14 +209,16 @@ class GraphQLResponseDecodeTests: XCTestCase {
     func testFromAppSyncResponse_withOnlyData_decodePayload() {
         SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
         let json: JSONValue = [
-            "onCreatePost": [
-                "__typename": "Post",
-                "id": "123",
-                "title": "test",
-                "author": "authorId",
-                "_version": 1,
-               "_deleted": nil,
-               "_lastChangedAt": 1707773705221
+            "data": [
+                "onCreatePost": [
+                    "__typename": "Post",
+                    "id": "123",
+                    "title": "test",
+                    "author": "authorId",
+                    "_version": 1,
+                   "_deleted": nil,
+                   "_lastChangedAt": 1707773705221
+                ]
             ]
         ]
 
@@ -269,14 +271,16 @@ class GraphQLResponseDecodeTests: XCTestCase {
     func testFromAppSyncResponse_withDataAndErrors_decodePayload() {
         SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
         let json: JSONValue = [
-            "onCreatePost": [
-                "__typename": "Post",
-                "id": "123",
-                "title": "test",
-                "author": "authorId",
-                "_version": 1,
-               "_deleted": nil,
-               "_lastChangedAt": 1707773705221
+            "data": [
+                "onCreatePost": [
+                    "__typename": "Post",
+                    "id": "123",
+                    "title": "test",
+                    "author": "authorId",
+                    "_version": 1,
+                   "_deleted": nil,
+                   "_lastChangedAt": 1707773705221
+                ],
             ],
             "errors": [
                 ["message": "error1"],
@@ -362,14 +366,16 @@ class GraphQLResponseDecodeTests: XCTestCase {
     func testFromAppSyncSubscriptionResponse_withJsonString_decodeCorrectly() {
         SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
         let payloadJson: JSONValue = [
-            "onCreatePost": [
-                "__typename": "Post",
-                "id": "123",
-                "title": "test",
-                "author": "authorId",
-                "_version": 1,
-               "_deleted": nil,
-               "_lastChangedAt": 1707773705221
+            "data": [
+                "onCreatePost": [
+                    "__typename": "Post",
+                    "id": "123",
+                    "title": "test",
+                    "author": "authorId",
+                    "_version": 1,
+                   "_deleted": nil,
+                   "_lastChangedAt": 1707773705221
+                ]
             ]
         ]
 
@@ -381,8 +387,8 @@ class GraphQLResponseDecodeTests: XCTestCase {
         )
         XCTAssertNoThrow(try response.get())
         let mutationSync = try! response.get()
-        XCTAssertEqual(payloadJson.onCreatePost?.id?.stringValue, mutationSync.model.identifier)
-        XCTAssertEqual(payloadJson.onCreatePost?.__typename?.stringValue, mutationSync.model.modelName)
+        XCTAssertEqual(payloadJson.data?.onCreatePost?.id?.stringValue, mutationSync.model.identifier)
+        XCTAssertEqual(payloadJson.data?.onCreatePost?.__typename?.stringValue, mutationSync.model.modelName)
     }
 
     func testFromAppSyncSubscriptionResponse_withWrongJsonString_failWithTransformationError() {

--- a/packages/amplify_datastore/example/ios/unit_tests/GraphQLResponse+DecodeTests.swift
+++ b/packages/amplify_datastore/example/ios/unit_tests/GraphQLResponse+DecodeTests.swift
@@ -116,7 +116,7 @@ class GraphQLResponseDecodeTests: XCTestCase {
             "a": ["b"]
         ]
         let expectedJson = "{\"a\":[\"b\"]}"
-        let result: Result<String, APIError> = GraphQLResponse<String>.decodeDataPayload(json, modelName: nil)
+        let result: Result<String, APIError> = GraphQLResponse<String>.decodeDataPayload(json, modelName: "Post")
         XCTAssertNoThrow(try result.get())
         XCTAssertEqual(expectedJson, try result.get())
     }
@@ -137,7 +137,7 @@ class GraphQLResponseDecodeTests: XCTestCase {
             "author": "authorId",
         ], modelName: "Post"))
 
-        let result: Result<AnyModel, APIError> = GraphQLResponse<AnyModel>.decodeDataPayload(json, modelName: nil)
+        let result: Result<AnyModel, APIError> = GraphQLResponse<AnyModel>.decodeDataPayload(json, modelName: "Post")
         XCTAssertNoThrow(try result.get())
         XCTAssertEqual(expectedModel.modelName, try result.get().modelName)
         XCTAssertEqual(expectedModel.id, try result.get().id)
@@ -227,7 +227,11 @@ class GraphQLResponseDecodeTests: XCTestCase {
             "author": "authorId",
         ], modelName: "Post"))
 
-        let result: Result<GraphQLResponse<MutationSync<AnyModel>>, APIError> = .fromAppSyncResponse(json: json, decodePath: "onCreatePost", modelName: nil)
+        let result: Result<GraphQLResponse<MutationSync<AnyModel>>, APIError> = .fromAppSyncResponse(
+            json: json,
+            decodePath: "onCreatePost",
+            modelName: "Post"
+        )
         XCTAssertNoThrow(try result.get())
         let mutationSync = try! result.get()
         XCTAssertNoThrow(try mutationSync.get())
@@ -244,7 +248,11 @@ class GraphQLResponseDecodeTests: XCTestCase {
             ]
         ]
 
-        let result: Result<GraphQLResponse<MutationSync<AnyModel>>, APIError> = .fromAppSyncResponse(json: json, decodePath: "onCreatePost", modelName: nil)
+        let result: Result<GraphQLResponse<MutationSync<AnyModel>>, APIError> = .fromAppSyncResponse(
+            json: json,
+            decodePath: "onCreatePost",
+            modelName: "Post"
+        )
         XCTAssertNoThrow(try result.get())
         let mutationSync = try! result.get()
         XCTAssertThrowsError(try mutationSync.get()) { error in
@@ -283,7 +291,11 @@ class GraphQLResponseDecodeTests: XCTestCase {
             "author": "authorId",
         ], modelName: "Post"))
 
-        let result: Result<GraphQLResponse<MutationSync<AnyModel>>, APIError> = .fromAppSyncResponse(json: json, decodePath: "onCreatePost", modelName: nil)
+        let result: Result<GraphQLResponse<MutationSync<AnyModel>>, APIError> = .fromAppSyncResponse(
+            json: json,
+            decodePath: "onCreatePost",
+            modelName: "Post"
+        )
         XCTAssertNoThrow(try result.get())
         let mutationSync = try! result.get()
         XCTAssertThrowsError(try mutationSync.get()) { error in
@@ -305,7 +317,11 @@ class GraphQLResponseDecodeTests: XCTestCase {
             "a": "b"
         ]
 
-        let result: Result<GraphQLResponse<MutationSync<AnyModel>>, APIError> = .fromAppSyncResponse(json: json, decodePath: "onCreatePost", modelName: nil)
+        let result: Result<GraphQLResponse<MutationSync<AnyModel>>, APIError> = .fromAppSyncResponse(
+            json: json,
+            decodePath: "onCreatePost",
+            modelName: "Post"
+        )
         XCTAssertThrowsError(try result.get()) { error in
             if case .unknown(let description, _, _) = (error as! APIError) {
                 XCTAssertEqual("Failed to get data object or errors from GraphQL response", description)
@@ -325,7 +341,7 @@ class GraphQLResponseDecodeTests: XCTestCase {
         ]
 
         let jsonString = String(data: try! JSONEncoder().encode(json), encoding: .utf8)!
-        let response: GraphQLResponse<AnyModel> = .fromAppSyncResponse(string: jsonString, decodePath: nil)
+        let response: GraphQLResponse<AnyModel> = .fromAppSyncResponse(string: jsonString, decodePath: nil, modelName: "Post")
         XCTAssertNoThrow(try response.get())
         XCTAssertEqual(json.id?.stringValue, try response.get().identifier)
         XCTAssertEqual(json.__typename?.stringValue, try response.get().modelName)
@@ -334,7 +350,7 @@ class GraphQLResponseDecodeTests: XCTestCase {
     func testFromAppSyncResponse_withBrokenJsonString_failWithTransformationError() {
         SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
         let jsonString = "{"
-        let response: GraphQLResponse<AnyModel> = .fromAppSyncResponse(string: jsonString, decodePath: nil)
+        let response: GraphQLResponse<AnyModel> = .fromAppSyncResponse(string: jsonString, decodePath: nil, modelName: "Post")
         XCTAssertThrowsError(try response.get()) { error in
             guard case .transformationError = error as! GraphQLResponseError<AnyModel> else {
                 XCTFail("Should failed with transformationError")
@@ -358,7 +374,11 @@ class GraphQLResponseDecodeTests: XCTestCase {
         ]
 
         let jsonString = String(data: try! JSONEncoder().encode(payloadJson), encoding: .utf8)!
-        let response: GraphQLResponse<MutationSync<AnyModel>> = .fromAppSyncResponse(string: jsonString, decodePath: "onCreatePost")
+        let response: GraphQLResponse<MutationSync<AnyModel>> = .fromAppSyncResponse(
+            string: jsonString,
+            decodePath: "onCreatePost",
+            modelName: "Post"
+        )
         XCTAssertNoThrow(try response.get())
         let mutationSync = try! response.get()
         XCTAssertEqual(payloadJson.onCreatePost?.id?.stringValue, mutationSync.model.identifier)
@@ -368,7 +388,11 @@ class GraphQLResponseDecodeTests: XCTestCase {
     func testFromAppSyncSubscriptionResponse_withWrongJsonString_failWithTransformationError() {
         SchemaData.modelSchemaRegistry.registerModels(registry: ModelRegistry.self)
         let jsonString = "{"
-        let response: GraphQLResponse<MutationSync<AnyModel>> = .fromAppSyncSubscriptionResponse(string: jsonString, decodePath: nil)
+        let response: GraphQLResponse<MutationSync<AnyModel>> = .fromAppSyncSubscriptionResponse(
+            string: jsonString,
+            decodePath: nil,
+            modelName: "Post"
+        )
         XCTAssertThrowsError(try response.get()) { error in
             guard case .transformationError = error as! GraphQLResponseError<MutationSync<AnyModel>> else {
                 XCTFail("Should failed with transformationError")

--- a/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
@@ -22,6 +22,7 @@ public class FlutterApiPlugin: APICategoryPlugin
     
     public func query<R>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success where R : Decodable {
         let response = await asyncQuery(nativeRequest: request.toNativeGraphQLRequest())
+        
         return try decodeGraphQLPayloadJson(request: request, payload: response.payloadJson)
     }
     

--- a/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
@@ -99,10 +99,13 @@ public class FlutterApiPlugin: APICategoryPlugin
         guard let payload else {
             throw DataStoreError.decodingError("Request payload could not be empty", "")
         }
+        
+        let datastoreOptions = request.options?.pluginOptions as? AWSAPIPluginDataStoreOptions
 
         return GraphQLResponse<R>.fromAppSyncResponse(
             string: payload,
-            decodePath: request.decodePath
+            decodePath: request.decodePath,
+            modelName: datastoreOptions?.modelName
         )
     }
 

--- a/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
@@ -100,12 +100,14 @@ public class FlutterApiPlugin: APICategoryPlugin
             throw DataStoreError.decodingError("Request payload could not be empty", "")
         }
         
-        let datastoreOptions = request.options?.pluginOptions as? AWSAPIPluginDataStoreOptions
-        
+        guard let datastoreOptions = request.options?.pluginOptions as? AWSAPIPluginDataStoreOptions else {
+            throw DataStoreError.decodingError("Failed to decode the GraphQLRequest due to a missing options field.", "")
+        }
+
         return GraphQLResponse<R>.fromAppSyncResponse(
             string: payload,
             decodePath: request.decodePath,
-            modelName: datastoreOptions?.modelName
+            modelName: datastoreOptions.modelName
         )
     }
 
@@ -117,12 +119,14 @@ public class FlutterApiPlugin: APICategoryPlugin
             throw DataStoreError.decodingError("Request payload could not be empty", "")
         }
         
-        let datastoreOptions = request.options?.pluginOptions as? AWSAPIPluginDataStoreOptions
+        guard let datastoreOptions = request.options?.pluginOptions as? AWSAPIPluginDataStoreOptions else {
+            throw DataStoreError.decodingError("Failed to decode the GraphQLRequest due to a missing options field.", "")
+        }
 
         return GraphQLResponse<R>.fromAppSyncSubscriptionResponse(
             string: payload,
             decodePath: request.decodePath,
-            modelName: datastoreOptions?.modelName
+            modelName: datastoreOptions.modelName
         )
     }
     

--- a/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
@@ -102,14 +102,10 @@ public class FlutterApiPlugin: APICategoryPlugin
         
         let datastoreOptions = request.options?.pluginOptions as? AWSAPIPluginDataStoreOptions
         
-        guard let modelName = datastoreOptions?.modelName else {
-            throw DataStoreError.decodingError("Request modelName can not be null", "")
-        }
-
         return GraphQLResponse<R>.fromAppSyncResponse(
             string: payload,
             decodePath: request.decodePath,
-            modelName: modelName
+            modelName: datastoreOptions?.modelName
         )
     }
 
@@ -122,15 +118,11 @@ public class FlutterApiPlugin: APICategoryPlugin
         }
         
         let datastoreOptions = request.options?.pluginOptions as? AWSAPIPluginDataStoreOptions
-        
-        guard let modelName = datastoreOptions?.modelName else {
-            throw DataStoreError.decodingError("Request modelName can not be null", "")
-        }
 
         return GraphQLResponse<R>.fromAppSyncSubscriptionResponse(
             string: payload,
             decodePath: request.decodePath,
-            modelName: modelName
+            modelName: datastoreOptions?.modelName
         )
     }
     

--- a/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
@@ -101,11 +101,15 @@ public class FlutterApiPlugin: APICategoryPlugin
         }
         
         let datastoreOptions = request.options?.pluginOptions as? AWSAPIPluginDataStoreOptions
+        
+        guard let modelName = datastoreOptions?.modelName else {
+            throw DataStoreError.decodingError("Request modelName can not be null", "")
+        }
 
         return GraphQLResponse<R>.fromAppSyncResponse(
             string: payload,
             decodePath: request.decodePath,
-            modelName: datastoreOptions?.modelName
+            modelName: modelName
         )
     }
 
@@ -116,10 +120,17 @@ public class FlutterApiPlugin: APICategoryPlugin
         guard let payload else {
             throw DataStoreError.decodingError("Request payload could not be empty", "")
         }
+        
+        let datastoreOptions = request.options?.pluginOptions as? AWSAPIPluginDataStoreOptions
+        
+        guard let modelName = datastoreOptions?.modelName else {
+            throw DataStoreError.decodingError("Request modelName can not be null", "")
+        }
 
         return GraphQLResponse<R>.fromAppSyncSubscriptionResponse(
             string: payload,
-            decodePath: request.decodePath
+            decodePath: request.decodePath,
+            modelName: modelName
         )
     }
     

--- a/packages/amplify_datastore/ios/Classes/api/GraphQLRequest+Extension.swift
+++ b/packages/amplify_datastore/ios/Classes/api/GraphQLRequest+Extension.swift
@@ -22,7 +22,7 @@ extension GraphQLRequest {
             variablesJson: variablesJson ?? "{}",
             responseType: String(describing: self.responseType),
             decodePath: self.decodePath,
-            authMode: (datastoreOptions?.authType ?? self.authMode).map { String(describing: $0) }
+            authMode: datastoreOptions?.authType.map { String(describing: $0) }
         )
     }
 }

--- a/packages/amplify_datastore/ios/Classes/api/GraphQLRequest+Extension.swift
+++ b/packages/amplify_datastore/ios/Classes/api/GraphQLRequest+Extension.swift
@@ -13,13 +13,16 @@ extension GraphQLRequest {
         let variablesJson = self.variables
             .flatMap { try? JSONSerialization.data(withJSONObject: $0, options: []) }
             .flatMap { String(data: $0, encoding: .utf8) }
+        
+        let datastoreOptions = self.options?.pluginOptions as? AWSAPIPluginDataStoreOptions
 
         return NativeGraphQLRequest(
             document: self.document,
             apiName: self.apiName,
             variablesJson: variablesJson ?? "{}",
             responseType: String(describing: self.responseType),
-            decodePath: self.decodePath
+            decodePath: self.decodePath,
+            authMode: (datastoreOptions?.authType ?? self.authMode).map { String(describing: $0) }
         )
     }
 }

--- a/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
+++ b/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
@@ -30,12 +30,6 @@ extension GraphQLResponse {
                 .unknown("Unable to deserialize json data", "Check the event structure.")
             ))
         }
-        
-        // we expect when flutter calls this to provide a modelName
-        guard let modelName = modelName else {
-            return .failure(.transformationError(string, .unknown("Unable to get modelName", "Please provide a modelName")))
-        }
-        
 
         let result: Result<GraphQLResponse<R>, APIError> = toJson(data: data).flatMap {
             fromAppSyncResponse(json: $0, decodePath: decodePath, modelName: modelName)

--- a/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
+++ b/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
@@ -101,7 +101,8 @@ extension GraphQLResponse {
         modelName: String
     ) -> Result<GraphQLResponse<R>, APIError> {
         var data = decodePath != nil ? json.data?.value(at: decodePath!) : json
-        let errors = json.errors?.asArray
+        let errorsArray = json.errors?.asArray
+        let errors = errorsArray.isEmpty ? nil : errorsArray
         data = data?.isNull == true ? nil : data
         switch (data, errors) {
         case (.some(let data), .none):

--- a/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
+++ b/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
@@ -162,7 +162,8 @@ extension GraphQLResponse {
             return encodeDataPayloadToString(dataPayload).map { $0 as! R }
         }
         
-        /// This is included to allow multi-platform support. Requests that do not have `__typename` 
+        /// This allows multi-platform support. Not all platform requests include `__typename`
+        /// in the selection set. This adds it to the response based on the model name for proper decoding.
         let dataPayloadWithTypeName = (dataPayload.asObject?.merging(
             ["__typename": .string(modelName)],
             uniquingKeysWith: { a, _ in a }

--- a/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
+++ b/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
@@ -129,10 +129,17 @@ extension GraphQLResponse {
             return nil
         }
 
-        let extensions = errorObject.enumerated().filter { !["message", "locations", "path", "extensions"].contains($0.element.key) }
+        var extensions = errorObject.enumerated().filter { !["message", "locations", "path", "extensions"].contains($0.element.key) }
             .reduce([String: JSONValue]()) { partialResult, item in
                 partialResult.merging([item.element.key: item.element.value]) { $1 }
             }
+
+        if error.message?.stringValue?.contains("Unauthorized") == true {
+            extensions = extensions.merging(
+                ["errorType": "Unauthorized"],
+                uniquingKeysWith: { _, a in a }
+            )
+        }
 
         return (try? jsonEncoder.encode(error))
             .flatMap { try? jsonDecoder.decode(GraphQLError.self, from: $0) }

--- a/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
+++ b/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
@@ -100,8 +100,9 @@ extension GraphQLResponse {
         decodePath: String?,
         modelName: String
     ) -> Result<GraphQLResponse<R>, APIError> {
-        let data = decodePath != nil ? json.value(at: decodePath!) : json
+        var data = decodePath != nil ? json.data?.value(at: decodePath!) : json
         let errors = json.errors?.asArray
+        data = data?.isNull == true ? nil : data
         switch (data, errors) {
         case (.some(let data), .none):
             return decodeDataPayload(data, modelName: modelName).map { .success($0) }

--- a/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
+++ b/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
@@ -22,7 +22,7 @@ extension GraphQLResponse {
     public static func fromAppSyncResponse<R: Decodable>(
         string: String,
         decodePath: String?,
-        modelName: String? = nil
+        modelName: String
     ) -> GraphQLResponse<R> {
         guard let data = string.data(using: .utf8) else {
             return .failure(.transformationError(
@@ -44,7 +44,7 @@ extension GraphQLResponse {
     public static func fromAppSyncSubscriptionResponse<R: Decodable>(
         string: String,
         decodePath: String?,
-        modelName: String? = nil
+        modelName: String
     ) -> GraphQLResponse<R> {
         guard let data = string.data(using: .utf8) else {
             return .failure(.transformationError(
@@ -98,7 +98,7 @@ extension GraphQLResponse {
     static func fromAppSyncResponse<R: Decodable>(
         json: JSONValue,
         decodePath: String?,
-        modelName: String?
+        modelName: String
     ) -> Result<GraphQLResponse<R>, APIError> {
         let data = decodePath != nil ? json.value(at: decodePath!) : json
         let errors = json.errors?.asArray
@@ -147,23 +147,17 @@ extension GraphQLResponse {
 
     static func decodeDataPayload<R: Decodable>(
         _ dataPayload: JSONValue,
-        modelName: String?
+        modelName: String
     ) -> Result<R, APIError> {
         if R.self == String.self {
             return encodeDataPayloadToString(dataPayload).map { $0 as! R }
         }
 
-        let dataPayloadWithTypeName = modelName.flatMap {
-            dataPayload.asObject?.merging(
-                ["__typename": .string($0)]
-            ) { a, _ in a }
-        }.map { JSONValue.object($0) } ?? dataPayload
-
         if R.self == AnyModel.self {
-            return decodeDataPayloadToAnyModel(dataPayloadWithTypeName).map { $0 as! R }
+            return decodeDataPayloadToAnyModel(dataPayload, modelName: modelName).map { $0 as! R }
         }
 
-        return fromJson(dataPayloadWithTypeName)
+        return fromJson(dataPayload)
             .flatMap { data in
                 Result<R, Error> { try jsonDecoder.decode(R.self, from: data) }
                     .mapError { APIError.operationError("Could not decode json to type \(R.self)", "", $0)}
@@ -171,29 +165,19 @@ extension GraphQLResponse {
     }
 
     static func decodeDataPayloadToAnyModel(
-        _ dataPayload: JSONValue
+        _ dataPayload: JSONValue,
+        modelName: String
     ) -> Result<AnyModel, APIError> {
-        guard let typeName = dataPayload.__typename?.stringValue else {
-            return .failure(.operationError(
-                "Could not retrieve __typename from object",
-                """
-                Could not retrieve the `__typename` attribute from the return value. Be sure to include __typename in \
-                the selection set of the GraphQL operation. GraphQL:
-                \(dataPayload)
-                """
-            ))
-        }
-
         return encodeDataPayloadToString(dataPayload).flatMap { underlyingModelString in
             do {
                 return .success(.init(try ModelRegistry.decode(
-                    modelName: typeName,
+                    modelName: modelName,
                     from: underlyingModelString,
                     jsonDecoder: jsonDecoder
                 )))
             } catch {
                 return .failure(.operationError(
-                    "Could not decode to \(typeName) with \(underlyingModelString)",
+                    "Could not decode to \(modelName) with \(underlyingModelString)",
                     ""
                 ))
             }

--- a/packages/amplify_datastore/ios/Classes/pigeons/NativePluginBindings.swift
+++ b/packages/amplify_datastore/ios/Classes/pigeons/NativePluginBindings.swift
@@ -215,6 +215,7 @@ struct NativeGraphQLRequest {
   var responseType: String? = nil
   var decodePath: String? = nil
   var options: String? = nil
+  var authMode: String? = nil
 
   static func fromList(_ list: [Any?]) -> NativeGraphQLRequest? {
     let document = list[0] as! String
@@ -223,6 +224,7 @@ struct NativeGraphQLRequest {
     let responseType: String? = nilOrValue(list[3])
     let decodePath: String? = nilOrValue(list[4])
     let options: String? = nilOrValue(list[5])
+    let authMode: String? = nilOrValue(list[6])
 
     return NativeGraphQLRequest(
       document: document,
@@ -230,7 +232,8 @@ struct NativeGraphQLRequest {
       variablesJson: variablesJson,
       responseType: responseType,
       decodePath: decodePath,
-      options: options
+      options: options,
+      authMode: authMode
     )
   }
   func toList() -> [Any?] {
@@ -241,6 +244,7 @@ struct NativeGraphQLRequest {
       responseType,
       decodePath,
       options,
+      authMode,
     ]
   }
 }

--- a/packages/amplify_datastore/ios/Classes/pigeons/NativePluginBindings.swift
+++ b/packages/amplify_datastore/ios/Classes/pigeons/NativePluginBindings.swift
@@ -162,21 +162,17 @@ struct NativeAWSCredentials {
 /// Generated class from Pigeon that represents data sent in messages.
 struct NativeGraphQLResponse {
   var payloadJson: String? = nil
-  var errorsJson: String? = nil
 
   static func fromList(_ list: [Any?]) -> NativeGraphQLResponse? {
     let payloadJson: String? = nilOrValue(list[0])
-    let errorsJson: String? = nilOrValue(list[1])
 
     return NativeGraphQLResponse(
-      payloadJson: payloadJson,
-      errorsJson: errorsJson
+      payloadJson: payloadJson
     )
   }
   func toList() -> [Any?] {
     return [
       payloadJson,
-      errorsJson,
     ]
   }
 }

--- a/packages/amplify_datastore/ios/internal/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
+++ b/packages/amplify_datastore/ios/internal/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
@@ -81,7 +81,7 @@ final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber, AmplifyC
         case .success(let mutationSync):
             modelsFromSubscription.send(.payload(mutationSync))
         case .failure(let failure):
-            log.error(error: failure)
+            log.error(failure.errorDescription)
         }
     }
 

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -321,16 +321,26 @@ class _NativeAmplifyApi
 
   @override
   Future<NativeGraphQLResponse> mutate(NativeGraphQLRequest request) async {
-    final flutterRequest = nativeRequestToGraphQLRequest(request);
-    final response = await Amplify.API.mutate(request: flutterRequest).response;
-    return graphQLResponseToNativeResponse(response);
+    try {
+      final flutterRequest = nativeRequestToGraphQLRequest(request);
+      final response =
+          await Amplify.API.mutate(request: flutterRequest).response;
+      return graphQLResponseToNativeResponse(response);
+    } on Exception catch (e) {
+      return handleGraphQLOperationException(e, request);
+    }
   }
 
   @override
   Future<NativeGraphQLResponse> query(NativeGraphQLRequest request) async {
-    final flutterRequest = nativeRequestToGraphQLRequest(request);
-    final response = await Amplify.API.query(request: flutterRequest).response;
-    return graphQLResponseToNativeResponse(response);
+    try {
+      final flutterRequest = nativeRequestToGraphQLRequest(request);
+      final response =
+          await Amplify.API.query(request: flutterRequest).response;
+      return graphQLResponseToNativeResponse(response);
+    } on Exception catch (e) {
+      return handleGraphQLOperationException(e, request);
+    }
   }
 
   @override
@@ -345,12 +355,7 @@ class _NativeAmplifyApi
         (GraphQLResponse<String> event) =>
             sendSubscriptionEvent(flutterRequest.id, event),
         onError: (Object error) {
-          final errorPayload = jsonEncode({
-            'errors': [
-              {'message': error.toString()}
-            ]
-          });
-          sendSubscriptionStreamErrorEvent(flutterRequest.id, errorPayload);
+          sendSubscriptionStreamErrorEvent(flutterRequest.id, error);
         },
         onDone: () => sendNativeCompleteEvent(flutterRequest.id));
 

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -343,10 +343,13 @@ class _NativeAmplifyApi
 
     final subscription = operation.listen(
         (GraphQLResponse<String> event) =>
-            sendNativeDataEvent(flutterRequest.id, event.data),
-        onError: (error) {
-          // TODO(equartey): verify that error.toString() is the correct payload format. Should match AppSync
-          final errorPayload = error.toString();
+            sendSubscriptionEvent(flutterRequest.id, event),
+        onError: (Object error) {
+          final errorPayload = jsonEncode({
+            'errors': [
+              {'message': error.toString()}
+            ]
+          });
           sendNativeErrorEvent(flutterRequest.id, errorPayload);
         },
         onDone: () => sendNativeCompleteEvent(flutterRequest.id));

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -350,7 +350,7 @@ class _NativeAmplifyApi
               {'message': error.toString()}
             ]
           });
-          sendNativeErrorEvent(flutterRequest.id, errorPayload);
+          sendSubscriptionStreamErrorEvent(flutterRequest.id, errorPayload);
         },
         onDone: () => sendNativeCompleteEvent(flutterRequest.id));
 

--- a/packages/amplify_datastore/lib/src/native_plugin.g.dart
+++ b/packages/amplify_datastore/lib/src/native_plugin.g.dart
@@ -152,17 +152,13 @@ class NativeAWSCredentials {
 class NativeGraphQLResponse {
   NativeGraphQLResponse({
     this.payloadJson,
-    this.errorsJson,
   });
 
   String? payloadJson;
 
-  String? errorsJson;
-
   Object encode() {
     return <Object?>[
       payloadJson,
-      errorsJson,
     ];
   }
 
@@ -170,7 +166,6 @@ class NativeGraphQLResponse {
     result as List<Object?>;
     return NativeGraphQLResponse(
       payloadJson: result[0] as String?,
-      errorsJson: result[1] as String?,
     );
   }
 }

--- a/packages/amplify_datastore/lib/src/native_plugin.g.dart
+++ b/packages/amplify_datastore/lib/src/native_plugin.g.dart
@@ -214,6 +214,7 @@ class NativeGraphQLRequest {
     this.responseType,
     this.decodePath,
     this.options,
+    this.authMode,
   });
 
   String document;
@@ -228,6 +229,8 @@ class NativeGraphQLRequest {
 
   String? options;
 
+  String? authMode;
+
   Object encode() {
     return <Object?>[
       document,
@@ -236,6 +239,7 @@ class NativeGraphQLRequest {
       responseType,
       decodePath,
       options,
+      authMode,
     ];
   }
 
@@ -248,6 +252,7 @@ class NativeGraphQLRequest {
       responseType: result[3] as String?,
       decodePath: result[4] as String?,
       options: result[5] as String?,
+      authMode: result[6] as String?,
     );
   }
 }

--- a/packages/amplify_datastore/lib/src/utils/native_api_helpers.dart
+++ b/packages/amplify_datastore/lib/src/utils/native_api_helpers.dart
@@ -91,7 +91,8 @@ void sendSubscriptionEvent(
 }
 
 /// Send an error event for the given [subscriptionId] and [errorPayload]
-void sendNativeErrorEvent(String subscriptionId, String? errorPayload) {
+void sendSubscriptionStreamErrorEvent(
+    String subscriptionId, String? errorPayload) {
   final event = NativeGraphQLSubscriptionResponse(
     subscriptionId: subscriptionId,
     payloadJson: errorPayload,

--- a/packages/amplify_datastore/lib/src/utils/native_api_helpers.dart
+++ b/packages/amplify_datastore/lib/src/utils/native_api_helpers.dart
@@ -73,20 +73,22 @@ void sendNativeStartAckEvent(String subscriptionId) {
 /// If the response has errors, the event type will be `error`, otherwise `data`
 void sendSubscriptionEvent(
     String subscriptionId, GraphQLResponse<String> response) {
-  final payloadJson = response.hasErrors
-      ? jsonEncode({"errors": response.errors})
-      : response.data;
+  if (response.hasErrors) {
+    final errorPayload = jsonEncode({"errors": response.errors});
+    sendNativeErrorEvent(subscriptionId, errorPayload);
+    return;
+  }
 
   final event = NativeGraphQLSubscriptionResponse(
     subscriptionId: subscriptionId,
-    payloadJson: payloadJson,
-    type: response.hasErrors ? "error" : "data",
+    payloadJson: response.data,
+    type: "data",
   );
   _sendSubscriptionEvent(event);
 }
 
 /// Send an error event for the given [subscriptionId] and [errorPayload]
-void sendNativeErrorEvent(String subscriptionId, String errorPayload) {
+void sendNativeErrorEvent(String subscriptionId, String? errorPayload) {
   final event = NativeGraphQLSubscriptionResponse(
     subscriptionId: subscriptionId,
     payloadJson: errorPayload,

--- a/packages/amplify_datastore/lib/src/utils/native_api_helpers.dart
+++ b/packages/amplify_datastore/lib/src/utils/native_api_helpers.dart
@@ -38,12 +38,14 @@ APIAuthorizationType? nativeToApiAuthorizationType(String? authMode) {
 /// Convert a [GraphQLResponse] to a [NativeGraphQLResponse]
 NativeGraphQLResponse graphQLResponseToNativeResponse(
     GraphQLResponse<String> response) {
-  final errorJson = jsonEncode(
-      response.errors.whereNotNull().map((e) => e.toJson()).toList());
-  return NativeGraphQLResponse(
-    payloadJson: response.data,
-    errorsJson: errorJson,
-  );
+  final errorJson =
+      response.errors.whereNotNull().map((e) => e.toJson()).toList();
+  final data = jsonDecode(response.data ?? '{}');
+  final payload = jsonEncode({
+    'data': data,
+    'errors': errorJson,
+  });
+  return NativeGraphQLResponse(payloadJson: payload);
 }
 
 /// Returns a connecting event [NativeGraphQLResponse] for the given [subscriptionId]

--- a/packages/amplify_datastore/lib/src/utils/native_api_helpers.dart
+++ b/packages/amplify_datastore/lib/src/utils/native_api_helpers.dart
@@ -27,7 +27,7 @@ APIAuthorizationType? nativeToApiAuthorizationType(String? authMode) {
     case 'amazonCognitoUserPools':
       return APIAuthorizationType.userPools;
     case 'function':
-      return APIAuthorizationType.userPools;
+      return APIAuthorizationType.function;
     case 'none':
       return APIAuthorizationType.none;
     default:

--- a/packages/amplify_datastore/lib/src/utils/native_api_helpers.dart
+++ b/packages/amplify_datastore/lib/src/utils/native_api_helpers.dart
@@ -75,7 +75,7 @@ void sendSubscriptionEvent(
     String subscriptionId, GraphQLResponse<String> response) {
   final payloadJson = response.hasErrors
       ? jsonEncode({"errors": response.errors})
-      : jsonEncode(response.data);
+      : response.data;
 
   final event = NativeGraphQLSubscriptionResponse(
     subscriptionId: subscriptionId,

--- a/packages/amplify_datastore/pigeons/native_plugin.dart
+++ b/packages/amplify_datastore/pigeons/native_plugin.dart
@@ -110,7 +110,6 @@ class LegacyCredentialStoreData {
 
 class NativeGraphQLResponse {
   String? payloadJson;
-  String? errorsJson;
 }
 
 class NativeGraphQLSubscriptionResponse {

--- a/packages/amplify_datastore/pigeons/native_plugin.dart
+++ b/packages/amplify_datastore/pigeons/native_plugin.dart
@@ -126,4 +126,5 @@ class NativeGraphQLRequest {
   String? responseType;
   String? decodePath;
   String? options;
+  String? authMode;
 }


### PR DESCRIPTION
*Description of changes:*
- This resolves multi auth issues by enabling the auth mode to be passed from the Swift project to Flutter. 
- Modifies subscription stream errors to conform to Swift's error Json structure. 
- Improves decoding logic by passing `modelName` which should always have a value.
- Fix for cancellables crash
- GraphQL requests response now match AppSync response payloads
- Fix to allow initial sync to complete when a model does not have sufficient permissions before a user is signed in 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
