### PR TITLE
fix(smithy): Await Future return in try block (Dart 3.13 beta lint)

### DIFF
--- a/packages/smithy/smithy/lib/src/behavior/retryer.dart
+++ b/packages/smithy/smithy/lib/src/behavior/retryer.dart
@@ -43,7 +43,7 @@ class Retryer {
           currentOperation = operation;
           final result = await operation.valueOrCancellation();
           if (result is! R || operation.isCanceled) {
-            return completer.operation.cancel();
+            return await completer.operation.cancel();
           }
           return completer.complete(result);
         } on Exception catch (e) {


### PR DESCRIPTION
### Problem

Dart `3.13.0-167.1.beta` newly enforces the `unawaited_return_in_try_block` static warning. The `test-dart-vm (beta)` CI job runs `dart analyze --fatal-infos --fatal-warnings .` and now fails for `packages/smithy/smithy`:

```
warning - lib/src/behavior/retryer.dart:46:13 - Returning a 'Future' without 'await' inside a try block. Try adding an 'await'. - unawaited_return_in_try_block
```

### Fix

`CancelableOperation.cancel()` returns a `Future`, and the enclosing closure (`Future<void>(() async { ... })`) is `async`, so the bare `return` sits inside a `try`/`catch`. Add the missing `await` — exactly the analyzer's recommended correction ("Try adding an 'await'."):

```diff
           if (result is! R || operation.isCanceled) {
-            return completer.operation.cancel();
+            return await completer.operation.cancel();
           }
```

This is behavior-preserving: in an `async` function, `return future;` and `return await future;` complete the outer future at the same time. The only difference is that errors from `cancel()` are now routed through the local `try`/`catch`, which rethrows non-retryable exceptions — matching the lint's intent.

### Verification

- `dart pub get` ✓
- `dart analyze --fatal-infos --fatal-warnings .` → `No issues found!` ✓
- `dart test test/http/http_operation_test.dart` → 5/5 pass, including **"HttpOperation can cancel operation"** which exercises the modified cancellation path ✓
- `dart format` → no changes ✓
