### PR TITLE
Fix/app life cycle datastore websockets

### DIFF
--- a/packages/api/amplify_api/lib/amplify_api.dart
+++ b/packages/api/amplify_api/lib/amplify_api.dart
@@ -5,4 +5,4 @@ library amplify_api;
 
 export 'package:amplify_api/src/api_plugin_impl.dart';
 export 'package:amplify_api_dart/amplify_api_dart.dart'
-    hide AmplifyAPIDart, ConnectivityPlatform, ConnectivityStatus;
+    hide AmplifyAPIDart, ConnectivityPlatform, ProcessLifeCycle, ConnectivityStatus;

--- a/packages/api/amplify_api/lib/src/api_plugin_impl.dart
+++ b/packages/api/amplify_api/lib/src/api_plugin_impl.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_api/src/connectivity_plus_platform.dart';
+import 'package:amplify_api/src/flutter_life_cycle.dart';
 import 'package:amplify_api_dart/amplify_api_dart.dart';
 import 'package:amplify_core/amplify_core.dart';
 
@@ -14,6 +15,7 @@ class AmplifyAPI extends AmplifyAPIDart with AWSDebuggable {
     super.options,
   }) : super(
           connectivity: const ConnectivityPlusPlatform(),
+          processLifeCycle: FlutterLifeCycle(),
         );
 
   @override

--- a/packages/api/amplify_api/lib/src/flutter_life_cycle.dart
+++ b/packages/api/amplify_api/lib/src/flutter_life_cycle.dart
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:async';
+
+import 'package:amplify_api_dart/amplify_api_dart.dart';
+import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
+
+/// {@template amplify_api.flutter_life_cycle}
+/// Creates a stream of [ProcessStatus] mapped from [AppLifecycleListener](https://api.flutter.dev/flutter/widgets/AppLifecycleListener-class.html).
+/// {@endtemplate}
+@internal
+class FlutterLifeCycle extends ProcessLifeCycle {
+  /// {@macro amplify_api.flutter_life_cycle}
+  FlutterLifeCycle() {
+    AppLifecycleListener(
+      onStateChange: _onStateChange,
+    );
+  }
+
+  final _stateController =
+      StreamController<ProcessStatus>.broadcast(sync: true);
+
+  @override
+  Stream<ProcessStatus> get onStateChanged => _stateController.stream;
+
+  void _onStateChange(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.detached:
+        _stateController.add(ProcessStatus.detached);
+      case AppLifecycleState.paused:
+        _stateController.add(ProcessStatus.paused);
+      case AppLifecycleState.hidden:
+        _stateController.add(ProcessStatus.hidden);
+      case AppLifecycleState.inactive:
+        _stateController.add(ProcessStatus.inactive);
+      case AppLifecycleState.resumed:
+        _stateController.add(ProcessStatus.resumed);
+    }
+  }
+}

--- a/packages/api/amplify_api_dart/lib/amplify_api_dart.dart
+++ b/packages/api/amplify_api_dart/lib/amplify_api_dart.dart
@@ -8,14 +8,12 @@ export 'package:amplify_core/src/types/api/api_types.dart'
     hide WebSocketOptions;
 
 export 'src/api_plugin_impl.dart';
-
 /// API plugin options
 export 'src/api_plugin_options.dart';
-
 /// Model helpers
 export 'src/graphql/model_helpers/model_mutations.dart';
 export 'src/graphql/model_helpers/model_queries.dart';
 export 'src/graphql/model_helpers/model_subscriptions.dart';
-
 /// Network connectivity util not needed by consumers of Flutter package amplify_api.
 export 'src/graphql/web_socket/types/connectivity_platform.dart';
+export 'src/graphql/web_socket/types/process_life_cycle.dart';

--- a/packages/api/amplify_api_dart/lib/src/api_plugin_impl.dart
+++ b/packages/api/amplify_api_dart/lib/src/api_plugin_impl.dart
@@ -11,6 +11,7 @@ import 'package:amplify_api_dart/src/graphql/web_socket/blocs/web_socket_bloc.da
 import 'package:amplify_api_dart/src/graphql/web_socket/services/web_socket_service.dart';
 import 'package:amplify_api_dart/src/graphql/web_socket/state/web_socket_state.dart';
 import 'package:amplify_api_dart/src/graphql/web_socket/types/connectivity_platform.dart';
