### PR TITLE
chore(infra): bump deps

### DIFF
--- a/infra-gen2/package-lock.json
+++ b/infra-gen2/package-lock.json
@@ -13,18 +13,18 @@
         "backends/storage/*"
       ],
       "dependencies": {
-        "aws-amplify": "^6.3.6",
+        "aws-amplify": "^6.4.3",
         "infra-common": "1.0.0"
       },
       "devDependencies": {
         "@aws-amplify/backend": "^1.0.4",
-        "@aws-amplify/backend-cli": "^1.2.0",
-        "aws-cdk": "^2.145.0",
-        "aws-cdk-lib": "^2.145.0",
+        "@aws-amplify/backend-cli": "^1.2.1",
+        "aws-cdk": "^2.150.0",
+        "aws-cdk-lib": "^2.150.0",
         "constructs": "^10.3.0",
-        "esbuild": "^0.21.5",
-        "tsx": "^4.15.4",
-        "typescript": "^5.4.5"
+        "esbuild": "^0.23.0",
+        "tsx": "^4.16.2",
+        "typescript": "^5.5.4"
       }
     },
     "backends/api/api-multi-auth": {
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@aws-amplify/analytics": {
-      "version": "7.0.37",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.37.tgz",
-      "integrity": "sha512-SfP+1f1IxVWwPZiJyVFTE/UYi5QSpuBJGvPH5CzpaWiJKoiwgvCB750Iohjrg6wp2JiGYxmwJc8Dw/aYFl0a4Q==",
+      "version": "7.0.40",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.40.tgz",
+      "integrity": "sha512-5re1/Po4C9/vAlnHm275bg0JP2HU/IPfqU9LwGxBA3UQSLL44Tm4R+oN8V08rtfkfjKiWISyBbhpw0EJXgagHw==",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.398.0",
         "@aws-sdk/client-kinesis": "3.398.0",
@@ -344,22 +344,22 @@
       }
     },
     "node_modules/@aws-amplify/api": {
-      "version": "6.0.39",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.39.tgz",
-      "integrity": "sha512-tzEMT8NFJ3mgNas2ufjPcrVvNnz3tXsoFZpcX2g4cmH1oPT1xN2XlEr8/u3E+B4FhG+NKpUCjkoFUv+bIJ4bzg==",
+      "version": "6.0.42",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.42.tgz",
+      "integrity": "sha512-+KztlUvD0htmApXWn6x9viwUS/lVDpF9dttw78LbFUqPkqJBSVOKmtAIRIBSPSdtBa0PZ5D/95IAWexOvR0apg==",
       "dependencies": {
-        "@aws-amplify/api-graphql": "4.1.8",
-        "@aws-amplify/api-rest": "4.0.37",
+        "@aws-amplify/api-graphql": "4.1.11",
+        "@aws-amplify/api-rest": "4.0.40",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.1.8.tgz",
-      "integrity": "sha512-7mh3nTylJbQuUDiSGIj3bPKWzs0jHTlYU8qlwYtzJv/QRtgq1RnpMhhwl3+DN41zjIyVQQ3u/e+VHZ4bdA+BwQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.1.11.tgz",
+      "integrity": "sha512-RAUG6y2VrTVjIQnOGgLS5e77XAtLDdf1d4Lj4oScN1dEp+38DyGgbyVew9AQpmD9f+KvpHkM/R0dHYFTSD8/JA==",
       "dependencies": {
-        "@aws-amplify/api-rest": "4.0.37",
-        "@aws-amplify/core": "6.3.4",
+        "@aws-amplify/api-rest": "4.0.40",
+        "@aws-amplify/core": "6.3.7",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-sdk/types": "3.387.0",
         "graphql": "15.8.0",
@@ -392,9 +392,9 @@
       }
     },
     "node_modules/@aws-amplify/api-rest": {
-      "version": "4.0.37",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.37.tgz",
-      "integrity": "sha512-xS65OzUG43+XupB8Zw+Kdeopg8ieypgRQBgPKIZrzp1o45vrGcW5PEgTnN1jortXJ3F2maTHLxT8SItxaEepUw==",
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.40.tgz",
+      "integrity": "sha512-WCWHG6+XBiNu+eFZOyZOLTkfpHdIQUPec0ixNPc+7o14jbxuDJ5WsmQG67c0HhYdAr+hV+hdfroYxivQzDb7Bg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -424,9 +424,9 @@
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "6.3.8",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.3.8.tgz",
-      "integrity": "sha512-yHcsFxHCqFl7fELMB1zpol/5t16AHBnse3JbGK/0rwt/KHNTQMku/rv/ieYsOcTLIS1zbaMTZtN46vAvxC4AqA==",
+      "version": "6.3.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.3.11.tgz",
+      "integrity": "sha512-dUA9X32OuoqOwFRc7UIkLZ0O82Bj5tk/vv5fGWqsBgSZGT2XfycvO9D7URBmOBuMMASMPjv2nqkdQbNWDWN9ow==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -491,21 +491,21 @@
       }
     },
     "node_modules/@aws-amplify/backend-cli": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-cli/-/backend-cli-1.2.0.tgz",
-      "integrity": "sha512-JzjyyapvczbhBKGkKG2j9PVNqxIC9mjRpTTxXUsAo1iI/RWmPK/drn24iMj8XyOBp2dUFblLH//McU/F5waGcg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-cli/-/backend-cli-1.2.1.tgz",
+      "integrity": "sha512-flCxfdjqvtg1bvAvNKR4SEdtHwjLG6AwWE+gop/ycZBHgsHQYb04+g4rvpTzHZAs2OWXFr68gPc+YdkJBnzfDA==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.0.1",
+        "@aws-amplify/backend-deployer": "^1.0.2",
         "@aws-amplify/backend-output-schemas": "^1.1.0",
         "@aws-amplify/backend-secret": "^1.0.0",
