### PR TITLE
fix(auth): Await Future returns in try blocks (Dart 3.13 beta lint)

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/hosted_ui_state_machine.dart
@@ -116,7 +116,7 @@ final class HostedUiStateMachine
         state: event.state,
         codeVerifier: event.codeVerifier,
       );
-      return resolve(HostedUiEvent.exchange(parameters));
+      return await resolve(HostedUiEvent.exchange(parameters));
     } on SignedOutException {
       emit(const HostedUiState.signedOut());
     }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -1327,7 +1327,7 @@ final class SignInStateMachine
       _challengeParameters = challengeResp.challengeParameters ?? BuiltMap();
       _session = challengeResp.session;
 
-      return _processChallenge();
+      return await _processChallenge();
     } on ResourceNotFoundException {
       // For device flows, retry with normal SRP sign-in when the device is not
       // found. This protects against the case where a device has been removed


### PR DESCRIPTION
## Problem

Dart `3.13.0-167.1.beta` newly enforces the `unawaited_return_in_try_block` lint. The `test-dart-vm` (beta) job runs `dart analyze --fatal-infos --fatal-warnings .` in `packages/auth/amplify_auth_cognito_dart` and fails with 2 warnings:

- `lib/src/state/machines/hosted_ui_state_machine.dart:119` — Returning a `Future` without `await` inside a try block
- `lib/src/state/machines/sign_in_state_machine.dart:1330` — same

## Fix

Added `await` to the two `Future`-returning `return` statements inside the `try` blocks. Both enclosing functions are already `async`; awaiting is the correct behavior in these state machines (it ensures errors surface within the handler's `try`/`catch` and the dispatcher's error-handling context). No `// ignore` suppressions.

- `hosted_ui_state_machine.dart` (`onFoundState`): the only code that throws `SignedOutException` is `_platform.onFoundState()`, which is already awaited above this line; the `resolve(exchange)` chain does not throw it, so behavior is unchanged.
- `sign_in_state_machine.dart` (`_respondToChallenge`): `_processChallenge()` is already `await`ed at every other call site; the `ResourceNotFoundException` device-retry guard (`_challengeName == passwordVerifier`) is unaffected.

## Verification

Verified against the exact CI SDK `3.13.0-167.1.beta`:

- Before: `2 issues found.`
- After: `No issues found!`

State-machine regression tests pass (`sign_in_state_machine_test.dart`, `hosted_ui_state_machine_test.dart`): `All tests passed!` (26 tests).
