### PR TITLE
poc(delim): potential jank exposure from bad deprecation transition handling

### DIFF
--- a/packages/amplify_core/lib/src/category/amplify_storage_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_storage_category.dart
@@ -235,3 +235,35 @@ class StorageCategory extends AmplifyCategory<StoragePluginInterface> {
     );
   }
 }
+
+class SubpathStrategy with AWSSerializable<Map<String, Object?>> {
+  /// Default constructor syntactic sugar for DX parity
+  const SubpathStrategy.include() : this._();
+
+  const SubpathStrategy._({
+    this.excludeSubPaths = false,
+    this.delimiter = '/',
+  });
+
+  /// Constructor for SubpathStrategy for excluding subpaths, option to specify the delimiter
+  const SubpathStrategy.exclude({String? delimiter = '/'})
+      : this._(
+          excludeSubPaths: true,
+          delimiter: delimiter ?? '/',
+        );
+
+  /// Whether to exclude objects under the sub paths of the path to list.
+  final bool excludeSubPaths;
+
+  /// The delimiter to use when evaluating sub paths. If [excludeSubPaths] is
+  /// false, this value has no impact on behavior.
+  final String delimiter;
+
+  @override
+  Map<String, Object?> toJson() {
+    return <String, dynamic>{
+      'excludeSubPaths': excludeSubPaths,
+      'delimiter': delimiter,
+    };
+  }
+}

--- a/packages/amplify_core/lib/src/types/storage/list_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/list_options.dart
@@ -12,12 +12,19 @@ class StorageListOptions
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
   /// {@macro amplify_core.storage.list_options}
-  const StorageListOptions({
+  StorageListOptions({
     this.pageSize = 1000,
     this.nextToken,
     this.pluginOptions,
-    this.subpathStrategy = const SubpathStrategy.include(),
-  });
+    required this.subpathStrategy,
+  }) {
+    // ignore: deprecated_member_use_from_same_package
+    if (pluginOptions?.excludeSubPaths != subpathStrategy.excludeSubPaths) {
+      throw ArgumentError(
+        'pluginOptions cannot be required if excludedSubpaths is false.',
+      );
+    }
+  }
 
   /// The number of object to be listed in each page.
   final int pageSize;
@@ -55,6 +62,10 @@ abstract class StorageListPluginOptions
         AWSEquatable<StorageListPluginOptions>,
         AWSSerializable<Map<String, Object?>>,
         AWSDebuggable {
+  @Deprecated('use subpathStrategy.excludeSubPaths instead')
+  final bool excludeSubPaths;
+
   /// {@macro amplify_core.storage.list_plugin_options}
-  const StorageListPluginOptions();
+  // ignore: deprecated_consistency, sort_constructors_first, avoid_positional_boolean_parameters
+  const StorageListPluginOptions(this.excludeSubPaths);
 }

--- a/packages/amplify_core/lib/src/types/storage/list_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/list_options.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:aws_common/aws_common.dart';
+import 'package:amplify_core/amplify_core.dart';
 
 /// {@template amplify_core.storage.list_options}
 /// Configurable options for `Amplify.Storage.list`.
@@ -16,6 +16,7 @@ class StorageListOptions
     this.pageSize = 1000,
     this.nextToken,
     this.pluginOptions,
+    this.subpathStrategy = const SubpathStrategy.include(),
   });
 
   /// The number of object to be listed in each page.
@@ -27,8 +28,12 @@ class StorageListOptions
   /// {@macro amplify_core.storage.list_plugin_options}
   final StorageListPluginOptions? pluginOptions;
 
+  /// Subpathstrategy for specifying storage subpath behavior
+  final SubpathStrategy subpathStrategy;
+
   @override
-  List<Object?> get props => [pageSize, nextToken, pluginOptions];
+  List<Object?> get props =>
+      [pageSize, nextToken, pluginOptions, subpathStrategy];
 
   @override
   String get runtimeTypeName => 'StorageListOptions';
@@ -38,6 +43,7 @@ class StorageListOptions
         'pageSize': pageSize,
         'nextToken': nextToken,
         'pluginOptions': pluginOptions?.toJson(),
+        'subpathStrategy': subpathStrategy.toJson(),
       };
 }
 

