### PR TITLE
fix(api): web socket error handling

### DIFF
--- a/packages/api/amplify_api_dart/lib/src/graphql/web_socket/types/web_socket_types.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/web_socket/types/web_socket_types.dart
@@ -144,8 +144,15 @@ class WebSocketError extends WebSocketMessagePayload implements Exception {
   final List<Map<String, dynamic>> errors;
 
   static WebSocketError fromJson(Map<String, dynamic> json) {
-    final errors = json['errors'] as List?;
-    return WebSocketError(errors?.cast() ?? []);
+    final errors = json['errors'];
+    List<Map<String, dynamic>>? errorsList = [];
+    if (errors is List?) {
+      errorsList = errors?.cast();
+    } else if (errors is Map<String, dynamic>) {
+      errorsList = [errors];
+    }
+
+    return WebSocketError(errorsList ?? []);
   }
 
   @override

--- a/packages/api/amplify_api_dart/test/web_socket/web_socket_types_test.dart
+++ b/packages/api/amplify_api_dart/test/web_socket/web_socket_types_test.dart
@@ -125,5 +125,33 @@ void main() {
         errorMessage,
       );
     });
+    test('WebsocketMessage should decode errors as a Map', () {
+      const errorMessage = 'Max number of 100 subscriptions reached';
+      const errorType = 'MaxSubscriptionsReachedError';
+      const errorMap = {'errorType': errorType, 'message': errorMessage};
+      final entry = {
+        'id': 'xyz-456',
+        'type': 'error',
+        'payload': {'data': null, 'errors': errorMap},
+      };
+      final message = WebSocketMessage.fromJson(entry);
+      expect(message.messageType, MessageType.error);
+      expect(
+        message.payload!.toJson()['errors'],
+        [errorMap],
+      );
+
+      /// GraphQLResponseDecoder should handle a payload with errors.
+      final response = GraphQLResponseDecoder.instance.decode<String>(
+        request: GraphQLRequest<String>(
+          document: '',
+        ),
+        response: message.payload!.toJson(),
+      );
+      expect(
+        response.errors.first.message,
+        errorMessage,
+      );
+    });
   });
 }


### PR DESCRIPTION
*Description of changes:*
Adds error handling when web socket error type is a Map.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
