### PR TITLE
Feat: Adding interfaces for fetchCurrentDevice API

### DIFF
--- a/packages/amplify_core/lib/src/category/amplify_auth_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_auth_category.dart
@@ -1355,6 +1355,37 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
         () => defaultPlugin.rememberDevice(),
       );
 
+  /// {@template amplify_core.amplify_auth_category.fetch_current_device}
+  /// Retrieves the current device.
+  ///
+  /// For more information about device tracking, see the
+  /// [Amplify docs](https://docs.amplify.aws/lib/auth/device_features/q/platform/flutter/).
+  ///
+  /// ## Examples
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="imports"?>
+  /// ```dart
+  /// import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+  /// import 'package:amplify_flutter/amplify_flutter.dart';
+  /// ```
+  ///
+  /// <?code-excerpt "doc/lib/auth.dart" region="fetch-current-device"?>
+  /// ```dart
+  /// Future<AuthDevice> getCurrentUserDevice() async {
+  ///   try {
+  ///     final device = await Amplify.Auth.fetchCurrentDevice();
+  ///     safePrint('Device: $device');
+  ///   } on AuthException catch (e) {
+  ///     safePrint('Get current device failed with error: $e');
+  ///   }
+  /// }
+  /// ```
+  /// {@endtemplate}
+  Future<AuthDevice> fetchCurrentDevice() => identifyCall(
+        AuthCategoryMethod.fetchCurrentDevice,
+        () => defaultPlugin.fetchCurrentDevice(),
+      );
+
   /// {@template amplify_core.amplify_auth_category.forget_device}
   /// Forgets the current device.
   ///

--- a/packages/amplify_core/lib/src/http/amplify_category_method.dart
+++ b/packages/amplify_core/lib/src/http/amplify_category_method.dart
@@ -52,7 +52,8 @@ enum AuthCategoryMethod with AmplifyCategoryMethod {
   setMfaPreference('49'),
   getMfaPreference('50'),
   setUpTotp('51'),
-  verifyTotpSetup('52');
+  verifyTotpSetup('52'),
+  fetchCurrentDevice('59');
 
   const AuthCategoryMethod(this.method);
 

--- a/packages/amplify_core/lib/src/plugin/amplify_auth_plugin_interface.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_auth_plugin_interface.dart
@@ -189,6 +189,11 @@ abstract class AuthPluginInterface extends AmplifyPluginInterface {
     throw UnimplementedError('forgetDevice() has not been implemented.');
   }
 
+  /// {@macro amplify_core.amplify_auth_category.fetch_current_device}
+  Future<AuthDevice> fetchCurrentDevice() {
+    throw UnimplementedError('fetchCurrentDevice() has not been implemented.');
+  }
+
   /// {@macro amplify_core.amplify_auth_category.fetch_devices}
   Future<List<AuthDevice>> fetchDevices() {
     throw UnimplementedError('fetchDevices() has not been implemented.');

--- a/packages/auth/amplify_auth_cognito_dart/example/lib/common.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/lib/common.dart
@@ -104,6 +104,10 @@ Future<List<AuthUserAttribute>> fetchUserAttributes() async {
   return Amplify.Auth.fetchUserAttributes();
 }
 
+Future<AuthDevice> fetchCurrentDevice() async {
+  return Amplify.Auth.fetchCurrentDevice();
+}
+
 Future<List<AuthDevice>> fetchDevices() async {
   return Amplify.Auth.fetchDevices();
 }


### PR DESCRIPTION
*Issue #, if available:*

Issue https://github.com/aws-amplify/amplify-flutter/issues/1472

*Description of changes:*

Adding interfaces for requested API to fetchCurrentDevice information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
