### PR TITLE
fix(datastore): Catch invalid JSON

### DIFF
--- a/packages/amplify_datastore/lib/src/method_channel_datastore.dart
+++ b/packages/amplify_datastore/lib/src/method_channel_datastore.dart
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'dart:convert';
+
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_datastore/amplify_datastore.dart';
 import 'package:amplify_datastore/src/types/observe_query_executor.dart';
@@ -172,10 +174,12 @@ class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
   Future<void> delete<T extends Model>(T model, {QueryPredicate? where}) async {
     try {
       await _setUpObserveIfNeeded();
+      final serializedModel = model.toJson();
+      _validateModelJson(serializedModel);
       var methodChannelDeleteInput = <String, dynamic>{
         'modelName': model.getInstanceType().modelName(),
         if (where != null) 'queryPredicate': where.serializeAsMap(),
-        'serializedModel': model.toJson(),
+        'serializedModel': serializedModel,
       };
       await _channel.invokeMethod('delete', methodChannelDeleteInput);
     } on PlatformException catch (e) {
@@ -187,14 +191,51 @@ class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
   Future<void> save<T extends Model>(T model, {QueryPredicate? where}) async {
     try {
       await _setUpObserveIfNeeded();
+      final serializedModel = model.toJson();
+      _validateModelJson(serializedModel);
       var methodChannelSaveInput = <String, dynamic>{
         'modelName': model.getInstanceType().modelName(),
         if (where != null) 'queryPredicate': where.serializeAsMap(),
-        'serializedModel': model.toJson(),
+        'serializedModel': serializedModel,
       };
       await _channel.invokeMethod('save', methodChannelSaveInput);
     } on PlatformException catch (e) {
       throw _deserializeException(e);
+    }
+  }
+
+  /// Validates that a model's serialized JSON map can be encoded to JSON.
+  ///
+  /// This catches values that are not representable in JSON (e.g. NaN,
+  /// Infinity, or unexpected non-serializable objects) before they reach
+  /// the native platform, where they would cause crashes such as iOS
+  /// NSInvalidArgumentException from NSJSONSerialization.
+  /// See: https://github.com/aws-amplify/amplify-flutter/issues/5891
+  static void _validateModelJson(Map<String, dynamic> json) {
+    try {
+      jsonEncode(json);
+    } on JsonUnsupportedObjectError catch (e) {
+      if (e.unsupportedObject is double) {
+        final value = e.unsupportedObject as double;
+        throw DataStoreException(
+          'Model contains a non-finite double value '
+          '(${value.isNaN ? "NaN" : value}). '
+          'NaN and Infinity are not valid JSON values and cannot be '
+          'serialized for DataStore operations.',
+          recoverySuggestion:
+              'Ensure all double fields contain finite values before saving. '
+              'You can check with value.isFinite, or replace non-finite values '
+              'with null or a valid default.',
+        );
+      }
+      throw DataStoreException(
+        'Model contains a value that cannot be serialized to JSON: '
+        '${e.unsupportedObject} (${e.unsupportedObject.runtimeType}). '
+        '${e.cause ?? ''}',
+        recoverySuggestion:
+            'Ensure all model fields contain JSON-serializable values '
+            '(String, int, finite double, bool, null, Map, or List).',
+      );
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/aws-amplify/amplify-flutter/issues/5891

The issue is that we don't validate the JSON. Flutter-Android just throws an exception:  
```
I/amplify:flutter:datastore( 7607): Saved item: SerializedModel{id='ccaa7124-2252-4626-bb42-fa719206f9c1', serializedData={createdAt=null, temperature=NaN, humidity=NaN, id=ccaa7124-2252-4626-bb42-fa719206f9c1, pressure=NaN, sensorId=sensor-001, updatedAt=null}, modelName=SensorReading}
W/System.err( 7607): SLF4J(W): No SLF4J providers were found.
W/System.err( 7607): SLF4J(W): Defaulting to no-operation (NOP) logger implementation
W/System.err( 7607): SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
W/amplify:aws-datastore( 7607): Storage adapter subscription ended in error
W/amplify:aws-datastore( 7607): java.lang.IllegalArgumentException: NaN is not a valid double value as per JSON specification. To override this behavior, use GsonBuilder.serializeSpecialFloatingPointValues() method.
W/amplify:aws-datastore( 7607):         at com.google.gson.Gson.checkValidFloatingPoint(Gson.java:509)
W/amplify:aws-datastore( 7607):         at com.google.gson.Gson$1.write(Gson.java:471)
[...]
I/amplify:flutter:datastore( 7607): Saved item: SerializedModel{id='c0ff3757-e30e-44d7-bf66-2cad51e20b1d', serializedData={createdAt=null, temperature=NaN, humidity=NaN, id=c0ff3757-e30e-44d7-bf66-2cad51e20b1d, pressure=NaN, sensorId=sensor-001, updatedAt=null}, modelName=SensorReading}
I/flutter ( 7607): Model toJson: {id: cead8be8-ecd6-46a0-b969-599b2d062795, sensorId: sensor-001, temperature: NaN, humidity: NaN, pressure: NaN, createdAt: null, updatedAt: null}
I/flutter ( 7607): Attempting to save model with NaN values...
I/amplify:aws-datastore( 7607): Orchestrator lock acquired.
I/amplify:aws-datastore( 7607): DataStore plugin initialized.
I/amplify:aws-datastore( 7607): Orchestrator lock released.
I/amplify:flutter:datastore( 7607): Saved item: SerializedModel{id='cead8be8-ecd6-46a0-b969-599b2d062795', serializedData={createdAt=null, temperature=NaN, humidity=NaN, id=cead8be8-ecd6-46a0-b969-599b2d062795, pressure=NaN, sensorId=sensor-001, updatedAt=null}, modelName=SensorReading}
```
  
iOS simply crashes.  
  
With this fix, we validate the JSON before passing it to the native platform. This means we get an exception:  
```
flutter: Error saving model: DataStoreException {
  "message": "Model contains a value that cannot be serialized to JSON: NaN (double). NoSuchMethodError: Class 'double' has no instance method 'toJson'.\nReceiver: NaN\nTried calling: toJson()",
  "recoverySuggestion": "Ensure all model fields contain JSON-serializable values (String, int, double, bool, null, Map, or List) before calling Amplify.DataStore.save()."
}
```
but the app does not crash anymore.