### PR TITLE
fix(cognito): Add `invalidTokenException` to `SignOutPartialFailure.props`

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_out_state.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/state/sign_out_state.dart
@@ -110,6 +110,7 @@ final class SignOutPartialFailure extends SignOutState {
     hostedUiException,
     globalSignOutException,
     revokeTokenException,
+    invalidTokenException,
   ];
 
   @override


### PR DESCRIPTION
Addresses https://github.com/aws-amplify/amplify-flutter/issues/6206

### Problem

SignOutPartialFailure has an invalidTokenException field but it was missing from the props list (used by Equatable for equality comparison). This means two 
SignOutPartialFailure instances with different invalidTokenException values would incorrectly compare as equal, which can cause state machine transitions to be 
silently dropped — the state machine won't emit a new state if it considers the old and new states "equal."

### Reproduction

Sign in a user, restart the app (hot restart or force-stop/relaunch), then call signIn(). The sign-out flow triggered internally produces a SignOutPartialFailure 
with an invalidTokenException, but because the field is excluded from equality props, state changes aren't properly propagated, leading to the "A user is already 
signed in" error reported in #6206.

### Fix

Add invalidTokenException to the props list in SignOutPartialFailure so equality comparisons account for all fields, and state transitions are emitted correctly.