### PR TITLE
feat(aft): Generate list of Github tags

### DIFF
--- a/packages/aft/lib/src/commands/publish_command.dart
+++ b/packages/aft/lib/src/commands/publish_command.dart
@@ -213,6 +213,14 @@ class PublishCommand extends AmplifyCommand with GlobOptions, PublishHelpers {
         'dry-run',
         help: 'Passes `--dry-run` flag to `dart` or `flutter` publish command',
         negatable: false,
+      )
+      ..addFlag(
+        'tags',
+        help:
+            'Prints the list of GitHub tags that would be created for '
+            'packages to be published, one per line, in the format '
+            r'"${package}-v${version}".',
+        negatable: false,
       );
   }
 
@@ -221,6 +229,8 @@ class PublishCommand extends AmplifyCommand with GlobOptions, PublishHelpers {
 
   @override
   late final bool dryRun = argResults!['dry-run'] as bool;
+
+  late final bool tags = argResults!['tags'] as bool;
 
   @override
   String get description =>
@@ -248,6 +258,16 @@ class PublishCommand extends AmplifyCommand with GlobOptions, PublishHelpers {
 
     if (packagesNeedingPublish.isEmpty) {
       logger.info('No packages need publishing!');
+      return;
+    }
+
+    // If --tags is set, print the GitHub tags and exit.
+    if (tags) {
+      stdout.writeln();
+      for (final package in packagesNeedingPublish) {
+        final version = package.pubspecInfo.pubspec.version;
+        stdout.writeln('New tag: ${package.name}-v$version');
+      }
       return;
     }
 


### PR DESCRIPTION
This add a feature to generate tags related to a release. This can be used in Github workflows.
Here is a demo:
```
user@workstation amplify-flutter % aft publish --dry-run
Downloading packages... . 
! amplify_lints 3.1.4 from path packages/amplify_lints (overridden)
! aws_common 0.7.12 from path packages/aws_common (overridden)
! aws_signature_v4 0.6.10 from path packages/aws_signature_v4 (overridden)
  grpc 5.0.0 (5.1.0 available)
  protobuf 5.1.0 (6.0.0 available)
! pub_server 0.0.0 from path packages/test/pub_server (overridden)
! smithy 0.7.10 from path packages/smithy/smithy (overridden)
! smithy_aws 0.7.10 from path packages/smithy/smithy_aws (overridden)
! smithy_codegen 0.3.2 from path packages/smithy/smithy_codegen (overridden)
  win32 5.15.0 (6.0.1 available)
No dependencies would change in `/Users/user/Dev/aft-tag-list/amplify-flutter/packages/aft`.
3 packages have newer versions incompatible with dependency constraints.
Try `dart pub outdated` for more information.
Building package executable... 
Built aft:aft.
Found Dart SDK: 3.11.0
Preparing to publish (dry run): 
2.11.1 amplify_kinesis
2.10.1 amplify_auth_cognito

The following packages will not be published: 
2.10.0 amplify_flutter
2.10.1 amplify_core
2.10.2 amplify_datastore
2.10.1 amplify_datastore_plugin_interface
3.1.4 amplify_lints
2.10.0 amplify_analytics_pinpoint
0.4.15 amplify_analytics_pinpoint_dart
2.10.0 amplify_api
0.5.16 amplify_api_dart
0.11.19 amplify_auth_cognito_dart
2.5.1 amplify_authenticator
0.7.12 aws_common
0.6.10 aws_signature_v4
0.4.16 amplify_db_common
0.4.17 amplify_db_common_dart
2.10.2 amplify_push_notifications
2.10.0 amplify_push_notifications_pinpoint
0.5.16 amplify_secure_storage
0.5.10 amplify_secure_storage_dart
0.7.10 smithy
0.7.10 smithy_aws
2.10.0 amplify_storage_s3
0.4.17 amplify_storage_s3_dart
0.3.11 worker_bee
0.3.10 worker_bee_builder
2.11.0 amplify_foundation_dart
2.11.0 amplify_foundation_dart_bridge
0.1.0 amplify_kinesis_dart
Proceed with publish (y/N)? 
user@workstation amplify-flutter % aft publish --tags   
Downloading packages... . 
! amplify_lints 3.1.4 from path packages/amplify_lints (overridden)
! aws_common 0.7.12 from path packages/aws_common (overridden)
! aws_signature_v4 0.6.10 from path packages/aws_signature_v4 (overridden)
  grpc 5.0.0 (5.1.0 available)
  protobuf 5.1.0 (6.0.0 available)
! pub_server 0.0.0 from path packages/test/pub_server (overridden)
! smithy 0.7.10 from path packages/smithy/smithy (overridden)
! smithy_aws 0.7.10 from path packages/smithy/smithy_aws (overridden)
! smithy_codegen 0.3.2 from path packages/smithy/smithy_codegen (overridden)
  win32 5.15.0 (6.0.1 available)
No dependencies would change in `/Users/user/Dev/aft-tag-list/amplify-flutter/packages/aft`.
3 packages have newer versions incompatible with dependency constraints.
Try `dart pub outdated` for more information.
Building package executable... 
Built aft:aft.
Found Dart SDK: 3.11.0

New tag: amplify_kinesis-v2.11.1
New tag: amplify_auth_cognito-v2.10.1
user@workstation amplify-flutter % ./demo-tag.sh 
Would run: git tag "amplify_kinesis-v2.11.1"
Would run: git tag "amplify_auth_cognito-v2.10.1"
Would run: git push origin --tags
```