### PR TITLE
fix(auth): Remove code comment

### DIFF
--- a/packages/amplify_core/lib/src/config/amplify_outputs/auth/auth_outputs.dart
+++ b/packages/amplify_core/lib/src/config/amplify_outputs/auth/auth_outputs.dart
@@ -46,7 +46,7 @@ class AuthOutputs
   final String? userPoolClientId;
 
   /// The Cognito User Pool Endpoint.
-  final String? userPoolEndpoint; //Gen 1 only
+  final String? userPoolEndpoint;
 
   /// A fixed string that must be used in all API requests to the app client
   /// if the the app client has one configured.


### PR DESCRIPTION
By modifying the `amplify_outputs.json`, this field is supported in Gen 2 too what makes this comment unnecessary.