### PR TITLE
chore(authenticator): expose social_button

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/amplify_authenticator.dart
+++ b/packages/authenticator/amplify_authenticator/lib/amplify_authenticator.dart
@@ -93,6 +93,7 @@ export 'src/widgets/form_field.dart'
         SignUpFormField,
         TotpSetupFormField,
         VerifyUserFormField;
+export 'src/widgets/social/social_button.dart';
 
 /// {@template amplify_authenticator.authenticator}
 /// # Amplify Authenticator

--- a/packages/authenticator/amplify_authenticator/lib/src/widgets/form.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/widgets/form.dart
@@ -12,7 +12,6 @@ import 'package:amplify_authenticator/src/utils/list.dart';
 import 'package:amplify_authenticator/src/widgets/button.dart';
 import 'package:amplify_authenticator/src/widgets/component.dart';
 import 'package:amplify_authenticator/src/widgets/form_field.dart';
-import 'package:amplify_authenticator/src/widgets/social/social_button.dart';
 // ignore: implementation_imports
 import 'package:amplify_core/src/config/amplify_outputs/auth/identity_provider.dart';
 // ignore: implementation_imports


### PR DESCRIPTION
*Issue #, if available:*
[#3513](https://github.com/aws-amplify/amplify-flutter/issues/3513)

*Description of changes:*
export social_button to amplify_authenticator dart package for public use out of the box

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
