### PR TITLE
feat: Add wasm support to `amplify_core`, `amplify_foundation` and `aws_common`

### DIFF
--- a/.github/workflows/amplify_core.yaml
+++ b/.github/workflows/amplify_core.yaml
@@ -9,6 +9,7 @@ on:
       - '.github/composite_actions/setup_firefox/action.yaml'
       - '.github/workflows/amplify_core.yaml'
       - '.github/workflows/dart_dart2js.yaml'
+      - '.github/workflows/dart_dart2wasm.yaml'
       - '.github/workflows/dart_ddc.yaml'
       - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
@@ -27,6 +28,7 @@ on:
       - '.github/composite_actions/setup_firefox/action.yaml'
       - '.github/workflows/amplify_core.yaml'
       - '.github/workflows/dart_dart2js.yaml'
+      - '.github/workflows/dart_dart2wasm.yaml'
       - '.github/workflows/dart_ddc.yaml'
       - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
@@ -82,6 +84,13 @@ jobs:
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
+    secrets: inherit
+    with:
+      package-name: amplify_core
+      working-directory: packages/amplify_core
+  dart2wasm_test:
+    needs: test
+    uses: ./.github/workflows/dart_dart2wasm.yaml
     secrets: inherit
     with:
       package-name: amplify_core

--- a/.github/workflows/amplify_foundation_dart.yaml
+++ b/.github/workflows/amplify_foundation_dart.yaml
@@ -6,7 +6,11 @@ on:
       - main
       - stable
     paths:
+      - '.github/composite_actions/setup_firefox/action.yaml'
       - '.github/workflows/amplify_foundation_dart.yaml'
+      - '.github/workflows/dart_dart2js.yaml'
+      - '.github/workflows/dart_dart2wasm.yaml'
+      - '.github/workflows/dart_ddc.yaml'
       - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
       - 'packages/amplify_foundation/amplify_foundation_dart/**/*.dart'
@@ -17,7 +21,11 @@ on:
       - 'packages/amplify_lints/pubspec.yaml'
   pull_request:
     paths:
+      - '.github/composite_actions/setup_firefox/action.yaml'
       - '.github/workflows/amplify_foundation_dart.yaml'
+      - '.github/workflows/dart_dart2js.yaml'
+      - '.github/workflows/dart_dart2wasm.yaml'
+      - '.github/workflows/dart_ddc.yaml'
       - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
       - 'packages/amplify_foundation/amplify_foundation_dart/**/*.dart'
@@ -55,6 +63,27 @@ jobs:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     secrets: inherit 
+    with:
+      package-name: amplify_foundation_dart
+      working-directory: packages/amplify_foundation/amplify_foundation_dart
+  ddc_test:
+    needs: test
+    uses: ./.github/workflows/dart_ddc.yaml
+    secrets: inherit
+    with:
+      package-name: amplify_foundation_dart
+      working-directory: packages/amplify_foundation/amplify_foundation_dart
+  dart2js_test:
+    needs: test
+    uses: ./.github/workflows/dart_dart2js.yaml
+    secrets: inherit
+    with:
+      package-name: amplify_foundation_dart
+      working-directory: packages/amplify_foundation/amplify_foundation_dart
+  dart2wasm_test:
+    needs: test
+    uses: ./.github/workflows/dart_dart2wasm.yaml
+    secrets: inherit
     with:
       package-name: amplify_foundation_dart
       working-directory: packages/amplify_foundation/amplify_foundation_dart

--- a/.github/workflows/aws_common.yaml
+++ b/.github/workflows/aws_common.yaml
@@ -9,6 +9,7 @@ on:
       - '.github/composite_actions/setup_firefox/action.yaml'
       - '.github/workflows/aws_common.yaml'
       - '.github/workflows/dart_dart2js.yaml'
+      - '.github/workflows/dart_dart2wasm.yaml'
       - '.github/workflows/dart_ddc.yaml'
       - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
@@ -23,6 +24,7 @@ on:
       - '.github/composite_actions/setup_firefox/action.yaml'
       - '.github/workflows/aws_common.yaml'
       - '.github/workflows/dart_dart2js.yaml'
