### PR TITLE
chore: Ignore submodule symlinks (add them to `.gitignore`)

### DIFF
--- a/packages/notifications/push/amplify_push_notifications/example/.gitignore
+++ b/packages/notifications/push/amplify_push_notifications/example/.gitignore
@@ -44,3 +44,4 @@ app.*.map.json
 /android/app/release
 
 amplify_outputs.dart
+/linux/flutter/ephemeral/.plugin_symlinks/


### PR DESCRIPTION
Avoids this after bootstrapping the repo: 
<img width="510" height="314" alt="Screenshot 2026-02-19 at 18 50 23" src="https://github.com/user-attachments/assets/8cdbe6f9-fde5-4425-aab7-6a7a4870f033" />
