### PR TITLE
fix(datastore): added missing defaultAuthType method

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -901,6 +901,7 @@ class AmplifyDataStorePlugin :
 
     override fun addApiPlugin(
         authProvidersList: List<String>,
+        endpoints: Map<String, String>,
         callback: (kotlin.Result<Unit>) -> Unit
     ) {
         try {

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/pigeons/NativePluginBindings.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/pigeons/NativePluginBindings.kt
@@ -360,13 +360,6 @@ class NativeApiPlugin(private val binaryMessenger: BinaryMessenger) {
       callback(result)
     }
   }
-  fun getEndpointAuthorizationType(apiNameArg: String?, callback: (String?) -> Unit) {
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.getEndpointAuthorizationType", codec)
-    channel.send(listOf(apiNameArg)) {
-      val result = it as String?
-      callback(result)
-    }
-  }
   fun mutate(requestArg: NativeGraphQLRequest, callback: (NativeGraphQLResponse) -> Unit) {
     val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.mutate", codec)
     channel.send(listOf(requestArg)) {
@@ -542,7 +535,7 @@ private object NativeApiBridgeCodec : StandardMessageCodec() {
  * Generated interface from Pigeon that represents a handler of messages from Flutter.
  */
 interface NativeApiBridge {
-  fun addApiPlugin(authProvidersList: List<String>, callback: (Result<Unit>) -> Unit)
+  fun addApiPlugin(authProvidersList: List<String>, endpoints: Map<String, String>, callback: (Result<Unit>) -> Unit)
   fun sendSubscriptionEvent(event: NativeGraphQLSubscriptionResponse, callback: (Result<Unit>) -> Unit)
 
   companion object {
@@ -559,7 +552,8 @@ interface NativeApiBridge {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val authProvidersListArg = args[0] as List<String>
-            api.addApiPlugin(authProvidersListArg) { result: Result<Unit> ->
+            val endpointsArg = args[1] as Map<String, String>
+            api.addApiPlugin(authProvidersListArg, endpointsArg) { result: Result<Unit> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(wrapError(error))

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/pigeons/NativePluginBindings.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/pigeons/NativePluginBindings.kt
@@ -360,6 +360,13 @@ class NativeApiPlugin(private val binaryMessenger: BinaryMessenger) {
       callback(result)
     }
   }
+  fun getEndpointAuthorizationType(apiNameArg: String?, callback: (String?) -> Unit) {
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.getEndpointAuthorizationType", codec)
+    channel.send(listOf(apiNameArg)) {
+      val result = it as String?
+      callback(result)
+    }
+  }
   fun mutate(requestArg: NativeGraphQLRequest, callback: (NativeGraphQLResponse) -> Unit) {
     val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.mutate", codec)
     channel.send(listOf(requestArg)) {

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -80,11 +80,12 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin, NativeAmplify
         }
     }
     
-    func addApiPlugin(authProvidersList: [String], completion: @escaping (Result<Void, Error>) -> Void) {
+    func addApiPlugin(authProvidersList: [String], endpoints: [String: String], completion: @escaping (Result<Void, Error>) -> Void) {
         do {
             let authProviders = authProvidersList.compactMap {
                 AWSAuthorizationType(rawValue: $0)
             }
+            
             try Amplify.add(
                 plugin: FlutterApiPlugin(
                     apiAuthProviderFactory: FlutterAuthProviders(
@@ -92,7 +93,8 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin, NativeAmplify
                         nativeApiPlugin: nativeApiPlugin
                     ), 
                     nativeApiPlugin: nativeApiPlugin,
-                    subscriptionEventBus: nativeSubscriptionEventBus
+                    subscriptionEventBus: nativeSubscriptionEventBus,
+                    endpoints: endpoints
                 )
             )
             return completion(.success(()))

--- a/packages/amplify_datastore/ios/Classes/pigeons/NativePluginBindings.swift
+++ b/packages/amplify_datastore/ios/Classes/pigeons/NativePluginBindings.swift
@@ -374,6 +374,13 @@ class NativeApiPlugin {
       completion(result)
     }
   }
+  func getEndpointAuthorizationType(apiName apiNameArg: String?, completion: @escaping (String?) -> Void) {
+    let channel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.getEndpointAuthorizationType", binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([apiNameArg] as [Any?]) { response in
+      let result: String? = nilOrValue(response)
+      completion(result)
+    }
+  }
   func mutate(request requestArg: NativeGraphQLRequest, completion: @escaping (NativeGraphQLResponse) -> Void) {
     let channel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.mutate", binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([requestArg] as [Any?]) { response in

--- a/packages/amplify_datastore/ios/Classes/pigeons/NativePluginBindings.swift
+++ b/packages/amplify_datastore/ios/Classes/pigeons/NativePluginBindings.swift
@@ -374,13 +374,6 @@ class NativeApiPlugin {
       completion(result)
     }
   }
-  func getEndpointAuthorizationType(apiName apiNameArg: String?, completion: @escaping (String?) -> Void) {
-    let channel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.getEndpointAuthorizationType", binaryMessenger: binaryMessenger, codec: codec)
-    channel.sendMessage([apiNameArg] as [Any?]) { response in
-      let result: String? = nilOrValue(response)
-      completion(result)
-    }
-  }
   func mutate(request requestArg: NativeGraphQLRequest, completion: @escaping (NativeGraphQLResponse) -> Void) {
     let channel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.mutate", binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([requestArg] as [Any?]) { response in
@@ -563,7 +556,7 @@ class NativeApiBridgeCodec: FlutterStandardMessageCodec {
 ///
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol NativeApiBridge {
-  func addApiPlugin(authProvidersList: [String], completion: @escaping (Result<Void, Error>) -> Void)
+  func addApiPlugin(authProvidersList: [String], endpoints: [String: String], completion: @escaping (Result<Void, Error>) -> Void)
   func sendSubscriptionEvent(event: NativeGraphQLSubscriptionResponse, completion: @escaping (Result<Void, Error>) -> Void)
 }
 
@@ -578,7 +571,8 @@ class NativeApiBridgeSetup {
       addApiPluginChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let authProvidersListArg = args[0] as! [String]
-        api.addApiPlugin(authProvidersList: authProvidersListArg) { result in
+        let endpointsArg = args[1] as! [String: String]
+        api.addApiPlugin(authProvidersList: authProvidersListArg, endpoints: endpointsArg) { result in
           switch result {
             case .success:
               reply(wrapResult(nil))

--- a/packages/amplify_datastore/ios/Classes/types/model/FlutterModelSchema.swift
+++ b/packages/amplify_datastore/ios/Classes/types/model/FlutterModelSchema.swift
@@ -97,12 +97,3 @@ struct FlutterModelSchema {
         return (fields, name)
     }
 }
-
-// TODO: Migrate to Async Swift v2
-// This enables custom selection set behavior within Amplify-Swift v1.
-// Which allows models to be decoded when created on Android and received to iOS
-//extension FlutterModelSchema: SubscriptionSelectionSetBehavior {
-//    public var includePrimaryKeysOnly: Bool {
-//        return true
-//    }    
-//}

--- a/packages/amplify_datastore/ios/internal/Amplify/Categories/Logging/LogLevel.swift
+++ b/packages/amplify_datastore/ios/internal/Amplify/Categories/Logging/LogLevel.swift
@@ -9,12 +9,12 @@
 ///
 public extension Amplify {
     enum LogLevel: Int, Codable {
+        case none
         case error
         case warn
         case info
         case debug
         case verbose
-        case none
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()

--- a/packages/amplify_datastore/ios/internal/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/Internal/OSLogWrapper.swift
+++ b/packages/amplify_datastore/ios/internal/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/Internal/OSLogWrapper.swift
@@ -29,7 +29,7 @@ final class OSLogWrapper: Logger {
     }
 
     public func error(_ message: @autoclosure () -> String) {
-        guard enabled else { return }
+        guard enabled, logLevel.rawValue >= LogLevel.error.rawValue else { return }
         os_log("%@",
                log: osLog,
                type: OSLogType.error,
@@ -37,7 +37,7 @@ final class OSLogWrapper: Logger {
     }
 
     public func error(error: Error) {
-        guard enabled else { return }
+        guard enabled, logLevel.rawValue >= LogLevel.error.rawValue else { return }
         os_log("%@",
                log: osLog,
                type: OSLogType.error,

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -331,14 +331,13 @@ class _NativeAmplifyApi
     if (apiName == null) {
       throw DataStoreException('No API name provided');
     }
-    final endpoint =
-        endpoints?.firstWhereOrNull((e) => e.keys.first == apiName);
+    final endpoint = endpoints?.firstWhereOrNull((e) => e[apiName] != null);
     if (endpoint == null) {
       throw DataStoreException(
         'No endpoint found for $apiName',
       );
     }
-    return endpoint.values.first.rawValue;
+    return endpoint[apiName]?.name;
   }
 
   @override

--- a/packages/amplify_datastore/lib/src/native_plugin.g.dart
+++ b/packages/amplify_datastore/lib/src/native_plugin.g.dart
@@ -349,8 +349,6 @@ abstract class NativeApiPlugin {
 
   Future<String?> getLatestAuthToken(String providerName);
 
-  String? getEndpointAuthorizationType(String? apiName);
-
   Future<NativeGraphQLResponse> mutate(NativeGraphQLRequest request);
 
   Future<NativeGraphQLResponse> query(NativeGraphQLRequest request);
@@ -378,24 +376,6 @@ abstract class NativeApiPlugin {
               'Argument for dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.getLatestAuthToken was null, expected non-null String.');
           final String? output =
               await api.getLatestAuthToken(arg_providerName!);
-          return output;
-        });
-      }
-    }
-    {
-      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.getEndpointAuthorizationType',
-          codec,
-          binaryMessenger: binaryMessenger);
-      if (api == null) {
-        channel.setMessageHandler(null);
-      } else {
-        channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.getEndpointAuthorizationType was null.');
-          final List<Object?> args = (message as List<Object?>?)!;
-          final String? arg_apiName = (args[0] as String?);
-          final String? output = api.getEndpointAuthorizationType(arg_apiName);
           return output;
         });
       }
@@ -634,13 +614,15 @@ class NativeApiBridge {
 
   static const MessageCodec<Object?> codec = _NativeApiBridgeCodec();
 
-  Future<void> addApiPlugin(List<String?> arg_authProvidersList) async {
+  Future<void> addApiPlugin(List<String?> arg_authProvidersList,
+      Map<String?, String?> arg_endpoints) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.amplify_datastore.NativeApiBridge.addApiPlugin',
         codec,
         binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList =
-        await channel.send(<Object?>[arg_authProvidersList]) as List<Object?>?;
+        await channel.send(<Object?>[arg_authProvidersList, arg_endpoints])
+            as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',

--- a/packages/amplify_datastore/lib/src/native_plugin.g.dart
+++ b/packages/amplify_datastore/lib/src/native_plugin.g.dart
@@ -349,6 +349,8 @@ abstract class NativeApiPlugin {
 
   Future<String?> getLatestAuthToken(String providerName);
 
+  String? getEndpointAuthorizationType(String? apiName);
+
   Future<NativeGraphQLResponse> mutate(NativeGraphQLRequest request);
 
   Future<NativeGraphQLResponse> query(NativeGraphQLRequest request);
@@ -376,6 +378,24 @@ abstract class NativeApiPlugin {
               'Argument for dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.getLatestAuthToken was null, expected non-null String.');
           final String? output =
               await api.getLatestAuthToken(arg_providerName!);
+          return output;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.getEndpointAuthorizationType',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.getEndpointAuthorizationType was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_apiName = (args[0] as String?);
+          final String? output = api.getEndpointAuthorizationType(arg_apiName);
           return output;
         });
       }

--- a/packages/amplify_datastore/pigeons/native_plugin.dart
+++ b/packages/amplify_datastore/pigeons/native_plugin.dart
@@ -30,6 +30,8 @@ abstract class NativeApiPlugin {
   @async
   String? getLatestAuthToken(String providerName);
 
+  String? getEndpointAuthorizationType(String? apiName);
+
   @async
   NativeGraphQLResponse mutate(NativeGraphQLRequest request);
 

--- a/packages/amplify_datastore/pigeons/native_plugin.dart
+++ b/packages/amplify_datastore/pigeons/native_plugin.dart
@@ -30,8 +30,6 @@ abstract class NativeApiPlugin {
   @async
   String? getLatestAuthToken(String providerName);
 
-  String? getEndpointAuthorizationType(String? apiName);
-
   @async
   NativeGraphQLResponse mutate(NativeGraphQLRequest request);
 
@@ -65,7 +63,8 @@ abstract class NativeAuthBridge {
 @HostApi()
 abstract class NativeApiBridge {
   @async
-  void addApiPlugin(List<String> authProvidersList);
+  void addApiPlugin(
+      List<String> authProvidersList, Map<String, String> endpoints);
 
   @async
   void sendSubscriptionEvent(NativeGraphQLSubscriptionResponse event);


### PR DESCRIPTION
*Description of changes:*
Adds missing interface and method Amplify Swift DataStore to retrieve the auth type of a endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
