### PR TITLE
chore(storage): add e2e tests for upload data api

### DIFF
--- a/packages/amplify_core/lib/src/category/amplify_storage_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_storage_category.dart
@@ -144,7 +144,6 @@ class StorageCategory extends AmplifyCategory<StoragePluginInterface> {
     required StoragePath path,
     void Function(StorageTransferProgress)? onProgress,
     StorageUploadDataOptions? options,
-    StorageBucket? bucket,
   }) {
     return identifyCall(
       StorageCategoryMethod.uploadData,
@@ -153,7 +152,6 @@ class StorageCategory extends AmplifyCategory<StoragePluginInterface> {
         data: data,
         onProgress: onProgress,
         options: options,
-        bucket: bucket,
       ),
     );
   }

--- a/packages/amplify_core/lib/src/plugin/amplify_storage_plugin_interface.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_storage_plugin_interface.dart
@@ -63,7 +63,6 @@ abstract class StoragePluginInterface extends AmplifyPluginInterface {
     required StorageDataPayload data,
     void Function(StorageTransferProgress)? onProgress,
     StorageUploadDataOptions? options,
-    StorageBucket? bucket,
   }) {
     throw UnimplementedError('uploadData() has not been implemented.');
   }

--- a/packages/amplify_core/lib/src/types/storage/upload_data_options.dart
+++ b/packages/amplify_core/lib/src/types/storage/upload_data_options.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:aws_common/aws_common.dart';
+import 'package:amplify_core/amplify_core.dart';
 
 /// {@template amplify_core.storage.upload_data_options}
 /// Configurable options for `Amplify.Storage.uploadData`.
@@ -15,16 +15,20 @@ class StorageUploadDataOptions
   const StorageUploadDataOptions({
     this.metadata = const {},
     this.pluginOptions,
+    this.bucket,
   });
 
   /// The metadata attached to the object to be uploaded.
   final Map<String, String> metadata;
 
+  /// Optionally specify which bucket to target.
+  final StorageBucket? bucket;
+
   /// {@macro amplify_core.storage.upload_data_plugin_options}
   final StorageUploadDataPluginOptions? pluginOptions;
 
   @override
-  List<Object?> get props => [metadata, pluginOptions];
+  List<Object?> get props => [metadata, pluginOptions, bucket];
 
   @override
   String get runtimeTypeName => 'StorageUploadDataOptions';
@@ -33,6 +37,7 @@ class StorageUploadDataOptions
   Map<String, Object?> toJson() => {
         'metadata': metadata,
         'pluginOptions': pluginOptions?.toJson(),
+        'bucket': bucket,
       };
 }
 

