### PR TITLE
chore: add GH actions for issue open, close, comment, label events

### DIFF
--- a/.github/workflows/issue_closed.yml
+++ b/.github/workflows/issue_closed.yml
@@ -1,0 +1,32 @@
+name: Issue Closed
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  cleanup-labels:
+    runs-on: ubuntu-latest
+    if: ${{ (contains(github.event.issue.labels.*.name, 'pending-community-response') || contains(github.event.issue.labels.*.name, 'pending-maintainer-response') || contains(github.event.issue.labels.*.name, 'pending-close-response-required') || contains(github.event.issue.labels.*.name, 'pending-release')|| contains(github.event.issue.labels.*.name, 'pending-triage')) }}
+    steps:
+      - name: remove unnecessary labels after closing
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY_NAME: ${{ github.event.repository.full_name }}
+        run: |
+          gh issue edit $ISSUE_NUMBER --repo $REPOSITORY_NAME --remove-label "pending-close-response-required" --remove-label "pending-community-response" --remove-label "pending-maintainer-response" --remove-label "pending-release" --remove-label "pending-triage"
+
+  comment-visibility-warning:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/closed-issue-message@36b7048ea77bb834d16e7a7c5b5471ac767a4ca1 # v1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          message: |
+            This issue is now closed. Comments on closed issues are hard for our team to see. 
+            If you need more assistance, please open a new issue that references this one.

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -1,0 +1,31 @@
+name: Issue Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  adjust-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      REPOSITORY_NAME: ${{ github.event.repository.full_name }}
+    steps:
+      - name: remove pending-community-response when new comment received
+        if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) && !github.event.issue.pull_request }}
+        shell: bash
+        run: |
+          gh issue edit $ISSUE_NUMBER --repo $REPOSITORY_NAME --remove-label "pending-community-response"
+      - name: add pending-maintainer-response when new community comment received
+        if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) }}
+        shell: bash
+        run: |
+          gh issue edit $ISSUE_NUMBER --repo $REPOSITORY_NAME --add-label "pending-maintainer-response"
+      - name: remove pending-maintainer-response when new owner/member comment received
+        if: ${{ contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) }}
+        shell: bash
+        run: |
+          gh issue edit $ISSUE_NUMBER --repo $REPOSITORY_NAME --remove-label "pending-maintainer-response"

--- a/.github/workflows/issue_labeled.yml
+++ b/.github/workflows/issue_labeled.yml
@@ -1,0 +1,20 @@
+name: Issue Labeled
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  remove-pending-triage-label:
+    runs-on: ubuntu-latest
+    if: ${{ contains(fromJSON('["question", "bug", "feature-request"]'), github.event.label.name) }}
+    permissions:
+      issues: write
+    steps:
+      - name: Remove the pending-triage label
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY_NAME: ${{ github.event.repository.full_name }}
+        run: |
+          gh issue edit $ISSUE_NUMBER --repo $REPOSITORY_NAME --remove-label "pending-triage"

--- a/.github/workflows/issue_opened.yml
+++ b/.github/workflows/issue_opened.yml
@@ -1,0 +1,39 @@
+name: Issue Opened
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-issue-opened-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      REPOSITORY_NAME: ${{ github.event.repository.full_name }}
+    steps:
+      - name: Add the pending-triage label
+        shell: bash
+        run: |
+          gh issue edit $ISSUE_NUMBER --repo $REPOSITORY_NAME --add-label "pending-triage"
+      - name: Add the pending-maintainer-response label
+        if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.issue.author_association) }}
+        shell: bash
+        run: |
+          gh issue edit $ISSUE_NUMBER --repo $REPOSITORY_NAME --add-label "pending-maintainer-response"
+
+  maintainer-opened:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    if: ${{ contains(fromJSON('["MEMBER", "OWNER"]'), github.event.issue.author_association) }}
+    steps:
+      - name: Post comment if maintainer opened.
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY_NAME: ${{ github.event.repository.full_name }}
+        run: |
+          gh issue comment $ISSUE_NUMBER --repo $REPOSITORY_NAME -b "This issue was opened by a maintainer of this repository; updates will be posted here. If you are also experiencing this issue, please comment here with any relevant information so that we're aware and can prioritize accordingly."


### PR DESCRIPTION
*Description of changes:*
- Adds GH actions for issue open, issue close, issue comment, and issue label events

GH actions copied from Amplify Android (https://github.com/aws-amplify/amplify-android/tree/main/.github/workflows) with "notify" jobs removed  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
