### PR TITLE
chore(): cleanup stale branch references in Github Actions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - stable
-      - next
     paths:
       - "actions/**/*.dart"
       - "actions/**/*.yaml"

--- a/.github/workflows/aft.yaml
+++ b/.github/workflows/aft.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - stable
-      - next
     paths:
       - "packages/aft/**/*.dart"
   pull_request:


### PR DESCRIPTION
*Description of changes:*
cleanup references to the now delete "next" branch in Github Actions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
