### PR TITLE
docs: update GraphQL response data docs

### DIFF
--- a/packages/amplify_core/lib/src/types/api/graphql/graphql_response.dart
+++ b/packages/amplify_core/lib/src/types/api/graphql/graphql_response.dart
@@ -16,7 +16,9 @@ class GraphQLResponse<T> {
 
   /// Response data matching the type of the request.
   ///
-  /// This will be `null` if there are any GraphQL errors during execution.
+  /// Per GraphQL, [data] and [errors] are separate response fields: [data] may 
+  /// be non-null when [errors] is non-empty (partial success). Check [hasErrors]
+  /// before treating the response as fully successful.
   final T? data;
 
   /// A list of errors from execution. If no errors, it will be an empty list.


### PR DESCRIPTION
# Clarify behavior of `data` field in response documentation as independent from `errors` field

**Issue #, if available:**

N/A

**Description of changes:**

Updates the `GraphQLResponse.data` dartdoc in `amplify_core`. The previous comment stated that `data` will be `null` whenever `errors` is non-empty, which does not match the GraphQL response format or Amplify's decoding behavior.

Per the [GraphQL response format](https://graphql.org/learn/serving-over-http/#response), `data` and `errors` are separate top-level fields. Field-level errors can be returned alongside a partial `data` payload (partial success). Amplify's `GraphQLResponseDecoder` preserves decoded `data` when the server returns both `data` and `errors`, for example:

```dart
// packages/api/amplify_api_dart/lib/src/graphql/helpers/graphql_response_decoder.dart
    // Found a JSON object to represent the model, parse it using model's fromJSON.
    T decodedData;

    if (modelType is PaginatedModelType) {
      final filter = request.variables['filter'] as Map<String, dynamic>?;
      final limit = request.variables['limit'] as int?;

      final resultNextToken = dataJson![_nextToken] as String?;
      dynamic requestForNextResult;
      // If result has nextToken property, prepare a request for the next page of results.
      if (resultNextToken != null) {
        final variablesWithNextToken = <String, dynamic>{
          ...request.variables,
          _nextToken: resultNextToken,
        };
        requestForNextResult = GraphQLRequest<T>(
          document: request.document,
          decodePath: request.decodePath,
          variables: variablesWithNextToken,
          modelType: request.modelType,
          authorizationMode: request.authorizationMode,
          apiName: request.apiName,
        );
      }
      decodedData =
          modelType.fromJson(
                dataJson!,
                limit: limit,
                filter: filter,
                requestForNextResult:
                    requestForNextResult
                        as GraphQLRequest<PaginatedResult<Model>>?,
              )
              as T;
    } else {
      decodedData = modelType.fromJson(dataJson!) as T;
    }
    return GraphQLResponse<T>(data: decodedData, errors: errors);
```

The updated documentation clarifies that `data` may be non-null when `errors` is non-empty, and directs callers to check `hasErrors` before treating the response as fully successful.

No runtime or API changes—documentation only.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