-        "@aws-amplify/cli-core": "^1.1.0",
-        "@aws-amplify/client-config": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.1",
+        "@aws-amplify/cli-core": "^1.1.1",
+        "@aws-amplify/client-config": "^1.1.1",
+        "@aws-amplify/deployed-backend-client": "^1.1.0",
         "@aws-amplify/form-generator": "^1.0.0",
-        "@aws-amplify/model-generator": "^1.0.1",
-        "@aws-amplify/platform-core": "^1.0.2",
-        "@aws-amplify/sandbox": "^1.1.0",
+        "@aws-amplify/model-generator": "^1.0.2",
+        "@aws-amplify/platform-core": "^1.0.3",
+        "@aws-amplify/sandbox": "^1.1.1",
         "@aws-amplify/schema-generator": "^1.1.0",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
@@ -551,13 +551,13 @@
       }
     },
     "node_modules/@aws-amplify/backend-deployer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-deployer/-/backend-deployer-1.0.1.tgz",
-      "integrity": "sha512-zeTrhItGYWMZ6bWMcRHiGp4qnEAbWH1JEp81tNToWlFO+RFrBhPwjh3wYwWvqXbnhyNvcVBBVeFcnMgJuDikdQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-deployer/-/backend-deployer-1.0.2.tgz",
+      "integrity": "sha512-ypwEN2nFHdZ6HANcECrvVSVmHCD9BtvQ7vK15wr27islgtrlsIotEet88tRolXnuj5mtvMjMOds0XKVZ8mpq6A==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.0.0",
-        "@aws-amplify/plugin-types": "^1.0.1",
+        "@aws-amplify/platform-core": "^1.0.3",
+        "@aws-amplify/plugin-types": "^1.1.0",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
       },
@@ -631,27 +631,27 @@
       }
     },
     "node_modules/@aws-amplify/cli-core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cli-core/-/cli-core-1.1.0.tgz",
-      "integrity": "sha512-fqRNvL7OHBiLvNStbNi1bTXWPnnu/XhHTVSjbURzUmhgiy91g48dNWVsHuwpMBPbW30Wjyh+itCQwkjc9wfqwQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cli-core/-/cli-core-1.1.1.tgz",
+      "integrity": "sha512-oOYJQROK0cVKJXZFWjzLb9MK8fYnQHcq6appUcteXo4hExwBGBRZ6IzYrGjklHKm24/2sdBUQ+lrezL2wesqdQ==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.0.0",
+        "@aws-amplify/platform-core": "^1.0.3",
         "@inquirer/prompts": "^3.0.0",
         "execa": "^8.0.1",
         "kleur": "^4.1.5"
       }
     },
     "node_modules/@aws-amplify/client-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/client-config/-/client-config-1.1.0.tgz",
-      "integrity": "sha512-1VKawwoAvY6H41B4TzDfC36404Guceh+q8MZlY0+3vu2g5UUCZLKhZeYCsiGaq6v0xPBUbe9UYoHbYkfTJMxdQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/client-config/-/client-config-1.1.1.tgz",
+      "integrity": "sha512-Rd0Hk8ZH49fZVxQyR4WUc73L24g0d24JBgHdiWgQNPJ5jAO9vE/V51bh2E/zVzm37GcmeZWCRDLCUjBHedYvig==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.2",
-        "@aws-amplify/model-generator": "^1.0.1",
-        "@aws-amplify/platform-core": "^1.0.1",
+        "@aws-amplify/deployed-backend-client": "^1.1.0",
+        "@aws-amplify/model-generator": "^1.0.2",
+        "@aws-amplify/platform-core": "^1.0.3",
         "zod": "^3.22.2"
       },
       "peerDependencies": {
@@ -717,9 +717,9 @@
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.3.4.tgz",
-      "integrity": "sha512-SjqBvnQTP5PYRnaLMct5gjrD2nydKgOo7YR7D7vgK6fGe6+UhAwDlorI5mfGgT4tyryuicKOvyX17Pwwvczqvw==",
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.3.7.tgz",
+      "integrity": "sha512-OfUUrhgBW0EyjjXoTORR+vFEtnl8owY1CubId3R2aRPrpg1xi9SDrAT8ZX/o1gUPfGOHkalKBF3xhoQSHNh8Vg==",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "3.398.0",
@@ -1399,11 +1399,11 @@
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "5.0.39",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.39.tgz",
-      "integrity": "sha512-a0NZgWjFIrHR/v8ppgAEj6PG2/CCz9DkbFmz/2t0QX01eBU/evMtE22RzWNJQCfkhn+opP1VkXgpynNaW9f04w==",
+      "version": "5.0.42",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.42.tgz",
+      "integrity": "sha512-9snUylqDXDjma50S4mHVoOlXJc3YkMaaRYbiYe9XjRvg8MFlOAM9UGipdk4PCjcZoYg3CHfGjPs+YlQXlGBzKQ==",
       "dependencies": {
-        "@aws-amplify/api": "6.0.39",
+        "@aws-amplify/api": "6.0.42",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
@@ -1415,13 +1415,13 @@
       }
     },
     "node_modules/@aws-amplify/deployed-backend-client": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/deployed-backend-client/-/deployed-backend-client-1.0.2.tgz",
-      "integrity": "sha512-EwRGYLrH1PangGs6p9oQGDBOLaD5xKtcIwIi/dwjI/OhzwZ2eNZNikJxlRMul9sunL7tXEawhn8lZsZz+6ITTA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/deployed-backend-client/-/deployed-backend-client-1.1.0.tgz",
+      "integrity": "sha512-1tXYOrjrl6skqdjo8nOnOgm67FeOwnPV5nY/7BVPL5ZbfWdV95NzZ574mGbQDXfz5k9vJIuTCXA6UyAslhNgCQ==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/platform-core": "^1.0.0",
+        "@aws-amplify/platform-core": "^1.0.3",
         "zod": "^3.22.2"
       },
       "peerDependencies": {
@@ -2516,16 +2516,16 @@
       }
     },
     "node_modules/@aws-amplify/model-generator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/model-generator/-/model-generator-1.0.1.tgz",