+import 'package:amplify_api_dart/src/graphql/web_socket/types/process_life_cycle.dart';
 import 'package:amplify_api_dart/src/util/amplify_api_config.dart';
 import 'package:amplify_api_dart/src/util/amplify_authorization_rest_client.dart';
 import 'package:amplify_core/amplify_core.dart';
@@ -30,8 +31,10 @@ class AmplifyAPIDart extends APIPluginInterface with AWSDebuggable {
   AmplifyAPIDart({
     APIPluginOptions options = const APIPluginOptions(),
     ConnectivityPlatform connectivity = const ConnectivityPlatform(),
+    ProcessLifeCycle processLifeCycle = const ProcessLifeCycle(),
   })  : _options = options,
-        _connectivity = connectivity {
+        _connectivity = connectivity,
+        _processLifeCycle = processLifeCycle {
     _options.authProviders.forEach(registerAuthProvider);
   }
 
@@ -42,6 +45,9 @@ class AmplifyAPIDart extends APIPluginInterface with AWSDebuggable {
 
   /// Creates a stream representing network connectivity at the hardware level.
   final ConnectivityPlatform _connectivity;
+
+  /// Creates a stream representing the process life cycle state.
+  final ProcessLifeCycle _processLifeCycle;
 
   /// A map of the keys from the Amplify API config with auth modes to HTTP clients
   /// to use for requests to that endpoint/auth mode. e.g. { "myEndpoint.AWS_IAM": AWSHttpClient}
@@ -277,6 +283,7 @@ class AmplifyAPIDart extends APIPluginInterface with AWSDebuggable {
       wsService: AmplifyWebSocketService(),
       subscriptionOptions: _options.subscriptionOptions,
       connectivity: _connectivity,
+      processLifeCycle: _processLifeCycle,
     );
   }
 

--- a/packages/api/amplify_api_dart/lib/src/graphql/web_socket/blocs/web_socket_bloc.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/web_socket/blocs/web_socket_bloc.dart
@@ -9,6 +9,7 @@ import 'package:amplify_api_dart/src/graphql/web_socket/services/web_socket_serv
 import 'package:amplify_api_dart/src/graphql/web_socket/state/web_socket_state.dart';
 import 'package:amplify_api_dart/src/graphql/web_socket/state/ws_subscriptions_state.dart';
 import 'package:amplify_api_dart/src/graphql/web_socket/types/connectivity_platform.dart';
+import 'package:amplify_api_dart/src/graphql/web_socket/types/process_life_cycle.dart';
 import 'package:amplify_api_dart/src/graphql/web_socket/types/subscriptions_event.dart';
 import 'package:amplify_api_dart/src/graphql/web_socket/types/web_socket_types.dart';
 import 'package:amplify_core/amplify_core.dart' hide SubscriptionEvent;
@@ -33,8 +34,10 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
     required WebSocketService wsService,
     required GraphQLSubscriptionOptions subscriptionOptions,
     required ConnectivityPlatform connectivity,
+    required ProcessLifeCycle processLifeCycle,
     AWSHttpClient? pollClientOverride,
   })  : _connectivity = connectivity,
+        _processLifeCycle = processLifeCycle,
         _pollClient = pollClientOverride ?? AWSHttpClient() {
     final subBlocs = <String, SubscriptionBloc<Object?>>{};
 
@@ -49,6 +52,7 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
     );
     final blocStream = _wsEventStream.asyncExpand(_eventTransformer);
     _networkSubscription = _getConnectivityStream();
+    _processLifeCycleSubscription = _getProcessLifecycleStream();
     _stateSubscription = blocStream.listen(_emit);
     add(const InitEvent());
   }
@@ -81,9 +85,13 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
   late final Stream<WebSocketEvent> _wsEventStream = _wsEventController.stream;
   late final StreamSubscription<WebSocketState> _stateSubscription;
   late final StreamSubscription<ConnectivityStatus> _networkSubscription;
+  late final StreamSubscription<ProcessStatus> _processLifeCycleSubscription;
 
   /// Creates a stream representing network connectivity at the hardware level.
   final ConnectivityPlatform _connectivity;
+
+  /// Creates a stream representing the process life cycle state.
+  final ProcessLifeCycle _processLifeCycle;
 
   /// The underlying event stream, used only in testing.
   @visibleForTesting
@@ -164,6 +172,8 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
       yield* _networkLoss();
     } else if (event is NetworkFoundEvent) {
       yield* _networkFound();
+    } else if (event is ProcessUnpausedEvent) {
+      yield* _processUnpaused();
     } else if (event is PollSuccessEvent) {
       yield* _pollSuccess();
     } else if (event is PollFailedEvent) {
@@ -328,6 +338,16 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
     yield* const Stream.empty();
   }
 
