### PR TITLE
feat(auth): add custom headers support for Cognito Auth requests

### DIFF
--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -35,11 +35,14 @@ class AmplifyAuthCognito extends AmplifyAuthCognitoDart with AWSDebuggable {
   /// To change the default behavior of credential storage,
   /// provide a [SecureStorageFactory] value. If no value is provided,
   /// storage will be configured with default [AmplifySecureStorageConfig] values.
-  AmplifyAuthCognito({SecureStorageFactory? secureStorageFactory})
-    : super(
+  AmplifyAuthCognito({
+    SecureStorageFactory? secureStorageFactory,
+    AuthPluginOptions? authPluginOptions,
+  }) : super(
         secureStorageFactory:
             secureStorageFactory ?? AmplifySecureStorage.factoryFrom(),
         hostedUiPlatformFactory: HostedUiPlatformImpl.new,
+        authPluginOptions: authPluginOptions,
       );
 
   /// A plugin key which can be used with `Amplify.Auth.getPlugin` to retrieve

--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -36,13 +36,12 @@ class AmplifyAuthCognito extends AmplifyAuthCognitoDart with AWSDebuggable {
   /// provide a [SecureStorageFactory] value. If no value is provided,
   /// storage will be configured with default [AmplifySecureStorageConfig] values.
   AmplifyAuthCognito({
+    super.authPluginOptions,
     SecureStorageFactory? secureStorageFactory,
-    AuthPluginOptions? authPluginOptions,
   }) : super(
          secureStorageFactory:
              secureStorageFactory ?? AmplifySecureStorage.factoryFrom(),
          hostedUiPlatformFactory: HostedUiPlatformImpl.new,
-         authPluginOptions: authPluginOptions,
        );
 
   /// A plugin key which can be used with `Amplify.Auth.getPlugin` to retrieve

--- a/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito/lib/src/auth_plugin_impl.dart
@@ -39,11 +39,11 @@ class AmplifyAuthCognito extends AmplifyAuthCognitoDart with AWSDebuggable {
     SecureStorageFactory? secureStorageFactory,
     AuthPluginOptions? authPluginOptions,
   }) : super(
-        secureStorageFactory:
-            secureStorageFactory ?? AmplifySecureStorage.factoryFrom(),
-        hostedUiPlatformFactory: HostedUiPlatformImpl.new,
-        authPluginOptions: authPluginOptions,
-      );
+         secureStorageFactory:
+             secureStorageFactory ?? AmplifySecureStorage.factoryFrom(),
+         hostedUiPlatformFactory: HostedUiPlatformImpl.new,
+         authPluginOptions: authPluginOptions,
+       );
 
   /// A plugin key which can be used with `Amplify.Auth.getPlugin` to retrieve
   /// a Cognito-specific Auth category interface.

--- a/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/amplify_auth_cognito_dart.dart
@@ -10,6 +10,7 @@ export 'src/asf/asf_context_data.dart';
 export 'src/asf/asf_context_data_provider.dart';
 export 'src/asf/asf_device_info_collector.dart' show ASFDeviceInfoCollector;
 export 'src/auth_plugin_impl.dart';
+export 'src/auth_plugin_options.dart';
 export 'src/exception/device_not_tracked_exception.dart';
 export 'src/exception/invalid_account_type_exception.dart';
 export 'src/jwt/src/cognito.dart';

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -64,9 +64,11 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
   AmplifyAuthCognitoDart({
     SecureStorageFactory? secureStorageFactory,
     @protected HostedUiPlatformFactory? hostedUiPlatformFactory,
+    AuthPluginOptions? authPluginOptions,
   }) : _secureStorageFactory =
            secureStorageFactory ?? AmplifySecureStorageWorker.factoryFrom(),
-       _hostedUiPlatformFactory = hostedUiPlatformFactory;
+       _hostedUiPlatformFactory = hostedUiPlatformFactory,
+       _authPluginOptions = authPluginOptions ?? const AuthPluginOptions();
 
   /// A plugin key which can be used with `Amplify.Auth.getPlugin` to retrieve
   /// a Cognito-specific Auth category interface.
@@ -97,6 +99,9 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
   /// }
   /// ```
   final HostedUiPlatformFactory? _hostedUiPlatformFactory;
+
+  /// The plugin options, including the optional custom headers callback.
+  final AuthPluginOptions _authPluginOptions;
 
   late CognitoAuthStateMachine _stateMachine = CognitoAuthStateMachine(
     dependencyManager: dependencies,
@@ -163,7 +168,8 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
       ..addInstance<SecureStorageInterface>(
         _secureStorageFactory(AmplifySecureStorageScope.awsCognitoAuthPlugin),
       )
-      ..addInstance<AmplifyLogger>(logger);
+      ..addInstance<AmplifyLogger>(logger)
+      ..addInstance<AuthPluginOptions>(_authPluginOptions);
     if (_hostedUiPlatformFactory != null) {
       _stateMachine.addBuilder<HostedUiPlatform>(_hostedUiPlatformFactory);
     }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_options.dart
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:aws_common/aws_common.dart';
+import 'package:meta/meta.dart';
+
+/// {@template amplify_auth_cognito_dart.auth_plugin_options}
+/// The plugin options for the Amplify Auth Cognito plugin.
+///
+/// Use these options to configure custom headers for all Cognito Auth requests.
+/// This is useful for integrating with AWS WAF intelligent threat protection
+/// (CAPTCHA, Challenge, Bot Control) or other custom header use cases.
+///
+/// ## Example
+///
+/// ```dart
+/// final authPlugin = AmplifyAuthCognitoDart(
+///   authPluginOptions: AuthPluginOptions(
+///     headers: () async => {
+///       'x-aws-waf-token': await getWafToken(),
+///     },
+///   ),
+/// );
+/// ```
+/// {@endtemplate}
+@immutable
+class AuthPluginOptions with AWSDebuggable {
+  /// {@macro amplify_auth_cognito_dart.auth_plugin_options}
+  const AuthPluginOptions({
+    this.headers,
+  });
+
+  /// An optional async function that returns custom headers to be included
+  /// in every Cognito Auth HTTP request.
+  ///
+  /// The headers returned by this function are merged with existing request
+  /// headers. If a custom header has the same key as an existing header,
+  /// the custom header value takes precedence.
+  final Future<Map<String, String>> Function()? headers;
+
+  @override
+  String get runtimeTypeName => 'AuthPluginOptions';
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_options.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_options.dart
@@ -26,9 +26,7 @@ import 'package:meta/meta.dart';
 @immutable
 class AuthPluginOptions with AWSDebuggable {
   /// {@macro amplify_auth_cognito_dart.auth_plugin_options}
-  const AuthPluginOptions({
-    this.headers,
-  });
+  const AuthPluginOptions({this.headers});
 
   /// An optional async function that returns custom headers to be included
   /// in every Cognito Auth HTTP request.

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/sdk_bridge.dart
@@ -110,11 +110,13 @@ class WrappedCognitoIdentityClient implements CognitoIdentityClient {
     required String region,
     required AWSCredentialsProvider credentialsProvider,
     required DependencyManager dependencyManager,
+    List<HttpRequestInterceptor> additionalRequestInterceptors = const [],
   }) : _base = CognitoIdentityClient(
          region: region,
          credentialsProvider: credentialsProvider,
-         requestInterceptors: const [
-           WithHeader(AWSHeaders.cacheControl, 'no-store'),
+         requestInterceptors: [
+           const WithHeader(AWSHeaders.cacheControl, 'no-store'),
+           ...additionalRequestInterceptors,
          ],
        ),
        _dependencyManager = dependencyManager;
@@ -183,6 +185,7 @@ class WrappedCognitoIdentityProviderClient
     String? endpoint,
     required AWSCredentialsProvider credentialsProvider,
     required DependencyManager dependencyManager,
+    List<HttpRequestInterceptor> additionalRequestInterceptors = const [],
   }) : _base = CognitoIdentityProviderClient(
          region: region,
          credentialsProvider: credentialsProvider,
@@ -191,8 +194,9 @@ class WrappedCognitoIdentityProviderClient
              : (endpoint.startsWith('http')
                    ? Uri.parse(endpoint)
                    : Uri.parse('https://$endpoint')),
-         requestInterceptors: const [
-           WithHeader(AWSHeaders.cacheControl, 'no-store'),
+         requestInterceptors: [
+           const WithHeader(AWSHeaders.cacheControl, 'no-store'),
+           ...additionalRequestInterceptors,
          ],
        ),
        _dependencyManager = dependencyManager;

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/interceptors/with_custom_headers.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/sdk/src/cognito_identity_provider/interceptors/with_custom_headers.dart
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:aws_common/aws_common.dart';
+import 'package:smithy/smithy.dart';
+
+/// An [HttpRequestInterceptor] that adds custom headers from an async callback
+/// to every request.
+///
+/// Custom headers are merged with existing request headers. If a custom header
+/// has the same key as an existing header, the custom header value takes
+/// precedence.
+class WithCustomHeaders extends HttpRequestInterceptor {
+  /// Creates a [WithCustomHeaders] interceptor with the given [headers]
+  /// callback.
+  const WithCustomHeaders(this.headers);
+
+  /// The async callback that returns the custom headers.
+  final Future<Map<String, String>> Function() headers;
+
+  @override
+  Future<AWSBaseHttpRequest> intercept(AWSBaseHttpRequest request) async {
+    final customHeaders = await headers();
+    request.headers.addAll(customHeaders);
+    return request;
+  }
+}

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/configuration_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/configuration_state_machine.dart
@@ -5,15 +5,18 @@ import 'dart:async';
 
 // ignore: implementation_imports
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_info_store_manager.dart';
+import 'package:amplify_auth_cognito_dart/src/auth_plugin_options.dart';
 import 'package:amplify_auth_cognito_dart/src/credentials/auth_plugin_credentials_provider.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/sdk_bridge.dart';
+import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/interceptors/with_custom_headers.dart';
 import 'package:amplify_auth_cognito_dart/src/state/cognito_state_machine.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_core/amplify_core.dart';
 // ignore: implementation_imports
 import 'package:amplify_core/src/config/amplify_outputs/analytics/analytics_outputs.dart';
+import 'package:smithy/smithy.dart';
 
 /// {@template amplify_auth_cognito.configuration_state_machine}
 /// Manages configuration of the Auth category.
@@ -73,12 +76,24 @@ final class ConfigurationStateMachine
     }
     addInstance(authOutputs);
     final waiters = <Future<void>>[];
+
+    // Build additional request interceptors from AuthPluginOptions.
+    // AuthPluginOptions is registered by `_init()` in the plugin impl and will
+    // always be present in normal usage. The nullable lookup is defensive for
+    // tests that may configure the state machine without the full plugin setup.
+    final authPluginOptions = get<AuthPluginOptions>();
+    final additionalInterceptors = <HttpRequestInterceptor>[
+      if (authPluginOptions?.headers != null)
+        WithCustomHeaders(authPluginOptions!.headers!),
+    ];
+
     addInstance<CognitoIdentityProviderClient>(
       WrappedCognitoIdentityProviderClient(
         region: authOutputs.awsRegion,
         credentialsProvider: _credentialsProvider,
         dependencyManager: this,
         endpoint: authOutputs.userPoolEndpoint,
+        additionalRequestInterceptors: additionalInterceptors,
       ),
     );
 
@@ -93,6 +108,7 @@ final class ConfigurationStateMachine
           region: authOutputs.awsRegion,
           credentialsProvider: _credentialsProvider,
           dependencyManager: this,
+          additionalRequestInterceptors: additionalInterceptors,
         ),
       );
     }

