### PR TITLE
chore: update `aft generate workflows`, regenerate dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -352,40 +352,6 @@ updates:
       - dependency-name: "amplify_storage_s3"
       - dependency-name: "amplify_storage_s3_dart"
   - package-ecosystem: "pub"
-    directory: "packages/amplify/amplify_flutter/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_analytics_pinpoint"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_api"
-      - dependency-name: "amplify_api_dart"
-      - dependency-name: "amplify_flutter"
-      - dependency-name: "amplify_auth_cognito"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "smithy_codegen"
-      - dependency-name: "amplify_datastore"
-      - dependency-name: "amplify_datastore_plugin_interface"
-      - dependency-name: "amplify_storage_s3"
-      - dependency-name: "amplify_storage_s3_dart"
-  - package-ecosystem: "pub"
     directory: "packages/amplify_core"
     schedule:
       interval: "daily"
@@ -427,48 +393,6 @@ updates:
       json_serializable:
         patterns:
           - "json_serializable"
-      test:
-        patterns:
-          - "test"
-  - package-ecosystem: "pub"
-    directory: "packages/amplify_core/doc"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_analytics_pinpoint"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_api"
-      - dependency-name: "amplify_api_dart"
-      - dependency-name: "amplify_flutter"
-      - dependency-name: "amplify_auth_cognito"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "smithy_codegen"
-      - dependency-name: "amplify_datastore"
-      - dependency-name: "amplify_datastore_plugin_interface"
-      - dependency-name: "amplify_storage_s3"
-      - dependency-name: "amplify_storage_s3_dart"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      build_runner:
-        patterns:
-          - "build_runner"
       test:
         patterns:
           - "test"
@@ -517,39 +441,6 @@ updates:
       mockito:
         patterns:
           - "org.mockito:*"
-  - package-ecosystem: "pub"
-    directory: "packages/amplify_datastore/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_api"
-      - dependency-name: "amplify_api_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_flutter"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "amplify_datastore"
-      - dependency-name: "amplify_datastore_plugin_interface"
-      - dependency-name: "amplify_auth_cognito"
-      - dependency-name: "amplify_analytics_pinpoint"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "smithy_codegen"
-      - dependency-name: "amplify_authenticator"
   - package-ecosystem: "pub"
     directory: "packages/amplify_datastore/example"
     schedule:
@@ -658,19 +549,6 @@ updates:
       - dependency-name: "amplify_lints"
       - dependency-name: "aws_common"
   - package-ecosystem: "pub"
-    directory: "packages/amplify_native_legacy_wrapper/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_native_legacy_wrapper"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_common"
-  - package-ecosystem: "pub"
     directory: "packages/analytics/amplify_analytics_pinpoint"
     schedule:
       interval: "daily"
@@ -726,50 +604,6 @@ updates:
       mockito:
         patterns:
           - "org.mockito:*"
-  - package-ecosystem: "pub"
-    directory: "packages/analytics/amplify_analytics_pinpoint/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_analytics_pinpoint"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_api"
-      - dependency-name: "amplify_api_dart"
-      - dependency-name: "amplify_flutter"
-      - dependency-name: "amplify_auth_cognito"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "smithy_codegen"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      build_runner:
-        patterns:
-          - "build_runner"
-      built_value:
-        patterns:
-          - "built_value"
-      json_annotation:
-        patterns:
-          - "json_annotation"
-      json_serializable:
-        patterns:
-          - "json_serializable"
   - package-ecosystem: "pub"
     directory: "packages/analytics/amplify_analytics_pinpoint/example"
     schedule:
@@ -891,42 +725,6 @@ updates:
       build_runner:
         patterns:
           - "build_runner"
-  - package-ecosystem: "pub"
-    directory: "packages/api/amplify_api/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_api"
-      - dependency-name: "amplify_api_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_flutter"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "amplify_auth_cognito"
-      - dependency-name: "amplify_analytics_pinpoint"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "smithy_codegen"
-      - dependency-name: "amplify_authenticator"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      async:
-        patterns:
-          - "async"
   - package-ecosystem: "pub"
     directory: "packages/api/amplify_api/example"
     schedule:
@@ -1098,52 +896,6 @@ updates:
         patterns:
           - "test"
   - package-ecosystem: "pub"
