### PR TITLE
fix(secure_storage): add missing macOS plugin

### DIFF
--- a/packages/secure_storage/amplify_secure_storage/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/pubspec.yaml
@@ -36,6 +36,8 @@ flutter:
         pluginClass: AmplifySecureStoragePlugin
       ios:
         pluginClass: AmplifySecureStoragePlugin
+      macos:
+        pluginClass: AmplifySecureStoragePlugin
       windows:
         dartPluginClass: AmplifySecureStorageDart
       linux:


### PR DESCRIPTION
it's fixing #5361

*Issue*
#5361 

*Description of changes:*
I just added macOS plugin to pubspec, it works now, I think we also need to bump new version to amplify_secure_storage: 0.5.6
