### PR TITLE
fix(amplify_push_notifications): replace removeFirst() with removeAt(…

### DIFF
--- a/packages/notifications/push/amplify_push_notifications/android/src/main/kotlin/com/amazonaws/amplify/amplify_push_notifications/PushNotificationEventsStreamHandler.kt
+++ b/packages/notifications/push/amplify_push_notifications/android/src/main/kotlin/com/amazonaws/amplify/amplify_push_notifications/PushNotificationEventsStreamHandler.kt
@@ -102,7 +102,7 @@ class PushNotificationEventsStreamHandler constructor(
         try {
             eventSink?.let {
                 while (eventQueue.isNotEmpty()) {
-                    val eventFromQueue = eventQueue.removeFirst()
+                    val eventFromQueue = eventQueue.removeAt(0)
                     // Check if it is an Error event and handle accordingly by using .error method
                     if (eventFromQueue.event.eventName == NativeEvent.ERROR.eventName) {
                         val exception = eventFromQueue.error


### PR DESCRIPTION
…0) for Android < 11 compatibility

The removeFirst() method from the Kotlin standard library is only available on Android 11 (API 30) and above, or when running on a full Java 11+ runtime. On older Android versions, this causes a NoSuchMethodError at runtime.

This commit replaces removeFirst() with removeAt(0), which provides the same behavior and works correctly on all supported Android API levels (minSdk 21+).

No functional behavior changes have been made — only improved runtime compatibility.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
