### PR TITLE
feat(auth): Disable social sign-in button on awaiting actions

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/blocs/auth/auth_bloc.dart
@@ -377,8 +377,6 @@ class StateMachineBloc
         final result = await _authService.signIn(data.username, data.password);
         await _processSignInResult(result, isSocialSignIn: false);
       } else if (data is AuthSocialSignInData) {
-        // Do not await a social sign-in since multiple sign-in attempts
-        // can occur.
         await _authService
             .signInWithProvider(
               data.provider,
@@ -392,6 +390,13 @@ class StateMachineBloc
                   ? logger.info
                   : logger.error;
               log('Error signing in', error, stackTrace);
+              // Emit exception so that the UI can exit loading state
+              _exceptionController.add(
+                AuthenticatorException(
+                  error,
+                  showBanner: error is! UserCancelledException,
+                ),
+              );
             });
       } else {
         throw StateError('Bad sign in data: $data');

--- a/packages/authenticator/amplify_authenticator/lib/src/state/authenticator_state.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/state/authenticator_state.dart
@@ -529,10 +529,15 @@ class AuthenticatorState extends ChangeNotifier {
     _setIsBusy(false);
   }
 
-  /// Perform sicial sign in with the given provider
+  /// Perform social sign in with the given provider
   Future<void> signInWithProvider(AuthProvider provider) async {
+    _setIsBusy(true);
     final signInData = AuthSocialSignInData(provider: provider);
     _authBloc.add(AuthSignIn(signInData));
+    // Wait for either a state change (sign-in success/failure) or an exception
+    // (including user cancellation)
+    await nextBlocEvent();
+    _setIsBusy(false);
   }
 
   /// Sign out the currecnt user

--- a/packages/authenticator/amplify_authenticator/lib/src/widgets/social/social_button.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/widgets/social/social_button.dart
@@ -193,47 +193,53 @@ class _SocialSignInButtonState
   @override
   Widget build(BuildContext context) {
     final resolver = stringResolver.buttons;
-    return ConstrainedBox(
-      constraints: const BoxConstraints(minHeight: 40),
-      child: OutlinedButton(
-        focusNode: focusNode,
-        style: ButtonStyle(foregroundColor: getButtonForegroundColor(context)),
-        onPressed: state.isBusy
-            ? null
-            : () => state.signInWithProvider(widget.provider),
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final padding = calculatePadding(constraints);
-            return Padding(
-              padding: EdgeInsets.symmetric(horizontal: padding),
-              child: Row(
-                mainAxisAlignment: padding == 0
-                    ? MainAxisAlignment.center
-                    : MainAxisAlignment.start,
-                children: [
-                  SizedBox.square(
-                    dimension: logoSize,
-                    child: Padding(
-                      padding: widget.provider.logoInsets,
-                      child: icon,
+    final isBusy = state.isBusy;
+    return Opacity(
+      opacity: isBusy ? 0.5 : 1.0,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: 40),
+        child: OutlinedButton(
+          focusNode: focusNode,
+          style: ButtonStyle(
+            foregroundColor: getButtonForegroundColor(context),
+          ),
+          onPressed: isBusy
+              ? null
+              : () => state.signInWithProvider(widget.provider),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final padding = calculatePadding(constraints);
+              return Padding(
+                padding: EdgeInsets.symmetric(horizontal: padding),
+                child: Row(
+                  mainAxisAlignment: padding == 0
+                      ? MainAxisAlignment.center
+                      : MainAxisAlignment.start,
+                  children: [
+                    SizedBox.square(
+                      dimension: logoSize,
+                      child: Padding(
+                        padding: widget.provider.logoInsets,
+                        child: icon,
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: spacing),
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 4),
-                      child: Text(
-                        resolver.resolve(
-                          context,
-                          ButtonResolverKey.signInWith(widget.provider),
+                    const SizedBox(width: spacing),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 4),
+                        child: Text(
+                          resolver.resolve(
+                            context,
+                            ButtonResolverKey.signInWith(widget.provider),
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                ],
-              ),
-            );
-          },
+                  ],
+                ),
+              );
+            },
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Avoid double actions

*Issue #, if available:*
Part of https://github.com/aws-amplify/amplify-flutter/issues/6368#issuecomment-3426799831 and https://github.com/aws-amplify/amplify-flutter/issues/6368#issuecomment-3770658965

*Description of changes:*
Disables the social sign in button while a request is running to avoid multiple clicks and weird behavior because of this.

Without this changes:

https://github.com/user-attachments/assets/9761497d-c193-4841-8a39-3151985cd09b

With this change:

https://github.com/user-attachments/assets/ff115a68-f89a-4d69-9fcd-efb0f53959f0




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
