### PR TITLE
fix(amplify_push_notifications): replace removeFirst() with removeAt(0) for Android < 11 compatibility

### DIFF
--- a/packages/notifications/push/amplify_push_notifications/android/src/main/kotlin/com/amazonaws/amplify/amplify_push_notifications/PushNotificationEventsStreamHandler.kt
+++ b/packages/notifications/push/amplify_push_notifications/android/src/main/kotlin/com/amazonaws/amplify/amplify_push_notifications/PushNotificationEventsStreamHandler.kt
@@ -102,7 +102,7 @@ class PushNotificationEventsStreamHandler constructor(
         try {
             eventSink?.let {
                 while (eventQueue.isNotEmpty()) {
-                    val eventFromQueue = eventQueue.removeFirst()
+                    val eventFromQueue = eventQueue.removeAt(0)
                     // Check if it is an Error event and handle accordingly by using .error method
                     if (eventFromQueue.event.eventName == NativeEvent.ERROR.eventName) {
                         val exception = eventFromQueue.error


### PR DESCRIPTION
### Summary

This pull request fixes a crash that occurs on Android devices running versions lower than Android 11 (API 30) due to the usage of the `removeFirst()` method from the Kotlin standard library.

The method `removeFirst()` is only available on Android 11+ (API 30+) or when running on a full Java 11+ runtime. When executed on older Android versions, it results in a `NoSuchMethodError`.

### Changes

- Replaced: 
  ```kotlin 
  eventQueue.removeFirst()
  ```

- With:
  ```kotlin
  eventQueue.removeAt(0)
  ```
### Technical background

`removeFirst()` is implemented as a default interface method, which is not supported by older Android runtimes.
`removeAt(0)` provides the same behavior and works correctly on all supported Android API levels (`minSdkVersion 21+`).

No functional behavior changes have been made — only improved runtime compatibility.

### Checklist
- [x] Verified that behavior is unchanged on Android 11+.
- [x] Verified that crash is fixed on Android 10 and below.
- [x] No new dependencies introduced.
- [x] Maintains API compatibility.

cc: @tyllark