### PR TITLE
fix(analyzer): Resolve invalid_export_of_internal_element

### DIFF
--- a/packages/amplify/amplify_flutter/lib/amplify_flutter.dart
+++ b/packages/amplify/amplify_flutter/lib/amplify_flutter.dart
@@ -6,7 +6,14 @@ library;
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_flutter/src/amplify_impl.dart';
 
-export 'package:amplify_core/amplify_core.dart' hide Amplify, WebSocketOptions;
+export 'package:amplify_core/amplify_core.dart'
+    hide
+        Amplify,
+        WebSocketOptions,
+        // `@internal` serializers re-exported by amplify_core's barrel; not
+        // part of the supported public API.
+        zAmplifyOutputsSerializable,
+        zConfigMapSerializable;
 export 'package:amplify_secure_storage/amplify_secure_storage.dart';
 
 /// Top level singleton Amplify object.

--- a/packages/amplify/amplify_flutter/lib/amplify_flutter.dart
+++ b/packages/amplify/amplify_flutter/lib/amplify_flutter.dart
@@ -6,14 +6,12 @@ library;
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_flutter/src/amplify_impl.dart';
 
-export 'package:amplify_core/amplify_core.dart'
-    hide
-        Amplify,
-        WebSocketOptions,
-        // `@internal` serializers re-exported by amplify_core's barrel; not
-        // part of the supported public API.
-        zAmplifyOutputsSerializable,
-        zConfigMapSerializable;
+// Re-exports amplify_core's barrel, which intentionally surfaces the
+// `@internal` `zAmplifyOutputsSerializable` / `zConfigMapSerializable`
+// serializers. They are kept exported to preserve the existing public API;
+// they are not part of the supported public surface.
+// ignore: invalid_export_of_internal_element
+export 'package:amplify_core/amplify_core.dart' hide Amplify, WebSocketOptions;
 export 'package:amplify_secure_storage/amplify_secure_storage.dart';
 
 /// Top level singleton Amplify object.

--- a/packages/amplify_core/lib/amplify_core.dart
+++ b/packages/amplify_core/lib/amplify_core.dart
@@ -121,6 +121,11 @@ export 'src/types/temporal/temporal_timestamp.dart';
 
 /// Util
 export 'src/util/parsers.dart';
+// `zAmplifyOutputsSerializable` and `zConfigMapSerializable` are `@internal`
+// codegen annotations that are consumed across this package via this barrel,
+// so they must stay exported here. They are intentionally not part of the
+// supported public API (note the `z` prefix and `@internal` annotation).
+// ignore: invalid_export_of_internal_element
 export 'src/util/serializable.dart';
 export 'src/util/uuid.dart';
 

--- a/packages/aws_signature_v4/lib/aws_signature_v4.dart
+++ b/packages/aws_signature_v4/lib/aws_signature_v4.dart
@@ -14,4 +14,8 @@ export 'src/request/aws_date_time.dart';
 export 'src/request/aws_signed_request.dart';
 export 'src/request/canonical_request/canonical_request.dart';
 export 'src/signer/aws_algorithm.dart';
+// `zSigningTest` is an `@internal` symbol consumed across this package (and
+// its tests) via this barrel, so it must stay exported here. It is
+// intentionally not part of the supported public API.
+// ignore: invalid_export_of_internal_element
 export 'src/signer/aws_signer.dart';


### PR DESCRIPTION
## Problem

CI's `stable` toolchain moved to **Dart 3.12.2 / analyzer 13.3.0**, which newly enforces `invalid_export_of_internal_element` as a **warning**. Because the VM `Analyze` step runs `dart analyze --fatal-infos --fatal-warnings`, this fails on **main** (and every PR) for three packages:

| Package | File | Flagged `@internal` members |
|---|---|---|
| `amplify_core` | `lib/amplify_core.dart:124` | `zAmplifyOutputsSerializable`, `zConfigMapSerializable` |
| `aws_signature_v4` | `lib/aws_signature_v4.dart:17` | `zSigningTest` |
| `amplify_flutter` | `lib/amplify_flutter.dart:9` | `zAmplifyOutputsSerializable`, `zConfigMapSerializable` (via core re-export) |

This is **pre-existing on main** (the scheduled builds for all three have been red) and unrelated to any feature work.

## Approach: suppress the lint, do NOT change the public API

The flagged symbols are `@internal`, `z`-prefixed codegen/test helpers consumed internally across each package (and its tests) via the package's own public barrel import. They cannot be `hide`-d from the source barrels without breaking ~17 internal call sites.

All three packages use a documented `// ignore: invalid_export_of_internal_element`. **No package's exported public API changes** — this is important so `aft` does not classify the change as breaking and trigger a major version bump. An earlier revision added the symbols to `amplify_flutter`'s `hide` clause, but that removed them from its public surface; switched to `// ignore:` for consistency and to keep the API byte-for-byte identical.

## Verification

- All three packages pass `dart analyze --fatal-infos --fatal-warnings .` locally with no breakage.
- CI (analyzer 13.3.0) confirms the previously-failing `test-dart-vm` / `test-flutter-vm` Analyze jobs are now green on this branch.
- Local analyzer is 3.11 (cannot fire this lint), so warning-resolution is validated by CI.