-      "integrity": "sha512-3pwl6US5OB0Vr0C/y7Cu1Bt5+lnIOi8+SYkH6PswQaOKEE7kWSlxe8lphDg+NDbXI83vgX1GlbNgi0KuofruPA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/model-generator/-/model-generator-1.0.2.tgz",
+      "integrity": "sha512-8K6KZZM4m1RL06cKHcyWhjSrbe0t5EhOMVgnmgJgdnajIQt898XUEjihZLa//YrBflshgf9V/OoQwneTtdfCKQ==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.1",
+        "@aws-amplify/deployed-backend-client": "^1.1.0",
         "@aws-amplify/graphql-generator": "^0.4.0",
         "@aws-amplify/graphql-types-generator": "^3.6.0",
-        "@aws-amplify/platform-core": "^1.0.0",
+        "@aws-amplify/platform-core": "^1.0.3",
         "@aws-sdk/client-appsync": "^3.465.0",
         "@aws-sdk/client-s3": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
@@ -2538,9 +2538,9 @@
       }
     },
     "node_modules/@aws-amplify/notifications": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.37.tgz",
-      "integrity": "sha512-Ga7/9DayEZEBjH7WB32Bo6gPFXwcC7tH4rEleYRlNsY/k+mD/yMosqLwtNtn8MezHWZDyv0tg/bp+7TXZIrg0A==",
+      "version": "2.0.40",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.40.tgz",
+      "integrity": "sha512-gE9mbX7QGBkeHvUCyRPPF5YGlJxvQCyj4yPHMdftjEu5moXApn+KFCyCtSJT1QO7odsj1XF5OvsDnZYSZe459Q==",
       "dependencies": {
         "lodash": "^4.17.21",
         "tslib": "^2.5.0"
@@ -2550,12 +2550,12 @@
       }
     },
     "node_modules/@aws-amplify/platform-core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/platform-core/-/platform-core-1.0.2.tgz",
-      "integrity": "sha512-LSs1cjq2m2TuQPkfaV7tHM+ZOOcgd1t1RHIcImwxhe2eWpjMjWnnA3o/Dj6E4UKQIV5r5zSZ0ogyAUV8FGiLIA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/platform-core/-/platform-core-1.0.3.tgz",
+      "integrity": "sha512-7nawglEF7WKDdAVI5edwZiaxH0vSH6/0TC6X/NKBTULOqYfTjMGffFHqSZv22287SZims2m/ngVgtYceue6BLQ==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/plugin-types": "^1.0.0",
+        "@aws-amplify/plugin-types": "^1.1.0",
         "@aws-sdk/client-sts": "^3.465.0",
         "is-ci": "^3.0.1",
         "lodash.mergewith": "^4.6.2",
@@ -2564,9 +2564,9 @@
       }
     },
     "node_modules/@aws-amplify/plugin-types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.0.1.tgz",
-      "integrity": "sha512-2F8j9POq2/NQcEpFZAfee0Kwnuzta8p1w5UonK22uXX7lJnOnWrdHfV431izD7ffv1W9X1xTiO/1cLUO7U8BKQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.1.0.tgz",
+      "integrity": "sha512-BWPf8pQ5dQXpVSgTxVwEDaNRNM4DcwkfxxN4Tb+edkvmidMNZGKZt0cnWDC8+K7qGXm3ml3NS79grNFychDlSw==",
       "dev": true,
       "peerDependencies": {
         "@aws-sdk/types": "^3.465.0",
@@ -2575,17 +2575,17 @@
       }
     },
     "node_modules/@aws-amplify/sandbox": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/sandbox/-/sandbox-1.1.0.tgz",
-      "integrity": "sha512-MbdFqZM2PNNJIMGZAPca6CYOehHZD8Nn1u8BVWOmuiSzAms62RJZBQMc0Euak+UWZ5R7g2qv321+y53ZNLKfOg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/sandbox/-/sandbox-1.1.1.tgz",
+      "integrity": "sha512-WnxHVA4MCVKQZilpFtnQn0V5J6Lo65po3hQ7kj33Kc7SMysdoXpUJu1rP87VGrFgTVx0oBT/WrTKiVhE0XVzQA==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.0.1",
+        "@aws-amplify/backend-deployer": "^1.0.2",
         "@aws-amplify/backend-secret": "^1.0.0",
-        "@aws-amplify/cli-core": "^1.1.0",
-        "@aws-amplify/client-config": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.2",
-        "@aws-amplify/platform-core": "^1.0.2",
+        "@aws-amplify/cli-core": "^1.1.1",
+        "@aws-amplify/client-config": "^1.1.1",
+        "@aws-amplify/deployed-backend-client": "^1.1.0",
+        "@aws-amplify/platform-core": "^1.0.3",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.465.0",
         "@aws-sdk/client-lambda": "^3.465.0",
@@ -2604,54 +2604,54 @@
       }
     },
     "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/client-lambda": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.616.0.tgz",
-      "integrity": "sha512-ap7wPwpQEsuoY49Ksj8VoldTevlrWSlEMDnJghcYt3q/Kru9cACMVvI8Tkqwl03zt2nfES+2jR2o4ciUKcsItw==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.620.1.tgz",
+      "integrity": "sha512-JzjL+iGMjmpqRw/UTXqlgcDyMnjPV80RFg+eJDYWesfdPVQpZYLQH7Mz2dyhphj3V+NRTF2GNYoXKgOwewQuBw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.616.0",
-        "@aws-sdk/client-sts": "3.616.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/credential-provider-node": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/client-sso-oidc": "3.620.1",
+        "@aws-sdk/client-sts": "3.620.1",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/credential-provider-node": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/eventstream-serde-browser": "^3.0.4",
+        "@smithy/core": "^2.3.0",
+        "@smithy/eventstream-serde-browser": "^3.0.5",
         "@smithy/eventstream-serde-config-resolver": "^3.0.3",
         "@smithy/eventstream-serde-node": "^3.0.4",
