### PR TITLE
Feat/passwordless autosignin

### DIFF
--- a/packages/amplify_core/doc/lib/auth.dart
+++ b/packages/amplify_core/doc/lib/auth.dart
@@ -171,6 +171,26 @@ Future<void> _handleSignInResult(SignInResult result) async {
     case AuthSignInStep.done:
       safePrint('Sign in is complete');
     // #enddocregion handle-confirm-signin-done
+    // #docregion handle-confirm-signin-first-factor-selection
+    case AuthSignInStep.continueSignInWithFirstFactorSelection:
+      final allowedfirstFactorTypes = result.nextStep.availableFactors!;
+      if (allowedfirstFactorTypes.length == 1) {
+        return _handleFirstFactorSelection(allowedfirstFactorTypes.first);
+      }
+      final selection = await _promptUserFirstFactorPreference(
+        allowedfirstFactorTypes,
+      );
+      safePrint('Selected first factor type: $selection');
+      return _handleFirstFactorSelection(selection);
+    // #enddocregion handle-confirm-signin-first-factor-selection
+    // #docregion handle-confirm-signin-otp
+    case AuthSignInStep.confirmSignInWithOtp:
+      safePrint('Enter a one-time code');
+    // #enddocregion handle-confirm-signin-otp
+    // #docregion handle-confirm-signin-password
+    case AuthSignInStep.confirmSignInWithPassword:
+      safePrint('Enter your Password');
+    // #enddocregion handle-confirm-signin-password
     // #docregion handle-signin, handle-confirm-signin-sms, handle-confirm-signin-new-password, handle-confirm-signin-custom-challenge, handle-confirm-signin-reset-password, handle-confirm-signin-confirm-signup, handle-confirm-signin-done, handle-confirm-signin-mfa-selection, handle-confirm-signin-totp-setup, handle-confirm-signin-totp-code, handle-confirm-signin-email-code, handle-confirm-signin-mfa-setup-selection, handle-confirm-signin-email-setup
   }
 }
@@ -242,7 +262,30 @@ Future<void> _handleMfaSelection(MfaType selection) async {
     );
     return _handleSignInResult(result);
   } on AuthException catch (e) {
-    safePrint('Error resending code: ${e.message}');
+    safePrint('Error selecting MFA type: ${e.message}');
+  }
+}
+// #enddocregion handle-mfa-selection
+
+// #docregion prompt-user-preference
+Future<AuthFactorType> _promptUserFirstFactorPreference(
+  Set<AuthFactorType> allowedTypes,
+) async {
+  // #enddocregion prompt-user-preference
+  throw UnimplementedError();
+  // #docregion prompt-user-preference
+}
+// #enddocregion prompt-user-preference
+
+// #docregion handle-mfa-selection
+Future<void> _handleFirstFactorSelection(AuthFactorType selection) async {
+  try {
+    final result = await Amplify.Auth.confirmSignIn(
+      confirmationValue: selection.value,
+    );
+    return _handleSignInResult(result);
+  } on AuthException catch (e) {
+    safePrint('Error selecting first factor preference: ${e.message}');
   }
 }
 // #enddocregion handle-mfa-selection

--- a/packages/amplify_core/lib/src/category/amplify_auth_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_auth_category.dart
@@ -594,6 +594,13 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
     ),
   );
 
+  /// {@template amplify_core.amplify_auth_category.autoSignIn}
+  /// {@endtemplate}
+  Future<SignInResult> autoSignIn({AutoSignInOptions? options}) => identifyCall(
+    AuthCategoryMethod.confirmSignIn,
+    () => defaultPlugin.autoSignIn(options: options),
+  );
+
   /// {@template amplify_core.amplify_auth_category.sign_out}
   /// Sign the user out of the current device.
   ///

