### PR TITLE
feat(ci): Windows - Support multiple attempts with timeouts

### DIFF
--- a/.github/workflows/e2e_windows.yaml
+++ b/.github/workflows/e2e_windows.yaml
@@ -59,11 +59,14 @@ jobs:
           scope: ${{ inputs.package-name }}
           secret-identifier: ${{ secrets.AWS_SECRET_IDENTIFIER }}
 
+      - name: Enable running PowerShell scripts
+        run: Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+
       - name: Run integration tests
-        timeout-minutes: 60
+        timeout-minutes: 320
         run: |
           flutter config --enable-windows-desktop
-          dart pub global run aft exec --include=${{ inputs.package-name }} -- flutter test integration_test/main_test.dart -d windows
+          ${{ github.workspace }}/build-support/windows_timeout_attempts.ps1 5 60 "dart pub global run aft exec --include=${{ inputs.package-name }} -- flutter test integration_test/main_test.dart -d windows"
 
       - name: Log success/failure
         if: always()

--- a/build-support/linux_like_timeout.ps1
+++ b/build-support/linux_like_timeout.ps1
@@ -1,0 +1,186 @@
+# This copies the behavior of the Linux timeout command
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$false)]
+    [Alias('k')]
+    [string]$KillAfter = "",
+
+    [Parameter(Mandatory=$false)]
+    [Alias('s')]
+    [string]$Signal,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$Preserve,
+
+    [Parameter(Mandatory=$true, Position=0, ValueFromRemainingArguments=$false)]
+    [string]$Duration,
+
+    [Parameter(Mandatory=$true, Position=1, ValueFromRemainingArguments=$true)]
+    [string[]]$Command
+)
+
+# Exit codes
+$EXIT_TIMEOUT = 124
+$EXIT_KILLED = 137
+
+# Function to parse duration string (supports s, m, h, d suffixes like Linux timeout)
+function Parse-Duration {
+    param([string]$durationStr)
+
+    if ([string]::IsNullOrWhiteSpace($durationStr)) {
+        return 0
+    }
+
+    # Match number followed by optional suffix
+    if ($durationStr -match '^(\d+(?:\.\d+)?)(s|m|h|d)?$') {
+        $value = [double]$matches[1]
+        $suffix = $matches[2]
+
+        switch ($suffix) {
+            'm' { return [int]($value * 60) }      # minutes to seconds
+            'h' { return [int]($value * 3600) }    # hours to seconds
+            'd' { return [int]($value * 86400) }   # days to seconds
+            default { return [int]$value }         # seconds (default) or 's' suffix
+        }
+    }
+    else {
+        throw "Invalid duration format: $durationStr. Use a number optionally followed by s, m, h, or d (e.g., 10, 5m, 2h, 1d)"
+    }
+}
+
+try {
+    # Parse duration and kill-after timeout
+    $durationSeconds = Parse-Duration $Duration
+    $killAfterSeconds = 0
+
+    if (-not [string]::IsNullOrWhiteSpace($KillAfter)) {
+        $killAfterSeconds = Parse-Duration $KillAfter
+    }
+
+    if ($durationSeconds -le 0) {
+        throw "Duration must be greater than 0"
+    }
+
+    # Split command into executable and arguments
+    # Support both "command arg1 arg2" format and separate arguments
+    $executable = ""
+    $arguments = ""
+
+    if ($Command.Length -eq 1 -and $Command[0] -match '\s') {
+        # Single string with spaces - parse it as "executable args"
+        $parts = $Command[0] -split '\s+', 2
+        $executable = $parts[0]
+        if ($parts.Length -gt 1) {
+            $arguments = $parts[1]
+        }
+    }
+    else {
+        # Multiple arguments or single word command
+        $executable = $Command[0]
+        if ($Command.Length -gt 1) {
+            $arguments = $Command[1..($Command.Length - 1)] -join " "
+        }
+    }
+
+    # Start the process
+    $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $processInfo.FileName = $executable
+    $processInfo.Arguments = $arguments
+    $processInfo.UseShellExecute = $false
+    # Don't redirect - let output flow naturally to console for live display
+    $processInfo.RedirectStandardOutput = $false
+    $processInfo.RedirectStandardError = $false
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $processInfo
+
+    # Start the process
+    $started = $process.Start()
+
+    if (-not $started) {
+        Write-Error "Failed to start process: $executable"
+        exit 1
+    }
+
+    # Wait for the process to exit or timeout
+    $exited = $process.WaitForExit($durationSeconds * 1000)
+
+    if ($exited) {
+        # Process completed within timeout
+        $exitCode = $process.ExitCode
+
+        # Cleanup
+        Get-EventSubscriber | Where-Object { $_.SourceObject -eq $process } | Unregister-Event
+        $process.Dispose()
+
+        exit $exitCode
+    }
+    else {
+        # Timeout occurred
+        Write-Warning "Command timed out after $Duration"
+
+        # Try graceful termination first
+        try {
+            $process.CloseMainWindow() | Out-Null
+        }
+        catch {
+            # Window might not exist
+        }
+
+        if ($killAfterSeconds -gt 0) {
+            # Wait for KillAfter duration before force killing
+            $gracefulExit = $process.WaitForExit($killAfterSeconds * 1000)
+
+            if (-not $gracefulExit) {
+                Write-Warning "Force killing process after $KillAfter additional time"
+                $process.Kill()
+
+                # Cleanup
+                Get-EventSubscriber | Where-Object { $_.SourceObject -eq $process } | Unregister-Event
+                $process.Dispose()
+
+                exit $EXIT_KILLED
+            }
+        }
+        else {
+            # Force kill immediately
+            try {
+                $process.Kill()
+            }
+            catch {
+                # Process might have already exited
+            }
+        }
+
+        # Cleanup
+        Get-EventSubscriber | Where-Object { $_.SourceObject -eq $process } | Unregister-Event
+        $process.Dispose()
+
+        if ($Preserve) {
+            exit $EXIT_TIMEOUT
+        }
+        else {
+            exit $EXIT_TIMEOUT
+        }
+    }
+}
+catch {
+    Write-Error "Error executing command: $_"
+
+    # Cleanup if needed
+    if ($process -ne $null) {
+        try {
+            if (-not $process.HasExited) {
+                $process.Kill()
+            }
+            Get-EventSubscriber | Where-Object { $_.SourceObject -eq $process } | Unregister-Event -ErrorAction SilentlyContinue
+            $process.Dispose()
+        }
+        catch {
+            # Best effort cleanup
+        }
+    }
+
+    exit 1
+}

