### PR TITLE
fix(datastore): Restart Sync Engine when network on/off

### DIFF
--- a/packages/amplify/amplify_flutter/lib/amplify_flutter.dart
+++ b/packages/amplify/amplify_flutter/lib/amplify_flutter.dart
@@ -6,7 +6,7 @@ library amplify_flutter;
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_flutter/src/amplify_impl.dart';
 
-export 'package:amplify_core/amplify_core.dart' hide Amplify;
+export 'package:amplify_core/amplify_core.dart' hide Amplify, WebSocketOptions;
 export 'package:amplify_secure_storage/amplify_secure_storage.dart';
 
 /// Top level singleton Amplify object.

--- a/packages/amplify_core/lib/amplify_core.dart
+++ b/packages/amplify_core/lib/amplify_core.dart
@@ -62,11 +62,11 @@ export 'src/state_machine/transition.dart';
 
 /// Analytics
 export 'src/types/analytics/analytics_types.dart';
-// ignore: invalid_export_of_internal_element
-export 'src/types/api/api_types.dart' show WebSocketOptions;
 
 /// API
 export 'src/types/api/api_types.dart' hide WebSocketOptions;
+// ignore: invalid_export_of_internal_element
+export 'src/types/api/api_types.dart' show WebSocketOptions;
 
 /// App path provider
 export 'src/types/app_path_provider/app_path_provider.dart';

--- a/packages/amplify_core/lib/amplify_core.dart
+++ b/packages/amplify_core/lib/amplify_core.dart
@@ -62,9 +62,11 @@ export 'src/state_machine/transition.dart';
 
 /// Analytics
 export 'src/types/analytics/analytics_types.dart';
+// ignore: invalid_export_of_internal_element
+export 'src/types/api/api_types.dart' show WebSocketOptions;
 
 /// API
-export 'src/types/api/api_types.dart';
+export 'src/types/api/api_types.dart' hide WebSocketOptions;
 
 /// App path provider
 export 'src/types/app_path_provider/app_path_provider.dart';

--- a/packages/amplify_core/lib/src/types/api/api_types.dart
+++ b/packages/amplify_core/lib/src/types/api/api_types.dart
@@ -22,6 +22,7 @@ export 'graphql/graphql_response.dart';
 export 'graphql/graphql_response_error.dart';
 export 'graphql/graphql_subscription_operation.dart';
 export 'graphql/graphql_subscription_options.dart';
+export 'graphql/web_socket_options.dart';
 export 'hub/api_hub_event.dart';
 export 'hub/api_subscription_hub_event.dart';
 // Types

--- a/packages/amplify_core/lib/src/types/api/graphql/web_socket_options.dart
+++ b/packages/amplify_core/lib/src/types/api/graphql/web_socket_options.dart
@@ -1,0 +1,21 @@
+import 'package:meta/meta.dart'; // Importing the 'meta' package to use the @internal annotation
+
+/// An internal class to control websocket features after API plugin has been initialized.
+@internal
+class WebSocketOptions {
+  /// Private constructor to prevent instantiation
+  WebSocketOptions._();
+
+  /// Private static boolean field
+  static bool _autoReconnect = true;
+
+  /// Static getter method for the boolean field
+  @internal
+  static bool get autoReconnect => _autoReconnect;
+
+  /// Static setter method for the boolean field
+  @internal
+  static set autoReconnect(bool value) {
+    _autoReconnect = value;
+  }
+}

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/pigeons/NativePluginBindings.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/pigeons/NativePluginBindings.kt
@@ -387,6 +387,12 @@ class NativeApiPlugin(private val binaryMessenger: BinaryMessenger) {
       callback()
     }
   }
