### PR TITLE
fix(api): GraphQLResponse.toString() include data & errors

### DIFF
--- a/packages/amplify_core/lib/src/types/api/graphql/graphql_response.dart
+++ b/packages/amplify_core/lib/src/types/api/graphql/graphql_response.dart
@@ -33,10 +33,10 @@ class GraphQLResponse<T> {
 
   @override
   String toString() {
-    if (hasErrors) {
-      final errors = this.errors.map((error) => error.toJson()).toList();
-      return 'GraphQLResponse<$T> error: ${prettyPrintJson(errors)}';
-    }
-    return 'GraphQLResponse<$T> success: ${prettyPrintJson(data)}';
+    final obj = {
+      'data': data,
+      'errors': errors,
+    };
+    return 'GraphQLResponse<$T>: ${prettyPrintJson(obj)}';
   }
 }


### PR DESCRIPTION
*Description of changes:*
This changes the output of `GraphQLResponse.toString()` to include both `data` and `error` properties regardless of the presence of errors. Since a valid GraphQL response could contain a both, users previously would be missing context when errors were present. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
