### PR TITLE
chore(auth): legacy credential provider to use AuthOutputs instead of AmplifyConfig types

### DIFF
--- a/packages/auth/amplify_auth_cognito/lib/src/credentials/legacy_credential_provider_android.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/credentials/legacy_credential_provider_android.dart
@@ -47,11 +47,12 @@ class LegacyCredentialProviderAndroid implements LegacyCredentialProvider {
     String username,
     AuthOutputs authOutputs,
   ) async {
-    if (authOutputs.userPoolId == null) return null;
+    final userPoolId = authOutputs.userPoolId;
+    if (userPoolId == null) return null;
     final bridge = _stateMachine.expect<auth_cognito.NativeAuthBridge>();
     final device = await bridge.fetchLegacyDeviceSecrets(
       username,
-      authOutputs.userPoolId!,
+      userPoolId,
     );
     return device?.toLegacyDeviceDetails();
   }
@@ -61,12 +62,12 @@ class LegacyCredentialProviderAndroid implements LegacyCredentialProvider {
     String username,
     AuthOutputs authOutputs,
   ) async {
-    if (authOutputs.userPoolId != null) {
-      final bridge = _stateMachine.expect<auth_cognito.NativeAuthBridge>();
-      return bridge.deleteLegacyDeviceSecrets(
-        username,
-        authOutputs.userPoolId!,
-      );
-    }
+    final userPoolId = authOutputs.userPoolId;
+    if (userPoolId == null) return;
+    final bridge = _stateMachine.expect<auth_cognito.NativeAuthBridge>();
+    return bridge.deleteLegacyDeviceSecrets(
+      username,
+      userPoolId,
+    );
   }
 }

--- a/packages/auth/amplify_auth_cognito/lib/src/credentials/legacy_credential_provider_android.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/credentials/legacy_credential_provider_android.dart
@@ -10,9 +10,7 @@ import 'package:amplify_auth_cognito/src/native_auth_plugin.g.dart'
 import 'package:amplify_auth_cognito_dart/src/credentials/legacy_credential_provider.dart';
 import 'package:amplify_auth_cognito_dart/src/state/cognito_state_machine.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
-import 'package:amplify_core/src/config/auth/cognito/credentials_provider.dart';
-import 'package:amplify_core/src/config/auth/cognito/oauth.dart';
-import 'package:amplify_core/src/config/auth/cognito/user_pool.dart';
+import 'package:amplify_core/src/config/amplify_outputs/auth/auth_outputs.dart';
 
 /// {@template amplify_auth_cognito.legacy_android_credential_provider}
 /// The implementation of [LegacyCredentialProvider] for migrating
