### PR TITLE
fix(authenticator): fixed skip button in verify user dialog to be more visible in dark mode

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/widgets/button.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/widgets/button.dart
@@ -583,9 +583,8 @@ class SkipVerifyUserButton extends StatelessAuthenticatorComponent {
       onPressed: state.skipVerifyUser,
       child: Text(
         stringResolver.buttons.skip(context),
-        style: TextStyle(
+        style: const TextStyle(
           fontSize: AuthenticatorButtonConstants.fontSize,
-          color: Theme.of(context).primaryColor,
         ),
       ),
     );


### PR DESCRIPTION
*Issue #, if available:*
#5984 

*Description of changes:*
removed explicit styling of SkipVerifyUserButton text child widget, allowing material to handle the styling

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
