### PR TITLE
feat(aft): Add `--no-example` flag to bootstrap

### DIFF
--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -68,7 +68,9 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
-        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }} --verbose
+        # Example apps aren't needed here, and `--no-example` avoids
+        # resolving a Dart package's Flutter example without a Flutter SDK.
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }} --no-example --verbose
 
       - name: Setup Package
         if: "always() && steps.bootstrap.conclusion == 'success'"

--- a/.github/workflows/dart_dart2wasm.yaml
+++ b/.github/workflows/dart_dart2wasm.yaml
@@ -68,7 +68,9 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
-        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }} --verbose
+        # Example apps aren't needed here, and `--no-example` avoids
+        # resolving a Dart package's Flutter example without a Flutter SDK.
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }} --no-example --verbose
 
       - name: Setup Package
         if: "always() && steps.bootstrap.conclusion == 'success'"

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -68,7 +68,9 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
-        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }} --verbose
+        # Example apps aren't needed here, and `--no-example` avoids
+        # resolving a Dart package's Flutter example without a Flutter SDK.
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }} --no-example --verbose
 
       - name: Setup Package
         if: "always() && steps.bootstrap.conclusion == 'success'"

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -72,7 +72,9 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         timeout-minutes: 20
-        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }} --verbose
+        # Example apps aren't needed here, and `--no-example` avoids
+        # resolving a Dart package's Flutter example without a Flutter SDK.
+        run: aft bootstrap --fail-fast --include=${{ inputs.package-name }} --no-example --verbose
 
       - name: Setup Package
         if: "always() && steps.bootstrap.conclusion == 'success'"

--- a/packages/aft/lib/src/commands/bootstrap_command.dart
+++ b/packages/aft/lib/src/commands/bootstrap_command.dart
@@ -24,6 +24,15 @@ class BootstrapCommand extends AmplifyCommand with GlobOptions, FailFastOption {
         help: 'Runs build_runner for packages which need it',
         negatable: true,
         defaultsTo: true,
+      )
+      ..addFlag(
+        'example',
+        help:
+            'Also run `pub get`/`upgrade` in each `example/`. Disable when '
+            'Flutter is unavailable (e.g. Dart-only CI jobs) to skip resolving '
+            'a Flutter example.',
+        negatable: true,
+        defaultsTo: true,
       );
   }
 
@@ -40,6 +49,7 @@ class BootstrapCommand extends AmplifyCommand with GlobOptions, FailFastOption {
 
   late final bool upgrade = argResults!['upgrade'] as bool;
   late final bool build = argResults!['build'] as bool;
+  late final bool example = argResults!['example'] as bool;
 
   /// Creates an empty `amplifyconfiguration.dart` file.
   Future<void> _createEmptyConfig(PackageInfo package) async {
@@ -129,7 +139,12 @@ const amplifyEnvironments = <String, String>{};
         .nonNulls;
     for (final package in bootstrapPackages) {
       await pubAction(
-        arguments: [if (upgrade) 'upgrade' else 'get'],
+        // Examples are bootstrapped as their own packages above, so pub's
+        // implicit `example/` resolution can be skipped with `--no-example`.
+        arguments: [
+          if (upgrade) 'upgrade' else 'get',
+          if (!example) '--no-example',
+        ],
         package: package,
       );
     }


### PR DESCRIPTION
dart pub get/upgrade also resolves a nested example/. aft already bootstraps examples as their own packages, and resolving them needs Flutter when the example is a Flutter app — which the Dart-only web/native CI jobs don't have.

Add an opt-in --no-example flag (default keeps the existing behavior) and pass it from those jobs so a Dart package with a Flutter example bootstraps there.

Needed for https://github.com/aws-amplify/amplify-flutter/pull/7059