### PR TITLE
fix(secure_storage): Await Future return in try block (Dart 3.13 beta lint)

### DIFF
--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_web.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/platforms/amplify_secure_storage_web.dart
@@ -133,7 +133,7 @@ class _IndexedDBStorage extends AmplifySecureStorageInterface {
     final store = database.getObjectStore(storeName);
     try {
       final result = store.get(key.toJS).future;
-      return result.then((value) => (value as JSString?)?.toDart);
+      return await result.then((value) => (value as JSString?)?.toDart);
     } on Object catch (e) {
       throw SecureStorageException(e.toString());
     }


### PR DESCRIPTION
### Issue

Dart beta `3.13.0-167.1.beta` newly enforces the `unawaited_return_in_try_block` lint. CI runs `dart analyze --fatal-infos --fatal-warnings .`, which now fails the `test-dart-vm (beta)` job:

```
warning - lib/src/platforms/amplify_secure_storage_web.dart:136:7 - Returning a 'Future' without 'await' inside a try block. Try adding an 'await'. - unawaited_return_in_try_block
```

### Cause

In `_IndexedDBStorage.read`, the future returned by `result.then(...)` was returned from inside a `try` block **without** `await`. Because the function returns before the future completes, a rejection from the IndexedDB `get` request escapes the surrounding `try`/`catch` and is **not** wrapped in `SecureStorageException` — inconsistent with the sibling `write`/`delete` methods (which both `await` and wrap).

### Fix

Add `await` to the return (the enclosing `read` method is already `async`):

```dart
- return result.then((value) => (value as JSString?)?.toDart);
+ return await result.then((value) => (value as JSString?)?.toDart);
```

This is the lint's recommended fix (not a `// ignore`). It makes async exceptions catchable by the surrounding `catch`, so IndexedDB read failures are now consistently surfaced as `SecureStorageException`, matching `write`/`delete`.

### Verification

- `dart analyze --fatal-infos --fatal-warnings .` → **No issues found!**
- `dart format --set-exit-if-changed` → clean
- Web target compiles via `dart compile js` (exercises the modified `read`)

Fixes the failing `test-dart-vm (beta)` analyze step.