-        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.1.0",
+        "@smithy/util-stream": "^3.1.2",
         "@smithy/util-utf8": "^3.0.0",
         "@smithy/util-waiter": "^3.1.2",
         "tslib": "^2.6.2"
@@ -2661,44 +2661,44 @@
       }
     },
     "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/client-sso": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
-      "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.620.1.tgz",
+      "integrity": "sha512-4Ox0BSs+atrAhLvjNHN2uiYvSTdpMv//IS4l4XRoQG0cJKIPLs3OU3PL5H0X1NfZehz9/8FTWl5Lv81uw4j1eA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -2710,45 +2710,45 @@
       }
     },
     "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
-      "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.620.1.tgz",
+      "integrity": "sha512-gm69ttbkr7Kbg/Zzr3SczyLWkLgmK3bEZtkvbM/40ZW5ItYhDzJE48Ovs2lyA64h2YsOftDqqwcbJirAAdTgSg==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/credential-provider-node": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/credential-provider-node": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -2759,50 +2759,50 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.616.0"
+        "@aws-sdk/client-sts": "^3.620.1"
       }
     },
     "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/client-sts": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
-      "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.620.1.tgz",
+      "integrity": "sha512-d+ECGFDg0IsDdmfKU2O0VeMYKZcmbfBaA9HkZnZ39wu1BlXGI73xJe8cfmzbobvu+Ly+bAfHdLCpgIY+pD4D7g==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.616.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/credential-provider-node": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/client-sso-oidc": "3.620.1",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/credential-provider-node": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -2814,16 +2814,18 @@
       }
     },
     "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/core": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.616.0.tgz",
-      "integrity": "sha512-O/urkh2kECs/IqZIVZxyeyHZ7OR2ZWhLNK7btsVQBQvJKrEspLrk/Fp20Qfg5JDerQfBN83ZbyRXLJOOucdZpw==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.620.1.tgz",
+      "integrity": "sha512-6Ejce93dDlDnovl6oYtxj3I/SJMOQoFdmmtM4+4W/cgMWH+l00T5aszVxDLjjPfu3Ryt7dNhrXaYeK2Ue1ZBmg==",
       "dev": true,
       "dependencies": {
-        "@smithy/core": "^2.2.7",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/signature-v4": "^4.0.0",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/core": "^2.3.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.6.2"
       },
@@ -2831,20 +2833,35 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.616.0.tgz",
-      "integrity": "sha512-1rgCkr7XvEMBl7qWCo5BKu3yAxJs71dRaZ55Xnjte/0ZHH6Oc93ZrHzyYy6UH6t0nZrH+FAuw7Yko2YtDDwDeg==",
+    "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.2",
-        "@smithy/node-http-handler": "^3.1.3",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.620.0.tgz",
+      "integrity": "sha512-BI2BdrSKDmB/2ouB/NJR0PT0x/+5fmoF6XOE78hFBb4F5w/yynGgcJY936dF+oREfpME6ehjB2b0okGg78Scpw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2852,18 +2869,18 @@
       }
     },
     "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
-      "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.620.1.tgz",
+      "integrity": "sha512-m9jwigMPRlRRhoPxCQZMOwQUd6imEJbksF6tSMYNae76DIvrCi4z2Jhp6RJ9Mij8cnewUZCAmvu2FlK9+n9M7A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.616.0",
-        "@aws-sdk/credential-provider-process": "3.614.0",
-        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.620.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.620.1",
         "@aws-sdk/credential-provider-web-identity": "3.609.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
@@ -2873,23 +2890,39 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.616.0"
+        "@aws-sdk/client-sts": "^3.620.1"
       }
     },
     "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
-      "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.620.1.tgz",
+      "integrity": "sha512-KaprIJW2azM+oTIHi7S1ayJ3oQqoFwpMBWFpZM1nvSzaPucrZIUmX2m4uVrMM4LfXsfUsgMkrme2rBI1fGAjCg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.616.0",
-        "@aws-sdk/credential-provider-ini": "3.616.0",
-        "@aws-sdk/credential-provider-process": "3.614.0",
-        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.620.0",
+        "@aws-sdk/credential-provider-ini": "3.620.1",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.620.1",
         "@aws-sdk/credential-provider-web-identity": "3.609.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
@@ -2900,12 +2933,12 @@
       }
     },
     "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
-      "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.620.1.tgz",
+      "integrity": "sha512-cFU8e6ctdkWR8BRCnHFzs37N+ilbHf1OT2EeMjt1ZDE9FgTD5L5BTgVWDxnPmyQnEoBs1p4PyNPHkpHY5EmswQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.616.0",
+        "@aws-sdk/client-sso": "3.620.1",
         "@aws-sdk/token-providers": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -2918,13 +2951,13 @@
       }
     },
     "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
-      "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2933,13 +2966,13 @@
       }
     },
     "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
-      "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2948,14 +2981,14 @@
       }
     },
     "node_modules/@aws-amplify/sandbox/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
-      "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.620.0.tgz",
+      "integrity": "sha512-bvS6etn+KsuL32ubY5D3xNof1qkenpbJXf/ugGXbg0n98DvDFQ/F+SMLxHgbnER5dsKYchNnhmtI6/FC3HFu/A==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -3010,28 +3043,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-amplify/sandbox/node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/@aws-amplify/schema-generator": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@aws-amplify/schema-generator/-/schema-generator-1.2.0.tgz",
@@ -3043,9 +3054,9 @@
       }
     },
     "node_modules/@aws-amplify/storage": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.5.0.tgz",