+      - '.github/workflows/dart_dart2wasm.yaml'
       - '.github/workflows/dart_ddc.yaml'
       - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
@@ -74,6 +76,13 @@ jobs:
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
+    secrets: inherit
+    with:
+      package-name: aws_common
+      working-directory: packages/aws_common
+  dart2wasm_test:
+    needs: test
+    uses: ./.github/workflows/dart_dart2wasm.yaml
     secrets: inherit
     with:
       package-name: aws_common

--- a/.github/workflows/dart_dart2wasm.yaml
+++ b/.github/workflows/dart_dart2wasm.yaml
@@ -1,0 +1,93 @@
+name: Dart (dart2wasm)
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        description: The name of the package being tested
+        required: true
+        type: string
+      working-directory:
+        description: The working directory relative to the repo root
+        required: true
+        type: string
+
+jobs:
+  test-dart-2wasm:
+    # These tests heavily leverage build_runner which benefits from faster runners
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      # Allows other matrix items to run if one fails
+      fail-fast: false
+      matrix:
+        sdk:
+          # Minimum supported Dart version
+          - "3.10.0"
+          - stable
+          - beta
+        browser:
+          - chrome
+          - firefox
+        # Skips 'beta' tests on PRs
+        exclude:
+          - sdk: ${{ (github.event_name == 'pull_request') && 'beta' || 'NONE' }}
+    steps:
+      - name: Cache Pub dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # 5.0.5
+        with:
+          path: |
+            ~/.pub-cache/hosted
+            ~/.pub-cache/git
+          key: os:ubuntu-latest;sdk:${{ matrix.sdk }};packages:${{ inputs.working-directory }}
+          restore-keys: |
+            os:ubuntu-latest;sdk:${{ matrix.sdk }};packages:${{ inputs.working-directory }}
+            os:ubuntu-latest;sdk:${{ matrix.sdk }}
+            os:ubuntu-latest
+
+      - name: Git Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Git Submodules
+        run: git submodule update --init
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@03a180dbe1de8ea7fb700663cbb7d24ca4bbe82c # main
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - name: Setup aft
+        shell: bash # Run in bash regardless of platform
+        run: dart pub global activate -spath packages/aft
+
+      - name: Setup Firefox
+        if: ${{ matrix.browser == 'firefox' }}
+        uses: ./.github/composite_actions/setup_firefox
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bootstrap
+        id: bootstrap
+        timeout-minutes: 20
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }} --verbose
+
+      - name: Setup Package
+        if: "always() && steps.bootstrap.conclusion == 'success'"
+        shell: bash # Run in bash regardless of platform
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [ -e tool/setup.sh ]; then
+            ./tool/setup.sh
+          fi
+
+      - name: Run Tests
+        if: "always() && steps.bootstrap.conclusion == 'success'"
+        # `--force-jit` works around a Dart 3.10.x regression where AOT
+        # compilation of the build_runner entrypoint fails on package graphs
+        # containing native-assets build hooks. Fixed in Dart 3.11+; see
+        # https://github.com/dart-lang/build/issues/4343.
+        #
+        # `-c dart2wasm` opts this run into the WASM compiler. The default
+        # (dart2js) path is exercised separately by dart_dart2js.yaml so both
+        # web compilers stay covered.
+        run: dart run build_runner build test --force-jit --release --delete-conflicting-outputs && dart test -p ${{ matrix.browser }} -c dart2wasm
+        working-directory: ${{ inputs.working-directory }}

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -241,6 +241,7 @@ ${dependabotGroups.join('\n')}
 
     const ddcWorkflow = 'dart_ddc.yaml';
     const dart2JsWorkflow = 'dart_dart2js.yaml';
