### PR TITLE
chore(amplify_db_common): Update sqlite3-native-library

### DIFF
--- a/packages/common/amplify_db_common/android/build.gradle
+++ b/packages/common/amplify_db_common/android/build.gradle
@@ -49,5 +49,5 @@ android {
 
 dependencies {
     // Keep in sync with: https://github.com/simolus3/sqlite3.dart/blob/main/sqlite3_flutter_libs/android/build.gradle
-    implementation 'eu.simonbinder:sqlite3-native-library:3.43.0'
+    implementation 'eu.simonbinder:sqlite3-native-library:3.50.1'
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes #6176 

*Description of changes:*
Update sqlite3-native-library to latest version to support 16KiB page size on android. See issue for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
