### PR TITLE
fix(ci): Reuse chromedriver for each test attempt

### DIFF
--- a/.github/workflows/e2e_web.yaml
+++ b/.github/workflows/e2e_web.yaml
@@ -63,7 +63,8 @@ jobs:
         run: |
           # 5 attemps
           # 60 minutes timeout each
-          "${{ github.workspace }}/build-support/linux_timeout_attempts.sh" 5 60 'bash -c "chromedriver --port=4444 & aft exec --include=${{ inputs.package-name }} -- ${{ github.workspace }}/build-support/integ_test.sh -d web-server"'
+          chromedriver --port=4444 &
+          "${{ github.workspace }}/build-support/linux_timeout_attempts.sh" 5 60 "aft exec --include=${{ inputs.package-name }} -- ${{ github.workspace }}/build-support/integ_test.sh -d web-server"
 
       - name: Log success/failure
         if: always()


### PR DESCRIPTION
Don't create a new chromedriver on each attempt since the port is already used from attempt 2 on.

```
Starting ChromeDriver 144.0.7559.96 (d7b80622cfab91c265741194e7942eefd2d21811-refs/branch-heads/7559@{#3667}) on port 4444
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
[1769780948.245][SEVERE]: bind() failed: Address already in use (98)
IPv6 port not available. Exiting...
```