+    const dart2WasmWorkflow = 'dart_dart2wasm.yaml';
     const nativeWorkflow = 'dart_native.yaml';
     final e2eWorkflows = {
       'android': 'e2e_android.yaml',
@@ -259,6 +260,10 @@ ${dependabotGroups.join('\n')}
     final needsNativeTest = isDartPackage && package.unitTestDirectory != null;
     final needsWebTest = package.pubspecInfo.pubspec.devDependencies
         .containsKey('build_test');
+    // A package opts into dart2wasm browser coverage by adding a
+    // `test/wasm_smoke_test.dart` file. This is additive to (not a
+    // replacement for) the default dart2js web test job.
+    final needsWasmTest = needsWebTest && package.hasWasmTest;
     // TODO(dnys1): Enable E2E runs for Dart packages
     final needsE2ETest =
         package.flavor == PackageFlavor.flutter &&
@@ -275,6 +280,7 @@ ${dependabotGroups.join('\n')}
       analyzeAndTestWorkflow,
       if (needsNativeTest) nativeWorkflow,
       if (needsWebTest) ...[ddcWorkflow, dart2JsWorkflow],
+      if (needsWasmTest) dart2WasmWorkflow,
       if (needsE2ETest) ...e2eWorkflows.values,
       if (hasFfigen) ffigenWorkflow,
     ];