+  fun deviceOffline(callback: () -> Unit) {
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.deviceOffline", codec)
+    channel.send(null) {
+      callback()
+    }
+  }
   fun onStop(callback: () -> Unit) {
     val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.onStop", codec)
     channel.send(null) {

--- a/packages/amplify_datastore/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/amplify_datastore/example/ios/Runner.xcodeproj/project.pbxproj
@@ -693,6 +693,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = DCGZ9P88MJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -700,7 +701,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.amplify.amplifyDatastoreExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.amplify.quelija.amplifyDatastoreExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -927,6 +928,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = DCGZ9P88MJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -934,7 +936,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.amplify.amplifyDatastoreExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.amplify.quelija.amplifyDatastoreExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -950,6 +952,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = DCGZ9P88MJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -957,7 +960,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.amplify.amplifyDatastoreExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.amplify.quelija.amplifyDatastoreExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/packages/amplify_datastore/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/amplify_datastore/example/ios/Runner.xcodeproj/project.pbxproj
@@ -693,7 +693,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = DCGZ9P88MJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -701,7 +700,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.amplify.quelija.amplifyDatastoreExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.amplify.amplifyDatastoreExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -928,7 +927,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = DCGZ9P88MJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -936,7 +934,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.amplify.quelija.amplifyDatastoreExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.amplify.amplifyDatastoreExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -952,7 +950,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = DCGZ9P88MJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -960,7 +957,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.amplify.quelija.amplifyDatastoreExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.amplify.amplifyDatastoreExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/packages/amplify_datastore/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/amplify_datastore/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -70,6 +70,13 @@
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Profile"

--- a/packages/amplify_datastore/example/ios/Runner/Info.plist
+++ b/packages/amplify_datastore/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -43,9 +47,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/packages/amplify_datastore/example/lib/main.dart
+++ b/packages/amplify_datastore/example/lib/main.dart
@@ -318,7 +318,8 @@ class _MyAppState extends State<MyApp> {
             displayQueryButtons(
                 _isAmplifyConfigured, _queriesToView, updateQueriesToView),
 
-displaySyncButtons(),
+            // Start/Stop/Clear buttons
+            displaySyncButtons(),
 
             Padding(padding: EdgeInsets.all(5.0)),
             Text("Listen to DataStore Hub"),

--- a/packages/amplify_datastore/example/lib/main.dart
+++ b/packages/amplify_datastore/example/lib/main.dart
@@ -162,11 +162,12 @@ class _MyAppState extends State<MyApp> {
   void listenToHub() {
     setState(() {
       hubSubscription = Amplify.Hub.listen(HubChannel.DataStore, (msg) {
-        if (msg.type case DataStoreHubEventType.networkStatus) {
-          print('Network status message: $msg');
+        final payload = msg.payload;
+        if (payload is NetworkStatusEvent) {
+          print('Network status active: ${payload.active}');
           return;
         }
-        print(msg);
+        print(msg.type);
       });
       _listeningToHub = true;
     });
@@ -316,6 +317,8 @@ class _MyAppState extends State<MyApp> {
             // Row for query buttons
             displayQueryButtons(
                 _isAmplifyConfigured, _queriesToView, updateQueriesToView),
+
+displaySyncButtons(),
 
             Padding(padding: EdgeInsets.all(5.0)),
             Text("Listen to DataStore Hub"),

--- a/packages/amplify_datastore/example/lib/queries_display_widgets.dart
+++ b/packages/amplify_datastore/example/lib/queries_display_widgets.dart
@@ -183,21 +183,27 @@ Widget displaySyncButtons() {
       width: 5,
     ),
     ElevatedButton.icon(
-        onPressed: () {
-          Amplify.DataStore.start();
-        },
-        label: Icon(Icons.play_arrow)),
+      onPressed: () {
+        Amplify.DataStore.start();
+      },
+      icon: Icon(Icons.play_arrow),
+      label: const Text("Start"),
+    ),
     divider,
     ElevatedButton.icon(
-        onPressed: () {
-          Amplify.DataStore.stop();
-        },
-        label: Icon(Icons.stop)),
+      onPressed: () {
+        Amplify.DataStore.stop();
+      },
+      icon: Icon(Icons.stop),
+      label: const Text("Stop"),
+    ),
     divider,
     ElevatedButton.icon(
-        onPressed: () {
-          Amplify.DataStore.clear();
-        },
-        label: Icon(Icons.delete_sweep)),
+      onPressed: () {
+        Amplify.DataStore.clear();
+      },
+      icon: Icon(Icons.delete_sweep),
+      label: const Text("Clear"),
+    ),
   ]);
 }

--- a/packages/amplify_datastore/example/lib/queries_display_widgets.dart
+++ b/packages/amplify_datastore/example/lib/queries_display_widgets.dart
@@ -175,3 +175,29 @@ Widget getWidgetToDisplayComment(
         }),
   );
 }
+
+Widget displaySyncButtons() {
+  return Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+    VerticalDivider(
+      color: Colors.white,
+      width: 5,
+    ),
+    ElevatedButton.icon(
+        onPressed: () {
+          Amplify.DataStore.start();
+        },
+        label: Icon(Icons.play_arrow)),
+    divider,
+    ElevatedButton.icon(
+        onPressed: () {
+          Amplify.DataStore.stop();
+        },
+        label: Icon(Icons.stop)),
+    divider,
+    ElevatedButton.icon(
+        onPressed: () {
+          Amplify.DataStore.clear();
+        },
+        label: Icon(Icons.delete_sweep)),
+  ]);
+}

--- a/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
@@ -265,9 +265,7 @@ public class FlutterApiPlugin: APICategoryPlugin, AWSAPIAuthInformation
     public func patch(request: RESTRequest) async throws -> RESTTask.Success {
         preconditionFailure("method not supported")
     }
