### PR TITLE
chore(auth): device metadata repository to use AuthOutputs instead of CognitoUserPoolConfig

### DIFF
--- a/packages/auth/amplify_auth_cognito_test/test/state/sign_in_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/sign_in_state_machine_test.dart
@@ -186,7 +186,7 @@ void main() {
               ),
           completion(isA<Configured>()),
         );
-        deviceRepo = DeviceMetadataRepository(userPoolConfig, secureStorage);
+        deviceRepo = DeviceMetadataRepository(mockConfig.auth!, secureStorage);
         stateMachine.addInstance<DeviceMetadataRepository>(deviceRepo);
       });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- device metadata repository to get AuthOutputs instead of CognitoUserPoolConfig from dependency manager

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
