### PR TITLE
chore: fix null-aware-elements warning in form field

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/widgets/form_field.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/widgets/form_field.dart
@@ -317,12 +317,10 @@ abstract class AuthenticatorFormFieldState<
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              // ignore: use_null_aware_elements
-              if (surlabel != null) surlabel!,
+              ?surlabel,
               SizedBox(height: labelGap),
               buildFormField(context),
-              // ignore: use_null_aware_elements
-              if (companionWidget != null) companionWidget!,
+              ?companionWidget,
             ],
           ),
         ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* It appears that recent updates might have introduced [`use_null_aware_elements`](https://dart.dev/tools/linter-rules/use_null_aware_elements) checks that affect existing code and hence causing linter issues in PRs. This ignores the check for existing code. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