--- a/packages/auth/amplify_auth_cognito_dart/test/sdk/with_custom_headers_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/sdk/with_custom_headers_test.dart
@@ -40,9 +40,7 @@ void main() {
         () async => {'x-existing': 'new-value'},
       );
 
-      final request = _createRequest(
-        headers: {'x-existing': 'old-value'},
-      );
+      final request = _createRequest(headers: {'x-existing': 'old-value'});
       final result = await interceptor.intercept(request);
 
       expect(result.headers['x-existing'], 'new-value');
@@ -53,9 +51,7 @@ void main() {
         () async => {'x-custom': 'custom-value'},
       );
 
-      final request = _createRequest(
-        headers: {'x-existing': 'existing-value'},
-      );
+      final request = _createRequest(headers: {'x-existing': 'existing-value'});
       final result = await interceptor.intercept(request);
 
       expect(result.headers['x-existing'], 'existing-value');
@@ -63,13 +59,9 @@ void main() {
     });
 
     test('handles empty headers from callback', () async {
-      final interceptor = WithCustomHeaders(
-        () async => {},
-      );
+      final interceptor = WithCustomHeaders(() async => {});
 
-      final request = _createRequest(
-        headers: {'x-existing': 'existing-value'},
-      );
+      final request = _createRequest(headers: {'x-existing': 'existing-value'});
       final result = await interceptor.intercept(request);
 
       expect(result.headers['x-existing'], 'existing-value');
@@ -88,10 +80,7 @@ void main() {
         return AWSHttpResponse(
           statusCode: 200,
           body: utf8.encode(
-            json.encode({
-              'UserConfirmed': false,
-              'UserSub': 'test-user-sub',
-            }),
+            json.encode({'UserConfirmed': false, 'UserSub': 'test-user-sub'}),
           ),
         );
       });
@@ -138,23 +127,18 @@ void main() {
         return AWSHttpResponse(
           statusCode: 200,
           body: utf8.encode(
-            json.encode({
-              'UserConfirmed': false,
-              'UserSub': 'test-user-sub',
-            }),
+            json.encode({'UserConfirmed': false, 'UserSub': 'test-user-sub'}),
           ),
         );
       });
 
       // No WithCustomHeaders interceptor -- only the standard one.