--- a/packages/amplify_core/lib/src/category/amplify_auth_category.dart
+++ b/packages/amplify_core/lib/src/category/amplify_auth_category.dart
@@ -130,7 +130,7 @@ class AuthCategory extends AmplifyCategory<AuthPluginInterface> {
   /// {@endtemplate}
   Future<SignUpResult> signUp({
     required String username,
-    required String password,
+    String? password,
     SignUpOptions? options,
   }) => identifyCall(
     AuthCategoryMethod.signUp,

--- a/packages/amplify_core/lib/src/config/auth/cognito/authentication_flow_type.dart
+++ b/packages/amplify_core/lib/src/config/auth/cognito/authentication_flow_type.dart
@@ -22,7 +22,11 @@ enum AuthenticationFlowType {
   /// Authentication flow which starts without SRP and directly moves to custom
   /// auth flow.
   @JsonValue('CUSTOM_AUTH_WITHOUT_SRP')
-  customAuthWithoutSrp('CUSTOM_AUTH_WITHOUT_SRP');
+  customAuthWithoutSrp('CUSTOM_AUTH_WITHOUT_SRP'),
+
+  /// Authentication flow used for user discovering enabled first factors for a user.
+  @JsonValue('USER_AUTH')
+  userAuth('USER_AUTH');
 
   const AuthenticationFlowType(this.value);
 

--- a/packages/amplify_core/lib/src/plugin/amplify_auth_plugin_interface.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_auth_plugin_interface.dart
@@ -40,6 +40,11 @@ abstract class AuthPluginInterface extends AmplifyPluginInterface {
     throw UnimplementedError('resendSignUpCode() has not been implemented');
   }
 
+  /// {@macro amplify_core.amplify_auth_category.auto_sign_in}
+  Future<SignInResult> autoSignIn({AutoSignInOptions? options}) {
+    throw UnimplementedError('autoSignIn() has not been implemented');
+  }
+
   /// {@macro amplify_core.amplify_auth_category.sign_in}
   Future<SignInResult> signIn({
     required String username,

--- a/packages/amplify_core/lib/src/plugin/amplify_auth_plugin_interface.dart
+++ b/packages/amplify_core/lib/src/plugin/amplify_auth_plugin_interface.dart
@@ -17,7 +17,7 @@ abstract class AuthPluginInterface extends AmplifyPluginInterface {
   /// {@macro amplify_core.amplify_auth_category.sign_up}
   Future<SignUpResult> signUp({
     required String username,
-    required String password,
+    String? password,
     SignUpOptions? options,
   }) {
     throw UnimplementedError('signUp() has not been implemented');

--- a/packages/amplify_core/lib/src/types/auth/auth_types.dart
+++ b/packages/amplify_core/lib/src/types/auth/auth_types.dart
@@ -32,6 +32,8 @@ export 'attribute/update_user_attributes_options.dart';
 export 'auth_code_delivery_details.dart';
 export 'auth_device.dart';
 export 'auth_next_step.dart';
+// Auto Sign In
+export 'auto_sign_in/auto_sign_in_options.dart';
 // Hub
 export 'hub/auth_hub_event.dart';
 // MFA

--- a/packages/amplify_core/lib/src/types/auth/auth_types.dart
+++ b/packages/amplify_core/lib/src/types/auth/auth_types.dart
@@ -54,6 +54,7 @@ export 'session/auth_user.dart';
 export 'session/fetch_auth_session_options.dart';
 export 'session/get_current_user_options.dart';
 export 'session/sign_in_details.dart';
+export 'sign_in/auth_factor_type.dart';
 // Sign In
 export 'sign_in/auth_next_sign_in_step.dart';
 export 'sign_in/auth_provider.dart';

--- a/packages/amplify_core/lib/src/types/auth/auto_sign_in/auto_sign_in_options.dart
+++ b/packages/amplify_core/lib/src/types/auth/auto_sign_in/auto_sign_in_options.dart
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+/// {@category Auth}
+/// {@template amplify_core.types.auth.auto_sign_in_options}
+/// Options passed to `Amplify.Auth.autoSignIn`.
+/// {@endtemplate}
+class AutoSignInOptions
+    with
+        AWSEquatable<AutoSignInOptions>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  /// {@macro amplify_core.types.auth.auto_sign_in_options}
+  const AutoSignInOptions({this.pluginOptions});
+
+  /// {@macro amplify_core.auth.auto_sign_in_plugin_options}
+  final AutoSignInPluginOptions? pluginOptions;
+
+  @override
+  List<Object?> get props => [pluginOptions];
+
+  @override
+  String get runtimeTypeName => 'AutoSignInOptions';
+
+  @override
+  Map<String, Object?> toJson() => {'pluginOptions': pluginOptions?.toJson()};
+}
+
+/// @nodoc
+/// {@template amplify_core.auth.auto_sign_in_plugin_options}
+/// Plugin-specific options for `Amplify.Auth.autoSignIn`.
+/// {@endtemplate}
+abstract class AutoSignInPluginOptions
+    with
+        AWSEquatable<AutoSignInPluginOptions>,
+        AWSSerializable<Map<String, Object?>>,
+        AWSDebuggable {
+  /// {@macro amplify_core.auth.auto_sign_in_plugin_options}
+  const AutoSignInPluginOptions();
+}

--- a/packages/amplify_core/lib/src/types/auth/sign_in/auth_factor_type.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/auth_factor_type.dart
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:json_annotation/json_annotation.dart';
+
+/// {@category Auth}
+/// {@template amplify_core.auth.auth_factor_type}
+/// Enumeration of the possible mechanisms that can be used to authenticate a user when 
+/// signing in with USER_AUTH.
+/// {@endtemplate}
+enum AuthFactorType {
+  /// Sign in using the user's password
+  @JsonValue('PASSWORD')
+  password('PASSWORD'),
+
+  /// Sign in using the user's password via a Secure Remote Password flow
+  @JsonValue('PASSWORD_SRP')
+  passwordSrp('PASSWORD_SRP'),
+
+  ///Sign in using a One Time Password sent to the user's email address
+  @JsonValue('EMAIL_OTP')
+  emailOtp('EMAIL_OTP'),
+
+  /// Sign in using a One Time Password sent to the user's SMS number
+  @JsonValue('SMS_OTP')
+  smsOtp('SMS_OTP'),
+
+  /// Sign in with WebAuthn (i.e. PassKey)
+  @JsonValue('WEB_AUTHN')
+  webAuthn('WEB_AUTHN');
+
+  const AuthFactorType(this.value);
+
+  final String value;
+}

--- a/packages/amplify_core/lib/src/types/auth/sign_in/auth_factor_type.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/auth_factor_type.dart
@@ -5,7 +5,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 /// {@category Auth}
 /// {@template amplify_core.auth.auth_factor_type}
-/// Enumeration of the possible mechanisms that can be used to authenticate a user when 
+/// Enumeration of the possible mechanisms that can be used to authenticate a user when
 /// signing in with USER_AUTH.
 /// {@endtemplate}
 enum AuthFactorType {

--- a/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.dart
@@ -16,6 +16,7 @@ class AuthNextSignInStep extends AuthNextStep
     this.missingAttributes = const [],
     this.allowedMfaTypes,
     this.totpSetupDetails,
+    this.availableFactors,
   });
 
   factory AuthNextSignInStep.fromJson(Map<String, Object?> json) =>
@@ -42,12 +43,19 @@ class AuthNextSignInStep extends AuthNextStep
   /// authenticator ([AuthSignInStep.continueSignInWithTotpSetup]).
   final TotpSetupDetails? totpSetupDetails;
 
+  /// {@macro amplify_core.auth.available_factors}
+  ///
+  /// This is non-null when the sign-in step requires association of a first factor
+  /// authentication to be selected ([AuthSignInStep.continueSignInWithFirstFactorSelection]).
+  final Set<AuthFactorType>? availableFactors;
+
   @override
   List<Object?> get props => [
     signInStep,
     missingAttributes,
     allowedMfaTypes,
     totpSetupDetails,
+    availableFactors,
   ];
 
   @override

--- a/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.g.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/auth_next_sign_in_step.g.dart
@@ -50,6 +50,12 @@ AuthNextSignInStep _$AuthNextSignInStepFromJson(
           ? null
           : TotpSetupDetails.fromJson(v as Map<String, dynamic>),
     ),
+    availableFactors: $checkedConvert(
+      'availableFactors',
+      (v) => (v as List<dynamic>?)
+          ?.map((e) => $enumDecode(_$AuthFactorTypeEnumMap, e))
+          .toSet(),
+    ),
   );
   return val;
 });
@@ -68,6 +74,11 @@ Map<String, dynamic> _$AuthNextSignInStepToJson(AuthNextSignInStep instance) =>
         'allowedMfaTypes': value,
       if (instance.totpSetupDetails?.toJson() case final value?)
         'totpSetupDetails': value,
+      if (instance.availableFactors
+              ?.map((e) => _$AuthFactorTypeEnumMap[e]!)
+              .toList()
+          case final value?)
+        'availableFactors': value,
     };
 
 const _$AuthSignInStepEnumMap = {
@@ -78,12 +89,16 @@ const _$AuthSignInStepEnumMap = {
   AuthSignInStep.continueSignInWithTotpSetup: 'continueSignInWithTotpSetup',
   AuthSignInStep.continueSignInWithEmailMfaSetup:
       'continueSignInWithEmailMfaSetup',
+  AuthSignInStep.continueSignInWithFirstFactorSelection:
+      'continueSignInWithFirstFactorSelection',
   AuthSignInStep.confirmSignInWithSmsMfaCode: 'confirmSignInWithSmsMfaCode',
   AuthSignInStep.confirmSignInWithTotpMfaCode: 'confirmSignInWithTotpMfaCode',
   AuthSignInStep.confirmSignInWithOtpCode: 'confirmSignInWithOtpCode',
   AuthSignInStep.confirmSignInWithNewPassword: 'confirmSignInWithNewPassword',
   AuthSignInStep.confirmSignInWithCustomChallenge:
       'confirmSignInWithCustomChallenge',
+  AuthSignInStep.confirmSignInWithOtp: 'confirmSignInWithOtp',
+  AuthSignInStep.confirmSignInWithPassword: 'confirmSignInWithPassword',
   AuthSignInStep.resetPassword: 'resetPassword',
   AuthSignInStep.confirmSignUp: 'confirmSignUp',
   AuthSignInStep.done: 'done',
@@ -93,4 +108,12 @@ const _$MfaTypeEnumMap = {
   MfaType.sms: 'SMS',
   MfaType.totp: 'TOTP',
   MfaType.email: 'EMAIL',
+};
+
+const _$AuthFactorTypeEnumMap = {
+  AuthFactorType.password: 'PASSWORD',
+  AuthFactorType.passwordSrp: 'PASSWORD_SRP',
+  AuthFactorType.emailOtp: 'EMAIL_OTP',
+  AuthFactorType.smsOtp: 'SMS_OTP',
+  AuthFactorType.webAuthn: 'WEB_AUTHN',
 };

--- a/packages/amplify_core/lib/src/types/auth/sign_in/auth_sign_in_step.dart
+++ b/packages/amplify_core/lib/src/types/auth/sign_in/auth_sign_in_step.dart
@@ -21,6 +21,9 @@ enum AuthSignInStep {
   /// continuing.
   continueSignInWithEmailMfaSetup,
 
+  /// The sign-in is not complete and the user must select a first factor method.
+  continueSignInWithFirstFactorSelection,
+
   /// The sign-in is not complete and must be confirmed with an SMS code.
   confirmSignInWithSmsMfaCode,
 
@@ -38,6 +41,12 @@ enum AuthSignInStep {
   /// The sign-in is not complete and must be confirmed with the answer to a
   /// custom challenge.
   confirmSignInWithCustomChallenge,
+
+  /// The sign-in is not complete and must be confirmed with an one time password code.
+  confirmSignInWithOtp,
+
+  /// The sign-in is not complete and must be confirmed with a password.
+  confirmSignInWithPassword,
 
   /// The sign-in is not complete and the user must reset their password before
   /// proceeding.

--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -90,7 +90,7 @@ class AmplifyAuthCognito extends AmplifyAuthCognitoDart with AWSDebuggable {
   @override
   Future<CognitoSignUpResult> signUp({
     required String username,
-    required String password,
+    String? password,
     SignUpOptions? options,
   }) async {
     options ??= const SignUpOptions();

--- a/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
@@ -20,6 +20,7 @@ export 'src/model/attribute/cognito_send_user_attribute_verification_code_plugin
 export 'src/model/attribute/cognito_update_user_attribute_plugin_options.dart';
 export 'src/model/attribute/cognito_update_user_attributes_plugin_options.dart';
 export 'src/model/auth_result.dart';
+export 'src/model/auto_sign_in/cognito_auto_sign_in_plugin_options.dart';
 export 'src/model/device/cognito_device.dart';
 export 'src/model/mfa/cognito_verify_totp_setup_plugin_options.dart';
 export 'src/model/password/cognito_confirm_reset_password_plugin_options.dart';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -379,7 +379,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
   @override
   Future<CognitoSignUpResult> signUp({
     required String username,
-    required String password,
+    String? password,
     SignUpOptions? options,
   }) async {
     options ??= const SignUpOptions();

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -494,6 +494,7 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
             missingAttributes: challenge.requiredAttributes,
             allowedMfaTypes: challenge.allowedMfaTypes,
             totpSetupDetails: challenge.totpSetupResult,
+            availableFactors: challenge.allowedfirstFactorTypes,
           ),
         );
 
@@ -527,7 +528,8 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
           parameters: SignInParameters(
             (p) => p
               ..username = username
-              ..password = password,
+              ..password = password
+              ..preferredFirstFactor = pluginOptions.preferredFirstFactor,
           ),
           clientMetadata: pluginOptions.clientMetadata,
         ),

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/constants.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/constants.dart
@@ -104,4 +104,7 @@ abstract class CognitoConstants {
 
   /// The `REFRESH_TOKEN` parameter
   static const refreshToken = 'REFRESH_TOKEN';
+
+  /// The `PREFERRED_CHALLENGE` parameter
+  static const preferredChallenge = 'PREFERRED_CHALLENGE';
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/auto_sign_in/cognito_auto_sign_in_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/auto_sign_in/cognito_auto_sign_in_plugin_options.dart
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_core/amplify_core.dart';
+
+part 'cognito_auto_sign_in_plugin_options.g.dart';
+
+/// {@template amplify_auth_cognito_dart.cognito_auto_sign_in_plugin_options}
+/// Cognito options for `Amplify.Auth.autoSignIn`.
+/// {@endtemplate}
+@zAmplifySerializable
+class CognitoAutoSignInPluginOptions extends AutoSignInPluginOptions {
+  /// {@macro amplify_auth_cognito_dart.cognito_auto_sign_in_plugin_options}
+  const CognitoAutoSignInPluginOptions({this.clientMetadata = const {}});
+
+  /// {@macro amplify_auth_cognito_dart.cognito_auto_sign_in_plugin_options}
+  factory CognitoAutoSignInPluginOptions.fromJson(Map<String, Object?> json) =>
+      _$CognitoAutoSignInPluginOptionsFromJson(json);
+
+  /// {@template amplify_auth_cognito_dart.cognito_auto_sign_in_plugin_options.client_metadata}
+  /// A map of custom key-value pairs that you can provide as input for certain
+  /// custom workflows that this action triggers.
+  /// {@endtemplate}
+  final Map<String, String> clientMetadata;
+
+  @override
+  List<Object?> get props => [clientMetadata];
+
+  @override
+  String get runtimeTypeName => 'CognitoAutoSignInPluginOptions';
+
+  @override
+  Map<String, Object?> toJson() => _$CognitoAutoSignInPluginOptionsToJson(this);
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/auto_sign_in/cognito_auto_sign_in_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/auto_sign_in/cognito_auto_sign_in_plugin_options.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cognito_auto_sign_in_plugin_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CognitoAutoSignInPluginOptions _$CognitoAutoSignInPluginOptionsFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('CognitoAutoSignInPluginOptions', json, ($checkedConvert) {
+  final val = CognitoAutoSignInPluginOptions(
+    clientMetadata: $checkedConvert(
+      'clientMetadata',
+      (v) =>
+          (v as Map<String, dynamic>?)?.map(
+            (k, e) => MapEntry(k, e as String),
+          ) ??
+          const {},
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$CognitoAutoSignInPluginOptionsToJson(
+  CognitoAutoSignInPluginOptions instance,
+) => <String, dynamic>{'clientMetadata': instance.clientMetadata};

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/sign_in_parameters.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/sign_in_parameters.dart
@@ -4,6 +4,7 @@
 @internal
 library;
 
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:meta/meta.dart';
@@ -25,6 +26,9 @@ abstract class SignInParameters
 
   /// The password of the user, if initating an SRP-based flow.
   String? get password;
+
+  /// The preferred first factor of the user, if initating an USER_AUTH flow.
+  AuthFactorType? get preferredFirstFactor;
 
   /// The `built_value` serializer for [SignInParameters].
   static Serializer<SignInParameters> get serializer =>

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/sign_in_parameters.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/sign_in_parameters.dart
@@ -30,6 +30,9 @@ abstract class SignInParameters
   /// The preferred first factor of the user, if initating an USER_AUTH flow.
   AuthFactorType? get preferredFirstFactor;
 
+  /// The session, if initating an USER_AUTH flow after sign up.
+  String? get session;
+
   /// The `built_value` serializer for [SignInParameters].
   static Serializer<SignInParameters> get serializer =>
       _$signInParametersSerializer;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/sign_in_parameters.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/sign_in_parameters.g.dart
@@ -38,6 +38,17 @@ class _$SignInParametersSerializer
           serializers.serialize(value, specifiedType: const FullType(String)),
         );
     }
+    value = object.preferredFirstFactor;
+    if (value != null) {
+      result
+        ..add('preferredFirstFactor')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(AuthFactorType),
+          ),
+        );
+    }
     return result;
   }
 
@@ -71,6 +82,14 @@ class _$SignInParametersSerializer
                   )
                   as String?;
           break;
+        case 'preferredFirstFactor':
+          result.preferredFirstFactor =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(AuthFactorType),
+                  )
+                  as AuthFactorType?;
+          break;
       }
     }
 
@@ -83,12 +102,18 @@ class _$SignInParameters extends SignInParameters {
   final String username;
   @override
   final String? password;
+  @override
+  final AuthFactorType? preferredFirstFactor;
 
   factory _$SignInParameters([
     void Function(SignInParametersBuilder)? updates,
   ]) => (SignInParametersBuilder()..update(updates))._build();
 
-  _$SignInParameters._({required this.username, this.password}) : super._();
+  _$SignInParameters._({
+    required this.username,
+    this.password,
+    this.preferredFirstFactor,
+  }) : super._();
   @override
   SignInParameters rebuild(void Function(SignInParametersBuilder) updates) =>
       (toBuilder()..update(updates)).build();
@@ -102,7 +127,8 @@ class _$SignInParameters extends SignInParameters {
     if (identical(other, this)) return true;
     return other is SignInParameters &&
         username == other.username &&
-        password == other.password;
+        password == other.password &&
+        preferredFirstFactor == other.preferredFirstFactor;
   }
 
   @override
@@ -110,6 +136,7 @@ class _$SignInParameters extends SignInParameters {
     var _$hash = 0;
     _$hash = $jc(_$hash, username.hashCode);
     _$hash = $jc(_$hash, password.hashCode);
+    _$hash = $jc(_$hash, preferredFirstFactor.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -118,7 +145,8 @@ class _$SignInParameters extends SignInParameters {
   String toString() {
     return (newBuiltValueToStringHelper(r'SignInParameters')
           ..add('username', username)
-          ..add('password', password))
+          ..add('password', password)
+          ..add('preferredFirstFactor', preferredFirstFactor))
         .toString();
   }
 }
@@ -135,6 +163,11 @@ class SignInParametersBuilder
   String? get password => _$this._password;
   set password(String? password) => _$this._password = password;
 
+  AuthFactorType? _preferredFirstFactor;
+  AuthFactorType? get preferredFirstFactor => _$this._preferredFirstFactor;
+  set preferredFirstFactor(AuthFactorType? preferredFirstFactor) =>
+      _$this._preferredFirstFactor = preferredFirstFactor;
+
   SignInParametersBuilder();
 
   SignInParametersBuilder get _$this {
@@ -142,6 +175,7 @@ class SignInParametersBuilder
     if ($v != null) {
       _username = $v.username;
       _password = $v.password;
+      _preferredFirstFactor = $v.preferredFirstFactor;
       _$v = null;
     }
     return this;
@@ -170,6 +204,7 @@ class SignInParametersBuilder
             'username',
           ),
           password: password,
+          preferredFirstFactor: preferredFirstFactor,
         );
     replace(_$result);
     return _$result;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/sign_in_parameters.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/sign_in_parameters.g.dart
@@ -49,6 +49,14 @@ class _$SignInParametersSerializer
           ),
         );
     }
