### PR TITLE
feat(ci): Web - Multiple attempts with timeouts

### DIFF
--- a/.github/workflows/e2e_web.yaml
+++ b/.github/workflows/e2e_web.yaml
@@ -59,10 +59,11 @@ jobs:
       - uses: ./.github/composite_actions/setup_chromedriver
 
       - name: Run integration tests
-        timeout-minutes: 60
+        timeout-minutes: 320
         run: |
-          chromedriver --port=4444 &
-          aft exec --include=${{ inputs.package-name }} -- "<AFT_ROOT>/build-support/integ_test.sh" -d web-server
+          # 5 attemps
+          # 60 minutes timeout each
+          "${{ github.workspace }}/build-support/linux_timeout_attempts.sh" 5 60 'bash -c "chromedriver --port=4444 & aft exec --include=${{ inputs.package-name }} -- ${{ github.workspace }}/build-support/integ_test.sh -d web-server"'
 
       - name: Log success/failure
         if: always()


### PR DESCRIPTION
This allows us to configure multiple attempts for Web runners, each with a timeout to increase test stability.
For now, we set 5 attempts with 60min timeout each.