### PR TITLE
chore(auth): cognito keys to not use AmplifyConfig types

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/integration_test/federated_sign_in_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/federated_sign_in_test.dart
@@ -145,7 +145,7 @@ void main() {
       // Clear but do not sign out so that tokens are still valid.
       // ignore: invalid_use_of_protected_member
       await cognitoPlugin.stateMachine.clearCredentials(
-        CognitoUserPoolKeys(userPoolConfig),
+        CognitoUserPoolKeys(userPoolConfig.appClientId),
       );
 
       final session = await cognitoPlugin.federateToIdentityPool(

--- a/packages/auth/amplify_auth_cognito_dart/example/integration_test/hosted_ui_web_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/example/integration_test/hosted_ui_web_test.dart
@@ -375,7 +375,7 @@ callback(JSON.stringify(items));
     final data =
         (jsonDecode(json) as Map<String, Object?>).cast<String, String?>();
     final keys = HostedUiKeys(
-      config.auth!.awsPlugin!.auth!.default$!.oAuth!,
+      config.auth!.awsPlugin!.auth!.default$!.oAuth!.appClientId,
     );
     CognitoUserPoolTokens? userPoolTokens;
     final accessToken = data[keys[HostedUiKey.accessToken]];
@@ -390,7 +390,7 @@ callback(JSON.stringify(items));
     }
 
     final awsKeys = CognitoIdentityPoolKeys(
-      config.auth!.awsPlugin!.credentialsProvider!.default$!,
+      config.auth!.awsPlugin!.credentialsProvider!.default$!.poolId,
     );
     AWSCredentials? awsCredentials;
     final identityId = data[awsKeys[CognitoIdentityPoolKey.identityId]];

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_context_data_provider.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_context_data_provider.dart
@@ -29,7 +29,7 @@ final class ASFContextDataProvider with AWSDebuggable, AWSLoggerMixin {
 
   /// The unique device ID (`DeviceID`).
   Future<String> get _deviceId async {
-    final userPoolKeys = CognitoUserPoolKeys(_userPoolConfig!);
+    final userPoolKeys = CognitoUserPoolKeys(_userPoolConfig!.appClientId);
     var deviceId = await _secureStorage.read(
       key: userPoolKeys[CognitoUserPoolKey.asfDeviceId],
     );

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -307,7 +307,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
     }
     await stateMachine.acceptAndComplete(
       CredentialStoreEvent.clearCredentials(
-        CognitoIdentityPoolKeys(identityPoolConfig),
+        CognitoIdentityPoolKeys(identityPoolConfig.poolId),
       ),
     );
   }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/cognito_keys.dart
@@ -9,7 +9,6 @@ import 'dart:collection';
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart'
     show AuthFlowType;
-import 'package:amplify_core/amplify_core.dart';
 import 'package:meta/meta.dart';
 
 /// {@template amplify_auth_cognito_dart.cognito_user_pool_key}
@@ -110,17 +109,16 @@ enum HostedUiKey {
 final class CognitoIdentityPoolKeys
     extends CognitoKeys<CognitoIdentityPoolKey> {
   /// {@macro amplify_auth_cognito.cognito_identity_pool_keys}
-  const CognitoIdentityPoolKeys(this.config);
+  const CognitoIdentityPoolKeys(this.identityPoolId);
 
-  /// The Cognito identity pool configuration, used to determine the key
-  /// prefixes.
-  final CognitoIdentityCredentialsProvider config;
+  /// The Cognito identity pool Id, used to determine the key prefixes.
+  final String identityPoolId;
 
   @override
   List<CognitoIdentityPoolKey> get _values => CognitoIdentityPoolKey.values;
 
   @override
-  String get prefix => config.poolId;
+  String get prefix => identityPoolId;
 }
 
 /// {@template amplify_auth_cognito.cognito_user_pool_keys}
@@ -129,16 +127,16 @@ final class CognitoIdentityPoolKeys
 /// {@endtemplate}
 final class CognitoUserPoolKeys extends CognitoKeys<CognitoUserPoolKey> {
   /// {@macro amplify_auth_cognito.cognito_user_pool_keys}
-  const CognitoUserPoolKeys(this.config);
+  const CognitoUserPoolKeys(this.userPoolClientId);
 
-  /// The Cognito user pool configuration, used to determine the key prefixes.
-  final CognitoUserPoolConfig config;
+  /// The Cognito user pool client Id, used to determine the key prefixes.
+  final String userPoolClientId;
 
   @override
   List<CognitoUserPoolKey> get _values => CognitoUserPoolKey.values;
 
   @override
-  String get prefix => config.appClientId;
+  String get prefix => userPoolClientId;
 }
 
 /// {@template amplify_auth_cognito.cognito_user_pool_keys}
@@ -147,10 +145,10 @@ final class CognitoUserPoolKeys extends CognitoKeys<CognitoUserPoolKey> {
 /// {@endtemplate}
 final class CognitoDeviceKeys extends CognitoKeys<CognitoDeviceKey> {
   /// {@macro amplify_auth_cognito.cognito_user_pool_keys}
-  const CognitoDeviceKeys(this.config, this.username);
+  const CognitoDeviceKeys(this.userPoolClientId, this.username);
 
-  /// The Cognito user pool configuration, used to determine the key prefixes.
-  final CognitoUserPoolConfig config;
+  /// The Cognito user pool client Id, used to determine the key prefixes.
+  final String userPoolClientId;
 
   /// Device keys are tracked by username.
   final String username;
@@ -159,7 +157,7 @@ final class CognitoDeviceKeys extends CognitoKeys<CognitoDeviceKey> {
   List<CognitoDeviceKey> get _values => CognitoDeviceKey.values;
 
   @override
-  String get prefix => '${config.appClientId}.$username';
+  String get prefix => '$userPoolClientId.$username';
 }
 
 /// {@template amplify_auth_cognito.hosted_ui_keys}
@@ -168,16 +166,16 @@ final class CognitoDeviceKeys extends CognitoKeys<CognitoDeviceKey> {
 /// {@endtemplate}
 final class HostedUiKeys extends CognitoKeys<HostedUiKey> {
   /// {@macro amplify_auth_cognito.hosted_ui_keys}
-  const HostedUiKeys(this.config);
+  const HostedUiKeys(this.userPoolClientId);
 
-  /// The Cognito OAuth configuration, used to determine the key prefixes.
-  final CognitoOAuthConfig config;
+  /// The Cognito user pool client Id, used to determine the key prefixes.
+  final String userPoolClientId;
 
   @override
   List<HostedUiKey> get _values => HostedUiKey.values;
 
   @override
-  String get prefix => '${config.appClientId}.hostedUi';
+  String get prefix => '$userPoolClientId.hostedUi';
 }
 
 /// {@template amplify_auth_cognito.cognito_keys}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/device_metadata_repository.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/device_metadata_repository.dart
@@ -32,7 +32,7 @@ class DeviceMetadataRepository {
   /// Retrieves the device secrets for [username].
   Future<CognitoDeviceSecrets?> get(String username) async {
     CognitoDeviceSecrets? deviceSecrets;
-    final deviceKeys = CognitoDeviceKeys(_userPoolConfig, username);
+    final deviceKeys = CognitoDeviceKeys(_userPoolConfig.appClientId, username);
     final deviceKey = await _secureStorage.read(
       key: deviceKeys[CognitoDeviceKey.deviceKey],
     );
@@ -61,7 +61,7 @@ class DeviceMetadataRepository {
 
   /// Save the [deviceSecrets] for [username].
   Future<void> put(String username, CognitoDeviceSecrets deviceSecrets) async {
-    final deviceKeys = CognitoDeviceKeys(_userPoolConfig, username);
+    final deviceKeys = CognitoDeviceKeys(_userPoolConfig.appClientId, username);
     await _secureStorage.write(
       key: deviceKeys[CognitoDeviceKey.deviceKey],
       value: deviceSecrets.deviceKey,
@@ -82,7 +82,7 @@ class DeviceMetadataRepository {
 
   /// Clears the device secrets for [username].
   Future<void> remove(String username) async {
-    final deviceKeys = CognitoDeviceKeys(_userPoolConfig, username);
+    final deviceKeys = CognitoDeviceKeys(_userPoolConfig.appClientId, username);
     for (final key in deviceKeys) {
       await _secureStorage.delete(key: key);
     }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
@@ -40,7 +40,7 @@ abstract class HostedUiPlatform implements Closeable {
   CognitoOAuthConfig get config => dependencyManager.expect();
 
   /// The Hosted UI storage keys.
-  late final HostedUiKeys _keys = HostedUiKeys(config);
+  late final HostedUiKeys _keys = HostedUiKeys(config.appClientId);
 
   /// The secure storage plugin.
   SecureStorageInterface get _secureStorage => dependencyManager.getOrCreate();

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart
@@ -105,7 +105,7 @@ final class CredentialStoreStateMachine
     CognitoUserPoolTokens? userPoolTokens;
     final userPoolConfig = authConfig.userPoolConfig;
     if (userPoolConfig != null) {
-      final keys = CognitoUserPoolKeys(userPoolConfig);
+      final keys = CognitoUserPoolKeys(userPoolConfig.appClientId);
       final accessToken = await _secureStorage.read(
         key: keys[CognitoUserPoolKey.accessToken],
       );
@@ -140,7 +140,7 @@ final class CredentialStoreStateMachine
 
     final hostedUiConfig = authConfig.hostedUiConfig;
     if (hostedUiConfig != null) {
-      final keys = HostedUiKeys(hostedUiConfig);
+      final keys = HostedUiKeys(hostedUiConfig.appClientId);
       final accessToken = await _secureStorage.read(
         key: keys[HostedUiKey.accessToken],
       );
@@ -174,7 +174,7 @@ final class CredentialStoreStateMachine
     AWSCredentials? awsCredentials;
     final identityPoolConfig = authConfig.identityPoolConfig;
     if (identityPoolConfig != null) {
-      final keys = CognitoIdentityPoolKeys(identityPoolConfig);
+      final keys = CognitoIdentityPoolKeys(identityPoolConfig.poolId);
       identityId = await _secureStorage.read(
         key: keys[CognitoIdentityPoolKey.identityId],
       );
@@ -239,7 +239,7 @@ final class CredentialStoreStateMachine
 
     final userPoolConfig = authConfig.userPoolConfig;
     if (userPoolConfig != null) {
-      final keys = CognitoUserPoolKeys(userPoolConfig);
+      final keys = CognitoUserPoolKeys(userPoolConfig.appClientId);
       if (userPoolTokens != null &&
           userPoolTokens.signInMethod == CognitoSignInMethod.default$) {
         signInDetails as CognitoSignInDetailsApiBased?;
@@ -258,7 +258,7 @@ final class CredentialStoreStateMachine
 
     final hostedUiConfig = authConfig.hostedUiConfig;
     if (hostedUiConfig != null) {
-      final keys = HostedUiKeys(hostedUiConfig);
+      final keys = HostedUiKeys(hostedUiConfig.appClientId);
       if (userPoolTokens != null &&
           (userPoolTokens.signInMethod == CognitoSignInMethod.hostedUi)) {
         signInDetails as CognitoSignInDetailsHostedUi?;
@@ -275,7 +275,7 @@ final class CredentialStoreStateMachine
 
     final identityPoolConfig = authConfig.identityPoolConfig;
     if (identityPoolConfig != null) {
-      final keys = CognitoIdentityPoolKeys(identityPoolConfig);
+      final keys = CognitoIdentityPoolKeys(identityPoolConfig.poolId);
       if (identityId != null) {
         items[keys[CognitoIdentityPoolKey.identityId]] = identityId;
       }
@@ -356,7 +356,8 @@ final class CredentialStoreStateMachine
   Future<void> _migrateDeviceSecrets(String username) async {
     final credentialProvider = get<LegacyCredentialProvider>();
     final authConfig = expect<AuthConfiguration>();
-    final userPoolKeys = CognitoUserPoolKeys(authConfig.userPoolConfig!);
+    final userPoolKeys =
+        CognitoUserPoolKeys(authConfig.userPoolConfig!.appClientId);
     if (credentialProvider == null) return;
     try {
       final legacySecrets = await credentialProvider.fetchLegacyDeviceSecrets(
@@ -439,7 +440,7 @@ final class CredentialStoreStateMachine
 
     final userPoolConfig = authConfig.userPoolConfig;
     if (userPoolConfig != null) {
-      final userPoolKeys = CognitoUserPoolKeys(userPoolConfig);
+      final userPoolKeys = CognitoUserPoolKeys(userPoolConfig.appClientId);
       for (final key in userPoolKeys) {
         if (shouldDelete(key)) {
           deletions.add(key);
@@ -449,7 +450,7 @@ final class CredentialStoreStateMachine
 
     final hostedUiConfig = authConfig.hostedUiConfig;
     if (hostedUiConfig != null) {
-      final hostedUiKeys = HostedUiKeys(hostedUiConfig);
+      final hostedUiKeys = HostedUiKeys(hostedUiConfig.appClientId);
       for (final key in hostedUiKeys) {
         if (shouldDelete(key)) {
           deletions.add(key);
@@ -459,7 +460,8 @@ final class CredentialStoreStateMachine
 
     final identityPoolConfig = authConfig.identityPoolConfig;
     if (identityPoolConfig != null) {
-      final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig);
+      final identityPoolKeys =
+          CognitoIdentityPoolKeys(identityPoolConfig.poolId);
       for (final key in identityPoolKeys) {
         if (shouldDelete(key)) {
           deletions.add(key);

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
@@ -32,7 +32,7 @@ final class HostedUiStateMachine
   String get runtimeTypeName => 'HostedUiStateMachine';
 
   CognitoOAuthConfig get _config => expect();
-  HostedUiKeys get _keys => HostedUiKeys(_config);
+  HostedUiKeys get _keys => HostedUiKeys(_config.appClientId);
   SecureStorageInterface get _secureStorage => getOrCreate();
 
   /// The platform-specific behavior.
@@ -194,7 +194,7 @@ final class HostedUiStateMachine
     // credentials.
     if (_identityPoolConfig != null) {
       await manager.clearCredentials(
-        CognitoIdentityPoolKeys(_identityPoolConfig!),
+        CognitoIdentityPoolKeys(_identityPoolConfig!.poolId),
       );
 
       await manager.loadSession();

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -61,11 +61,6 @@ final class SignInStateMachine
   /// Parameters to the flow.
   late SignInParameters parameters;
 
-  /// The configured identity pool.
-  // TODO(nikahsn): remove after refactoring CognitoIdentityPoolKeys to use
-  // AmplifyOutputs type
-  CognitoIdentityCredentialsProvider? get identityPoolConfig => get();
-
   AuthOutputs get _authOutputs {
     final authOutputs = get<AuthOutputs>();
     if (authOutputs?.userPoolId == null ||
@@ -741,9 +736,9 @@ final class SignInStateMachine
 
     // Clear anonymous credentials, if there were any, and fetch authenticated
     // credentials.
-    if (identityPoolConfig case final identityPoolConfig?) {
+    if (_authOutputs.identityPoolId case final identityPoolId?) {
       await manager.clearCredentials(
-        CognitoIdentityPoolKeys(identityPoolConfig),
+        CognitoIdentityPoolKeys(identityPoolId),
       );
 
       await manager.loadSession();

--- a/packages/auth/amplify_auth_cognito_test/lib/common/mock_config.dart
+++ b/packages/auth/amplify_auth_cognito_test/lib/common/mock_config.dart
@@ -135,9 +135,11 @@ final hostedUiConfig = CognitoOAuthConfig.fromAuthOutputs(mockConfig.auth!);
 final authConfig = AuthConfiguration.fromAmplifyOutputs(mockConfig);
 final userPoolConfig = authConfig.userPoolConfig!;
 final identityPoolConfig = authConfig.identityPoolConfig!;
-final userPoolKeys = CognitoUserPoolKeys(userPoolConfig);
-final deviceKeys = CognitoDeviceKeys(userPoolConfig, userSub);
-final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig);
+final userPoolKeys = CognitoUserPoolKeys(mockConfig.auth!.userPoolClientId!);
+final deviceKeys =
+    CognitoDeviceKeys(mockConfig.auth!.userPoolClientId!, userSub);
+final identityPoolKeys =
+    CognitoIdentityPoolKeys(mockConfig.auth!.identityPoolId!);
 final userPoolTokens = CognitoUserPoolTokens(
   accessToken: accessToken,
   idToken: idToken,

--- a/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_test.dart
@@ -26,7 +26,7 @@ void main() {
   late SecureStorageInterface secureStorage;
   late HostedUiPlatform platform;
   late DependencyManager dependencyManager;
-  final keys = HostedUiKeys(hostedUiConfig);
+  final keys = HostedUiKeys(hostedUiConfig.appClientId);
 
   AWSLogger().logLevel = LogLevel.verbose;
 

--- a/packages/auth/amplify_auth_cognito_test/test/plugin/auth_providers_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/plugin/auth_providers_test.dart
@@ -66,8 +66,8 @@ void main() {
 
     seedStorage(
       secureStorage,
-      userPoolKeys: CognitoUserPoolKeys(userPoolConfig),
-      identityPoolKeys: CognitoIdentityPoolKeys(identityPoolConfig),
+      userPoolKeys: CognitoUserPoolKeys(userPoolConfig.appClientId),
+      identityPoolKeys: CognitoIdentityPoolKeys(identityPoolConfig.poolId),
     );
 
     await plugin.addPlugin(authProviderRepo: testAuthRepo);

--- a/packages/auth/amplify_auth_cognito_test/test/plugin/delete_user_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/plugin/delete_user_test.dart
@@ -23,8 +23,8 @@ void main() {
   final authConfig = AuthConfiguration.fromAmplifyOutputs(mockConfig);
   final userPoolConfig = authConfig.userPoolConfig!;
   final identityPoolConfig = authConfig.identityPoolConfig!;
-  final userPoolKeys = CognitoUserPoolKeys(userPoolConfig);
-  final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig);
+  final userPoolKeys = CognitoUserPoolKeys(userPoolConfig.appClientId);
+  final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig.poolId);
 
   late AmplifyAuthCognitoDart plugin;
   late CognitoAuthStateMachine stateMachine;

--- a/packages/auth/amplify_auth_cognito_test/test/plugin/forget_device_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/plugin/forget_device_test.dart
@@ -15,8 +15,8 @@ import 'package:test/test.dart';
 void main() {
   AmplifyLogger().logLevel = LogLevel.verbose;
 
-  final userPoolKeys = CognitoUserPoolKeys(userPoolConfig);
-  final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig);
+  final userPoolKeys = CognitoUserPoolKeys(userPoolConfig.appClientId);
+  final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig.poolId);
   final testAuthRepo = AmplifyAuthProviderRepository();
 
   late DeviceMetadataRepository repo;
@@ -31,7 +31,7 @@ void main() {
         secureStorage,
         userPoolKeys: userPoolKeys,
         identityPoolKeys: identityPoolKeys,
-        deviceKeys: CognitoDeviceKeys(userPoolConfig, username),
+        deviceKeys: CognitoDeviceKeys(userPoolConfig.appClientId, username),
       );
       plugin = AmplifyAuthCognitoDart(
         secureStorageFactory: (_) => secureStorage,

--- a/packages/auth/amplify_auth_cognito_test/test/plugin/remember_device_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/plugin/remember_device_test.dart
@@ -17,8 +17,8 @@ enum DeviceState { untracked, tracked, remembered }
 void main() {
   AmplifyLogger().logLevel = LogLevel.verbose;
 
-  final userPoolKeys = CognitoUserPoolKeys(userPoolConfig);
-  final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig);
+  final userPoolKeys = CognitoUserPoolKeys(userPoolConfig.appClientId);
+  final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig.poolId);
   final testAuthRepo = AmplifyAuthProviderRepository();
   final mockUpdateDeviceStatusResponse = UpdateDeviceStatusResponse();
 
@@ -44,7 +44,7 @@ void main() {
         secureStorage,
         userPoolKeys: userPoolKeys,
         identityPoolKeys: identityPoolKeys,
-        deviceKeys: CognitoDeviceKeys(userPoolConfig, username),
+        deviceKeys: CognitoDeviceKeys(userPoolConfig.appClientId, username),
       );
       plugin = AmplifyAuthCognitoDart(
         secureStorageFactory: (_) => secureStorage,

--- a/packages/auth/amplify_auth_cognito_test/test/plugin/reset_password_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/plugin/reset_password_test.dart
@@ -20,8 +20,8 @@ void main() {
   final authConfig = AuthConfiguration.fromAmplifyOutputs(mockConfig);
   final userPoolConfig = authConfig.userPoolConfig!;
   final identityPoolConfig = authConfig.identityPoolConfig!;
-  final userPoolKeys = CognitoUserPoolKeys(userPoolConfig);
-  final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig);
+  final userPoolKeys = CognitoUserPoolKeys(userPoolConfig.appClientId);
+  final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig.poolId);
 
   late AmplifyAuthCognitoDart plugin;
   late CognitoAuthStateMachine stateMachine;

--- a/packages/auth/amplify_auth_cognito_test/test/plugin/sign_out_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/plugin/sign_out_test.dart
@@ -23,9 +23,9 @@ final throwsSignedOutException = throwsA(isA<SignedOutException>());
 // Follows signOut test cases:
 // https://github.com/aws-amplify/amplify-android/tree/main/aws-auth-cognito/src/test/resources/feature-test/testsuites/signOut
 void main() {
-  final userPoolKeys = CognitoUserPoolKeys(userPoolConfig);
-  final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig);
-  final hostedUiKeys = HostedUiKeys(hostedUiConfig);
+  final userPoolKeys = CognitoUserPoolKeys(userPoolConfig.appClientId);
+  final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig.poolId);
+  final hostedUiKeys = HostedUiKeys(hostedUiConfig.appClientId);
 
   late AmplifyAuthCognitoDart plugin;
   late CognitoAuthStateMachine stateMachine;

--- a/packages/auth/amplify_auth_cognito_test/test/state/hosted_ui_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/hosted_ui_state_machine_test.dart
@@ -70,7 +70,7 @@ class FailingHostedUiPlatform extends HostedUiPlatform {
 
 void main() {
   AWSLogger().logLevel = LogLevel.verbose;
-  final keys = HostedUiKeys(hostedUiConfig);
+  final keys = HostedUiKeys(hostedUiConfig.appClientId);
 
   group('HostedUiStateMachine', () {
     late MockOAuthServer server;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- update CognitoIdentityPoolKeys to use identity pool Id instead of CognitoIdentityCredentialsProvider
- update CognitoUserPoolKeys to use user pool client id instead of CognitoUserPoolConfig
- update CognitoDeviceKeys to use user pool client id instead of CognitoUserPoolConfig
- update HostedUiKeys to use user pool client id instead of CognitoOAuthConfig


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