-    directory: "packages/auth/amplify_auth_cognito/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_api"
-      - dependency-name: "amplify_api_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_flutter"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "amplify_auth_cognito"
-      - dependency-name: "amplify_analytics_pinpoint"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "smithy_codegen"
-      - dependency-name: "amplify_authenticator"
-      - dependency-name: "amplify_native_legacy_wrapper"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      async:
-        patterns:
-          - "async"
-      http:
-        patterns:
-          - "http"
-      stack_trace:
-        patterns:
-          - "stack_trace"
-      test:
-        patterns:
-          - "test"
-  - package-ecosystem: "pub"
     directory: "packages/auth/amplify_auth_cognito_dart"
     schedule:
       interval: "daily"
@@ -1249,88 +1001,6 @@ updates:
         patterns:
           - "test"
   - package-ecosystem: "pub"
-    directory: "packages/auth/amplify_auth_cognito_dart/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "smithy_codegen"
-      - dependency-name: "example_common"
-      - dependency-name: "amplify_api_dart"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      build_runner:
-        patterns:
-          - "build_runner"
-      build_web_compilers:
-        patterns:
-          - "build_web_compilers"
-      mime:
-        patterns:
-          - "mime"
-      test:
-        patterns:
-          - "test"
-  - package-ecosystem: "pub"
-    directory: "packages/auth/amplify_auth_cognito_test"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "smithy_codegen"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      async:
-        patterns:
-          - "async"
-      built_value:
-        patterns:
-          - "built_value"
-      http:
-        patterns:
-          - "http"
-      test:
-        patterns:
-          - "test"
-      build_runner:
-        patterns:
-          - "build_runner"
-      build_web_compilers:
-        patterns:
-          - "build_web_compilers"
-  - package-ecosystem: "pub"
     directory: "packages/authenticator/amplify_authenticator"
     schedule:
       interval: "daily"
@@ -1408,100 +1078,6 @@ updates:
       uuid:
         patterns:
           - "uuid"
-  - package-ecosystem: "pub"
-    directory: "packages/authenticator/amplify_authenticator/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_auth_cognito"
-      - dependency-name: "amplify_analytics_pinpoint"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "smithy_codegen"
-      - dependency-name: "amplify_flutter"
-      - dependency-name: "amplify_authenticator"
-      - dependency-name: "amplify_api"
-      - dependency-name: "amplify_api_dart"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      uuid:
-        patterns:
-          - "uuid"
-  - package-ecosystem: "pub"
-    directory: "packages/authenticator/amplify_authenticator_test"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_authenticator"
-      - dependency-name: "amplify_auth_cognito"
-      - dependency-name: "amplify_analytics_pinpoint"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "smithy_codegen"
-      - dependency-name: "amplify_flutter"
-  - package-ecosystem: "pub"
-    directory: "packages/authenticator/amplify_authenticator_test/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_authenticator"
-      - dependency-name: "amplify_auth_cognito"
-      - dependency-name: "amplify_analytics_pinpoint"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "smithy_codegen"
-      - dependency-name: "amplify_flutter"
   - package-ecosystem: "pub"
     directory: "packages/aws_common"
     schedule:
@@ -1599,27 +1175,6 @@ updates:
         patterns:
           - "build_web_compilers"
   - package-ecosystem: "pub"
-    directory: "packages/aws_signature_v4/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      build_runner:
-        patterns:
-          - "build_runner"
-      build_web_compilers:
-        patterns:
-          - "build_web_compilers"
-  - package-ecosystem: "pub"
     directory: "packages/common/amplify_db_common"
     schedule:
       interval: "daily"
@@ -1661,33 +1216,6 @@ updates:
       mockito:
         patterns:
           - "org.mockito:*"
-  - package-ecosystem: "pub"
-    directory: "packages/common/amplify_db_common/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      drift:
-        patterns:
-          - "drift"
-      drift_dev:
-        patterns:
-          - "drift_dev"
-      build_runner:
-        patterns:
-          - "build_runner"
   - package-ecosystem: "pub"
     directory: "packages/common/amplify_db_common/example"
     schedule:
@@ -1783,72 +1311,6 @@ updates:
         patterns:
           - "drift_dev"
   - package-ecosystem: "pub"
