### PR TITLE
feat/auth-export-unmet-password-requirements export

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/authenticator/amplify_authenticator/lib/amplify_authenticator.dart
@@ -42,6 +42,7 @@ export 'package:amplify_authenticator/src/utils/dial_code.dart' show DialCode;
 export 'package:amplify_authenticator/src/utils/dial_code_options.dart'
     show DialCodeOptions;
 
+export 'src/utils/unmet_password_requirements.dart';
 export 'src/enums/enums.dart' show AuthenticatorStep, Gender;
 export 'src/l10n/auth_strings_resolver.dart' hide ButtonResolverKeyType;
 export 'src/models/authenticator_exception.dart';


### PR DESCRIPTION
Need to export UnmetPasswordRequirements as developers can not currently override class: InputResolver  method: passwordRequires.

Amplify_authenticator is exporting auth_strings_resolver and auth_strings_resolver exports input_resolver. Input resolver has a few methods that are meant to be exposed to the public to be overriden. 

file:amplify_authenticator.dart
`export 'src/l10n/auth_strings_resolver.dart' hide ButtonResolverKeyType;`

file: auth_string_resolver.dart
`export 'input_resolver.dart';`

In method  passwordRequires one of the parameters is of type `UnmetPasswordRequirements`. Previously the API was called `PasswordProtectionSettings` which was exported for developer usage.

``` 
  String passwordRequires(
    BuildContext context,
    UnmetPasswordRequirements requirements,
  ) 
```

The solution here is exporting the UnmetPasswordRequirements so that developers can override the InputResolver class. If Amplify doesn't want to continue extending this API, I recommend using the dart keyword sealed so that the class can't be extended.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