@@ -25,53 +23,49 @@ class LegacyCredentialProviderAndroid implements LegacyCredentialProvider {
   final CognitoAuthStateMachine _stateMachine;
 
   @override
-  Future<CredentialStoreData?> fetchLegacyCredentials({
-    CognitoUserPoolConfig? userPoolConfig,
-    CognitoIdentityCredentialsProvider? identityPoolConfig,
-    CognitoOAuthConfig? hostedUiConfig,
-  }) async {
+  Future<CredentialStoreData?> fetchLegacyCredentials(
+    AuthOutputs authOutputs,
+  ) async {
     final bridge = _stateMachine.expect<auth_cognito.NativeAuthBridge>();
     final legacyCredentials = await bridge.getLegacyCredentials(
-      identityPoolConfig?.poolId,
-      userPoolConfig?.appClientId,
+      authOutputs.identityPoolId,
+      authOutputs.userPoolClientId,
     );
     return legacyCredentials.toCredentialStoreData();
   }
 
   @override
-  Future<void> deleteLegacyCredentials({
-    CognitoUserPoolConfig? userPoolConfig,
-    CognitoIdentityCredentialsProvider? identityPoolConfig,
-    CognitoOAuthConfig? hostedUiConfig,
-  }) {
+  Future<void> deleteLegacyCredentials(
+    AuthOutputs authOutputs,
+  ) {
     final bridge = _stateMachine.expect<auth_cognito.NativeAuthBridge>();
     return bridge.clearLegacyCredentials();
   }
 
   @override
-  Future<LegacyDeviceDetails?> fetchLegacyDeviceSecrets({
-    required String username,
-    CognitoUserPoolConfig? userPoolConfig,
-  }) async {
-    if (userPoolConfig == null) return null;
+  Future<LegacyDeviceDetails?> fetchLegacyDeviceSecrets(
+    String username,
+    AuthOutputs authOutputs,
+  ) async {
+    if (authOutputs.userPoolId == null) return null;
     final bridge = _stateMachine.expect<auth_cognito.NativeAuthBridge>();
     final device = await bridge.fetchLegacyDeviceSecrets(
       username,
-      userPoolConfig.poolId,
+      authOutputs.userPoolId!,
     );
     return device?.toLegacyDeviceDetails();
   }
 
   @override
-  Future<void> deleteLegacyDeviceSecrets({
-    required String username,
-    CognitoUserPoolConfig? userPoolConfig,
-  }) async {
-    if (userPoolConfig != null) {
+  Future<void> deleteLegacyDeviceSecrets(
+    String username,
+    AuthOutputs authOutputs,
+  ) async {
+    if (authOutputs.userPoolId != null) {
       final bridge = _stateMachine.expect<auth_cognito.NativeAuthBridge>();
       return bridge.deleteLegacyDeviceSecrets(
         username,
-        userPoolConfig.poolId,
+        authOutputs.userPoolId!,
       );
     }
   }

--- a/packages/auth/amplify_auth_cognito/lib/src/credentials/legacy_credential_provider_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/credentials/legacy_credential_provider_impl.dart
@@ -12,6 +12,8 @@ import 'package:amplify_auth_cognito_dart/src/state/cognito_state_machine.dart';
 // ignore: implementation_imports, invalid_use_of_internal_member
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
+// ignore: implementation_imports
+import 'package:amplify_core/src/config/amplify_outputs/auth/auth_outputs.dart';
 
 /// {@template amplify_auth_cognito.legacy_credential_provider_impl}
 /// The implementation of [LegacyCredentialProvider] for migrating
@@ -35,54 +37,46 @@ class LegacyCredentialProviderImpl implements LegacyCredentialProvider {
   }();
 
   @override
-  Future<CredentialStoreData?> fetchLegacyCredentials({
-    CognitoUserPoolConfig? userPoolConfig,
-    CognitoIdentityCredentialsProvider? identityPoolConfig,
-    CognitoOAuthConfig? hostedUiConfig,
-  }) async {
+  Future<CredentialStoreData?> fetchLegacyCredentials(
+    AuthOutputs authOutputs,
+  ) async {
     if (_instance == null) return null;
     return _instance.fetchLegacyCredentials(
-      userPoolConfig: userPoolConfig,
-      identityPoolConfig: identityPoolConfig,
-      hostedUiConfig: hostedUiConfig,
+      authOutputs,
     );
   }
 
   @override
-  Future<void> deleteLegacyCredentials({
-    CognitoUserPoolConfig? userPoolConfig,
-    CognitoIdentityCredentialsProvider? identityPoolConfig,
-    CognitoOAuthConfig? hostedUiConfig,
-  }) async {
+  Future<void> deleteLegacyCredentials(
+    AuthOutputs authOutputs,
+  ) async {
     if (_instance == null) return;
     return _instance.deleteLegacyCredentials(
-      userPoolConfig: userPoolConfig,
-      identityPoolConfig: identityPoolConfig,
-      hostedUiConfig: hostedUiConfig,
+      authOutputs,
     );
   }
 
   @override
-  Future<LegacyDeviceDetails?> fetchLegacyDeviceSecrets({
-    required String username,
-    CognitoUserPoolConfig? userPoolConfig,
-  }) async {
+  Future<LegacyDeviceDetails?> fetchLegacyDeviceSecrets(
+    String username,
+    AuthOutputs authOutputs,
+  ) async {
     if (_instance == null) return null;
     return _instance.fetchLegacyDeviceSecrets(
-      username: username,
-      userPoolConfig: userPoolConfig,
+      username,
+      authOutputs,
     );
   }
 
   @override
-  Future<void> deleteLegacyDeviceSecrets({
-    required String username,
-    CognitoUserPoolConfig? userPoolConfig,
-  }) async {
+  Future<void> deleteLegacyDeviceSecrets(
+    String username,
+    AuthOutputs authOutputs,
+  ) async {
     if (_instance == null) return;
     return _instance.deleteLegacyDeviceSecrets(
-      username: username,
-      userPoolConfig: userPoolConfig,
+      username,
+      authOutputs,
     );
   }
 }

--- a/packages/auth/amplify_auth_cognito/lib/src/credentials/legacy_credential_provider_ios.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/credentials/legacy_credential_provider_ios.dart
@@ -34,17 +34,17 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
     AuthOutputs authOutputs,
   ) async {
     CognitoUserPoolTokens? userPoolTokens;
-    if (authOutputs.userPoolClientId != null) {
+    final userPoolClientId = authOutputs.userPoolClientId;
+    if (userPoolClientId != null) {
       final userPoolStorage = await _getUserPoolStorage();
-      final cognitoUserKeys =
-          LegacyCognitoUserKeys(authOutputs.userPoolClientId!);
+      final cognitoUserKeys = LegacyCognitoUserKeys(userPoolClientId);
       final currentUserId = await userPoolStorage.read(
         key: cognitoUserKeys[LegacyCognitoKey.currentUser],
       );
       if (currentUserId != null) {
         final userPoolKeys = LegacyCognitoUserPoolKeys(
           currentUserId,
-          authOutputs.userPoolClientId!,
+          userPoolClientId,
         );
         final accessToken = await userPoolStorage.read(
           key: userPoolKeys[LegacyCognitoUserPoolKey.accessToken],
@@ -72,9 +72,10 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
 
     String? identityId;
     AWSCredentials? awsCredentials;
-    if (authOutputs.identityPoolId != null) {
+    final identityPoolId = authOutputs.identityPoolId;
+    if (identityPoolId != null) {
       final identityPoolStorage = await _getIdentityPoolStorage(
-        authOutputs.identityPoolId!,
+        identityPoolId,
       );
       const identityPoolKeys = LegacyCognitoIdentityPoolKeys();
       identityId = await identityPoolStorage.read(
@@ -125,17 +126,17 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
   Future<void> deleteLegacyCredentials(
     AuthOutputs authOutputs,
   ) async {
-    if (authOutputs.userPoolClientId != null) {
+    final userPoolClientId = authOutputs.userPoolClientId;
+    if (userPoolClientId != null) {
       final userPoolStorage = await _getUserPoolStorage();
-      final cognitoUserKeys =
-          LegacyCognitoUserKeys(authOutputs.userPoolClientId!);
+      final cognitoUserKeys = LegacyCognitoUserKeys(userPoolClientId);
       final currentUser = await userPoolStorage.read(
         key: cognitoUserKeys[LegacyCognitoKey.currentUser],
       );
       if (currentUser != null) {
         final userPoolKeys = LegacyCognitoUserPoolKeys(
           currentUser,
-          authOutputs.userPoolClientId!,
+          userPoolClientId,
         );
         await userPoolStorage.deleteMany([
           userPoolKeys[LegacyCognitoUserPoolKey.accessToken],
@@ -165,17 +166,18 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
     String username,
     AuthOutputs authOutputs,
   ) async {
-    if (authOutputs.userPoolClientId == null) return null;
+    final userPoolClientId = authOutputs.userPoolClientId;
+    if (userPoolClientId == null) return null;
     final userPoolStorage = await _getUserPoolStorage();
-    final cognitoUserKeys =
-        LegacyCognitoUserKeys(authOutputs.userPoolClientId!);
+    final cognitoUserKeys = LegacyCognitoUserKeys(userPoolClientId);
     final currentUserId = await userPoolStorage.read(
       key: cognitoUserKeys[LegacyCognitoKey.currentUser],
     );
-    if (currentUserId == null || authOutputs.userPoolId == null) return null;
+    final userPoolId = authOutputs.userPoolId;
+    if (currentUserId == null || userPoolId == null) return null;
     final keys = LegacyDeviceSecretKeys(
       currentUserId,
-      authOutputs.userPoolId!,
+      userPoolId,
     );
     final deviceKey = await userPoolStorage.read(
       key: keys[LegacyDeviceSecretKey.id],
@@ -187,7 +189,7 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
       key: keys[LegacyDeviceSecretKey.group],
     );
 
-    final asfKeys = LegacyAsfDeviceKeys(currentUserId, authOutputs.userPoolId!);
+    final asfKeys = LegacyAsfDeviceKeys(currentUserId, userPoolId);
     final asfDeviceId = await userPoolStorage.read(
       key: asfKeys[LegacyAsfDeviceKey.id],
     );
@@ -205,16 +207,17 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
     String username,
     AuthOutputs authOutputs,
   ) async {
-    if (authOutputs.userPoolClientId == null) return;
+    final userPoolClientId = authOutputs.userPoolClientId;
+    if (userPoolClientId == null) return;
     final userPoolStorage = await _getUserPoolStorage();
-    final cognitoUserKeys =
-        LegacyCognitoUserKeys(authOutputs.userPoolClientId!);
+    final cognitoUserKeys = LegacyCognitoUserKeys(userPoolClientId);
     final currentUserId = await userPoolStorage.read(
       key: cognitoUserKeys[LegacyCognitoKey.currentUser],
     );
-    if (currentUserId == null || authOutputs.userPoolId == null) return;
-    final keys = LegacyDeviceSecretKeys(currentUserId, authOutputs.userPoolId!);
-    final asfKeys = LegacyAsfDeviceKeys(currentUserId, authOutputs.userPoolId!);
+    final userPoolId = authOutputs.userPoolId;
+    if (currentUserId == null || userPoolId == null) return;
+    final keys = LegacyDeviceSecretKeys(currentUserId, userPoolId);
+    final asfKeys = LegacyAsfDeviceKeys(currentUserId, userPoolId);
     await userPoolStorage.deleteMany([
       keys[LegacyDeviceSecretKey.id],
       keys[LegacyDeviceSecretKey.secret],

--- a/packages/auth/amplify_auth_cognito/lib/src/credentials/legacy_credential_provider_ios.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/credentials/legacy_credential_provider_ios.dart
@@ -14,6 +14,8 @@ import 'package:amplify_auth_cognito_dart/src/credentials/legacy_credential_prov
 import 'package:amplify_auth_cognito_dart/src/state/cognito_state_machine.dart';
 // ignore: implementation_imports, invalid_use_of_internal_member
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
+// ignore: implementation_imports
+import 'package:amplify_core/src/config/amplify_outputs/auth/auth_outputs.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:async/async.dart';
 
@@ -28,22 +30,21 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
   final CognitoAuthStateMachine _stateMachine;
 
   @override
-  Future<CredentialStoreData?> fetchLegacyCredentials({
-    CognitoUserPoolConfig? userPoolConfig,
-    CognitoIdentityCredentialsProvider? identityPoolConfig,
-    CognitoOAuthConfig? hostedUiConfig,
-  }) async {
+  Future<CredentialStoreData?> fetchLegacyCredentials(
+    AuthOutputs authOutputs,
+  ) async {
     CognitoUserPoolTokens? userPoolTokens;
-    if (userPoolConfig != null) {
+    if (authOutputs.userPoolClientId != null) {
       final userPoolStorage = await _getUserPoolStorage();
-      final cognitoUserKeys = LegacyCognitoUserKeys(userPoolConfig);
+      final cognitoUserKeys =
+          LegacyCognitoUserKeys(authOutputs.userPoolClientId!);
       final currentUserId = await userPoolStorage.read(
         key: cognitoUserKeys[LegacyCognitoKey.currentUser],
       );
       if (currentUserId != null) {
         final userPoolKeys = LegacyCognitoUserPoolKeys(
           currentUserId,
-          userPoolConfig,
+          authOutputs.userPoolClientId!,
         );
         final accessToken = await userPoolStorage.read(
           key: userPoolKeys[LegacyCognitoUserPoolKey.accessToken],
@@ -56,7 +57,7 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
         );
         if (accessToken != null && refreshToken != null && idToken != null) {
           // TODO(Jordan-Nelson): fetch sign in method from keychain on iOS
-          final signInMethod = hostedUiConfig != null
+          final signInMethod = authOutputs.oauth != null
               ? CognitoSignInMethod.hostedUi
               : CognitoSignInMethod.default$;
           userPoolTokens = CognitoUserPoolTokens(
@@ -71,10 +72,9 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
 
     String? identityId;
     AWSCredentials? awsCredentials;
-    final identityPoolId = identityPoolConfig?.poolId;
-    if (identityPoolId != null) {
+    if (authOutputs.identityPoolId != null) {
       final identityPoolStorage = await _getIdentityPoolStorage(
-        identityPoolId,
+        authOutputs.identityPoolId!,
       );
       const identityPoolKeys = LegacyCognitoIdentityPoolKeys();
       identityId = await identityPoolStorage.read(
@@ -122,21 +122,20 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
   }
 
   @override
-  Future<void> deleteLegacyCredentials({
-    CognitoUserPoolConfig? userPoolConfig,
-    CognitoIdentityCredentialsProvider? identityPoolConfig,
-    CognitoOAuthConfig? hostedUiConfig,
-  }) async {
-    if (userPoolConfig != null) {
+  Future<void> deleteLegacyCredentials(
+    AuthOutputs authOutputs,
+  ) async {
+    if (authOutputs.userPoolClientId != null) {
       final userPoolStorage = await _getUserPoolStorage();
-      final cognitoUserKeys = LegacyCognitoUserKeys(userPoolConfig);
+      final cognitoUserKeys =
+          LegacyCognitoUserKeys(authOutputs.userPoolClientId!);
       final currentUser = await userPoolStorage.read(
         key: cognitoUserKeys[LegacyCognitoKey.currentUser],
       );
       if (currentUser != null) {
         final userPoolKeys = LegacyCognitoUserPoolKeys(
           currentUser,
-          userPoolConfig,
+          authOutputs.userPoolClientId!,
         );
         await userPoolStorage.deleteMany([
           userPoolKeys[LegacyCognitoUserPoolKey.accessToken],
@@ -147,9 +146,9 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
       }
     }
 
-    final identityPoolId = identityPoolConfig?.poolId;
-    if (identityPoolId != null) {
-      final identityPoolStorage = await _getIdentityPoolStorage(identityPoolId);
+    if (authOutputs.identityPoolId != null) {
+      final identityPoolStorage =
+          await _getIdentityPoolStorage(authOutputs.identityPoolId!);
       const identityPoolKeys = LegacyCognitoIdentityPoolKeys();
       await identityPoolStorage.deleteMany([
         identityPoolKeys[LegacyCognitoIdentityPoolKey.identityId],
@@ -162,20 +161,21 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
   }
 
   @override
-  Future<LegacyDeviceDetails?> fetchLegacyDeviceSecrets({
-    required String username,
-    CognitoUserPoolConfig? userPoolConfig,
-  }) async {
-    if (userPoolConfig == null) return null;
+  Future<LegacyDeviceDetails?> fetchLegacyDeviceSecrets(
+    String username,
+    AuthOutputs authOutputs,
+  ) async {
+    if (authOutputs.userPoolClientId == null) return null;
     final userPoolStorage = await _getUserPoolStorage();
-    final cognitoUserKeys = LegacyCognitoUserKeys(userPoolConfig);
+    final cognitoUserKeys =
+        LegacyCognitoUserKeys(authOutputs.userPoolClientId!);
     final currentUserId = await userPoolStorage.read(
       key: cognitoUserKeys[LegacyCognitoKey.currentUser],
     );
-    if (currentUserId == null) return null;
+    if (currentUserId == null || authOutputs.userPoolId == null) return null;
     final keys = LegacyDeviceSecretKeys(
       currentUserId,
-      userPoolConfig,
+      authOutputs.userPoolId!,
     );
     final deviceKey = await userPoolStorage.read(
       key: keys[LegacyDeviceSecretKey.id],
@@ -187,7 +187,7 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
       key: keys[LegacyDeviceSecretKey.group],
     );
 
-    final asfKeys = LegacyAsfDeviceKeys(currentUserId, userPoolConfig);
+    final asfKeys = LegacyAsfDeviceKeys(currentUserId, authOutputs.userPoolId!);
     final asfDeviceId = await userPoolStorage.read(
       key: asfKeys[LegacyAsfDeviceKey.id],
     );
@@ -201,19 +201,20 @@ class LegacyCredentialProviderIOS implements LegacyCredentialProvider {
   }
 
   @override
-  Future<void> deleteLegacyDeviceSecrets({
-    required String username,
-    CognitoUserPoolConfig? userPoolConfig,
-  }) async {
-    if (userPoolConfig == null) return;
+  Future<void> deleteLegacyDeviceSecrets(
+    String username,
+    AuthOutputs authOutputs,
+  ) async {
+    if (authOutputs.userPoolClientId == null) return;
     final userPoolStorage = await _getUserPoolStorage();
-    final cognitoUserKeys = LegacyCognitoUserKeys(userPoolConfig);
+    final cognitoUserKeys =
+        LegacyCognitoUserKeys(authOutputs.userPoolClientId!);
     final currentUserId = await userPoolStorage.read(
       key: cognitoUserKeys[LegacyCognitoKey.currentUser],
     );
-    if (currentUserId == null) return;
-    final keys = LegacyDeviceSecretKeys(currentUserId, userPoolConfig);
-    final asfKeys = LegacyAsfDeviceKeys(currentUserId, userPoolConfig);
+    if (currentUserId == null || authOutputs.userPoolId == null) return;
+    final keys = LegacyDeviceSecretKeys(currentUserId, authOutputs.userPoolId!);
+    final asfKeys = LegacyAsfDeviceKeys(currentUserId, authOutputs.userPoolId!);
     await userPoolStorage.deleteMany([
       keys[LegacyDeviceSecretKey.id],
       keys[LegacyDeviceSecretKey.secret],

--- a/packages/auth/amplify_auth_cognito/lib/src/credentials/legacy_ios_cognito_keys.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/credentials/legacy_ios_cognito_keys.dart
@@ -11,7 +11,6 @@ library amplify_auth_cognito.credentials.legacy_ios_cognito_keys;
 
 import 'dart:collection';
 
-import 'package:amplify_core/amplify_core.dart';
 import 'package:meta/meta.dart';
 
 /// Discrete keys stored for Legacy Cognito operations on iOS.
@@ -77,17 +76,17 @@ enum LegacyAsfDeviceKey {
 /// {@endtemplate}
 class LegacyCognitoUserKeys extends LegacyIOSCognitoKeys<LegacyCognitoKey> {
   /// {@macro amplify_auth_cognito.legacy_cognito_identity_pool_keys}
-  const LegacyCognitoUserKeys(this.config);
+  const LegacyCognitoUserKeys(this.userPoolClientId);
 
-  /// The Cognito identity pool configuration, used to determine the key
+  /// The Cognito user pool client id , used to determine the key
   /// prefixes.
-  final CognitoUserPoolConfig config;
+  final String userPoolClientId;
 
   @override
   List<LegacyCognitoKey> get _values => LegacyCognitoKey.values;
 
   @override
-  String? get prefix => config.appClientId;
+  String? get prefix => userPoolClientId;
 }
 
 /// {@template amplify_auth_cognito.legacy_cognito_identity_pool_keys}
@@ -114,11 +113,11 @@ class LegacyCognitoIdentityPoolKeys
 class LegacyCognitoUserPoolKeys
     extends LegacyIOSCognitoKeys<LegacyCognitoUserPoolKey> {
   /// {@macro amplify_auth_cognito.cognito_user_pool_keys}
-  const LegacyCognitoUserPoolKeys(this.currentUserId, this.config);
+  const LegacyCognitoUserPoolKeys(this.currentUserId, this.userPoolClientId);
 
-  /// The Cognito identity pool configuration, used to determine the key
+  /// The Cognito user pool client id, used to determine the key
   /// prefixes.
-  final CognitoUserPoolConfig config;
+  final String userPoolClientId;
 
   /// The current user ID, used to determine the key prefixes.
   final String currentUserId;
@@ -127,7 +126,7 @@ class LegacyCognitoUserPoolKeys
   List<LegacyCognitoUserPoolKey> get _values => LegacyCognitoUserPoolKey.values;
 
   @override
-  String get prefix => '${config.appClientId}.$currentUserId';
+  String get prefix => '$userPoolClientId.$currentUserId';
 }
 
 /// {@template amplify_auth_cognito.cognito_user_pool_keys}
@@ -137,11 +136,11 @@ class LegacyCognitoUserPoolKeys
 class LegacyDeviceSecretKeys
     extends LegacyIOSCognitoKeys<LegacyDeviceSecretKey> {
   /// {@macro amplify_auth_cognito.cognito_user_pool_keys}
-  const LegacyDeviceSecretKeys(this.currentUserId, this.config);
+  const LegacyDeviceSecretKeys(this.currentUserId, this.userPoolId);
 
-  /// The Cognito identity pool configuration, used to determine the key
+  /// The Cognito user pool id, used to determine the key
   /// prefixes.
-  final CognitoUserPoolConfig config;
+  final String userPoolId;
 
   /// The current user ID, used to determine the key prefixes.
   final String currentUserId;
@@ -150,7 +149,7 @@ class LegacyDeviceSecretKeys
   List<LegacyDeviceSecretKey> get _values => LegacyDeviceSecretKey.values;
 
   @override
-  String get prefix => '${config.poolId}.$currentUserId.device';
+  String get prefix => '$userPoolId.$currentUserId.device';
 }
 
 /// {@template amplify_auth_cognito.cognito_user_pool_keys}
@@ -159,11 +158,11 @@ class LegacyDeviceSecretKeys
 /// {@endtemplate}
 class LegacyAsfDeviceKeys extends LegacyIOSCognitoKeys<LegacyAsfDeviceKey> {
   /// {@macro amplify_auth_cognito.cognito_user_pool_keys}
-  const LegacyAsfDeviceKeys(this.currentUserId, this.config);
+  const LegacyAsfDeviceKeys(this.currentUserId, this.userPoolId);
 
-  /// The Cognito identity pool configuration, used to determine the key
+  /// The Cognito user pool id, used to determine the key
   /// prefixes.
-  final CognitoUserPoolConfig config;
+  final String userPoolId;
 
   /// The current user ID, used to determine the key prefixes.
   final String currentUserId;
@@ -172,7 +171,7 @@ class LegacyAsfDeviceKeys extends LegacyIOSCognitoKeys<LegacyAsfDeviceKey> {
   List<LegacyAsfDeviceKey> get _values => LegacyAsfDeviceKey.values;
 
   @override
-  String get prefix => '${config.poolId}.$currentUserId.asf.device';
+  String get prefix => '$userPoolId.$currentUserId.asf.device';
 }
 
 /// {@template amplify_auth_cognito.cognito_keys}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/legacy_credential_provider.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/credentials/legacy_credential_provider.dart
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_auth_cognito_dart/src/state/state/auth_state.dart';
-import 'package:amplify_core/amplify_core.dart';
+// ignore: implementation_imports
+import 'package:amplify_core/src/config/amplify_outputs/auth/auth_outputs.dart';
 
 /// {@template amplify_auth_cognito_dart.legacy_credential_provider}
 /// Provides methods to fetch and delete legacy credentials if they exist.
@@ -12,30 +13,26 @@ abstract interface class LegacyCredentialProvider {
   const LegacyCredentialProvider();
 
   /// Fetches legacy credentials if they are present.
-  Future<CredentialStoreData?> fetchLegacyCredentials({
-    CognitoUserPoolConfig? userPoolConfig,
-    CognitoIdentityCredentialsProvider? identityPoolConfig,
-    CognitoOAuthConfig? hostedUiConfig,
-  });
+  Future<CredentialStoreData?> fetchLegacyCredentials(
+    AuthOutputs authOutputs,
+  );
 
   /// Fetches legacy device secrets if they are present.
-  Future<LegacyDeviceDetails?> fetchLegacyDeviceSecrets({
-    required String username,
-    CognitoUserPoolConfig? userPoolConfig,
-  });
+  Future<LegacyDeviceDetails?> fetchLegacyDeviceSecrets(
+    String username,
+    AuthOutputs authOutputs,
+  );
 
   /// Deletes legacy credentials if they are present.
-  Future<void> deleteLegacyCredentials({
-    CognitoUserPoolConfig? userPoolConfig,
-    CognitoIdentityCredentialsProvider? identityPoolConfig,
-    CognitoOAuthConfig? hostedUiConfig,
-  });
+  Future<void> deleteLegacyCredentials(
+    AuthOutputs authOutputs,
+  );
 
   /// Deletes legacy device secrets if they are present.
-  Future<void> deleteLegacyDeviceSecrets({
-    required String username,
-    CognitoUserPoolConfig? userPoolConfig,
-  });
+  Future<void> deleteLegacyDeviceSecrets(
+    String username,
+    AuthOutputs authOutputs,
+  );
 }
 
 /// {@template amplify_auth_cognito_dart.legacy_device_details}

--- a/packages/auth/amplify_auth_cognito_test/lib/common/mock_legacy_credential_provider.dart
+++ b/packages/auth/amplify_auth_cognito_test/lib/common/mock_legacy_credential_provider.dart
@@ -3,9 +3,7 @@
 
 import 'package:amplify_auth_cognito_dart/src/credentials/legacy_credential_provider.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
-import 'package:amplify_core/src/config/auth/cognito/credentials_provider.dart';
-import 'package:amplify_core/src/config/auth/cognito/oauth.dart';
-import 'package:amplify_core/src/config/auth/cognito/user_pool.dart';
+import 'package:amplify_core/src/config/amplify_outputs/auth/auth_outputs.dart';
 
 class MockLegacyCredentialProvider implements LegacyCredentialProvider {
   MockLegacyCredentialProvider({CredentialStoreData? initialData})
@@ -14,36 +12,32 @@ class MockLegacyCredentialProvider implements LegacyCredentialProvider {
   CredentialStoreData? data;
 
   @override
-  Future<void> deleteLegacyCredentials({
-    CognitoUserPoolConfig? userPoolConfig,
-    CognitoIdentityCredentialsProvider? identityPoolConfig,
-    CognitoOAuthConfig? hostedUiConfig,
-  }) async {
+  Future<void> deleteLegacyCredentials(
+    AuthOutputs authOutputs,
+  ) async {
     data = null;
   }
 
   @override
-  Future<CredentialStoreData?> fetchLegacyCredentials({
-    CognitoUserPoolConfig? userPoolConfig,
-    CognitoIdentityCredentialsProvider? identityPoolConfig,
-    CognitoOAuthConfig? hostedUiConfig,
-  }) async {
+  Future<CredentialStoreData?> fetchLegacyCredentials(
+    AuthOutputs authOutputs,
+  ) async {
     return data;
   }
 
   @override
-  Future<LegacyDeviceDetails?> fetchLegacyDeviceSecrets({
-    required String username,
-    CognitoUserPoolConfig? userPoolConfig,
-  }) async {
+  Future<LegacyDeviceDetails?> fetchLegacyDeviceSecrets(
+    String username,
+    AuthOutputs authOutputs,
+  ) async {
     return null;
   }
 
   @override
-  Future<void> deleteLegacyDeviceSecrets({
-    required String username,
-    CognitoUserPoolConfig? userPoolConfig,
-  }) async {
+  Future<void> deleteLegacyDeviceSecrets(
+    String username,
+    AuthOutputs authOutputs,
+  ) async {
     return;
   }
 }

--- a/packages/auth/amplify_auth_cognito_test/test/state/credential_store_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/credential_store_state_machine_test.dart
@@ -31,8 +31,7 @@ void main() {
       secureStorage = MockSecureStorage();
       manager = DependencyManager()
         ..addInstance(secureStorage)
-        ..addInstance(mockConfig.auth!)
-        ..addInstance(authConfig);
+        ..addInstance(mockConfig.auth!);
       stateMachine = CognitoAuthStateMachine(dependencyManager: manager);
     });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- legacy credential provider to use AuthOutputs instead of AmplifyConfig types
- legacy ios cognito keys to have an String field instead of CognitoUserPoolConfig
- credential store state machine to use AuthOutputs instead of AuthConfiguration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
