### PR TITLE
feat(aft): Add `--bootstrap` flag to publish command for new packages

### DIFF
--- a/packages/aft/lib/src/commands/apache_license.dart
+++ b/packages/aft/lib/src/commands/apache_license.dart
@@ -1,0 +1,197 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Full text of the Apache License, Version 2.0.
+const String apacheLicenseText = '''
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the copyright owner or its representative for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal, or
+      written communication sent to the copyright owner or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the copyright owner for the purpose of discussing
+      and improving the Work, but excluding communication that is conspicuously
+      marked or otherwise designated in writing by the copyright owner as
+      "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+''';

--- a/packages/aft/lib/src/commands/publish_command.dart
+++ b/packages/aft/lib/src/commands/publish_command.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:aft/aft.dart';
+import 'package:aft/src/commands/apache_license.dart';
 import 'package:aft/src/constraints_checker.dart';
 import 'package:aft/src/options/glob_options.dart';
 import 'package:aft/src/publish_scheduler.dart';
@@ -17,6 +18,10 @@ import 'package:path/path.dart' as p;
 mixin PublishHelpers on AmplifyCommand {
   bool get dryRun;
   bool get force;
+  bool get bootstrap;
+
+  /// Names of packages that are not yet published on pub.dev.
+  final Set<String> _newPackages = {};
 
   /// Gathers the subset of packages which are publishable and whose latest
   /// version is not already available on `pub.dev`.
@@ -86,6 +91,7 @@ mixin PublishHelpers on AmplifyCommand {
       ], (v) => v);
       if (publishedVersion == null) {
         logger.info('No published info for package ${package.name}');
+        _newPackages.add(package.name);
         return package;
       }
 
