### PR TITLE
feat: bump json_annotation dependency to v4.9

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -39,6 +39,13 @@ jobs:
         with:
           version: 9
 
+      - name: Setup aft
+        shell: bash # Run in bash regardless of platform
+        run: dart pub global activate -spath packages/aft
+
+      - name: aft link
+        run: aft link
+
       - name: Get Packages
         working-directory: actions
         run: dart pub get
@@ -58,6 +65,13 @@ jobs:
         uses: dart-lang/setup-dart@e58aeb62aef51dcc4d0ba8eada7c08092aad5314 # main
         with:
           sdk: 3.3.0
+
+      - name: Setup aft
+        shell: bash # Run in bash regardless of platform
+        run: dart pub global activate -spath packages/aft
+
+      - name: aft link
+        run: aft link
 
       - name: Get Packages
         working-directory: actions

--- a/actions/pubspec.yaml
+++ b/actions/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   aws_common: ^0.6.1
   collection: ^1.18.0
   js: ^0.6.7
-  json_annotation: ">=4.8.1 <4.9.0"
+  json_annotation: ">=4.9.0 <4.10.0"
   path: ">=1.8.0 <2.0.0"
   process: ^5.0.0
   retry: ^3.1.2
@@ -24,7 +24,7 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_test: ^2.2.0
   checks: ^0.2.2
-  json_serializable: 6.7.1
+  json_serializable: 6.8.0
   test: ^1.22.1
 
 aft:

--- a/packages/aft/pubspec.yaml
+++ b/packages/aft/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   glob: ^2.1.0
   graphs: ^2.1.0
   io: ^1.0.4
-  json_annotation: ">=4.8.1 <4.9.0"
+  json_annotation: ">=4.9.0 <4.10.0"
   markdown: ^5.0.0
   mason: ^0.1.0-dev.40
   mason_logger: ^0.2.5
@@ -68,7 +68,7 @@ dev_dependencies:
   build_runner: ^2.4.0
   built_value_generator: 8.8.1
   checks: ^0.2.2
-  json_serializable: 6.7.1
+  json_serializable: 6.8.0
   test: ^1.22.1
   test_descriptor: ^2.0.1
 

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -34,4 +34,4 @@ dev_dependencies:
   build_runner: ^2.4.0
   flutter_test:
     sdk: flutter
-  json_serializable: 6.7.1
+  json_serializable: 6.8.0

