### PR TITLE
fix(ci): Fix post-action logging on Windows

### DIFF
--- a/.github/composite_actions/log_cw_metric_wrapper/action.yaml
+++ b/.github/composite_actions/log_cw_metric_wrapper/action.yaml
@@ -58,6 +58,10 @@ runs:
       with:
         persist-credentials: false
         submodules: true
+        # Skip git clean/reset to avoid failures from Windows file locks after
+        # long-running tests. Safe here because this checkout only needs the
+        # composite action files and nothing runs after it.
+        clean: false
 
     - name: Configure AWS credentials
       if: env.SKIP_CW != 'true'


### PR DESCRIPTION
Fixes this:  
<img width="825" height="956" alt="Screenshot 2026-02-23 at 14 33 44" src="https://github.com/user-attachments/assets/23a8bb41-7bb4-4228-9e84-b5c53475a7cc" />


Skip git clean/reset to avoid failures from Windows file locks after long-running tests. Safe here because this checkout only needs the composite action files and nothing runs after it.