### PR TITLE
fix(datastore): corrected getToken return value for oidc

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/FlutterAuthProvider.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/FlutterAuthProvider.kt
@@ -105,7 +105,7 @@ class FlutterAuthProviders(
                 }
                 launch(Dispatchers.Main) {
                     nativeApiPlugin.getLatestAuthToken(authType.name) { resultToken ->
-                        result.success(resultToken)
+                        result.success(resultToken.getOrNull())
                     }
                 }
 


### PR DESCRIPTION
*Issue #, if available:*
[6263](https://github.com/aws-amplify/amplify-flutter/issues/6263)

*Description of changes:*
Updated getToken to extract the oidc token from the getLatestAuthToken result

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
