### PR TITLE
fix(auth): handle fallthrough exceptions in sign out state

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -1074,6 +1074,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
         hostedUiException: result.hostedUiException,
         globalSignOutException: result.globalSignOutException,
         revokeTokenException: result.revokeTokenException,
+        invalidTokenException: result.invalidTokenException,
       ),
       SignOutFailure(:final exception) => CognitoSignOutResult.failed(
         AuthException.fromException(exception),

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_result.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_result.dart
@@ -119,17 +119,17 @@ final class CognitoPartialSignOut extends CognitoSignOutResult {
     'signedOutLocally': signedOutLocally,
   };
 }
+
 /// {@template amplify_auth_cognito_dart.model.signout.hosted_ui_exception}
 /// Exception thrown trying to sign out with an invalid userpool token (one or more of the Id, Access, or Refresh Token).
 /// {@endtemplate}
 class InvalidTokenException extends AuthServiceException {
   /// {@macro amplify_auth_cognito_dart.model.signout.invalid_token_exception}
-  const InvalidTokenException({
-    super.underlyingException,
-  }) : super(
-         'The provided user pool token is invalid',
-         recoverySuggestion: 'See underlyingException for more details',
-       );
+  const InvalidTokenException({super.underlyingException})
+    : super(
+        'The provided user pool token is invalid',
+        recoverySuggestion: 'See underlyingException for more details',
+      );
 
   @override
   String get runtimeTypeName => 'InvalidTokenException';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_result.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_result.dart
@@ -26,6 +26,7 @@ sealed class CognitoSignOutResult extends SignOutResult
     HostedUiException? hostedUiException,
     GlobalSignOutException? globalSignOutException,
     RevokeTokenException? revokeTokenException,
+    InvalidTokenException? invalidTokenException,
   }) = CognitoPartialSignOut._;
 
   /// Whether credentials have been cleared from the local device.
@@ -108,6 +109,7 @@ final class CognitoPartialSignOut extends CognitoSignOutResult {
     hostedUiException,
     globalSignOutException,
     revokeTokenException,
+    invalidTokenException,
     signedOutLocally,
   ];
 
@@ -116,6 +118,7 @@ final class CognitoPartialSignOut extends CognitoSignOutResult {
     'hostedUiException': hostedUiException?.toString(),
     'globalSignOutException': globalSignOutException?.toString(),
     'revokeTokenException': revokeTokenException?.toString(),
+    'invalidTokenException': invalidTokenException?.toString(),
     'signedOutLocally': signedOutLocally,
   };
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_result.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signout/cognito_sign_out_result.dart
@@ -85,6 +85,7 @@ final class CognitoPartialSignOut extends CognitoSignOutResult {
     this.hostedUiException,
     this.globalSignOutException,
     this.revokeTokenException,
+    this.invalidTokenException,
   }) : super._();
 
   /// The exception that occurred during Hosted UI sign out.
@@ -95,6 +96,9 @@ final class CognitoPartialSignOut extends CognitoSignOutResult {
 
   /// The exception that occurred while revoking the token.
   final RevokeTokenException? revokeTokenException;
+
+  /// The exception that occurred while signing out with an invalid userpool token.
+  final InvalidTokenException? invalidTokenException;
 
   @override
   bool get signedOutLocally => true;
@@ -114,6 +118,21 @@ final class CognitoPartialSignOut extends CognitoSignOutResult {
     'revokeTokenException': revokeTokenException?.toString(),
     'signedOutLocally': signedOutLocally,
   };
+}
+/// {@template amplify_auth_cognito_dart.model.signout.hosted_ui_exception}
+/// Exception thrown trying to sign out with an invalid userpool token (one or more of the Id, Access, or Refresh Token).
+/// {@endtemplate}
+class InvalidTokenException extends AuthServiceException {
+  /// {@macro amplify_auth_cognito_dart.model.signout.invalid_token_exception}
+  const InvalidTokenException({
+    super.underlyingException,
+  }) : super(
+         'The provided user pool token is invalid',
+         recoverySuggestion: 'See underlyingException for more details',
+       );
+
+  @override
+  String get runtimeTypeName => 'InvalidTokenException';
 }
 
 /// {@template amplify_auth_cognito_dart.model.signout.hosted_ui_exception}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_out_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_out_state_machine.dart
