### PR TITLE
fix(auth): handle SMS_OTP challenge in USER_AUTH flow

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/constants.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/constants.dart
@@ -63,6 +63,9 @@ abstract class CognitoConstants {
   /// The `EMAIL_OTP_CODE` parameter.
   static const challengeParamEmailOtpCode = 'EMAIL_OTP_CODE';
 
+  /// The `SMS_OTP_CODE` parameter.
+  static const challengeParamSmsOtpCode = 'SMS_OTP_CODE';
+
   /// The `SOFTWARE_TOKEN_MFA_CODE` parameter.
   static const challengeParamSoftwareTokenMfaCode = 'SOFTWARE_TOKEN_MFA_CODE';
 

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
@@ -32,7 +32,8 @@ extension ChallengeNameTypeBridge on ChallengeNameType {
       AuthSignInStep.continueSignInWithMfaSetupSelection,
     ChallengeNameType.softwareTokenMfa =>
       AuthSignInStep.confirmSignInWithTotpMfaCode,
-    ChallengeNameType.emailOtp => AuthSignInStep.confirmSignInWithOtpCode,
+    ChallengeNameType.emailOtp ||
+    ChallengeNameType.smsOtp => AuthSignInStep.confirmSignInWithOtpCode,
     ChallengeNameType.selectChallenge =>
       AuthSignInStep.continueSignInWithFirstFactorSelection,
     ChallengeNameType.password ||

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -368,6 +368,9 @@ final class SignInStateMachine
       ChallengeNameType.emailOtp when hasUserResponse => createEmailOtpRequest(
         event,
       ),
+      ChallengeNameType.smsOtp when hasUserResponse => createSmsOtpRequest(
+        event,
+      ),
       ChallengeNameType.selectMfaType when hasUserResponse =>
         createSelectMfaRequest(event),
       ChallengeNameType.mfaSetup when hasUserResponse => handleMfaSetup(
@@ -513,6 +516,23 @@ final class SignInStateMachine
         ..challengeResponses.addAll({
           CognitoConstants.challengeParamUsername: cognitoUsername,
           CognitoConstants.challengeParamEmailOtpCode: event.answer,
+        })
+        ..clientMetadata.addAll(event.clientMetadata);
+    });
+  }
+
+  /// Creates the response object for an SMS OTP challenge.
+  @protected
+  Future<RespondToAuthChallengeRequest> createSmsOtpRequest(
+    SignInRespondToChallenge event,
+  ) async {
+    return RespondToAuthChallengeRequest.build((b) {
+      b
+        ..clientId = _authOutputs.userPoolClientId
+        ..challengeName = _challengeName
+        ..challengeResponses.addAll({
+          CognitoConstants.challengeParamUsername: cognitoUsername,
+          CognitoConstants.challengeParamSmsOtpCode: event.answer,
         })
         ..clientMetadata.addAll(event.clientMetadata);
     });


### PR DESCRIPTION
Description:

Adds SMS_OTP challenge support for passwordless sign-in with `USER_AUTH` flow.

Without this fix, `Amplify.Auth.signIn` with `preferredFirstFactor: AuthFactorType.smsOtp` throws `InvalidStateException: Unrecognized challenge type: SMS_OTP`.

Fixes #5728
Fixes #6094