### PR TITLE
feat(storage): update s3 storage service to support multiple s3 client for multi-bucket support

### DIFF
--- a/packages/amplify_core/lib/src/types/storage/storage_bucket_from_outputs.dart
+++ b/packages/amplify_core/lib/src/types/storage/storage_bucket_from_outputs.dart
@@ -23,16 +23,8 @@ class StorageBucketFromOutputs implements StorageBucket {
             'file has storage configuration.',
       ),
     );
-
-    final bucket = storageOutputs!.buckets?.singleWhere(
-      (e) => e.name == _name,
-      orElse: () => throw const InvalidStorageBucketException(
-        'Unable to lookup bucket from provided name in Amplify Outputs file.',
-        recoverySuggestion: 'Make sure Amplify Outputs file has the specified '
-            'bucket configuration.',
-      ),
-    );
-    if (bucket == null) {
+    final buckets = storageOutputs!.buckets;
+    if (buckets == null) {
       throw const InvalidStorageBucketException(
         'Amplify Outputs storage configuration does not have buckets specified.',
         recoverySuggestion:
@@ -40,6 +32,17 @@ class StorageBucketFromOutputs implements StorageBucket {
             'buckets specified.',
       );
     }
-    return BucketInfo(bucketName: bucket.bucketName, region: bucket.awsRegion);
+    final bucket = buckets.singleWhere(
+      (e) => e.name == _name,
+      orElse: () => throw const InvalidStorageBucketException(
+        'Unable to lookup bucket from provided name in Amplify Outputs file.',
+        recoverySuggestion: 'Make sure Amplify Outputs file has the specified '
+            'bucket configuration.',
+      ),
+    );
+    return BucketInfo(
+      bucketName: bucket.bucketName,
+      region: bucket.awsRegion,
+    );
   }
 }

--- a/packages/amplify_core/lib/src/types/storage/storage_bucket_from_outputs.dart
+++ b/packages/amplify_core/lib/src/types/storage/storage_bucket_from_outputs.dart
@@ -17,15 +17,29 @@ class StorageBucketFromOutputs implements StorageBucket {
     assert(
       storageOutputs != null,
       const InvalidStorageBucketException(
-        'Amplify Storage is not configured.',
+        'Amplify Outputs file does not have storage configuration.',
         recoverySuggestion:
-            'Make sure storage exists in the Amplify Outputs file.',
+            'Make sure Amplify Storage is configured and the Amplify Outputs '
+            'file has storage configuration.',
       ),
     );
-    // TODO(nikahsn): fix after adding buckets to StorageOutputs.
-    return BucketInfo(
-      bucketName: _name,
-      region: storageOutputs!.awsRegion,
+
+    final bucket = storageOutputs!.buckets?.singleWhere(
+      (e) => e.name == _name,
+      orElse: () => throw const InvalidStorageBucketException(
+        'Unable to lookup bucket from provided name in Amplify Outputs file.',
+        recoverySuggestion: 'Make sure Amplify Outputs file has the specified '
+            'bucket configuration.',
+      ),
     );
+    if (bucket == null) {
+      throw const InvalidStorageBucketException(
+        'Amplify Outputs storage configuration does not have buckets specified.',
+        recoverySuggestion:
+            'Make sure Amplify Outputs file has storage configuration with '
+            'buckets specified.',
+      );
+    }
+    return BucketInfo(bucketName: bucket.bucketName, region: bucket.awsRegion);
   }
 }

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/s3_client_info.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/s3_client_info.dart
@@ -2,6 +2,7 @@ import 'package:amplify_storage_s3_dart/src/sdk/src/s3/s3_client.dart';
 import 'package:meta/meta.dart';
 import 'package:smithy_aws/smithy_aws.dart';
 
+/// It holds Amazon S3 client information.
 @internal
 class S3ClientInfo {
   const S3ClientInfo({required this.client, required this.config});

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/s3_client_info.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/s3_client_info.dart
@@ -1,0 +1,11 @@
+import 'package:amplify_storage_s3_dart/src/sdk/src/s3/s3_client.dart';
+import 'package:meta/meta.dart';
+import 'package:smithy_aws/smithy_aws.dart';
+
+@internal
+class S3ClientInfo {
+  const S3ClientInfo({required this.client, required this.config});
+
+  final S3Client client;
+  final S3ClientConfig config;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- update storage bucket from outputs to get the bucket info from storage outputs
- update storage service to create and cache s3 clients based on the bucket info
- update storage service to move sigv4 signer fields to getUrl method as they are used only by this method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
