### PR TITLE
Deprecated: feat(storage): add delimiter support to list API

### DIFF
--- a/packages/amplify_core/lib/src/types/storage/list_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/list_options.dart
@@ -16,7 +16,10 @@ class StorageListOptions
     this.pageSize = 1000,
     this.nextToken,
     this.pluginOptions,
+    // this.subpathStrategy,
   });
+
+  // final SubpathStrategy subpathStrategy;
 
   /// The number of object to be listed in each page.
   final int pageSize;

--- a/packages/amplify_core/lib/src/types/storage/list_result.dart
+++ b/packages/amplify_core/lib/src/types/storage/list_result.dart
@@ -9,10 +9,10 @@ import 'package:amplify_core/amplify_core.dart';
 class StorageListResult<Item extends StorageItem> {
   /// {@macro amplify_core.storage.list_result}
   const StorageListResult(
+    // this.excludedSubpaths,
     this.items, {
     required this.hasNextPage,
     this.nextToken,
-    // this.excludedSubpaths,
   });
 
   /// The objects listed in the current page.

--- a/packages/amplify_core/lib/src/types/storage/list_result.dart
+++ b/packages/amplify_core/lib/src/types/storage/list_result.dart
@@ -12,10 +12,13 @@ class StorageListResult<Item extends StorageItem> {
     this.items, {
     required this.hasNextPage,
     this.nextToken,
+    // this.excludedSubpaths,
   });
 
   /// The objects listed in the current page.
   final List<Item> items;
+
+  // final List<String> excludedSubpaths;
 
   /// Whether has next page that can be listed using [nextToken].
   final bool hasNextPage;

--- a/packages/amplify_core/lib/src/types/storage/subpath_strategy.dart
+++ b/packages/amplify_core/lib/src/types/storage/subpath_strategy.dart
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+/// {@template amplify_core.storage.subpath_strategy}
+/// Presents .. 
+/// {@endtemplate}
+class StorageSubpathStrategy {
+  /// {@macro amplify_core.storage.subpath_strategy}
+  const StorageSubpathStrategy({
+    required this.path,
+    this.options,
+  });
+
+  /// ..
+  final StoragePath path;
+
+  /// ..
+  final StorageListOptions? options;
+}

--- a/packages/amplify_core/lib/src/types/storage/subpath_strategy.dart
+++ b/packages/amplify_core/lib/src/types/storage/subpath_strategy.dart
@@ -4,11 +4,11 @@
 // import 'package:amplify_core/amplify_core.dart';
 //
 // /// {@template amplify_core.storage.subpath_strategy}
-// /// Presents .. 
+// /// Presents ..
 // /// {@endtemplate}
-// class StorageSubpathStrategy {
+// class SubpathStrategy {
 //   /// {@macro amplify_core.storage.subpath_strategy}
-//   const StorageSubpathStrategy({
+//   const SubpathStrategy({
 //     required this.path,
 //     this.options,
 //   });

--- a/packages/amplify_core/lib/src/types/storage/subpath_strategy.dart
+++ b/packages/amplify_core/lib/src/types/storage/subpath_strategy.dart
@@ -1,21 +1,21 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-import 'package:amplify_core/amplify_core.dart';
-
-/// {@template amplify_core.storage.subpath_strategy}
-/// Presents .. 
-/// {@endtemplate}
-class StorageSubpathStrategy {
-  /// {@macro amplify_core.storage.subpath_strategy}
-  const StorageSubpathStrategy({
-    required this.path,
-    this.options,
-  });
-
-  /// ..
-  final StoragePath path;
-
-  /// ..
-  final StorageListOptions? options;
-}
+// // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// // SPDX-License-Identifier: Apache-2.0
+//
+// import 'package:amplify_core/amplify_core.dart';
+//
+// /// {@template amplify_core.storage.subpath_strategy}
+// /// Presents .. 
+// /// {@endtemplate}
+// class StorageSubpathStrategy {
+//   /// {@macro amplify_core.storage.subpath_strategy}
+//   const StorageSubpathStrategy({
+//     required this.path,
+//     this.options,
+//   });
+//
+//   /// ..
+//   final StoragePath path;
+//
+//   /// ..
+//   final StorageListOptions? options;
+// }

--- a/packages/storage/amplify_storage_s3/example/integration_test/list_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/list_test.dart
@@ -71,7 +71,9 @@ void main() {
       });
 
       group('list() with options', () {
-        group('excluding sub paths', () {
+        group(
+            '@Deprecated for StorageListOptions.subpathStrategy, excluding sub paths with excludeSubPaths & delimiter',
+            () {
           testWidgets('default delimiter', (_) async {
             final listResult = await Amplify.Storage.list(
               path: StoragePath.fromString('$uniquePrefix/'),
@@ -111,6 +113,44 @@ void main() {
             );
             expect(listResult.metadata.delimiter, '#');
           });
+        });
+
+        group('excluding sub paths with StorageListOptions.subpathStrategy',
+            () {
+          // testWidgets('default delimiter', (_) async {
+          //   final listResult = await Amplify.Storage.list(
+          //     path: StoragePath.fromString('$uniquePrefix/'),
+          //     options: const StorageListOptions(
+          //        subpaths: Subpaths.exclude(delimiter: "-"),
+          //     ),
+          //   ).result as S3ListResult;
+          //
+          //   expect(listResult.items.length, 3);
+          //   expect(listResult.items.first.path, contains('file1.txt'));
+          //
+          //   expect(listResult.metadata.subPaths.length, 1);
+          //   expect(listResult.metadata.subPaths.first, '$uniquePrefix/subdir/');
+          //   expect(listResult.metadata.delimiter, '/');
+          // });
+          //
+          // testWidgets('custom delimiter', (_) async {
+          //   final listResult = await Amplify.Storage.list(
+          //     path: StoragePath.fromString('$uniquePrefix/'),
+          //     options: const StorageListOptions(
+          // subpaths: Subpaths.exclude(delimiter: "-"),
+          //     ),
+          //   ).result as S3ListResult;
+          //
+          //   expect(listResult.items.length, 3);
+          //   expect(listResult.items.first.path, contains('file1.txt'));
+          //
+          //   expect(listResult.metadata.subPaths.length, 1);
+          //   expect(
+          //     listResult.metadata.subPaths.first,
+          //     '$uniquePrefix/subdir2#',
+          //   );
+          //   expect(listResult.metadata.delimiter, '-');
+          // });
         });
 
         testWidgets('should respect pageSize limitation', (_) async {

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_plugin_options.dart
@@ -41,10 +41,12 @@ class S3ListPluginOptions extends StorageListPluginOptions {
 
   /// Whether to exclude objects under the sub paths of the path to list. The
   /// default value is `false`.
+  // @Deprecated('use StorageListOptions.subpathStrategy instead')
   final bool excludeSubPaths;
 
   /// The delimiter to use when evaluating sub paths. If [excludeSubPaths] is
   /// false, this value has no impact on behavior.
+  // @Deprecated('use StorageListOptions.subpathStrategy instead')
   final String delimiter;
 
   /// Whether to list all objects under a given path without pagination. The

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_result.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_result.dart
@@ -57,6 +57,7 @@ class S3ListResult extends StorageListResult<S3Item> {
 }
 
 /// The metadata returned from the Storage S3 plugin `list` API.
+// @Deprecated('use StorageListResult.excludedSubpaths instead')
 class S3ListMetadata {
   /// Creates a S3ListMetadata from the `commonPrefix` and `delimiter`
   /// properties of the [s3.ListObjectsV2Output].

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
@@ -153,7 +153,7 @@ void main() {
       });
 
       test(
-          'should attach delimiter to the ListObjectV2Request when options excludeSubPaths is set to true',
+          'Deprecated for StorageListOptions.subpathStrategy, should attach delimiter to the ListObjectV2Request when options excludeSubPaths is set to true',
           () async {
         final testS3Objects = [1, 2, 3, 4, 5]
             .map(
@@ -211,6 +211,67 @@ void main() {
         );
 
         expect(result.metadata.subPaths, equals(testSubPaths));
+      });
+
+      test(
+          'StorageListOptions.subpathStrategy, should attach delimiter to the ListObjectV2Request when StorageListOptions.subpathStrategy.exclude() is called',
+          () async {
+        // final testS3Objects = [1, 2, 3, 4, 5]
+        //     .map(
+        //       (e) => S3Object(
+        //         key: '${testPrefix}object-$e',
+        //         size: Int64(100 * 4),
+        //         eTag: 'object-$e-eTag',
+        //       ),
+        //     )
+        //     .toList();
+        // const testPath = StoragePath.fromString('album');
+        // const testOptions = StorageListOptions(
+        //   pageSize: testPageSize,
+        //   pluginOptions: S3ListPluginOptions(excludeSubPaths: true),
+        // );
+        // const testSubPaths = [
+        //   'album#folder1',
+        //   'album#folder2',
+        //   'album#folder1#sub-folder1',
+        // ];
+        // final testPaginatedResult =
+        //     PaginatedResult<ListObjectsV2Output, int, String>(
+        //   ListObjectsV2Output(
+        //     contents: testS3Objects,
+        //     commonPrefixes: [
+        //       CommonPrefix(prefix: testSubPaths[0]),
+        //       CommonPrefix(prefix: testSubPaths[1]),
+        //       CommonPrefix(
+        //         prefix: testSubPaths[2],
+        //       ),
+        //     ],
+        //     delimiter: testDelimiter,
+        //     name: testBucketName,
+        //     maxKeys: testPageSize,
+        //   ),
+        //   next: ([int? pageSize]) {
+        //     throw UnimplementedError();
+        //   },
+        //   nextContinuationToken: testNextContinuationToken,
+        // );
+        // final smithyOperation = MockSmithyOperation<
+        //     PaginatedResult<ListObjectsV2Output, int, String>>();
+        //
+        // when(
+        //   () => smithyOperation.result,
+        // ).thenAnswer((_) async => testPaginatedResult);
+        //
+        // when(
+        //   () => s3Client.listObjectsV2(any()),
+        // ).thenAnswer((_) => smithyOperation);
+        //
+        // final result = await storageS3Service.list(
+        //   path: testPath,
+        //   options: testOptions,
+        // );
+        //
+        // expect(result.metadata.subPaths, equals(testSubPaths));
       });
 
       test(


### PR DESCRIPTION
# Deprecated, see [new pr](https://github.com/aws-amplify/amplify-flutter/pull/5192)

*Description of changes:*

~~This change will enable delimiter support by passing a `Delimiter` option in the underlying `ListObjectsV2` API.~~

~~Main changes to list API as specified:~~
~~- add `SubpathStrategy` class~~
~~- add `SubpathStrategy` to `StorageListOptions` as member~~
~~- add `@Deprecated` decorators to `S3ListPluginOptions.excludeSubPaths`, `S3ListPluginOptions.delimiter`, and `S3ListMetadata.subPaths`~~
~~- add `excludedSubpaths: List<String>` to `StorageListResult`~~
~~- add unit and integration tests~~

~~This is a parent PR. see [implementation](https://github.com/aws-amplify/amplify-flutter/pull/5112) and unit & integration tests hotlinked splits~~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