--- a/packages/storage/amplify_storage_s3/example/integration_test/download_data_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/download_data_test.dart
@@ -142,7 +142,9 @@ void main() {
           await Amplify.Storage.uploadData(
             path: StoragePath.fromString(publicPath),
             data: StorageDataPayload.bytes(bytesData),
-            bucket: secondaryBucket,
+            options: StorageUploadDataOptions(
+              bucket: secondaryBucket,
+            ),
           ).result;
 
           final downloadResult = await Amplify.Storage.downloadData(

--- a/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_properties_test.dart
@@ -112,14 +112,18 @@ void main() {
         await Amplify.Storage.uploadData(
           data: StorageDataPayload.bytes(data),
           path: StoragePath.fromString(path),
-          options: const StorageUploadDataOptions(metadata: metadata),
-          bucket: mainBucket,
+          options: StorageUploadDataOptions(
+            metadata: metadata,
+            bucket: mainBucket,
+          ),
         ).result;
         await Amplify.Storage.uploadData(
           data: StorageDataPayload.bytes(data),
           path: StoragePath.fromString(path),
-          options: const StorageUploadDataOptions(metadata: metadata),
-          bucket: secondaryBucket,
+          options: StorageUploadDataOptions(
+            metadata: metadata,
+            bucket: secondaryBucket,
+          ),
         ).result;
       });
 
@@ -156,8 +160,10 @@ void main() {
         await Amplify.Storage.uploadData(
           data: StorageDataPayload.bytes(data),
           path: StoragePath.fromString(expectedResolvedPath),
-          options: const StorageUploadDataOptions(metadata: metadata),
-          bucket: secondaryBucket,
+          options: StorageUploadDataOptions(
+            metadata: metadata,
+            bucket: secondaryBucket,
+          ),
         ).result;
         final result = await Amplify.Storage.getProperties(
           path: StoragePath.fromIdentityId(

--- a/packages/storage/amplify_storage_s3/example/integration_test/remove_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/remove_test.dart
@@ -78,7 +78,9 @@ void main() {
           await Amplify.Storage.uploadData(
             data: StorageDataPayload.bytes('data'.codeUnits),
             path: storagePath,
-            bucket: mainBucket,
+            options: StorageUploadDataOptions(
+              bucket: mainBucket,
+            ),
           ).result;
         });
 
@@ -95,7 +97,9 @@ void main() {
           await Amplify.Storage.uploadData(
             data: StorageDataPayload.bytes('data'.codeUnits),
             path: storagePath,
-            bucket: secondaryBucket,
+            options: StorageUploadDataOptions(
+              bucket: secondaryBucket,
+            ),
           ).result;
 
           expect(

--- a/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/upload_data_test.dart
@@ -252,6 +252,59 @@ void main() {
         });
       });
 
+      group('multi-bucket', () {
+        final mainBucket =
+            StorageBucket.fromOutputs('Storage Integ Test main bucket');
+        final secondaryBucket = StorageBucket.fromOutputs(
+          'Storage Integ Test secondary bucket',
+        );
+
+        testWidgets('uploads to multiple buckets', (_) async {
+          final path = 'public/multi-bucket-upload-data-${uuid()}';
+          final storagePath = StoragePath.fromString(path);
+          final data = 'multi bucket upload data byte'.codeUnits;
+          addTearDownMultiBucket(
+            storagePath,
+            [mainBucket, secondaryBucket],
+          );
+          //  main bucket
+          final mainResult = await Amplify.Storage.uploadData(
+            data: StorageDataPayload.bytes(data),
+            path: storagePath,
+            options: StorageUploadDataOptions(
+              bucket: mainBucket,
+            ),
+          ).result;
+          expect(mainResult.uploadedItem.path, path);
+
+          final downloadMainResult = await Amplify.Storage.downloadData(
+            path: storagePath,
+            options: StorageDownloadDataOptions(
+              bucket: mainBucket,
+            ),
+          ).result;
+          expect(downloadMainResult.bytes, data);
+
+          // secondary bucket
+          final secondaryResult = await Amplify.Storage.uploadData(
+            data: StorageDataPayload.bytes(data),
+            path: storagePath,
+            options: StorageUploadDataOptions(
+              bucket: secondaryBucket,
+            ),
+          ).result;
+          expect(secondaryResult.uploadedItem.path, path);
+
+          final downloadSecondaryResult = await Amplify.Storage.downloadData(
+            path: storagePath,
+            options: StorageDownloadDataOptions(
+              bucket: secondaryBucket,
+            ),
+          ).result;
+          expect(downloadSecondaryResult.bytes, data);
+        });
+      });
+
       group('upload progress', () {
         testWidgets('reports progress for byte data', (_) async {
           final path = 'public/upload-data-progress-bytes-${uuid()}';

--- a/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/amplify_storage_s3_dart_impl.dart
@@ -276,7 +276,6 @@ class AmplifyStorageS3Dart extends StoragePluginInterface
     required StoragePath path,
     void Function(S3TransferProgress)? onProgress,
     StorageUploadDataOptions? options,
-    StorageBucket? bucket,
   }) {
     final s3PluginOptions = reifyPluginOptions(
       pluginOptions: options?.pluginOptions,
@@ -285,6 +284,7 @@ class AmplifyStorageS3Dart extends StoragePluginInterface
 
     final s3Options = StorageUploadDataOptions(
       metadata: options?.metadata ?? const {},
+      bucket: options?.bucket,
       pluginOptions: s3PluginOptions,
     );
 
@@ -293,7 +293,6 @@ class AmplifyStorageS3Dart extends StoragePluginInterface
       dataPayload: data,
       options: s3Options,
       onProgress: onProgress,
-      bucket: bucket,
     );
 
     return S3UploadDataOperation(

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -329,9 +329,8 @@ class StorageS3Service {
     void Function(S3TransferProgress)? onProgress,
     FutureOr<void> Function()? onDone,
     FutureOr<void> Function()? onError,
-    StorageBucket? bucket,
   }) {
-    final s3ClientInfo = getS3ClientInfo(storageBucket: bucket);
+    final s3ClientInfo = getS3ClientInfo(storageBucket: options.bucket);
     final uploadDataTask = S3UploadTask.fromDataPayload(
       dataPayload,
       s3Client: s3ClientInfo.client,

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -610,6 +610,12 @@ void main() {
       test('should forward options to StorageS3Service.uploadData API',
           () async {
         const testOptions = StorageUploadDataOptions(
+          bucket: StorageBucket.fromBucketInfo(
+            BucketInfo(
+              bucketName: 'test-bucket',
+              region: 'test-region',
+            ),
+          ),
           pluginOptions: S3UploadDataPluginOptions(
             getProperties: true,
             useAccelerateEndpoint: true,
@@ -643,48 +649,6 @@ void main() {
         expect(
           capturedOptions,
           testOptions,
-        );
-      });
-
-      test('should forward bucket to StorageS3Service.uploadData API',
-          () async {
-        const testBucket = StorageBucket.fromBucketInfo(
-          BucketInfo(
-            bucketName: 'test-bucket',
-            region: 'test-region',
-          ),
-        );
-        when(
-          () => storageS3Service.uploadData(
-            path: testPath,
-            dataPayload: any(named: 'dataPayload'),
-            options: any(named: 'options'),
-            bucket: testBucket,
-          ),
-        ).thenAnswer((_) => testS3UploadTask);
-
-        when(() => testS3UploadTask.result).thenAnswer((_) async => testItem);
-        uploadDataOperation = storageS3Plugin.uploadData(
-          data: testData,
-          path: testPath,
-          bucket: testBucket,
-        );
-        final capturedBucket = verify(
-          () => storageS3Service.uploadData(
-            path: testPath,
-            dataPayload: any(named: 'dataPayload'),
-            options: any(
-              named: 'options',
-            ),
-            bucket: captureAny<StorageBucket>(
-              named: 'bucket',
-            ),
-          ),
-        ).captured.last;
-
-        expect(
-          capturedBucket,
-          testBucket,
         );
       });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- fix upload data api to move optional bucket param from api param to StorageUploadDataOptions
- update unit tests
- add e2e tests for upload data 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