-    
-    private var cancellable: AnyCancellable?
-    
+        
     public func reachabilityPublisher(for apiName: String?) throws -> AnyPublisher<ReachabilityUpdate, Never>? {
         return networkMonitor.publisher.compactMap( { event in
             switch event {

--- a/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/FlutterApiPlugin.swift
@@ -268,16 +268,18 @@ public class FlutterApiPlugin: APICategoryPlugin, AWSAPIAuthInformation
     }
         
     public func reachabilityPublisher(for apiName: String?) throws -> AnyPublisher<ReachabilityUpdate, Never>? {
-        return networkMonitor.publisher.compactMap( { event in
-            switch event {
-                case (.offline, .online):
-                    return ReachabilityUpdate(isOnline: true)
-                case (.online, .offline):
-                    return ReachabilityUpdate(isOnline: false)
-                default:
-                    return nil
-            }
-        }).eraseToAnyPublisher()
+        return networkMonitor.publisher
+                .compactMap { event in
+                    switch event {
+                    case (.offline, .online):
+                        return ReachabilityUpdate(isOnline: true)
+                    case (.online, .offline):
+                        return ReachabilityUpdate(isOnline: false)
+                    default:
+                        return nil
+                    }
+                }
+                .eraseToAnyPublisher()
     }
     
     public func reachabilityPublisher() throws -> AnyPublisher<ReachabilityUpdate, Never>? {

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -5,7 +5,7 @@ import Flutter
 import UIKit
 import Combine
 
-public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin, NativeAmplifyBridge, NativeAuthBridge, NativeApiBridge {    
+public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin, NativeAmplifyBridge, NativeAuthBridge, NativeApiBridge {
     private let bridge: DataStoreBridge
     private let modelSchemaRegistry: FlutterSchemaRegistry
     private let customTypeSchemaRegistry: FlutterSchemaRegistry
@@ -613,9 +613,6 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin, NativeAmplify
                         error: error,
                         flutterResult: flutterResult)
                 case .success():
-                    DispatchQueue.main.async {
-                        self.nativeApiPlugin.onStop {}
-                    }
                     print("Successfully stopped datastore cloud syncing")
                     flutterResult(nil)
                 }

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -145,8 +145,6 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin, NativeAmplify
                     nil
                 )
             }
-            // TODO: Migrate to Async Swift v2
-            //            AmplifyAWSServiceConfiguration.addUserAgentPlatform(.flutter, version: "\(version) /datastore")
             try Amplify.configure(with : .data(data))
             return completion(.success(()))
         } catch let error as ConfigurationError {

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -5,7 +5,7 @@ import Flutter
 import UIKit
 import Combine
 
-public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin, NativeAmplifyBridge, NativeAuthBridge, NativeApiBridge {
+public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin, NativeAmplifyBridge, NativeAuthBridge, NativeApiBridge {    
     private let bridge: DataStoreBridge
     private let modelSchemaRegistry: FlutterSchemaRegistry
     private let customTypeSchemaRegistry: FlutterSchemaRegistry
@@ -615,6 +615,9 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin, NativeAmplify
                         error: error,
                         flutterResult: flutterResult)
                 case .success():
+                    DispatchQueue.main.async {
+                        self.nativeApiPlugin.onStop {}
+                    }
                     print("Successfully stopped datastore cloud syncing")
                     flutterResult(nil)
                 }

--- a/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
+++ b/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
@@ -142,7 +142,7 @@ extension GraphQLResponse {
             )
         }
         
-        if error.message?.stringValue?.contains("FlutterNetworkException") == true {
+        if error.message?.stringValue?.contains("NetworkException") == true {
             extensions = extensions.merging(
                 ["errorType": "FlutterNetworkException"],
                 uniquingKeysWith: { _, a in a }

--- a/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
+++ b/packages/amplify_datastore/ios/Classes/api/GraphQLResponse+Decode.swift
@@ -141,7 +141,14 @@ extension GraphQLResponse {
                 uniquingKeysWith: { _, a in a }
             )
         }
-
+        
+        if error.message?.stringValue?.contains("FlutterNetworkException") == true {
+            extensions = extensions.merging(
+                ["errorType": "FlutterNetworkException"],
+                uniquingKeysWith: { _, a in a }
+            )
+        }
+        
         return (try? jsonEncoder.encode(error))
             .flatMap { try? jsonDecoder.decode(GraphQLError.self, from: $0) }
             .map {

--- a/packages/amplify_datastore/ios/Classes/pigeons/NativePluginBindings.swift
+++ b/packages/amplify_datastore/ios/Classes/pigeons/NativePluginBindings.swift
@@ -401,6 +401,12 @@ class NativeApiPlugin {
       completion()
     }
   }
+  func deviceOffline(completion: @escaping () -> Void) {
+    let channel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.deviceOffline", binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage(nil) { _ in
+      completion()
+    }
+  }
   func onStop(completion: @escaping () -> Void) {
     let channel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.onStop", binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage(nil) { _ in

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -380,24 +380,21 @@ class NativeAmplifyApi
 
   @override
   Future<void> deviceOffline() async {
-    await notifySubscriptionsDisconnected();
+    await _notifySubscriptionsDisconnected();
   }
 
-  Future<void> notifySubscriptionsDisconnected() async {
+  Future<void> _notifySubscriptionsDisconnected() async {
     _subscriptionsCache.forEach((subId, stream) async {
-      // Send Swift subscriptions an expected error message when network was lost.
+      // Send Swift subscriptions an expected error message when network is lost.
       // Swift side is expecting this string to transform into the correct error type.
-      // This will cause the Sync Engine to stop and in order to recover it later we must
-      // unsubscribe and close the websocket.
+      // This will cause the Sync Engine to enter retry mode and in order to recover it
+      // later we must unsubscribe and close the websocket.
       GraphQLResponseError error = GraphQLResponseError(
         message: 'FlutterNetworkException - Network disconnected',
       );
       sendSubscriptionStreamErrorEvent(subId, error.toJson());
       // Note: the websocket will still be closing after this line.
-      // There may be a small delay in sync engine recovery if turned back on
-      // within ~60 seconds. This is due to the reconnection logic doing a retry/backoff.
-      // TODO(equartey): To decrease the delay, expose some way to shutdown the web socket
-      // w/o going through the reconnection logic.
+      // There may be a small delay in shutdown.
       await unsubscribe(subId);
       await stream.cancel();
     });

--- a/packages/amplify_datastore/lib/src/native_plugin.g.dart
+++ b/packages/amplify_datastore/lib/src/native_plugin.g.dart
@@ -358,6 +358,8 @@ abstract class NativeApiPlugin {
 
   Future<void> unsubscribe(String subscriptionId);
 
+  Future<void> deviceOffline();
+
   Future<void> onStop();
 
   static void setup(NativeApiPlugin? api, {BinaryMessenger? binaryMessenger}) {
@@ -460,6 +462,21 @@ abstract class NativeApiPlugin {
           assert(arg_subscriptionId != null,
               'Argument for dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.unsubscribe was null, expected non-null String.');
           await api.unsubscribe(arg_subscriptionId!);
+          return;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.deviceOffline',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          // ignore message
+          await api.deviceOffline();
           return;
         });
       }

--- a/packages/amplify_datastore/pigeons/native_plugin.dart
+++ b/packages/amplify_datastore/pigeons/native_plugin.dart
@@ -43,6 +43,9 @@ abstract class NativeApiPlugin {
   void unsubscribe(String subscriptionId);
 
   @async
+  void deviceOffline();
+
+  @async
   void onStop();
 }
 

--- a/packages/api/amplify_api_dart/lib/amplify_api_dart.dart
+++ b/packages/api/amplify_api_dart/lib/amplify_api_dart.dart
@@ -4,7 +4,8 @@
 /// Amplify API for Dart
 library amplify_api_dart;
 
-export 'package:amplify_core/src/types/api/api_types.dart';
+export 'package:amplify_core/src/types/api/api_types.dart'
+    hide WebSocketOptions;
 
 export 'src/api_plugin_impl.dart';
 

--- a/packages/api/amplify_api_dart/lib/src/graphql/web_socket/blocs/subscriptions_bloc.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/web_socket/blocs/subscriptions_bloc.dart
@@ -142,11 +142,7 @@ class SubscriptionBloc<T>
   }
 
   Stream<WsSubscriptionState<T>> _complete(SubscriptionComplete event) async* {
-    assert(
-      _currentState is SubscriptionListeningState,
-      'State should always be listening when completed.',
-    );
-    yield (_currentState as SubscriptionListeningState<T>).complete();
+    yield _currentState.complete();
     await close();
   }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/5217
*Description of changes:*
- Added Native Swift network monitor to listen to hardware level events
- Added callback for Swift to tell Flutter network was lost
- Logic to close Web socket on network loss
- Added an internal `WebSocketOptions` as a static way to turn off reconnection logic. This allows Swift DataStore remote sync engine to control when to reestablish the subscriptions.

**Note:** Currently there exists a delay in restarting the sync engine from a network loss event if the connection is not immediately reestablished. This is due to the retry/back off logic from the Swift remote sync engine. Once network is turned back on, DataStore will eventually restart the sync engine if it was previously running and `Amplify.Datastore.stop()` was never called. 
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