--- a/build-support/windows_timeout_attempts.ps1
+++ b/build-support/windows_timeout_attempts.ps1
@@ -1,0 +1,91 @@
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [int]$NumAttempts,
+
+    [Parameter(Mandatory=$true, Position=1)]
+    [int]$AttemptTimeoutMinutes,
+
+    [Parameter(Mandatory=$true, Position=2, ValueFromRemainingArguments=$true)]
+    [string[]]$Command
+)
+
+$ErrorActionPreference = "Stop"
+
+# Get the directory where this script is located
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$timeoutScript = Join-Path $scriptDir "linux_like_timeout.ps1"
+
+for ($i = 1; $i -le $NumAttempts; $i++) {
+    $startTime = Get-Date
+
+    Write-Host ""
+    Write-Host "===================================================================="
+    Write-Host "ATTEMPT $i OF $NumAttempts - STARTING"
+    Write-Host "   Timeout: $AttemptTimeoutMinutes minutes"
+    Write-Host "   Started at: $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))"
+    Write-Host "===================================================================="
+    Write-Host ""
+
+    # Execute the command with timeout
+    $exitCode = 0
+    try {
+        # Build argument list for timeout script
+        $timeoutArgs = @("${AttemptTimeoutMinutes}m") + $Command
+        & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $timeoutScript $timeoutArgs
+        $exitCode = $LASTEXITCODE
+    }
+    catch {
+        $exitCode = 1
+    }
+
+    $endTime = Get-Date
+    $duration = $endTime - $startTime
+    $minutes = [math]::Floor($duration.TotalMinutes)
+    $seconds = $duration.Seconds
+
+    if ($exitCode -eq 0) {
+        Write-Host ""
+        Write-Host "===================================================================="
+        Write-Host "ATTEMPT $i SUCCEEDED"
+        Write-Host "   Duration: $minutes minutes $seconds seconds"
+        Write-Host "   Finished at: $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))"
+        Write-Host "===================================================================="
+        Write-Host ""
+        exit 0
+    }
+
+    if ($exitCode -eq 124) {
+        Write-Host ""
+        Write-Host "===================================================================="
+        Write-Host "ATTEMPT $i TIMED OUT"
+        Write-Host "   Duration: $minutes minutes $seconds seconds"
+        Write-Host "   Time: $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))"
+        Write-Host "===================================================================="
+        Write-Host ""
+    }
+    else {
+        Write-Host ""
+        Write-Host "===================================================================="
+        Write-Host "ATTEMPT $i FAILED"
+        Write-Host "   Exit code: $exitCode"
+        Write-Host "   Duration: $minutes minutes $seconds seconds"
+        Write-Host "   Time: $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))"
+        Write-Host "===================================================================="
+        Write-Host ""
+    }
+
+    if ($i -lt $NumAttempts) {
+        Write-Host "Preparing for next retry..."
+        Write-Host "   Waiting 10 seconds before next attempt..."
+        Start-Sleep -Seconds 10
+        Write-Host "   Ready for next attempt"
+    }
+}
+
+Write-Host ""
+Write-Host "===================================================================="
+Write-Host "  ALL $NumAttempts ATTEMPTS FAILED"
+Write-Host "  Time: $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))"
+Write-Host "===================================================================="
+Write-Host ""
+exit 1


### PR DESCRIPTION
This allows us to configure multiple attempts for Windows runners, each with a timeout to increase test stability.  
For now, we set 5 attempts with 60min timeout each.