### PR TITLE
chore(): Updated browser-actions/setup-firefox and actions/cache version

### DIFF
--- a/.github/composite_actions/setup_firefox/action.yaml
+++ b/.github/composite_actions/setup_firefox/action.yaml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: browser-actions/setup-firefox@2904820ff2e2cfeadf033d26ce136d65509ce7fc # 1.1.0
+    - uses: browser-actions/setup-firefox@634a60ccd6599686158cf5a570481b4cd30455a2 # 1.5.4
     - shell: bash
       run: firefox --version
     - shell: bash

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -33,7 +33,7 @@ jobs:
           - sdk: ${{ (github.event_name == 'pull_request') && 'beta' || 'NONE' }}
     steps:
       - name: Cache Pub dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # 3.3.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # 4.2.0
         with:
           path: |
             ~/.pub-cache/hosted

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -33,7 +33,7 @@ jobs:
           - sdk: ${{ (github.event_name == 'pull_request') && 'beta' || 'NONE' }}
     steps:
       - name: Cache Pub dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # 3.3.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # 4.2.0
         with:
           path: |
             ~/.pub-cache/hosted

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Cache Pub dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # 3.3.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # 4.2.0
         with:
           path: |
             ~/.pub-cache/hosted

--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -29,7 +29,7 @@ jobs:
           - sdk: ${{ (github.event_name == 'pull_request') && 'beta' || 'NONE' }}
     steps:
       - name: Cache Pub dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # 3.3.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # 4.2.0
         with:
           path: |
             ~/.pub-cache/hosted


### PR DESCRIPTION
*Description of changes:*
Updated browser-actions/setup-firefox to [v1.5.3+](https://github.com/browser-actions/setup-firefox/blob/master/CHANGELOG.md#153-2025-01-19) to support compression changes for linux downloads.

Updated actions/cache to v4.2.0 as [v3.3.2 ](https://github.com/actions/cache/blob/main/RELEASES.md#420)was deprecated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
