### PR TITLE
fix(core): Add IDENTITYPOOL to AuthRuleProvider enum

### DIFF
--- a/packages/amplify_core/lib/src/types/models/auth_rule.dart
+++ b/packages/amplify_core/lib/src/types/models/auth_rule.dart
@@ -22,7 +22,7 @@ enum ModelOperation {
   SEARCH,
 }
 
-enum AuthRuleProvider { APIKEY, OIDC, IAM, USERPOOLS, FUNCTION }
+enum AuthRuleProvider { APIKEY, OIDC, IAM, IDENTITYPOOL, USERPOOLS, FUNCTION }
 
 @immutable
 class AuthRule {


### PR DESCRIPTION
*Issue #, if available:*
Fixes #6971 

*Description of changes:*
It seems that this is not used anywhere in the repo. Maybe the tests can tell us more.
Kept .IAM for backward compatibility.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
