### PR TITLE
fix(datastore): Clear subscriptions on Stop

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/pigeons/NativePluginBindings.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/pigeons/NativePluginBindings.kt
@@ -387,6 +387,12 @@ class NativeApiPlugin(private val binaryMessenger: BinaryMessenger) {
       callback()
     }
   }
+  fun onStop(callback: () -> Unit) {
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.onStop", codec)
+    channel.send(null) {
+      callback()
+    }
+  }
 }
 /**
  * Bridge for calling Amplify from Flutter into Native

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -234,6 +234,9 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin, NativeAmplify
             onStart(flutterResult: result)
         case "stop":
             onStop(flutterResult: result)
+            DispatchQueue.main.async {
+                self.nativeApiPlugin.onStop {}
+            }
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/packages/amplify_datastore/ios/Classes/pigeons/NativePluginBindings.swift
+++ b/packages/amplify_datastore/ios/Classes/pigeons/NativePluginBindings.swift
@@ -401,6 +401,12 @@ class NativeApiPlugin {
       completion()
     }
   }
+  func onStop(completion: @escaping () -> Void) {
+    let channel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.onStop", binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage(nil) { _ in
+      completion()
+    }
+  }
 }
 /// Bridge for calling Amplify from Flutter into Native
 ///

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -375,4 +375,14 @@ class NativeAmplifyApi
       _subscriptionsCache.remove(subscriptionId);
     }
   }
+
+  /// Amplify.DataStore.Stop() callback
+  ///
+  /// Clean up subscriptions on stop.
+  @override
+  Future<void> onStop() async {
+    _subscriptionsCache.forEach((subId, _) async {
+      await unsubscribe(subId);
+    });
+  }
 }

--- a/packages/amplify_datastore/lib/src/native_plugin.g.dart
+++ b/packages/amplify_datastore/lib/src/native_plugin.g.dart
@@ -358,6 +358,8 @@ abstract class NativeApiPlugin {
 
   Future<void> unsubscribe(String subscriptionId);
 
+  Future<void> onStop();
+
   static void setup(NativeApiPlugin? api, {BinaryMessenger? binaryMessenger}) {
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
@@ -458,6 +460,20 @@ abstract class NativeApiPlugin {
           assert(arg_subscriptionId != null,
               'Argument for dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.unsubscribe was null, expected non-null String.');
           await api.unsubscribe(arg_subscriptionId!);
+          return;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.amplify_datastore.NativeApiPlugin.onStop', codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          // ignore message
+          await api.onStop();
           return;
         });
       }

--- a/packages/amplify_datastore/pigeons/native_plugin.dart
+++ b/packages/amplify_datastore/pigeons/native_plugin.dart
@@ -41,6 +41,9 @@ abstract class NativeApiPlugin {
 
   @async
   void unsubscribe(String subscriptionId);
+
+  @async
+  void onStop();
 }
 
 /// Bridge for calling Amplify from Flutter into Native


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/5184
*Description of changes:*

- Adds onStop() call back for Swift to Flutter
- Clears the Sync subscriptions onStop 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