-      final client = CognitoIdentityProviderClient(
+      const client = CognitoIdentityProviderClient(
         region: 'us-east-1',
-        credentialsProvider: const AWSCredentialsProvider(
+        credentialsProvider: AWSCredentialsProvider(
           AWSCredentials('accessKeyId', 'secretAccessKey'),
         ),
-        requestInterceptors: const [
-          WithHeader(AWSHeaders.cacheControl, 'no-store'),
-        ],
+        requestInterceptors: [WithHeader(AWSHeaders.cacheControl, 'no-store')],
       );
 
       await client

--- a/packages/auth/amplify_auth_cognito_dart/test/sdk/with_custom_headers_test.dart
+++ b/packages/auth/amplify_auth_cognito_dart/test/sdk/with_custom_headers_test.dart
@@ -1,0 +1,176 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:convert';
+
+import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
+import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/interceptors/with_custom_headers.dart';
+import 'package:aws_common/aws_common.dart';
+import 'package:aws_common/testing.dart';
+import 'package:smithy/smithy.dart' show WithHeader;
+import 'package:test/test.dart';
+
+AWSHttpRequest _createRequest({Map<String, String>? headers}) {
+  return AWSHttpRequest(
+    method: AWSHttpMethod.post,
+    uri: Uri.parse('https://cognito-idp.us-east-1.amazonaws.com'),
+    headers: headers ?? {},
+  );
+}
+
+void main() {
+  group('WithCustomHeaders', () {
+    test('adds custom headers to the request', () async {
+      final interceptor = WithCustomHeaders(
+        () async => {
+          'x-custom-header': 'custom-value',
+          'x-another-header': 'another-value',
+        },
+      );
+
+      final request = _createRequest();
+      final result = await interceptor.intercept(request);
+
+      expect(result.headers['x-custom-header'], 'custom-value');
+      expect(result.headers['x-another-header'], 'another-value');
+    });
+
+    test('custom headers override existing headers', () async {
+      final interceptor = WithCustomHeaders(
+        () async => {'x-existing': 'new-value'},
+      );
+
+      final request = _createRequest(
+        headers: {'x-existing': 'old-value'},
+      );
+      final result = await interceptor.intercept(request);
+
+      expect(result.headers['x-existing'], 'new-value');
+    });
+
+    test('preserves existing headers when no conflict', () async {
+      final interceptor = WithCustomHeaders(
+        () async => {'x-custom': 'custom-value'},
+      );
+
+      final request = _createRequest(
+        headers: {'x-existing': 'existing-value'},
+      );
+      final result = await interceptor.intercept(request);
+
+      expect(result.headers['x-existing'], 'existing-value');
+      expect(result.headers['x-custom'], 'custom-value');
+    });
+
+    test('handles empty headers from callback', () async {
+      final interceptor = WithCustomHeaders(
+        () async => {},
+      );
+
+      final request = _createRequest(
+        headers: {'x-existing': 'existing-value'},
+      );
+      final result = await interceptor.intercept(request);
+
+      expect(result.headers['x-existing'], 'existing-value');
+      expect(result.headers.length, 1);
+    });
+  });
+
+  group('WithCustomHeaders integration', () {
+    test('custom headers are present on outgoing SDK requests', () async {
+      // Captured request headers from the mock HTTP client.
+      late Map<String, String> capturedHeaders;
+
+      final mockHttpClient = MockAWSHttpClient((request, isCancelled) {
+        capturedHeaders = Map.of(request.headers);
+        // Return a valid SignUp JSON response.
+        return AWSHttpResponse(
+          statusCode: 200,
+          body: utf8.encode(
+            json.encode({
+              'UserConfirmed': false,
+              'UserSub': 'test-user-sub',
+            }),
+          ),
+        );
+      });
+
+      // Create a real CognitoIdentityProviderClient with the
+      // WithCustomHeaders interceptor wired in.
+      final client = CognitoIdentityProviderClient(
+        region: 'us-east-1',
+        credentialsProvider: const AWSCredentialsProvider(
+          AWSCredentials('accessKeyId', 'secretAccessKey'),
+        ),
+        requestInterceptors: [
+          const WithHeader(AWSHeaders.cacheControl, 'no-store'),
+          WithCustomHeaders(
+            () async => {
+              'x-aws-waf-token': 'my-waf-token',
+              'x-custom-header': 'custom-value',
+            },
+          ),
+        ],
+      );
+
+      await client
+          .signUp(
+            SignUpRequest(
+              clientId: 'test-client-id',
+              username: 'testuser',
+              password: 'TestPassword123!',
+            ),
+            client: mockHttpClient,
+          )
+          .result;
+
+      expect(capturedHeaders['x-aws-waf-token'], 'my-waf-token');
+      expect(capturedHeaders['x-custom-header'], 'custom-value');
+      expect(capturedHeaders[AWSHeaders.cacheControl], 'no-store');
+    });
+
+    test('SDK requests succeed without custom headers interceptor', () async {
+      late Map<String, String> capturedHeaders;
+
+      final mockHttpClient = MockAWSHttpClient((request, isCancelled) {
+        capturedHeaders = Map.of(request.headers);
+        return AWSHttpResponse(
+          statusCode: 200,
+          body: utf8.encode(
+            json.encode({
+              'UserConfirmed': false,
+              'UserSub': 'test-user-sub',
+            }),
+          ),
+        );
+      });
+
+      // No WithCustomHeaders interceptor -- only the standard one.
+      final client = CognitoIdentityProviderClient(
+        region: 'us-east-1',
+        credentialsProvider: const AWSCredentialsProvider(
+          AWSCredentials('accessKeyId', 'secretAccessKey'),
+        ),
+        requestInterceptors: const [
+          WithHeader(AWSHeaders.cacheControl, 'no-store'),
+        ],
+      );
+
+      await client
+          .signUp(
+            SignUpRequest(
+              clientId: 'test-client-id',
+              username: 'testuser',
+              password: 'TestPassword123!',
+            ),
+            client: mockHttpClient,
+          )
+          .result;
+
+      expect(capturedHeaders[AWSHeaders.cacheControl], 'no-store');
+      expect(capturedHeaders['x-aws-waf-token'], isNull);
+      expect(capturedHeaders['x-custom-header'], isNull);
+    });
+  });
+}

--- a/packages/auth/amplify_auth_cognito_test/test/state/configuration_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/configuration_state_machine_test.dart
@@ -160,108 +160,103 @@ void main() {
     });
 
     group('custom headers', () {
-      test('configure succeeds with AuthPluginOptions headers callback',
-          () async {
-        stateMachine.addInstance<AuthPluginOptions>(
-          AuthPluginOptions(
-            headers: () async => {
-              'x-aws-waf-token': 'test-waf-token',
-              'x-custom-header': 'custom-value',
-            },
-          ),
-        );
+      test(
+        'configure succeeds with AuthPluginOptions headers callback',
+        () async {
+          stateMachine.addInstance<AuthPluginOptions>(
+            AuthPluginOptions(
+              headers: () async => {
+                'x-aws-waf-token': 'test-waf-token',
+                'x-custom-header': 'custom-value',
+              },
+            ),
+          );
 
-        final configurationStateMachine = stateMachine.getOrCreate(
-          ConfigurationStateMachine.type,
-        );
+          final configurationStateMachine = stateMachine.getOrCreate(
+            ConfigurationStateMachine.type,
+          );
 
-        stateMachine
-            .dispatch(ConfigurationEvent.configure(mockConfig))
-            .ignore();
-        await expectLater(
-          configurationStateMachine.stream.startWith(
-            configurationStateMachine.currentState,
-          ),
-          emitsInOrder(<Matcher>[
-            isA<NotConfigured>(),
-            isA<Configuring>(),
-            isA<Configured>(),
-          ]),
-        );
+          stateMachine
+              .dispatch(ConfigurationEvent.configure(mockConfig))
+              .ignore();
+          await expectLater(
+            configurationStateMachine.stream.startWith(
+              configurationStateMachine.currentState,
+            ),
+            emitsInOrder(<Matcher>[
+              isA<NotConfigured>(),
+              isA<Configuring>(),
+              isA<Configured>(),
+            ]),
+          );
 
-        // Verify that a CognitoIdentityProviderClient was registered.
-        expect(
-          stateMachine.get<CognitoIdentityProviderClient>(),
-          isNotNull,
-        );
+          // Verify that a CognitoIdentityProviderClient was registered.
+          expect(stateMachine.get<CognitoIdentityProviderClient>(), isNotNull);
 
-        await stateMachine.close();
-      });
+          await stateMachine.close();
+        },
+      );
 
       test(
-          'configure succeeds without AuthPluginOptions (no custom headers)',
-          () async {
-        // Do not add AuthPluginOptions -- simulates default behavior.
-        final configurationStateMachine = stateMachine.getOrCreate(
-          ConfigurationStateMachine.type,
-        );
+        'configure succeeds without AuthPluginOptions (no custom headers)',
+        () async {
+          // Do not add AuthPluginOptions -- simulates default behavior.
+          final configurationStateMachine = stateMachine.getOrCreate(
+            ConfigurationStateMachine.type,
+          );
 
-        stateMachine
-            .dispatch(ConfigurationEvent.configure(mockConfig))
-            .ignore();
-        await expectLater(
-          configurationStateMachine.stream.startWith(
-            configurationStateMachine.currentState,
-          ),
-          emitsInOrder(<Matcher>[
-            isA<NotConfigured>(),
-            isA<Configuring>(),
-            isA<Configured>(),
-          ]),
-        );
+          stateMachine
+              .dispatch(ConfigurationEvent.configure(mockConfig))
+              .ignore();
+          await expectLater(
+            configurationStateMachine.stream.startWith(
+              configurationStateMachine.currentState,
+            ),
+            emitsInOrder(<Matcher>[
+              isA<NotConfigured>(),
+              isA<Configuring>(),
+              isA<Configured>(),
+            ]),
+          );
 
-        // Verify that a CognitoIdentityProviderClient was still registered.
-        expect(
-          stateMachine.get<CognitoIdentityProviderClient>(),
-          isNotNull,
-        );
+          // Verify that a CognitoIdentityProviderClient was still registered.
+          expect(stateMachine.get<CognitoIdentityProviderClient>(), isNotNull);
 
-        await stateMachine.close();
-      });
+          await stateMachine.close();
+        },
+      );
 
       test(
-          'configure succeeds with AuthPluginOptions without headers callback',
-          () async {
-        // AuthPluginOptions with null headers (default).
-        stateMachine.addInstance<AuthPluginOptions>(
-          const AuthPluginOptions(),
-        );
+        'configure succeeds with AuthPluginOptions without headers callback',
+        () async {
+          // AuthPluginOptions with null headers (default).
+          stateMachine.addInstance<AuthPluginOptions>(
+            const AuthPluginOptions(),
+          );
 
-        final configurationStateMachine = stateMachine.getOrCreate(
-          ConfigurationStateMachine.type,
-        );
+          final configurationStateMachine = stateMachine.getOrCreate(
+            ConfigurationStateMachine.type,
+          );
 
-        stateMachine
-            .dispatch(ConfigurationEvent.configure(mockConfig))
-            .ignore();
-        await expectLater(
-          configurationStateMachine.stream.startWith(
-            configurationStateMachine.currentState,
-          ),
-          emitsInOrder(<Matcher>[
-            isA<NotConfigured>(),
-            isA<Configuring>(),
-            isA<Configured>(),
-          ]),
-        );
+          stateMachine
+              .dispatch(ConfigurationEvent.configure(mockConfig))
+              .ignore();
+          await expectLater(
+            configurationStateMachine.stream.startWith(
+              configurationStateMachine.currentState,
+            ),
+            emitsInOrder(<Matcher>[
+              isA<NotConfigured>(),
+              isA<Configuring>(),
+              isA<Configured>(),
+            ]),
+          );
 
-        expect(
-          stateMachine.get<CognitoIdentityProviderClient>(),
-          isNotNull,
-        );
+          expect(stateMachine.get<CognitoIdentityProviderClient>(), isNotNull);
 
-        await stateMachine.close();
-      });
+          await stateMachine.close();
+        },
+      );
     });
   });
 }