-      "integrity": "sha512-7fAL605SmFUyUqC8CdTB3PeBpJ9bnQSTRt+8k3dZt4hpYEhwguJYwSsZb4ZyvDCsFrVyg8UhSGZPM1EsbpNgMA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.5.3.tgz",
+      "integrity": "sha512-9rq8BrP3mh5FtPJsLDGHyBejICDMcLPWumKxPjw+IpOHlZAiQ5eobdWOAp/BDcL5Ug8ejNi9z3qMDGvr6xLPRw==",
       "dependencies": {
         "@aws-sdk/types": "3.398.0",
         "@smithy/md5-js": "2.0.7",
@@ -3123,27 +3134,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/storage/node_modules/fast-xml-parser": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
-      "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        }
-      ],
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
@@ -3735,50 +3725,50 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.616.0.tgz",
-      "integrity": "sha512-jj+4B2vs8Ph5d1iQ5pBiXgpb0y5Hlh/73JWWiC9QjnjDpXy9qdHCNOf5bb3+suKjouzUORTZ/vxe6xuD5Z8kzQ==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.620.1.tgz",
+      "integrity": "sha512-fIxXZdLQeVSWn7karagGorlpWdUp0iBv0eZ9QJqsfCe+aaprzGh4Z2QKwxnHP8EjpKxQEhlaIMhwOaaBqECnKQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.616.0",
-        "@aws-sdk/client-sts": "3.616.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/credential-provider-node": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/client-sso-oidc": "3.620.1",
+        "@aws-sdk/client-sts": "3.620.1",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/credential-provider-node": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/eventstream-serde-browser": "^3.0.4",
+        "@smithy/core": "^2.3.0",
+        "@smithy/eventstream-serde-browser": "^3.0.5",
         "@smithy/eventstream-serde-config-resolver": "^3.0.3",
         "@smithy/eventstream-serde-node": "^3.0.4",
-        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -3791,44 +3781,44 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/client-sso": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
-      "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.620.1.tgz",
+      "integrity": "sha512-4Ox0BSs+atrAhLvjNHN2uiYvSTdpMv//IS4l4XRoQG0cJKIPLs3OU3PL5H0X1NfZehz9/8FTWl5Lv81uw4j1eA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -3840,45 +3830,45 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
-      "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.620.1.tgz",
+      "integrity": "sha512-gm69ttbkr7Kbg/Zzr3SczyLWkLgmK3bEZtkvbM/40ZW5ItYhDzJE48Ovs2lyA64h2YsOftDqqwcbJirAAdTgSg==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/credential-provider-node": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/credential-provider-node": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -3889,50 +3879,50 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.616.0"
+        "@aws-sdk/client-sts": "^3.620.1"
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/client-sts": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
-      "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.620.1.tgz",
+      "integrity": "sha512-d+ECGFDg0IsDdmfKU2O0VeMYKZcmbfBaA9HkZnZ39wu1BlXGI73xJe8cfmzbobvu+Ly+bAfHdLCpgIY+pD4D7g==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.616.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/credential-provider-node": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/client-sso-oidc": "3.620.1",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/credential-provider-node": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -3944,16 +3934,18 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/core": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.616.0.tgz",
-      "integrity": "sha512-O/urkh2kECs/IqZIVZxyeyHZ7OR2ZWhLNK7btsVQBQvJKrEspLrk/Fp20Qfg5JDerQfBN83ZbyRXLJOOucdZpw==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.620.1.tgz",
+      "integrity": "sha512-6Ejce93dDlDnovl6oYtxj3I/SJMOQoFdmmtM4+4W/cgMWH+l00T5aszVxDLjjPfu3Ryt7dNhrXaYeK2Ue1ZBmg==",
       "dev": true,
       "dependencies": {
-        "@smithy/core": "^2.2.7",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/signature-v4": "^4.0.0",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/core": "^2.3.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.6.2"
       },
@@ -3961,20 +3953,35 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.616.0.tgz",
-      "integrity": "sha512-1rgCkr7XvEMBl7qWCo5BKu3yAxJs71dRaZ55Xnjte/0ZHH6Oc93ZrHzyYy6UH6t0nZrH+FAuw7Yko2YtDDwDeg==",
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.2",
-        "@smithy/node-http-handler": "^3.1.3",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.620.0.tgz",
+      "integrity": "sha512-BI2BdrSKDmB/2ouB/NJR0PT0x/+5fmoF6XOE78hFBb4F5w/yynGgcJY936dF+oREfpME6ehjB2b0okGg78Scpw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3982,18 +3989,18 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
-      "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.620.1.tgz",
+      "integrity": "sha512-m9jwigMPRlRRhoPxCQZMOwQUd6imEJbksF6tSMYNae76DIvrCi4z2Jhp6RJ9Mij8cnewUZCAmvu2FlK9+n9M7A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.616.0",
-        "@aws-sdk/credential-provider-process": "3.614.0",
-        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.620.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.620.1",
         "@aws-sdk/credential-provider-web-identity": "3.609.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
@@ -4003,23 +4010,39 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.616.0"
+        "@aws-sdk/client-sts": "^3.620.1"
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
-      "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.620.1.tgz",
+      "integrity": "sha512-KaprIJW2azM+oTIHi7S1ayJ3oQqoFwpMBWFpZM1nvSzaPucrZIUmX2m4uVrMM4LfXsfUsgMkrme2rBI1fGAjCg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.616.0",
-        "@aws-sdk/credential-provider-ini": "3.616.0",
-        "@aws-sdk/credential-provider-process": "3.614.0",
-        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.620.0",
+        "@aws-sdk/credential-provider-ini": "3.620.1",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.620.1",
         "@aws-sdk/credential-provider-web-identity": "3.609.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
@@ -4030,12 +4053,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
-      "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.620.1.tgz",
+      "integrity": "sha512-cFU8e6ctdkWR8BRCnHFzs37N+ilbHf1OT2EeMjt1ZDE9FgTD5L5BTgVWDxnPmyQnEoBs1p4PyNPHkpHY5EmswQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.616.0",
+        "@aws-sdk/client-sso": "3.620.1",
         "@aws-sdk/token-providers": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -4048,13 +4071,13 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
-      "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -4063,13 +4086,13 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
-      "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -4078,14 +4101,14 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
-      "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.620.0.tgz",
+      "integrity": "sha512-bvS6etn+KsuL32ubY5D3xNof1qkenpbJXf/ugGXbg0n98DvDFQ/F+SMLxHgbnER5dsKYchNnhmtI6/FC3HFu/A==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -4138,28 +4161,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
@@ -5768,27 +5769,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-firehose/node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/@aws-sdk/client-iam": {
       "version": "3.338.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.338.0.tgz",