@@ -395,6 +401,17 @@ jobs:
       package-name: ${package.name}
       working-directory: $repoRelativePath
 ''');
+        if (needsWasmTest) {
+          workflowContents.write('''
+  dart2wasm_test:
+    needs: test
+    uses: ./.github/workflows/$dart2WasmWorkflow
+    secrets: inherit
+    with:
+      package-name: ${package.name}
+      working-directory: $repoRelativePath
+''');
+        }
       }
     }
 
@@ -403,6 +420,7 @@ jobs:
         'test',
         if (needsNativeTest) 'native_test',
         if (needsWebTest) ...['ddc_test', 'dart2js_test'],
+        if (needsWasmTest) 'dart2wasm_test',
       ];
       final needsAwsConfig = File(
         p.join(package.path, 'tool', 'pull_test_backend.sh'),

--- a/packages/aft/lib/src/config/config.dart
+++ b/packages/aft/lib/src/config/config.dart
@@ -237,6 +237,18 @@ class PackageInfo
     return dir.existsSync();
   }
 
+  /// Whether this package opts into `dart2wasm` browser test coverage.
+  ///
+  /// A package opts in by adding a `test/wasm_smoke_test.dart` file. This
+  /// is additive: the default (dart2js) browser test job still runs for all
+  /// web packages — opting in adds a parallel `dart2wasm` run so both web
+  /// compilers stay covered. Packages turn this on as their web code is
+  /// verified to compile and pass under `dart2wasm`.
+  bool get hasWasmTest {
+    final expectedPath = p.join(path, 'test', 'wasm_smoke_test.dart');
+    return File(expectedPath).existsSync();
+  }
+
   /// The integration test directory within the enclosing directory, if any
   Directory? get integrationTestDirectory {
     final expectedPath = p.join(path, 'integration_test');

--- a/packages/amplify_core/build.yaml
+++ b/packages/amplify_core/build.yaml
@@ -9,6 +9,9 @@ targets:
           dart2js_args:
             - --define=dart.vm.product=true
             - --enable-asserts
+          dart2wasm_args:
+            - --define=dart.vm.product=true
+            - --enable-asserts
       source_gen:combining_builder:
         options:
           # TODO(equartey): Remove when customAuthWithSrp & customAuthWithoutSrp are supported by CLI

--- a/packages/amplify_core/test/wasm_smoke_test.dart
+++ b/packages/amplify_core/test/wasm_smoke_test.dart
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@TestOn('browser')
+library;
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:test/test.dart';
+
+/// Smoke test: proves dart2wasm compilation + browser execution works.
+///
+/// Run with: dart test test/wasm_smoke_test.dart -p chrome -c dart2wasm
+void main() {
+  group('WASM smoke test', () {
+    test('zIsWeb is true on web targets', () {
+      expect(zIsWeb, isTrue, reason: 'zIsWeb must be true on web targets');
+    });
+
+    test('core types are functional', () {
+      final temporal = TemporalDateTime(DateTime.utc(2020, 1, 2, 3, 4, 5));
+      expect(temporal.toString(), startsWith('2020-01-02T03:04:05'));
+    });
+
+    test('exceptions are functional', () {
+      const exception = AmplifyAlreadyConfiguredException('test message');
+      expect(exception.message, 'test message');
+      expect(exception, isA<AmplifyException>());
+    });
+  });
+}

--- a/packages/amplify_foundation/amplify_foundation_dart/dart_test.yaml
+++ b/packages/amplify_foundation/amplify_foundation_dart/dart_test.yaml
@@ -1,0 +1,11 @@
+# Enable dart2wasm compiler for browser tests
+compilers:
+  - dart2wasm
+
+override_platforms:
+  chrome:
+    settings:
+      arguments: --headless
+  firefox:
+    settings:
+      arguments: -headless

--- a/packages/amplify_foundation/amplify_foundation_dart/dart_test.yaml
+++ b/packages/amplify_foundation/amplify_foundation_dart/dart_test.yaml
@@ -1,7 +1,6 @@
-# Enable dart2wasm compiler for browser tests
-compilers:
-  - dart2wasm
-
+# Browser tests default to dart2js. To run under dart2wasm (opt-in), pass
+# `-c dart2wasm` on the command line, e.g.:
+#   dart test test/wasm_smoke_test.dart -p chrome -c dart2wasm
 override_platforms:
   chrome:
     settings:

--- a/packages/amplify_foundation/amplify_foundation_dart/pubspec.yaml
+++ b/packages/amplify_foundation/amplify_foundation_dart/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
 dev_dependencies:
   amplify_lints: ">=3.1.4 <3.2.0"
   build_runner: ^2.4.15
+  build_test: ^3.1.1
   build_web_compilers: ^4.1.4
   json_serializable: ^6.11.0
   test: ^1.22.1

--- a/packages/amplify_foundation/amplify_foundation_dart/test/wasm_smoke_test.dart
+++ b/packages/amplify_foundation/amplify_foundation_dart/test/wasm_smoke_test.dart
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@TestOn('browser')
+library;
+
+import 'package:amplify_foundation_dart/amplify_foundation_dart.dart';
+import 'package:test/test.dart';
+
+/// Smoke test: proves dart2wasm compilation + browser execution works.
+///
+/// Run with: dart test test/wasm_smoke_test.dart -p chrome -c dart2wasm
+void main() {
+  group('WASM smoke test', () {
+    test('platform detection is correct under dart2wasm', () {
+      expect(zIsWeb, isTrue, reason: 'zIsWeb must be true on web targets');
+      // When run with -c dart2wasm, zIsWasm should be true.
+      // When run with -c dart2js, zIsWasm should be false.
+      // We don't assert zIsWasm here since this test runs under both compilers.
+    });
+
+    test('core types are functional', () {
+      final creds = StaticCredentials('accessKeyId', 'secretAccessKey');
+      expect(creds.accessKeyId, 'accessKeyId');
+      expect(creds.secretAccessKey, 'secretAccessKey');
+    });
+
+    test('Result type works', () {
+      final result = Result<String>.ok('hello');
+      switch (result) {
+        case Ok(:final value):
+          expect(value, 'hello');
+        case Error():
+          fail('Expected Ok, got Error');
+      }
+    });
+  });
+}

--- a/packages/amplify_foundation/amplify_foundation_dart/test/wasm_smoke_test.dart
+++ b/packages/amplify_foundation/amplify_foundation_dart/test/wasm_smoke_test.dart
@@ -20,13 +20,13 @@ void main() {
     });
 
     test('core types are functional', () {
-      final creds = StaticCredentials('accessKeyId', 'secretAccessKey');
+      const creds = StaticCredentials('accessKeyId', 'secretAccessKey');
       expect(creds.accessKeyId, 'accessKeyId');
       expect(creds.secretAccessKey, 'secretAccessKey');
     });
 
     test('Result type works', () {
-      final result = Result<String>.ok('hello');
+      const result = Result<String>.ok('hello');
       switch (result) {
         case Ok(:final value):
           expect(value, 'hello');

--- a/packages/aws_common/build.yaml
+++ b/packages/aws_common/build.yaml
@@ -9,3 +9,6 @@ targets:
           dart2js_args:
             - --define=dart.vm.product=true
             - --enable-asserts
+          dart2wasm_args:
+            - --define=dart.vm.product=true
+            - --enable-asserts

--- a/packages/aws_common/dart_test.yaml
+++ b/packages/aws_common/dart_test.yaml
@@ -1,4 +1,11 @@
+# Enable dart2wasm compiler for browser tests
+compilers:
+  - dart2wasm
+
 override_platforms:
+  chrome:
+    settings:
+      arguments: --headless
   firefox:
     settings:
       arguments: -headless

--- a/packages/aws_common/dart_test.yaml
+++ b/packages/aws_common/dart_test.yaml
@@ -1,7 +1,6 @@
-# Enable dart2wasm compiler for browser tests
-compilers:
-  - dart2wasm
-
+# Browser tests default to dart2js. To run under dart2wasm (opt-in), pass
+# `-c dart2wasm` on the command line, e.g.:
+#   dart test test/wasm_smoke_test.dart -p chrome -c dart2wasm
 override_platforms:
   chrome:
     settings:

--- a/packages/aws_common/lib/src/js/readable_stream.dart
+++ b/packages/aws_common/lib/src/js/readable_stream.dart
@@ -36,22 +36,30 @@ extension type UnderlyingSource<T extends JSAny>._(JSObject _)
       return cancel!.call(reason).toJS;
     }
 
-    return UnderlyingSource.__(
-      start: start == null ? undefined : promiseStart.toJS,
-      pull: pull == null ? undefined : promisePull.toJS,
-      cancel: cancel == null ? undefined : promiseCancel.toJS,
-      type: type.jsValue?.toJS ?? undefined,
-      autoAllocateChunkSize: autoAllocateChunkSize?.toJS ?? undefined,
-    );
+    // Build the JS object manually using js_interop_unsafe to avoid
+    // setting properties to `null`/`undefined` which dart2wasm may
+    // serialize differently than dart2js. The browser's ReadableStream
+    // constructor rejects `{type: null}` — the `type` property must
+    // either be `"bytes"` or completely absent for default streams.
+    final obj = JSObject();
+    if (start != null) {
+      obj['start'] = promiseStart.toJS;
+    }
+    if (pull != null) {
+      obj['pull'] = promisePull.toJS;
+    }
+    if (cancel != null) {
+      obj['cancel'] = promiseCancel.toJS;
+    }
+    final typeValue = type.jsValue;
+    if (typeValue != null) {
+      obj['type'] = typeValue.toJS;
+    }
+    if (autoAllocateChunkSize != null) {
+      obj['autoAllocateChunkSize'] = autoAllocateChunkSize.toJS;
+    }
+    return obj as UnderlyingSource<T>;
   }
-
-  external factory UnderlyingSource.__({
-    JSFunction? start,
-    JSFunction? pull,
-    JSFunction? cancel,
-    JSAny? type,
-    JSAny? autoAllocateChunkSize,
-  });
 
   /// This is a method, called immediately when the object is constructed.
   ///
@@ -222,11 +230,39 @@ final class ReadableStreamView extends StreamView<List<int>> {
         progressSink.add(bytesRead);
       }
     } on Object catch (e, st) {
-      sink.addError(e, st);
+      // Under dart2wasm, errors from ReadableStream's controller.error()
+      // arrive as JSValue-wrapped objects instead of being automatically
+      // unwrapped to Dart types (as dart2js does). Unwrap them so that
+      // downstream Dart code sees the original error value.
+      final error = _unwrapJSError(e);
+      sink.addError(error, st);
     } finally {
       unawaited(sink.close());
       unawaited(progressSink.close());
     }
+  }
+
+  /// Attempts to unwrap a JS error value to its Dart equivalent.
+  ///
+  /// Under dart2wasm, errors that pass through JS boundaries (e.g. via
+  /// `ReadableStream.controller.error()`) arrive as opaque `JSValue`
+  /// wrappers. Under dart2js they are automatically converted to Dart
+  /// types. This method normalizes the behavior.
+  static Object _unwrapJSError(Object error) {
+    if (error is JSAny) {
+      // Try to convert the JSAny to a Dart string if it's a JSString.
+      if (error.isA<JSString>()) {
+        return (error as JSString).toDart;
+      }
+      // For other JS types, try dartify for common conversions.
+      try {
+        final dartified = error.dartify();
+        if (dartified != null) return dartified;
+      } on Object {
+        // dartify may throw for unsupported types — fall through.
+      }
+    }
+    return error;
   }
 }
 

--- a/packages/aws_common/lib/src/js/readable_stream.dart
+++ b/packages/aws_common/lib/src/js/readable_stream.dart
@@ -249,6 +249,11 @@ final class ReadableStreamView extends StreamView<List<int>> {
   /// wrappers. Under dart2js they are automatically converted to Dart
   /// types. This method normalizes the behavior.
   static Object _unwrapJSError(Object error) {
+    // Under dart2wasm, JS errors arrive as opaque interop values and this
+    // runtime check is the intended way to detect them. The lint guards
+    // against platform-inconsistent checks, which is acceptable here since
+    // this code only runs on web.
+    // ignore: invalid_runtime_check_with_js_interop_types
     if (error is JSAny) {
       // Try to convert the JSAny to a Dart string if it's a JSString.
       if (error.isA<JSString>()) {

--- a/packages/aws_common/lib/src/util/globals.dart
+++ b/packages/aws_common/lib/src/util/globals.dart
@@ -30,7 +30,11 @@ const bool zReleaseMode = bool.fromEnvironment('dart.vm.product');
 
 /// Whether running on the Web.
 ///
-/// Since JS does not support integers, an int and a double will be identical
-/// when representing the same value. However, this will not be true for all
-/// other compilation targets.
-const bool zIsWeb = identical(0, 0.0);
+/// This checks for the availability of the `dart:js_interop` library,
+/// which is present for both the `dart2js` (pure JS) and `dart2wasm`
+/// (Wasm + JS glue) compilation targets, and absent on VM/native.
+///
+/// The previous implementation (`identical(0, 0.0)`) is broken under
+/// `dart2wasm` because WASM has distinct integer and double types,
+/// causing `identical(0, 0.0)` to return `false` even on web.
+const bool zIsWeb = bool.fromEnvironment('dart.library.js_interop');

--- a/packages/aws_common/test/http/downgrade_test.dart
+++ b/packages/aws_common/test/http/downgrade_test.dart
@@ -27,7 +27,10 @@ void main() {
         ..sink.add(AlpnProtocol.http1_1.value)
         ..sink.add(isSecure);
       httpServerQueue = StreamQueue(httpServerChannel.stream);
-      host = 'localhost:${await httpServerQueue.next}';
+      // Under dart2wasm, numbers from spawnHybridUri arrive as double
+      // (e.g. 50064.0 instead of 50064), so we must convert to int.
+      final port = (await httpServerQueue.next as num).toInt();
+      host = 'localhost:$port';
     });
 
     tearDownAll(() {

--- a/packages/aws_common/test/http/http_common.dart
+++ b/packages/aws_common/test/http/http_common.dart
@@ -52,7 +52,10 @@ void clientTest(
             ..sink.add(protocol.value)
             ..sink.add(secure);
           httpServerQueue = StreamQueue(httpServerChannel.stream);
-          host = 'localhost:${await httpServerQueue.next}';
+          // Under dart2wasm, numbers from spawnHybridUri arrive as double
+          // (e.g. 63515.0 instead of 63515), so we must convert to int.
+          final port = (await httpServerQueue.next as num).toInt();
+          host = 'localhost:$port';
           client = debugClient..supportedProtocols = supportedProtocols;
         });
         tearDown(() async {

--- a/packages/aws_common/test/js/underlying_source_branches_test.dart
+++ b/packages/aws_common/test/js/underlying_source_branches_test.dart
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:aws_common/src/js/readable_stream.dart';
+import 'package:test/test.dart';
+
+/// Exercises every branch of the `UnderlyingSource` factory so the
+/// property-by-property build path is fully verified under both dart2js and
+/// dart2wasm. The existing readable_stream_test only covers `start` and
+/// `pull` with a default `type`.
+void main() {
+  group('UnderlyingSource branch coverage', () {
+    test('default type => no "type" key is set on the JS object', () {
+      final source = UnderlyingSource<JSAny>(
+        start: (_) async {},
+      );
+      final obj = source as JSObject;
+      // The whole point of the fix: default streams must NOT carry a `type`
+      // property (neither null nor undefined-as-a-set-key).
+      expect(obj.has('type'), isFalse, reason: 'default type must be absent');
+      expect(obj.has('start'), isTrue);
+      expect(obj.has('pull'), isFalse, reason: 'unset callbacks are omitted');
+      expect(obj.has('cancel'), isFalse);
+      expect(obj.has('autoAllocateChunkSize'), isFalse);
+    });
+
+    test('bytes type => "type" key is set to "bytes"', () {
+      final source = UnderlyingSource<JSAny>(
+        pull: (_) async {},
+        type: ReadableStreamType.bytes,
+        autoAllocateChunkSize: 1024,
+      );
+      final obj = source as JSObject;
+      expect(obj.has('type'), isTrue);
+      expect((obj['type'] as JSString).toDart, 'bytes');
+      expect(obj.has('autoAllocateChunkSize'), isTrue);
+      expect((obj['autoAllocateChunkSize'] as JSNumber).toDartInt, 1024);
+      expect(obj.has('pull'), isTrue);
+      expect(obj.has('start'), isFalse);
+    });
+
+    test('cancel branch sets a callable "cancel" function on the object', () {
+      final source = UnderlyingSource<JSAny>(
+        pull: (_) async {},
+        cancel: ([JSString? reason]) async {},
+      );
+      final obj = source as JSObject;
+      expect(obj.has('cancel'), isTrue);
+      // The value must be a JS function (the wrapped Dart callback), not a
+      // stray null/undefined.
+      expect(obj['cancel'].isA<JSFunction>(), isTrue);
+    });
+
+    test('stream built from the factory pull branch produces data', () {
+      // End-to-end exercise of the `pull`-only path the factory builds for
+      // every web HTTP request body, confirming the manually-built object is
+      // accepted by the browser's ReadableStream constructor.
+      final readableStream = Stream.fromIterable([
+        [1, 2, 3],
+        [4, 5, 6],
+      ]).asReadableStream();
+      expect(
+        readableStream.stream,
+        emitsInOrder([
+          orderedEquals([1, 2, 3]),
+          orderedEquals([4, 5, 6]),
+          emitsDone,
+        ]),
+      );
+    });
+  });
+}

--- a/packages/aws_common/test/js/underlying_source_branches_test.dart
+++ b/packages/aws_common/test/js/underlying_source_branches_test.dart
@@ -17,9 +17,7 @@ import 'package:test/test.dart';
 void main() {
   group('UnderlyingSource branch coverage', () {
     test('default type => no "type" key is set on the JS object', () {
-      final source = UnderlyingSource<JSAny>(
-        start: (_) async {},
-      );
+      final source = UnderlyingSource<JSAny>(start: (_) async {});
       final obj = source as JSObject;
       // The whole point of the fix: default streams must NOT carry a `type`
       // property (neither null nor undefined-as-a-set-key).

--- a/packages/aws_common/test/wasm_smoke_test.dart
+++ b/packages/aws_common/test/wasm_smoke_test.dart
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@TestOn('browser')
+library;
+
+import 'package:aws_common/aws_common.dart';
+import 'package:test/test.dart';
+
+/// Smoke test: proves dart2wasm compilation + browser execution works.
+///
+/// Run with: dart test test/wasm_smoke_test.dart -p chrome -c dart2wasm
+void main() {
+  group('WASM smoke test', () {
+    test('zIsWeb is true on web targets', () {
+      expect(zIsWeb, isTrue, reason: 'zIsWeb must be true on web targets');
+    });
+
+    test('AWSHttpRequest can be constructed', () {
+      final request = AWSHttpRequest.get(Uri.parse('https://example.com'));
+      expect(request.method, AWSHttpMethod.get);
+      expect(request.uri.host, 'example.com');
+    });
+
+    test('AWSHttpClient can be instantiated', () {
+      final client = AWSHttpClient();
+      expect(client, isNotNull);
+      client.close();
+    });
+  });
+}


### PR DESCRIPTION
This add wasm support to the base layer of amplify-flutter.