### PR TITLE
chore(dev): use ubuntu image from amazon ECR public gallery instead o…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM public.ecr.aws/ubuntu/ubuntu:latest
 
 ## Dockerfile for local development of Amplify Flutter packages on Linux
 


### PR DESCRIPTION
Description of changes:
use ubuntu image from amazon ECR public gallery instead of docket hub

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.