### PR TITLE
chore(actions): e2e android tests to run with API 34

### DIFF
--- a/.github/composite_actions/launch_android_emulator/action.yaml
+++ b/.github/composite_actions/launch_android_emulator/action.yaml
@@ -3,7 +3,7 @@ description: Launches an Android emulator and caches it for further action runs
 inputs:
   api-level:
     description: "API level of the platform and system image - e.g. 23 for Android Marshmallow, 29 for Android 10"
-    default: "33"
+    default: "34"
   target:
     description: "target of the system image - default, google_apis, google_apis_playstore, aosp_atd, google_atd, android-wear, android-wear-cn, android-tv or google-tv"
     default: google_apis

--- a/.github/composite_actions/launch_android_emulator/dist/main.cjs
+++ b/.github/composite_actions/launch_android_emulator/dist/main.cjs
@@ -15908,7 +15908,7 @@
             case 4:
               // returning from await.
               $async$goto = 5;
-              return A._asyncAwait(A.Core_withGroup(t2._as(t1.core), "Install/update Android platform (33)", new A.SdkManager__ensureBuildTools_closure4(), t4), $async$_ensureBuildTools$0);
+              return A._asyncAwait(A.Core_withGroup(t2._as(t1.core), "Install/update Android platform (34)", new A.SdkManager__ensureBuildTools_closure4(), t4), $async$_ensureBuildTools$0);
             case 5:
               // returning from await.
               targetTriplet = $async$self.apiLevel.toString$0(0) + ";" + $async$self.target.toString$0(0) + ";" + $async$self.abi.toString$0(0);
@@ -15961,7 +15961,7 @@
                 $async$goto = 1;
                 break;
               }
-              _0_0 = A.ToolCache_find(t2._as(t1.toolCache), "cmdline-tools", "10406996");
+              _0_0 = A.ToolCache_find(t2._as(t1.toolCache), "cmdline-tools", "11076708");
               if (_0_0 != null) {
                 t2._as(t1.core).info("Found cached cmdline-tools install: " + _0_0);
                 // goto return
@@ -15978,7 +15978,7 @@
                 default:
                   t3 = null;
               }
-              downloadUrl = "https://dl.google.com/android/repository/commandlinetools-" + t3 + "-10406996_latest.zip";
+              downloadUrl = "https://dl.google.com/android/repository/commandlinetools-" + t3 + "-11076708_latest.zip";
               t2._as(t1.core).info("Downloading cmdline-tools from " + downloadUrl);
               $async$goto = 3;
               return A._asyncAwait(A.ToolCache_downloadTool(t2._as(t1.toolCache), downloadUrl), $async$call$0);
@@ -15993,7 +15993,7 @@
               extractPath = $async$result;
               t2._as(t1.core).info("Extracted cmdline-tools to " + extractPath);
               $async$goto = 5;
-              return A._asyncAwait(A.ToolCache_cacheDir(t2._as(t1.toolCache), extractPath, "cmdline-tools", "10406996"), $async$call$0);
+              return A._asyncAwait(A.ToolCache_cacheDir(t2._as(t1.toolCache), extractPath, "cmdline-tools", "11076708"), $async$call$0);
             case 5:
               // returning from await.
               toolCachePath = $async$result;
@@ -16021,7 +16021,7 @@
   };
   A.SdkManager__ensureBuildTools_closure1.prototype = {
     call$1(line) {
-      return B.JSString_methods.startsWith$1(A._asString(line), "build-tools;33");
+      return B.JSString_methods.startsWith$1(A._asString(line), "build-tools;34");
     },
     $signature: 1
   };
@@ -16087,10 +16087,10 @@
             case 0:
               // Function start
               $async$goto = 2;
-              return A._asyncAwait($.$get$SdkManager__sdkmanager().call$1(A._setArrayType(["platforms;android-33"], type$.JSArray_String)), $async$call$0);
+              return A._asyncAwait($.$get$SdkManager__sdkmanager().call$1(A._setArrayType(["platforms;android-34"], type$.JSArray_String)), $async$call$0);
             case 2:
               // returning from await.
-              type$.JSObject._as(self.core).info("Successfully installed platforms;android-33");
+              type$.JSObject._as(self.core).info("Successfully installed platforms;android-34");
               // implicit return
               return A._asyncReturn(null, $async$completer);
           }

--- a/.github/workflows/e2e_android.yaml
+++ b/.github/workflows/e2e_android.yaml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         api-level:
           - 24
-          - 33
+          - 34
         channel:
           - beta
           - stable

--- a/actions/bin/launch_android_emulator.yaml
+++ b/actions/bin/launch_android_emulator.yaml
@@ -3,7 +3,7 @@ description: Launches an Android emulator and caches it for further action runs
 inputs:
   api-level:
     description: "API level of the platform and system image - e.g. 23 for Android Marshmallow, 29 for Android 10"
-    default: "33"
+    default: "34"
   target:
     description: "target of the system image - default, google_apis, google_apis_playstore, aosp_atd, google_atd, android-wear, android-wear-cn, android-tv or google-tv"
     default: google_apis

--- a/actions/lib/src/android/sdk_manager.dart
+++ b/actions/lib/src/android/sdk_manager.dart
@@ -42,7 +42,7 @@ final class SdkManager {
 
   /// The current `compileSdk` used by the repo.
   // TODO(dnys1): Extract from aft.yaml?
-  static const compileSdk = 33;
+  static const compileSdk = 34;
 
   /// The install directory for cmdline-tools.
   ///
@@ -79,7 +79,7 @@ final class SdkManager {
   /// Latest version of the cmdline-tools
   ///
   /// From: https://developer.android.com/studio#command-line-tools-only
-  static const _latestCmdlineToolsVersion = '10406996';
+  static const _latestCmdlineToolsVersion = '11076708';
 
   /// Installs the latest version of cmdline-tools if not already available.
   Future<void> _ensureCmdlineTools() async =>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- all the android projects use compileSdk 34 but our ci e2e tests were running with api 33, this updates the ci to run with api 34
- the android command line tools to use the current latest version ([ref](https://developer.android.com/studio#command-line-tools-only))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