+  Stream<WebSocketState> _processUnpaused() async* {
+    final state = _currentState;
+    if (state is ConnectedState) {
+      yield state.reconnecting(networkState: NetworkState.disconnected);
+      add(const ReconnectEvent());
+    }
+    // TODO(dnys1): Yield broken on web debug build.
+    yield* const Stream.empty();
+  }
+
   /// Handle successful polls
   Stream<WebSocketState> _pollSuccess() async* {
     // TODO(dnys1): Yield broken on web debug build.
@@ -467,6 +487,7 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
     await Future.wait<void>([
       // TODO(equartey): https://github.com/fluttercommunity/plus_plugins/issues/1382
       if (!isWindows()) _networkSubscription.cancel(),
+      _processLifeCycleSubscription.cancel(),
       Future.value(_pollClient.close()),
       _stateSubscription.cancel(),
       _wsEventController.close(),
@@ -505,6 +526,41 @@ class WebSocketBloc with AWSDebuggable, AmplifyLoggerMixin {
       onError: (Object e, StackTrace st) =>
           logger.error('Error in connectivity stream $e, $st'),
     );
+  }
+
+  /// Process life cycle stream monitors when the process resumes from a paused state.
+  StreamSubscription<ProcessStatus> _getProcessLifecycleStream() {
+    var prev = ProcessStatus.detached;
+    return _processLifeCycle.onStateChanged.listen(
+      (state) {
+        if (_isUnpausing(state, prev)) {
+          // ignore: invalid_use_of_internal_member
+          if (!WebSocketOptions.autoReconnect) {
+            _shutdownWithException(
+              const NetworkException(
+                'Unable to recover network connection, web socket will close.',
+                recoverySuggestion: 'Avoid pausing the process.',
+              ),
+              StackTrace.current,
+            );
+          } else {
+            add(const ProcessUnpausedEvent());
+          }
+        }
+
+        prev = state;
+      },
+      onError: (Object e, StackTrace st) =>
+          logger.error('Error in process life cycle stream $e, $st'),
+    );
+  }
+
+  bool _isUnpausing(ProcessStatus current, ProcessStatus previous) {
+    if (previous != ProcessStatus.paused) return false;
+
+    return current == ProcessStatus.hidden ||
+        current == ProcessStatus.inactive ||
+        current == ProcessStatus.resumed;
   }
 
   Future<void> _poll() async {

--- a/packages/api/amplify_api_dart/lib/src/graphql/web_socket/types/process_life_cycle.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/web_socket/types/process_life_cycle.dart
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Possible process life cycle states
+enum ProcessStatus {
+  /// Engine is running without a view.
+  detached,
+  /// Application is not visible to the user or responding to user input.
+  paused,
+  /// All views of an application are hidden.
+  hidden,
+  /// A view of the application is visible, but none have input.
+  inactive,
+  /// Default running mode.
+  resumed,
+}
+
+/// {@template amplify_api_dart.process_life_cycle}
+/// Used to create a stream representing the process life cycle state.
+///
+/// The generated stream is empty.
+/// {@endtemplate}
+class ProcessLifeCycle {
+  /// {@macro amplify_api_dart.process_life_cycle}
+  const ProcessLifeCycle();
+
+  /// Generates a new stream of [ProcessStatus].
+  Stream<ProcessStatus> get onStateChanged => const Stream.empty();
+}

--- a/packages/api/amplify_api_dart/lib/src/graphql/web_socket/types/web_socket_event.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/web_socket/types/web_socket_event.dart
@@ -88,6 +88,19 @@ class NetworkLossEvent extends NetworkEvent {
   String get runtimeTypeName => 'NetworkLossEvent';
 }
 
+/// Discrete class for when the process is unpaused
+/// Triggers when AppLifecycleListener detects the process has been unpaused.
+class ProcessUnpausedEvent extends WebSocketEvent {
+  /// Create a process unpaused event
+  const ProcessUnpausedEvent();
+
+  @override
+  String get runtimeTypeName => 'ProcessUnpausedEvent';
+
+  @override
+  Map<String, Object?> toJson() => const {};
+}
+
 /// Triggers when a successful ping to AppSync is made
 class PollSuccessEvent extends WebSocketEvent {
   /// Create a successful Poll event

--- a/packages/api/amplify_api_dart/test/graphql_test.dart
+++ b/packages/api/amplify_api_dart/test/graphql_test.dart
@@ -292,6 +292,7 @@ void main() {
         subscriptionOptions: subscriptionOptions,
         pollClientOverride: mockClient.client,
         connectivity: const ConnectivityPlatform(),
+        processLifeCycle: const MockProcessLifeCycle(),
       );
 
       sendMockConnectionAck(mockWebSocketBloc!, mockWebSocketService!);
@@ -613,6 +614,7 @@ void main() {
         subscriptionOptions: subscriptionOptions,
         pollClientOverride: mockClient.client,
         connectivity: const ConnectivityPlatform(),
+        processLifeCycle: const MockProcessLifeCycle(),
       );
 
       final blocReady = Completer<void>();

--- a/packages/api/amplify_api_dart/test/util.dart
+++ b/packages/api/amplify_api_dart/test/util.dart
@@ -10,6 +10,7 @@ import 'package:amplify_api_dart/src/graphql/web_socket/blocs/web_socket_bloc.da
 import 'package:amplify_api_dart/src/graphql/web_socket/services/web_socket_service.dart';
 import 'package:amplify_api_dart/src/graphql/web_socket/state/web_socket_state.dart';
 import 'package:amplify_api_dart/src/graphql/web_socket/types/connectivity_platform.dart';
+import 'package:amplify_api_dart/src/graphql/web_socket/types/process_life_cycle.dart';
 import 'package:amplify_api_dart/src/graphql/web_socket/types/web_socket_types.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_core/src/config/amplify_outputs/data/data_outputs.dart';
@@ -327,6 +328,16 @@ class MockConnectivity extends ConnectivityPlatform {
   @override
   Stream<ConnectivityStatus> get onConnectivityChanged =>
       mockNetworkStreamController.stream;
+}
+
+late StreamController<ProcessStatus> mockProcessLifeCycleController;
+
+class MockProcessLifeCycle extends ProcessLifeCycle {
+  const MockProcessLifeCycle();
+
+  @override
+  Stream<ProcessStatus> get onStateChanged =>
+      mockProcessLifeCycleController.stream;
 }
 
 /// Ensures a query predicate converts to JSON correctly.

--- a/packages/api/amplify_api_dart/test/web_socket/web_socket_bloc_test.dart
+++ b/packages/api/amplify_api_dart/test/web_socket/web_socket_bloc_test.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:amplify_api_dart/src/graphql/web_socket/blocs/web_socket_bloc.dart';
 import 'package:amplify_api_dart/src/graphql/web_socket/state/web_socket_state.dart';
 import 'package:amplify_api_dart/src/graphql/web_socket/types/connectivity_platform.dart';
+import 'package:amplify_api_dart/src/graphql/web_socket/types/process_life_cycle.dart';
 import 'package:amplify_api_dart/src/graphql/web_socket/types/web_socket_types.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:test/test.dart';
@@ -54,6 +55,7 @@ void main() {
     if (!noConnectivity) {
       mockNetworkStreamController = StreamController<ConnectivityStatus>();
     }
+    mockProcessLifeCycleController = StreamController<ProcessStatus>();
     mockPollClient = MockPollClient();
     service = MockWebSocketService();
 
@@ -66,6 +68,7 @@ void main() {
       connectivity: noConnectivity
           ? const ConnectivityPlatform()
           : const MockConnectivity(),
+      processLifeCycle: const MockProcessLifeCycle(),
     );
 
     sendMockConnectionAck(bloc!, service!);
@@ -307,6 +310,143 @@ void main() {
       mockPollClient.induceTimeout = false;
     });
 
+    test('should reconnect when process unpauses', () async {
+      var dataCompleter = Completer<String>();
+      final subscribeEvent = SubscribeEvent(
+        subscriptionRequest,
+        () {
+          service!.channel.sink.add(mockDataString);
+        },
+      );
+
+      final bloc = getWebSocketBloc();
+
+      expect(
+        bloc.stream,
+        emitsInOrder(
+          [
+            isA<DisconnectedState>(),
+            isA<ConnectingState>(),
+            isA<ConnectedState>(),
+            isA<ReconnectingState>(),
+            isA<ConnectingState>(),
+            isA<ConnectedState>(),
+          ],
+        ),
+      );
+
+      bloc.subscribe(subscribeEvent).listen(
+            expectAsync1(
+              (event) {
+                expect(event.data, json.encode(mockSubscriptionData));
+                dataCompleter.complete(event.data);
+              },
+              count: 2,
+            ),
+          );
+
+      await dataCompleter.future;
+      dataCompleter = Completer<String>();
+
+      mockProcessLifeCycleController
+        ..add(ProcessStatus.paused)
+        ..add(ProcessStatus.resumed);
+
+      await expectLater(bloc.stream, emitsThrough(isA<ConnectedState>()));
+
+      service!.channel.sink.add(mockDataString);
+      await dataCompleter.future;
+    });
+
+    test('should throttle reconnect after repeated unpausing', () async {
+      final blocReady = Completer<void>();
+      final subscribeEvent = SubscribeEvent(
+        subscriptionRequest,
+        blocReady.complete,
+      );
+
+      final bloc = getWebSocketBloc();
+
+      expect(
+        bloc.stream,
+        emitsInOrder(
+          [
+            isA<DisconnectedState>(),
+            isA<ConnectingState>(),
+            isA<ConnectedState>(),
+            isA<ReconnectingState>(),
+            isA<ConnectingState>(),
+            isA<ConnectedState>(),
+          ],
+        ),
+        reason:
+            'Bloc should debounce multiple reconnection triggers while unpausing.',
+      );
+
+      bloc.subscribe(
+        subscribeEvent,
+      );
+
+      await blocReady.future;
+
+      mockProcessLifeCycleController
+        ..add(ProcessStatus.paused)
+        ..add(ProcessStatus.resumed)
+        ..add(ProcessStatus.paused)
+        ..add(ProcessStatus.resumed)
+        ..add(ProcessStatus.paused)
+        ..add(ProcessStatus.resumed)
+        ..add(ProcessStatus.paused)
+        ..add(ProcessStatus.resumed)
+        ..add(ProcessStatus.paused)
+        ..add(ProcessStatus.resumed);
+    });
+
+    test('should reconnect multiple times after unpausing', () async {
+      final blocReady = Completer<void>();
+      final subscribeEvent = SubscribeEvent(
+        subscriptionRequest,
+        blocReady.complete,
+      );
+
+      final bloc = getWebSocketBloc()
+        ..subscribe(
+          subscribeEvent,
+        );
+
+      await blocReady.future;
+
+      mockProcessLifeCycleController..add(ProcessStatus.paused)
+      ..add(ProcessStatus.resumed);
+
+      await expectLater(bloc.stream, emitsThrough(isA<ReconnectingState>()));
+
+      mockProcessLifeCycleController..add(ProcessStatus.paused)
+      ..add(ProcessStatus.resumed);
+
+      await expectLater(bloc.stream, emitsThrough(isA<ConnectedState>()));
+
+      mockProcessLifeCycleController..add(ProcessStatus.paused)
+      ..add(ProcessStatus.resumed);
+
+      await expectLater(bloc.stream, emitsThrough(isA<ReconnectingState>()));
+
+      mockProcessLifeCycleController..add(ProcessStatus.paused)
+      ..add(ProcessStatus.resumed);
+
+      await expectLater(bloc.stream, emitsThrough(isA<ConnectedState>()));
+
+      mockProcessLifeCycleController..add(ProcessStatus.paused)
+      ..add(ProcessStatus.resumed);
+
+      await expectLater(bloc.stream, emitsThrough(isA<ReconnectingState>()));
+
+      mockProcessLifeCycleController..add(ProcessStatus.paused)
+      ..add(ProcessStatus.resumed);
+
+      await expectLater(bloc.stream, emitsThrough(isA<ConnectedState>()));
+    });
+
     test(
         'subscribe() ignores a WebSocket message that comes while the bloc is disconnected',
         () async {
@@ -348,6 +488,7 @@ void main() {
 
           final badService = MockWebSocketService(badInit: true);
           mockNetworkStreamController = StreamController<ConnectivityStatus>();
+          mockProcessLifeCycleController = StreamController<ProcessStatus>();
           final bloc = WebSocketBloc(
             config: testApiKeyConfig,
             authProviderRepo: getTestAuthProviderRepo(),
@@ -355,6 +496,7 @@ void main() {
             subscriptionOptions: subscriptionOptions,
             pollClientOverride: mockPollClient.client,
             connectivity: const MockConnectivity(),
+            processLifeCycle: const MockProcessLifeCycle(),
           );
 
           expect(


### PR DESCRIPTION
*Issue #, if available:*
#5041 

*Description of changes:*
Added an app life cycle stream/listener to reconnect API web sockets after the app is paused and resumed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
