### PR TITLE
feat: move App Sync subscription headers to protocol

### DIFF
--- a/packages/api/amplify_api_dart/lib/src/decorators/web_socket_auth_utils.dart
+++ b/packages/api/amplify_api_dart/lib/src/decorators/web_socket_auth_utils.dart
@@ -26,28 +26,18 @@ const _requiredHeaders = {
   AWSHeaders.contentType: 'application/json; charset=utf-8',
 };
 
-// AppSync expects "{}" encoded in the URI as the payload during handshake.
-const _emptyBody = <String, dynamic>{};
+/// The default payload to include to AppSync.
+///
+/// AppSync expects "{}" encoded in the URI as the payload during handshake.
+@internal
+const appSyncDefaultPayload = <String, dynamic>{};
 
 /// Generate a URI for the connection and all subscriptions.
 ///
 /// See https://docs.aws.amazon.com/appsync/latest/devguide/real-time-websocket-client.html#handshake-details-to-establish-the-websocket-connection=
-Future<Uri> generateConnectionUri(
-  ApiOutputs config,
-  AmplifyAuthProviderRepository authRepo,
-) async {
-  // First, generate auth query parameters.
-  final authorizationHeaders = await _generateAuthorizationHeaders(
-    config,
-    isConnectionInit: true,
-    authRepo: authRepo,
-    body: _emptyBody,
-  );
-  final encodedAuthHeaders =
-      base64.encode(json.encode(authorizationHeaders).codeUnits);
+Future<Uri> generateConnectionUri(ApiOutputs config) async {
   final authQueryParameters = {
-    'header': encodedAuthHeaders,
-    'payload': base64.encode(utf8.encode(json.encode(_emptyBody))),
+    'payload': base64.encode(utf8.encode(json.encode(appSyncDefaultPayload))),
   };
   // Conditionally format the URI for a) AppSync domain b) custom domain.
   var endpointUriHost = Uri.parse(config.url).host;
@@ -86,7 +76,7 @@ Future<WebSocketSubscriptionRegistrationMessage>
   required GraphQLRequest<T> request,
 }) async {
   final body = {'variables': request.variables, 'query': request.document};
-  final authorizationHeaders = await _generateAuthorizationHeaders(
+  final authorizationHeaders = await generateAuthorizationHeaders(
     config,
     isConnectionInit: false,
     authRepo: authRepo,
@@ -114,7 +104,8 @@ Future<WebSocketSubscriptionRegistrationMessage>
 /// a canonical HTTP request that is authorized but never sent. The headers from
 /// the HTTP request are reformatted and returned. This logic applies for all auth
 /// modes as determined by [authRepo] parameter.
-Future<Map<String, String>> _generateAuthorizationHeaders(
+@internal
+Future<Map<String, String>> generateAuthorizationHeaders(
   ApiOutputs config, {
   required bool isConnectionInit,
   required AmplifyAuthProviderRepository authRepo,

--- a/packages/api/amplify_api_dart/lib/src/graphql/web_socket/services/web_socket_service.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/web_socket/services/web_socket_service.dart
@@ -110,6 +110,10 @@ class AmplifyWebSocketService
     );
     final encodedAuthHeaders = base64Url
         .encode(json.encode(authorizationHeaders).codeUnits)
+        // remove padding char ("=") as it is optional in base64Url encoding and
+        // is not permitted in protocol names.
+        // Base64Url Spec: https://datatracker.ietf.org/doc/html/rfc4648#section-5
+        // Protocol name separators: https://www.rfc-editor.org/rfc/rfc2616 (see "separators")
         .replaceAll('=', '');
     return ['graphql-ws', 'header-$encodedAuthHeaders'];
   }

--- a/packages/api/amplify_api_dart/lib/src/graphql/web_socket/services/web_socket_service.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/web_socket/services/web_socket_service.dart
@@ -108,9 +108,9 @@ class AmplifyWebSocketService
       authRepo: authRepo,
       body: appSyncDefaultPayload,
     );
-    final encodedAuthHeaders = base64Url.encode(
-      json.encode(authorizationHeaders).codeUnits,
-    );
+    final encodedAuthHeaders = base64Url
+        .encode(json.encode(authorizationHeaders).codeUnits)
+        .replaceAll('=', '');
     return ['graphql-ws', 'header-$encodedAuthHeaders'];
   }
 

--- a/packages/api/amplify_api_dart/test/util.dart
+++ b/packages/api/amplify_api_dart/test/util.dart
@@ -89,9 +89,9 @@ const testApiKeyConfigCustomDomain = DataOutputs(
 );
 
 const expectedApiKeyWebSocketConnectionUrl =
-    'wss://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql?header=eyJBY2NlcHQiOiJhcHBsaWNhdGlvbi9qc29uLCB0ZXh0L2phdmFzY3JpcHQiLCJDb250ZW50LUVuY29kaW5nIjoiYW16LTEuMCIsIkNvbnRlbnQtVHlwZSI6ImFwcGxpY2F0aW9uL2pzb247IGNoYXJzZXQ9dXRmLTgiLCJYLUFwaS1LZXkiOiJhYmMtMTIzIiwiSG9zdCI6ImFiYzEyMy5hcHBzeW5jLWFwaS51cy1lYXN0LTEuYW1hem9uYXdzLmNvbSJ9&payload=e30%3D';
+    'wss://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql?payload=e30%3D';
 const expectedApiKeyWebSocketConnectionUrlCustomDomain =
-    'wss://foo.bar.aws.dev/graphql/realtime?header=eyJBY2NlcHQiOiJhcHBsaWNhdGlvbi9qc29uLCB0ZXh0L2phdmFzY3JpcHQiLCJDb250ZW50LUVuY29kaW5nIjoiYW16LTEuMCIsIkNvbnRlbnQtVHlwZSI6ImFwcGxpY2F0aW9uL2pzb247IGNoYXJzZXQ9dXRmLTgiLCJYLUFwaS1LZXkiOiJhYmMtMTIzIiwiSG9zdCI6ImZvby5iYXIuYXdzLmRldiJ9&payload=e30%3D';
+    'wss://foo.bar.aws.dev/graphql/realtime?payload=e30%3D';
 
 AmplifyAuthProviderRepository getTestAuthProviderRepo() {
   final testAuthProviderRepo = AmplifyAuthProviderRepository()
@@ -341,3 +341,24 @@ void testQueryPredicateTranslation(
 }
 
 final deepEquals = const DeepCollectionEquality().equals;
+
+/// Creates [DataOutputs] and [AmplifyAuthProviderRepository] for use in tests.
+(DataOutputs, AmplifyAuthProviderRepository) createOutputsAndRepo(
+  AmplifyAuthProvider authProvider,
+  APIAuthorizationType type, [
+  String? apiKey,
+]) {
+  final repo = AmplifyAuthProviderRepository()
+    ..registerAuthProvider(
+      type.authProviderToken,
+      authProvider,
+    );
+  final outputs = DataOutputs(
+    awsRegion: 'us-east-1',
+    url: 'https://example.com/',
+    defaultAuthorizationType: type,
+    authorizationTypes: [type],
+    apiKey: type == APIAuthorizationType.apiKey ? apiKey : null,
+  );
+  return (outputs, repo);
+}

--- a/packages/api/amplify_api_dart/test/web_socket/web_socket_service_test.dart
+++ b/packages/api/amplify_api_dart/test/web_socket/web_socket_service_test.dart
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:convert';
+
+import 'package:amplify_api_dart/src/graphql/providers/app_sync_api_key_auth_provider.dart';
+import 'package:amplify_api_dart/src/graphql/web_socket/services/web_socket_service.dart';
+import 'package:amplify_core/amplify_core.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+void main() {
+  group('AmplifyWebSocketService', () {
+    group('generateProtocols', () {});
+    const apiKey = 'fake-key';
+    test('should generate a protocol that includes the appropriate headers',
+        () async {
+      final (outputs, repo) = createOutputsAndRepo(
+        AppSyncApiKeyAuthProvider(),
+        APIAuthorizationType.apiKey,
+        apiKey,
+      );
+      final service = AmplifyWebSocketService();
+      final protocols = await service.generateProtocols(outputs, repo);
+      final encodedHeaders = protocols[1].replaceFirst('header-', '');
+      final headers = json.decode(
+        String.fromCharCodes(base64Url.decode(encodedHeaders)),
+      ) as Map<String, dynamic>;
+      expect(headers[xApiKey], apiKey);
+      expect(headers.containsKey(AWSHeaders.accept), true);
+      expect(headers.containsKey(AWSHeaders.contentEncoding), true);
+      expect(headers.containsKey(AWSHeaders.contentType), true);
+      expect(headers.containsKey(AWSHeaders.host), true);
+    });
+  });
+}


### PR DESCRIPTION
*Description of changes:*
- move subscription headers from query params to web socket protocol

AppSync has added support for headers via ws protocol, which is now preferred over using query parameters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
