### PR TITLE
feat(storage): multi bucket remove

### DIFF
--- a/packages/amplify_core/lib/src/types/storage/remove_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/remove_options.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:aws_common/aws_common.dart';
+import 'package:amplify_core/amplify_core.dart';
 
 /// {@template amplify_core.storage.remove_options}
 /// Configurable options for `Amplify.Storage.remove`.
@@ -14,13 +14,17 @@ class StorageRemoveOptions
   /// {@macro amplify_core.storage.remove_options}
   const StorageRemoveOptions({
     this.pluginOptions,
+    this.bucket,
   });
 
   /// {@macro amplify_core.storage.remove_plugin_options}
   final StorageRemovePluginOptions? pluginOptions;
 
+  /// Optionally specify which bucket to target
+  final StorageBucket? bucket;
+
   @override
-  List<Object?> get props => [pluginOptions];
+  List<Object?> get props => [pluginOptions, bucket];
 
   @override
   String get runtimeTypeName => 'StorageRemoveOptions';
@@ -28,6 +32,7 @@ class StorageRemoveOptions
   @override
   Map<String, Object?> toJson() => {
         'pluginOptions': pluginOptions?.toJson(),
+        'bucket': bucket,
       };
 }
 

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/object_exists.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/object_exists.dart
@@ -1,31 +1,12 @@
 import 'package:amplify_core/amplify_core.dart';
 
 /// Returns true if an object exists at the given [path].
-Future<bool> objectExists(StoragePath path) async {
+Future<bool> objectExists(StoragePath path, {StorageBucket? bucket}) async {
   try {
     await Amplify.Storage.getProperties(
       path: path,
+      options: StorageGetPropertiesOptions(bucket: bucket),
     ).result;
-    return true;
-  } on StorageNotFoundException {
-    return false;
-  }
-}
-
-/// Returns true if an object exists in multiple [buckets] at [path].
-Future<bool> objectExistsInBuckets(
-  StoragePath path,
-  List<StorageBucket> buckets,
-) async {
-  try {
-    await Future.wait(
-      buckets.map(
-        (bucket) => Amplify.Storage.getProperties(
-          path: path,
-          options: StorageGetPropertiesOptions(bucket: bucket),
-        ).result,
-      ),
-    );
     return true;
   } on StorageNotFoundException {
     return false;

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/object_exists.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/object_exists.dart
@@ -3,7 +3,29 @@ import 'package:amplify_core/amplify_core.dart';
 /// Returns true if an object exists at the given [path].
 Future<bool> objectExists(StoragePath path) async {
   try {
-    await Amplify.Storage.getProperties(path: path).result;
+    await Amplify.Storage.getProperties(
+      path: path,
+    ).result;
+    return true;
+  } on StorageNotFoundException {
+    return false;
+  }
+}
+
+/// Returns true if an object exists in multiple [buckets] at [path].
+Future<bool> objectExistsInBuckets(
+  StoragePath path,
+  List<StorageBucket> buckets,
+) async {
+  try {
+    await Future.wait(
+      buckets.map(
+        (bucket) => Amplify.Storage.getProperties(
+          path: path,
+          options: StorageGetPropertiesOptions(bucket: bucket),
+        ).result,
+      ),
+    );
     return true;
   } on StorageNotFoundException {
     return false;

--- a/packages/storage/amplify_storage_s3/example/integration_test/utils/tear_down.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/utils/tear_down.dart
@@ -36,6 +36,27 @@ void addTearDownPaths(List<StoragePath> paths) {
   );
 }
 
+/// Adds a tear down to remove the same object in multiple [buckets].
+void addTearDownMultiBucket(StoragePath path, List<StorageBucket> buckets) {
+  addTearDown(
+    () {
+      try {
+        return Future.wait(
+          buckets.map(
+            (bucket) => Amplify.Storage.remove(
+              path: path,
+              options: StorageRemoveOptions(bucket: bucket),
+            ).result,
+          ),
+        );
+      } on Exception catch (e) {
+        _logger.warn('Failed to remove files after test', e);
+        rethrow;
+      }
+    },
+  );
+}
+
 /// Adds a tear down to delete the current user.
 void addTearDownCurrentUser() {
   addTearDown(() {

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -388,6 +388,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface
 
     final s3Options = StorageRemoveOptions(
       pluginOptions: s3PluginOptions,
+      bucket: options?.bucket,
     );
 
     return S3RemoveOperation(

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -201,7 +201,7 @@ class StorageS3Service {
     return S3GetPropertiesResult(
       storageItem: S3Item.fromHeadObjectOutput(
         await headObject(
-          s3client: _defaultS3Client,
+          s3client: s3ClientInfo.client,
           bucket: s3ClientInfo.bucketName,
           key: resolvedPath,
         ),

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -456,11 +456,12 @@ class StorageS3Service {
     required StoragePath path,
     required StorageRemoveOptions options,
   }) async {
+    final s3ClientInfo = getS3ClientInfo(storageBucket: options.bucket);
     final resolvedPath = await _pathResolver.resolvePath(path: path);
 
     await _deleteObject(
-      s3client: _defaultS3Client,
-      bucket: _storageOutputs.bucketName,
+      s3client: s3ClientInfo.client,
+      bucket: s3ClientInfo.bucketName,
       key: resolvedPath,
     );
 


### PR DESCRIPTION
*Description of changes:*

- Updates `StorageRemoveOptions` to have a optional bucket param to specify target for operation
- Updates S3 impl to use bucket param
- Adds E2E tests
- Adds E2E utils

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
