### PR TITLE
feat(storage): Support pre-signed upload URLs

### DIFF
--- a/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
+++ b/packages/storage/amplify_storage_s3/example/integration_test/get_url_test.dart
@@ -109,6 +109,126 @@ void main() {
         });
       });
 
+      group('presigned URL upload (method: PUT)', () {
+        testWidgets('can upload via PUT presigned URL and verify content', (
+          _,
+        ) async {
+          final uploadPath = 'public/put-url-upload-${uuid()}';
+          final uploadData = 'uploaded via presigned PUT URL'.codeUnits;
+          addTearDownPath(StoragePath.fromString(uploadPath));
+
+          // Generate a PUT presigned URL
+          final putUrlResult = await Amplify.Storage.getUrl(
+            path: StoragePath.fromString(uploadPath),
+            options: const StorageGetUrlOptions(
+              pluginOptions: S3GetUrlPluginOptions(
+                method: StorageAccessMethod.put,
+                expiresIn: Duration(minutes: 5),
+              ),
+            ),
+          ).result;
+
+          // Upload via HTTP PUT using the presigned URL
+          final putResponse = await put(
+            putUrlResult.url,
+            body: uploadData,
+            headers: {'Content-Type': 'application/octet-stream'},
+          );
+          expect(putResponse.statusCode, 200);
+
+          // Verify the upload by downloading with a GET presigned URL
+          final getUrlResult = await Amplify.Storage.getUrl(
+            path: StoragePath.fromString(uploadPath),
+          ).result;
+          final actualData = await readData(getUrlResult.url);
+          expect(actualData, uploadData);
+        });
+
+        testWidgets('PUT presigned URL with text content type', (_) async {
+          final uploadPath = 'public/put-url-text-${uuid()}';
+          const uploadContent = 'Hello from presigned PUT URL!';
+          addTearDownPath(StoragePath.fromString(uploadPath));
+
+          final putUrlResult = await Amplify.Storage.getUrl(
+            path: StoragePath.fromString(uploadPath),
+            options: const StorageGetUrlOptions(
+              pluginOptions: S3GetUrlPluginOptions(
+                method: StorageAccessMethod.put,
+              ),
+            ),
+          ).result;
+
+          final putResponse = await put(
+            putUrlResult.url,
+            body: uploadContent,
+            headers: {'Content-Type': 'text/plain'},
+          );
+          expect(putResponse.statusCode, 200);
+
+          // Verify content
+          final getUrlResult = await Amplify.Storage.getUrl(
+            path: StoragePath.fromString(uploadPath),
+          ).result;
+          final downloadedContent = await read(getUrlResult.url);
+          expect(downloadedContent, uploadContent);
+        });
+
+        testWidgets('PUT presigned URL with useAccelerateEndpoint', (_) async {
+          final uploadPath = 'public/put-url-accelerate-${uuid()}';
+          final uploadData = 'accelerated upload'.codeUnits;
+          addTearDownPath(StoragePath.fromString(uploadPath));
+
+          final putUrlResult = await Amplify.Storage.getUrl(
+            path: StoragePath.fromString(uploadPath),
+            options: const StorageGetUrlOptions(
+              pluginOptions: S3GetUrlPluginOptions(
+                method: StorageAccessMethod.put,
+                useAccelerateEndpoint: true,
+              ),
+            ),
+          ).result;
+
+          expect(putUrlResult.url.host, contains('.s3-accelerate.'));
+
+          final putResponse = await put(putUrlResult.url, body: uploadData);
+          expect(putResponse.statusCode, 200);
+
+          // Verify
+          final getUrlResult = await Amplify.Storage.getUrl(
+            path: StoragePath.fromString(uploadPath),
+          ).result;
+          final actualData = await readData(getUrlResult.url);
+          expect(actualData, uploadData);
+        });
+
+        testWidgets('default method is GET (backward compatibility)', (
+          _,
+        ) async {
+          // Ensure that getUrl without method still works as a GET URL
+          final result = await Amplify.Storage.getUrl(
+            path: StoragePath.fromString(path),
+            options: const StorageGetUrlOptions(
+              pluginOptions: S3GetUrlPluginOptions(),
+            ),
+          ).result;
+          final actualData = await readData(result.url);
+          expect(actualData, data);
+        });
+
+        testWidgets('explicit method GET works the same as default', (_) async {
+          final result = await Amplify.Storage.getUrl(
+            path: StoragePath.fromString(path),
+            options: const StorageGetUrlOptions(
+              pluginOptions: S3GetUrlPluginOptions(
+                method: StorageAccessMethod.get,
+              ),
+            ),
+          ).result;
+          final actualData = await readData(result.url);
+          expect(actualData, data);
+        });
+      });
+
       group('with options', () {
         testWidgets('expiresIn', (_) async {
           const duration = Duration(seconds: 10);

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_plugin_options.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_plugin_options.dart
@@ -5,6 +5,15 @@ import 'package:amplify_core/amplify_core.dart';
 
 part 's3_get_url_plugin_options.g.dart';
 
+/// The HTTP method type for the presigned URL.
+enum StorageAccessMethod {
+  /// Generate a presigned URL for downloading (GET) an object.
+  get,
+
+  /// Generate a presigned URL for uploading (PUT) an object.
+  put,
+}
+
 /// {@template storage.amplify_storage_s3.get_url_plugin_options}
 /// The configurable parameters invoking the Storage S3 plugin `getUrl`
 /// API.
@@ -16,16 +25,19 @@ class S3GetUrlPluginOptions extends StorageGetUrlPluginOptions {
     Duration expiresIn = const Duration(minutes: 15),
     bool validateObjectExistence = false,
     bool useAccelerateEndpoint = false,
+    StorageAccessMethod method = StorageAccessMethod.get,
   }) : this._(
          expiresIn: expiresIn,
          validateObjectExistence: validateObjectExistence,
          useAccelerateEndpoint: useAccelerateEndpoint,
+         method: method,
        );
 
   const S3GetUrlPluginOptions._({
     this.expiresIn = const Duration(minutes: 15),
     this.validateObjectExistence = false,
     this.useAccelerateEndpoint = false,
+    this.method = StorageAccessMethod.get,
   });
 
   /// {@macro storage.amplify_storage_s3.get_url_plugin_options}
@@ -42,11 +54,21 @@ class S3GetUrlPluginOptions extends StorageGetUrlPluginOptions {
   /// {@macro storage.amplify_storage_s3.transfer_acceleration}
   final bool useAccelerateEndpoint;
 
+  /// The HTTP method type for the presigned URL.
+  ///
+  /// - [StorageAccessMethod.get]: Generate URL for downloading objects
+  ///   (default).
+  /// - [StorageAccessMethod.put]: Generate URL for uploading objects.
+  ///
+  /// Defaults to [StorageAccessMethod.get].
+  final StorageAccessMethod method;
+
   @override
   List<Object?> get props => [
     expiresIn,
     validateObjectExistence,
     useAccelerateEndpoint,
+    method,
   ];
 
   @override

--- a/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_plugin_options.g.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/model/s3_get_url_plugin_options.g.dart
@@ -24,6 +24,12 @@ S3GetUrlPluginOptions _$S3GetUrlPluginOptionsFromJson(
       'useAccelerateEndpoint',
       (v) => v as bool? ?? false,
     ),
+    method: $checkedConvert(
+      'method',
+      (v) =>
+          $enumDecodeNullable(_$StorageAccessMethodEnumMap, v) ??
+          StorageAccessMethod.get,
+    ),
   );
   return val;
 });
@@ -34,4 +40,10 @@ Map<String, dynamic> _$S3GetUrlPluginOptionsToJson(
   'expiresIn': instance.expiresIn.inMicroseconds,
   'validateObjectExistence': instance.validateObjectExistence,
   'useAccelerateEndpoint': instance.useAccelerateEndpoint,
+  'method': _$StorageAccessMethodEnumMap[instance.method]!,
+};
+
+const _$StorageAccessMethodEnumMap = {
+  StorageAccessMethod.get: 'get',
+  StorageAccessMethod.put: 'put',
 };

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/storage_s3_service_impl.dart
@@ -212,8 +212,12 @@ class StorageS3Service {
   }
 
   /// Takes in input from [AmplifyStorageS3Dart.getUrl] API to create a
-  /// `GET` [AWSHttpRequest], then `presign` it with [sigv4.AWSSigV4Signer], and
-  /// returns a [S3GetUrlResult] containing the presigned [Uri].
+  /// presigned [AWSHttpRequest] (GET or PUT), then `presign` it with
+  /// [sigv4.AWSSigV4Signer], and returns a [S3GetUrlResult] containing the
+  /// presigned [Uri].
+  ///
+  /// When [S3GetUrlPluginOptions.method] is [StorageAccessMethod.put], the
+  /// generated presigned URL can be used to upload objects via HTTP PUT.
   ///
   /// {@macro storage.s3_service.throw_exception_unknown_smithy_exception}
   Future<S3GetUrlResult> getUrl({
@@ -253,8 +257,13 @@ class StorageS3Service {
           .replaceFirst(RegExp(r'\.s3\.'), '.s3-accelerate.');
     }
 
+    // Determine HTTP method based on the StorageAccessMethod option
+    final httpMethod = s3PluginOptions.method == StorageAccessMethod.put
+        ? AWSHttpMethod.put
+        : AWSHttpMethod.get;
+
     final urlRequest = AWSHttpRequest.raw(
-      method: AWSHttpMethod.get,
+      method: httpMethod,
       host: host,
       path: '/$resolvedPath',
     );

--- a/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/amplify_storage_s3_dart_test.dart
@@ -318,6 +318,77 @@ void main() {
         final result = await getUrlOperation.result;
         expect(result, testResult);
       });
+
+      test(
+        'should forward options with method PUT to StorageS3Service.getUrl() API',
+        () async {
+          const testOptions = StorageGetUrlOptions(
+            pluginOptions: S3GetUrlPluginOptions(
+              expiresIn: Duration(minutes: 5),
+              method: StorageAccessMethod.put,
+            ),
+          );
+
+          when(
+            () => storageS3Service.getUrl(
+              path: testPath,
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((_) async => testResult);
+
+          final getUrlOperation = storageS3Plugin.getUrl(
+            path: testPath,
+            options: testOptions,
+          );
+
+          final capturedOptions = verify(
+            () => storageS3Service.getUrl(
+              path: testPath,
+              options: captureAny<StorageGetUrlOptions>(named: 'options'),
+            ),
+          ).captured.last;
+
+          expect(capturedOptions, isA<StorageGetUrlOptions>());
+          final options = capturedOptions as StorageGetUrlOptions;
+          expect(options.pluginOptions, isA<S3GetUrlPluginOptions>());
+          final pluginOptions = options.pluginOptions! as S3GetUrlPluginOptions;
+          expect(pluginOptions.method, StorageAccessMethod.put);
+          expect(pluginOptions.expiresIn, const Duration(minutes: 5));
+
+          final result = await getUrlOperation.result;
+          expect(result, testResult);
+        },
+      );
+
+      test(
+        'should default method to GET when not specified in plugin options',
+        () async {
+          const testOptions = StorageGetUrlOptions(
+            pluginOptions: S3GetUrlPluginOptions(),
+          );
+
+          when(
+            () => storageS3Service.getUrl(
+              path: testPath,
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((_) async => testResult);
+
+          storageS3Plugin.getUrl(path: testPath, options: testOptions);
+
+          final capturedOptions = verify(
+            () => storageS3Service.getUrl(
+              path: testPath,
+              options: captureAny<StorageGetUrlOptions>(named: 'options'),
+            ),
+          ).captured.last;
+
+          expect(capturedOptions, isA<StorageGetUrlOptions>());
+          final options = capturedOptions as StorageGetUrlOptions;
+          final pluginOptions = options.pluginOptions! as S3GetUrlPluginOptions;
+          expect(pluginOptions.method, StorageAccessMethod.get);
+        },
+      );
     });
 
     group('downloadData() API', () {

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/storage_s3_service_test.dart
@@ -760,6 +760,179 @@ void main() {
         );
       });
 
+      test(
+        'should use AWSHttpMethod.get by default when method is not specified',
+        () async {
+          const testOptions = StorageGetUrlOptions(
+            pluginOptions: S3GetUrlPluginOptions(expiresIn: testExpiresIn),
+          );
+
+          when(
+            () => awsSigV4Signer.presign(
+              any(),
+              credentialScope: any(named: 'credentialScope'),
+              serviceConfiguration: any(named: 'serviceConfiguration'),
+              expiresIn: any(named: 'expiresIn'),
+            ),
+          ).thenAnswer((_) async => testUrl);
+
+          await storageS3Service.getUrl(path: testPath, options: testOptions);
+
+          final capturedRequest = verify(
+            () => awsSigV4Signer.presign(
+              captureAny<AWSHttpRequest>(),
+              credentialScope: any(named: 'credentialScope'),
+              expiresIn: any(named: 'expiresIn'),
+              serviceConfiguration: any(named: 'serviceConfiguration'),
+            ),
+          ).captured.first;
+
+          expect(capturedRequest, isA<AWSHttpRequest>());
+          final request = capturedRequest as AWSHttpRequest;
+          expect(request.method, AWSHttpMethod.get);
+        },
+      );
+
+      test(
+        'should use AWSHttpMethod.get when method is StorageAccessMethod.get',
+        () async {
+          const testOptions = StorageGetUrlOptions(
+            pluginOptions: S3GetUrlPluginOptions(
+              expiresIn: testExpiresIn,
+              method: StorageAccessMethod.get,
+            ),
+          );
+
+          when(
+            () => awsSigV4Signer.presign(
+              any(),
+              credentialScope: any(named: 'credentialScope'),
+              serviceConfiguration: any(named: 'serviceConfiguration'),
+              expiresIn: any(named: 'expiresIn'),
+            ),
+          ).thenAnswer((_) async => testUrl);
+
+          await storageS3Service.getUrl(path: testPath, options: testOptions);
+
+          final capturedRequest = verify(
+            () => awsSigV4Signer.presign(
+              captureAny<AWSHttpRequest>(),
+              credentialScope: any(named: 'credentialScope'),
+              expiresIn: any(named: 'expiresIn'),
+              serviceConfiguration: any(named: 'serviceConfiguration'),
+            ),
+          ).captured.first;
+
+          expect(capturedRequest, isA<AWSHttpRequest>());
+          final request = capturedRequest as AWSHttpRequest;
+          expect(request.method, AWSHttpMethod.get);
+        },
+      );
+
+      test(
+        'should use AWSHttpMethod.put when method is StorageAccessMethod.put',
+        () async {
+          const testOptions = StorageGetUrlOptions(
+            pluginOptions: S3GetUrlPluginOptions(
+              expiresIn: testExpiresIn,
+              method: StorageAccessMethod.put,
+            ),
+          );
+
+          when(
+            () => awsSigV4Signer.presign(
+              any(),
+              credentialScope: any(named: 'credentialScope'),
+              serviceConfiguration: any(named: 'serviceConfiguration'),
+              expiresIn: any(named: 'expiresIn'),
+            ),
+          ).thenAnswer((_) async => testUrl);
+
+          await storageS3Service.getUrl(path: testPath, options: testOptions);
+
+          final capturedRequest = verify(
+            () => awsSigV4Signer.presign(
+              captureAny<AWSHttpRequest>(),
+              credentialScope: any(named: 'credentialScope'),
+              expiresIn: any(named: 'expiresIn'),
+              serviceConfiguration: any(named: 'serviceConfiguration'),
+            ),
+          ).captured.first;
+
+          expect(capturedRequest, isA<AWSHttpRequest>());
+          final request = capturedRequest as AWSHttpRequest;
+          expect(request.method, AWSHttpMethod.put);
+        },
+      );
+
+      test(
+        'should return correct url and expiresAt when method is StorageAccessMethod.put',
+        () {
+          runZoned(() async {
+            const testOptions = StorageGetUrlOptions(
+              pluginOptions: S3GetUrlPluginOptions(
+                expiresIn: testExpiresIn,
+                method: StorageAccessMethod.put,
+              ),
+            );
+
+            when(
+              () => awsSigV4Signer.presign(
+                any(),
+                credentialScope: any(named: 'credentialScope'),
+                serviceConfiguration: any(named: 'serviceConfiguration'),
+                expiresIn: any(named: 'expiresIn'),
+              ),
+            ).thenAnswer((_) async => testUrl);
+
+            final result = await storageS3Service.getUrl(
+              path: testPath,
+              options: testOptions,
+            );
+
+            expect(result.url, testUrl);
+            expect(result.expiresAt, testBaseDateTime.add(testExpiresIn));
+          }, zoneValues: {testDateTimeNowOverride: testBaseDateTime});
+        },
+      );
+
+      test(
+        'should generate transfer acceleration enabled URL with PUT method',
+        () async {
+          const testOptions = StorageGetUrlOptions(
+            pluginOptions: S3GetUrlPluginOptions(
+              useAccelerateEndpoint: true,
+              method: StorageAccessMethod.put,
+            ),
+          );
+
+          when(
+            () => awsSigV4Signer.presign(
+              any(),
+              credentialScope: any(named: 'credentialScope'),
+              serviceConfiguration: any(named: 'serviceConfiguration'),
+              expiresIn: any(named: 'expiresIn'),
+            ),
+          ).thenAnswer((_) async => testUrl);
+
+          await storageS3Service.getUrl(path: testPath, options: testOptions);
+
+          final capturedRequest = verify(
+            () => awsSigV4Signer.presign(
+              captureAny<AWSHttpRequest>(),
+              credentialScope: any(named: 'credentialScope'),
+              expiresIn: any(named: 'expiresIn'),
+              serviceConfiguration: any(named: 'serviceConfiguration'),
+            ),
+          ).captured.first;
+
+          expect(capturedRequest, isA<AWSHttpRequest>());
+          final request = capturedRequest as AWSHttpRequest;
+          expect(request.method, AWSHttpMethod.put);
+          expect(request.uri.host, contains('.s3-accelerate.'));
+        },
+      );
+
       group('bucket name has dots (".")', () {
         late AWSSigV4Signer pathStyleAwsSigV4Signer;
         late StorageS3Service pathStyleStorageS3Service;


### PR DESCRIPTION
Extends the existing `getUrl` API to support generating pre-signed URLs for PUT (upload) operations, enabling developers to use standard HTTP clients and third-party tools to upload files to S3 via pre-signed URLs.