-    directory: "packages/common/amplify_db_common_dart/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "example_common"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      drift:
-        patterns:
-          - "drift"
-      build_runner:
-        patterns:
-          - "build_runner"
-      build_web_compilers:
-        patterns:
-          - "build_web_compilers"
-      drift_dev:
-        patterns:
-          - "drift_dev"
-  - package-ecosystem: "pub"
-    directory: "packages/example_common"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_lints"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      test:
-        patterns:
-          - "test"
-  - package-ecosystem: "pub"
-    directory: "packages/example_common/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "example_common"
-      - dependency-name: "amplify_lints"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      build_runner:
-        patterns:
-          - "build_runner"
-      build_web_compilers:
-        patterns:
-          - "build_web_compilers"
-  - package-ecosystem: "pub"
     directory: "packages/notifications/push/amplify_push_notifications"
     schedule:
       interval: "daily"
@@ -1925,25 +1387,6 @@ updates:
       - dependency-name: "worker_bee"
       - dependency-name: "worker_bee_builder"
   - package-ecosystem: "pub"
-    directory: "packages/notifications/push/amplify_push_notifications/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_push_notifications"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-  - package-ecosystem: "pub"
     directory: "packages/notifications/push/amplify_push_notifications_pinpoint"
     schedule:
       interval: "daily"
@@ -1983,36 +1426,6 @@ updates:
       built_value_generator:
         patterns:
           - "built_value_generator"
-  - package-ecosystem: "pub"
-    directory: "packages/notifications/push/amplify_push_notifications_pinpoint/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_auth_cognito"
-      - dependency-name: "amplify_analytics_pinpoint"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "smithy_codegen"
-      - dependency-name: "amplify_flutter"
-      - dependency-name: "amplify_push_notifications_pinpoint"
-      - dependency-name: "amplify_push_notifications"
   - package-ecosystem: "pub"
     directory: "packages/notifications/push/amplify_push_notifications_pinpoint/example"
     schedule:
@@ -2108,22 +1521,6 @@ updates:
       - dependency-name: "worker_bee"
       - dependency-name: "worker_bee_builder"
   - package-ecosystem: "pub"
-    directory: "packages/secure_storage/amplify_secure_storage/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-  - package-ecosystem: "pub"
     directory: "packages/secure_storage/amplify_secure_storage_dart"
     schedule:
       interval: "daily"
@@ -2190,6 +1587,976 @@ updates:
       build_web_compilers:
         patterns:
           - "build_web_compilers"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/smithy"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      intl:
+        patterns:
+          - "intl"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      xml:
+        patterns:
+          - "xml"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      stack_trace:
+        patterns:
+          - "stack_trace"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/smithy_aws"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "smithy"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      intl:
+        patterns:
+          - "intl"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      xml:
+        patterns:
+          - "xml"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      file:
+        patterns:
+          - "file"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/smithy/smithy_codegen"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      code_builder:
+        patterns:
+          - "code_builder"
+      dart_style:
+        patterns:
+          - "dart_style"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      xml:
+        patterns:
+          - "xml"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/storage/amplify_storage_s3"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_storage_s3_dart"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+  - package-ecosystem: "pub"
+    directory: "packages/storage/amplify_storage_s3/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_authenticator"
+      - dependency-name: "amplify_storage_s3"
+      - dependency-name: "amplify_storage_s3_dart"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      drift:
+        patterns:
+          - "drift"
+      http:
+        patterns:
+          - "http"
+      stack_trace:
+        patterns:
+          - "stack_trace"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/storage/amplify_storage_s3_dart"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      drift:
+        patterns:
+          - "drift"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      drift_dev:
+        patterns:
+          - "drift_dev"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/storage/amplify_storage_s3_dart/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_storage_s3_dart"
+      - dependency-name: "example_common"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+  - package-ecosystem: "pub"
+    directory: "packages/worker_bee/e2e"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      built_value:
+        patterns:
+          - "built_value"
+      test:
+        patterns:
+          - "test"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+  - package-ecosystem: "pub"
+    directory: "packages/worker_bee/worker_bee"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      stack_trace:
+        patterns:
+          - "stack_trace"
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value_generator:
+        patterns:
+          - "built_value_generator"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/worker_bee/worker_bee_builder"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "worker_bee"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      code_builder:
+        patterns:
+          - "code_builder"
+      dart_style:
+        patterns:
+          - "dart_style"
+      source_gen:
+        patterns:
+          - "source_gen"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify/amplify_flutter/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_datastore"
+      - dependency-name: "amplify_datastore_plugin_interface"
+      - dependency-name: "amplify_storage_s3"
+      - dependency-name: "amplify_storage_s3_dart"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify_core/doc"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_datastore"
+      - dependency-name: "amplify_datastore_plugin_interface"
+      - dependency-name: "amplify_storage_s3"
+      - dependency-name: "amplify_storage_s3_dart"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify_datastore/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "amplify_datastore"
+      - dependency-name: "amplify_datastore_plugin_interface"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_authenticator"
+  - package-ecosystem: "pub"
+    directory: "packages/amplify_native_legacy_wrapper/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_native_legacy_wrapper"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_common"
+  - package-ecosystem: "pub"
+    directory: "packages/analytics/amplify_analytics_pinpoint/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      built_value:
+        patterns:
+          - "built_value"
+      json_annotation:
+        patterns:
+          - "json_annotation"
+      json_serializable:
+        patterns:
+          - "json_serializable"
+  - package-ecosystem: "pub"
+    directory: "packages/api/amplify_api/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_authenticator"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+  - package-ecosystem: "pub"
+    directory: "packages/auth/amplify_auth_cognito/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_authenticator"
+      - dependency-name: "amplify_native_legacy_wrapper"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      http:
+        patterns:
+          - "http"
+      stack_trace:
+        patterns:
+          - "stack_trace"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/auth/amplify_auth_cognito_dart/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "example_common"
+      - dependency-name: "amplify_api_dart"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      mime:
+        patterns:
+          - "mime"
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/auth/amplify_auth_cognito_test"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      async:
+        patterns:
+          - "async"
+      built_value:
+        patterns:
+          - "built_value"
+      http:
+        patterns:
+          - "http"
+      test:
+        patterns:
+          - "test"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+  - package-ecosystem: "pub"
+    directory: "packages/authenticator/amplify_authenticator/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_authenticator"
+      - dependency-name: "amplify_api"
+      - dependency-name: "amplify_api_dart"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      uuid:
+        patterns:
+          - "uuid"
+  - package-ecosystem: "pub"
+    directory: "packages/authenticator/amplify_authenticator_test"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_authenticator"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_flutter"
+  - package-ecosystem: "pub"
+    directory: "packages/authenticator/amplify_authenticator_test/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_authenticator"
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_flutter"
+  - package-ecosystem: "pub"
+    directory: "packages/aws_signature_v4/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+  - package-ecosystem: "pub"
+    directory: "packages/common/amplify_db_common/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      drift:
+        patterns:
+          - "drift"
+      drift_dev:
+        patterns:
+          - "drift_dev"
+      build_runner:
+        patterns:
+          - "build_runner"
+  - package-ecosystem: "pub"
+    directory: "packages/common/amplify_db_common_dart/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "example_common"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      drift:
+        patterns:
+          - "drift"
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+      drift_dev:
+        patterns:
+          - "drift_dev"
+  - package-ecosystem: "pub"
+    directory: "packages/example_common"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      test:
+        patterns:
+          - "test"
+  - package-ecosystem: "pub"
+    directory: "packages/example_common/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "example_common"
+      - dependency-name: "amplify_lints"
+    # Group dependencies which have a constraint set in the global "pubspec.yaml"
+    groups:
+      build_runner:
+        patterns:
+          - "build_runner"
+      build_web_compilers:
+        patterns:
+          - "build_web_compilers"
+  - package-ecosystem: "pub"
+    directory: "packages/notifications/push/amplify_push_notifications/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_push_notifications"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+  - package-ecosystem: "pub"
+    directory: "packages/notifications/push/amplify_push_notifications_pinpoint/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_auth_cognito"
+      - dependency-name: "amplify_analytics_pinpoint"
+      - dependency-name: "amplify_analytics_pinpoint_dart"
+      - dependency-name: "amplify_core"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "aws_signature_v4"
+      - dependency-name: "amplify_db_common_dart"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
+      - dependency-name: "smithy"
+      - dependency-name: "smithy_aws"
+      - dependency-name: "amplify_db_common"
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_auth_cognito_dart"
+      - dependency-name: "smithy_codegen"
+      - dependency-name: "amplify_flutter"
+      - dependency-name: "amplify_push_notifications_pinpoint"
+      - dependency-name: "amplify_push_notifications"
+  - package-ecosystem: "pub"
+    directory: "packages/secure_storage/amplify_secure_storage/example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Ignore patch version bumps
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+      # Ignore all repo packages
+      - dependency-name: "amplify_secure_storage"
+      - dependency-name: "amplify_secure_storage_dart"
+      - dependency-name: "aws_common"
+      - dependency-name: "amplify_lints"
+      - dependency-name: "worker_bee"
+      - dependency-name: "worker_bee_builder"
   - package-ecosystem: "pub"
     directory: "packages/secure_storage/amplify_secure_storage_dart/example"
     schedule:
