### PR TITLE
fix(sigv4): Convert empty query parameters to null

### DIFF
--- a/packages/aws_signature_v4/lib/src/signer/aws_signer.dart
+++ b/packages/aws_signature_v4/lib/src/signer/aws_signer.dart
@@ -256,7 +256,8 @@ class AWSSigV4Signer {
   }) {
     // The signing process requires component keys be encoded. However, the
     // actual HTTP request should have the pre-encoded keys.
-    Map<String, String>? queryParameters = Map.of(canonicalRequest.queryParameters);
+    Map<String, String>? queryParameters =
+        Map.of(canonicalRequest.queryParameters);
 
     // Similar to query parameters, some header values are canonicalized for
     // signing. However their original values should be included in the
@@ -285,8 +286,8 @@ class AWSSigV4Signer {
     }
 
     // Web sends an OPTIONS request to verify CORS compatibility with the URL.
-    // A 404 can be returned if the URL contains unexpected query Parameters 
-    // and URI.toString() appends a "?" to the URL for an empty query parameter 
+    // A 404 can be returned if the URL contains unexpected query Parameters
+    // and URI.toString() appends a "?" to the URL for an empty query parameter
     // map. Set the query parameter to null if it empty to avoid this.
     // https://github.com/dart-lang/sdk/issues/51656
     queryParameters = queryParameters.isEmpty ? null : queryParameters;

--- a/packages/aws_signature_v4/lib/src/signer/aws_signer.dart
+++ b/packages/aws_signature_v4/lib/src/signer/aws_signer.dart
@@ -256,7 +256,7 @@ class AWSSigV4Signer {
   }) {
     // The signing process requires component keys be encoded. However, the
     // actual HTTP request should have the pre-encoded keys.
-    final queryParameters = Map.of(canonicalRequest.queryParameters);
+    Map<String, String>? queryParameters = Map.of(canonicalRequest.queryParameters);
 
     // Similar to query parameters, some header values are canonicalized for
     // signing. However their original values should be included in the
@@ -283,6 +283,13 @@ class AWSSigV4Signer {
         headers[AWSHeaders.securityToken] = sessionToken;
       }
     }
+
+    // Web sends an OPTIONS request to verify CORS compatability with the URL.
+    // A 404 can be returned if the URL contains unexpected query Parameters 
+    // and URI.toString() appends a "?" to the URL for an empty query parameter 
+    // map. Set the query parameter to null if it empty to avoid this.
+    // https://github.com/dart-lang/sdk/issues/51656
+    queryParameters = queryParameters.isEmpty ? null : queryParameters;
 
     // On Web, sign the `Host` and `Content-Length` headers, but do not send
     // them as part of the request, since these will be included automatically

--- a/packages/aws_signature_v4/lib/src/signer/aws_signer.dart
+++ b/packages/aws_signature_v4/lib/src/signer/aws_signer.dart
@@ -284,7 +284,7 @@ class AWSSigV4Signer {
       }
     }
 
-    // Web sends an OPTIONS request to verify CORS compatability with the URL.
+    // Web sends an OPTIONS request to verify CORS compatibility with the URL.
     // A 404 can be returned if the URL contains unexpected query Parameters 
     // and URI.toString() appends a "?" to the URL for an empty query parameter 
     // map. Set the query parameter to null if it empty to avoid this.


### PR DESCRIPTION
*Issue #, if available:*
#6008 

*Description of changes:*
Web builds send an OPTions request to verify CORS compatibility with the URL and a 404 can be returned if the URL contains unexpected query Parameters. URI.toString() appends a "?" to the URL for an empty query parameter map and we are currently setting null a query parameter to an empty map. 

This fix converts empty query parameters to null if it empty to prevent the URL from unintentionally having a "?" appended. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
