### PR TITLE
chore: Extend `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ amplify_outputs*.dart
 
 # Custom Actions output
 **/*.cjs.deps
+.flutter-plugins-dependencies


### PR DESCRIPTION
This file should not be checked in, even the file itself says so.