### PR TITLE
chore(dep): update mime version to ^2.0.0

### DIFF
--- a/packages/aft/test/version_bump/data/repo_snapshot/packages/aws_common/pubspec.yaml
+++ b/packages/aft/test/version_bump/data/repo_snapshot/packages/aws_common/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   json_annotation: ">=4.9.0 <4.10.0"
   logging: ^1.0.0
   meta: ^1.7.0
-  mime: ^1.0.0
+  mime: ">=1.0.0 <3.0.0"
   os_detect: ^2.0.2
   path: ">=1.8.0 <2.0.0"
   stream_transform: ^2.0.0

--- a/packages/aft/test/version_bump/data/repo_snapshot/pubspec.yaml
+++ b/packages/aft/test/version_bump/data/repo_snapshot/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   intl: ">=0.18.0 <1.0.0"
   json_annotation: ">=4.9.0 <4.10.0"
   json_serializable: 6.8.0
-  mime: ^1.0.0
+  mime: ">=1.0.0 <3.0.0"
   oauth2: ^2.0.2
   package_info_plus: ^8.0.0
   pigeon: ^11.0.0

--- a/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   checks: ^0.3.0
   cli_script: ^0.3.0
   io: ^1.0.0
-  mime: ^1.0.0
+  mime: ">=1.0.0 <3.0.0"
   path: ">=1.8.0 <2.0.0"
   shelf: ^1.4.0
   test: ^1.22.1

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   json_annotation: ">=4.9.0 <4.10.0"
   logging: ^1.0.0
   meta: ^1.7.0
-  mime: ^1.0.0
+  mime: ">=1.0.0 <3.0.0"
   os_detect: ^2.0.2
   path: ">=1.8.0 <2.0.0"
   stream_transform: ^2.0.0

--- a/packages/test/pub_server/lib/src/server.dart
+++ b/packages/test/pub_server/lib/src/server.dart
@@ -16,7 +16,7 @@ import 'package:pub_server/src/database.dart';
 import 'package:pub_server/src/models.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:shelf/shelf.dart';
-import 'package:shelf_multipart/form_data.dart';
+import 'package:shelf_multipart/shelf_multipart.dart';
 import 'package:shelf_router/shelf_router.dart';
 
 part 'server.g.dart';
@@ -146,15 +146,22 @@ class PubServer {
   /// https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md#publishing-packages
   @Route.post('/api/packages/versions/newUpload')
   Future<Response> upload(Request request) async {
-    if (!request.isMultipartForm) {
+    if (request.multipart() == null) {
       return Response.badRequest(
         body: 'Expected multipart request',
       );
     }
 
+    final formDataRequest = request.formData();
+    if (formDataRequest == null) {
+      return Response.badRequest(
+        body: 'Expected multipart request to contain form data',
+      );
+    }
+
     final FormData packageTar;
     try {
-      packageTar = await request.multipartFormData.singleWhere(
+      packageTar = await formDataRequest.formData.singleWhere(
         (part) => part.filename == 'package.tar.gz',
       );
     } on StateError {

--- a/packages/test/pub_server/pubspec.yaml
+++ b/packages/test/pub_server/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   pub_semver: ^2.1.3
   pubspec_parse: ^1.2.2
   shelf: ^1.4.0
-  shelf_multipart: ^1.0.0
+  shelf_multipart: ^2.0.0
   shelf_router: ^1.1.3
   yaml: ^3.1.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   intl: ">=0.18.0 <1.0.0"
   json_annotation: ">=4.9.0 <4.10.0"
   json_serializable: 6.8.0
-  mime: ^1.0.0
+  mime: ">=1.0.0 <3.0.0"
   oauth2: ^2.0.2
   package_info_plus: ^8.0.0
   pigeon: ^11.0.0


### PR DESCRIPTION
*Issue #, if available:* #5564 

*Description of changes:*
- update mime version to ^2.0.0

P.S. the range is needed bc shelf_multipart has dependecy on mime: ^1.0.0. I updated the shelf_multipart version to v2 eventhough the v2 is still using mime:^1.0.0. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
