### PR TITLE
chore(test): added mfa selection in sms mfa required test

### DIFF
--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -254,7 +254,6 @@ void main() {
             preferred: MfaType.sms,
           ),
         );
-        //await signOutUser(assertComplete: true);
 
         // Verify we can set SMS as preferred and forego selection.
 
@@ -268,15 +267,8 @@ void main() {
           );
           final mfaCode = await getOtpCode(UserAttribute.phone(phoneNumber));
           await signOutUser();
-          await Amplify.Auth.signIn(
-            username: username,
-            password: password,
-          ); // NOW: this is going to auth state that expects an otp code, but the test originally was working with this state as expecting an mfa code....
+          await Amplify.Auth.signIn(username: username, password: password);
 
-          // as of May 2025, cognito has stopped defaulting to sms mfa and now asks for mfa type selection in the normal flow
-          //final selectMfaRes = await Amplify.Auth.confirmSignIn(
-          //  confirmationValue: 'SMS',
-          //);
           check(
             selectMfaRes.nextStep.signInStep,
           ).equals(AuthSignInStep.confirmSignInWithSmsMfaCode);

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -281,7 +281,7 @@ void main() {
             password: password,
           );
 
-            // as of May 2025, cognito has stopped defaulting to sms mfa and now asks for mfa type selection in the normal flow
+          // as of May 2025, cognito has stopped defaulting to sms mfa and now asks for mfa type selection in the normal flow
           final selectMfaRes = await Amplify.Auth.confirmSignIn(
             confirmationValue: 'SMS',
           );

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -258,7 +258,7 @@ void main() {
         // Verify we can set SMS as preferred and forego selection.
 
         {
-          await signOutUser(assertComplete: true);
+          //await signOutUser(assertComplete: true);
           check(await cognitoPlugin.fetchMfaPreference()).equals(
             const UserMfaPreference(
               enabled: {MfaType.sms, MfaType.email},

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -275,6 +275,7 @@ void main() {
             ),
           );
           final mfaCode = await getOtpCode(UserAttribute.phone(phoneNumber));
+          await signOutUser();
           final signInRes = await Amplify.Auth.signIn(
             username: username,
             password: password,

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -280,11 +280,16 @@ void main() {
             username: username,
             password: password,
           );
+
+            // as of May 2025, cognito has stopped defaulting to sms mfa and now asks for mfa type selection in the normal flow
+          final selectMfaRes = await Amplify.Auth.confirmSignIn(
+            confirmationValue: 'SMS',
+          );
           check(
-            signInRes.nextStep.signInStep,
-            because: 'Preference is SMS MFA now',
+            selectMfaRes.nextStep.signInStep,
           ).equals(AuthSignInStep.confirmSignInWithSmsMfaCode);
-          check(signInRes.nextStep.codeDeliveryDetails).isNotNull()
+
+          check(selectMfaRes.nextStep.codeDeliveryDetails).isNotNull()
             ..has(
               (d) => d.deliveryMedium,
               'deliveryMedium',

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -262,7 +262,7 @@ void main() {
           await cognitoPlugin.updateMfaPreference(sms: MfaPreference.preferred);
           check(await cognitoPlugin.fetchMfaPreference()).equals(
             const UserMfaPreference(
-              enabled: {MfaType.sms, MfaType.email},
+              enabled: {MfaType.sms},
               preferred: MfaType.sms,
             ),
           );

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -259,7 +259,6 @@ void main() {
         // Verify we can set SMS as preferred and forego selection.
 
         {
-          
           check(await cognitoPlugin.fetchMfaPreference()).equals(
             const UserMfaPreference(
               enabled: {MfaType.sms},

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -102,14 +102,17 @@ void main() {
         // as of May 2025, cognito has stopped defaulting to sms mfa and now asks for mfa type selection in the normal flow
         check(
           signInRes.nextStep.signInStep,
-          because: 'MFA is required so Cognito automatically enables SMS MFA', // change
+          because:
+              'MFA is required so Cognito automatically enables SMS MFA', // change
         ).equals(AuthSignInStep.continueSignInWithMfaSelection);
 
         final selectMfaRes = await Amplify.Auth.confirmSignIn(
-          confirmationValue: 'SMS_MFA'
+          confirmationValue: 'SMS_MFA',
         );
-        
-        check(selectMfaRes.nextStep.signInStep).equals(AuthSignInStep.confirmSignInWithSmsMfaCode);
+
+        check(
+          selectMfaRes.nextStep.signInStep,
+        ).equals(AuthSignInStep.confirmSignInWithSmsMfaCode);
 
         final confirmRes = await Amplify.Auth.confirmSignIn(
           confirmationValue: await mfaCode.code,

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -254,7 +254,7 @@ void main() {
             preferred: MfaType.sms,
           ),
         );
-        await signOutUser(assertComplete: true);
+        //await signOutUser(assertComplete: true);
 
         // Verify we can set SMS as preferred and forego selection.
 

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -259,24 +259,18 @@ void main() {
         // Verify we can set SMS as preferred and forego selection.
 
         {
-          check(await cognitoPlugin.fetchMfaPreference()).equals(
-            const UserMfaPreference(
-              enabled: {MfaType.sms},
-              preferred: MfaType.sms,
-            ),
-          );
           await cognitoPlugin.updateMfaPreference(
-            email: MfaPreference.preferred,
+            sms: MfaPreference.preferred,
           );
           check(await cognitoPlugin.fetchMfaPreference()).equals(
             const UserMfaPreference(
               enabled: {MfaType.sms, MfaType.email},
-              preferred: MfaType.email,
+              preferred: MfaType.sms,
             ),
           );
           final mfaCode = await getOtpCode(UserAttribute.phone(phoneNumber));
           await signOutUser();
-          await Amplify.Auth.signIn(username: username, password: password);
+          await Amplify.Auth.signIn(username: username, password: password); // NOW: this is going to auth state that expects an otp code, but the test originally was working with this state as expecting an mfa code....
 
           // as of May 2025, cognito has stopped defaulting to sms mfa and now asks for mfa type selection in the normal flow
           final selectMfaRes = await Amplify.Auth.confirmSignIn(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -62,6 +62,7 @@ void main() {
           username: username,
           password: password,
         );
+
         check(
           resignInRes.nextStep.signInStep,
         ).equals(AuthSignInStep.confirmSignInWithOtpCode);
@@ -99,11 +100,10 @@ void main() {
           username: username,
           password: password,
         );
-        
+
         check(
           signInRes.nextStep.signInStep,
-          because:
-              'MFA is required so Cognito will ask for MFA type',
+          because: 'MFA is required so Cognito will ask for MFA type',
         ).equals(AuthSignInStep.continueSignInWithMfaSelection);
 
         final selectMfaRes = await Amplify.Auth.confirmSignIn(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -259,12 +259,19 @@ void main() {
 
         {
           await signOutUser(assertComplete: true);
-
-          await cognitoPlugin.updateMfaPreference(sms: MfaPreference.preferred);
           check(await cognitoPlugin.fetchMfaPreference()).equals(
             const UserMfaPreference(
               enabled: {MfaType.sms, MfaType.email},
               preferred: MfaType.sms,
+            ),
+          );
+          await cognitoPlugin.updateMfaPreference(
+            email: MfaPreference.preferred,
+          );
+          check(await cognitoPlugin.fetchMfaPreference()).equals(
+            const UserMfaPreference(
+              enabled: {MfaType.sms, MfaType.email},
+              preferred: MfaType.email,
             ),
           );
           final mfaCode = await getOtpCode(UserAttribute.phone(phoneNumber));

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -89,6 +89,7 @@ void main() {
           password,
           autoConfirm: true,
           verifyAttributes: false,
+          enableMfa: true,
           attributes: {
             AuthUserAttributeKey.phoneNumber: phoneNumber,
             AuthUserAttributeKey.email: username,

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -276,10 +276,7 @@ void main() {
           );
           final mfaCode = await getOtpCode(UserAttribute.phone(phoneNumber));
           await signOutUser();
-          await Amplify.Auth.signIn(
-            username: username,
-            password: password,
-          );
+          await Amplify.Auth.signIn(username: username, password: password);
 
           // as of May 2025, cognito has stopped defaulting to sms mfa and now asks for mfa type selection in the normal flow
           final selectMfaRes = await Amplify.Auth.confirmSignIn(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -228,8 +228,7 @@ void main() {
 
         check(
           signInRes.nextStep.signInStep,
-          because:
-              'MFA is required so Cognito automatically enables SMS MFA', // change
+          because: 'MFA is required so Cognito prompts MFA type selection',
         ).equals(AuthSignInStep.continueSignInWithMfaSelection);
 
         final selectMfaRes = await Amplify.Auth.confirmSignIn(
@@ -247,7 +246,8 @@ void main() {
 
         check(
           await cognitoPlugin.fetchMfaPreference(),
-          because: 'MFA is required so Cognito automatically enables SMS MFA',
+          because:
+              'SMS MFA has been selected so Cognito fetches SMS as preferred',
         ).equals(
           const UserMfaPreference(
             enabled: {MfaType.sms},

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -89,7 +89,6 @@ void main() {
           password,
           autoConfirm: true,
           verifyAttributes: false,
-          enableMfa: true,
           attributes: {
             AuthUserAttributeKey.phoneNumber: phoneNumber,
             AuthUserAttributeKey.email: username,
@@ -100,10 +99,17 @@ void main() {
           username: username,
           password: password,
         );
+        // as of May 2025, cognito has stopped defaulting to sms mfa and now asks for mfa type selection in the normal flow
         check(
           signInRes.nextStep.signInStep,
-          because: 'MFA is required so Cognito automatically enables SMS MFA',
-        ).equals(AuthSignInStep.confirmSignInWithSmsMfaCode);
+          because: 'MFA is required so Cognito automatically enables SMS MFA', // change
+        ).equals(AuthSignInStep.continueSignInWithMfaSelection);
+
+        final selectMfaRes = await Amplify.Auth.confirmSignIn(
+          confirmationValue: 'SMS_MFA'
+        );
+        
+        check(selectMfaRes.nextStep.signInStep).equals(AuthSignInStep.confirmSignInWithSmsMfaCode);
 
         final confirmRes = await Amplify.Auth.confirmSignIn(
           confirmationValue: await mfaCode.code,

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -274,9 +274,9 @@ void main() {
           ); // NOW: this is going to auth state that expects an otp code, but the test originally was working with this state as expecting an mfa code....
 
           // as of May 2025, cognito has stopped defaulting to sms mfa and now asks for mfa type selection in the normal flow
-          final selectMfaRes = await Amplify.Auth.confirmSignIn(
-            confirmationValue: 'SMS',
-          );
+          //final selectMfaRes = await Amplify.Auth.confirmSignIn(
+          //  confirmationValue: 'SMS',
+          //);
           check(
             selectMfaRes.nextStep.signInStep,
           ).equals(AuthSignInStep.confirmSignInWithSmsMfaCode);

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -107,7 +107,7 @@ void main() {
         ).equals(AuthSignInStep.continueSignInWithMfaSelection);
 
         final selectMfaRes = await Amplify.Auth.confirmSignIn(
-          confirmationValue: 'SMS_MFA',
+          confirmationValue: 'SMS',
         );
 
         check(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -259,9 +259,7 @@ void main() {
         // Verify we can set SMS as preferred and forego selection.
 
         {
-          await cognitoPlugin.updateMfaPreference(
-            sms: MfaPreference.preferred,
-          );
+          await cognitoPlugin.updateMfaPreference(sms: MfaPreference.preferred);
           check(await cognitoPlugin.fetchMfaPreference()).equals(
             const UserMfaPreference(
               enabled: {MfaType.sms, MfaType.email},
@@ -270,7 +268,10 @@ void main() {
           );
           final mfaCode = await getOtpCode(UserAttribute.phone(phoneNumber));
           await signOutUser();
-          await Amplify.Auth.signIn(username: username, password: password); // NOW: this is going to auth state that expects an otp code, but the test originally was working with this state as expecting an mfa code....
+          await Amplify.Auth.signIn(
+            username: username,
+            password: password,
+          ); // NOW: this is going to auth state that expects an otp code, but the test originally was working with this state as expecting an mfa code....
 
           // as of May 2025, cognito has stopped defaulting to sms mfa and now asks for mfa type selection in the normal flow
           final selectMfaRes = await Amplify.Auth.confirmSignIn(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -276,7 +276,7 @@ void main() {
           );
           final mfaCode = await getOtpCode(UserAttribute.phone(phoneNumber));
           await signOutUser();
-          final signInRes = await Amplify.Auth.signIn(
+          await Amplify.Auth.signIn(
             username: username,
             password: password,
           );

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -254,14 +254,15 @@ void main() {
             preferred: MfaType.sms,
           ),
         );
+        await signOutUser(assertComplete: true);
 
         // Verify we can set SMS as preferred and forego selection.
 
         {
-          //await signOutUser(assertComplete: true);
+          
           check(await cognitoPlugin.fetchMfaPreference()).equals(
             const UserMfaPreference(
-              enabled: {MfaType.sms, MfaType.email},
+              enabled: {MfaType.sms},
               preferred: MfaType.sms,
             ),
           );

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -225,9 +225,19 @@ void main() {
           username: username,
           password: password,
         );
+
         check(
           signInRes.nextStep.signInStep,
-          because: 'MFA is required so Cognito automatically enables SMS MFA',
+          because:
+              'MFA is required so Cognito automatically enables SMS MFA', // change
+        ).equals(AuthSignInStep.continueSignInWithMfaSelection);
+
+        final selectMfaRes = await Amplify.Auth.confirmSignIn(
+          confirmationValue: 'SMS',
+        );
+
+        check(
+          selectMfaRes.nextStep.signInStep,
         ).equals(AuthSignInStep.confirmSignInWithSmsMfaCode);
 
         final confirmRes = await Amplify.Auth.confirmSignIn(

--- a/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/mfa_sms_email_required_test.dart
@@ -260,6 +260,13 @@ void main() {
         {
           await signOutUser(assertComplete: true);
 
+          await cognitoPlugin.updateMfaPreference(sms: MfaPreference.preferred);
+          check(await cognitoPlugin.fetchMfaPreference()).equals(
+            const UserMfaPreference(
+              enabled: {MfaType.sms, MfaType.email},
+              preferred: MfaType.sms,
+            ),
+          );
           final mfaCode = await getOtpCode(UserAttribute.phone(phoneNumber));
           final signInRes = await Amplify.Auth.signIn(
             username: username,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Cognito now requires selection of MFA type as an auth step if both sms and email are enabled, updating our sms + email test to reflect these changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
