### PR TITLE
chore: support multiple graphql or rest APIs

### DIFF
--- a/packages/amplify_core/lib/src/config/amplify_config.dart
+++ b/packages/amplify_core/lib/src/config/amplify_config.dart
@@ -3,6 +3,7 @@
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
 
 part 'amplify_config.g.dart';
 
@@ -74,12 +75,14 @@ class AmplifyConfig with AWSEquatable<AmplifyConfig>, AWSSerializable {
     );
   }
 
+  @internal
   AmplifyOutputs toAmplifyOutputs() {
     final appSync = auth?.awsPlugin?.appSync;
     return AmplifyOutputs(
       version: '1',
       auth: auth?.toAuthOutputs(),
       data: api?.toDataOutputs(appSync: appSync),
+      restApi: api?.toRestApiOutputs(),
       analytics: analytics?.toAnalyticsOutputs(),
       notifications: notifications?.toNotificationsOutputs(),
       storage: storage?.toStorageOutputs(),

--- a/packages/amplify_core/lib/src/config/amplify_outputs/amplify_outputs.g.dart
+++ b/packages/amplify_core/lib/src/config/amplify_outputs/amplify_outputs.g.dart
@@ -19,9 +19,11 @@ AmplifyOutputs _$AmplifyOutputsFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] == null
           ? null
           : AuthOutputs.fromJson(json['auth'] as Map<String, dynamic>),
-      data: json['data'] == null
-          ? null
-          : DataOutputs.fromJson(json['data'] as Map<String, dynamic>),
+      data: _dataFromJson(json['data'] as Map<String, Object?>?),
+      restApi: (json['rest_api'] as Map<String, dynamic>?)?.map(
+        (k, e) =>
+            MapEntry(k, RestApiOutputs.fromJson(e as Map<String, dynamic>)),
+      ),
       notifications: json['notifications'] == null
           ? null
           : NotificationsOutputs.fromJson(
@@ -45,7 +47,9 @@ Map<String, dynamic> _$AmplifyOutputsToJson(AmplifyOutputs instance) {
   val['version'] = instance.version;
   writeNotNull('analytics', instance.analytics?.toJson());
   writeNotNull('auth', instance.auth?.toJson());
-  writeNotNull('data', instance.data?.toJson());
+  writeNotNull('data', _dataToJson(instance.data));
+  writeNotNull(
+      'rest_api', instance.restApi?.map((k, e) => MapEntry(k, e.toJson())));
   writeNotNull('notifications', instance.notifications?.toJson());
   writeNotNull('storage', instance.storage?.toJson());
   writeNotNull('custom', instance.custom);

--- a/packages/amplify_core/lib/src/config/amplify_outputs/rest_api/rest_api_outputs.dart
+++ b/packages/amplify_core/lib/src/config/amplify_outputs/rest_api/rest_api_outputs.dart
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'rest_api_outputs.g.dart';
+
+/// {@template amplify_core.amplify_outputs.rest_api_outputs}
+/// An internal representation of Rest API.
+///
+/// This class should not be exposed publicly since the Gen 2 schema does not
+/// support Rest API. This class exists to support Gen 1 configs that use Rest API.
+/// {@endtemplate}
+@zAmplifyOutputsSerializable
+class RestApiOutputs
+    with AWSEquatable<RestApiOutputs>, AWSSerializable, AWSDebuggable {
+  /// {@macro amplify_core.amplify_outputs.rest_api_outputs}
+  const RestApiOutputs({
+    required this.awsRegion,
+    required this.url,
+    this.apiKey,
+    required this.authorizationType,
+  });
+
+  factory RestApiOutputs.fromJson(Map<String, Object?> json) =>
+      _$RestApiOutputsFromJson(json);
+
+  /// The AWS region of Amazon AWS Gateway resources.
+  final String awsRegion;
+
+  /// The AWS Gateway endpoint URL.
+  final String url;
+
+  /// The AppSync API Key.
+  final String? apiKey;
+
+  /// The authorization type.
+  final APIAuthorizationType authorizationType;
+
+  @override
+  List<Object?> get props => [
+        awsRegion,
+        url,
+        apiKey,
+        authorizationType,
+      ];
+
+  @override
+  String get runtimeTypeName => 'RestApiOutputs';
+
+  @override
+  Object? toJson() {
+    return _$RestApiOutputsToJson(this);
+  }
+}

--- a/packages/amplify_core/lib/src/config/amplify_outputs/rest_api/rest_api_outputs.g.dart
+++ b/packages/amplify_core/lib/src/config/amplify_outputs/rest_api/rest_api_outputs.g.dart
@@ -1,0 +1,45 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package
+
+part of 'rest_api_outputs.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+RestApiOutputs _$RestApiOutputsFromJson(Map<String, dynamic> json) =>
+    RestApiOutputs(
+      awsRegion: json['aws_region'] as String,
+      url: json['url'] as String,
+      apiKey: json['api_key'] as String?,
+      authorizationType: $enumDecode(
+          _$APIAuthorizationTypeEnumMap, json['authorization_type']),
+    );
+
+Map<String, dynamic> _$RestApiOutputsToJson(RestApiOutputs instance) {
+  final val = <String, dynamic>{
+    'aws_region': instance.awsRegion,
+    'url': instance.url,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('api_key', instance.apiKey);
+  val['authorization_type'] =
+      _$APIAuthorizationTypeEnumMap[instance.authorizationType]!;
+  return val;
+}
+
+const _$APIAuthorizationTypeEnumMap = {
+  APIAuthorizationType.none: 'NONE',
+  APIAuthorizationType.apiKey: 'API_KEY',
+  APIAuthorizationType.iam: 'AWS_IAM',
+  APIAuthorizationType.oidc: 'OPENID_CONNECT',
+  APIAuthorizationType.userPools: 'AMAZON_COGNITO_USER_POOLS',
+  APIAuthorizationType.function: 'AWS_LAMBDA',
+};

--- a/packages/amplify_core/lib/src/config/analytics/analytics_config.dart
+++ b/packages/amplify_core/lib/src/config/analytics/analytics_config.dart
@@ -4,6 +4,7 @@
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_core/src/config/amplify_outputs/analytics/amazon_pinpoint_outputs.dart';
 import 'package:amplify_core/src/config/amplify_outputs/analytics/analytics_outputs.dart';
+import 'package:meta/meta.dart';
 
 export 'pinpoint_config.dart' hide PinpointPluginConfigFactory;
 
@@ -33,6 +34,7 @@ class AnalyticsConfig extends AmplifyPluginConfigMap {
   @override
   Map<String, Object?> toJson() => _$AnalyticsConfigToJson(this);
 
+  @internal
   AnalyticsOutputs? toAnalyticsOutputs() {
     final plugin = awsPlugin?.pinpointAnalytics;
     if (plugin == null) {

--- a/packages/amplify_core/lib/src/config/api/api_config.dart
+++ b/packages/amplify_core/lib/src/config/api/api_config.dart
@@ -3,6 +3,8 @@
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_core/src/config/amplify_outputs/data/data_outputs.dart';
+import 'package:amplify_core/src/config/amplify_outputs/rest_api/rest_api_outputs.dart';
+import 'package:meta/meta.dart';
 
 export 'aws_api_config.dart' hide AWSApiPluginConfigFactory;
 
@@ -32,24 +34,59 @@ class ApiConfig extends AmplifyPluginConfigMap {
   @override
   Map<String, Object?> toJson() => _$ApiConfigToJson(this);
 
-  DataOutputs? toDataOutputs({AWSConfigMap<CognitoAppSyncConfig>? appSync}) {
-    final plugin = appSync?.default$;
+  @internal
+  Map<String, DataOutputs>? toDataOutputs({
+    AWSConfigMap<CognitoAppSyncConfig>? appSync,
+  }) {
+    final plugins = _getPlugins(EndpointType.graphQL);
+    if (plugins == null) {
+      return null;
+    }
+    return plugins.map((key, plugin) {
+      final defaultAuthorizationType = plugin.authorizationType;
+      final awsRegion = plugin.region;
+      final url = plugin.endpoint;
+      final allModes = (appSync?.all.values ?? []);
+      final authorizationTypes = allModes
+          .where((plugin) => plugin.apiUrl == url && plugin.region == awsRegion)
+          .map((config) => config.authMode)
+          .where((mode) => mode != defaultAuthorizationType)
+          .toList();
+      final data = DataOutputs(
+        awsRegion: awsRegion,
+        url: url,
+        defaultAuthorizationType: defaultAuthorizationType,
+        apiKey: plugin.apiKey,
+        authorizationTypes: authorizationTypes,
+      );
+      return MapEntry(key, data);
+    });
+  }
+
+  @internal
+  Map<String, RestApiOutputs>? toRestApiOutputs() {
+    final plugins = _getPlugins(EndpointType.rest);
+    if (plugins == null) {
+      return null;
+    }
+    return plugins.map((key, plugin) {
+      final rest = RestApiOutputs(
+        awsRegion: plugin.region,
+        url: plugin.endpoint,
+        authorizationType: plugin.authorizationType,
+        apiKey: plugin.apiKey,
+      );
+      return MapEntry(key, rest);
+    });
+  }
+
+  Map<String, AWSApiConfig>? _getPlugins(EndpointType endpointType) {
+    final plugin = awsPlugin;
     if (plugin == null) {
       return null;
     }
-    final region = plugin.region;
-    final url = plugin.apiUrl;
-    final apiKey = plugin.apiKey;
-    final defaultAuthorizationType = plugin.authMode;
-    final modes = appSync?.all.values.map((config) => config.authMode) ?? [];
-    final authorizationTypes =
-        modes.where((mode) => mode != defaultAuthorizationType).toList();
-    return DataOutputs(
-      awsRegion: region,
-      url: url,
-      defaultAuthorizationType: defaultAuthorizationType,
-      apiKey: apiKey,
-      authorizationTypes: authorizationTypes,
-    );
+    final entries =
+        plugin.all.entries.where((p) => p.value.endpointType == endpointType);
+    return Map<String, AWSApiConfig>.fromEntries(entries);
   }
 }

--- a/packages/amplify_core/lib/src/config/auth/auth_config.dart
+++ b/packages/amplify_core/lib/src/config/auth/auth_config.dart
@@ -6,6 +6,7 @@ import 'package:amplify_core/src/config/amplify_outputs/auth/auth_outputs.dart';
 import 'package:amplify_core/src/config/amplify_outputs/auth/oauth_outputs.dart';
 import 'package:amplify_core/src/config/amplify_outputs/auth/oauth_response_type.dart';
 import 'package:amplify_core/src/config/amplify_outputs/auth/password_policy.dart';
+import 'package:meta/meta.dart';
 
 export 'cognito_config.dart' hide CognitoPluginConfigFactory;
 
@@ -79,6 +80,7 @@ class AuthConfig extends AmplifyPluginConfigMap {
   @override
   AuthConfig copy() => AuthConfig(plugins: Map.of(plugins));
 
+  @internal
   AuthOutputs? toAuthOutputs() {
     final plugin = awsPlugin?.auth?.default$;
     final userPool = awsPlugin?.cognitoUserPool?.default$;

--- a/packages/amplify_core/lib/src/config/storage/storage_config.dart
+++ b/packages/amplify_core/lib/src/config/storage/storage_config.dart
@@ -3,6 +3,7 @@
 
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_core/src/config/amplify_outputs/storage/storage_outputs.dart';
+import 'package:meta/meta.dart';
 
 export 's3_config.dart' hide S3PluginConfigFactory;
 
@@ -32,6 +33,7 @@ class StorageConfig extends AmplifyPluginConfigMap {
   @override
   Map<String, Object?> toJson() => _$StorageConfigToJson(this);
 
+  @internal
   StorageOutputs? toStorageOutputs() {
     final plugin = awsPlugin;
     if (plugin == null) {

--- a/packages/amplify_core/test/config/amplify_outputs_mapping/amplify_outputs_mapping_test.dart
+++ b/packages/amplify_core/test/config/amplify_outputs_mapping/amplify_outputs_mapping_test.dart
@@ -41,6 +41,57 @@ void main() {
       expect(mappedOutputs.data, null);
       expect(mappedOutputs.notifications, null);
     });
+
+    test('maps config with multiple api plugins', () async {
+      // hand written config for testing purposes.
+      const config = '''
+        {
+          "api": {
+            "plugins": {
+              "awsAPIPlugin": {
+                "data1": {
+                  "endpointType": "GraphQL",
+                  "endpoint": "fake-data-url-1",
+                  "region": "us-east-1",
+                  "authorizationType": "AWS_IAM",
+                  "apiKey": "fake-data-api-key"
+                },
+                "data2": {
+                  "endpointType": "GraphQL",
+                  "endpoint": "fake-data-url-2",
+                  "region": "us-east-1",
+                  "authorizationType": "AWS_IAM",
+                  "apiKey": "fake-data-api-key"
+                },
+                "rest1": {
+                  "endpointType": "REST",
+                  "endpoint": "fake-rest-url-1",
+                  "region": "us-east-1",
+                  "authorizationType": "AWS_IAM",
+                  "apiKey": "fake-data-api-key"
+                },
+                "rest2": {
+                  "endpointType": "REST",
+                  "endpoint": "fake-rest-url-2",
+                  "region": "us-east-1",
+                  "authorizationType": "AWS_IAM",
+                  "apiKey": "fake-data-api-key"
+                }
+              }
+            }
+          }
+        }
+      ''';
+      final configJson = jsonDecode(config) as Map<String, Object?>;
+      final amplifyConfig = AmplifyConfig.fromJson(configJson);
+      final mappedOutputs = amplifyConfig.toAmplifyOutputs();
+      expect(mappedOutputs.data?.length, 2);
+      expect(mappedOutputs.restApi?.length, 2);
+      final dataUrls = mappedOutputs.data?.values.map((d) => d.url);
+      final restUrls = mappedOutputs.restApi?.values.map((d) => d.url);
+      expect(dataUrls, ['fake-data-url-1', 'fake-data-url-2']);
+      expect(restUrls, ['fake-rest-url-1', 'fake-rest-url-2']);
+    });
   });
 }
 


### PR DESCRIPTION
*Description of changes:*
- mark all `to*Outputs()` methods as internal
- add rest API to AmplifyOutputs, add mapping from AmplifyOutputs to AmplifyConfig
- update AmplifyOutputs to allow for multiple GraphQL APIs, add custom json mapping
- add tests for multiple API plugins


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
