### PR TITLE
chore(auth): credential store state machine to use AuthOutputs instead of AmplifyConfig types

### DIFF
--- a/packages/auth/amplify_auth_cognito_test/test/state/credential_store_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/credential_store_state_machine_test.dart
@@ -31,7 +31,7 @@ void main() {
       secureStorage = MockSecureStorage();
       manager = DependencyManager()
         ..addInstance(secureStorage)
-        ..addInstance(mockConfig)
+        ..addInstance(mockConfig.auth!)
         ..addInstance(authConfig);
       stateMachine = CognitoAuthStateMachine(dependencyManager: manager);
     });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- update credential store state machine to use AuthOutputs instead of AuthConfiguration from the dependency manager

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
