### PR TITLE
fix(notifications): allow configuration when auth token is expired

### DIFF
--- a/packages/notifications/push/amplify_push_notifications_pinpoint/lib/src/pinpoint_provider.dart
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/lib/src/pinpoint_provider.dart
@@ -190,6 +190,15 @@ class PinpointProvider implements ServiceProviderClient {
       // `AnalyticsException` converts `AWSHttpException` to `NetworkException`.
     } on NetworkException catch (e) {
       _logger.error('Network problem when registering device: ', e);
+      // This is to allow configuration if `EndpointClient.updateEndpoint()`
+      // throws UnknownException due to expired token.
+      // the underlying exception is `NotAuthorizedException` with
+      // `Invalid login token. Token expired` message.
+    } on UnknownException catch (e) {
+      _logger.error(
+        'Could not update Pinpoint endpoint to register the device: ',
+        e,
+      );
     }
   }
 

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/test/pinpoint_provider_test.dart
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/test/pinpoint_provider_test.dart
@@ -319,6 +319,48 @@ void main() {
       verify(mockEndpointClient.updateEndpoint);
     });
 
+    test('registerDevice should run successfully when token is expired',
+        () async {
+      when(
+        () => mockAmplifyAuthProviderRepository.getAuthProvider(
+          APIAuthorizationType.iam.authProviderToken,
+        ),
+      ).thenReturn(awsIamAmplifyAuthProvider);
+      when(
+        () => mockAnalyticsClient.init(
+          pinpointAppId: any(named: 'pinpointAppId'),
+          region: any(named: 'region'),
+          authProvider: any(named: 'authProvider'),
+        ),
+      ).thenAnswer((realInvocation) async {});
+
+      final mockEndpointClient = MockEndpointClient();
+
+      when(mockEndpointClient.updateEndpoint)
+          .thenThrow(const UnknownException('message'));
+
+      when(
+        () => mockAnalyticsClient.endpointClient,
+      ).thenReturn(mockEndpointClient);
+
+      await expectLater(
+        pinpointProvider.init(
+          config: notificationsPinpointConfig,
+          authProviderRepo: mockAmplifyAuthProviderRepository,
+          analyticsClient: mockAnalyticsClient,
+        ),
+        completes,
+      );
+
+      expect(
+        pinpointProvider.registerDevice(
+          '',
+        ),
+        completes,
+      );
+      verify(mockEndpointClient.updateEndpoint);
+    });
+
     test('recordEvent should run successfully', () async {
       when(
         () => mockAmplifyAuthProviderRepository.getAuthProvider(


### PR DESCRIPTION
*Issue #, if available:* #5109

*Description of changes:*
- this is to allow Amplify Push Notifications to configure successfully when refresh token is expired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
