### PR TITLE
Added IOT Core device service to service list

### DIFF
--- a/packages/aws_common/lib/src/config/aws_service.dart
+++ b/packages/aws_common/lib/src/config/aws_service.dart
@@ -558,6 +558,9 @@ class AWSService {
   /// AWS IoT
   static const iot = AWSService('iot');
 
+  /// AWS IoT Core Device
+  static const iotCore = AWSService('iotdevicegateway');
+
   /// AWS IoT 1-Click Devices Service
   static const iot1ClickDevicesService = AWSService('iot1click');
 


### PR DESCRIPTION
*Description of changes:*
Added iotdevicegateway to the list of AWS services. It is needed to create signed WebSocket URL for MQTT connection to AWS IoT Core service as mentioned on [this](https://docs.aws.amazon.com/iot/latest/developerguide/protocols.html) page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