@@ -155,7 +161,11 @@ mixin PublishHelpers on AmplifyCommand {
 
   /// Publishes the package using `pub`.
   Future<void> publish(PackageInfo package) async {
-    logger.info('Publishing ${package.name}${dryRun ? ' (dry run)' : ''}...');
+    final isNew = _newPackages.contains(package.name);
+    logger.info(
+      'Publishing ${package.name}${dryRun ? ' (dry run)' : ''}'
+      '${isNew ? ' (new package)' : ''}...',
+    );
     final publishCmd = await Process.start(
       package.flavor.entrypoint,
       ['pub', 'publish', if (dryRun) '--dry-run'],
@@ -221,6 +231,14 @@ class PublishCommand extends AmplifyCommand with GlobOptions, PublishHelpers {
             'packages to be published, one per line, in the format '
             r'"${package}-v${version}".',
         negatable: false,
+      )
+      ..addFlag(
+        'bootstrap',
+        help:
+            'Bootstraps new (previously unpublished) packages by publishing '
+            'a minimal placeholder version (0.0.1-wip) to pub.dev. This '
+            'reserves the package name and allows future automated publishes.',
+        negatable: false,
       );
   }
 
@@ -231,6 +249,9 @@ class PublishCommand extends AmplifyCommand with GlobOptions, PublishHelpers {
   late final bool dryRun = argResults!['dry-run'] as bool;
 
   late final bool tags = argResults!['tags'] as bool;
+
+  @override
+  late final bool bootstrap = argResults!['bootstrap'] as bool;
 
   @override
   String get description =>
@@ -269,6 +290,27 @@ class PublishCommand extends AmplifyCommand with GlobOptions, PublishHelpers {
         stdout.writeln('New tag: ${package.name}-v$version');
       }
       return;
+    }
+
+    // If --bootstrap is set, run the bootstrap flow instead of normal publish.
+    if (bootstrap) {
+      await _runNewPackageBootstrap(packagesNeedingPublish);
+      return;
+    }
+
+    // Block publishing if any packages have never been published.
+    final newPackagesInPublish = packagesNeedingPublish
+        .where((pkg) => _newPackages.contains(pkg.name))
+        .toList();
+    if (newPackagesInPublish.isNotEmpty) {
+      logger.error(
+        'The following packages have never been published to pub.dev:\n'
+        '${newPackagesInPublish.map((pkg) => '  - ${pkg.name}').join('\n')}\n'
+        '\n'
+        'These packages must be bootstrapped locally before they can be published.\n'
+        'Run locally: aft publish --bootstrap',
+      );
+      exit(1);
     }
 
     stdout
@@ -315,6 +357,186 @@ class PublishCommand extends AmplifyCommand with GlobOptions, PublishHelpers {
           ? 'All packages passed pre-publish checks'
           : 'All packages were successfully published',
     );
+  }
+
+  /// Bootstraps new packages by publishing minimal placeholder versions to
+  /// pub.dev, reserving the package names for future automated publishes.
+  Future<void> _runNewPackageBootstrap(List<PackageInfo> packagesNeedingPublish) async {
+    final newPackages = packagesNeedingPublish
+        .where((pkg) => _newPackages.contains(pkg.name))
+        .toList();
+
+    if (newPackages.isEmpty) {
+      logger.info(
+        'No new packages to bootstrap. All packages already exist on pub.dev.',
+      );
+      return;
+    }
+
+    stdout.writeln(
+      'Bootstrapping ${newPackages.length} new '
+      'package${newPackages.length == 1 ? '' : 's'}'
+      '${dryRun ? ' (dry run)' : ''}:\n'
+      '${newPackages.map((pkg) => '  - ${pkg.name}').join('\n')}',
+    );
+
+    final tmpBase = Directory.systemTemp.createTempSync('aft_bootstrap_');
+
+    try {
+      for (final package in newPackages) {
+        await _createBootstrapPackage(package, tmpBase);
+      }
+    } finally {
+      if (tmpBase.existsSync()) {
+        tmpBase.deleteSync(recursive: true);
+        logger.debug('Cleaned up temp directory: ${tmpBase.path}');
+      }
+    }
+
+    if (dryRun) {
+      stdout.writeln('\nDry run complete. No packages were published.');
+    } else {
+      stdout.writeln('\nAll new packages bootstrapped successfully.');
+    }
+  }
+
+  /// Scaffolds a minimal placeholder package in a temp directory using
+  /// `dart create`, then overwrites the pubspec/README/LICENSE and publishes
+  /// it (or shows what would be published if [dryRun] is set).
+  Future<void> _createBootstrapPackage(
+    PackageInfo package,
+    Directory tmpBase,
+  ) async {
+    final pubspec = package.pubspecInfo.pubspec;
+    final pkgName = package.name;
+
+    // Scaffold with `dart create -t package`
+    logger.debug('Scaffolding $pkgName with dart create...');
+    final createResult = await Process.run(
+      'dart',
+      ['create', '-t', 'package', pkgName],
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
+      workingDirectory: tmpBase.path,
+    );
+    if (createResult.exitCode != 0) {
+      logger
+        ..error('Failed to scaffold $pkgName:')
+        ..error(createResult.stderr as String);
+      exit(createResult.exitCode);
+    }
+
+    final pkgDir = Directory(p.join(tmpBase.path, pkgName));
+    const description = 'Initial package for setting up CI/CD deployments.';
+    final sdkConstraint =
+        pubspec.environment['sdk']?.toString() ?? '>=3.0.0 <4.0.0';
+
+    // `dart create -t package` scaffolds example/ and test/ directories that
+    // aren't needed for a bootstrap placeholder — remove them.
+    final exampleDir = Directory(p.join(pkgDir.path, 'example'));
+    if (exampleDir.existsSync()) exampleDir.deleteSync(recursive: true);
+    final testDir = Directory(p.join(pkgDir.path, 'test'));
+    if (testDir.existsSync()) testDir.deleteSync(recursive: true);
+
+    // Overwrite pubspec.yaml
+    final pubspecYaml = StringBuffer()
+      ..writeln('name: $pkgName')
+      ..writeln('version: 0.0.1-wip')
+      ..writeln('description: $description');
+    if (pubspec.repository != null) {
+      pubspecYaml.writeln('repository: ${pubspec.repository}');
+    } else if (pubspec.homepage != null) {
+      pubspecYaml.writeln('homepage: ${pubspec.homepage}');
+    }
+    pubspecYaml
+      ..writeln('environment:')
+      ..writeln("  sdk: '$sdkConstraint'");
+    File(p.join(pkgDir.path, 'pubspec.yaml'))
+        .writeAsStringSync(pubspecYaml.toString());
+
+    // Overwrite README.md
+    File(p.join(pkgDir.path, 'README.md')).writeAsStringSync(
+      '# $pkgName\n'
+      '\n'
+      'This is for setting up automated deployments '
+      'of this package.\n',
+    );
+
+    // Overwrite CHANGELOG.md
+    File(p.join(pkgDir.path, 'CHANGELOG.md')).writeAsStringSync(
+      '## 0.0.1-wip\n'
+      '\n'
+      '- Initial package for setting up CI/CD deployments.\n',
+    );
+
+    // Write Apache 2.0 license
+    File(p.join(pkgDir.path, 'LICENSE')).writeAsStringSync(apacheLicenseText);
+
+    final adminUrl = 'https://pub.dev/packages/$pkgName/admin';
+    final repoInfo = pubspec.repository?.toString() ??
+        pubspec.homepage?.toString();
+
+    if (dryRun) {
+      stdout
+        ..writeln('\n--- Bootstrap dry run: $pkgName ---')
+        ..writeln('Temp directory: ${pkgDir.path}');
+      _printNextSteps(pkgName, adminUrl: adminUrl, repoInfo: repoInfo);
+      return;
+    }
+
+    // Run dart pub publish --force in the temp directory
+    logger.info('Publishing $pkgName v0.0.1-wip...');
+    final publishResult = await Process.run(
+      'dart',
+      ['pub', 'publish', '--force'],
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
+      workingDirectory: pkgDir.path,
+    );
+    if (verbose) {
+      stdout.write(publishResult.stdout);
+      stderr.write(publishResult.stderr);
+    }
+    if (publishResult.exitCode != 0) {
+      logger
+        ..error('Failed to bootstrap $pkgName:')
+        ..error(publishResult.stdout as String)
+        ..error(publishResult.stderr as String);
+      exit(publishResult.exitCode);
+    }
+
+    stdout.writeln('\n\u2705 Published $pkgName v0.0.1-wip to pub.dev');
+    _printNextSteps(pkgName, adminUrl: adminUrl, repoInfo: repoInfo);
+  }
+
+  void _printNextSteps(
+    String pkgName, {
+    required String adminUrl,
+    required String? repoInfo,
+  }) {
+    stdout
+      ..writeln('')
+      ..writeln('Next steps for $pkgName:')
+      ..writeln('  1. Transfer to your verified publisher:')
+      ..writeln('     $adminUrl')
+      ..writeln(
+        '     \u2192 Under "Publisher", click "Transfer to a verified '
+        'publisher"',
+      )
+      ..writeln('  2. Enable automated publishing:')
+      ..writeln(
+        '     \u2192 Under "Automated publishing", enable publishing '
+        'from GitHub Actions',
+      );
+    if (repoInfo != null) {
+      stdout.writeln('     \u2192 Set the repository to: $repoInfo');
+    }
+    stdout
+      ..writeln('     \u2192 Set the tag pattern to: $pkgName-v{{version}}')
+      ..writeln(
+        '  3. Once configured, CI can publish future versions '
+        'automatically via OIDC.',
+      );
   }
 }
 

--- a/packages/aft/lib/src/commands/serve_command.dart
+++ b/packages/aft/lib/src/commands/serve_command.dart
@@ -31,6 +31,9 @@ class ServeCommand extends AmplifyCommand with GlobOptions, PublishHelpers {
   bool get dryRun => false;
 
   @override
+  bool get bootstrap => false;
+
+  @override
   String get description =>
       'Serves all packages in the Amplify Flutter repo '
       'on a local pub server.';


### PR DESCRIPTION
When we want to publish with CI/CD, the package needs to exist on pub.dev and we manually need to set the publisher and the git repo (or OIDC). This feature enables us to publish a bootstrap version by running it locally. Afterwards, we can set up everything and run the actual release with CI/CD.