+    value = object.session;
+    if (value != null) {
+      result
+        ..add('session')
+        ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)),
+        );
+    }
     return result;
   }
 
@@ -90,6 +98,14 @@ class _$SignInParametersSerializer
                   )
                   as AuthFactorType?;
           break;
+        case 'session':
+          result.session =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(String),
+                  )
+                  as String?;
+          break;
       }
     }
 
@@ -104,6 +120,8 @@ class _$SignInParameters extends SignInParameters {
   final String? password;
   @override
   final AuthFactorType? preferredFirstFactor;
+  @override
+  final String? session;
 
   factory _$SignInParameters([
     void Function(SignInParametersBuilder)? updates,
@@ -113,6 +131,7 @@ class _$SignInParameters extends SignInParameters {
     required this.username,
     this.password,
     this.preferredFirstFactor,
+    this.session,
   }) : super._();
   @override
   SignInParameters rebuild(void Function(SignInParametersBuilder) updates) =>
@@ -128,7 +147,8 @@ class _$SignInParameters extends SignInParameters {
     return other is SignInParameters &&
         username == other.username &&
         password == other.password &&
-        preferredFirstFactor == other.preferredFirstFactor;
+        preferredFirstFactor == other.preferredFirstFactor &&
+        session == other.session;
   }
 
   @override
@@ -137,6 +157,7 @@ class _$SignInParameters extends SignInParameters {
     _$hash = $jc(_$hash, username.hashCode);
     _$hash = $jc(_$hash, password.hashCode);
     _$hash = $jc(_$hash, preferredFirstFactor.hashCode);
+    _$hash = $jc(_$hash, session.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -146,7 +167,8 @@ class _$SignInParameters extends SignInParameters {
     return (newBuiltValueToStringHelper(r'SignInParameters')
           ..add('username', username)
           ..add('password', password)
-          ..add('preferredFirstFactor', preferredFirstFactor))
+          ..add('preferredFirstFactor', preferredFirstFactor)
+          ..add('session', session))
         .toString();
   }
 }
@@ -168,6 +190,10 @@ class SignInParametersBuilder
   set preferredFirstFactor(AuthFactorType? preferredFirstFactor) =>
       _$this._preferredFirstFactor = preferredFirstFactor;
 
+  String? _session;
+  String? get session => _$this._session;
+  set session(String? session) => _$this._session = session;
+
   SignInParametersBuilder();
 
   SignInParametersBuilder get _$this {
@@ -176,6 +202,7 @@ class SignInParametersBuilder
       _username = $v.username;
       _password = $v.password;
       _preferredFirstFactor = $v.preferredFirstFactor;
+      _session = $v.session;
       _$v = null;
     }
     return this;
@@ -205,6 +232,7 @@ class SignInParametersBuilder
           ),
           password: password,
           preferredFirstFactor: preferredFirstFactor,
+          session: session,
         );
     replace(_$result);
     return _$result;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/sign_up_parameters.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/sign_up_parameters.dart
