### PR TITLE
chore(auth): fix fetch current device test

### DIFF
--- a/packages/auth/amplify_auth_cognito_test/test/plugin/fetch_current_device_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/plugin/fetch_current_device_test.dart
@@ -15,7 +15,8 @@ void main() {
   AmplifyLogger().logLevel = LogLevel.verbose;
 
   final userPoolKeys = CognitoUserPoolKeys(userPoolConfig.appClientId);
-  final identityPoolKeys = CognitoIdentityPoolKeys(identityPoolConfig.poolId);
+  final identityPoolKeys =
+      CognitoIdentityPoolKeys(mockConfig.auth!.identityPoolId!);
   final testAuthRepo = AmplifyAuthProviderRepository();
   final mockDevice = DeviceType(deviceKey: deviceKey);
   final mockDeviceResponse = GetDeviceResponse(device: mockDevice);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- fix the fetch current device test. this may have happened after merging the fetch current device changes and the auth refactoring change that removed the userPoolConfig from `packages/auth/amplify_auth_cognito_test/lib/common/mock_config.dart`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