--- a/packages/amplify_core/lib/src/types/storage/list_result.dart
+++ b/packages/amplify_core/lib/src/types/storage/list_result.dart
@@ -9,10 +9,14 @@ import 'package:amplify_core/amplify_core.dart';
 class StorageListResult<Item extends StorageItem> {
   /// {@macro amplify_core.storage.list_result}
   const StorageListResult(
+    this.excludedSubpaths,
     this.items, {
     required this.hasNextPage,
     this.nextToken,
   });
+
+  /// The subpaths that have been excluded
+  final List<String> excludedSubpaths;
 
   /// The objects listed in the current page.
   final List<Item> items;

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -133,7 +133,10 @@ class AmplifyStorageS3Dart extends StoragePluginInterface
       pluginOptions: options?.pluginOptions,
       defaultPluginOptions: const S3ListPluginOptions(),
     );
+
     final s3Options = StorageListOptions(
+      subpathStrategy:
+          options?.subpathStrategy ?? const SubpathStrategy.include(),
       pluginOptions: s3PluginOptions,
       nextToken: options?.nextToken,
       pageSize: options?.pageSize ?? 1000,

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_plugin_options.dart
@@ -11,16 +11,18 @@ part 's3_list_plugin_options.g.dart';
 @zAmplifySerializable
 class S3ListPluginOptions extends StorageListPluginOptions {
   /// {@macro storage.amplify_storage_s3.list_plugin_options}
+
   const S3ListPluginOptions({
+    // ignore: avoid_unused_constructor_parameters
     bool excludeSubPaths = false,
+    // ignore: avoid_unused_constructor_parameters
     String delimiter = '/',
-  }) : this._(
-          excludeSubPaths: excludeSubPaths,
-          delimiter: delimiter,
-        );
+  }) : this._();
 
   const S3ListPluginOptions._({
+    // ignore: deprecated_consistency
     this.excludeSubPaths = false,
+    // ignore: deprecated_consistency
     this.delimiter = '/',
     this.listAll = false,
   });