@@ -7383,27 +7363,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-kinesis/node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/@aws-sdk/client-lambda": {
       "version": "3.338.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.338.0.tgz",
@@ -8921,27 +8880,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-personalize-events/node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/@aws-sdk/client-rds": {
       "version": "3.338.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-rds/-/client-rds-3.338.0.tgz",
@@ -9932,28 +9870,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
@@ -12767,9 +12683,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.0.tgz",
+      "integrity": "sha512-3sG8Zwa5fMcA9bgqB8AfWPQ+HFke6uD3h1s3RIwUNK8EG7a4buxvuFTs3j1IMs2NXAk9F30C/FF4vxRgQCcmoQ==",
       "cpu": [
         "ppc64"
       ],
@@ -12779,13 +12695,13 @@
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.0.tgz",
+      "integrity": "sha512-+KuOHTKKyIKgEEqKbGTK8W7mPp+hKinbMBeEnNzjJGyFcWsfrXjSTNluJHCY1RqhxFurdD8uNXQDei7qDlR6+g==",
       "cpu": [
         "arm"
       ],
@@ -12795,13 +12711,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.0.tgz",
+      "integrity": "sha512-EuHFUYkAVfU4qBdyivULuu03FhJO4IJN9PGuABGrFy4vUuzk91P2d+npxHcFdpUnfYKy0PuV+n6bKIpHOB3prQ==",
       "cpu": [
         "arm64"
       ],
@@ -12811,13 +12727,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.0.tgz",
+      "integrity": "sha512-WRrmKidLoKDl56LsbBMhzTTBxrsVwTKdNbKDalbEZr0tcsBgCLbEtoNthOW6PX942YiYq8HzEnb4yWQMLQuipQ==",
       "cpu": [
         "x64"
       ],
@@ -12827,13 +12743,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
+      "integrity": "sha512-YLntie/IdS31H54Ogdn+v50NuoWF5BDkEUFpiOChVa9UnKpftgwzZRrI4J132ETIi+D8n6xh9IviFV3eXdxfow==",
       "cpu": [
         "arm64"
       ],
@@ -12843,13 +12759,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.0.tgz",
+      "integrity": "sha512-IMQ6eme4AfznElesHUPDZ+teuGwoRmVuuixu7sv92ZkdQcPbsNHzutd+rAfaBKo8YK3IrBEi9SLLKWJdEvJniQ==",
       "cpu": [
         "x64"
       ],
@@ -12859,13 +12775,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.0.tgz",
+      "integrity": "sha512-0muYWCng5vqaxobq6LB3YNtevDFSAZGlgtLoAc81PjUfiFz36n4KMpwhtAd4he8ToSI3TGyuhyx5xmiWNYZFyw==",
       "cpu": [
         "arm64"
       ],
@@ -12875,13 +12791,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.0.tgz",
+      "integrity": "sha512-XKDVu8IsD0/q3foBzsXGt/KjD/yTKBCIwOHE1XwiXmrRwrX6Hbnd5Eqn/WvDekddK21tfszBSrE/WMaZh+1buQ==",
       "cpu": [
         "x64"
       ],
@@ -12891,13 +12807,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.0.tgz",
+      "integrity": "sha512-SEELSTEtOFu5LPykzA395Mc+54RMg1EUgXP+iw2SJ72+ooMwVsgfuwXo5Fn0wXNgWZsTVHwY2cg4Vi/bOD88qw==",
       "cpu": [
         "arm"
       ],
@@ -12907,13 +12823,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.0.tgz",
+      "integrity": "sha512-j1t5iG8jE7BhonbsEg5d9qOYcVZv/Rv6tghaXM/Ug9xahM0nX/H2gfu6X6z11QRTMT6+aywOMA8TDkhPo8aCGw==",
       "cpu": [
         "arm64"
       ],
@@ -12923,13 +12839,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.0.tgz",
+      "integrity": "sha512-P7O5Tkh2NbgIm2R6x1zGJJsnacDzTFcRWZyTTMgFdVit6E98LTxO+v8LCCLWRvPrjdzXHx9FEOA8oAZPyApWUA==",
       "cpu": [
         "ia32"
       ],
@@ -12939,13 +12855,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.0.tgz",
+      "integrity": "sha512-InQwepswq6urikQiIC/kkx412fqUZudBO4SYKu0N+tGhXRWUqAx+Q+341tFV6QdBifpjYgUndV1hhMq3WeJi7A==",
       "cpu": [
         "loong64"
       ],
@@ -12955,13 +12871,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.0.tgz",
+      "integrity": "sha512-J9rflLtqdYrxHv2FqXE2i1ELgNjT+JFURt/uDMoPQLcjWQA5wDKgQA4t/dTqGa88ZVECKaD0TctwsUfHbVoi4w==",
       "cpu": [
         "mips64el"
       ],
@@ -12971,13 +12887,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.0.tgz",
+      "integrity": "sha512-cShCXtEOVc5GxU0fM+dsFD10qZ5UpcQ8AM22bYj0u/yaAykWnqXJDpd77ublcX6vdDsWLuweeuSNZk4yUxZwtw==",
       "cpu": [
         "ppc64"
       ],
@@ -12987,13 +12903,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.0.tgz",
+      "integrity": "sha512-HEtaN7Y5UB4tZPeQmgz/UhzoEyYftbMXrBCUjINGjh3uil+rB/QzzpMshz3cNUxqXN7Vr93zzVtpIDL99t9aRw==",
       "cpu": [
         "riscv64"
       ],
@@ -13003,13 +12919,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.0.tgz",
+      "integrity": "sha512-WDi3+NVAuyjg/Wxi+o5KPqRbZY0QhI9TjrEEm+8dmpY9Xir8+HE/HNx2JoLckhKbFopW0RdO2D72w8trZOV+Wg==",
       "cpu": [
         "s390x"
       ],