@@ -88,7 +88,7 @@ final class SignOutStateMachine
       await manager.clearCredentials();
       return emit(const SignOutState.success());
     } on Exception catch (e) {
-      // on any other exception, we should clear credentials and rethrow the exception
+      // unable to read tokens, clear the credentials to clear this invalid state.
       invalidTokenException = InvalidTokenException(underlyingException: e);
       await dispatchAndComplete(const CredentialStoreEvent.clearCredentials());
       return emit(

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_out_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_out_state_machine.dart
@@ -89,9 +89,7 @@ final class SignOutStateMachine
       return emit(const SignOutState.success());
     } on Exception catch (e) {
       // on any other exception, we should clear credentials and rethrow the exception
-      invalidTokenException = InvalidTokenException(
-        underlyingException: e,
-      );
+      invalidTokenException = InvalidTokenException(underlyingException: e);
       await dispatchAndComplete(const CredentialStoreEvent.clearCredentials());
       return emit(
         SignOutState.partialFailure(

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_out_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_out_state_machine.dart
@@ -80,6 +80,10 @@ final class SignOutStateMachine
       // to clear the credentials associated with the non-existent user.
       await manager.clearCredentials();
       return emit(const SignOutState.success());
+    } on Exception catch (e) {
+      // on any other exception, we should clear credentials and rethrow the exception
+      await dispatchAndComplete(const CredentialStoreEvent.clearCredentials());
+      return emit(SignOutFailure(e));
     }
 
     // Capture results of individual steps to determine overall success.

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_out_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_out_state.dart
@@ -40,6 +40,7 @@ sealed class SignOutState extends AuthState<SignOutStateType> {
     HostedUiException? hostedUiException,
     GlobalSignOutException? globalSignOutException,
     RevokeTokenException? revokeTokenException,
+    InvalidTokenException? invalidTokenException,
   }) = SignOutPartialFailure;
 
   /// {@macro amplify_auth_cognito.sign_out_failure}
@@ -89,6 +90,7 @@ final class SignOutPartialFailure extends SignOutState {
     this.hostedUiException,
     this.globalSignOutException,
     this.revokeTokenException,
+    this.invalidTokenException,
   }) : super._();
 
   /// The exception that occurred during Hosted UI sign out.
@@ -99,6 +101,9 @@ final class SignOutPartialFailure extends SignOutState {
 
   /// The exception that occurred while revoking the token.
   final RevokeTokenException? revokeTokenException;
+  
+  /// The exception that occurred while signing out with an invalid userpool token.
+  final InvalidTokenException? invalidTokenException;
 
   @override
   List<Object?> get props => [

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_out_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_out_state.dart
@@ -101,7 +101,7 @@ final class SignOutPartialFailure extends SignOutState {
 
   /// The exception that occurred while revoking the token.
   final RevokeTokenException? revokeTokenException;
-  
+
   /// The exception that occurred while signing out with an invalid userpool token.
   final InvalidTokenException? invalidTokenException;
 

--- a/packages/test/amplify_auth_integration_test/lib/src/test_runner.dart
+++ b/packages/test/amplify_auth_integration_test/lib/src/test_runner.dart
@@ -305,10 +305,11 @@ Future<void> signOutUser({bool assertComplete = false}) async {
       :final hostedUiException,
       :final globalSignOutException,
       :final revokeTokenException,
+      :final invalidTokenException,
     ):
       _logger.error(
         'Error signing out:',
-        hostedUiException ?? globalSignOutException ?? revokeTokenException,
+        hostedUiException ?? globalSignOutException ?? revokeTokenException ?? invalidTokenException,
       );
     case CognitoFailedSignOut(:final exception):
       _logger.error('Error signing out:', exception);


### PR DESCRIPTION
*Issue #, if available:*
#6205 

*Description of changes:*

_onInitiate in our sign out state machine function catches only two exceptions, we add a catch all that also clears the credential store in this PR to handle other cases. Notably this allows users to exit a bad state where they would be unable to sign in or out properly if they have refresh token rotation enabled (linked issue), which causes the `REFRESH_TOKEN_AUTH` flow to be disabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
