### PR TITLE
fix(datastore): FlutterSerializedModel.extractJsonValue returns `.some(nil)` instead of `nil`

### DIFF
--- a/packages/amplify_datastore/example/ios/unit_tests/AmplifySerializedModelUnitTests.swift
+++ b/packages/amplify_datastore/example/ios/unit_tests/AmplifySerializedModelUnitTests.swift
@@ -192,4 +192,13 @@ class AmplifySerializedModelUnitTests: XCTestCase {
             }
         }
     }
+    
+    func test_extracts_some_nil() throws {
+        let output = try FlutterSerializedModelData.BlogWithNullSerializedModel.jsonValue(for: "post")
+        
+        // This ensures if a property has a `null` json value, it gets returned as `.some(nil)`
+        // Per https://github.com/aws-amplify/amplify-swift/blob/cb80b91c38d99932af28df6be07633ee0563be08/Amplify/Categories/DataStore/Model/JSONHelper/JSONValueHolder.swift#L33-L34
+        XCTAssertNotNil(output)
+        XCTAssertNil(output!)
+    }
 }

--- a/packages/amplify_datastore/example/ios/unit_tests/resources/FlutterSerializedModelData.swift
+++ b/packages/amplify_datastore/example/ios/unit_tests/resources/FlutterSerializedModelData.swift
@@ -9,6 +9,12 @@ struct FlutterSerializedModelData {
             "id": JSONValue.string("999"),
             "name": JSONValue.string("blog name"),
         ], modelName: "Blog")
+    static var BlogWithNullSerializedModel: FlutterSerializedModel =
+        .init(map: [
+            "id": JSONValue.string("999"),
+            "name": JSONValue.string("blog name"),
+            "post": JSONValue.null,
+        ], modelName: "Blog")
     static var CommentSerializedModel: FlutterSerializedModel =
         .init(map: [
             "id": JSONValue.string("999"),

--- a/packages/amplify_datastore/ios/Classes/types/model/FlutterSerializedModel.swift
+++ b/packages/amplify_datastore/ios/Classes/types/model/FlutterSerializedModel.swift
@@ -97,7 +97,7 @@ public struct FlutterSerializedModel: Model, ModelIdentifiable, JSONValueHolder 
         case .string(let deserializedValue):
             return deserializedValue
         case .null:
-            return nil
+            return .some(nil)
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/5162

*Description of changes:*
DataStore's `FlutterSerializedModel.extractJsonValue` had the incorrect return time for a json value of `null`. [Amplify Swift library expects](https://github.com/aws-amplify/amplify-swift/blob/cb80b91c38d99932af28df6be07633ee0563be08/Amplify/Categories/DataStore/Model/JSONHelper/JSONValueHolder.swift#L33-L34) it to be `.some(nil)`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