@@ -13019,13 +12935,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.0.tgz",
+      "integrity": "sha512-a3pMQhUEJkITgAw6e0bWA+F+vFtCciMjW/LPtoj99MhVt+Mfb6bbL9hu2wmTZgNd994qTAEw+U/r6k3qHWWaOQ==",
       "cpu": [
         "x64"
       ],
@@ -13035,13 +12951,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.0.tgz",
+      "integrity": "sha512-cRK+YDem7lFTs2Q5nEv/HHc4LnrfBCbH5+JHu6wm2eP+d8OZNoSMYgPZJq78vqQ9g+9+nMuIsAO7skzphRXHyw==",
       "cpu": [
         "x64"
       ],
@@ -13051,13 +12967,29 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.0.tgz",
+      "integrity": "sha512-suXjq53gERueVWu0OKxzWqk7NxiUWSUlrxoZK7usiF50C6ipColGR5qie2496iKGYNLhDZkPxBI3erbnYkU0rQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.0.tgz",
+      "integrity": "sha512-6p3nHpby0DM/v15IFKMjAaayFhqnXV52aEmv1whZHX56pdkK+MEaLoQWj+H42ssFarP1PcomVhbsR4pkz09qBg==",
       "cpu": [
         "x64"
       ],
@@ -13067,13 +12999,13 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.0.tgz",
+      "integrity": "sha512-BFelBGfrBwk6LVrmFzCq1u1dZbG4zy/Kp93w2+y83Q5UGYF1d8sCzeLI9NXjKyujjBBniQa8R8PzLFAUrSM9OA==",
       "cpu": [
         "x64"
       ],
@@ -13083,13 +13015,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.0.tgz",
+      "integrity": "sha512-lY6AC8p4Cnb7xYHuIxQ6iYPe6MfO2CC43XXKo9nBXDb35krYt7KGhQnOkRGar5psxYkircpCqfbNDB4uJbS2jQ==",
       "cpu": [
         "arm64"
       ],
@@ -13099,13 +13031,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.0.tgz",
+      "integrity": "sha512-7L1bHlOTcO4ByvI7OXVI5pNN6HSu6pUQq9yodga8izeuB1KcT2UkHaH6118QJwopExPn0rMHIseCTx1CRo/uNA==",
       "cpu": [
         "ia32"
       ],
@@ -13115,13 +13047,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.0.tgz",
+      "integrity": "sha512-Arm+WgUFLUATuoxCJcahGuk6Yj9Pzxd6l11Zb/2aAuv5kWWvvfhLFo2fni4uSK5vzlUdCGZ/BdV5tH8klj8p8g==",
       "cpu": [
         "x64"
       ],
@@ -13131,7 +13063,7 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@graphql-codegen/core": {
@@ -13468,9 +13400,9 @@
       }
     },
     "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@graphql-tools/utils": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.3.1.tgz",
-      "integrity": "sha512-Yhk1F0MNk4/ctgl3d0DKq++ZPovvZuh1ixWuUEVAxrFloYOAVwJ+rvGI1lsopArdJly8QXClT9lkvOxQszMw/w==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.3.2.tgz",
+      "integrity": "sha512-iaqOHS4f90KNADBHqVsRBjKpM6iSvsUg1q5GhWMK03loYLaDzftrEwcsl0OkSSnRhJvAsT7q4q3r3YzRoV0v1g==",
       "dev": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -14554,9 +14486,9 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.4.tgz",
-      "integrity": "sha512-Eo4anLZX6ltGJTZ5yJMc80gZPYYwBn44g0h7oFq6et+TYr5dUsTpIcDbz2evsOKIZhZ7zBoFWHtBXQ4QQeb5xA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.5.tgz",
+      "integrity": "sha512-dEyiUYL/ekDfk+2Ra4GxV+xNnFoCmk1nuIXg+fMChFTrM2uI/1r9AdiTYzPqgb72yIv/NtAj6C3dG//1wwgakQ==",
       "dev": true,
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^3.0.4",
@@ -15309,9 +15241,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.14.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
-      "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
+      "version": "20.14.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.13.tgz",
+      "integrity": "sha512-+bHoGiZb8UiQ0+WEtmph2IWQCjIqg8MDZMAV+ppRRhUZnquF5mQkP/9vpSwJClEiSM/C7fZZExPzfU0vJTyp8w==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -15337,22 +15269,13 @@
         "debug": "^4.1.1"
       }
     },
-    "node_modules/@whatwg-node/events": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
-      "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
-      "dev": true,
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@whatwg-node/fetch": {
-      "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
-      "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.19.tgz",
+      "integrity": "sha512-J+zopRcUVOhkiQYlHpxOEZuOgZtqW9xMaNQFDjESm9vRcyATms+E2/p2mZiVQGllPqWflkA3SzoJC1MxV4Pf9g==",
       "dev": true,
       "dependencies": {
-        "@whatwg-node/node-fetch": "^0.5.7",
+        "@whatwg-node/node-fetch": "^0.5.16",
         "urlpattern-polyfill": "^10.0.0"
       },
       "engines": {
@@ -15360,19 +15283,18 @@
       }
     },
     "node_modules/@whatwg-node/node-fetch": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
