### PR TITLE
chore(deps): Upgrade`package_info_plus`, `win32`, `win32_registry` and `device_info_plus`

### DIFF
--- a/.github/composite_actions/install_dependencies/action.yaml
+++ b/.github/composite_actions/install_dependencies/action.yaml
@@ -21,8 +21,12 @@ runs:
     #  Install aft from path, links packages and runs build runner where needed.
     - name: Partial aft bootstrap
       shell: bash
+      # `--force-jit` on the build_runner invocation works around a Dart 3.10.x
+      # regression (AOT compile fails when native-assets build hooks are in the
+      # package graph). Fixed in Dart 3.11+; see
+      # https://github.com/dart-lang/build/issues/4343.
       run: |
         git submodule update --init
         dart pub global activate -spath packages/aft
         dart pub global run aft link
-        dart pub global run aft exec --include="amplify_secure_storage_dart,amplify_auth_cognito_dart" -- dart run build_runner build --delete-conflicting-outputs
+        dart pub global run aft exec --include="amplify_secure_storage_dart,amplify_auth_cognito_dart" -- dart run build_runner build --force-jit --delete-conflicting-outputs

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Dart
         uses: dart-lang/setup-dart@03a180dbe1de8ea7fb700663cbb7d24ca4bbe82c # main
         with:
-          sdk: 3.9.0
+          sdk: 3.10.0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # 4.4.0
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Dart
         uses: dart-lang/setup-dart@03a180dbe1de8ea7fb700663cbb7d24ca4bbe82c # main
         with:
-          sdk: 3.9.0
+          sdk: 3.10.0
 
       - name: Setup aft
         shell: bash # Run in bash regardless of platform

--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -31,7 +31,7 @@ jobs:
           - "any" # latest
         include:
           - channel: "stable"
-            flutter-version: "3.35.0"
+            flutter-version: "3.38.1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
@@ -87,7 +87,7 @@ jobs:
           - "any" # latest
         include:
           - channel: "stable"
-            flutter-version: "3.35.0"
+            flutter-version: "3.38.1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
@@ -162,7 +162,7 @@ jobs:
           - "any" # latest
         include:
           - channel: "stable"
-            flutter-version: "3.35.0"
+            flutter-version: "3.38.1"
         ios-version:
           - "15.0"
           - "17.5"

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         sdk:
           # Minimum supported Dart version
-          - "3.9.0"
+          - "3.10.0"
           - stable
           - beta
         browser:

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -81,5 +81,9 @@ jobs:
 
       - name: Run Tests
         if: "always() && steps.bootstrap.conclusion == 'success'"
-        run: dart run build_runner build test --release --delete-conflicting-outputs && dart test -p ${{ matrix.browser }}
+        # `--force-jit` works around a Dart 3.10.x regression where AOT
+        # compilation of the build_runner entrypoint fails on package graphs
+        # containing native-assets build hooks. Fixed in Dart 3.11+; see
+        # https://github.com/dart-lang/build/issues/4343.
+        run: dart run build_runner build test --force-jit --release --delete-conflicting-outputs && dart test -p ${{ matrix.browser }}
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         sdk:
           # Minimum supported Dart version
-          - "3.9.0"
+          - "3.10.0"
           - stable
           - beta
         browser:

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -81,7 +81,11 @@ jobs:
 
       - name: Run Tests
         if: "always() && steps.bootstrap.conclusion == 'success'"
-        run: dart run build_runner build test --delete-conflicting-outputs && dart test -p ${{ matrix.browser }}
+        # `--force-jit` works around a Dart 3.10.x regression where AOT
+        # compilation of the build_runner entrypoint fails on package graphs
+        # containing native-assets build hooks. Fixed in Dart 3.11+; see
+        # https://github.com/dart-lang/build/issues/4343.
+        run: dart run build_runner build test --force-jit --delete-conflicting-outputs && dart test -p ${{ matrix.browser }}
         working-directory: ${{ inputs.working-directory }}
 
       - name: Log success/failure

--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         sdk:
           # Minimum supported Dart version
-          - "3.9.0"
+          - "3.10.0"
           - stable
           - beta
         # Skips 'beta' tests on PRs

--- a/.github/workflows/e2e_windows.yaml
+++ b/.github/workflows/e2e_windows.yaml
@@ -62,10 +62,15 @@ jobs:
       - name: Enable running PowerShell scripts
         run: Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
+      - name: Enable Windows desktop
+        run: flutter config --enable-windows-desktop
+
+      - name: Build Windows app (runs native-assets build hooks to download win32 DLL)
+        run: dart pub global run aft exec --include=${{ inputs.package-name }} -- flutter build windows --debug
+
       - name: Run integration tests
         timeout-minutes: 320
         run: |
-          flutter config --enable-windows-desktop
           ${{ github.workspace }}/build-support/windows_timeout_attempts.ps1 5 60 "dart pub global run aft exec --include=${{ inputs.package-name }} -- flutter test integration_test/main_test.dart -d windows"
 
       - name: Log success/failure

--- a/.github/workflows/e2e_windows.yaml
+++ b/.github/workflows/e2e_windows.yaml
@@ -62,15 +62,10 @@ jobs:
       - name: Enable running PowerShell scripts
         run: Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
-      - name: Enable Windows desktop
-        run: flutter config --enable-windows-desktop
-
-      - name: Build Windows app (runs native-assets build hooks to download win32 DLL)
-        run: dart pub global run aft exec --include=${{ inputs.package-name }} -- flutter build windows --debug
-
       - name: Run integration tests
         timeout-minutes: 320
         run: |
+          flutter config --enable-windows-desktop
           ${{ github.workspace }}/build-support/windows_timeout_attempts.ps1 5 60 "dart pub global run aft exec --include=${{ inputs.package-name }} -- flutter test integration_test/main_test.dart -d windows"
 
       - name: Log success/failure

--- a/.github/workflows/flutter_vm.yaml
+++ b/.github/workflows/flutter_vm.yaml
@@ -30,7 +30,7 @@ jobs:
           - "any" # latest
         include:
           - channel: "stable"
-            flutter-version: "3.35.0"
+            flutter-version: "3.38.1"
         # Skips 'beta' tests on PRs
         exclude:
           - channel: ${{ (github.event_name == 'pull_request') && 'beta' || 'NONE' }}

--- a/actions/pubspec.yaml
+++ b/actions/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   aws_common: ^0.6.1

--- a/canaries/pubspec.yaml
+++ b/canaries/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: none
 version: 1.0.0+0
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_analytics_pinpoint: ^2.0.0

--- a/infra-gen2/pubspec.yaml
+++ b/infra-gen2/pubspec.yaml
@@ -2,7 +2,7 @@ name: infra_gen2
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_core: any

--- a/infra/pubspec.yaml
+++ b/infra/pubspec.yaml
@@ -2,7 +2,7 @@ name: infra
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_core: any

--- a/packages/aft/lib/src/commands/generate/generate_goldens_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_goldens_command.dart
@@ -293,10 +293,15 @@ override_platforms:
     }
 
     // Run built_value generator
