### PR TITLE
test: anchor OS-only @TestOn selectors on vm to exclude browser runs under Dart 3.12

### DIFF
--- a/packages/amplify_core/test/http/user_agent_test.dart
+++ b/packages/amplify_core/test/http/user_agent_test.dart
@@ -21,15 +21,15 @@ void main() {
       expect(osIdentifier, matches(RegExp(r'^Safari/[\d\.]+$')));
     });
 
-    test('Windows', testOn: 'windows', () {
+    test('Windows', testOn: 'vm && windows', () {
       expect(osIdentifier, matches(RegExp(r'^windows/[\d\.]+$')));
     });
 
-    test('macOS', testOn: 'mac-os', () {
+    test('macOS', testOn: 'vm && mac-os', () {
       expect(osIdentifier, matches(RegExp(r'^macos/[\d\.]+$')));
     });
 
-    test('Linux', testOn: 'linux', () {
+    test('Linux', testOn: 'vm && linux', () {
       expect(osIdentifier, matches(RegExp(r'^linux/[\d\.]+$')));
     });
   });

--- a/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_io_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_io_test.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-@TestOn('windows || mac-os || linux')
+@TestOn('vm && (windows || mac-os || linux)')
 library;
 
 import 'dart:async';

--- a/packages/secure_storage/amplify_secure_storage_test/test/linux_test.dart
+++ b/packages/secure_storage/amplify_secure_storage_test/test/linux_test.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-@TestOn('linux')
+@TestOn('vm && linux')
 library;
 
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';

--- a/packages/secure_storage/amplify_secure_storage_test/test/mac_os_test.dart
+++ b/packages/secure_storage/amplify_secure_storage_test/test/mac_os_test.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-@TestOn('mac-os')
+@TestOn('vm && mac-os')
 library;
 
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';

--- a/packages/secure_storage/amplify_secure_storage_test/test/windows_test.dart
+++ b/packages/secure_storage/amplify_secure_storage_test/test/windows_test.dart
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-@TestOn('windows')
+@TestOn('vm && windows')
 library;
 
 import 'package:amplify_secure_storage_dart/amplify_secure_storage_dart.dart';


### PR DESCRIPTION
## Summary

amplify-flutter's **web** test jobs (dart2js / dart2wasm / ddc on `chrome` & `firefox`) began failing around 2026-06-29 once CI's floating `stable` Dart moved to **3.12.2**, which ships **`package:test` 1.31.2**.

That release changed how **OS platform selectors** are evaluated. A selector that names only an operating system — e.g. `@TestOn('linux')`, `@TestOn('windows || mac-os || linux')`, or a per-test `testOn: 'linux'` — now evaluates **`true` for browser runs on a matching host OS**. CI's web runners are Linux, so VM/desktop-only tests that import `dart:io` / FFI got pulled into the browser suites and failed:

- `amplify_core` → `test/http/user_agent_test.dart` `User-Agent Linux`: `Expected: match '^linux/[\d\.]+$'`, `Actual: 'Chrome/149.0.0.0'`
- `amplify_auth_cognito_test` → `hosted_ui_platform_io_test.dart`: `Unsupported operation: InternetAddress.loopbackIPv4` (a `dart:io` `HttpServer`)
- `amplify_secure_storage_test` → `linux/mac_os/windows_test.dart`: FFI bindings unavailable on web

This is a **pre-existing mainline bug** that the Dart version bump merely surfaced — it also blocks the version-bump PR #7064.

## Root cause

Pre-3.12, an OS-only selector implicitly excluded browser runtimes. `package:test` 1.31.2 changed selector evaluation so an OS-only clause is `true` whenever the **host** OS matches — regardless of whether the test is executing on the VM or in a browser. As a result, `dart test -p chrome` on a Linux runner now includes every `@TestOn('linux')` / `testOn: 'linux'` test.

## Fix

Anchor each OS-only selector on the `vm` runtime by prepending `vm && `. This restores the intended pre-3.12 semantics (run on those desktop OSes **on the VM**, never in a browser) **without changing which OSes run** and **without touching any test logic**:

| Before | After |
| --- | --- |
| `@TestOn('windows \|\| mac-os \|\| linux')` | `@TestOn('vm && (windows \|\| mac-os \|\| linux)')` |
| `@TestOn('linux')` | `@TestOn('vm && linux')` |
| `@TestOn('mac-os')` | `@TestOn('vm && mac-os')` |
| `@TestOn('windows')` | `@TestOn('vm && windows')` |
| `testOn: 'linux'` | `testOn: 'vm && linux'` |
| `testOn: 'mac-os'` | `testOn: 'vm && mac-os'` |
| `testOn: 'windows'` | `testOn: 'vm && windows'` |

iOS/Android are also `vm`, but the existing OS clause already excludes them, so coverage is unchanged. The only behavioral change is that browsers are now excluded — the intended behavior.

### Files changed (5)

- `packages/amplify_core/test/http/user_agent_test.dart` — vm-anchors the per-test `testOn:` for the Windows / macOS / Linux cases (the `chrome` / `firefox` / `safari` cases are left untouched — they're correctly browser-anchored).
- `packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_io_test.dart` — `@TestOn('vm && (windows || mac-os || linux)')` (uses `dart:io` `HttpServer.bind(InternetAddress.loopbackIPv4)`).
- `packages/secure_storage/amplify_secure_storage_test/test/linux_test.dart` — `@TestOn('vm && linux')` (FFI: libsecret).
- `packages/secure_storage/amplify_secure_storage_test/test/mac_os_test.dart` — `@TestOn('vm && mac-os')` (FFI: Cupertino bindings).
- `packages/secure_storage/amplify_secure_storage_test/test/windows_test.dart` — `@TestOn('vm && windows')` (FFI: Win32 DPAPI).

## Scope — deliberately NOT changed

- Selectors already anchored on a runtime (`@TestOn('vm')`, `@TestOn('browser')`, `@TestOn('chrome')`, `@TestOn('node')`) — correct as-is.
- `@OnPlatform({'browser': Skip(...)})` annotations — already exclude browsers correctly.
- Flutter `example/integration_test/**` and `example/test_driver/**` desktop tests — those run via `flutter test` / `flutter drive` on real devices, **not** via `dart test -p chrome`, so they're unaffected by this selector change.

## Verification (local, with `test` 1.31.2 resolved)

- **Bug reproduced** — with the original selectors, `dart test -p chrome test/http/user_agent_test.dart` ran `User-Agent Linux` and failed: `Expected: match '^linux/[\d\.]+$'` / `Actual: 'Chrome/149.0.0.0'`.
- **Fix verified on chrome** — with the vm-anchored selectors, the OS cases are skipped and only the browser/agnostic cases run: `+4: All tests passed!`.
- **VM coverage preserved** — on the VM, `user_agent_test.dart` and `hosted_ui_platform_io_test.dart` still run their OS cases and pass (`+4: All tests passed!`).
- `dart format --set-exit-if-changed` on all 5 files → `Formatted 5 files (0 changed)`.
- `dart analyze --fatal-infos --fatal-warnings` on `amplify_core`, `amplify_secure_storage_test`, `amplify_auth_cognito_test` → `No issues found!`.

## Unblocks

- Web `stable` / `beta` test jobs on `main`.
- Version-bump PR #7064 (same failures; this fix removes them).
