### PR TITLE
chore: Cherry Pick Bump version

### DIFF
--- a/packages/amplify_core/CHANGELOG.md
+++ b/packages/amplify_core/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.4.2
+
+### Features
+- feat(api): move App Sync subscription headers to protocol ([#5301](https://github.com/aws-amplify/amplify-flutter/pull/5301))
+
+### Fixes
+- fix(api): Reconnect WebSocket when resuming app from a paused state ([#5567](https://github.com/aws-amplify/amplify-flutter/pull/5567))
+
 ## 2.4.1
 
 ### Fixes

--- a/packages/amplify_core/lib/src/version.dart
+++ b/packages/amplify_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.4.1';
+const packageVersion = '2.4.2';

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_core
 description: The base package containing common types and utilities that are shared across the Amplify Flutter packages.
-version: 2.4.1
+version: 2.4.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_core
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.10.0
-  aws_common: ">=0.7.3 <0.8.0"
+  aws_common: ">=0.7.4 <0.8.0"
   aws_signature_v4: ">=0.6.3 <0.7.0"
   collection: ^1.15.0
   graphs: ^2.1.0

--- a/packages/amplify_datastore/CHANGELOG.md
+++ b/packages/amplify_datastore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.2
+
+- Minor bug fixes and improvements
+
 ## 2.4.1
 
 ### Fixes

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore
 description: The Amplify Flutter DataStore category plugin, providing a queryable, on-device data store.
-version: 2.4.1
+version: 2.4.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_datastore
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   amplify_datastore_plugin_interface: ">=2.4.1 <2.5.0"
-  amplify_core: ">=2.4.1 <2.5.0"
+  amplify_core: ">=2.4.2 <2.5.0"
   plugin_platform_interface: ^2.0.0
   meta: ^1.7.0
   collection: ^1.14.13

--- a/packages/api/amplify_api/CHANGELOG.md
+++ b/packages/api/amplify_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.2
+
+### Fixes
+- fix(api): Reconnect WebSocket when resuming app from a paused state ([#5567](https://github.com/aws-amplify/amplify-flutter/pull/5567))
+
 ## 2.4.1
 
 - Minor bug fixes and improvements

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api
 description: The Amplify Flutter API category plugin, supporting GraphQL and REST operations.
-version: 2.4.1
+version: 2.4.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/api/amplify_api
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -19,8 +19,8 @@ platforms:
   web:
 
 dependencies:
-  amplify_api_dart: ">=0.5.5 <0.6.0"
-  amplify_core: ">=2.4.1 <2.5.0"
+  amplify_api_dart: ">=0.5.6 <0.6.0"
+  amplify_core: ">=2.4.2 <2.5.0"
   amplify_flutter: ">=2.4.1 <2.5.0"
   connectivity_plus: ^6.0.1
   flutter:

--- a/packages/api/amplify_api_dart/CHANGELOG.md
+++ b/packages/api/amplify_api_dart/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.5.6
+
+### Features
+- feat(api): move App Sync subscription headers to protocol ([#5301](https://github.com/aws-amplify/amplify-flutter/pull/5301))
+
+### Fixes
+- fix(api): Reconnect WebSocket when resuming app from a paused state ([#5567](https://github.com/aws-amplify/amplify-flutter/pull/5567))
+
 ## 0.5.5
 
 ### Fixes

--- a/packages/api/amplify_api_dart/pubspec.yaml
+++ b/packages/api/amplify_api_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_dart
 description: The Amplify API category plugin in Dart-only, supporting GraphQL and REST operations.
-version: 0.5.5
+version: 0.5.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/api/amplify_api_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -9,9 +9,9 @@ environment:
   sdk: ^3.3.0
 
 dependencies:
-  amplify_core: ">=2.4.1 <2.5.0"
+  amplify_core: ">=2.4.2 <2.5.0"
   async: ^2.10.0
-  aws_common: ">=0.7.3 <0.8.0"
+  aws_common: ">=0.7.4 <0.8.0"
   collection: ^1.15.0
   json_annotation: ">=4.9.0 <4.10.0"
   meta: ^1.7.0

--- a/packages/auth/amplify_auth_cognito/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.2
+
+- Minor bug fixes and improvements
+
 ## 2.4.1
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito
 description: The Amplify Flutter Auth category plugin using the AWS Cognito provider.
-version: 2.4.1
+version: 2.4.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/auth/amplify_auth_cognito
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -21,8 +21,8 @@ platforms:
 dependencies:
   amplify_analytics_pinpoint: ">=2.4.1 <2.5.0"
   amplify_analytics_pinpoint_dart: ">=0.4.5 <0.5.0"
-  amplify_auth_cognito_dart: ">=0.11.5 <0.12.0"
-  amplify_core: ">=2.4.1 <2.5.0"
+  amplify_auth_cognito_dart: ">=0.11.6 <0.12.0"
+  amplify_core: ">=2.4.2 <2.5.0"
   amplify_flutter: ">=2.4.1 <2.5.0"
   amplify_secure_storage: ">=0.5.7 <0.6.0"
   async: ^2.10.0

--- a/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
+++ b/packages/auth/amplify_auth_cognito_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.6
+
+- Minor bug fixes and improvements
+
 ## 0.11.5
 
 - Minor bug fixes and improvements

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_auth_cognito_dart
 description: A Dart-only implementation of the Amplify Auth plugin for Cognito.
-version: 0.11.5
+version: 0.11.6
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/auth/amplify_auth_cognito_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,10 +10,10 @@ environment:
 
 dependencies:
   amplify_analytics_pinpoint_dart: ">=0.4.5 <0.5.0"
-  amplify_core: ">=2.4.1 <2.5.0"
+  amplify_core: ">=2.4.2 <2.5.0"
   amplify_secure_storage_dart: ">=0.5.3 <0.6.0"
   async: ^2.10.0
-  aws_common: ">=0.7.3 <0.8.0"
+  aws_common: ">=0.7.4 <0.8.0"
   aws_signature_v4: ">=0.6.3 <0.7.0"
   built_collection: ^5.0.0
   built_value: ^8.6.0

--- a/packages/authenticator/amplify_authenticator/CHANGELOG.md
+++ b/packages/authenticator/amplify_authenticator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.0
+
+### Features
+- feat(authenticator): export unmet password requirements ([#5437](https://github.com/aws-amplify/amplify-flutter/pull/5437))
+
 ## 2.1.3
 
 - Minor bug fixes and improvements

--- a/packages/authenticator/amplify_authenticator/lib/src/version.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.1.3';
+const packageVersion = '2.2.0';

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_authenticator
 description: A prebuilt Sign In and Sign Up experience for the Amplify Auth category
-version: 2.1.3
+version: 2.2.0
 homepage: https://ui.docs.amplify.aws/flutter/connected-components/authenticator
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/authenticator/amplify_authenticator
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -10,11 +10,11 @@ environment:
   flutter: ">=3.19.0"
 
 dependencies:
-  amplify_auth_cognito: ">=2.4.1 <2.5.0"
-  amplify_core: ">=2.4.1 <2.5.0"
+  amplify_auth_cognito: ">=2.4.2 <2.5.0"
+  amplify_core: ">=2.4.2 <2.5.0"
   amplify_flutter: ">=2.4.1 <2.5.0"
   async: ^2.10.0
-  aws_common: ">=0.7.3 <0.8.0"
+  aws_common: ">=0.7.4 <0.8.0"
   collection: ^1.15.0
   flutter:
     sdk: flutter

--- a/packages/aws_common/CHANGELOG.md
+++ b/packages/aws_common/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.4
+
+- Minor bug fixes and improvements
+
 ## 0.7.3
 
 ### Features

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aws_common
 description: Common types and utilities used across AWS and Amplify packages.
-version: 0.7.3
+version: 0.7.4
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/aws_common
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/notifications/push/amplify_push_notifications/CHANGELOG.md
+++ b/packages/notifications/push/amplify_push_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.2
+
+- Minor bug fixes and improvements
+
 ## 2.4.1
 
 - Minor bug fixes and improvements

--- a/packages/notifications/push/amplify_push_notifications/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_push_notifications
 description: The Amplify Flutter Push Notifications package implementing features agnostic of an AWS Service such as Pinpoint.
-version: 2.4.1
+version: 2.4.2
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=3.19.0"
 
 dependencies:
-  amplify_core: ">=2.4.1 <2.5.0"
+  amplify_core: ">=2.4.2 <2.5.0"
   amplify_secure_storage: ">=0.5.5 <0.6.0"
   async: ^2.10.0
   flutter:


### PR DESCRIPTION
### Features
- feat(api): move App Sync subscription headers to protocol ([#5301](https://github.com/aws-amplify/amplify-flutter/pull/5301))
- feat(authenticator): export unmet password requirements ([#5437](https://github.com/aws-amplify/amplify-flutter/pull/5437))

### Fixes
- fix(api): Reconnect WebSocket when resuming app from a paused state ([#5567](https://github.com/aws-amplify/amplify-flutter/pull/5567))

Updated-Components: amplify_lints, Amplify Flutter, Amplify Dart, Amplify UI, DB Common, Secure Storage, AWS Common, Smithy, Worker Bee


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