+    // `--force-jit` avoids a Dart 3.10.x regression where AOT compilation of
+    // the build_runner entrypoint fails when the package graph contains
+    // native-assets build hooks. Fixed in Dart 3.11+; see
+    // https://github.com/dart-lang/build/issues/4343.
     final buildRunnerCmd = await Process.start('dart', [
       'run',
       'build_runner',
       'build',
+      '--force-jit',
       '--delete-conflicting-outputs',
     ], workingDirectory: outputPath);
     buildRunnerCmd.stdout

--- a/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_sdk_command.dart
@@ -251,9 +251,18 @@ class GenerateSdkCommand extends AmplifyCommand with GlobOptions {
 
     // Run built_value generator
     logger.info('Running build_runner...');
+    // `--force-jit`: see https://github.com/dart-lang/build/issues/4343
+    // AOT compile fails on Dart 3.10.x when native-assets build hooks are
+    // present in the package graph. Fixed in Dart 3.11+.
     final buildRunnerCmd = await Process.start(
       'dart',
-      ['run', 'build_runner', 'build', '--delete-conflicting-outputs'],
+      [
+        'run',
+        'build_runner',
+        'build',
+        '--force-jit',
+        '--delete-conflicting-outputs',
+      ],
       mode: verbose ? ProcessStartMode.inheritStdio : ProcessStartMode.normal,
       workingDirectory: package.path,
     );

--- a/packages/aft/lib/src/commands/publish_command.dart
+++ b/packages/aft/lib/src/commands/publish_command.dart
@@ -361,7 +361,9 @@ class PublishCommand extends AmplifyCommand with GlobOptions, PublishHelpers {
 
   /// Bootstraps new packages by publishing minimal placeholder versions to
   /// pub.dev, reserving the package names for future automated publishes.
-  Future<void> _runNewPackageBootstrap(List<PackageInfo> packagesNeedingPublish) async {
+  Future<void> _runNewPackageBootstrap(
+    List<PackageInfo> packagesNeedingPublish,
+  ) async {
     final newPackages = packagesNeedingPublish
         .where((pkg) => _newPackages.contains(pkg.name))
         .toList();
@@ -451,8 +453,9 @@ class PublishCommand extends AmplifyCommand with GlobOptions, PublishHelpers {
     pubspecYaml
       ..writeln('environment:')
       ..writeln("  sdk: '$sdkConstraint'");
-    File(p.join(pkgDir.path, 'pubspec.yaml'))
-        .writeAsStringSync(pubspecYaml.toString());
+    File(
+      p.join(pkgDir.path, 'pubspec.yaml'),
+    ).writeAsStringSync(pubspecYaml.toString());
 
     // Overwrite README.md
     File(p.join(pkgDir.path, 'README.md')).writeAsStringSync(
@@ -473,8 +476,8 @@ class PublishCommand extends AmplifyCommand with GlobOptions, PublishHelpers {
     File(p.join(pkgDir.path, 'LICENSE')).writeAsStringSync(apacheLicenseText);
 
     final adminUrl = 'https://pub.dev/packages/$pkgName/admin';
-    final repoInfo = pubspec.repository?.toString() ??
-        pubspec.homepage?.toString();
+    final repoInfo =
+        pubspec.repository?.toString() ?? pubspec.homepage?.toString();
 
     if (dryRun) {
       stdout
@@ -553,6 +556,12 @@ Future<void> runBuildRunner(
   // Run `pub get` to ensure `build_runner` is available.
   await runPub(package.flavor, ['get'], package, verbose: verbose);
   logger.debug('Running build_runner for ${package.name}...');
+  // Force JIT compilation to avoid a regression in Dart 3.10.x where
+  // `dart compile exe` (used by `build_runner`'s default AOT path) fails when
+  // the package graph contains native-assets build hooks (e.g. from `win32`,
+  // `sqlite3`). See https://github.com/dart-lang/build/issues/4343 and
+  // https://github.com/dart-lang/sdk/issues/62593. The fix ships in Dart 3.11+;
+  // forcing JIT keeps bootstrap working on the minimum supported SDK (3.10.0).
   final buildRunnerCmd = await Process.start(
     package.flavor.entrypoint,
     [
@@ -560,6 +569,7 @@ Future<void> runBuildRunner(
       'run',
       'build_runner',
       'build',
+      '--force-jit',
       '--delete-conflicting-outputs',
     ],
     runInShell: true,

--- a/packages/aft/pubspec.yaml
+++ b/packages/aft/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.2
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   args: ^2.5.0

--- a/packages/amplify/amplify_flutter/example/linux/CMakeLists.txt
+++ b/packages/amplify/amplify_flutter/example/linux/CMakeLists.txt
@@ -122,6 +122,12 @@ foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
     COMPONENT Runtime)
 endforeach(bundled_library)
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/amplify/amplify_flutter/example/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the Amplify Flutter client libraries.
 publish_to: none
 
 environment:
-  flutter: ">=3.35.0"
-  sdk: ^3.9.0
+  flutter: ">=3.38.1"
+  sdk: ^3.10.0
 
 dependencies:
   amplify_analytics_pinpoint: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/amplify/amplify_flutter/example/windows/CMakeLists.txt
+++ b/packages/amplify/amplify_flutter/example/windows/CMakeLists.txt
@@ -86,6 +86,12 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     COMPONENT Runtime)
 endif()
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/amplify_core/doc/pubspec.yaml
+++ b/packages/amplify_core/doc/pubspec.yaml
@@ -7,8 +7,8 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_analytics_pinpoint: any

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   async: ^2.10.0

--- a/packages/amplify_datastore/example/pubspec.yaml
+++ b/packages/amplify_datastore/example/pubspec.yaml
@@ -6,8 +6,8 @@ description: Demonstrates how to use the amplify_datastore plugin.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   flutter:

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   flutter:

--- a/packages/amplify_datastore_plugin_interface/pubspec.yaml
+++ b/packages/amplify_datastore_plugin_interface/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_core: ">=2.11.0 <2.12.0"

--- a/packages/amplify_foundation/amplify_foundation_dart/pubspec.yaml
+++ b/packages/amplify_foundation/amplify_foundation_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   json_annotation: ^4.9.0

--- a/packages/amplify_foundation/amplify_foundation_dart_bridge/pubspec.yaml
+++ b/packages/amplify_foundation/amplify_foundation_dart_bridge/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_foundation_dart: ">=2.11.0 <2.12.0"

--- a/packages/amplify_lints/pubspec.yaml
+++ b/packages/amplify_lints/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   flutter_lints: ^6.0.0

--- a/packages/amplify_native_legacy_wrapper/example/pubspec.yaml
+++ b/packages/amplify_native_legacy_wrapper/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0
 publish_to: "none"
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_native_legacy_wrapper: ^0.1.0

--- a/packages/amplify_native_legacy_wrapper/pubspec.yaml
+++ b/packages/amplify_native_legacy_wrapper/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   flutter:

--- a/packages/analytics/amplify_analytics_pinpoint/example/linux/CMakeLists.txt
+++ b/packages/analytics/amplify_analytics_pinpoint/example/linux/CMakeLists.txt
@@ -122,6 +122,12 @@ foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
     COMPONENT Runtime)
 endforeach(bundled_library)
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
@@ -7,8 +7,8 @@ version: 0.1.0
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_analytics_pinpoint: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/analytics/amplify_analytics_pinpoint/example/windows/CMakeLists.txt
+++ b/packages/analytics/amplify_analytics_pinpoint/example/windows/CMakeLists.txt
@@ -86,6 +86,12 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     COMPONENT Runtime)
 endif()
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.16.0
-  package_info_plus: ^9.0.0
+  package_info_plus: ^10.1.0
   path_provider: ^2.0.11
 
 dev_dependencies:

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/an
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   amplify_db_common: ">=0.4.17 <0.5.0"
   amplify_secure_storage: ">=0.5.17 <0.6.0"
   aws_common: ">=0.7.12 <0.8.0"
-  device_info_plus: ^12.0.0
+  device_info_plus: ^13.1.0
 
   flutter:
     sdk: flutter

--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/an
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_core: ">=2.11.0 <2.12.0"

--- a/packages/api/amplify_api/example/linux/CMakeLists.txt
+++ b/packages/api/amplify_api/example/linux/CMakeLists.txt
@@ -122,6 +122,12 @@ foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
     COMPONENT Runtime)
 endforeach(bundled_library)
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/api/amplify_api/example/pubspec.yaml
+++ b/packages/api/amplify_api/example/pubspec.yaml
@@ -6,8 +6,8 @@ description: Demonstrates how to use the amplify_api plugin.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/api/amplify_api/example/windows/CMakeLists.txt
+++ b/packages/api/amplify_api/example/windows/CMakeLists.txt
@@ -86,6 +86,12 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     COMPONENT Runtime)
 endif()
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/ap
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/api/amplify_api_dart/pubspec.yaml
+++ b/packages/api/amplify_api_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/ap
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_core: ">=2.11.0 <2.12.0"

--- a/packages/auth/amplify_auth_cognito/example/linux/CMakeLists.txt
+++ b/packages/auth/amplify_auth_cognito/example/linux/CMakeLists.txt
@@ -122,6 +122,12 @@ foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
     COMPONENT Runtime)
 endforeach(bundled_library)
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/auth/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_api: any

--- a/packages/auth/amplify_auth_cognito/example/windows/CMakeLists.txt
+++ b/packages/auth/amplify_auth_cognito/example/windows/CMakeLists.txt
@@ -86,6 +86,12 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     COMPONENT Runtime)
 endif()
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/au
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_auth_cognito_dart: any

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_device_info_collector.windows.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_device_info_collector.windows.dart
@@ -29,8 +29,8 @@ final class ASFDeviceInfoWindows extends ASFDeviceInfoPlatform {
   /// {@macro amplify_auth_cognito_dart.asf.asf_device_info_windows}
   ASFDeviceInfoWindows() : super.base();
 
-  WindowsException get _lastException =>
-      WindowsException(HRESULT_FROM_WIN32(GetLastError()));
+  WindowsException _exceptionFor(WIN32_ERROR error) =>
+      WindowsException(error.toHRESULT());
 
   /// Retrieves the package information.
   /// Adapted from:
@@ -38,29 +38,39 @@ final class ASFDeviceInfoWindows extends ASFDeviceInfoPlatform {
   /// - https://github.com/dart-windows/win32/blob/5f305167bfe181abbc663a7f7f2a0787910fac21/example/filever.dart#L22
   /// - https://learn.microsoft.com/en-us/windows/win32/api/winver/nf-winver-verqueryvaluea
   late final PackageInfo? _packageInfo = using((arena) {
-    final lptstrFilename = wsalloc(MAX_PATH);
-    arena.onReleaseAll(() => free(lptstrFilename));
-    if (FAILED(GetModuleFileName(0, lptstrFilename, MAX_PATH))) {
-      logger.error('Could not retrieve filename', _lastException);
+    final lptstrFilename = wsalloc(MAX_PATH, arena);
+    final fileNameResult = GetModuleFileName(null, lptstrFilename, MAX_PATH);
+    if (fileNameResult.value == 0) {
+      logger.error(
+        'Could not retrieve filename',
+        _exceptionFor(fileNameResult.error),
+      );
       return null;
     }
-    final verSize = GetFileVersionInfoSize(lptstrFilename, nullptr);
+    final filenamePcwstr = PCWSTR(lptstrFilename);
+    final verSizeResult = GetFileVersionInfoSize(filenamePcwstr, null);
+    final verSize = verSizeResult.value;
     if (verSize == 0) {
-      logger.error('Could not retrieve file info size', _lastException);
+      logger.error(
+        'Could not retrieve file info size',
+        _exceptionFor(verSizeResult.error),
+      );
       return null;
     }
     final verData = arena<BYTE>(verSize);
-    if (FAILED(GetFileVersionInfo(lptstrFilename, NULL, verSize, verData))) {
-      logger.error('Could not retrieve file info', _lastException);
+    final verInfoResult = GetFileVersionInfo(filenamePcwstr, verSize, verData);
+    if (!verInfoResult.value) {
+      logger.error(
+        'Could not retrieve file info',
+        _exceptionFor(verInfoResult.error),
+      );
       return null;
     }
 
     final fileInfoPtr = arena<Pointer<VS_FIXEDFILEINFO>>();
     final lenFileInfo = arena<UINT>();
-    final lpSubBlock = TEXT(r'\');
-    arena.onReleaseAll(() => free(lpSubBlock));
-    if (FAILED(VerQueryValue(verData, lpSubBlock, fileInfoPtr, lenFileInfo))) {
-      logger.error('Could not query file info', _lastException);
+    if (!VerQueryValue(verData, arena.pcwstr(r'\'), fileInfoPtr, lenFileInfo)) {
+      logger.error('Could not query file info');
       return null;
     }
 
@@ -74,12 +84,14 @@ final class ASFDeviceInfoWindows extends ASFDeviceInfoPlatform {
 
     final lpTranslate = arena<Pointer<_LANGANDCODEPAGE>>();
     final lenTranslate = arena<UINT>();
-    final lpTranslateSubBlock = TEXT(r'\VarFileInfo\Translation');
-    arena.onReleaseAll(() => free(lpTranslateSubBlock));
-    if (FAILED(
-      VerQueryValue(verData, lpTranslateSubBlock, lpTranslate, lenTranslate),
+    final lpTranslateSubBlock = arena.pcwstr(r'\VarFileInfo\Translation');
+    if (!VerQueryValue(
+      verData,
+      lpTranslateSubBlock,
+      lpTranslate,
+      lenTranslate,
     )) {
-      logger.error('Could not retrieve translation info', _lastException);
+      logger.error('Could not retrieve translation info');
     }
 
     String toHex(int value) => value.toRadixString(16).padLeft(4, '0');
@@ -88,20 +100,17 @@ final class ASFDeviceInfoWindows extends ASFDeviceInfoPlatform {
       final langCodepageArr = lpTranslate.value;
       final n = lenTranslate.value / sizeOf<_LANGANDCODEPAGE>();
       final langCodepages = [
-        // TODO(equartey): `.elementAt(i)` is depreciated in Dart 3.3.0. Use `(langCodepageArr + i).ref` when min Dart version is 3.3.0 or higher
-        // ignore: deprecated_member_use
-        for (var i = 0; i < n; i++) langCodepageArr.elementAt(i).ref,
+        for (var i = 0; i < n; i++) (langCodepageArr + i).ref,
       ];
       for (final _LANGANDCODEPAGE(:wLanguage, :wCodepage) in langCodepages) {
         final lpBuffer = arena<LPWSTR>();
         final puLen = arena<UINT>();
         final lang = toHex(wLanguage);
         final codepage = toHex(wCodepage);
-        final lpSubBlock = TEXT('\\StringFileInfo\\$lang$codepage\\$name');
-        arena.onReleaseAll(() => free(lpSubBlock));
-        if (SUCCEEDED(
-          VerQueryValue(lpTranslateSubBlock, lpSubBlock, lpBuffer, puLen),
-        )) {
+        final lpSubBlock = arena.pcwstr(
+          '\\StringFileInfo\\$lang$codepage\\$name',
+        );
+        if (VerQueryValue(lpTranslateSubBlock, lpSubBlock, lpBuffer, puLen)) {
           if (lpBuffer != nullptr && puLen.value > 0) {
             return lpBuffer.value.toDartString(length: puLen.value);
           }
@@ -134,32 +143,28 @@ final class ASFDeviceInfoWindows extends ASFDeviceInfoPlatform {
   // https://github.com/fluttercommunity/plus_plugins/blob/e8d3b445ce52012456126a3844ddb49b92c5c850/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
 
   late final _WindowsDeviceInfo _systemInfo = using((arena) {
-    // TODO(dnys1): Use better mechanism for determining OS version.
-    // See:
-    // - https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexw
-    // - https://github.com/dart-windows/win32/blob/5f305167bfe181abbc663a7f7f2a0787910fac21/example/manifest/README.md
+    // See: https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-rtlgetversion
     var osVersion = 'Windows';
     final osVersionInfo = arena<OSVERSIONINFO>()
       ..ref.dwOSVersionInfoSize = sizeOf<OSVERSIONINFO>();
-    if (SUCCEEDED(GetVersionEx(osVersionInfo))) {
+    final status = RtlGetVersion(osVersionInfo);
+    if (status.isOk) {
       final OSVERSIONINFO(:dwMajorVersion, :dwMinorVersion, :dwBuildNumber) =
           osVersionInfo.ref;
       osVersion += '/$dwMajorVersion.$dwMinorVersion.$dwBuildNumber';
     } else {
-      logger.error('Error retrieving OS version', _lastException);
+      logger.error('Error retrieving OS version: $status');
     }
-    if (IsWindows10OrGreater() == TRUE) {
+    if (IsWindows10OrGreater()) {
       osVersion += '/10+';
     }
-    if (IsWindowsServer() == TRUE) {
+    if (IsWindowsServer()) {
       osVersion += '/Server';
     }
     // See: https://stackoverflow.com/a/65912938
-    final sqmClientKey = Registry.openPath(
-      RegistryHive.localMachine,
-      path: r'SOFTWARE\Microsoft\SQMClient',
-    );
-    final deviceId = sqmClientKey.getStringValue('MachineId');
+    final sqmClientKey = LOCAL_MACHINE.open(r'SOFTWARE\Microsoft\SQMClient');
+    final deviceId = sqmClientKey.getString('MachineId');
+    sqmClientKey.close();
     return (osVersion: osVersion, deviceId: deviceId);
   });
 
@@ -170,12 +175,16 @@ final class ASFDeviceInfoWindows extends ASFDeviceInfoPlatform {
   late final Future<String?> deviceLanguage = using((arena) async {
     // From: https://learn.microsoft.com/en-us/windows/win32/intl/locale-name-constants
     const LOCALE_NAME_MAX_LENGTH = 85;
-    final lpLocaleName = wsalloc(LOCALE_NAME_MAX_LENGTH);
-    arena.onReleaseAll(() => free(lpLocaleName));
-    if (FAILED(
-      GetUserDefaultLocaleName(lpLocaleName, LOCALE_NAME_MAX_LENGTH),
-    )) {
-      logger.error('Could not retrieve device language', _lastException);
+    final lpLocaleName = wsalloc(LOCALE_NAME_MAX_LENGTH, arena);
+    final result = GetUserDefaultLocaleName(
+      lpLocaleName,
+      LOCALE_NAME_MAX_LENGTH,
+    );
+    if (result.value == 0) {
+      logger.error(
+        'Could not retrieve device language',
+        _exceptionFor(result.error),
+      );
       return null;
     }
     return lpLocaleName.toDartString();
@@ -185,25 +194,23 @@ final class ASFDeviceInfoWindows extends ASFDeviceInfoPlatform {
   late final Future<String?> deviceName = using((arena) async {
     // Retrieves the computer's name using `GetComputerName`:
     // https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getcomputernamew
-    final lpBuffer = arena<Uint16>(256).cast<Utf16>();
+    final lpBuffer = wsalloc(256, arena);
     final nSize = arena<DWORD>()..value = 256;
-    if (FAILED(GetComputerName(lpBuffer, nSize))) {
-      logger.error('Could not retrieve computer name', _lastException);
+    final result = GetComputerName(lpBuffer, nSize);
+    if (!result.value) {
+      logger.error(
+        'Could not retrieve computer name',
+        _exceptionFor(result.error),
+      );
       return null;
     }
     return lpBuffer.toDartString(length: nSize.value);
   });
 
   @override
-  // TODO(Jordan-Nelson): Use new enums when min win32 version is v5.4.0 or
-  // higher
-  // ignore: deprecated_member_use
   Future<int?> get screenHeightPixels async => GetSystemMetrics(SM_CYSCREEN);
 
   @override
-  // TODO(Jordan-Nelson): Use new enums when min win32 version is v5.4.0 or
-  // higher
-  // ignore: deprecated_member_use
   Future<int?> get screenWidthPixels async => GetSystemMetrics(SM_CXSCREEN);
 
   @override

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/au
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_analytics_pinpoint_dart: ">=0.4.13 <0.5.0"

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -34,8 +34,8 @@ dependencies:
   stream_transform: ^2.1.0
   uuid: ^4.5.1
   web: ^1.1.1
-  win32: ^5.14.0
-  win32_registry: ^2.1.0
+  win32: ^6.1.0
+  win32_registry: ^3.0.3
   worker_bee: ">=0.3.9 <0.4.0"
 
 dev_dependencies:

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   stream_transform: ^2.1.0
   uuid: ^4.5.1
   web: ^1.1.1
-  win32: ^6.1.0
+  win32: ^6.0.1
   win32_registry: ^3.0.3
   worker_bee: ">=0.3.9 <0.4.0"
 

--- a/packages/auth/amplify_auth_cognito_test/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_test/pubspec.yaml
@@ -3,7 +3,7 @@ description: Tests for the amplify_auth_cognito_dart package.
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_analytics_pinpoint_dart: any

--- a/packages/authenticator/amplify_authenticator/example/linux/CMakeLists.txt
+++ b/packages/authenticator/amplify_authenticator/example/linux/CMakeLists.txt
@@ -122,6 +122,12 @@ foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
     COMPONENT Runtime)
 endforeach(bundled_library)
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/authenticator/amplify_authenticator/example/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/example/pubspec.yaml
@@ -18,8 +18,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/authenticator/amplify_authenticator/example/windows/CMakeLists.txt
+++ b/packages/authenticator/amplify_authenticator/example/windows/CMakeLists.txt
@@ -86,6 +86,12 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     COMPONENT Runtime)
 endif()
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/au
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_auth_cognito: ">=2.11.0 <2.12.0"

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   intl: ^0.20.2
   meta: ^1.16.0
   # TODO(equartey): Remove this once we have our own method of getting the app name
-  package_info_plus: ^9.0.0
+  package_info_plus: ^10.1.0
   qr_flutter: 4.1.0
   smithy: ">=0.7.10 <0.8.0"
   stream_transform: ^2.1.0

--- a/packages/authenticator/amplify_authenticator_test/example/linux/CMakeLists.txt
+++ b/packages/authenticator/amplify_authenticator_test/example/linux/CMakeLists.txt
@@ -123,6 +123,12 @@ foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
     COMPONENT Runtime)
 endforeach(bundled_library)
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/authenticator/amplify_authenticator_test/example/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator_test/example/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: "none"
 version: 0.1.0
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_authenticator: any

--- a/packages/authenticator/amplify_authenticator_test/example/windows/CMakeLists.txt
+++ b/packages/authenticator/amplify_authenticator_test/example/windows/CMakeLists.txt
@@ -87,6 +87,12 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     COMPONENT Runtime)
 endif()
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/authenticator/amplify_authenticator_test/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator_test/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_authenticator: any

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/aw
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   async: ^2.10.0

--- a/packages/aws_signature_v4/example/pubspec.yaml
+++ b/packages/aws_signature_v4/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: example
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   args: ^2.5.0

--- a/packages/aws_signature_v4/pubspec.yaml
+++ b/packages/aws_signature_v4/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/aw
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   async: ^2.10.0

--- a/packages/common/amplify_db_common/example/linux/CMakeLists.txt
+++ b/packages/common/amplify_db_common/example/linux/CMakeLists.txt
@@ -122,6 +122,12 @@ foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
     COMPONENT Runtime)
 endforeach(bundled_library)
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/common/amplify_db_common/example/pubspec.yaml
+++ b/packages/common/amplify_db_common/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the amplify_db_common plugin.
 publish_to: "none"
 
 environment:
-  flutter: ">=3.35.0"
-  sdk: ^3.9.0
+  flutter: ">=3.38.1"
+  sdk: ^3.10.0
 
 dependencies:
   amplify_db_common: ">=0.4.5 <0.5.0"

--- a/packages/common/amplify_db_common/example/windows/CMakeLists.txt
+++ b/packages/common/amplify_db_common/example/windows/CMakeLists.txt
@@ -89,6 +89,12 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     COMPONENT Runtime)
 endif()
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/common/amplify_db_common/pubspec.yaml
+++ b/packages/common/amplify_db_common/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/co
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_db_common_dart: ">=0.4.14 <0.5.0"

--- a/packages/common/amplify_db_common_dart/example/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/example/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_db_common_dart: ">=0.4.0 <0.5.0"

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/co
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_core: ">=2.11.0 <2.12.0"

--- a/packages/example_common/example/pubspec.yaml
+++ b/packages/example_common/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   example_common:

--- a/packages/example_common/pubspec.yaml
+++ b/packages/example_common/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   meta: ^1.16.0

--- a/packages/kinesis/amplify_firehose/example/pubspec.yaml
+++ b/packages/kinesis/amplify_firehose/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Example app for amplify_firehose.
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_auth_cognito: ">=2.10.0 <2.11.0"

--- a/packages/kinesis/amplify_firehose/pubspec.yaml
+++ b/packages/kinesis/amplify_firehose/pubspec.yaml
@@ -13,8 +13,8 @@ topics:
   - aws-amplify
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 platforms:
   ios:

--- a/packages/kinesis/amplify_firehose_dart/pubspec.yaml
+++ b/packages/kinesis/amplify_firehose_dart/pubspec.yaml
@@ -13,7 +13,7 @@ topics:
   - aws-amplify
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_core: ">=2.11.0 <2.12.0"

--- a/packages/kinesis/amplify_kinesis/example/pubspec.yaml
+++ b/packages/kinesis/amplify_kinesis/example/pubspec.yaml
@@ -5,8 +5,8 @@ version: 0.1.0
 publish_to: "none"
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/kinesis/amplify_kinesis/pubspec.yaml
+++ b/packages/kinesis/amplify_kinesis/pubspec.yaml
@@ -13,8 +13,8 @@ topics:
   - aws-amplify
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/kinesis/amplify_kinesis_dart/pubspec.yaml
+++ b/packages/kinesis/amplify_kinesis_dart/pubspec.yaml
@@ -13,7 +13,7 @@ topics:
   - aws-amplify
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_core: ">=2.11.0 <2.12.0"

--- a/packages/kinesis/amplify_record_cache_dart/pubspec.yaml
+++ b/packages/kinesis/amplify_record_cache_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/ki
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_db_common_dart: ">=0.4.17 <0.5.0"

--- a/packages/notifications/push/amplify_push_notifications/example/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications/example/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: "none"
 version: 0.1.0
 
 environment:
-  flutter: ">=3.35.0"
-  sdk: ^3.9.0
+  flutter: ">=3.38.1"
+  sdk: ^3.10.0
 
 dependencies:
   amplify_push_notifications:

--- a/packages/notifications/push/amplify_push_notifications/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_core: ">=2.11.0 <2.12.0"

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/example/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the amplify_push_notifications_pinpoint plu
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 # Helps `pana` since it does not detect Android support.
 platforms:

--- a/packages/secure_storage/amplify_secure_storage/example/linux/CMakeLists.txt
+++ b/packages/secure_storage/amplify_secure_storage/example/linux/CMakeLists.txt
@@ -122,6 +122,12 @@ foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
     COMPONENT Runtime)
 endforeach(bundled_library)
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/secure_storage/amplify_secure_storage/example/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/example/pubspec.yaml
@@ -4,8 +4,8 @@ description: Demonstrates how to use the amplify_secure_storage plugin and house
 publish_to: "none"
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_secure_storage: ">=0.3.0 <0.4.0"

--- a/packages/secure_storage/amplify_secure_storage/example/windows/CMakeLists.txt
+++ b/packages/secure_storage/amplify_secure_storage/example/windows/CMakeLists.txt
@@ -86,6 +86,12 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     COMPONENT Runtime)
 endif()
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/secure_storage/amplify_secure_storage/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/se
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_secure_storage_dart: ">=0.5.9 <0.6.0"

--- a/packages/secure_storage/amplify_secure_storage_dart/example/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/example/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_secure_storage_dart: ">=0.5.3 <0.6.0"

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/data_protection.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/data_protection.dart
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import 'dart:convert';
 import 'dart:ffi';
 import 'dart:typed_data';
@@ -5,15 +8,7 @@ import 'dart:typed_data';
 import 'package:amplify_secure_storage_dart/src/ffi/win32/utils.dart';
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart'
-    show
-        CryptProtectData,
-        CryptUnprotectData,
-        CRYPT_INTEGER_BLOB,
-        GetLastError,
-        // TODO(Jordan-Nelson): Use new enums when min win32 version is v5.4.0 or
-        // higher
-        // ignore: deprecated_member_use
-        ERROR_SUCCESS;
+    show CryptProtectData, CryptUnprotectData, CRYPT_INTEGER_BLOB, ERROR_SUCCESS;
 
 /// Encrypts the provided string as a [Uint8List].
 Uint8List encryptString(String value) {
@@ -35,21 +30,16 @@ Uint8List encrypt(Uint8List list) {
       ..ref.cbData = list.length
       ..ref.pbData = blob;
     final encryptedPtr = arena<CRYPT_INTEGER_BLOB>();
-    CryptProtectData(
+    final result = CryptProtectData(
       dataPtr,
-      nullptr, // no label
-      nullptr, // no added entropy
-      nullptr, // reserved
-      nullptr, // no prompt
+      null, // no label
+      null, // no added entropy
+      null, // no prompt
       0, // default flag
       encryptedPtr,
     );
-    final errorCode = GetLastError();
-    // TODO(Jordan-Nelson): Use new enums when min win32 version is v5.4.0 or
-    // higher
-    // ignore: deprecated_member_use
-    if (errorCode != ERROR_SUCCESS) {
-      throw getExceptionFromErrorCode(errorCode);
+    if (result.error != ERROR_SUCCESS) {
+      throw getExceptionFromErrorCode(result.error);
     }
     final encryptedBlob = encryptedPtr.ref;
     return encryptedBlob.pbData.asTypedList(encryptedBlob.cbData);
@@ -64,21 +54,16 @@ Uint8List decrypt(Uint8List list) {
       ..ref.cbData = list.length
       ..ref.pbData = blob;
     final unencryptedPtr = arena<CRYPT_INTEGER_BLOB>();
-    CryptUnprotectData(
+    final result = CryptUnprotectData(
       dataPtr,
-      nullptr, // no label
-      nullptr, // no added entropy
-      nullptr, // reserved
-      nullptr, // no prompt
+      null, // no label
+      null, // no added entropy
+      null, // no prompt
       0, // default flag
       unencryptedPtr,
     );
-    final errorCode = GetLastError();
-    // TODO(Jordan-Nelson): Use new enums when min win32 version is v5.4.0 or
-    // higher
-    // ignore: deprecated_member_use
-    if (errorCode != ERROR_SUCCESS) {
-      throw getExceptionFromErrorCode(errorCode);
+    if (result.error != ERROR_SUCCESS) {
+      throw getExceptionFromErrorCode(result.error);
     }
     final unencryptedDataBlob = unencryptedPtr.ref;
     final unencryptedBlob = unencryptedDataBlob.pbData.asTypedList(

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/data_protection.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/data_protection.dart
@@ -8,11 +8,7 @@ import 'dart:typed_data';
 import 'package:amplify_secure_storage_dart/src/ffi/win32/utils.dart';
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart'
-    show
-        CryptProtectData,
-        CryptUnprotectData,
-        CRYPT_INTEGER_BLOB,
-        ERROR_SUCCESS;
+    show CryptProtectData, CryptUnprotectData, CRYPT_INTEGER_BLOB;
 
 /// Encrypts the provided string as a [Uint8List].
 Uint8List encryptString(String value) {
@@ -42,7 +38,7 @@ Uint8List encrypt(Uint8List list) {
       0, // default flag
       encryptedPtr,
     );
-    if (result.error != ERROR_SUCCESS) {
+    if (!result.value) {
       throw getExceptionFromErrorCode(result.error);
     }
     final encryptedBlob = encryptedPtr.ref;
@@ -66,7 +62,7 @@ Uint8List decrypt(Uint8List list) {
       0, // default flag
       unencryptedPtr,
     );
-    if (result.error != ERROR_SUCCESS) {
+    if (!result.value) {
       throw getExceptionFromErrorCode(result.error);
     }
     final unencryptedDataBlob = unencryptedPtr.ref;

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/data_protection.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/data_protection.dart
@@ -8,7 +8,11 @@ import 'dart:typed_data';
 import 'package:amplify_secure_storage_dart/src/ffi/win32/utils.dart';
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart'
-    show CryptProtectData, CryptUnprotectData, CRYPT_INTEGER_BLOB, ERROR_SUCCESS;
+    show
+        CryptProtectData,
+        CryptUnprotectData,
+        CRYPT_INTEGER_BLOB,
+        ERROR_SUCCESS;
 
 /// Encrypts the provided string as a [Uint8List].
 Uint8List encryptString(String value) {

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/utils.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/ffi/win32/utils.dart
@@ -6,11 +6,11 @@ import 'dart:typed_data';
 
 import 'package:amplify_secure_storage_dart/src/exception/secure_storage_exception.dart';
 import 'package:amplify_secure_storage_dart/src/exception/unknown_exception.dart';
-import 'package:win32/win32.dart'
-    show Uint8ListBlobConversion, WindowsException, HRESULT_FROM_WIN32;
+import 'package:win32/win32.dart' show WindowsException, WIN32_ERROR;
 
 extension Uint8ListBlobConversionX on Uint8List {
-  /// Alternative to [allocatePointer] from win32, which accepts an allocator
+  /// Copies the bytes of this [Uint8List] into a native `Pointer<Uint8>`
+  /// using the provided [allocator].
   Pointer<Uint8> allocatePointerWith(Allocator allocator) {
     final blob = allocator<Uint8>(length);
     blob.asTypedList(length).setAll(0, this);
@@ -18,9 +18,9 @@ extension Uint8ListBlobConversionX on Uint8List {
   }
 }
 
-/// Returns a [SecureStorageException] from the Win32 error code
+/// Returns a [SecureStorageException] from the Win32 error code.
 SecureStorageException getExceptionFromErrorCode(int errorCode) {
-  final underlying = WindowsException(HRESULT_FROM_WIN32(errorCode));
+  final underlying = WindowsException(WIN32_ERROR(errorCode).toHRESULT());
   return UnknownException(
     'An unknown exception occurred.',
     recoverySuggestion: SecureStorageException.missingRecovery,

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   meta: ^1.16.0
   path: ^1.8.0
   web: ^1.1.1
-  win32: ^6.1.0
+  win32: ^6.0.1
   worker_bee: ">=0.3.10 <0.4.0"
 
 dev_dependencies:

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/se
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 # Explicitly declare platform support to help `pana`
 platforms:

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   meta: ^1.16.0
   path: ^1.8.0
   web: ^1.1.1
-  win32: ^5.14.0
+  win32: ^6.1.0
   worker_bee: ">=0.3.10 <0.4.0"
 
 dev_dependencies:

--- a/packages/secure_storage/amplify_secure_storage_test/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_test/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_secure_storage_dart: any

--- a/packages/smithy/goldens/lib/awsJson1_0/pubspec.yaml
+++ b/packages/smithy/goldens/lib/awsJson1_0/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib/awsJson1_1/pubspec.yaml
+++ b/packages/smithy/goldens/lib/awsJson1_1/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib/awsQuery/pubspec.yaml
+++ b/packages/smithy/goldens/lib/awsQuery/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib/ec2Query/pubspec.yaml
+++ b/packages/smithy/goldens/lib/ec2Query/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib/restJson1/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restJson1/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXml/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/awsJson1_0/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/awsJson1_0/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/awsJson1_1/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/awsJson1_1/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/awsQuery/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/awsQuery/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/custom/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/custom/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/ec2Query/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/ec2Query/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/restJson1/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restJson1/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXml/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/pubspec.yaml
+++ b/packages/smithy/goldens/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   aws_common: ^0.5.0+2

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/sm
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   async: ^2.10.0

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/sm
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   aws_common: ">=0.7.12 <0.8.0"

--- a/packages/smithy/smithy_codegen/bin/smithy_codegen.dart
+++ b/packages/smithy/smithy_codegen/bin/smithy_codegen.dart
@@ -119,10 +119,15 @@ analyzer:
   }
 
   // Run built_value generator
+  // `--force-jit` avoids a Dart 3.10.x regression where AOT compilation of the
+  // build_runner entrypoint fails when the package graph contains native-assets
+  // build hooks. Fixed in Dart 3.11+; see
+  // https://github.com/dart-lang/build/issues/4343.
   final buildRunnerCmd = await Process.start('dart', [
     'run',
     'build_runner',
     'build',
+    '--force-jit',
     '--delete-conflicting-outputs',
   ], workingDirectory: outputPath);
   buildRunnerCmd.stdout

--- a/packages/smithy/smithy_codegen/pubspec.yaml
+++ b/packages/smithy/smithy_codegen/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/sm
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   args: ^2.5.0

--- a/packages/smithy/smithy_test/pubspec.yaml
+++ b/packages/smithy/smithy_test/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/sm
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   async: ^2.10.0

--- a/packages/storage/amplify_storage_s3/example/lib/main.dart
+++ b/packages/storage/amplify_storage_s3/example/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:amplify_authenticator/amplify_authenticator.dart';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_secure_storage/amplify_secure_storage.dart';
 import 'package:amplify_storage_s3/amplify_storage_s3.dart';
-import 'package:file_picker/file_picker.dart';
+import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:path_provider/path_provider.dart';
@@ -125,26 +125,24 @@ class _HomeScreenState extends State<HomeScreen> {
 
   // upload a file to the S3 bucket
   Future<void> _uploadFile() async {
-    final result = await FilePicker.pickFiles(
-      type: FileType.image,
-      withReadStream: true,
-      withData: false,
+    const typeGroup = XTypeGroup(
+      label: 'images',
+      extensions: ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'],
+      mimeTypes: ['image/*'],
+      uniformTypeIdentifiers: ['public.image'],
     );
+    final file = await openFile(acceptedTypeGroups: [typeGroup]);
 
-    if (result == null) {
+    if (file == null) {
       _logger.debug('No file selected');
       return;
     }
 
-    final platformFile = result.files.single;
-
     try {
+      final size = await file.length();
       await Amplify.Storage.uploadFile(
-        localFile: AWSFile.fromStream(
-          platformFile.readStream!,
-          size: platformFile.size,
-        ),
-        path: StoragePath.fromString('public/${platformFile.name}'),
+        localFile: AWSFile.fromStream(file.openRead(), size: size),
+        path: StoragePath.fromString('public/${file.name}'),
         onProgress: (p) =>
             _logger.debug('Uploading: ${p.transferredBytes}/${p.totalBytes}'),
       ).result;

--- a/packages/storage/amplify_storage_s3/example/lib/main.dart
+++ b/packages/storage/amplify_storage_s3/example/lib/main.dart
@@ -125,7 +125,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   // upload a file to the S3 bucket
   Future<void> _uploadFile() async {
-    final result = await FilePicker.platform.pickFiles(
+    final result = await FilePicker.pickFiles(
       type: FileType.image,
       withReadStream: true,
       withData: false,

--- a/packages/storage/amplify_storage_s3/example/lib/main.dart
+++ b/packages/storage/amplify_storage_s3/example/lib/main.dart
@@ -125,7 +125,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   // upload a file to the S3 bucket
   Future<void> _uploadFile() async {
-    final result = await FilePicker.pickFiles(
+    final result = await FilePicker.platform.pickFiles(
       type: FileType.image,
       withReadStream: true,
       withData: false,

--- a/packages/storage/amplify_storage_s3/example/linux/CMakeLists.txt
+++ b/packages/storage/amplify_storage_s3/example/linux/CMakeLists.txt
@@ -122,6 +122,12 @@ foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
     COMPONENT Runtime)
 endforeach(bundled_library)
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/storage/amplify_storage_s3/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/storage/amplify_storage_s3/example/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <amplify_db_common/amplify_db_common_plugin.h>
+#include <file_selector_linux/file_selector_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) amplify_db_common_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "AmplifyDbCommonPlugin");
   amplify_db_common_plugin_register_with_registrar(amplify_db_common_registrar);
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/packages/storage/amplify_storage_s3/example/linux/flutter/generated_plugins.cmake
+++ b/packages/storage/amplify_storage_s3/example/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   amplify_db_common
+  file_selector_linux
   url_launcher_linux
 )
 

--- a/packages/storage/amplify_storage_s3/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/storage/amplify_storage_s3/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,7 +8,7 @@ import Foundation
 import amplify_auth_cognito
 import amplify_secure_storage
 import device_info_plus
-import file_picker
+import file_selector_macos
 import package_info_plus
 import url_launcher_macos
 
@@ -16,7 +16,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AmplifyAuthCognitoPlugin.register(with: registry.registrar(forPlugin: "AmplifyAuthCognitoPlugin"))
   AmplifySecureStoragePlugin.register(with: registry.registrar(forPlugin: "AmplifySecureStoragePlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
-  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/packages/storage/amplify_storage_s3/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/storage/amplify_storage_s3/example/macos/Runner/DebugProfile.entitlements
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/storage/amplify_storage_s3/example/macos/Runner/Release.entitlements
+++ b/packages/storage/amplify_storage_s3/example/macos/Runner/Release.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/storage/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   amplify_flutter: any
   amplify_secure_storage: any
   amplify_storage_s3: any
-  file_picker: any
+  file_picker: ^11.0.0
   flutter:
     sdk: flutter
   go_router: ^6.5.7
@@ -40,6 +40,11 @@ dev_dependencies:
   path: ^1.8.0
   stack_trace: ^1.10.0
   test: ^1.22.1
+
+dependency_overrides:
+  # file_picker declares win32 ^5.9.0 but the monorepo requires win32 ^6.1.0
+  # (for package_info_plus 10.x). Force the newer win32 used by amplify_secure_storage_dart.
+  win32: ^6.1.0
 
 flutter:
   uses-material-design: true

--- a/packages/storage/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_auth_cognito: any

--- a/packages/storage/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   amplify_flutter: any
   amplify_secure_storage: any
   amplify_storage_s3: any
-  file_picker: ^11.0.0
+  file_selector: ^1.1.0
   flutter:
     sdk: flutter
   go_router: ^6.5.7
@@ -40,11 +40,6 @@ dev_dependencies:
   path: ^1.8.0
   stack_trace: ^1.10.0
   test: ^1.22.1
-
-dependency_overrides:
-  # file_picker declares win32 ^5.9.0 but the monorepo requires win32 ^6.1.0
-  # (for package_info_plus 10.x). Force the newer win32 used by amplify_secure_storage_dart.
-  win32: ^6.1.0
 
 flutter:
   uses-material-design: true

--- a/packages/storage/amplify_storage_s3/example/windows/CMakeLists.txt
+++ b/packages/storage/amplify_storage_s3/example/windows/CMakeLists.txt
@@ -86,6 +86,12 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     COMPONENT Runtime)
 endif()
 
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/packages/storage/amplify_storage_s3/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/storage/amplify_storage_s3/example/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <amplify_db_common/amplify_db_common_plugin.h>
+#include <file_selector_windows/file_selector_windows.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AmplifyDbCommonPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AmplifyDbCommonPlugin"));
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/packages/storage/amplify_storage_s3/example/windows/flutter/generated_plugins.cmake
+++ b/packages/storage/amplify_storage_s3/example/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   amplify_db_common
+  file_selector_windows
   url_launcher_windows
 )
 

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/st
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/storage/amplify_storage_s3_dart/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_auth_cognito_dart: any

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/st
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_core: ">=2.11.0 <2.12.0"

--- a/packages/test/amplify_auth_integration_test/pubspec.yaml
+++ b/packages/test/amplify_auth_integration_test/pubspec.yaml
@@ -6,8 +6,8 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 dependencies:
   amplify_api: any

--- a/packages/test/amplify_integration_test/pubspec.yaml
+++ b/packages/test/amplify_integration_test/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/aws-amplify/amplify-flutter
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_auth_cognito_dart: any

--- a/packages/test/amplify_test/pubspec.yaml
+++ b/packages/test/amplify_test/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/aws-amplify/amplify-flutter
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   amplify_core: any

--- a/packages/test/pub_server/pubspec.yaml
+++ b/packages/test/pub_server/pubspec.yaml
@@ -6,7 +6,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   archive: ^4.0.0

--- a/packages/worker_bee/e2e/pubspec.yaml
+++ b/packages/worker_bee/e2e/pubspec.yaml
@@ -3,7 +3,7 @@ description: E2E tests for the worker_bee package.
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   aws_common: ">=0.4.0 <0.5.0"

--- a/packages/worker_bee/e2e_flutter_test/pubspec.yaml
+++ b/packages/worker_bee/e2e_flutter_test/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  flutter: ">=3.35.0"
-  sdk: ^3.9.0
+  flutter: ">=3.38.1"
+  sdk: ^3.10.0
 
 dependencies:
   e2e:

--- a/packages/worker_bee/e2e_test/pubspec.yaml
+++ b/packages/worker_bee/e2e_test/pubspec.yaml
@@ -3,7 +3,7 @@ description: E2E tests for the worker_bee package.
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   web: ^1.1.1

--- a/packages/worker_bee/worker_bee/example/pubspec.yaml
+++ b/packages/worker_bee/worker_bee/example/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/packages/worker_bee/worker_bee/pubspec.yaml
+++ b/packages/worker_bee/worker_bee/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/wo
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   async: ^2.10.0

--- a/packages/worker_bee/worker_bee_builder/pubspec.yaml
+++ b/packages/worker_bee/worker_bee_builder/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/wo
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   analyzer: ^9.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   source_gen: ^4.0.0
   stack_trace: ^1.10.0
   uuid: ^4.5.1
-  win32: ^6.1.0
+  win32: ^6.0.1
   xml: ^6.5.0
   test: ^1.22.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   json_serializable: ^6.11.0
   mime: ^2.0.0
   oauth2: ^2.0.2
-  package_info_plus: ^9.0.0
+  package_info_plus: ^10.1.0
   pigeon: ^26.0.0
   sqlite3: ^2.7.6
   source_gen: ^4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,8 +3,8 @@ publish_to: none
 
 # The current constraints for Dart and Flutter SDKs.
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.1"
 
 # Global dependency versions for third-party dependencies of
 # Amplify Flutter projects. These represent the values which

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   # This must roughly match what's included in `dart format`
   # on stable so that CI checks pass for generated code.
   dart_style: ^3.0.1
-  device_info_plus: ^12.0.0
+  device_info_plus: ^13.1.0
   drift: ^2.25.0
   drift_dev: ^2.25.1
   ffigen: ^9.0.0
@@ -43,7 +43,7 @@ dependencies:
   source_gen: ^4.0.0
   stack_trace: ^1.10.0
   uuid: ^4.5.1
-  win32: ^5.14.0
+  win32: ^6.1.0
   xml: ^6.5.0
   test: ^1.22.1
 

--- a/templates/dart-package/hooks/pubspec.yaml
+++ b/templates/dart-package/hooks/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_package_hooks
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   mason: ^0.1.1

--- a/templates/flutter-package/hooks/pubspec.yaml
+++ b/templates/flutter-package/hooks/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_package_hooks
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 dependencies:
   mason: ^0.1.1


### PR DESCRIPTION
# Upgrade `package_info_plus` 9.0.0 → 10.1.0

`package_info_plus 10.x` requires `win32 ^6.0.1` → cascading bumps.

## Dep bumps
| Package | Old | New |
|---|---|---|
| package_info_plus | ^9.0.0 | ^10.1.0 |
| win32 | ^5.14.0 | ^6.0.1 |
| win32_registry | ^2.1.0 | ^3.0.3 |
| device_info_plus | ^12.0.0 | ^13.1.0 |
| Dart | ^3.9.0 | ^3.10.0 |
| Flutter | >=3.35.0 | >=3.38.1 |

All lower bounds are the true minimum — versions below these require Dart ≥3.11.

## Required follow-ups
- **win32 5→6 FFI migration** in 3 files (`utils.dart`, `data_protection.dart`, `asf_device_info_collector.windows.dart`) — `Win32Result<T>`, `CryptProtectData` 7→6 args, `GetVersionEx`→`RtlGetVersion`, registry API, etc. [Migration guide](https://win32.pub/docs/migration/5xx-to-6xx).
- **`--force-jit` for build_runner** — Dart 3.10 + native-assets AOT regression ([dart-lang/build#4343](https://github.com/dart-lang/build/issues/4343)). Revert when Dart 3.11 is the floor.
- **`file_picker` → `file_selector`** in `amplify_storage_s3/example` — `file_picker` hard-pins `win32 ^5.9.0`, no win32 6.x version exists.
- **CMake native-assets install block** added to 9 example apps × {windows, linux} — fixes `error code 126` DLL-not-found at runtime ([flutter/flutter#165463](https://github.com/flutter/flutter/issues/165463)).
- **`CryptProtectData`/`CryptUnprotectData`**: check BOOL return before `GetLastError` per [MSDN](https://learn.microsoft.com/en-us/windows/win32/api/dpapi/nf-dpapi-cryptprotectdata) (pre-existing latent bug, fixed since we were in the file).

## Behavior change
Cognito ASF's Windows fingerprint now reports the real OS version (`Windows/10.0.22631`) instead of the AppCompat-shimmed `Windows/6.2.9200`. `RtlGetVersion` doesn't lie.

## Related Issues
https://github.com/aws-amplify/amplify-flutter/issues/6944
https://github.com/aws-amplify/amplify-flutter/issues/6873