@@ -29,6 +31,7 @@ class S3ListPluginOptions extends StorageListPluginOptions {
   ///
   /// Use this to list all objects without pagination.
   const S3ListPluginOptions.listAll({
+    @Deprecated('use subpathStrategy.excludeSubPaths instead')
     bool excludeSubPaths = false,
   }) : this._(
           excludeSubPaths: excludeSubPaths,
@@ -41,10 +44,11 @@ class S3ListPluginOptions extends StorageListPluginOptions {
 
   /// Whether to exclude objects under the sub paths of the path to list. The
   /// default value is `false`.
+  @Deprecated('use subpathStrategy.excludeSubPaths instead')
   final bool excludeSubPaths;
 
-  /// The delimiter to use when evaluating sub paths. If [excludeSubPaths] is
-  /// false, this value has no impact on behavior.
+  /// The delimiter formerly used to evaluate subpaths, superceded by SubpathStrategy.exclude(delimiter = '/') instead.
+  @Deprecated('use subpathStrategy.delimiter instead')
   final String delimiter;
 
   /// Whether to list all objects under a given path without pagination. The
@@ -53,10 +57,12 @@ class S3ListPluginOptions extends StorageListPluginOptions {
   /// This can be set by using [S3ListPluginOptions.listAll].
   ///
   /// Use with caution if numerous objects are under the given path.
+  // ignore: deprecated_consistency
   final bool listAll;
 
   @override
   List<Object?> get props => [
+        // ignore: deprecated_member_use_from_same_package
         excludeSubPaths,
         listAll,
       ];

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_plugin_options.dart
@@ -21,7 +21,7 @@ class S3ListPluginOptions extends StorageListPluginOptions {
 
   const S3ListPluginOptions._({
     // ignore: deprecated_consistency
-    this.excludeSubPaths = false,
+    super.excludeSubPaths,
     // ignore: deprecated_consistency
     this.delimiter = '/',
     this.listAll = false,

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_result.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_result.dart
@@ -13,6 +13,7 @@ import 'package:smithy/smithy.dart';
 class S3ListResult extends StorageListResult<S3Item> {
   /// {@macro storage.amplify_storage_s3.list_result}
   S3ListResult(
+    super.excludedSubpaths,
     super.items, {
     required super.hasNextPage,
     required this.metadata,
@@ -26,13 +27,20 @@ class S3ListResult extends StorageListResult<S3Item> {
     PaginatedResult<s3.ListObjectsV2Output, int, String> paginatedResult,
   ) {
     final output = paginatedResult.items;
+    // ignore: deprecated_member_use_from_same_package
     final metadata = S3ListMetadata.fromS3CommonPrefixes(
-      commonPrefixes: output.commonPrefixes?.toList(),
       delimiter: output.delimiter,
     );
+
+    final subPaths = output.commonPrefixes
+        ?.map((commonPrefix) => commonPrefix.prefix)
+        .whereType<String>()
+        .toList();
+
     final items = output.contents?.map(S3Item.fromS3Object).toList();
 
     return S3ListResult(
+      subPaths ?? <String>[],
       items ?? const <S3Item>[],
       hasNextPage: paginatedResult.hasNext,
       nextToken: paginatedResult.nextContinuationToken,
@@ -43,8 +51,14 @@ class S3ListResult extends StorageListResult<S3Item> {
   /// Merges two instances of [S3ListResult] into one.
   S3ListResult merge(S3ListResult other) {
     final items = <S3Item>[...this.items, ...other.items];
-    final metadata = this.metadata.merge(other.metadata);
+
+    final mergedSubPaths = <String>[
+      ...excludedSubpaths,
+      ...other.excludedSubpaths,
+    ];
+
     return S3ListResult(
+      mergedSubPaths,
       items,
       hasNextPage: other.hasNextPage,
       nextToken: other.nextToken,
@@ -59,17 +73,23 @@ class S3ListResult extends StorageListResult<S3Item> {
 /// The metadata returned from the Storage S3 plugin `list` API.
 class S3ListMetadata {
   /// Creates a S3ListMetadata from the `commonPrefix` and `delimiter`
-  /// properties of the [s3.ListObjectsV2Output].
+  /// properties of the [s3.ListObjectsV2Output]. Superceded by StorageListResult.fromPaginatedResult()
+  @Deprecated(
+    'use StorageListResult.fromPaginatedResult or S3ListMetadata.fromDelimiter instead',
+  )
   factory S3ListMetadata.fromS3CommonPrefixes({
+    @Deprecated('use StorageListResult.fromPaginatedResult instead')
     List<s3.CommonPrefix>? commonPrefixes,
     String? delimiter,
   }) {
+    @Deprecated('use StorageListResult.excludedSubpaths instead')
     final subPaths = commonPrefixes
         ?.map((commonPrefix) => commonPrefix.prefix)
         .whereType<String>()
         .toList();
 
     return S3ListMetadata._(
+      // ignore: deprecated_member_use_from_same_package
       subPaths: subPaths,
       delimiter: delimiter,
     );
@@ -78,10 +98,13 @@ class S3ListMetadata {
   S3ListMetadata._({
     List<String>? subPaths,
     this.delimiter,
+    // ignore: deprecated_member_use_from_same_package
   }) : subPaths = subPaths ?? const [];
 
-  /// Merges two instances of [S3ListMetadata] into one.
+  /// Formerly merged two instances of [S3ListMetadata] into one. Superceded by StorageListResult.merge().
+  @Deprecated('use StorageListResult.merge instead')
   S3ListMetadata merge(S3ListMetadata other) {
+    // ignore: deprecated_member_use_from_same_package
     final subPaths = <String>[...this.subPaths, ...other.subPaths];
     return S3ListMetadata._(subPaths: subPaths, delimiter: other.delimiter);
   }
@@ -89,6 +112,7 @@ class S3ListMetadata {
   /// Sub paths under the `path` parameter calling the `list` API.
   ///
   /// This list can be empty.
+  @Deprecated('use StorageListResult.excludedSubpaths instead')
   final List<String> subPaths;
 
   /// The delimiter used in S3 prefix if any.

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_result.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_list_result.dart
@@ -74,9 +74,6 @@ class S3ListResult extends StorageListResult<S3Item> {
 class S3ListMetadata {
   /// Creates a S3ListMetadata from the `commonPrefix` and `delimiter`
   /// properties of the [s3.ListObjectsV2Output]. Superceded by StorageListResult.fromPaginatedResult()
-  @Deprecated(
-    'use StorageListResult.fromPaginatedResult or S3ListMetadata.fromDelimiter instead',
-  )
   factory S3ListMetadata.fromS3CommonPrefixes({
     @Deprecated('use StorageListResult.fromPaginatedResult instead')
     List<s3.CommonPrefix>? commonPrefixes,

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -129,6 +129,21 @@ class StorageS3Service {
     final s3PluginOptions = options.pluginOptions as S3ListPluginOptions? ??
         const S3ListPluginOptions();
 
+    // TODO(hahnand): post-deprecation, remove tempDeprecationMigration variables and replace with subpathStrategy variables
+    // `sed -i 's/tempDeprecationMigrationDelimiter/subpathStrategy.delimiter/g; s/tempDeprecationMigrationExcludedSubpaths/subpathStrategy.excludedSubpaths/g' .`
+    final String? tempDeprecationMigrationDelimiter;
+    final bool tempDeprecationMigrationExcludedSubpaths;
+
+    tempDeprecationMigrationExcludedSubpaths =
+        // ignore: deprecated_member_use_from_same_package
+        (options.pluginOptions as S3ListPluginOptions?)?.excludeSubPaths ??
+            (options.subpathStrategy.excludeSubPaths);
+
+    tempDeprecationMigrationDelimiter =
+        // ignore: deprecated_member_use_from_same_package
+        (options.pluginOptions as S3ListPluginOptions?)?.delimiter ??
+            (options.subpathStrategy.delimiter);
+
     final resolvedPath = await _pathResolver.resolvePath(path: path);
 
     if (!s3PluginOptions.listAll) {
@@ -138,8 +153,8 @@ class StorageS3Service {
           ..prefix = resolvedPath
           ..maxKeys = options.pageSize
           ..continuationToken = options.nextToken
-          ..delimiter = s3PluginOptions.excludeSubPaths
-              ? s3PluginOptions.delimiter
+          ..delimiter = tempDeprecationMigrationExcludedSubpaths
+              ? tempDeprecationMigrationDelimiter
               : null;
       });
 
@@ -163,8 +178,8 @@ class StorageS3Service {
         builder
           ..bucket = _storageOutputs.bucketName
           ..prefix = resolvedPath
-          ..delimiter = s3PluginOptions.excludeSubPaths
-              ? s3PluginOptions.delimiter
+          ..delimiter = tempDeprecationMigrationExcludedSubpaths
+              ? tempDeprecationMigrationDelimiter
               : null;
       });
 

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -83,29 +83,27 @@ void main() {
       dependencyManager.close();
     });
 
-    group('pre-delim changes list()', () {
+    group('list()', () {
       const testPath = StoragePath.fromString('some/path');
       final testResult = S3ListResult(
         <String>[],
         <S3Item>[],
         hasNextPage: false,
-        // ignore: deprecated_member_use_from_same_package
-        metadata: S3ListMetadata.fromS3CommonPrefixes(
-          // ignore: deprecated_member_use_from_same_package
-          commonPrefixes: [],
-        ),
+        metadata: S3ListMetadata.fromS3CommonPrefixes(),
       );
 
       setUpAll(() {
         registerFallbackValue(
-          const StorageListOptions(),
+          const StorageListOptions(subpathStrategy: SubpathStrategy.include()),
         );
       });
 
       test('should forward default options to StorageS3Service.list() API',
           () async {
-        const defaultOptions =
-            StorageListOptions(pluginOptions: S3ListPluginOptions());
+        const defaultOptions = StorageListOptions(
+          pluginOptions: S3ListPluginOptions(),
+          subpathStrategy: SubpathStrategy.include(),
+        );
 
         when(
           () => storageS3Service.list(
@@ -142,6 +140,7 @@ void main() {
       test('should forward options to StorageS3Service.list() API', () async {
         const testOptions = StorageListOptions(
           pluginOptions: S3ListPluginOptions(excludeSubPaths: true),
+          subpathStrategy: SubpathStrategy.exclude(),
           nextToken: 'next-token-123',
           pageSize: 2,
         );
@@ -182,23 +181,28 @@ void main() {
       });
     });
 
-    group('post-delimiter changes list()', () {
+    group('deprecating behavior, list()', () {
       const testPath = StoragePath.fromString('some/path');
       final testResult = S3ListResult(
         <String>[],
         <S3Item>[],
         hasNextPage: false,
-        // ignore: deprecated_member_use_from_same_package
         metadata: S3ListMetadata.fromS3CommonPrefixes(),
       );
 
       setUpAll(() {
         registerFallbackValue(
-          const StorageListOptions(),
+          const StorageListOptions(subpathStrategy: SubpathStrategy.include()),
         );
       });
 
-      test('should forward default options to StorageS3Service.list() API',
+      // test cases:
+      // 'subpath information from subpathStrategy & S3ListMetadata should be same',
+      // Should prioritize delim information from subpathStrategy over pluginOptions',
+      // should prioritize excludedsubpath from subpathStrategy over pluginOptions',
+
+      test(
+          'Should prioritize delim information from subpathStrategy over pluginOptions',
           () async {
         const defaultOptions = StorageListOptions(
           pluginOptions: S3ListPluginOptions(),


### PR DESCRIPTION
- **feat(storage): limiting listing content to the given folder only**
- **chore(delim): jank showcase for delim changes**


## Do not merge
due to design, smooth deprecation behavior for the upcoming storage delimiter changes introduce software jank into our codebase. this pr is a poc of such


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
