### PR TITLE
fix(aws_common): Use isA for JS interop type check in catch clause

### DIFF
--- a/packages/aws_common/lib/src/io/aws_file_platform_html.dart
+++ b/packages/aws_common/lib/src/io/aws_file_platform_html.dart
@@ -179,8 +179,10 @@ class AWSFilePlatform extends AWSFile {
     late http.Response response;
     try {
       response = await BrowserClient().get(Uri.parse(path));
-    } on ProgressEvent catch (e) {
-      if (e.type == 'error') {
+    } on Object catch (e) {
+      final jsError = e as JSAny?;
+      if (jsError.isA<ProgressEvent>() &&
+          (jsError as ProgressEvent).type == 'error') {
         throw const InvalidFileException(
           message: 'Could resolve file blob from provide path.',
           recoverySuggestion:


### PR DESCRIPTION
Replace the typed catch clause `on ProgressEvent catch (e)` with an inline pattern that casts to `JSAny?` and uses `isA<ProgressEvent>()` for the type check. This avoids the
`invalid_runtime_check_with_js_interop_types` lint introduced in Dart 3.12 beta, which flags catch clauses and `is` checks using JS interop types as potentially platform-inconsistent.

The `as JSAny?` cast is a zero-cost extension type cast, and `isA` is the Dart-recommended approach for runtime-checking JS interop types.
