### PR TITLE
fix(authenticator): recover from exceptions during reset password flow

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -301,6 +301,8 @@ class StateMachineBloc
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e));
     }
+    // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
+    yield* const Stream.empty();
   }
 
   Stream<AuthState> _resetPassword(AuthResetPasswordData data) async* {
@@ -311,6 +313,8 @@ class StateMachineBloc
     } on Exception catch (e) {
       _exceptionController.add(AuthenticatorException(e));
     }
+    // Emit empty event to resolve bug with broken event handling on web (possible DDC issue)
+    yield* const Stream.empty();
   }
 
   void _notifyCodeSent(String? destination) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/5655
*Description of changes:*

- Added missing `yield*` for reset password work flow

Without this the UI on web would be hard locked and unable to return or progress to other screens. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