@@ -2763,137 +3130,6 @@ updates:
         patterns:
           - "test"
   - package-ecosystem: "pub"
-    directory: "packages/smithy/smithy"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      async:
-        patterns:
-          - "async"
-      built_value:
-        patterns:
-          - "built_value"
-      intl:
-        patterns:
-          - "intl"
-      json_annotation:
-        patterns:
-          - "json_annotation"
-      xml:
-        patterns:
-          - "xml"
-      build_runner:
-        patterns:
-          - "build_runner"
-      built_value_generator:
-        patterns:
-          - "built_value_generator"
-      json_serializable:
-        patterns:
-          - "json_serializable"
-      stack_trace:
-        patterns:
-          - "stack_trace"
-      test:
-        patterns:
-          - "test"
-  - package-ecosystem: "pub"
-    directory: "packages/smithy/smithy_aws"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "smithy"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      built_value:
-        patterns:
-          - "built_value"
-      intl:
-        patterns:
-          - "intl"
-      json_annotation:
-        patterns:
-          - "json_annotation"
-      xml:
-        patterns:
-          - "xml"
-      build_runner:
-        patterns:
-          - "build_runner"
-      built_value_generator:
-        patterns:
-          - "built_value_generator"
-      file:
-        patterns:
-          - "file"
-      json_serializable:
-        patterns:
-          - "json_serializable"
-      test:
-        patterns:
-          - "test"
-  - package-ecosystem: "pub"
-    directory: "packages/smithy/smithy_codegen"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      built_value:
-        patterns:
-          - "built_value"
-      code_builder:
-        patterns:
-          - "code_builder"
-      dart_style:
-        patterns:
-          - "dart_style"
-      json_annotation:
-        patterns:
-          - "json_annotation"
-      xml:
-        patterns:
-          - "xml"
-      build_runner:
-        patterns:
-          - "build_runner"
-      built_value_generator:
-        patterns:
-          - "built_value_generator"
-      json_serializable:
-        patterns:
-          - "json_serializable"
-      test:
-        patterns:
-          - "test"
-  - package-ecosystem: "pub"
     directory: "packages/smithy/smithy_test"
     schedule:
       interval: "daily"
@@ -2922,25 +3158,6 @@ updates:
         patterns:
           - "xml"
   - package-ecosystem: "pub"
-    directory: "packages/storage/amplify_storage_s3"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_storage_s3_dart"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-  - package-ecosystem: "pub"
     directory: "packages/storage/amplify_storage_s3/example"
     schedule:
       interval: "daily"
@@ -2985,130 +3202,6 @@ updates:
       test:
         patterns:
           - "test"