--- a/packages/amplify_core/lib/src/config/amplify_outputs/auth/password_policy.g.dart
+++ b/packages/amplify_core/lib/src/config/amplify_outputs/auth/password_policy.g.dart
@@ -14,7 +14,7 @@ PasswordPolicy _$PasswordPolicyFromJson(Map<String, dynamic> json) =>
       json,
       ($checkedConvert) {
         final val = PasswordPolicy(
-          minLength: $checkedConvert('min_length', (v) => v as int?),
+          minLength: $checkedConvert('min_length', (v) => (v as num?)?.toInt()),
           requireNumbers:
               $checkedConvert('require_numbers', (v) => v as bool? ?? false),
           requireLowercase:

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   collection: ^1.15.0
   graphs: ^2.1.0
   intl: ">=0.18.0 <1.0.0"
-  json_annotation: ">=4.8.1 <4.9.0"
+  json_annotation: ">=4.9.0 <4.10.0"
   logging: ^1.0.0
   meta: ^1.7.0
   retry: ^3.1.0
@@ -34,6 +34,6 @@ dev_dependencies:
       path: packages/code_excerpt_updater
       # TODO: Bump when global SDK >=3.1
       ref: 923adadacbb95f11d222e6fc6135f6dbb66f84ee
-  json_serializable: 6.7.1
+  json_serializable: 6.8.0
   path: any
   test: ^1.22.1

--- a/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
@@ -30,8 +30,8 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  json_annotation: ">=4.8.1 <4.9.0"
-  json_serializable: 6.7.1
+  json_annotation: ">=4.9.0 <4.10.0"
+  json_serializable: 6.8.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/api/amplify_api_dart/pubspec.yaml
+++ b/packages/api/amplify_api_dart/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   async: ^2.10.0
   aws_common: ">=0.7.1 <0.8.0"
   collection: ^1.15.0
-  json_annotation: ">=4.8.1 <4.9.0"
+  json_annotation: ">=4.9.0 <4.10.0"
   meta: ^1.7.0
   plugin_platform_interface: ^2.0.0
   stream_transform: ^2.0.1

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   http: ">=0.13.0 <2.0.0"
   intl: ">=0.18.0 <1.0.0"
   js: ">=0.6.4 <0.8.0"
-  json_annotation: ">=4.8.1 <4.9.0"
+  json_annotation: ">=4.9.0 <4.10.0"
   meta: ^1.7.0
   oauth2: ^2.0.2
   path: ">=1.8.0 <2.0.0"
@@ -46,7 +46,7 @@ dev_dependencies:
   build_web_compilers: ^4.0.0
   built_value_generator: 8.8.1
   ffigen: ^9.0.0
-  json_serializable: 6.7.1
+  json_serializable: 6.8.0
   mockito: ^5.0.0
   smithy_codegen:
     path: ../../smithy/smithy_codegen

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   collection: ^1.15.0
   http2: ^2.0.0
   js: ">=0.6.4 <0.8.0"
-  json_annotation: ">=4.8.1 <4.9.0"
+  json_annotation: ">=4.9.0 <4.10.0"
   logging: ^1.0.0
   meta: ^1.7.0
   mime: ^1.0.0
@@ -30,6 +30,6 @@ dev_dependencies:
   build_test: ^2.1.5
   build_web_compilers: ^4.0.0
   built_value_generator: 8.8.1
-  json_serializable: 6.7.1
+  json_serializable: 6.8.0
   stream_channel: ^2.1.0
   test: ^1.22.1

--- a/packages/aws_signature_v4/pubspec.yaml
+++ b/packages/aws_signature_v4/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   collection: ^1.15.0
   convert: ^3.0.0
   crypto: ^3.0.0
-  json_annotation: ">=4.8.1 <4.9.0"
+  json_annotation: ">=4.9.0 <4.10.0"
   meta: ^1.7.0
   path: ">=1.8.0 <2.0.0"
 
@@ -26,7 +26,7 @@ dev_dependencies:
   build_verify: ^3.0.0
   build_version: ^2.1.1
   build_web_compilers: ^4.0.0
-  json_serializable: 6.7.1
+  json_serializable: 6.8.0
   stream_channel: ^2.1.0
   test: ^1.22.1
 

--- a/packages/aws_signature_v4/test/c_test_suite/context.g.dart
+++ b/packages/aws_signature_v4/test/c_test_suite/context.g.dart
@@ -9,7 +9,7 @@ part of 'context.dart';
 Context _$ContextFromJson(Map<String, dynamic> json) => Context(
       credentials:
           AWSCredentials.fromJson(json['credentials'] as Map<String, dynamic>),
-      expirationInSeconds: json['expiration_in_seconds'] as int,
+      expirationInSeconds: (json['expiration_in_seconds'] as num).toInt(),
       normalize: json['normalize'] as bool,
       region: json['region'] as String,
       service: json['service'] as String,

--- a/packages/smithy/smithy/lib/src/ast/traits/aws/protocols/aws_query_trait.g.dart
+++ b/packages/smithy/smithy/lib/src/ast/traits/aws/protocols/aws_query_trait.g.dart
@@ -15,7 +15,7 @@ Map<String, dynamic> _$AwsQueryTraitToJson(AwsQueryTrait instance) =>
 AwsQueryErrorTrait _$AwsQueryErrorTraitFromJson(Map<String, dynamic> json) =>
     AwsQueryErrorTrait(
       code: json['code'] as String,
-      httpResponseCode: json['httpResponseCode'] as int,
+      httpResponseCode: (json['httpResponseCode'] as num).toInt(),
     );
 
 Map<String, dynamic> _$AwsQueryErrorTraitToJson(AwsQueryErrorTrait instance) =>

--- a/packages/smithy/smithy/lib/src/ast/traits/core/cors_trait.g.dart
+++ b/packages/smithy/smithy/lib/src/ast/traits/core/cors_trait.g.dart
@@ -8,7 +8,7 @@ part of 'cors_trait.dart';
 
 CorsTrait _$CorsTraitFromJson(Map<String, dynamic> json) => CorsTrait(
       origin: json['origin'] as String? ?? CorsTrait.defaultOrigin,
-      maxAge: json['maxAge'] as int? ?? CorsTrait.defaultMaxAge,
+      maxAge: (json['maxAge'] as num?)?.toInt() ?? CorsTrait.defaultMaxAge,
       additionalAllowedHeaders:
           (json['additionalAllowedHeaders'] as List<dynamic>?)
                   ?.map((e) => e as String)

--- a/packages/smithy/smithy/lib/src/ast/traits/core/length_trait.g.dart
+++ b/packages/smithy/smithy/lib/src/ast/traits/core/length_trait.g.dart
@@ -7,8 +7,8 @@ part of 'length_trait.dart';
 // **************************************************************************
 
 LengthTrait _$LengthTraitFromJson(Map<String, dynamic> json) => LengthTrait(
-      min: json['min'] as int?,
-      max: json['max'] as int?,
+      min: (json['min'] as num?)?.toInt(),
+      max: (json['max'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$LengthTraitToJson(LengthTrait instance) =>

--- a/packages/smithy/smithy/lib/src/ast/traits/http/http_trait.g.dart
+++ b/packages/smithy/smithy/lib/src/ast/traits/http/http_trait.g.dart
@@ -9,7 +9,7 @@ part of 'http_trait.dart';
 HttpTrait _$HttpTraitFromJson(Map<String, dynamic> json) => HttpTrait(
       method: json['method'] as String,
       uri: json['uri'] as String,
-      code: json['code'] as int? ?? 200,
+      code: (json['code'] as num?)?.toInt() ?? 200,
     );
 
 Map<String, dynamic> _$HttpTraitToJson(HttpTrait instance) => <String, dynamic>{

--- a/packages/smithy/smithy/lib/src/ast/traits/test/http_malformed_response_definition.g.dart
+++ b/packages/smithy/smithy/lib/src/ast/traits/test/http_malformed_response_definition.g.dart
@@ -13,7 +13,7 @@ HttpMalformedResponseDefinition _$HttpMalformedResponseDefinitionFromJson(
           ? null
           : HttpMalformedResponseBodyDefinition.fromJson(
               json['body'] as Map<String, dynamic>),
-      code: json['code'] as int,
+      code: (json['code'] as num).toInt(),
       headers: (json['headers'] as Map<String, dynamic>?)?.map(
             (k, e) => MapEntry(k, e as String),
           ) ??

--- a/packages/smithy/smithy/lib/src/ast/traits/test/http_response_test_case.g.dart
+++ b/packages/smithy/smithy/lib/src/ast/traits/test/http_response_test_case.g.dart
@@ -36,7 +36,7 @@ HttpResponseTestCase _$HttpResponseTestCaseFromJson(
           (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList() ??
               const [],
       appliesTo: $enumDecodeNullable(_$AppliesToEnumMap, json['appliesTo']),
-      code: json['code'] as int,
+      code: (json['code'] as num).toInt(),
     );
 
 Map<String, dynamic> _$HttpResponseTestCaseToJson(

--- a/packages/smithy/smithy/lib/src/ast/traits/waiters/waiter.g.dart
+++ b/packages/smithy/smithy/lib/src/ast/traits/waiters/waiter.g.dart
@@ -11,8 +11,8 @@ Waiter _$WaiterFromJson(Map<String, dynamic> json) => Waiter(
       acceptors: (json['acceptors'] as List<dynamic>)
           .map(AcceptorDefinition.fromJson)
           .toList(),
-      minDelay: json['minDelay'] as int? ?? Waiter.defaultMinDelay,
-      maxDelay: json['maxDelay'] as int? ?? Waiter.defaultMaxDelay,
+      minDelay: (json['minDelay'] as num?)?.toInt() ?? Waiter.defaultMinDelay,
+      maxDelay: (json['maxDelay'] as num?)?.toInt() ?? Waiter.defaultMaxDelay,
       tags:
           (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList() ??
               const [],

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   fixnum: ^1.0.0
   http_parser: ^4.0.0
   intl: ">=0.18.0 <1.0.0"
-  json_annotation: ">=4.8.1 <4.9.0"
+  json_annotation: ">=4.9.0 <4.10.0"
   meta: ^1.7.0
   path: ">=1.8.0 <2.0.0"
   retry: ^3.1.0
@@ -31,6 +31,6 @@ dev_dependencies:
   amplify_lints: ">=3.1.0 <3.2.0"
   build_runner: ^2.4.0
   built_value_generator: 8.8.1
-  json_serializable: 6.7.1
+  json_serializable: 6.8.0
   stack_trace: ^1.10.0
   test: ^1.22.1

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   crclib: ^3.0.0
   crypto: ^3.0.0
   intl: ">=0.18.0 <1.0.0"
-  json_annotation: ">=4.8.1 <4.9.0"
+  json_annotation: ">=4.9.0 <4.10.0"
   meta: ^1.7.0
   path: ">=1.8.0 <2.0.0"
   smithy: ">=0.7.1 <0.8.0"
@@ -30,7 +30,7 @@ dev_dependencies:
   built_value_generator: 8.8.1
   file: ">=6.0.0 <8.0.0"
   glob: ^2.0.2
-  json_serializable: 6.7.1
+  json_serializable: 6.8.0
   pubspec_parse: ^1.2.0
   test: ^1.22.1
   yaml: ^3.1.0

--- a/packages/smithy/smithy_aws/test/http/aws_retryer_test.g.dart
+++ b/packages/smithy/smithy_aws/test/http/aws_retryer_test.g.dart
@@ -45,14 +45,16 @@ TestSuiteGiven _$TestSuiteGivenFromJson(Map json) => $checkedCreate(
           ],
         );
         final val = TestSuiteGiven(
-          maxAttempts: $checkedConvert('max_attempts', (v) => v as int),
-          initialRetryTokens:
-              $checkedConvert('initial_retry_tokens', (v) => v as int),
+          maxAttempts:
+              $checkedConvert('max_attempts', (v) => (v as num).toInt()),
+          initialRetryTokens: $checkedConvert(
+              'initial_retry_tokens', (v) => (v as num).toInt()),
           exponentialBase:
               $checkedConvert('exponential_base', (v) => (v as num).toDouble()),
           exponentialPower: $checkedConvert(
               'exponential_power', (v) => (v as num).toDouble()),
-          maxBackoffTime: $checkedConvert('max_backoff_time', (v) => v as int),
+          maxBackoffTime:
+              $checkedConvert('max_backoff_time', (v) => (v as num).toInt()),
         );
         return val;
       },
@@ -96,7 +98,7 @@ TestCaseResponse _$TestCaseResponseFromJson(Map json) => $checkedCreate(
           allowedKeys: const ['status_code'],
         );
         final val = TestCaseResponse(
-          statusCode: $checkedConvert('status_code', (v) => v as int),
+          statusCode: $checkedConvert('status_code', (v) => (v as num).toInt()),
         );
         return val;
       },
@@ -114,8 +116,8 @@ TestCaseExpected _$TestCaseExpectedFromJson(Map json) => $checkedCreate(
         final val = TestCaseExpected(
           outcome: $checkedConvert(
               'outcome', (v) => $enumDecode(_$OutcomeEnumMap, v)),
-          retryQuota: $checkedConvert('retry_quota', (v) => v as int),
-          delay: $checkedConvert('delay', (v) => v as int?),
+          retryQuota: $checkedConvert('retry_quota', (v) => (v as num).toInt()),
+          delay: $checkedConvert('delay', (v) => (v as num?)?.toInt()),
         );
         return val;
       },

--- a/packages/smithy/smithy_codegen/pubspec.yaml
+++ b/packages/smithy/smithy_codegen/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   grpc: ^3.0.2
   html2md: ^1.2.5
   jmespath: ^2.0.0
-  json_annotation: ">=4.8.1 <4.9.0"
+  json_annotation: ">=4.9.0 <4.10.0"
   meta: ^1.7.0
   path: ">=1.8.0 <2.0.0"
   protobuf: ^2.0.1
@@ -43,7 +43,7 @@ dev_dependencies:
   build_verify: ^3.0.0
   build_version: ^2.1.0
   built_value_generator: 8.8.1
-  json_serializable: 6.7.1
+  json_serializable: 6.8.0
   smithy_test:
     path: ../smithy_test
   test: ^1.22.1

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_data_bytes_range.g.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_data_bytes_range.g.dart
@@ -12,8 +12,8 @@ S3DataBytesRange _$S3DataBytesRangeFromJson(Map<String, dynamic> json) =>
       json,
       ($checkedConvert) {
         final val = S3DataBytesRange(
-          start: $checkedConvert('start', (v) => v as int),
-          end: $checkedConvert('end', (v) => v as int),
+          start: $checkedConvert('start', (v) => (v as num).toInt()),
+          end: $checkedConvert('end', (v) => (v as num).toInt()),
         );
         return val;
       },

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_plugin_options.g.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_plugin_options.g.dart
@@ -17,7 +17,7 @@ S3GetUrlPluginOptions _$S3GetUrlPluginOptionsFromJson(
               'expiresIn',
               (v) => v == null
                   ? const Duration(minutes: 15)
-                  : Duration(microseconds: v as int)),
+                  : Duration(microseconds: (v as num).toInt())),
           validateObjectExistence: $checkedConvert(
               'validateObjectExistence', (v) => v as bool? ?? false),
           useAccelerateEndpoint: $checkedConvert(

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_item.g.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_item.g.dart
@@ -12,7 +12,7 @@ S3Item _$S3ItemFromJson(Map<String, dynamic> json) => $checkedCreate(
       ($checkedConvert) {
         final val = S3Item(
           path: $checkedConvert('path', (v) => v as String),
-          size: $checkedConvert('size', (v) => v as int?),
+          size: $checkedConvert('size', (v) => (v as num?)?.toInt()),
           lastModified: $checkedConvert('lastModified',
               (v) => v == null ? null : DateTime.parse(v as String)),
           eTag: $checkedConvert('eTag', (v) => v as String?),

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   built_value: ^8.6.0
   drift: ">=2.18.0 <2.19.0"
   fixnum: ^1.0.0
-  json_annotation: ">=4.8.1 <4.9.0"
+  json_annotation: ">=4.9.0 <4.10.0"
   meta: ^1.7.0
   path: ">=1.8.0 <2.0.0"
   smithy: ">=0.7.1 <0.8.0"
@@ -30,6 +30,6 @@ dev_dependencies:
   build_verify: ^3.0.0
   built_value_generator: 8.8.1
   drift_dev: ">=2.18.0 <2.19.0"
-  json_serializable: 6.7.1
+  json_serializable: 6.8.0
   mocktail: ^1.0.0
   test: ^1.22.1

--- a/packages/test/pub_server/pubspec.yaml
+++ b/packages/test/pub_server/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   file: ">=6.0.0 <8.0.0"
   git: ^2.2.0
   graphs: ^2.1.0
-  json_annotation: ">=4.8.1 <4.9.0"
+  json_annotation: ">=4.9.0 <4.10.0"
   meta: ^1.7.0
   path: ^1.8.0
   pub_semver: ^2.1.3
@@ -32,7 +32,7 @@ dev_dependencies:
   amplify_lints: ">=2.0.3 <2.1.0"
   build_runner: ^2.4.0
   drift_dev: ">=2.18.0 <2.19.0"
-  json_serializable: 6.7.1
+  json_serializable: 6.8.0
   pub_api_client: ">=2.4.0 <2.7.0" # v2.7.0 introduces a new required field - archive_sha256
   shelf_router_generator: ^1.0.5
   test: ^1.22.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,8 +33,8 @@ dependencies:
   graphs: ^2.1.0
   http: ">=0.13.0 <2.0.0"
   intl: ">=0.18.0 <1.0.0"
-  json_annotation: ">=4.8.1 <4.9.0"
-  json_serializable: 6.7.1
+  json_annotation: ">=4.9.0 <4.10.0"
+  json_serializable: 6.8.0
   mime: ^1.0.0
   oauth2: ^2.0.2
   package_info_plus: ^6.0.0


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/5196

*Description of changes:*
- update the "actions" GH actions workflow to run aft link
- Increase version range for json_annotation to `">=4.9.0 <4.10.0"`
- Increase version for json_serializable to 6.8.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