-      "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.19.tgz",
+      "integrity": "sha512-HSR/d2jGFuI2pcoQr7M92AjB9V7C8k8bFQ4NjJK9fwHyl1DyDnQYe+t1ygD84rCGNV8CIl1+OO5OamnvFzbqDw==",
       "dev": true,
       "dependencies": {
         "@kamilkisiela/fast-url-parser": "^1.1.4",
-        "@whatwg-node/events": "^0.1.0",
         "busboy": "^1.6.0",
         "fast-querystring": "^1.1.1",
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/ansi-escapes": {
@@ -15517,24 +15439,24 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.4.0.tgz",
-      "integrity": "sha512-7PastxeYN4zZsEtuwJYdctbxXlh6Hejd0s+WzOQfV0DKBWorRCpQkuEQ0rf93pswuCAKcURB5mE0SwKHpA+IQQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.4.3.tgz",
+      "integrity": "sha512-0GI72152TJplXFpaOl6L1Eu5YSUbp8CkhhmHrRNen8xnBFSO7kYHqnlrMK+D+tnTTwaTKjqLoKQ6A/noZJv/2g==",
       "dependencies": {
-        "@aws-amplify/analytics": "7.0.37",
-        "@aws-amplify/api": "6.0.39",
-        "@aws-amplify/auth": "6.3.8",
-        "@aws-amplify/core": "6.3.4",
-        "@aws-amplify/datastore": "5.0.39",
-        "@aws-amplify/notifications": "2.0.37",
-        "@aws-amplify/storage": "6.5.0",
+        "@aws-amplify/analytics": "7.0.40",
+        "@aws-amplify/api": "6.0.42",
+        "@aws-amplify/auth": "6.3.11",
+        "@aws-amplify/core": "6.3.7",
+        "@aws-amplify/datastore": "5.0.42",
+        "@aws-amplify/notifications": "2.0.40",
+        "@aws-amplify/storage": "6.5.3",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.148.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.148.1.tgz",
-      "integrity": "sha512-wiAi4vFJ52A42PpU3zRi2gVDqbTXSBVFrqKRqEd8wYL1mqa0qMv9FR35NsgbM1RL9s7g5ZljYvl+G2tXpcp5Eg==",
+      "version": "2.150.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.150.0.tgz",
+      "integrity": "sha512-leo4J70QrJp+SYm/87VuoOVfALsW11F7JpkAGu5TLL/qd2k/CbovZ8k9/3Ov+jCVsvAgdn9DeHL01Sn6hSl6Zg==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -15547,9 +15469,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.148.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.148.1.tgz",
-      "integrity": "sha512-jFo8Zf4c9hlll8gvk+FvERSXEAV3CPdfjtBdeypSf1QDgUbn0GmJyN5d8rXPR0z+IsA0PIDA4CV3aP9QWU5OLA==",
+      "version": "2.150.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.150.0.tgz",
+      "integrity": "sha512-A5dJ6iIAXlkSgUIKhhSd5slEjvDBiREv6/xw8CgrXU+puoFULu5bC0SOQARjTzcsAgAVtxdlaZ7qy7u9It7nHQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -17091,41 +17013,42 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.0.tgz",
+      "integrity": "sha512-1lvV17H2bMYda/WaFb2jLPeHU3zml2k4/yagNMG8Q/YtfMjCwEUZa2eXXMgZTVSL5q1n4H7sQ0X6CdJDqqeCFA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.23.0",
+        "@esbuild/android-arm": "0.23.0",
+        "@esbuild/android-arm64": "0.23.0",
+        "@esbuild/android-x64": "0.23.0",
+        "@esbuild/darwin-arm64": "0.23.0",
+        "@esbuild/darwin-x64": "0.23.0",
+        "@esbuild/freebsd-arm64": "0.23.0",
+        "@esbuild/freebsd-x64": "0.23.0",
+        "@esbuild/linux-arm": "0.23.0",
+        "@esbuild/linux-arm64": "0.23.0",
+        "@esbuild/linux-ia32": "0.23.0",
+        "@esbuild/linux-loong64": "0.23.0",
+        "@esbuild/linux-mips64el": "0.23.0",
+        "@esbuild/linux-ppc64": "0.23.0",
+        "@esbuild/linux-riscv64": "0.23.0",
+        "@esbuild/linux-s390x": "0.23.0",
+        "@esbuild/linux-x64": "0.23.0",
+        "@esbuild/netbsd-x64": "0.23.0",
+        "@esbuild/openbsd-arm64": "0.23.0",
+        "@esbuild/openbsd-x64": "0.23.0",
+        "@esbuild/sunos-x64": "0.23.0",
+        "@esbuild/win32-arm64": "0.23.0",
+        "@esbuild/win32-ia32": "0.23.0",
+        "@esbuild/win32-x64": "0.23.0"
       }
     },
     "node_modules/escalade": {
@@ -17233,19 +17156,24 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
-      "dev": true,
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fastq": {
@@ -20543,6 +20471,412 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
     "node_modules/tsx/node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -20643,9 +20977,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/infra-gen2/package.json
+++ b/infra-gen2/package.json
@@ -12,17 +12,20 @@
     "backends/storage/*"
   ],
   "dependencies": {
-    "aws-amplify": "^6.3.6",
+    "aws-amplify": "^6.4.3",
     "infra-common": "1.0.0"
   },
   "devDependencies": {
     "@aws-amplify/backend": "^1.0.4",
-    "@aws-amplify/backend-cli": "^1.2.0",
-    "aws-cdk": "^2.145.0",
-    "aws-cdk-lib": "^2.145.0",
+    "@aws-amplify/backend-cli": "^1.2.1",
+    "aws-cdk": "^2.150.0",
+    "aws-cdk-lib": "^2.150.0",
     "constructs": "^10.3.0",
-    "esbuild": "^0.21.5",
-    "tsx": "^4.15.4",
-    "typescript": "^5.4.5"
+    "esbuild": "^0.23.0",
+    "tsx": "^4.16.2",
+    "typescript": "^5.5.4"
+  },
+  "overrides": {
+    "fast-xml-parser": "^4.4.1"
   }
 }

--- a/infra/package.json
+++ b/infra/package.json
@@ -33,5 +33,8 @@
     "constructs": "^10.2.70",
     "node-fetch": "^3.3.2",
     "source-map-support": "^0.5.21"
+  },
+  "overrides": {
+    "fast-xml-parser": "^4.4.1"
   }
 }

--- a/infra/pnpm-lock.yaml
+++ b/infra/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/security/dependabot/28
*Description of changes:*

- Adds override for `"fast-xml-parser"` for both infra and infra-gen2
- Bumps all deps of infra-gen2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
