### PR TITLE
fix(ci): pin device_info_plus 

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   amplify_db_common: ">=0.4.16 <0.5.0"
   amplify_secure_storage: ">=0.5.15 <0.6.0"
   aws_common: ">=0.7.12 <0.8.0"
-  device_info_plus: ^12.0.0
+  device_info_plus: ">=12.0.0 <12.4.0"
 
   flutter:
     sdk: flutter

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   amplify_api_dart: ">=0.5.13 <0.6.0"
   amplify_core: ">=2.10.0 <2.11.0"
   amplify_flutter: ">=2.10.0 <2.11.0"
-  connectivity_plus: ^7.0.0
+  connectivity_plus: ">=7.0.0 <7.1.0"
   flutter:
     sdk: flutter
   meta: ^1.16.0

--- a/packages/storage/amplify_storage_s3/example/lib/main.dart
+++ b/packages/storage/amplify_storage_s3/example/lib/main.dart
@@ -125,7 +125,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   // upload a file to the S3 bucket
   Future<void> _uploadFile() async {
-    final result = await FilePicker.platform.pickFiles(
+    final result = await FilePicker.pickFiles(
       type: FileType.image,
       withReadStream: true,
       withData: false,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   # This must roughly match what's included in `dart format`
   # on stable so that CI checks pass for generated code.
   dart_style: ^3.0.1
-  device_info_plus: ^12.0.0
+  device_info_plus: ">=12.0.0 <12.4.0"
   drift: ^2.25.0
   drift_dev: ^2.25.1
   ffigen: ^9.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   built_value: ^8.10.1
   built_value_generator: ^8.10.1
   code_builder: ^4.10.1
-  connectivity_plus: ^7.0.0
+  connectivity_plus: ">=7.0.0 <7.1.0"
   # This must roughly match what's included in `dart format`
   # on stable so that CI checks pass for generated code.
   dart_style: ^3.0.1


### PR DESCRIPTION
device_info_plus 12.4.0 added isiOSAppOnVision which uses NSProcessInfo.isiOSAppOnVision, an API only available in Xcode 26.2+. Our CI runners use Xcode 16, causing compilation failures in all iOS builds that depend on device_info_plus.

Pin to <12.4.0 until CI runners are upgraded to Xcode 26.2+.

pin connectivity_plus <7.1.0 for the same reason

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