--- a/packages/auth/amplify_auth_cognito_test/test/state/configuration_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/configuration_state_machine_test.dart
@@ -5,7 +5,6 @@ import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoi
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart';
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
-import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/analytics_metadata_type.dart';
 import 'package:amplify_auth_cognito_dart/src/state/cognito_state_machine.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_auth_cognito_test/common/mock_config.dart';

--- a/packages/auth/amplify_auth_cognito_test/test/state/configuration_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/configuration_state_machine_test.dart
@@ -3,6 +3,8 @@
 
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_info_store_manager.dart';
 import 'package:amplify_analytics_pinpoint_dart/src/impl/analytics_client/endpoint_client/endpoint_store_keys.dart';
+import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
+import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/src/cognito_identity_provider/model/analytics_metadata_type.dart';
 import 'package:amplify_auth_cognito_dart/src/state/cognito_state_machine.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
@@ -155,6 +157,111 @@ void main() {
       );
 
       await stateMachine.close();
+    });
+
+    group('custom headers', () {
+      test('configure succeeds with AuthPluginOptions headers callback',
+          () async {
+        stateMachine.addInstance<AuthPluginOptions>(
+          AuthPluginOptions(
+            headers: () async => {
+              'x-aws-waf-token': 'test-waf-token',
+              'x-custom-header': 'custom-value',
+            },
+          ),
+        );
+
+        final configurationStateMachine = stateMachine.getOrCreate(
+          ConfigurationStateMachine.type,
+        );
+
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
+        await expectLater(
+          configurationStateMachine.stream.startWith(
+            configurationStateMachine.currentState,
+          ),
+          emitsInOrder(<Matcher>[
+            isA<NotConfigured>(),
+            isA<Configuring>(),
+            isA<Configured>(),
+          ]),
+        );
+
+        // Verify that a CognitoIdentityProviderClient was registered.
+        expect(
+          stateMachine.get<CognitoIdentityProviderClient>(),
+          isNotNull,
+        );
+
+        await stateMachine.close();
+      });
+
+      test(
+          'configure succeeds without AuthPluginOptions (no custom headers)',
+          () async {
+        // Do not add AuthPluginOptions -- simulates default behavior.
+        final configurationStateMachine = stateMachine.getOrCreate(
+          ConfigurationStateMachine.type,
+        );
+
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
+        await expectLater(
+          configurationStateMachine.stream.startWith(
+            configurationStateMachine.currentState,
+          ),
+          emitsInOrder(<Matcher>[
+            isA<NotConfigured>(),
+            isA<Configuring>(),
+            isA<Configured>(),
+          ]),
+        );
+
+        // Verify that a CognitoIdentityProviderClient was still registered.
+        expect(
+          stateMachine.get<CognitoIdentityProviderClient>(),
+          isNotNull,
+        );
+
+        await stateMachine.close();
+      });
+
+      test(
+          'configure succeeds with AuthPluginOptions without headers callback',
+          () async {
+        // AuthPluginOptions with null headers (default).
+        stateMachine.addInstance<AuthPluginOptions>(
+          const AuthPluginOptions(),
+        );
+
+        final configurationStateMachine = stateMachine.getOrCreate(
+          ConfigurationStateMachine.type,
+        );
+
+        stateMachine
+            .dispatch(ConfigurationEvent.configure(mockConfig))
+            .ignore();
+        await expectLater(
+          configurationStateMachine.stream.startWith(
+            configurationStateMachine.currentState,
+          ),
+          emitsInOrder(<Matcher>[
+            isA<NotConfigured>(),
+            isA<Configuring>(),
+            isA<Configured>(),
+          ]),
+        );
+
+        expect(
+          stateMachine.get<CognitoIdentityProviderClient>(),
+          isNotNull,
+        );
+
+        await stateMachine.close();
+      });
     });
   });
 }


### PR DESCRIPTION
### Description of changes
Add AuthPluginOptions with an async headers callback that injects custom HTTP headers (e.g. AWS WAF tokens) into all Cognito SDK requests via a WithCustomHeaders interceptor wired through the configuration state machine.

Includes @immutable/AWSDebuggable on AuthPluginOptions, unit and integration tests for the interceptor pipeline, and configuration state machine tests for the new option.

**Closes https://github.com/aws-amplify/amplify-flutter/issues/4435**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