@@ -23,5 +23,5 @@ abstract class SignUpParameters
   String get username;
 
   /// The new user's password.
-  String get password;
+  String? get password;
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/sign_up_parameters.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/sign_up_parameters.g.dart
@@ -10,14 +10,13 @@ class _$SignUpParameters extends SignUpParameters {
   @override
   final String username;
   @override
-  final String password;
+  final String? password;
 
   factory _$SignUpParameters([
     void Function(SignUpParametersBuilder)? updates,
   ]) => (SignUpParametersBuilder()..update(updates))._build();
 
-  _$SignUpParameters._({required this.username, required this.password})
-    : super._();
+  _$SignUpParameters._({required this.username, this.password}) : super._();
   @override
   SignUpParameters rebuild(void Function(SignUpParametersBuilder) updates) =>
       (toBuilder()..update(updates)).build();
@@ -98,11 +97,7 @@ class SignUpParametersBuilder
             r'SignUpParameters',
             'username',
           ),
-          password: BuiltValueNullFieldError.checkNotNull(
-            password,
-            r'SignUpParameters',
-            'password',
-          ),
+          password: password,
         );
     replace(_$result);
     return _$result;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_plugin_options.dart
@@ -27,7 +27,7 @@ class CognitoSignInPluginOptions extends SignInPluginOptions {
   final AuthenticationFlowType? authFlowType;
 
   /// {@template amplify_auth_cognito_dart.cognito_sign_in_plugin_options.preferred_first_factor}
-  /// The auth factor type the user should begin signing with if available. If the preferred 
+  /// The auth factor type the user should begin signing with if available. If the preferred
   /// first factor is not available, the flow would fallback to provide available first factors.
   /// {@endtemplate}
   final AuthFactorType? preferredFirstFactor;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_plugin_options.dart
@@ -13,6 +13,7 @@ class CognitoSignInPluginOptions extends SignInPluginOptions {
   /// {@macro amplify_auth_cognito.model.cognito_sign_in_plugin_options}
   const CognitoSignInPluginOptions({
     this.authFlowType,
+    this.preferredFirstFactor,
     this.clientMetadata = const {},
   });
 
@@ -24,6 +25,12 @@ class CognitoSignInPluginOptions extends SignInPluginOptions {
   /// Runtime override of the Authentication flow to use for sign in.
   /// {@endtemplate}
   final AuthenticationFlowType? authFlowType;
+
+  /// {@template amplify_auth_cognito_dart.cognito_sign_in_plugin_options.preferred_first_factor}
+  /// The auth factor type the user should begin signing with if available. If the preferred 
+  /// first factor is not available, the flow would fallback to provide available first factors.
+  /// {@endtemplate}
+  final AuthFactorType? preferredFirstFactor;
 
   /// {@template amplify_auth_cognito_dart.cognito_sign_in_plugin_options.client_metadata}
   /// A map of custom key-value pairs that you can provide as input for certain

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_plugin_options.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/signin/cognito_sign_in_plugin_options.g.dart
@@ -14,6 +14,10 @@ CognitoSignInPluginOptions _$CognitoSignInPluginOptionsFromJson(
       'authFlowType',
       (v) => $enumDecodeNullable(_$AuthenticationFlowTypeEnumMap, v),
     ),
+    preferredFirstFactor: $checkedConvert(
+      'preferredFirstFactor',
+      (v) => $enumDecodeNullable(_$AuthFactorTypeEnumMap, v),
+    ),
     clientMetadata: $checkedConvert(
       'clientMetadata',
       (v) =>
@@ -31,6 +35,8 @@ Map<String, dynamic> _$CognitoSignInPluginOptionsToJson(
 ) => <String, dynamic>{
   if (_$AuthenticationFlowTypeEnumMap[instance.authFlowType] case final value?)
     'authFlowType': value,
+  if (_$AuthFactorTypeEnumMap[instance.preferredFirstFactor] case final value?)
+    'preferredFirstFactor': value,
   'clientMetadata': instance.clientMetadata,
 };
 
@@ -39,4 +45,13 @@ const _$AuthenticationFlowTypeEnumMap = {
   AuthenticationFlowType.userPasswordAuth: 'USER_PASSWORD_AUTH',
   AuthenticationFlowType.customAuthWithSrp: 'CUSTOM_AUTH_WITH_SRP',
   AuthenticationFlowType.customAuthWithoutSrp: 'CUSTOM_AUTH_WITHOUT_SRP',
+  AuthenticationFlowType.userAuth: 'USER_AUTH',
+};
+
+const _$AuthFactorTypeEnumMap = {
+  AuthFactorType.password: 'PASSWORD',
+  AuthFactorType.passwordSrp: 'PASSWORD_SRP',
+  AuthFactorType.emailOtp: 'EMAIL_OTP',
+  AuthFactorType.smsOtp: 'SMS_OTP',
+  AuthFactorType.webAuthn: 'WEB_AUTHN',
 };

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
@@ -33,6 +33,7 @@ extension ChallengeNameTypeBridge on ChallengeNameType {
     ChallengeNameType.softwareTokenMfa =>
       AuthSignInStep.confirmSignInWithTotpMfaCode,
     ChallengeNameType.emailOtp => AuthSignInStep.confirmSignInWithOtpCode,
+    ChallengeNameType.selectChallenge => AuthSignInStep.continueSignInWithFirstFactorSelection,
     ChallengeNameType.adminNoSrpAuth ||
     ChallengeNameType.passwordVerifier ||
     ChallengeNameType.devicePasswordVerifier ||
@@ -91,6 +92,7 @@ extension AuthenticationFlowTypeBridge on AuthenticationFlowType {
     AuthenticationFlowType.customAuthWithSrp ||
     AuthenticationFlowType.customAuthWithoutSrp => AuthFlowType.customAuth,
     AuthenticationFlowType.userPasswordAuth => AuthFlowType.userPasswordAuth,
+    AuthenticationFlowType.userAuth => AuthFlowType.userAuth,
   };
 }
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
@@ -33,7 +33,8 @@ extension ChallengeNameTypeBridge on ChallengeNameType {
     ChallengeNameType.softwareTokenMfa =>
       AuthSignInStep.confirmSignInWithTotpMfaCode,
     ChallengeNameType.emailOtp => AuthSignInStep.confirmSignInWithOtpCode,
-    ChallengeNameType.selectChallenge => AuthSignInStep.continueSignInWithFirstFactorSelection,
+    ChallengeNameType.selectChallenge =>
+      AuthSignInStep.continueSignInWithFirstFactorSelection,
     ChallengeNameType.adminNoSrpAuth ||
     ChallengeNameType.passwordVerifier ||
     ChallengeNameType.devicePasswordVerifier ||

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/sign_up_event.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/event/sign_up_event.dart
@@ -35,7 +35,11 @@ sealed class SignUpEvent extends AuthEvent<SignUpEventType, SignUpStateType> {
   }) = SignUpConfirm;
 
   /// {@macro amplify_auth_cognito.sign_up_succeeded}
-  const factory SignUpEvent.succeeded({String? userId}) = SignUpSucceeded;
+  const factory SignUpEvent.succeeded({
+    String? username,
+    String? userId,
+    String? session,
+  }) = SignUpSucceeded;
 
   @override
   String get runtimeTypeName => 'SignUpEvent';
@@ -111,14 +115,20 @@ final class SignUpConfirm extends SignUpEvent {
 /// {@endtemplate}
 final class SignUpSucceeded extends SignUpEvent {
   /// {@macro amplify_auth_cognito.sign_up_succeeded}
-  const SignUpSucceeded({this.userId}) : super._();
+  const SignUpSucceeded({this.username, this.userId, this.session}) : super._();
+
+  /// The username of the user.
+  final String? username;
 
   /// The ID of the user.
   final String? userId;
+
+  /// The sign up session
+  final String? session;
 
   @override
   SignUpEventType get type => SignUpEventType.succeeded;
 
   @override
-  List<Object?> get props => [type, userId];
+  List<Object?> get props => [type, username, userId, session];
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -333,6 +333,7 @@ final class SignInStateMachine
       AuthFlowType.userAuth => initiateUserAuth(
         event,
         parameters.preferredFirstFactor?.value,
+        parameters.session,
       ),
       _ => throw StateError('Unsupported auth flow: $authFlowType'),
     };
@@ -592,6 +593,7 @@ final class SignInStateMachine
   Future<InitiateAuthRequest> initiateUserAuth(
     SignInInitiate event,
     String? preferredChallenge,
+    String? session,
   ) async {
     return InitiateAuthRequest.build((b) {
       b
@@ -602,7 +604,8 @@ final class SignInStateMachine
           if (preferredChallenge != null)
             CognitoConstants.preferredChallenge: preferredChallenge,
         })
-        ..clientMetadata.addAll(event.clientMetadata);
+        ..clientMetadata.addAll(event.clientMetadata)
+        ..session = session;
     });
   }
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -374,9 +374,8 @@ final class SignInStateMachine
       ),
       ChallengeNameType.newPasswordRequired when hasUserResponse =>
         createNewPasswordRequest(event),
-      ChallengeNameType.selectChallenge when hasUserResponse => createSelectFirstFactorRequest(
-        event,
-      ),
+      ChallengeNameType.selectChallenge when hasUserResponse =>
+        createSelectFirstFactorRequest(event),
       _ => null,
     };
   }
