### PR TITLE
fix(auth,core): Added auth userpool endpoint into AmplifyOutputs mapping

### DIFF
--- a/packages/amplify_core/lib/src/config/amplify_outputs/auth/auth_outputs.dart
+++ b/packages/amplify_core/lib/src/config/amplify_outputs/auth/auth_outputs.dart
@@ -20,6 +20,7 @@ class AuthOutputs
     required this.awsRegion,
     this.userPoolId,
     this.userPoolClientId,
+    this.userPoolEndpoint,
     this.appClientSecret,
     this.identityPoolId,
     this.passwordPolicy,
@@ -43,6 +44,9 @@ class AuthOutputs
 
   /// The Cognito User Pool Client ID.
   final String? userPoolClientId;
+
+  /// The Cognito User Pool Endpoint.
+  final String? userPoolEndpoint; //Gen 1 only
 
   /// A fixed string that must be used in all API requests to the app client
   /// if the the app client has one configured.
@@ -84,6 +88,7 @@ class AuthOutputs
         awsRegion,
         userPoolId,
         userPoolClientId,
+        userPoolEndpoint,
         identityPoolId,
         oauth,
         standardRequiredAttributes,

--- a/packages/amplify_core/lib/src/config/amplify_outputs/auth/auth_outputs.g.dart
+++ b/packages/amplify_core/lib/src/config/amplify_outputs/auth/auth_outputs.g.dart
@@ -17,6 +17,8 @@ AuthOutputs _$AuthOutputsFromJson(Map<String, dynamic> json) => $checkedCreate(
           userPoolId: $checkedConvert('user_pool_id', (v) => v as String?),
           userPoolClientId:
               $checkedConvert('user_pool_client_id', (v) => v as String?),
+          userPoolEndpoint:
+              $checkedConvert('user_pool_endpoint', (v) => v as String?),
           appClientSecret:
               $checkedConvert('app_client_secret', (v) => v as String?),
           identityPoolId:
@@ -65,6 +67,7 @@ AuthOutputs _$AuthOutputsFromJson(Map<String, dynamic> json) => $checkedCreate(
         'awsRegion': 'aws_region',
         'userPoolId': 'user_pool_id',
         'userPoolClientId': 'user_pool_client_id',
+        'userPoolEndpoint': 'user_pool_endpoint',
         'appClientSecret': 'app_client_secret',
         'identityPoolId': 'identity_pool_id',
         'passwordPolicy': 'password_policy',
@@ -91,6 +94,7 @@ Map<String, dynamic> _$AuthOutputsToJson(AuthOutputs instance) {
 
   writeNotNull('user_pool_id', instance.userPoolId);
   writeNotNull('user_pool_client_id', instance.userPoolClientId);
+  writeNotNull('user_pool_endpoint', instance.userPoolEndpoint);
   writeNotNull('app_client_secret', instance.appClientSecret);
   writeNotNull('identity_pool_id', instance.identityPoolId);
   writeNotNull('password_policy', instance.passwordPolicy?.toJson());

--- a/packages/amplify_core/lib/src/config/auth/auth_config.dart
+++ b/packages/amplify_core/lib/src/config/auth/auth_config.dart
@@ -137,6 +137,7 @@ class AuthConfig extends AmplifyPluginConfigMap {
       awsRegion: region,
       userPoolId: userPool?.poolId,
       userPoolClientId: userPool?.appClientId,
+      userPoolEndpoint: userPool?.endpoint,
       appClientSecret: userPool?.appClientSecret,
       identityPoolId: identityPool?.poolId,
       passwordPolicy: passwordPolicy,

--- a/packages/amplify_core/lib/src/version.dart
+++ b/packages/amplify_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.5.0';
+const packageVersion = '2.6.0';

--- a/packages/amplify_core/test/config/amplify_outputs_mapping/data/amplify_outputs.g.dart
+++ b/packages/amplify_core/test/config/amplify_outputs_mapping/data/amplify_outputs.g.dart
@@ -4,6 +4,7 @@ const amplifyConfig = '''{
     "aws_region": "us-east-1",
     "user_pool_id": "fake-user-pool",
     "user_pool_client_id": "fake-client-id",
+    "user_pool_endpoint": "fake-endpoint",
     "identity_pool_id": "fake-identity-pool-id",
     "password_policy": {
       "min_length": 8,

--- a/packages/amplify_core/test/config/amplify_outputs_mapping/data/amplifyconfiguration.g.dart
+++ b/packages/amplify_core/test/config/amplify_outputs_mapping/data/amplifyconfiguration.g.dart
@@ -10,7 +10,8 @@ const amplifyConfig = '''{
           "Default": {
             "PoolId": "fake-user-pool",
             "AppClientId": "fake-client-id",
-            "Region": "us-east-1"
+            "Region": "us-east-1",
+            "Endpoint": "fake-endpoint"
           }
         },
         "CredentialsProvider": {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/configuration_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/configuration_state_machine.dart
@@ -76,6 +76,7 @@ final class ConfigurationStateMachine
         region: authOutputs.awsRegion,
         credentialsProvider: _credentialsProvider,
         dependencyManager: this,
+        endpoint: authOutputs.userPoolEndpoint,
       ),
     );
 


### PR DESCRIPTION
*Issue #, if available:*
#5784 

*Description of changes:*
Auth user pool endpoint configuration was not included in the mapping from AmplifyConfig to AmplifyOutputs. This change adds a `userPoolEndpoint` field to AuthOutputs along with mapping logic. Additional any deleted references to this endpoint value were added back in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
