### PR TITLE
chore(version): Bump version

### DIFF
--- a/packages/secure_storage/amplify_secure_storage/CHANGELOG.md
+++ b/packages/secure_storage/amplify_secure_storage/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.6
+
+### Fixes
+- fix(secure_storage): add missing macOS plugin ([#5372](https://github.com/aws-amplify/amplify-flutter/pull/5372))
+
 ## 0.5.5
 
 ### Fixes

--- a/packages/secure_storage/amplify_secure_storage/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/pubspec.yaml
@@ -36,6 +36,8 @@ flutter:
         pluginClass: AmplifySecureStoragePlugin
       ios:
         pluginClass: AmplifySecureStoragePlugin
+      macos:
+        pluginClass: AmplifySecureStoragePlugin
       windows:
         dartPluginClass: AmplifySecureStorageDart
       linux:

--- a/packages/secure_storage/amplify_secure_storage/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_secure_storage
 description: A package for storing secrets, intended for use in Amplify libraries.
-version: 0.5.5
+version: 0.5.6
 homepage: https://github.com/aws-amplify/amplify-flutter/tree/main
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/secure_storage/amplify_secure_storage
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues


### PR DESCRIPTION
### Fixes
- fix(secure_storage): add missing macOS plugin ([#5372](https://github.com/aws-amplify/amplify-flutter/pull/5372))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