@@ -845,7 +844,7 @@ final class SignInStateMachine
       if (!isKnownFactorType) {
         throw ArgumentError('Must be one of $knownFactorTypes');
       }
-      
+
       b
         ..challengeName = ChallengeNameType.selectChallenge
         ..challengeResponses.addAll({

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_in_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_in_state.dart
@@ -47,6 +47,7 @@ sealed class SignInState extends AuthState<SignInStateType> {
     AuthCodeDeliveryDetails? codeDeliveryDetails,
     Set<MfaType>? allowedMfaTypes,
     TotpSetupDetails? totpSetupResult,
+    Set<AuthFactorType>? allowedfirstFactorTypes,
   ) = SignInChallenge;
 
   /// {@macro amplify_auth_cognito_dart.sign_in_success}
@@ -106,6 +107,7 @@ final class SignInChallenge extends SignInState {
     this.codeDeliveryDetails,
     this.allowedMfaTypes,
     this.totpSetupResult,
+    this.allowedfirstFactorTypes,
   );
 
   /// The name of the challenge requiring user input.
@@ -123,6 +125,9 @@ final class SignInChallenge extends SignInState {
   /// The allowed MFA types.
   final Set<MfaType>? allowedMfaTypes;
 
+  /// The allowed first factor types.
+  final Set<AuthFactorType>? allowedfirstFactorTypes;
+
   /// The TOTP secret code which can be rendered as a QR code and displayed
   /// to users.
   final TotpSetupDetails? totpSetupResult;
@@ -139,6 +144,7 @@ final class SignInChallenge extends SignInState {
     codeDeliveryDetails,
     allowedMfaTypes,
     totpSetupResult,
+    allowedfirstFactorTypes,
   ];
 }
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_up_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_up_state.dart
@@ -44,7 +44,11 @@ sealed class SignUpState extends AuthState<SignUpStateType> {
   const factory SignUpState.confirming() = SignUpConfirming;
 
   /// {@macro amplify_auth_cognito.sign_up_success}
-  const factory SignUpState.success({String? userId}) = SignUpSuccess;
+  const factory SignUpState.success({
+    String? username,
+    String? userId,
+    String? session,
+  }) = SignUpSuccess;
 
   /// {@macro amplify_auth_cognito.sign_up_failure}
   const factory SignUpState.failure(
@@ -126,16 +130,22 @@ final class SignUpConfirming extends SignUpState {
 /// {@endtemplate}
 final class SignUpSuccess extends SignUpState with SuccessState {
   /// {@macro amplify_auth_cognito.sign_up_success}
-  const SignUpSuccess({this.userId}) : super._();
+  const SignUpSuccess({this.username, this.userId, this.session}) : super._();
+
+  /// The username of the user.
+  final String? username;
 
   /// The ID of the user.
   final String? userId;
+
+  /// The sign up session
+  final String? session;
 
   @override
   SignUpStateType get type => SignUpStateType.success;
 
   @override
-  List<Object?> get props => [type, userId];
+  List<Object?> get props => [type, username, userId, session];
 }
 
 /// {@template amplify_auth_cognito.sign_up_failure}

--- a/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -261,6 +261,15 @@ class StateMachineBloc
             }
           }
           yield* _checkUserVerification();
+        case AuthSignInStep.continueSignInWithFirstFactorSelection:
+          // TODO: tyllark - Handle this case.
+          throw UnimplementedError();
+        case AuthSignInStep.confirmSignInWithOtp:
+          // TODO: tyllark - Handle this case.
+          throw UnimplementedError();
+        case AuthSignInStep.confirmSignInWithPassword:
+          // TODO: tyllark - Handle this case.
+          throw UnimplementedError();
       }
     } on AuthNotAuthorizedException {
       /// The .failAuthentication flag available in the DefineAuthChallenge Lambda trigger

--- a/packages/authenticator/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -26,6 +26,8 @@ abstract class AuthService {
 
   Future<SignUpResult> confirmSignUp(String username, String code);
 
+  Future<SignInResult> autoSignIn();
+
   Future<AuthUser?> get currentUser;
 
   /// Checks to see if a user has a valid session.
@@ -147,6 +149,11 @@ class AmplifyAuthService
         confirmationCode: code,
       ),
     );
+  }
+
+  @override
+  Future<SignInResult> autoSignIn() {
+    return _withUserAgent(() => Amplify.Auth.autoSignIn());
   }
 
   @override

