### PR TITLE
fix(core): Satisfy Dart 3.13 beta analyzer (await in try blocks + super parameter)

### DIFF
--- a/packages/amplify_core/doc/lib/auth.dart
+++ b/packages/amplify_core/doc/lib/auth.dart
@@ -62,7 +62,7 @@ Future<void> signUpUser({
       password: password,
       options: SignUpOptions(userAttributes: userAttributes),
     );
-    return _handleSignUpResult(result);
+    return await _handleSignUpResult(result);
   } on AuthException catch (e) {
     safePrint('Error signing up user: ${e.message}');
   }
@@ -79,7 +79,7 @@ Future<void> confirmUser({
       username: username,
       confirmationCode: confirmationCode,
     );
-    return _handleSignUpResult(result);
+    return await _handleSignUpResult(result);
   } on AuthException catch (e) {
     safePrint('Error confirming user: ${e.message}');
   }
@@ -203,7 +203,7 @@ Future<void> signInUser(String username, String password) async {
       username: username,
       password: password,
     );
-    return _handleSignInResult(result);
+    return await _handleSignInResult(result);
   } on AuthException catch (e) {
     safePrint('Error signing in: ${e.message}');
   }
@@ -216,7 +216,7 @@ Future<void> socialSignIn() async {
     final result = await Amplify.Auth.signInWithWebUI(
       provider: AuthProvider.google,
     );
-    return _handleSignInResult(result);
+    return await _handleSignInResult(result);
   } on AuthException catch (e) {
     safePrint('Error signing in: ${e.message}');
   }
@@ -239,7 +239,7 @@ Future<void> _handleResetPasswordResult(ResetPasswordResult result) async {
 Future<void> confirmMfaUser(String mfaCode) async {
   try {
     final result = await Amplify.Auth.confirmSignIn(confirmationValue: mfaCode);
-    return _handleSignInResult(result);
+    return await _handleSignInResult(result);
   } on AuthException catch (e) {
     safePrint('Error confirming MFA code: ${e.message}');
   }
@@ -260,7 +260,7 @@ Future<void> _handleMfaSelection(MfaType selection) async {
     final result = await Amplify.Auth.confirmSignIn(
       confirmationValue: selection.confirmationValue,
     );
-    return _handleSignInResult(result);
+    return await _handleSignInResult(result);
   } on AuthException catch (e) {
     safePrint('Error selecting MFA type: ${e.message}');
   }
@@ -283,7 +283,7 @@ Future<void> _handleFirstFactorSelection(AuthFactorType selection) async {
     final result = await Amplify.Auth.confirmSignIn(
       confirmationValue: selection.value,
     );
-    return _handleSignInResult(result);
+    return await _handleSignInResult(result);
   } on AuthException catch (e) {
     safePrint('Error selecting first factor preference: ${e.message}');
   }
@@ -340,7 +340,7 @@ Future<void> updatePassword({
 Future<void> resetPassword(String username) async {
   try {
     final result = await Amplify.Auth.resetPassword(username: username);
-    return _handleResetPasswordResult(result);
+    return await _handleResetPasswordResult(result);
   } on AuthException catch (e) {
     safePrint('Error resetting password: ${e.message}');
   }

--- a/packages/amplify_core/lib/src/types/auth/hub/auth_hub_event.dart
+++ b/packages/amplify_core/lib/src/types/auth/hub/auth_hub_event.dart
@@ -57,8 +57,7 @@ class AuthHubEvent extends HubEvent<AuthUser>
   /// Emitted when a user is deleted by calling `Amplify.Auth.deleteUser`.
   /// {@endtemplate}
   AuthHubEvent.userDeleted() : this._(AuthHubEventType.userDeleted);
-  AuthHubEvent._(this.type, {AuthUser? payload})
-    : super(type.eventName, payload: payload);
+  AuthHubEvent._(this.type, {super.payload}) : super(type.eventName);
 
   /// {@macro amplify_common.hub.auth_hub_event_type}
   final AuthHubEventType type;


### PR DESCRIPTION
## Problem

On the Dart **beta** channel (`3.13.0-167.1.beta`), the CI step `dart analyze --fatal-infos --fatal-warnings .` in `packages/amplify_core` fails with **9 issues** because two lints are now enforced and promoted to fatal:

- **`unawaited_return_in_try_block`** (warning) — 8 occurrences in `doc/lib/auth.dart` (lines 65, 82, 206, 219, 242, 263, 286, 343). Each is a `return <Future>;` inside a `try` block, so exceptions escape the `on AuthException catch` handler instead of being caught.
- **`use_super_parameters`** (info) — 1 occurrence in `lib/src/types/auth/hub/auth_hub_event.dart:60`, where `payload` is declared and manually forwarded to `super`.

Both are promoted to fatal by `--fatal-infos --fatal-warnings`, failing the `test-dart-vm (beta)` analyze job.

## Fix

- Added `await` to the 8 flagged `return` statements (`return await <call>;`). All enclosing functions are already `async` and return `Future<void>`; awaiting makes thrown exceptions catchable by the surrounding `on AuthException catch` — the intended behavior. No behavior change for the happy path.
- Converted the `AuthHubEvent._` constructor to use a super parameter: `{super.payload}` instead of declaring `{AuthUser? payload}` and forwarding `payload: payload` to `super`.

No `// ignore` comments — proper fixes only. License headers untouched; files run through `dart format`.

## Verification

Validated with the exact CI SDK (`Dart 3.13.0-167.1.beta`):

- Before: `dart analyze --fatal-infos --fatal-warnings .` → **9 issues** (exit 2)
- After: `dart analyze --fatal-infos --fatal-warnings .` → **No issues found!** (exit 0)
- `amplify_core` hub tests (which construct `AuthHubEvent`) pass: **10/10**
