### PR TITLE
fix(amplify_datastore): UninitializedPropertyAccessException crash on Android when amplify_datastore is included but not used

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/DataStoreHubEventStreamHandler.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/DataStoreHubEventStreamHandler.kt
@@ -223,6 +223,8 @@ class DataStoreHubEventStreamHandler : EventChannel.StreamHandler {
 
     override fun onCancel(p0: Any?) {
         eventSink = null
-        Amplify.Hub.unsubscribe(token)
+        if (this::token.isInitialized) {
+            Amplify.Hub.unsubscribe(token)
+        }
     }
 }


### PR DESCRIPTION
*Issue #6114*

*Description of changes:*
Added a check was the `token` variable initialised before using it in the `Amplify.Hub.unsubscribe` method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