--- a/packages/authenticator/amplify_authenticator/lib/src/services/amplify_auth_service.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/services/amplify_auth_service.dart
@@ -20,7 +20,7 @@ abstract class AuthService {
 
   Future<SignUpResult> signUp(
     String username,
-    String password,
+    String? password,
     Map<CognitoUserAttributeKey, String> authAttributes,
   );
 
@@ -127,7 +127,7 @@ class AmplifyAuthService
   @override
   Future<SignUpResult> signUp(
     String username,
-    String password,
+    String? password,
     Map<CognitoUserAttributeKey, String> attributes,
   ) {
     return _withUserAgent(() {

--- a/packages/authenticator/amplify_authenticator/test/sign_up_form_test.dart
+++ b/packages/authenticator/amplify_authenticator/test/sign_up_form_test.dart
@@ -15,7 +15,7 @@ class MockAuthService extends Mock implements AmplifyAuthService {
   @override
   Future<SignUpResult> signUp(
     String username,
-    String password,
+    String? password,
     Map<CognitoUserAttributeKey, String> attributes,
   ) {
     capturedUsername = username;
@@ -39,7 +39,7 @@ class MockAuthPlugin extends AmplifyAuthCognitoStub {
   @override
   Future<SignUpResult> signUp({
     required String username,
-    required String password,
+    String? password,
     SignUpOptions? options,
   }) {
     return authService.signUp(username, password, attributes);

--- a/packages/test/amplify_integration_test/lib/src/stubs/amplify_auth_cognito_stub.dart
+++ b/packages/test/amplify_integration_test/lib/src/stubs/amplify_auth_cognito_stub.dart
@@ -61,7 +61,7 @@ class AmplifyAuthCognitoStub extends AuthPluginInterface
   @override
   Future<SignUpResult> signUp({
     required String username,
-    required String password,
+    String? password,
     SignUpOptions? options,
   }) async {
     await Future<void>.delayed(delay);

--- a/packages/test/amplify_integration_test/lib/src/stubs/amplify_auth_cognito_stub.dart
+++ b/packages/test/amplify_integration_test/lib/src/stubs/amplify_auth_cognito_stub.dart
@@ -380,7 +380,7 @@ class AmplifyAuthCognitoStub extends AuthPluginInterface
 class MockCognitoUser {
   factory MockCognitoUser({
     required String username,
-    required String password,
+    String? password,
     String? email,
     String? phoneNumber,
   }) {
@@ -401,7 +401,7 @@ class MockCognitoUser {
   });
   final String sub;
   final String username;
-  final String password;
+  final String? password;
   final String? email;
   final String? phoneNumber;
 


### PR DESCRIPTION
*Description of changes:*
Added Auto Sign In to allow users to sign in with their sign up session so they are not required to enter another OTP.

```
Amplify.Auth.autoSignIn(
    options: const AutoSignInOptions(pluginOptions: CognitoAutoSignInPluginOptions()),
);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