-  - package-ecosystem: "pub"
-    directory: "packages/storage/amplify_storage_s3/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_auth_cognito"
-      - dependency-name: "amplify_analytics_pinpoint"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "amplify_db_common"
-      - dependency-name: "amplify_secure_storage"
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "smithy_codegen"
-      - dependency-name: "amplify_flutter"
-      - dependency-name: "amplify_authenticator"
-      - dependency-name: "amplify_storage_s3"
-      - dependency-name: "amplify_storage_s3_dart"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      drift:
-        patterns:
-          - "drift"
-      http:
-        patterns:
-          - "http"
-      stack_trace:
-        patterns:
-          - "stack_trace"
-      test:
-        patterns:
-          - "test"
-  - package-ecosystem: "pub"
-    directory: "packages/storage/amplify_storage_s3_dart"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      async:
-        patterns:
-          - "async"
-      built_value:
-        patterns:
-          - "built_value"
-      drift:
-        patterns:
-          - "drift"
-      json_annotation:
-        patterns:
-          - "json_annotation"
-      build_runner:
-        patterns:
-          - "build_runner"
-      built_value_generator:
-        patterns:
-          - "built_value_generator"
-      drift_dev:
-        patterns:
-          - "drift_dev"
-      json_serializable:
-        patterns:
-          - "json_serializable"
-      test:
-        patterns:
-          - "test"
-  - package-ecosystem: "pub"
-    directory: "packages/storage/amplify_storage_s3_dart/example"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "amplify_auth_cognito_dart"
-      - dependency-name: "amplify_analytics_pinpoint_dart"
-      - dependency-name: "amplify_core"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "aws_signature_v4"
-      - dependency-name: "amplify_db_common_dart"
-      - dependency-name: "amplify_secure_storage_dart"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-      - dependency-name: "smithy"
-      - dependency-name: "smithy_aws"
-      - dependency-name: "smithy_codegen"
-      - dependency-name: "amplify_storage_s3_dart"
-      - dependency-name: "example_common"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      build_runner:
-        patterns:
-          - "build_runner"
-      build_web_compilers:
-        patterns:
-          - "build_web_compilers"
   - package-ecosystem: "pub"
     directory: "packages/storage/amplify_storage_s3_dart/example"
     schedule:
@@ -3276,37 +3369,6 @@ updates:
         patterns:
           - "test"
   - package-ecosystem: "pub"
-    directory: "packages/worker_bee/e2e"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-      - dependency-name: "worker_bee"
-      - dependency-name: "worker_bee_builder"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      built_value:
-        patterns:
-          - "built_value"
-      test:
-        patterns:
-          - "test"
-      build_runner:
-        patterns:
-          - "build_runner"
-      build_web_compilers:
-        patterns:
-          - "build_web_compilers"
-      built_value_generator:
-        patterns:
-          - "built_value_generator"
-  - package-ecosystem: "pub"
     directory: "packages/worker_bee/e2e_flutter_test"
     schedule:
       interval: "daily"
@@ -3348,68 +3410,6 @@ updates:
       built_value_generator:
         patterns:
           - "built_value_generator"
-      test:
-        patterns:
-          - "test"
-  - package-ecosystem: "pub"
-    directory: "packages/worker_bee/worker_bee"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      async:
-        patterns:
-          - "async"
-      built_value:
-        patterns:
-          - "built_value"
-      stack_trace:
-        patterns:
-          - "stack_trace"
-      build_runner:
-        patterns:
-          - "build_runner"
-      built_value_generator:
-        patterns:
-          - "built_value_generator"
-      test:
-        patterns:
-          - "test"
-  - package-ecosystem: "pub"
-    directory: "packages/worker_bee/worker_bee_builder"
-    schedule:
-      interval: "daily"
-    ignore:
-      # Ignore patch version bumps
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-      # Ignore all repo packages
-      - dependency-name: "worker_bee"
-      - dependency-name: "aws_common"
-      - dependency-name: "amplify_lints"
-    # Group dependencies which have a constraint set in the global "pubspec.yaml"
-    groups:
-      async:
-        patterns:
-          - "async"
-      code_builder:
-        patterns:
-          - "code_builder"
-      dart_style:
-        patterns:
-          - "dart_style"
-      source_gen:
-        patterns:
-          - "source_gen"
       test:
         patterns:
           - "test"

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -119,6 +119,10 @@ $groupPubPackages
         dependentPackages.add(dependent);
       },
     );
+    // skip aft tests which include a snapshot of the mono repo
+    if (repoRelativePath.contains('snapshot')) {
+      return [];
+    }
     _dependabotConfig.write('''
   - package-ecosystem: "pub"
     directory: "$repoRelativePath"


### PR DESCRIPTION
*Description of changes:*
- Exclude the mono repo snapshot in aft/test from dependabot.yaml generation
- regenerate dependabot.yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
